### PR TITLE
feat: implement platform-specific ABI support for struct returns

### DIFF
--- a/include/Reussir/Conversion/TypeConverter.h
+++ b/include/Reussir/Conversion/TypeConverter.h
@@ -13,6 +13,7 @@
 #ifndef REUSSIR_CONVERSION_TYPECONVERTER_H
 #define REUSSIR_CONVERSION_TYPECONVERTER_H
 
+#include <llvm/TargetParser/Triple.h>
 #include <mlir/Conversion/LLVMCommon/TypeConverter.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Interfaces/DataLayoutInterfaces.h>
@@ -32,9 +33,40 @@ public:
 
   const mlir::DataLayout &getDataLayout() const { return dataLayout; }
 
+  /// Returns true if targeting Windows (any variant)
+  bool isWindowsTarget() const { return targetTriple.isOSWindows(); }
+
+  /// Returns true if targeting macOS/iOS/watchOS/tvOS
+  bool isDarwinTarget() const { return targetTriple.isOSDarwin(); }
+
+  /// Returns true if targeting x86_64 architecture
+  bool isX86_64() const { return targetTriple.getArch() == llvm::Triple::x86_64; }
+
+  /// Returns true if targeting AArch64/ARM64 architecture
+  bool isAArch64() const {
+    return targetTriple.getArch() == llvm::Triple::aarch64 ||
+           targetTriple.getArch() == llvm::Triple::aarch64_be;
+  }
+
+  /// Returns true if targeting a 32-bit architecture
+  bool is32Bit() const { return targetTriple.isArch32Bit(); }
+
+  /// Returns true if a struct return value should use the sret calling
+  /// convention (return via pointer argument) based on the target ABI.
+  ///
+  /// For Windows x64: structs of size != 1, 2, 4, 8 bytes use sret
+  /// For System V AMD64: structs > 16 bytes use sret (simplified rule)
+  /// For AAPCS64: structs > 16 bytes use sret (simplified rule)
+  bool shouldUseSret(mlir::Type llvmType) const;
+
+  /// Get the target triple
+  const llvm::Triple &getTargetTriple() const { return targetTriple; }
+
 private:
   mlir::DataLayout dataLayout;
+  llvm::Triple targetTriple;
 };
 } // namespace reussir
 
 #endif // REUSSIR_CONVERSION_TYPECONVERTER_H
+

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1409,7 +1409,7 @@ def ReussirStrSliceOp : ReussirStrOp<"slice", []> {
 }
 
 //===----------------------------------------------------------------------===//
-// Reussir Function Operations (CABI-aware replacements for func dialect)
+// Reussir Function Operations (Platform-aware ABI handling)
 //===----------------------------------------------------------------------===//
 
 def ReussirFuncOp : ReussirOp<"func", [


### PR DESCRIPTION
## Summary

This PR adds ABI-aware handling for struct return values, addressing Issue #166.

## Changes

### TypeConverter Enhancements
- Add target triple parsing and storage to \`LLVMTypeConverter\`
- Implement \`shouldUseSret()\` method with platform-specific ABI rules:
  - **Windows x64**: sret for structs not 1, 2, 4, or 8 bytes
  - **System V AMD64**: sret for structs > 16 bytes
  - **AAPCS64**: sret for structs > 16 bytes

### Lowering Pattern Updates
- \`ReussirFuncOpConversionPattern\`: Add sret pointer argument when needed
- \`ReussirReturnOpConversionPattern\`: Store to sret pointer instead of returning
- \`ReussirCallOpConversionPattern\`: Allocate stack space and pass sret pointer

### Infrastructure
- Pass target triple from Bridge and JIT to the lowering pipeline

## Testing
- All 136 tests pass on Linux
- Windows CI should now pass for \`str_select_e2e\` test

Fixes #166