### PR TITLE
[CI] add nightly release pipeline

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,8 +1,8 @@
 name: Nightly Release
 
 on:
-  schedule:
-    - cron: '0 3 * * *'  # 3 AM UTC daily
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Automated nightly builds for all supported platforms (Linux x64/ARM64, macOS ARM64, Windows x64) with GitHub Release publishing.

Fix #185 