### PR TITLE
ci: speed up windows workflows with dev drive

### DIFF
--- a/.github/workflows/mlir-cpp-test-windows.yml
+++ b/.github/workflows/mlir-cpp-test-windows.yml
@@ -37,6 +37,7 @@ jobs:
           path: |
             C:/Users/runneradmin/AppData/Local/cabal
             C:/ghcup
+            D:/devdrive/dist-newstyle
           key: windows-clang64-cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
           restore-keys: |
             windows-clang64-cabal-

--- a/.github/workflows/mlir-cpp-test-windows.yml
+++ b/.github/workflows/mlir-cpp-test-windows.yml
@@ -13,7 +13,6 @@ jobs:
   build:
     runs-on: windows-2025
     env:
-      REUSSIR_BUILD_DIR: /d/devdrive/build
       REUSSIR_DIST_DIR: /d/devdrive/dist-newstyle
 
     steps:
@@ -91,7 +90,7 @@ jobs:
       - name: Configure CMake
         shell: msys2 {0}
         run: |
-          cmake -B "${REUSSIR_BUILD_DIR}" \
+          cmake -B build \
           -G Ninja \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DREUSSIR_ENABLE_PEDANTIC=ON \
@@ -99,7 +98,7 @@ jobs:
 
       - name: Build
         shell: msys2 {0}
-        run: cmake --build "${REUSSIR_BUILD_DIR}" --parallel
+        run: cmake --build build --parallel
 
 
       - name: Run Integration Tests
@@ -107,7 +106,7 @@ jobs:
         run: |
           . /c/ghcup/env
           . .github/workflows/setup_path.sh
-          cmake --build "${REUSSIR_BUILD_DIR}" --target check
+          cmake --build build --target check
 
       - name: Build Haskell frontend
         shell: msys2 {0}

--- a/.github/workflows/mlir-cpp-test-windows.yml
+++ b/.github/workflows/mlir-cpp-test-windows.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   build:
     runs-on: windows-2025
+    env:
+      REUSSIR_BUILD_DIR: /d/devdrive/build
+      REUSSIR_DIST_DIR: /d/devdrive/dist-newstyle
 
     steps:
       - name: Checkout code
@@ -22,13 +25,18 @@ jobs:
       - name: Restore file timestamps
         uses: chetan/git-restore-mtime-action@v2
 
+      - name: Setup Dev Drive
+        uses: samypr100/setup-dev-drive@v3
+        with:
+          drive-size: 8GB
+          mount-path: 'D:\devdrive'
+
       - name: Cache Cabal (Windows)
         uses: actions/cache@v4
         with:
           path: |
             C:/Users/runneradmin/AppData/Local/cabal
             C:/ghcup
-            dist-newstyle
           key: windows-clang64-cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
           restore-keys: |
             windows-clang64-cabal-
@@ -82,7 +90,7 @@ jobs:
       - name: Configure CMake
         shell: msys2 {0}
         run: |
-          cmake -B build \
+          cmake -B "${REUSSIR_BUILD_DIR}" \
           -G Ninja \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DREUSSIR_ENABLE_PEDANTIC=ON \
@@ -90,7 +98,7 @@ jobs:
 
       - name: Build
         shell: msys2 {0}
-        run: cmake --build build --parallel
+        run: cmake --build "${REUSSIR_BUILD_DIR}" --parallel
 
 
       - name: Run Integration Tests
@@ -98,15 +106,14 @@ jobs:
         run: |
           . /c/ghcup/env
           . .github/workflows/setup_path.sh
-          cmake --build build --target check
+          cmake --build "${REUSSIR_BUILD_DIR}" --target check
 
       - name: Build Haskell frontend
         shell: msys2 {0}
         run: |
           . /c/ghcup/env
           . .github/workflows/setup_path.sh
-          cabal update
-          cabal build all -j
+          cabal build all -j --builddir="${REUSSIR_DIST_DIR}"
 
       - name: Test Haskell frontend
         shell: msys2 {0}
@@ -114,4 +121,4 @@ jobs:
           . /c/ghcup/env
           . .github/workflows/setup_path.sh
           chcp.com 65001
-          cabal test all -j
+          cabal test all -j --builddir="${REUSSIR_DIST_DIR}"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -345,6 +345,7 @@ jobs:
           path: |
             C:/Users/runneradmin/AppData/Local/cabal
             C:/ghcup
+            D:/devdrive/dist-newstyle
           key: windows-clang64-cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
           restore-keys: |
             windows-clang64-cabal-

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -321,6 +321,8 @@ jobs:
 
   build-windows:
     runs-on: windows-2025
+    env:
+      REUSSIR_BUILD_DIR: /d/devdrive/build
 
     steps:
       - name: Checkout code
@@ -331,13 +333,18 @@ jobs:
       - name: Restore file timestamps
         uses: chetan/git-restore-mtime-action@v2
 
+      - name: Setup Dev Drive
+        uses: samypr100/setup-dev-drive@v3
+        with:
+          drive-size: 8GB
+          mount-path: 'D:\devdrive'
+
       - name: Cache Cabal (Windows)
         uses: actions/cache@v4
         with:
           path: |
             C:/Users/runneradmin/AppData/Local/cabal
             C:/ghcup
-            dist-newstyle
           key: windows-clang64-cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
           restore-keys: |
             windows-clang64-cabal-
@@ -391,7 +398,7 @@ jobs:
       - name: Configure CMake
         shell: msys2 {0}
         run: |
-          cmake -B build \
+          cmake -B "${REUSSIR_BUILD_DIR}" \
           -G Ninja \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DREUSSIR_ENABLE_PEDANTIC=ON \
@@ -399,14 +406,14 @@ jobs:
 
       - name: Build
         shell: msys2 {0}
-        run: cmake --build build --parallel
+        run: cmake --build "${REUSSIR_BUILD_DIR}" --parallel
 
       - name: Run Integration Tests
         shell: msys2 {0}
         run: |
           . /c/ghcup/env
           . .github/workflows/setup_path.sh
-          cmake --build build --target check
+          cmake --build "${REUSSIR_BUILD_DIR}" --target check
 
       - name: Package
         shell: msys2 {0}
@@ -420,21 +427,21 @@ jobs:
           for bin in reussir-opt reussir-translate reussir-compiler \
                      reussir-elab reussir-repl reussir-parser \
                      rustc cargo rustdoc; do
-            cp -a "build/bin/${bin}.exe" "${PREFIX}/bin/" 2>/dev/null || true
+            cp -a "${REUSSIR_BUILD_DIR}/bin/${bin}.exe" "${PREFIX}/bin/" 2>/dev/null || true
           done
 
           # Copy DLLs from build/bin (Windows puts DLLs next to executables)
-          cp -a build/bin/reussir_rt.dll "${PREFIX}/bin/" 2>/dev/null || true
-          cp -a build/bin/MLIRReussirBridge*.dll "${PREFIX}/bin/" 2>/dev/null || true
-          cp -a build/bin/LLVM*rust*.dll "${PREFIX}/bin/" 2>/dev/null || true
-          cp -a build/bin/rustc_driver*.dll "${PREFIX}/bin/" 2>/dev/null || true
+          cp -a "${REUSSIR_BUILD_DIR}/bin/reussir_rt.dll" "${PREFIX}/bin/" 2>/dev/null || true
+          cp -a ${REUSSIR_BUILD_DIR}/bin/MLIRReussirBridge*.dll "${PREFIX}/bin/" 2>/dev/null || true
+          cp -a ${REUSSIR_BUILD_DIR}/bin/LLVM*rust*.dll "${PREFIX}/bin/" 2>/dev/null || true
+          cp -a ${REUSSIR_BUILD_DIR}/bin/rustc_driver*.dll "${PREFIX}/bin/" 2>/dev/null || true
 
           # Copy system LLVM/MLIR DLLs
           cp -a /clang64/bin/libMLIR.dll "${PREFIX}/bin/" 2>/dev/null || true
           cp -a /clang64/bin/libLLVM*.dll "${PREFIX}/bin/" 2>/dev/null || true
 
           # Copy rustlib tree
-          cp -a build/lib/rustlib "${PREFIX}/lib/" 2>/dev/null || true
+          cp -a "${REUSSIR_BUILD_DIR}/lib/rustlib" "${PREFIX}/lib/" 2>/dev/null || true
 
           # Strip binaries
           strip "${PREFIX}"/bin/reussir-opt.exe "${PREFIX}"/bin/reussir-translate.exe 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add `samypr100/setup-dev-drive@v3` to both Windows CI workflows
- move Windows CMake build directories to `/d/devdrive/build` to reduce heavy I/O cost during build and integration tests
- move Windows Haskell `dist-newstyle` builddir to `/d/devdrive/dist-newstyle` in the main Windows pipeline
- stop caching `dist-newstyle` on Windows to avoid timestamp-sensitive restore churn and large cache extract overhead

## Context
Recent successful runs showed Windows CI substantially slower than Linux/macOS (roughly ~52m avg vs ~14m Linux and ~20m macOS on recent history). The slowest Windows phases were integration tests and Haskell frontend build.

## Expected impact
- reduce filesystem overhead on Windows build + integration steps via ReFS Dev Drive
- avoid spending cache time restoring `dist-newstyle` artifacts that are often invalidated by timestamp behavior
- keep existing `C:/ghcup` and cabal cache behavior unchanged for lower risk