### PR TITLE
[ci] Use setup-dev-drive for Windows CI performance

### DIFF
--- a/.github/workflows/mlir-cpp-test-windows.yml
+++ b/.github/workflows/mlir-cpp-test-windows.yml
@@ -19,16 +19,26 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Dev Drive
+        uses: samypr100/setup-dev-drive@v3
+        with:
+          workspace-copy: true
+          trusted-dev-drive: true
+          env-mapping: |
+            CABAL_DIR,{{ DEV_DRIVE }}/cabal
+
       - name: Restore file timestamps
         uses: chetan/git-restore-mtime-action@v2
+        with:
+          working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
 
       - name: Cache Cabal (Windows)
         uses: actions/cache@v4
         with:
           path: |
-            C:/Users/runneradmin/AppData/Local/cabal
+            ${{ env.CABAL_DIR }}
             C:/ghcup
-            dist-newstyle
+            ${{ env.DEV_DRIVE_WORKSPACE }}/dist-newstyle
           key: windows-clang64-cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
           restore-keys: |
             windows-clang64-cabal-
@@ -63,16 +73,18 @@ jobs:
 
       - name: Setup GHCup Without Silly Upstream
         shell: msys2 {0}
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           export BOOTSTRAP_HASKELL_GHC_VERSION=9.14.1
           export BOOTSTRAP_HASKELL_CABAL_VERSION=latest
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
           . /c/ghcup/env
           cabal update
-          
+
 
       - name: Install Rust and Python dependencies
         shell: msys2 {0}
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           pip install lit
           rustup target add x86_64-pc-windows-gnullvm
@@ -81,6 +93,7 @@ jobs:
 
       - name: Configure CMake
         shell: msys2 {0}
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           cmake -B build \
           -G Ninja \
@@ -90,11 +103,13 @@ jobs:
 
       - name: Build
         shell: msys2 {0}
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: cmake --build build --parallel
 
 
       - name: Run Integration Tests
         shell: msys2 {0}
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           . /c/ghcup/env
           . .github/workflows/setup_path.sh
@@ -102,6 +117,7 @@ jobs:
 
       - name: Build Haskell frontend
         shell: msys2 {0}
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           . /c/ghcup/env
           . .github/workflows/setup_path.sh
@@ -110,6 +126,7 @@ jobs:
 
       - name: Test Haskell frontend
         shell: msys2 {0}
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           . /c/ghcup/env
           . .github/workflows/setup_path.sh

--- a/.github/workflows/mlir-cpp-test-windows.yml
+++ b/.github/workflows/mlir-cpp-test-windows.yml
@@ -75,6 +75,7 @@ jobs:
         shell: msys2 {0}
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
+          export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
           export BOOTSTRAP_HASKELL_GHC_VERSION=9.14.1
           export BOOTSTRAP_HASKELL_CABAL_VERSION=latest
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh

--- a/.github/workflows/mlir-cpp-test-windows.yml
+++ b/.github/workflows/mlir-cpp-test-windows.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Setup Dev Drive
         uses: samypr100/setup-dev-drive@v3
         with:
+          drive-size: 8GB
           workspace-copy: true
           trusted-dev-drive: true
           env-mapping: |

--- a/.github/workflows/mlir-cpp-test-windows.yml
+++ b/.github/workflows/mlir-cpp-test-windows.yml
@@ -70,6 +70,7 @@ jobs:
         shell: msys2 {0}
         run: |
           echo "GHCUP_MSYS2_ENV=CLANG64" >> $GITHUB_ENV
+          echo "GHCUP_MSYS2=$(cygpath -w /)" >> $GITHUB_ENV
 
       - name: Setup GHCup Without Silly Upstream
         shell: msys2 {0}

--- a/.github/workflows/mlir-cpp-test-windows.yml
+++ b/.github/workflows/mlir-cpp-test-windows.yml
@@ -25,7 +25,7 @@ jobs:
           workspace-copy: true
           trusted-dev-drive: true
           env-mapping: |
-            CABAL_DIR,{{ DEV_DRIVE }}/cabal
+            CABAL_DIR,{{ DEV_DRIVE }}\cabal
 
       - name: Restore file timestamps
         uses: chetan/git-restore-mtime-action@v2

--- a/.github/workflows/mlir-cpp-test-windows.yml
+++ b/.github/workflows/mlir-cpp-test-windows.yml
@@ -115,6 +115,7 @@ jobs:
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           . /c/ghcup/env
+          export GITHUB_WORKSPACE=$(cygpath "$DEV_DRIVE_WORKSPACE")
           . .github/workflows/setup_path.sh
           cmake --build build --target check
 
@@ -123,6 +124,7 @@ jobs:
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           . /c/ghcup/env
+          export GITHUB_WORKSPACE=$(cygpath "$DEV_DRIVE_WORKSPACE")
           . .github/workflows/setup_path.sh
           cabal update
           cabal build all -j
@@ -132,6 +134,7 @@ jobs:
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           . /c/ghcup/env
+          export GITHUB_WORKSPACE=$(cygpath "$DEV_DRIVE_WORKSPACE")
           . .github/workflows/setup_path.sh
           chcp.com 65001
           cabal test all -j


### PR DESCRIPTION
## Summary

- Adds `samypr100/setup-dev-drive@v3` as the second step (right after checkout) with `workspace-copy: true` and `trusted-dev-drive: true`, migrating the entire workspace to a ReFS Dev Drive before any other work begins
- Uses `env-mapping` to set `CABAL_DIR` to `{{ DEV_DRIVE }}/cabal` so the Cabal store also lives on the fast volume
- Updates `chetan/git-restore-mtime-action` to run against `${{ env.DEV_DRIVE_WORKSPACE }}` (uses the action's `working-directory` input)
- Updates the Cabal cache paths: `C:/Users/runneradmin/AppData/Local/cabal` → `${{ env.CABAL_DIR }}`, and `dist-newstyle` → `${{ env.DEV_DRIVE_WORKSPACE }}/dist-newstyle`
- Adds `working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}` to all build and test steps so CMake, Cabal, and Rust all operate on the dev drive

## Test plan

- [ ] Windows CI action runs without errors on this PR
- [ ] Cabal cache hits correctly on second run
- [ ] CMake build output lands under `DEV_DRIVE_WORKSPACE/build`
- [ ] All Haskell tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)