### PR TITLE
feat: add customizable target triple for cross-compilation

### DIFF
--- a/.skills/compilation/SKILL.md
+++ b/.skills/compilation/SKILL.md
@@ -12,9 +12,10 @@ It has several CLI options:
 ```bash
 reussir-compiler - Reussir Compiler
 
-Usage: reussir-compiler INPUT (-o|--output OUTPUT) [-O|--opt-level ARG] 
-                        [-t|--target ARG] [-l|--log-level ARG] 
-                        [-m|--module-name ARG]
+Usage: reussir-compiler INPUT (-o|--output OUTPUT) [-O|--opt-level ARG]
+                        [-t|--target ARG] [-l|--log-level ARG]
+                        [-m|--module-name ARG] [--target-triple TRIPLE]
+                        [--target-cpu CPU] [--target-features FEATURES]
 
   Compile a Reussir file
 
@@ -26,6 +27,10 @@ Available options:
   -t,--target ARG          Output target (llvm-ir, asm, object)
   -l,--log-level ARG       Log level (error, warning, info, debug, trace)
   -m,--module-name ARG     Module name
+  --target-triple TRIPLE   Target triple (default: native)
+  --target-cpu CPU         Target CPU (default: native)
+  --target-features FEATURES
+                           Target features (default: native)
   -h,--help                Show this help text
 ```
 
@@ -50,6 +55,14 @@ define weak_odr i32 @_RC10rc_project(ptr %0) local_unnamed_addr !dbg !3 {
   ret i32 %3, !dbg !6
 }
 ```
+
+To cross-compile for a specific target, use the `--target-triple` flag:
+
+```bash
+cabal run reussir-compiler -- tests/integration/frontend/projection.rr -o output.ll -tllvm-ir --target-triple x86_64-unknown-linux-gnu
+```
+
+You can also specify `--target-cpu` and `--target-features` for finer control over code generation.
 
 Using the `-ltrace` option, you can get more detailed information about the compilation process.
 

--- a/frontend/reussir-bridge/src/Reussir/Bridge.hs
+++ b/frontend/reussir-bridge/src/Reussir/Bridge.hs
@@ -27,10 +27,12 @@ module Reussir.Bridge (
 
     -- * Compilation
     compileForNativeMachine,
+    compileForTarget,
     compileProgram,
     hasTPDE,
     getNativeTargetTriple,
     getNativeTargetCPU,
+    getNativeTargetFeatures,
 
     -- * JIT Engine
     module Reussir.Bridge.JITEngine,

--- a/frontend/reussir-codegen/reussir-codegen.cabal
+++ b/frontend/reussir-codegen/reussir-codegen.cabal
@@ -102,6 +102,7 @@ library
         text-builder-linear ^>= 0.1.3,
         unicode-data ^>=0.8.0,
         reussir-bridge,
+        bytestring,
         directory,
         filepath,
         vector

--- a/frontend/reussir-codegen/src/Reussir/Codegen/Context/Codegen.hs
+++ b/frontend/reussir-codegen/src/Reussir/Codegen/Context/Codegen.hs
@@ -45,6 +45,9 @@ data TargetSpec = TargetSpec
     , outputTarget :: B.OutputTarget
     , logLevel :: B.LogLevel
     , moduleFilePath :: FilePath
+    , targetTriple :: Maybe T.Text
+    , targetCPU :: Maybe T.Text
+    , targetFeatures :: Maybe T.Text
     }
     deriving (Eq, Show)
 

--- a/frontend/reussir-codegen/test/Test/Codegen.hs
+++ b/frontend/reussir-codegen/test/Test/Codegen.hs
@@ -122,6 +122,9 @@ createSimpleModule =
             B.OutputObject
             B.LogWarning
             "test.rr"
+            Nothing
+            Nothing
+            Nothing
 
 -- Create the Tensor2x2 record type symbol
 tensor2x2Symbol :: Symbol
@@ -187,6 +190,9 @@ createTensor2x2Module =
             B.OutputObject
             B.LogWarning
             "test.rr"
+            Nothing
+            Nothing
+            Nothing
 
 -- Create matmul function: _ZN9Tensor2x2I3f64E6matmulE
 -- Takes two Tensor2x2, returns Tensor2x2
@@ -769,6 +775,9 @@ createFibonacciModule =
             B.OutputObject
             B.LogWarning
             "test.rr"
+            Nothing
+            Nothing
+            Nothing
 
 codegenTests :: TestTree
 codegenTests =

--- a/frontend/reussir-codegen/test/Test/Codegen/Context/Module.hs
+++ b/frontend/reussir-codegen/test/Test/Codegen/Context/Module.hs
@@ -40,6 +40,9 @@ runCodegenAsText codegen = do
                 B.OutputObject
                 B.LogInfo
                 "./module.mlir"
+                Nothing
+                Nothing
+                Nothing
     L.withStdOutLogger $ \logger -> do
         E.runEff $ L.runLog "Test.Codegen.Context.Module" logger defaultLogLevel $ runCodegen spec $ do
             codegen

--- a/frontend/reussir-codegen/test/Test/Codegen/IR.hs
+++ b/frontend/reussir-codegen/test/Test/Codegen/IR.hs
@@ -38,6 +38,9 @@ runCodegenAsText codegen = do
                 B.OutputObject
                 B.LogInfo
                 "./module.mlir"
+                Nothing
+                Nothing
+                Nothing
     L.withStdOutLogger $ \logger -> do
         E.runEff $ L.runLog "Test.Codegen.IR" logger defaultLogLevel $ runCodegen spec $ do
             codegen

--- a/frontend/reussir-codegen/test/Test/Codegen/Intrinsics/Arith.hs
+++ b/frontend/reussir-codegen/test/Test/Codegen/Intrinsics/Arith.hs
@@ -35,6 +35,9 @@ runCodegenAsText codegen = do
                 B.OutputObject
                 B.LogInfo
                 "./module.mlir"
+                Nothing
+                Nothing
+                Nothing
     L.withStdOutLogger $ \logger -> do
         E.runEff $ L.runLog "Test.Codegen.Intrinsics.Arith" logger defaultLogLevel $ runCodegen spec $ do
             codegen

--- a/frontend/reussir-codegen/test/Test/Codegen/Intrinsics/Math.hs
+++ b/frontend/reussir-codegen/test/Test/Codegen/Intrinsics/Math.hs
@@ -35,6 +35,9 @@ runCodegenAsText codegen = do
                 B.OutputObject
                 B.LogInfo
                 "./module.mlir"
+                Nothing
+                Nothing
+                Nothing
     L.withStdOutLogger $ \logger -> do
         E.runEff $ L.runLog "Test.Codegen.Intrinsics.Math" logger defaultLogLevel $ runCodegen spec $ do
             codegen

--- a/frontend/reussir-codegen/test/Test/Codegen/Location.hs
+++ b/frontend/reussir-codegen/test/Test/Codegen/Location.hs
@@ -32,6 +32,9 @@ runCodegenAsText codegen = do
                 B.OutputObject
                 B.LogInfo
                 "./module.mlir"
+                Nothing
+                Nothing
+                Nothing
     fmap TB.runBuilder $ L.withStdOutLogger $ \logger -> do
         E.runEff $
             L.runLog "Test.Codegen.Location" logger defaultLogLevel $

--- a/frontend/reussir-core/app/Compiler.hs
+++ b/frontend/reussir-core/app/Compiler.hs
@@ -26,6 +26,9 @@ data Args = Args
     , argOutputTarget :: OutputTarget
     , argLogLevel :: B.LogLevel
     , argModuleName :: String
+    , argTargetTriple :: Maybe String
+    , argTargetCPU :: Maybe String
+    , argTargetFeatures :: Maybe String
     }
 
 argsParser :: Parser Args
@@ -56,6 +59,12 @@ argsParser =
             )
         <*> strOption
             (long "module-name" <> short 'm' <> value "main" <> help "Module name")
+        <*> optional
+            (strOption (long "target-triple" <> metavar "TRIPLE" <> help "Target triple (default: native)"))
+        <*> optional
+            (strOption (long "target-cpu" <> metavar "CPU" <> help "Target CPU (default: native)"))
+        <*> optional
+            (strOption (long "target-features" <> metavar "FEATURES" <> help "Target features (default: native)"))
 
 parseOptLevel :: ReadM B.OptOption
 parseOptLevel = eitherReader $ \s -> case s of
@@ -106,6 +115,9 @@ main = do
                         , outputTarget = outputTarget'
                         , logLevel = argLogLevel args
                         , moduleFilePath = argInputFile args
+                        , targetTriple = T.pack <$> argTargetTriple args
+                        , targetCPU = T.pack <$> argTargetCPU args
+                        , targetFeatures = T.pack <$> argTargetFeatures args
                         }
 
             B.withReussirLogger (argLogLevel args) "reussir-compiler" $ \logger -> do

--- a/frontend/reussir-core/src/Reussir/Core/REPL.hs
+++ b/frontend/reussir-core/src/Reussir/Core/REPL.hs
@@ -457,6 +457,9 @@ generateExpressionModule funcName semiExpr exprType logLevel state = do
                         , IR.outputTarget = B.OutputObject
                         , IR.logLevel = logLevel
                         , IR.moduleFilePath = filePath
+                        , IR.targetTriple = Nothing
+                        , IR.targetCPU = Nothing
+                        , IR.targetFeatures = Nothing
                         }
 
             -- Create lowering context with all functions

--- a/lib/Bridge/Bridge.cppm
+++ b/lib/Bridge/Bridge.cppm
@@ -431,6 +431,7 @@ void reussir_bridge_compile_for_target(
   // Initialize native target so we can query TargetMachine for layout/triple.
   // llvm::InitializeNativeTarget();
   llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmPrinters();
   llvm::InitializeAllAsmParsers();
   spdlog::info("Initialized all targets.");

--- a/tests/integration/frontend/target_triple.rr
+++ b/tests/integration/frontend/target_triple.rr
@@ -1,0 +1,11 @@
+// RUN: %reussir-compiler %s -o %t.ll -t llvm-ir --target-triple x86_64-unknown-linux-gnu
+// RUN: %FileCheck %s --check-prefix=LLVM < %t.ll
+
+// LLVM: target triple = "x86_64-unknown-linux-gnu"
+
+// Also verify native compilation still works
+// RUN: %reussir-compiler %s -o %t.native.ll -t llvm-ir
+
+pub fn target_test(x : u32) -> u32 {
+    x
+}


### PR DESCRIPTION
## Summary
- Add `--target-triple`, `--target-cpu`, and `--target-features` CLI flags to `reussir-compiler`, enabling cross-compilation scenarios
- Add `compileForTarget` to `reussir-bridge` that accepts optional triple/cpu/features, defaulting CPU/features to empty strings when a custom triple is specified (avoids passing incompatible native values to foreign backends)
- Fix missing `InitializeAllTargetMCs()` in `Bridge.cppm` — without this, `createTargetMachine` segfaults for non-native targets because MC subtarget info isn't initialized

## Test plan
- [x] `cabal build reussir-compiler` compiles without errors
- [x] `cabal test reussir-codegen-test` — all 142 unit tests pass
- [x] `cabal run reussir-compiler -- --help` shows new flags
- [x] `cabal run reussir-compiler -- <file> -o out.ll -t llvm-ir --target-triple x86_64-unknown-linux-gnu` produces correct x86_64 LLVM IR on aarch64 host
- [x] Native compilation (without new flags) still works
- [x] `ninja check` — integration tests pass (including new `target_triple.rr`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)