### PR TITLE
[frontend][test] add tree-to-list e2e test with C driver

### DIFF
--- a/tests/integration/frontend/rbtree_to_list.c
+++ b/tests/integration/frontend/rbtree_to_list.c
@@ -1,0 +1,78 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+ * Memory layout for RC<List> (shared enum with Nil / Cons variants).
+ *
+ * The Reussir runtime allocates an RC box whose first word is the
+ * reference count, followed by the variant record:
+ *
+ *   offset  0:  int64_t  refcount
+ *   offset  8:  int64_t  tag         (0 = Nil, 1 = Cons)
+ *   offset 16:  int32_t  head        (valid when tag == 1)
+ *   offset 20:  (padding, 4 bytes)
+ *   offset 24:  void*    tail        (valid when tag == 1, next RC<List>)
+ *
+ * Total allocation: 32 bytes  (__reussir_allocate(align=8, size=32))
+ *
+ * The C trampoline returns the RC pointer directly, keeping the
+ * structure live (refcount >= 1) so we can safely inspect it here.
+ */
+typedef struct rc_list {
+    int64_t          refcount;
+    int64_t          tag;
+    int32_t          head;
+    int32_t          _pad;
+    struct rc_list  *tail;
+} rc_list_t;
+
+#define LIST_NIL  0
+#define LIST_CONS 1
+
+extern rc_list_t *test_to_list_ffi(void);
+
+int main(void) {
+    rc_list_t *list = test_to_list_ffi();
+
+    /* ---- inspect: print the raw RC structure ---- */
+    printf("List structure (RC layout):\n");
+    rc_list_t *p = list;
+    int idx = 0;
+    while (p->tag == LIST_CONS) {
+        printf("  [%d] @%p  rc=%ld  tag=%ld (Cons)  head=%d  tail=%p\n",
+               idx, (void *)p, (long)p->refcount, (long)p->tag,
+               p->head, (void *)p->tail);
+        p = p->tail;
+        idx++;
+    }
+    printf("  [%d] @%p  rc=%ld  tag=%ld (Nil)\n",
+           idx, (void *)p, (long)p->refcount, (long)p->tag);
+
+    /* ---- verify: expect [1, 2, 3, 4, 5, 6, 7, 8, 9] ---- */
+    int expected[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    int n = (int)(sizeof(expected) / sizeof(expected[0]));
+
+    p = list;
+    for (int i = 0; i < n; i++) {
+        if (p->tag != LIST_CONS) {
+            fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", i);
+            abort();
+        }
+        if (p->head != expected[i]) {
+            fprintf(stderr, "FAIL: at index %d: expected %d, got %d\n",
+                    i, expected[i], p->head);
+            abort();
+        }
+        p = p->tail;
+    }
+
+    if (p->tag != LIST_NIL) {
+        fprintf(stderr, "FAIL: expected Nil at end, got tag %ld\n",
+                (long)p->tag);
+        abort();
+    }
+
+    printf("PASS: list = [1, 2, 3, 4, 5, 6, 7, 8, 9]\n");
+    return 0;
+}

--- a/tests/integration/frontend/rbtree_to_list.rr
+++ b/tests/integration/frontend/rbtree_to_list.rr
@@ -1,0 +1,71 @@
+// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/rbtree_to_list.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// Helper: collect a binary search tree into an ordered Cons/Nil list
+// via in-order traversal. Tested standalone with a manually constructed
+// fixed tree before being used with the full make-tree port.
+
+enum [value] Color { Red, Black }
+
+enum Tree {
+    Branch(Color, Tree, i32, Tree),
+    Leaf
+}
+
+enum List {
+    Nil,
+    Cons(i32, List)
+}
+
+// In-order traversal with accumulator.
+// Processes right subtree first (into acc), prepends current key,
+// then processes left subtree -- producing an ascending list.
+fn tree_to_list_acc(t: Tree, acc: List) -> List {
+    match t {
+        Tree::Branch(_, l, k, r) =>
+            tree_to_list_acc(l, List::Cons{k, tree_to_list_acc(r, acc)}),
+        Tree::Leaf => acc
+    }
+}
+
+fn tree_to_list(t: Tree) -> List {
+    tree_to_list_acc(t, List::Nil {})
+}
+
+// Manually construct a fixed 9-node red-black tree:
+//
+//                4(Black)
+//               / \
+//          2(Red)   6(Red)
+//         / \       / \
+//       1(B) 3(B) 5(B)  8(B)
+//                       / \
+//                     7(R) 9(R)
+//
+// In-order traversal should produce: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+pub fn test_to_list() -> List {
+    let t = Tree::Branch{
+        Color::Black {},
+        Tree::Branch{
+            Color::Red {},
+            Tree::Branch{Color::Black {}, Tree::Leaf {}, 1, Tree::Leaf {}},
+            2,
+            Tree::Branch{Color::Black {}, Tree::Leaf {}, 3, Tree::Leaf {}}
+        },
+        4,
+        Tree::Branch{
+            Color::Red {},
+            Tree::Branch{Color::Black {}, Tree::Leaf {}, 5, Tree::Leaf {}},
+            6,
+            Tree::Branch{
+                Color::Black {},
+                Tree::Branch{Color::Red {}, Tree::Leaf {}, 7, Tree::Leaf {}},
+                8,
+                Tree::Branch{Color::Red {}, Tree::Leaf {}, 9, Tree::Leaf {}}
+            }
+        }
+    };
+    tree_to_list(t)
+}
+extern "C" trampoline "test_to_list_ffi" = test_to_list;


### PR DESCRIPTION
## Summary
- Add `rbtree_to_list.rr` with a `tree_to_list` helper that collects a BST into a sorted `Cons`/`Nil` list via in-order traversal with an accumulator
- Manually constructs a 9-node red-black tree (4 levels, asymmetric) and verifies the resulting list `[1..9]`
- Add `rbtree_to_list.c` C driver that walks the raw `RC<List>` structure through the trampoline, printing each node's address, refcount, tag, and payload before asserting correctness

## Test plan
- [x] `lit` passes for `rbtree_to_list.rr`
- [x] Full test suite (193 tests) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)