### PR TITLE
[frontend] Expose relocation-mode in reussir-compiler CLI

### DIFF
--- a/frontend/reussir-bridge/src/Reussir/Bridge.hs
+++ b/frontend/reussir-bridge/src/Reussir/Bridge.hs
@@ -28,6 +28,7 @@ module Reussir.Bridge (
     -- * Compilation
     compileForNativeMachine,
     compileForTarget,
+    compileForTargetWithModels,
     compileProgram,
     hasTPDE,
     getNativeTargetTriple,

--- a/frontend/reussir-bridge/src/Reussir/Bridge/Compiler.hs
+++ b/frontend/reussir-bridge/src/Reussir/Bridge/Compiler.hs
@@ -5,6 +5,7 @@ module Reussir.Bridge.Compiler (
     -- * Compilation
     compileForNativeMachine,
     compileForTarget,
+    compileForTargetWithModels,
     compileProgram,
     hasTPDE,
     getNativeTargetTriple,
@@ -136,6 +137,44 @@ compileForTarget ::
     Maybe ByteString ->
     IO ()
 compileForTarget mlirModule sourceName outputFile target opt logLevel mTriple mCPU mFeatures = do
+    compileForTargetWithModels
+        mlirModule
+        sourceName
+        outputFile
+        target
+        opt
+        logLevel
+        mTriple
+        mCPU
+        mFeatures
+        CodeModelDefault
+        RelocationModelDefault
+
+compileForTargetWithModels ::
+    -- | MLIR module content
+    ByteString ->
+    -- | Source name (for diagnostics)
+    String ->
+    -- | Output file path
+    FilePath ->
+    -- | Output target format
+    OutputTarget ->
+    -- | Optimization level
+    OptOption ->
+    -- | Log level
+    LogLevel ->
+    -- | Optional target triple (Nothing = native)
+    Maybe ByteString ->
+    -- | Optional target CPU (Nothing = native)
+    Maybe ByteString ->
+    -- | Optional target features (Nothing = native)
+    Maybe ByteString ->
+    -- | Target code model
+    CodeModel ->
+    -- | Target relocation model
+    RelocationModel ->
+    IO ()
+compileForTargetWithModels mlirModule sourceName outputFile target opt logLevel mTriple mCPU mFeatures codeModel relocationModel = do
     triple <- maybe getNativeTargetTriple pure mTriple
     -- When a custom triple is specified, default CPU/features to empty strings
     -- so LLVM picks appropriate defaults for the target architecture.
@@ -154,8 +193,8 @@ compileForTarget mlirModule sourceName outputFile target opt logLevel mTriple mC
             , targetTriple = triple
             , targetCPU = cpu
             , targetFeatures = features
-            , targetCodeModel = CodeModelDefault
-            , targetRelocationModel = RelocationModelDefault
+            , targetCodeModel = codeModel
+            , targetRelocationModel = relocationModel
             }
 
 compileProgram :: Program -> IO ()

--- a/frontend/reussir-core/app/Compiler.hs
+++ b/frontend/reussir-core/app/Compiler.hs
@@ -2,6 +2,7 @@
 
 module Main where
 
+import Data.Char (toLower)
 import Effectful (liftIO, runEff)
 import Effectful.Prim (runPrim)
 import Log (LogLevel (..))
@@ -13,6 +14,7 @@ import Text.Megaparsec (errorBundlePretty, runParser)
 
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
+import Data.Text.Encoding qualified as TE
 import Effectful.Log qualified as L
 import Reussir.Bridge qualified as B
 import Reussir.Codegen qualified as C
@@ -29,6 +31,7 @@ data Args = Args
     , argTargetTriple :: Maybe String
     , argTargetCPU :: Maybe String
     , argTargetFeatures :: Maybe String
+    , argRelocationMode :: B.RelocationModel
     }
 
 argsParser :: Parser Args
@@ -65,6 +68,12 @@ argsParser =
             (strOption (long "target-cpu" <> metavar "CPU" <> help "Target CPU (default: native)"))
         <*> optional
             (strOption (long "target-features" <> metavar "FEATURES" <> help "Target features (default: native)"))
+        <*> option
+            parseRelocationMode
+            ( long "relocation-mode"
+                <> value B.RelocationModelDefault
+                <> help "Relocation mode (default, static, pic, dynamic-no-pic, ropi, rwpi, ropi-rwpi)"
+            )
 
 parseOptLevel :: ReadM B.OptOption
 parseOptLevel = eitherReader $ \s -> case s of
@@ -93,6 +102,20 @@ parseLogLevel = eitherReader $ \s -> case s of
     "debug" -> Right B.LogDebug
     "trace" -> Right B.LogTrace
     _ -> Left $ "Unknown log level: " ++ s
+
+parseRelocationMode :: ReadM B.RelocationModel
+parseRelocationMode = eitherReader $ \s -> case map toLower s of
+    "default" -> Right B.RelocationModelDefault
+    "static" -> Right B.RelocationModelStatic
+    "pic" -> Right B.RelocationModelPIC
+    "dynamic" -> Right B.RelocationModelDynamic
+    "dynamic-no-pic" -> Right B.RelocationModelDynamic
+    "dynamic-nopic" -> Right B.RelocationModelDynamic
+    "ropi" -> Right B.RelocationModelROPI
+    "rwpi" -> Right B.RelocationModelRWPI
+    "ropi-rwpi" -> Right B.RelocationModelROPI_RWPI
+    "ropi_rwpi" -> Right B.RelocationModelROPI_RWPI
+    _ -> Left $ "Unknown relocation mode: " ++ s
 
 main :: IO ()
 main = do
@@ -129,8 +152,21 @@ main = do
                             MLIR -> do
                                 mlirText <- C.emitModuleToText module'
                                 liftIO $ TIO.writeFile (argOutputFile args) mlirText
-                            Backend _ ->
-                                C.emitModuleToBackend module'
+                            Backend target -> do
+                                mlirText <- C.emitModuleToText module'
+                                liftIO $
+                                    B.compileForTargetWithModels
+                                        (TE.encodeUtf8 mlirText)
+                                        (argModuleName args)
+                                        (argOutputFile args)
+                                        target
+                                        (argOptLevel args)
+                                        (argLogLevel args)
+                                        (TE.encodeUtf8 . T.pack <$> argTargetTriple args)
+                                        (TE.encodeUtf8 . T.pack <$> argTargetCPU args)
+                                        (TE.encodeUtf8 . T.pack <$> argTargetFeatures args)
+                                        B.CodeModelDefault
+                                        (argRelocationMode args)
   where
     toEffLogLevel :: B.LogLevel -> LogLevel
     toEffLogLevel = \case

--- a/tests/integration/frontend/relocation_mode.rr
+++ b/tests/integration/frontend/relocation_mode.rr
@@ -1,0 +1,11 @@
+// RUN: %reussir-compiler --help | %FileCheck %s --check-prefix=HELP
+// RUN: %reussir-compiler %s -o %t.pic.ll -t llvm-ir --relocation-mode pic
+// RUN: %reussir-compiler %s -o %t.dynamic.ll -t llvm-ir --relocation-mode dynamic-no-pic
+// RUN: %not %reussir-compiler %s -o %t.invalid.ll -t llvm-ir --relocation-mode invalid 2>&1 | %FileCheck %s --check-prefix=ERR
+
+// HELP: --relocation-mode ARG
+// ERR: Unknown relocation mode: invalid
+
+pub fn relocation_mode_test(x : u32) -> u32 {
+    x
+}


### PR DESCRIPTION
## Summary
- add a --relocation-mode option to reussir-compiler
- thread relocation model selection through backend compilation via bridge API
- add integration coverage for help text, valid modes, and invalid mode diagnostics

## Testing
- ctest --test-dir build --output-on-failure
- cabal test -j reussir-bridge-test reussir-core-test --test-show-details=direct
- /usr/bin/python3 tests/integration/lit build/tests/integration -v

Closes #203