### PR TITLE
feat(cabi): implement reussir.func, reussir.return, reussir.call for CABI alignment

### DIFF
--- a/include/Reussir/Conversion/IncDecCancellation.h
+++ b/include/Reussir/Conversion/IncDecCancellation.h
@@ -16,7 +16,7 @@
 #ifndef REUSSIR_CONVERSION_INCDECCANCELLATION_H
 #define REUSSIR_CONVERSION_INCDECCANCELLATION_H
 
-#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include "Reussir/IR/ReussirOps.h"
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/DialectConversion.h>
@@ -36,7 +36,7 @@ namespace reussir {
 // locally.
 //
 //===----------------------------------------------------------------------===//
-llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func);
+llvm::LogicalResult runIncDecCancellation(reussir::ReussirFuncOp func);
 
 } // namespace reussir
 

--- a/include/Reussir/Conversion/InferVariantTag.h
+++ b/include/Reussir/Conversion/InferVariantTag.h
@@ -16,10 +16,11 @@
 #ifndef REUSSIR_CONVERSION_INFERVARIANTTAG_H
 #define REUSSIR_CONVERSION_INFERVARIANTTAG_H
 
-#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include "Reussir/IR/ReussirOps.h"
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/DialectConversion.h>
+#include "llvm/Support/LogicalResult.h"
 
 #include "Reussir/IR/ReussirTypes.h"
 
@@ -62,7 +63,7 @@ namespace reussir {
 // attribute to the drop operation.
 //===----------------------------------------------------------------------===//
 
-void runTagInference(mlir::func::FuncOp func);
+llvm::LogicalResult runInferVariantTag(reussir::ReussirFuncOp func);
 
 } // namespace reussir
 

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -131,7 +131,7 @@ def ReussirRcDecrementExpansionPass
 // InferVariantTag
 //===----------------------------------------------------------------------===//
 def ReussirInferVariantTagPass
-    : Pass<"reussir-infer-variant-tag", "::mlir::func::FuncOp"> {
+    : Pass<"reussir-infer-variant-tag", "::reussir::ReussirFuncOp"> {
   let summary = "infer variant tags for drop operations";
   let description = [{
     `reussir-infer-variant-tag` infers variant tags for drop operations.
@@ -144,7 +144,7 @@ def ReussirInferVariantTagPass
 // IncDecCancellation
 //===----------------------------------------------------------------------===//
 def ReussirIncDecCancellationPass
-    : Pass<"reussir-inc-dec-cancellation", "::mlir::func::FuncOp"> {
+    : Pass<"reussir-inc-dec-cancellation", "::reussir::ReussirFuncOp"> {
   let summary = "cancel out adjacent increment and decrement operations";
   let description = [{
     `reussir-inc-dec-cancellation` cancels out adjacent increment and decrement
@@ -158,7 +158,7 @@ def ReussirIncDecCancellationPass
 // TokenInstantiation
 //===----------------------------------------------------------------------===//
 def ReussirTokenInstantiationPass
-    : Pass<"reussir-token-instantiation", "::mlir::func::FuncOp"> {
+    : Pass<"reussir-token-instantiation", "::reussir::ReussirFuncOp"> {
   let summary = "insert token instantiations for TokenAcceptor operations";
   let description = [{
     `reussir-token-instantiation` inserts token allocation operations for operations
@@ -210,7 +210,7 @@ def ReussirCompilePolymorphicFFIPass
 // TokenReuse
 //===----------------------------------------------------------------------===//
 def ReussirTokenReusePass
-    : Pass<"reussir-token-reuse", "::mlir::func::FuncOp"> {
+    : Pass<"reussir-token-reuse", "::reussir::ReussirFuncOp"> {
   let summary = "reuse tokens for operations";
   let description = [{
     `reussir-token-reuse` reuses tokens for operations.

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -16,6 +16,10 @@
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/RegionKindInterface.td"
+include "mlir/Interfaces/FunctionInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Dialect/Arith/IR/ArithBase.td"
 include "Reussir/IR/ReussirDialect.td"
 include "Reussir/IR/ReussirAttrs.td"
@@ -1406,3 +1410,91 @@ def ReussirStrSliceOp : ReussirStrOp<"slice", []> {
   }];
 }
 #endif // REUSSIR_IR_REUSSIROPS_TD
+
+//===----------------------------------------------------------------------===//
+// Reussir Function Operations
+//===----------------------------------------------------------------------===//
+
+def ReussirFuncOp : ReussirOp<"func", [
+  CallableOpInterface,
+  FunctionOpInterface,
+  IsolatedFromAbove,
+  Symbol
+]> {
+  let summary = "Define a function";
+  let description = [{
+    `reussir.func` defines a function in the Reussir dialect.
+    It replaces `func.func` to allow for improved handling of ABI-specific details
+    during lowering (CABI alignment).
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       TypeAttrOf<FunctionType>:$function_type,
+                       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs);
+  let regions = (region AnyRegion:$body);
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDeclaration = [{
+    // Add necessary helper methods if needed, or rely on 
+    // FunctionOpInterface methods
+    ::llvm::ArrayRef<::mlir::Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+    ::llvm::ArrayRef<::mlir::Type> getResultTypes() { return getFunctionType().getResults(); }
+
+    ::mlir::Region *getCallableRegion() { return isExternal() ? nullptr : &getBody(); }
+    ::llvm::ArrayRef<::mlir::Type> getCallableResults() { return getFunctionType().getResults(); }
+    ::mlir::ArrayAttr getCallableArgAttrs() { return getArgAttrs().value_or(nullptr); }
+    ::mlir::ArrayAttr getCallableResAttrs() { return getResAttrs().value_or(nullptr); }
+  }];
+}
+
+def ReussirReturnOp : ReussirOp<"return", [
+  Terminator,
+  ParentOneOf<["ReussirFuncOp"]>,
+  Pure,
+  ReturnLike
+]> {
+  let summary = "Return from a function";
+  let description = [{
+    `reussir.return` terminates a `reussir.func` and returns values.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+  let assemblyFormat = "($operands^ `:` type($operands))? attr-dict";
+}
+
+def ReussirCallOp : ReussirOp<"call", [
+  CallOpInterface,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Call a function";
+  let description = [{
+    `reussir.call` calls a function defined by `reussir.func`.
+  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<AnyType>:$operands,
+                       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs);
+  let results = (outs Variadic<AnyType>);
+
+  let assemblyFormat = [{
+    $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
+  }];
+  
+  let extraClassDeclaration = [{
+    ::mlir::CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<::mlir::SymbolRefAttr>("callee");
+    }
+    
+    void setCalleeFromCallable(::mlir::CallInterfaceCallable callee) {
+      (*this)->setAttr("callee", ::llvm::cast<::mlir::SymbolRefAttr>(callee));
+    }
+
+    ::mlir::Operation::operand_range getArgOperands() {
+      return getOperands();
+    }
+    
+    ::mlir::MutableOperandRange getArgOperandsMutable() {
+      return getOperandsMutable();
+    }
+  }];
+}

--- a/lib/Conversion/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Conversion/IncDecCancellation/IncDecCancellation.cpp
@@ -70,7 +70,7 @@ void eraseOrReplaceDecOp(ReussirRcDecOp decOp) {
 
 } // namespace
 
-llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
+llvm::LogicalResult runIncDecCancellation(reussir::ReussirFuncOp func) {
   mlir::AliasAnalysis aliasAnalysis(func);
   registerAliasAnalysisImplementations(aliasAnalysis);
   mlir::PostDominanceInfo postDominanceInfo(func);

--- a/lib/Conversion/InferVariantTag/InferVariantTag.cpp
+++ b/lib/Conversion/InferVariantTag/InferVariantTag.cpp
@@ -14,7 +14,7 @@
 
 #include <llvm/Support/Casting.h>
 #include <mlir/Analysis/AliasAnalysis.h>
-#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include "llvm/Support/LogicalResult.h"
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/Dominance.h>
 #include <mlir/IR/Value.h>
@@ -33,11 +33,14 @@ namespace {
 struct InferVariantTagPass
     : public impl::ReussirInferVariantTagPassBase<InferVariantTagPass> {
   using Base::Base;
-  void runOnOperation() override { runTagInference(getOperation()); }
+  void runOnOperation() override {
+    if (failed(runInferVariantTag(getOperation())))
+      signalPassFailure();
+  }
 };
 } // namespace
 
-void runTagInference(mlir::func::FuncOp func) {
+llvm::LogicalResult runInferVariantTag(reussir::ReussirFuncOp func) {
   // Initialize analyses
   mlir::AliasAnalysis aliasAnalysis(func);
   mlir::DominanceInfo dominanceInfo(func);
@@ -89,6 +92,7 @@ void runTagInference(mlir::func::FuncOp func) {
       }
     }
   });
+  return mlir::success();
 }
 
 } // namespace reussir

--- a/lib/Conversion/TokenInstantiation/TokenInstantiation.cpp
+++ b/lib/Conversion/TokenInstantiation/TokenInstantiation.cpp
@@ -18,7 +18,7 @@
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
 
-#include <mlir/Dialect/Func/IR/FuncOps.h>
+
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
@@ -104,7 +104,7 @@ class ReussirTokenInstantiationPass
           ReussirTokenInstantiationPass> {
 public:
   void runOnOperation() override {
-    mlir::func::FuncOp funcOp = getOperation();
+    ReussirFuncOp funcOp = getOperation();
 
     // Set up the pattern rewrite infrastructure
     mlir::RewritePatternSet patterns(&getContext());

--- a/tests/integration/conversion/reussir_func.mlir
+++ b/tests/integration/conversion/reussir_func.mlir
@@ -1,0 +1,38 @@
+// RUN: %reussir-opt %s --reussir-lowering-basic-ops | %FileCheck %s
+
+module @test {
+  reussir.func @simple_func(%arg0: i64) -> i64 {
+    reussir.return %arg0 : i64
+  }
+  // CHECK-LABEL: llvm.func @simple_func(%arg0: i64) -> i64
+  // CHECK: llvm.return %arg0 : i64
+
+  reussir.func private @private_func() {
+    reussir.return
+  }
+  // CHECK-LABEL: llvm.func private @private_func()
+  // CHECK: llvm.return
+
+  reussir.func @external_func() -> i64
+  // CHECK-LABEL: llvm.func @external_func() -> i64
+
+  reussir.func private @external_private_func() -> i64
+  // CHECK-LABEL: llvm.func @external_private_func() -> i64
+
+  reussir.func @caller() {
+    %c0 = arith.constant 0 : i64
+    %0 = reussir.call @simple_func(%c0) : (i64) -> i64
+    reussir.return
+  }
+  // CHECK-LABEL: llvm.func @caller()
+  // CHECK: llvm.call @simple_func(%{{.*}}) : (i64) -> i64
+
+  reussir.func @multi_return(%arg0: i64, %arg1: i64) -> (i64, i64) {
+    reussir.return %arg0, %arg1 : i64, i64
+  }
+  // CHECK-LABEL: llvm.func @multi_return(%arg0: i64, %arg1: i64) -> !llvm.struct<(i64, i64)>
+  // CHECK: %[[UNDEF:.*]] = llvm.mlir.undef : !llvm.struct<(i64, i64)>
+  // CHECK: %[[INS1:.*]] = llvm.insertvalue %arg0, %[[UNDEF]][0]
+  // CHECK: %[[INS2:.*]] = llvm.insertvalue %arg1, %[[INS1]][1]
+  // CHECK: llvm.return %[[INS2]]
+}

--- a/tests/integration/conversion/reussir_func_abi.mlir
+++ b/tests/integration/conversion/reussir_func_abi.mlir
@@ -1,0 +1,21 @@
+// RUN: %reussir-opt %s --reussir-lowering-basic-ops | %FileCheck %s
+
+module @test_abi attributes { llvm.target_triple = "x86_64-pc-windows-msvc" } {
+  reussir.func @large_struct_ret() -> !reussir.record<compound "Big" {i64, i64, i64}> {
+      %c0 = arith.constant 0 : i64
+      %0 = reussir.record.compound(%c0, %c0, %c0 : i64, i64, i64) : !reussir.record<compound "Big" {i64, i64, i64}>
+      reussir.return %0 : !reussir.record<compound "Big" {i64, i64, i64}>
+  }
+  // CHECK-LABEL: llvm.func @large_struct_ret(%arg0: !llvm.ptr {llvm.sret = !llvm.struct<"Big", (i64, i64, i64)>})
+  // CHECK: llvm.store %{{.*}}, %arg0
+  // CHECK: llvm.return
+
+  reussir.func @caller_abi() {
+      %0 = reussir.call @large_struct_ret() : () -> !reussir.record<compound "Big" {i64, i64, i64}>
+      reussir.return
+  }
+  // CHECK-LABEL: llvm.func @caller_abi()
+  // CHECK: %[[ALLOCA:.*]] = llvm.alloca
+  // CHECK: llvm.call @large_struct_ret(%[[ALLOCA]])
+  // CHECK: llvm.load %[[ALLOCA]]
+}


### PR DESCRIPTION
## Summary

Implements Issue #166 - CABI alignment for Windows and System V ABIs.

This PR introduces \`reussir.func\`, \`reussir.return\`, and \`reussir.call\` operations as replacements for \`func.func\`, \`func.return\`, and \`func.call\`. This enables the Reussir compiler to emit ABI-compliant code without requiring assembly trampolines or \`[[sysv_abi]]\` annotations.

## Changes

### Operation Definitions (\`ReussirOps.td\`)
- Added \`ReussirFuncOp\` with \`FunctionOpInterface\`, \`CallableOpInterface\`, and \`Symbol\` trait
- Added \`ReussirReturnOp\` as a terminator for \`ReussirFuncOp\`
- Added \`ReussirCallOp\` with \`CallOpInterface\` and \`SymbolUserOpInterface\`

### Implementation (\`ReussirOps.cpp\`)
- Implemented \`parse\` and \`print\` for \`ReussirFuncOp\` using MLIR 21 \`call_interface_impl\` APIs
- Implemented \`verifySymbolUses\` for \`ReussirCallOp\`

### Lowering (\`BasicOpsLowering.cpp\`)
- Added target-aware SRET lowering: on Windows x64, large struct returns use sret pattern
- Lowering patterns for \`ReussirFuncOp\` -> \`llvm.func\`
- Lowering patterns for \`ReussirReturnOp\` -> \`llvm.return\`
- Lowering patterns for \`ReussirCallOp\` -> \`llvm.call\`

### Pass Updates (\`Passes.td\`)
- Updated pass targets from \`mlir::func::FuncOp\` to \`reussir::ReussirFuncOp\`

### Tests
- Added \`reussir_func.mlir\` and \`reussir_func_abi.mlir\` integration tests

## Fixes

Closes #166