### PR TITLE
[backend] add LLVM allocation simplification pass for null runtime calls

### DIFF
--- a/include/Reussir/CMakeLists.txt
+++ b/include/Reussir/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(IR)
 add_subdirectory(Conversion)
 add_subdirectory(Analysis)
+add_subdirectory(LLVMPass)

--- a/include/Reussir/LLVMPass/AllocationSimplication.h
+++ b/include/Reussir/LLVMPass/AllocationSimplication.h
@@ -1,0 +1,28 @@
+//===- AllocationSimplication.h - Reussir LLVM allocation pass -*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass simplifies runtime allocation/deallocation calls when pointer
+// operands are compile-time null.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <llvm/IR/PassManager.h>
+
+namespace reussir::llvmpass {
+
+class AllocationSimplicationPass
+    : public llvm::PassInfoMixin<AllocationSimplicationPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module,
+                              llvm::ModuleAnalysisManager &);
+};
+
+} // namespace reussir::llvmpass
+

--- a/include/Reussir/LLVMPass/CMakeLists.txt
+++ b/include/Reussir/LLVMPass/CMakeLists.txt
@@ -1,0 +1,2 @@
+# This file is intentionally empty to enable add_subdirectory.
+

--- a/lib/Bridge/Bridge.cppm
+++ b/lib/Bridge/Bridge.cppm
@@ -81,6 +81,7 @@ module;
 #include "Reussir/Conversion/SCFOpsLowering.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
+#include "Reussir/LLVMPass/AllocationSimplication.h"
 
 export module Reussir.Bridge;
 
@@ -180,6 +181,7 @@ void createLoweringPipeline(mlir::PassManager &pm,
   pm.addPass(createCSEPass());
   pm.addPass(createCanonicalizerPass());
 }
+
 void runNPMOptimization(llvm::Module &llvmModule, ReussirOptOption opt) {
   if (opt == REUSSIR_OPT_NONE || opt == REUSSIR_OPT_TPDE)
     return;
@@ -218,6 +220,7 @@ void runNPMOptimization(llvm::Module &llvmModule, ReussirOptOption opt) {
 
   // Create the default optimization pipeline for the specified level
   llvm::ModulePassManager mpm = pb.buildPerModuleDefaultPipeline(optLevel);
+  mpm.addPass(reussir::llvmpass::AllocationSimplicationPass());
 
   // Run the optimization
   mpm.run(llvmModule, mam);

--- a/lib/Bridge/CMakeLists.txt
+++ b/lib/Bridge/CMakeLists.txt
@@ -32,6 +32,7 @@ add_mlir_library(MLIRReussirBridge
     MLIRReussir
     MLIRReussirBasicOpsLowering
     MLIRReussirSCFOpsLowering
+    ReussirLLVMAllocationSimplicationPass
     spdlog::spdlog
     ${TPDE_LINK_LIB}
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(IR)
 add_subdirectory(Conversion)
 add_subdirectory(RustCompiler)
+add_subdirectory(LLVMPass)
 add_subdirectory(Bridge)
 add_subdirectory(Analysis)

--- a/lib/LLVMPass/AllocationSimplication/AllocationSimplication.cpp
+++ b/lib/LLVMPass/AllocationSimplication/AllocationSimplication.cpp
@@ -1,0 +1,91 @@
+//===- AllocationSimplication.cpp - Reussir LLVM allocation pass ---------===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/LLVMPass/AllocationSimplication.h"
+
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+namespace reussir::llvmpass {
+namespace {
+
+bool isNullPointerArgument(llvm::Value *value) {
+  if (auto *constant =
+          llvm::dyn_cast<llvm::Constant>(value->stripPointerCasts())) {
+    return constant->isNullValue();
+  }
+  return false;
+}
+
+} // namespace
+
+llvm::PreservedAnalyses
+AllocationSimplicationPass::run(llvm::Module &module,
+                                llvm::ModuleAnalysisManager &) {
+  llvm::SmallVector<llvm::CallInst *, 8> callsToErase;
+  bool changed = false;
+
+  for (auto &function : module) {
+    for (auto &block : function) {
+      for (auto &inst : block) {
+        auto *call = llvm::dyn_cast<llvm::CallInst>(&inst);
+        if (!call)
+          continue;
+
+        auto *callee = call->getCalledFunction();
+        if (!callee)
+          continue;
+
+        llvm::StringRef calleeName = callee->getName();
+        if (calleeName == "__reussir_deallocate") {
+          if (call->arg_size() >= 1 &&
+              isNullPointerArgument(call->getArgOperand(0))) {
+            callsToErase.push_back(call);
+            changed = true;
+          }
+          continue;
+        }
+
+        if (calleeName == "__reussir_reallocate" && call->arg_size() == 5 &&
+            isNullPointerArgument(call->getArgOperand(0))) {
+          llvm::IRBuilder<> builder(call);
+          llvm::FunctionType *allocateTy = llvm::FunctionType::get(
+              call->getType(),
+              {call->getArgOperand(3)->getType(), call->getArgOperand(4)->getType()},
+              false);
+          llvm::FunctionCallee allocateFn =
+              module.getOrInsertFunction("__reussir_allocate", allocateTy);
+
+          auto *allocateCall = builder.CreateCall(
+              allocateTy, allocateFn.getCallee(),
+              {call->getArgOperand(3), call->getArgOperand(4)});
+          allocateCall->setDebugLoc(call->getDebugLoc());
+          allocateCall->setCallingConv(call->getCallingConv());
+          allocateCall->setTailCallKind(call->getTailCallKind());
+
+          call->replaceAllUsesWith(allocateCall);
+          callsToErase.push_back(call);
+          changed = true;
+        }
+      }
+    }
+  }
+
+  for (auto *call : callsToErase) {
+    call->eraseFromParent();
+  }
+
+  if (!changed) {
+    return llvm::PreservedAnalyses::all();
+  }
+  return llvm::PreservedAnalyses::none();
+}
+
+} // namespace reussir::llvmpass

--- a/lib/LLVMPass/AllocationSimplication/CMakeLists.txt
+++ b/lib/LLVMPass/AllocationSimplication/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(ReussirLLVMAllocationSimplicationPass STATIC
+  AllocationSimplication.cpp
+)
+
+set_target_properties(ReussirLLVMAllocationSimplicationPass PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+)
+

--- a/lib/LLVMPass/CMakeLists.txt
+++ b/lib/LLVMPass/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(AllocationSimplication)
+

--- a/tests/integration/frontend/issue_213_noop_deallocate_null.rr
+++ b/tests/integration/frontend/issue_213_noop_deallocate_null.rr
@@ -1,0 +1,22 @@
+// RUN: %reussir-compiler %s -o %t.ll -t llvm-ir
+// RUN: %FileCheck %s --check-prefix=LLVM < %t.ll
+
+fn apply1(f : i32 -> i32, x : i32) -> i32 {
+    f(x)
+}
+
+struct [shared] SBox {
+    f : i32 -> i32
+}
+
+pub fn test_sbox_multi() -> i32 {
+    let triple = |x : i32| x * 3;
+    let sb = SBox { f: triple };
+    let a = apply1(sb.f, 4);
+    let b = apply1(sb.f, 10);
+    a + b
+}
+
+// LLVM-LABEL: define {{.*}}@_RC15test_sbox_multi
+// LLVM-NOT: call void @__reussir_deallocate(ptr null
+// LLVM: ret i32


### PR DESCRIPTION
## Summary
- add a dedicated LLVM pass under lib/LLVMPass/AllocationSimplication
- remove no-op __reussir_deallocate(null, ...) calls
- rewrite __reussir_reallocate(null, old_align, old_size, new_align, new_size) to __reussir_allocate(new_align, new_size)
- wire the pass into MLIRReussirBridge NPM optimization pipeline
- add integration test for the shared-struct closure multiplicity reproducer from Issue #213


Closes #213