### PR TITLE
Desugar X::Y to X::Y{} for nullary enum variants

### DIFF
--- a/tests/integration/frontend/pattern_ctor_sugar_basic.rr
+++ b/tests/integration/frontend/pattern_ctor_sugar_basic.rr
@@ -1,0 +1,22 @@
+// RUN: %reussir-elab --mode semi %s | %FileCheck %s
+
+enum Option<T> {
+    Some(T),
+    None
+}
+
+fn foo() -> Option<i32> {
+    Option::None
+}
+
+fn bar() -> Option<i32> {
+    Option::None{}
+}
+
+// CHECK:      ;; Elaborated Functions
+// CHECK:      fn bar() -> Option<i32> {
+// CHECK-NEXT:     Option<i32>[1](Option::None<i32>() : Option::None<i32>) : Option<i32>
+// CHECK-NEXT: }
+// CHECK:      fn foo() -> Option<i32> {
+// CHECK-NEXT:     Option<i32>[1](Option::None<i32>() : Option::None<i32>) : Option<i32>
+// CHECK-NEXT: }

--- a/tests/integration/frontend/pattern_ctor_sugar_match.rr
+++ b/tests/integration/frontend/pattern_ctor_sugar_match.rr
@@ -1,0 +1,53 @@
+// RUN: %reussir-elab --mode semi %s | %FileCheck %s
+
+enum Option<T> {
+    Some(T),
+    None
+}
+
+fn is_some(x : Option<i32>) -> bool {
+    match x {
+        Option::Some(_) => true,
+        Option::None{} => false
+    }
+}
+
+fn none_val() -> Option<i32> {
+    Option::None
+}
+
+fn map_to_none(x : Option<i32>) -> Option<i32> {
+    match x {
+        Option::Some(_) => Option::None,
+        Option::None{} => Option::None
+    }
+}
+
+// CHECK:      ;; Elaborated Functions
+// CHECK:      fn none_val() -> Option<i32> {
+// CHECK-NEXT:     Option<i32>[1](Option::None<i32>() : Option::None<i32>) : Option<i32>
+// CHECK-NEXT: }
+// CHECK:      fn map_to_none(v0 (x): Option<i32>) -> Option<i32> {
+// CHECK-NEXT:     match v0 {
+// CHECK-NEXT:         switch (0) {
+// CHECK-NEXT:             ctor@0 => {
+// CHECK-NEXT:                 Option<i32>[1](Option::None<i32>() : Option::None<i32>) : Option<i32>
+// CHECK-NEXT:             }
+// CHECK-NEXT:             ctor@1 => {
+// CHECK-NEXT:                 Option<i32>[1](Option::None<i32>() : Option::None<i32>) : Option<i32>
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+// CHECK:      fn is_some(v0 (x): Option<i32>) -> bool {
+// CHECK-NEXT:     match v0 {
+// CHECK-NEXT:         switch (0) {
+// CHECK-NEXT:             ctor@0 => {
+// CHECK-NEXT:                 1.0 : bool
+// CHECK-NEXT:             }
+// CHECK-NEXT:             ctor@1 => {
+// CHECK-NEXT:                 0.0 : bool
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT: }


### PR DESCRIPTION
## Summary
- Desugar qualified paths like `Option::None` to `Option::None{}` when the path resolves to a fieldless enum variant, fixing a crash (`error "unimplemented yet"`) in `inferType` for `Syn.Var`
- Emit proper error messages for non-nullary qualified paths and unknown qualified variables
- Add integration tests for the sugar in both expression and match-body positions

## Test plan
- [x] `cabal build reussir-elab` compiles successfully
- [x] New tests `pattern_ctor_sugar_basic.rr` and `pattern_ctor_sugar_match.rr` pass
- [x] Full test suite (153 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)