### PR TITLE
[backend] fix TPDE again

### DIFF
--- a/cmake/TPDE.cmake
+++ b/cmake/TPDE.cmake
@@ -4,7 +4,7 @@
 include(FetchContent)
 
 # Set TPDE version to the specified commit
-set(TPDE_VERSION "529625132d3c1fd60af22c40ab42b7c069eb8e93")
+set(TPDE_VERSION "ddf19b0dbc1ae2d283097167537306fb83192b0e")
 
 # Disable TPDE_ENABLE_ENCODEGEN as requested
 set(TPDE_ENABLE_LLVM ON CACHE BOOL "Disable TPDE LLVM" FORCE)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the TPDE dependency commit used by CMake `FetchContent`.
> 
> - Bumps `TPDE_VERSION` in `cmake/TPDE.cmake` from `529625132d3c1fd60af22c40ab42b7c069eb8e93` to `ddf19b0dbc1ae2d283097167537306fb83192b0e`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bb03b0579c3f7237877500c8d698c5b71b34936. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->