### PR TITLE
[backend] use invariant.group/launder pair for devirtualization

### DIFF
--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -126,6 +126,26 @@ def ReussirTokenEnsureOp : ReussirTokenOp<"ensure", []> {
   }];
 }
 
+def ReussirTokenLaunderOp : ReussirTokenOp<"launder", []> {
+  let summary = "Launder a token";
+  let description = [{
+    `reussir.token.launder` launders a token for reuse.
+    ```mlir
+    %result = reussir.token.launder
+      (%token : !reussir.token<align: 8, size: 8>) 
+      : !reussir.token<align: 8, size: 8>
+    ```
+  }];
+  let results = (outs Res<ReussirTokenType,
+                          "output token", [MemAlloc<DefaultResource>]>:$result);
+  let arguments =
+      (ins Arg<ReussirTokenType,
+               "input token", [MemFree<DefaultResource>]>:$token);
+  let assemblyFormat = [{
+    `(` $token `:` type($token) `)` `:` type($result) attr-dict
+  }];
+}
+
 def ReussirTokenReallocOp : ReussirTokenOp<"realloc", []> {
   let summary = "Reallocate a token";
   let description = [{

--- a/include/Reussir/LLVMPass/RuntimeFunctionAttributor.h
+++ b/include/Reussir/LLVMPass/RuntimeFunctionAttributor.h
@@ -1,0 +1,27 @@
+//===- RuntimeFunctionAttributor.h - Reussir runtime attrib pass *- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass applies canonical LLVM function attributes to Reussir runtime
+// allocation/deallocation entry points.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <llvm/IR/PassManager.h>
+
+namespace reussir::llvmpass {
+
+class RuntimeFunctionAttributorPass
+    : public llvm::PassInfoMixin<RuntimeFunctionAttributorPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module,
+                              llvm::ModuleAnalysisManager &);
+};
+
+} // namespace reussir::llvmpass

--- a/lib/Bridge/Bridge.cppm
+++ b/lib/Bridge/Bridge.cppm
@@ -82,6 +82,7 @@ module;
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/LLVMPass/AllocationSimplication.h"
+#include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"
 
 export module Reussir.Bridge;
 
@@ -218,8 +219,10 @@ void runNPMOptimization(llvm::Module &llvmModule, ReussirOptOption opt) {
     return;
   }
 
-  // Create the default optimization pipeline for the specified level
-  llvm::ModulePassManager mpm = pb.buildPerModuleDefaultPipeline(optLevel);
+  // Create the default optimization pipeline for the specified level.
+  llvm::ModulePassManager mpm;
+  mpm.addPass(reussir::llvmpass::RuntimeFunctionAttributorPass());
+  mpm.addPass(pb.buildPerModuleDefaultPipeline(optLevel));
   mpm.addPass(reussir::llvmpass::AllocationSimplicationPass());
 
   // Run the optimization

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -2053,15 +2053,14 @@ void addRuntimeFunctions(mlir::ModuleOp module,
                                       {indexType, indexType}, {llvmPtrType});
   auto deallocFunc = addRuntimeFunction(
       body, "__reussir_deallocate", {llvmPtrType, indexType, indexType}, {});
-  // Add attributes to allocation functions
+  // Add common runtime attributes.
   mlir::OpBuilder builder(ctx);
   auto mustProgress = builder.getStringAttr("mustprogress");
   auto nounwind = builder.getStringAttr("nounwind");
   auto willreturn = builder.getStringAttr("willreturn");
   auto nocallback = builder.getStringAttr("nocallback");
-  auto allocKind = builder.getStrArrayAttr({"allockind", "alloc"});
-  auto passthroughAlloc = builder.getArrayAttr(
-      {mustProgress, nounwind, willreturn, nocallback, allocKind});
+  auto passthroughAlloc =
+      builder.getArrayAttr({mustProgress, nounwind, willreturn, nocallback});
 
   allocFunc->setAttr("passthrough", passthroughAlloc);
   allocFunc.setArgAttr(0, "llvm.allocalign", builder.getUnitAttr());
@@ -2070,9 +2069,8 @@ void addRuntimeFunctions(mlir::ModuleOp module,
   allocFunc.setArgAttr(0, "llvm.noundef", builder.getUnitAttr());
   allocFunc.setArgAttr(1, "llvm.noundef", builder.getUnitAttr());
 
-  auto freeKind = builder.getStrArrayAttr({"allockind", "free"});
-  auto passthroughDealloc = builder.getArrayAttr(
-      {mustProgress, nounwind, willreturn, nocallback, freeKind});
+  auto passthroughDealloc =
+      builder.getArrayAttr({mustProgress, nounwind, willreturn, nocallback});
   deallocFunc->setAttr("passthrough", passthroughDealloc);
   deallocFunc.setArgAttr(0, "llvm.nocapture", builder.getUnitAttr());
   deallocFunc.setArgAttr(0, "llvm.allocptr", builder.getUnitAttr());

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -482,8 +482,10 @@ struct ReussirRefLoadConversionPattern
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Type pointeeTy = op.getResult().getType();
     mlir::Type llvmPointeeTy = getTypeConverter()->convertType(pointeeTy);
-    rewriter.replaceOpWithNewOp<mlir::LLVM::LoadOp>(op, llvmPointeeTy,
-                                                    adaptor.getRef());
+    auto loadOp = rewriter.replaceOpWithNewOp<mlir::LLVM::LoadOp>(
+        op, llvmPointeeTy, adaptor.getRef());
+    if (op->hasAttr("reussir.invariant_group"))
+      loadOp.setInvariantGroup(true);
     return mlir::success();
   }
 };
@@ -681,16 +683,18 @@ struct ReussirRcCreateOpConversionPattern
     auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
     auto one = rewriter.create<mlir::arith::ConstantOp>(
         op.getLoc(), mlir::IntegerAttr::get(indexType, 1));
+    auto token = adaptor.getToken();
     auto refcntPtr = rewriter.create<mlir::LLVM::GEPOp>(
-        op.getLoc(), llvmPtrType, convertedBoxType, adaptor.getToken(),
+        op.getLoc(), llvmPtrType, convertedBoxType, token,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
-    auto elementPtr = rewriter.create<mlir::LLVM::GEPOp>(
-        op.getLoc(), llvmPtrType, convertedBoxType, adaptor.getToken(),
-        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1});
     rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), one, refcntPtr);
-    rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), adaptor.getValue(),
-                                         elementPtr);
-    rewriter.replaceOp(op, adaptor.getToken());
+    auto elementPtr = rewriter.create<mlir::LLVM::GEPOp>(
+        op.getLoc(), llvmPtrType, convertedBoxType, token,
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1});
+    auto objectPtr = rewriter.create<mlir::LLVM::StoreOp>(
+        op.getLoc(), adaptor.getValue(), elementPtr);
+    objectPtr.setInvariantGroup(true);
+    rewriter.replaceOp(op, token);
     return mlir::success();
   }
 
@@ -718,27 +722,28 @@ struct ReussirRcCreateOpConversionPattern
           op.getLoc(), llvmPtrType, *op.getVtable());
     } else
       vtable = null.getRes();
-
+    auto token = adaptor.getToken();
     auto statePtr = rewriter.create<mlir::LLVM::GEPOp>(
-        op.getLoc(), llvmPtrType, convertedBoxType, adaptor.getToken(),
+        op.getLoc(), llvmPtrType, convertedBoxType, token,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
     auto nextPtr = rewriter.create<mlir::LLVM::GEPOp>(
-        op.getLoc(), llvmPtrType, convertedBoxType, adaptor.getToken(),
+        op.getLoc(), llvmPtrType, convertedBoxType, token,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1});
     auto vtablePtr = rewriter.create<mlir::LLVM::GEPOp>(
-        op.getLoc(), llvmPtrType, convertedBoxType, adaptor.getToken(),
+        op.getLoc(), llvmPtrType, convertedBoxType, token,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 2});
     auto elementPtr = rewriter.create<mlir::LLVM::GEPOp>(
-        op.getLoc(), llvmPtrType, convertedBoxType, adaptor.getToken(),
+        op.getLoc(), llvmPtrType, convertedBoxType, token,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 3});
     rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), null, statePtr);
     rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), tailPtr, nextPtr);
-    rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), vtable, vtablePtr);
+    auto vtableStore =
+        rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), vtable, vtablePtr);
+    vtableStore.setInvariantGroup(true);
     rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), adaptor.getValue(),
                                          elementPtr);
-    rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), adaptor.getToken(),
-                                         regionPtr);
-    rewriter.replaceOp(op, adaptor.getToken());
+    rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), token, regionPtr);
+    rewriter.replaceOp(op, token);
     return mlir::success();
   }
 
@@ -997,7 +1002,9 @@ struct ReussirClosureCreateOpConversionPattern
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1, ClosureBoxType::VTABLE_INDEX});
     auto vtableAddr = rewriter.create<mlir::LLVM::AddressOfOp>(loc, llvmPtrType,
                                                                *op.getVtable());
-    rewriter.create<mlir::LLVM::StoreOp>(loc, vtableAddr, vtablePtrSlot);
+    auto vtableStore =
+        rewriter.create<mlir::LLVM::StoreOp>(loc, vtableAddr, vtablePtrSlot);
+    vtableStore.setInvariantGroup(true);
 
     // 3. Assign cursor (GEP[0, 1, 1]) to the value of GEP[0, 1, 2]
     //    (cursor points to the start of payload area)
@@ -1058,6 +1065,7 @@ struct ReussirRcDecOpConversionPattern
       // Load the vtable pointer
       auto vtable =
           rewriter.create<mlir::LLVM::LoadOp>(loc, llvmPtrType, vtablePtr);
+      vtable.setInvariantGroup(true);
 
       // Create LLVM struct type for vtable: { void*, void*, void* }
       // representing { drop, clone, evaluate } function pointers
@@ -1074,7 +1082,7 @@ struct ReussirRcDecOpConversionPattern
       // Load the drop function pointer
       auto dropFunc =
           rewriter.create<mlir::LLVM::LoadOp>(loc, llvmPtrType, dropPtr);
-      dropFunc.setInvariant(true);
+      dropFunc.setInvariantGroup(true);
 
       // Create function type for drop: void (*)(void*)
       auto voidType = mlir::LLVM::LLVMVoidType::get(rewriter.getContext());
@@ -1261,8 +1269,9 @@ public:
     auto alignedCursor = emitPointerAlign(cursor, inputType, rewriter);
 
     // Third, copy the input value to the aligned cursor.
-    rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), adaptor.getArg(),
-                                         alignedCursor);
+    auto payloadRef = rewriter.create<mlir::LLVM::StoreOp>(
+        op.getLoc(), adaptor.getArg(), alignedCursor);
+    payloadRef.setInvariantGroup(true);
 
     // Fourth, bump the cursor by the input type's size.
     auto newCursor = emitPointerBump(alignedCursor, inputType, rewriter);
@@ -1299,6 +1308,7 @@ struct ReussirClosureCloneOpConversionPattern
     // Load the vtable
     auto vtable =
         rewriter.create<mlir::LLVM::LoadOp>(loc, llvmPtrType, vtablePtr);
+    vtable.setInvariantGroup(true);
 
     // Create LLVM struct type for vtable: { void*, void*, void* }
     // representing { drop, clone, evaluate } function pointers
@@ -1314,7 +1324,7 @@ struct ReussirClosureCloneOpConversionPattern
     // Load the clone function pointer
     auto cloneFunc =
         rewriter.create<mlir::LLVM::LoadOp>(loc, llvmPtrType, clonePtr);
-    cloneFunc.setInvariant(true);
+    cloneFunc.setInvariantGroup(true);
 
     // Create function type for clone: void* (*)(void*)
     auto funcType =
@@ -1352,6 +1362,7 @@ struct ReussirClosureEvalOpConversionPattern
     // Load the vtable pointer
     auto vtable =
         rewriter.create<mlir::LLVM::LoadOp>(loc, llvmPtrType, vtablePtr);
+    vtable.setInvariantGroup(true);
 
     // Create LLVM struct type for vtable: { void*, void*, void* }
     // representing { drop, clone, evaluate } function pointers
@@ -1368,7 +1379,7 @@ struct ReussirClosureEvalOpConversionPattern
     // Load the evaluate function pointer
     auto evalFunc =
         rewriter.create<mlir::LLVM::LoadOp>(loc, llvmPtrType, evalPtr);
-    evalFunc.setInvariant(true);
+    evalFunc.setInvariantGroup(true);
 
     // Determine if the closure has a return value
     mlir::Type resultType =
@@ -1461,7 +1472,6 @@ struct ReussirClosureTransferOpConversionPattern
     ClosureBoxType closureBoxType =
         llvm::cast<ClosureBoxType>(srcRefType.getElementType());
     auto structType = converter->convertType(closureBoxType);
-
     // 1. Extract the cursor pointer from src
     // GEP[0, 1] to access the cursor field
     auto cursorPtrSlot = rewriter.create<mlir::LLVM::GEPOp>(
@@ -1475,30 +1485,68 @@ struct ReussirClosureTransferOpConversionPattern
     // Convert pointers to integers
     mlir::Value srcInt = rewriter.create<mlir::LLVM::PtrToIntOp>(
         loc, indexType, adaptor.getSrc());
+    mlir::Value dstInt = rewriter.create<mlir::LLVM::PtrToIntOp>(
+        loc, indexType, adaptor.getDst());
     mlir::Value cursorInt =
         rewriter.create<mlir::LLVM::PtrToIntOp>(loc, indexType, cursor);
 
     // Compute offset: cursor - src
-    mlir::Value offset = rewriter.create<mlir::arith::SubIOp>(
+    mlir::Value fullOffset = rewriter.create<mlir::arith::SubIOp>(
         loc, cursorInt, srcInt,
         mlir::arith::IntegerOverflowFlags::nsw |
             mlir::arith::IntegerOverflowFlags::nuw);
+    mlir::Value ptrSize = rewriter.create<mlir::arith::ConstantIntOp>(
+        loc, indexType,
+        converter->getDataLayout().getTypeSize(llvmPtrType).getFixedValue());
+    mlir::Value offset = rewriter.create<mlir::arith::SubIOp>(
+        loc, fullOffset, ptrSize,
+        mlir::arith::IntegerOverflowFlags::nsw |
+            mlir::arith::IntegerOverflowFlags::nuw);
+    mlir::Value srcPlusPtrSize = rewriter.create<mlir::arith::AddIOp>(
+        loc, srcInt, ptrSize,
+        mlir::arith::IntegerOverflowFlags::nsw |
+            mlir::arith::IntegerOverflowFlags::nuw);
+    mlir::Value src = rewriter.create<mlir::LLVM::IntToPtrOp>(loc, llvmPtrType,
+                                                              srcPlusPtrSize);
+    mlir::Value dstPlusPtrSize = rewriter.create<mlir::arith::AddIOp>(
+        loc, dstInt, ptrSize,
+        mlir::arith::IntegerOverflowFlags::nsw |
+            mlir::arith::IntegerOverflowFlags::nuw);
+    mlir::Value dst = rewriter.create<mlir::LLVM::IntToPtrOp>(loc, llvmPtrType,
+                                                              dstPlusPtrSize);
     // Call llvm.memcpy intrinsic
-    auto size =
+    auto closureSizeFixed =
         converter->getDataLayout().getTypeSize(closureBoxType).getFixedValue();
+    auto ptrSizeFixed =
+        converter->getDataLayout().getTypeSize(llvmPtrType).getFixedValue();
+    if (closureSizeFixed < ptrSizeFixed)
+      llvm::report_fatal_error("Closure size is smaller than pointer size");
+    auto size = closureSizeFixed - ptrSizeFixed;
     if (size > 32)
-      rewriter.create<mlir::LLVM::MemcpyOp>(loc, adaptor.getDst(),
-                                            adaptor.getSrc(), offset, false);
+      rewriter.create<mlir::LLVM::MemcpyOp>(loc, dst, src, offset, false);
     else {
       // directly copy the whole closure box
       mlir::IntegerAttr sizeAttr = mlir::IntegerAttr::get(indexType, size);
-      rewriter.create<mlir::LLVM::MemcpyInlineOp>(
-          loc, adaptor.getDst(), adaptor.getSrc(), sizeAttr, false);
+      rewriter.create<mlir::LLVM::MemcpyInlineOp>(loc, dst, src, sizeAttr,
+                                                  false);
     }
+    // (explicity transfer vtable)
+    auto vtablePtrSlot = rewriter.create<mlir::LLVM::GEPOp>(
+        loc, llvmPtrType, structType, adaptor.getSrc(),
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, ClosureBoxType::VTABLE_INDEX});
+    auto vtable =
+        rewriter.create<mlir::LLVM::LoadOp>(loc, llvmPtrType, vtablePtrSlot);
+    vtable.setInvariantGroup(true);
+    auto targetVtablePtrSlot = rewriter.create<mlir::LLVM::GEPOp>(
+        loc, llvmPtrType, structType, adaptor.getDst(),
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, ClosureBoxType::VTABLE_INDEX});
+    auto targetVtable =
+        rewriter.create<mlir::LLVM::StoreOp>(loc, vtable, targetVtablePtrSlot);
+    targetVtable.setInvariantGroup(true);
 
     // Update cursor to (dst + offset)
     auto newCursor = rewriter.create<mlir::LLVM::GEPOp>(
-        loc, llvmPtrType, rewriter.getI8Type(), adaptor.getDst(), offset,
+        loc, llvmPtrType, rewriter.getI8Type(), adaptor.getDst(), fullOffset,
         mlir::LLVM::GEPNoWrapFlags::inbounds);
 
     // Get the cursor slot in the destination closure box
@@ -1959,6 +2007,18 @@ struct ReussirTrampolineOpConversionPattern
     return mlir::success();
   }
 };
+struct ReussirTokenLaunderOpConversionPattern
+    : public mlir::OpConversionPattern<ReussirTokenLaunderOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirTokenLaunderOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::LaunderInvariantGroupOp>(
+        op, adaptor.getToken());
+    return mlir::success();
+  }
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -2037,6 +2097,22 @@ void addRuntimeFunctions(mlir::ModuleOp module,
 //===----------------------------------------------------------------------===//
 
 namespace {
+void markInvariantGroup(ReussirRefLoadOp op) {
+  auto ref = op.getRef();
+  // walk up the reference projection chain, if it originates from a rc borrow,
+  // mark it as invariant group
+  while (auto proj =
+             dyn_cast_if_present<ReussirRefProjectOp>(ref.getDefiningOp()))
+    ref = proj.getRef();
+
+  if (auto borrow = dyn_cast_if_present<ReussirRcBorrowOp>(ref.getDefiningOp()))
+    op->setAttr("reussir.invariant_group",
+                mlir::UnitAttr::get(op.getContext()));
+  if (auto inspect = dyn_cast_if_present<ReussirClosureInspectPayloadOp>(
+          ref.getDefiningOp()))
+    op->setAttr("reussir.invariant_group",
+                mlir::UnitAttr::get(op.getContext()));
+}
 struct BasicOpsLoweringPass
     : public impl::ReussirBasicOpsLoweringPassBase<BasicOpsLoweringPass> {
   using Base::Base;
@@ -2055,6 +2131,7 @@ struct BasicOpsLoweringPass
       mlir::populateMathToLibmConversionPatterns(patterns);
       mlir::ub::populateUBToLLVMConversionPatterns(converter, patterns);
       addRuntimeFunctions(getOperation(), converter);
+      getOperation().walk(markInvariantGroup);
       target.addIllegalDialect<mlir::func::FuncDialect,
                                mlir::arith::ArithDialect>();
       target.addIllegalOp<
@@ -2074,7 +2151,7 @@ struct BasicOpsLoweringPass
           ReussirClosureCreateOp, ReussirRcFetchDecOp, ReussirStrGlobalOp,
           ReussirStrLiteralOp, ReussirPanicOp, ReussirStrLenOp,
           ReussirStrUnsafeByteAtOp, ReussirStrUnsafeStartWithOp,
-          ReussirStrSliceOp, ReussirTrampolineOp>();
+          ReussirStrSliceOp, ReussirTrampolineOp, ReussirTokenLaunderOp>();
       target.addLegalDialect<mlir::LLVM::LLVMDialect>();
       if (failed(applyPartialConversion(getOperation(), target,
                                         std::move(patterns))))
@@ -2122,7 +2199,7 @@ void populateBasicOpsLoweringToLLVMConversionPatterns(
       ReussirStrLenOpConversionPattern,
       ReussirStrUnsafeByteAtOpConversionPattern,
       ReussirStrUnsafeStartWithOpConversionPattern,
-      ReussirStrSliceOpConversionPattern, ReussirTrampolineOpConversionPattern>(
-      converter, patterns.getContext());
+      ReussirStrSliceOpConversionPattern, ReussirTrampolineOpConversionPattern,
+      ReussirTokenLaunderOpConversionPattern>(converter, patterns.getContext());
 }
 } // namespace reussir

--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -594,8 +594,10 @@ struct ReussirTokenEnsureOpRewritePattern
           rewriter.createBlock(&nullableDispatchOp.getNonNullRegion(), {},
                                op.getType(), {op.getLoc()});
       rewriter.setInsertionPointToStart(thenBlock);
+      auto launderedToken = rewriter.create<ReussirTokenLaunderOp>(
+          op.getLoc(), op.getType(), thenBlock->getArgument(0));
       rewriter.create<mlir::scf::YieldOp>(op.getLoc(),
-                                          thenBlock->getArgument(0));
+                                          launderedToken->getResults());
     }
     {
       mlir::Block *elseBlock =

--- a/lib/LLVMPass/AllocationSimplication/CMakeLists.txt
+++ b/lib/LLVMPass/AllocationSimplication/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(ReussirLLVMAllocationSimplicationPass STATIC
   AllocationSimplication.cpp
+  RuntimeFunctionAttributor.cpp
 )
 
 set_target_properties(ReussirLLVMAllocationSimplicationPass PROPERTIES
   POSITION_INDEPENDENT_CODE ON
 )
-

--- a/lib/LLVMPass/AllocationSimplication/RuntimeFunctionAttributor.cpp
+++ b/lib/LLVMPass/AllocationSimplication/RuntimeFunctionAttributor.cpp
@@ -1,0 +1,96 @@
+//===- RuntimeFunctionAttributor.cpp - Reussir runtime attrib pass ------===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"
+
+#include <optional>
+
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Module.h>
+
+namespace reussir::llvmpass {
+namespace {
+
+bool setAllocateAttributes(llvm::Function &fn) {
+  bool changed = false;
+  llvm::LLVMContext &ctx = fn.getContext();
+  constexpr auto allocKind = llvm::AllocFnKind::Alloc |
+                             llvm::AllocFnKind::Uninitialized |
+                             llvm::AllocFnKind::Aligned;
+
+  if (!fn.hasFnAttribute(llvm::Attribute::AllocKind) ||
+      fn.getFnAttribute(llvm::Attribute::AllocKind).getAllocKind() !=
+          allocKind) {
+    fn.addFnAttr(llvm::Attribute::getWithAllocKind(ctx, allocKind));
+    changed = true;
+  }
+
+  if (!fn.hasFnAttribute(llvm::Attribute::AllocSize)) {
+    fn.addFnAttr(llvm::Attribute::getWithAllocSizeArgs(ctx, 1, std::nullopt));
+    changed = true;
+  } else {
+    auto allocSizeArgs =
+        fn.getFnAttribute(llvm::Attribute::AllocSize).getAllocSizeArgs();
+    if (allocSizeArgs.first != 0 || allocSizeArgs.second.has_value()) {
+      fn.addFnAttr(llvm::Attribute::getWithAllocSizeArgs(ctx, 1, std::nullopt));
+      changed = true;
+    }
+  }
+
+  if (fn.getFnAttribute("alloc-family").getValueAsString() != "reussir") {
+    fn.addFnAttr("alloc-family", "reussir");
+    changed = true;
+  }
+
+  return changed;
+}
+
+bool setDeallocateAttributes(llvm::Function &fn) {
+  bool changed = false;
+  llvm::LLVMContext &ctx = fn.getContext();
+  constexpr auto freeKind = llvm::AllocFnKind::Free;
+
+  if (!fn.hasFnAttribute(llvm::Attribute::AllocKind) ||
+      fn.getFnAttribute(llvm::Attribute::AllocKind).getAllocKind() !=
+          freeKind) {
+    fn.addFnAttr(llvm::Attribute::getWithAllocKind(ctx, freeKind));
+    changed = true;
+  }
+
+  if (fn.getFnAttribute("alloc-family").getValueAsString() != "reussir") {
+    fn.addFnAttr("alloc-family", "reussir");
+    changed = true;
+  }
+
+  if (fn.hasFnAttribute(llvm::Attribute::AllocSize)) {
+    fn.removeFnAttr(llvm::Attribute::AllocSize);
+    changed = true;
+  }
+
+  return changed;
+}
+
+} // namespace
+
+llvm::PreservedAnalyses
+RuntimeFunctionAttributorPass::run(llvm::Module &module,
+                                   llvm::ModuleAnalysisManager &) {
+  bool changed = false;
+
+  if (auto *allocate = module.getFunction("__reussir_allocate"))
+    changed |= setAllocateAttributes(*allocate);
+
+  if (auto *deallocate = module.getFunction("__reussir_deallocate"))
+    changed |= setDeallocateAttributes(*deallocate);
+
+  return changed ? llvm::PreservedAnalyses::none()
+                 : llvm::PreservedAnalyses::all();
+}
+
+} // namespace reussir::llvmpass

--- a/tests/integration/conversion/closure_uniqify_2.mlir
+++ b/tests/integration/conversion/closure_uniqify_2.mlir
@@ -22,14 +22,14 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK:   llvm.br ^[[JOIN:bb[0-9]+]](%[[INPUT]] : !llvm.ptr)
 // CHECK: ^[[ELSE]]:  // pred: ^bb0
 // CHECK:   %[[GEP_VTABLE:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, struct<(ptr, ptr)>)>
-// CHECK:   %[[VTABLE:.*]] = llvm.load %[[GEP_VTABLE]] : !llvm.ptr -> !llvm.ptr
+// CHECK:   %[[VTABLE:.*]] = llvm.load %[[GEP_VTABLE]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[GEP_CLONE:.*]] = llvm.getelementptr %[[VTABLE]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr, ptr)>
-// CHECK:   %[[CLONE_FUNC:.*]] = llvm.load %[[GEP_CLONE]] invariant : !llvm.ptr -> !llvm.ptr
+// CHECK:   %[[CLONE_FUNC:.*]] = llvm.load %[[GEP_CLONE]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[CLONED:.*]] = llvm.call %[[CLONE_FUNC]](%[[INPUT]]) : !llvm.ptr, (!llvm.ptr) -> !llvm.ptr
 // CHECK:   %[[GEP_VTABLE2:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, struct<(ptr, ptr)>)>
-// CHECK:   %[[VTABLE2:.*]] = llvm.load %[[GEP_VTABLE2]] : !llvm.ptr -> !llvm.ptr
+// CHECK:   %[[VTABLE2:.*]] = llvm.load %[[GEP_VTABLE2]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[GEP_DROP:.*]] = llvm.getelementptr %[[VTABLE2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr, ptr)>
-// CHECK:   %[[DROP_FUNC:.*]] = llvm.load %[[GEP_DROP]] invariant : !llvm.ptr -> !llvm.ptr
+// CHECK:   %[[DROP_FUNC:.*]] = llvm.load %[[GEP_DROP]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   llvm.call %[[DROP_FUNC]](%[[INPUT]]) : !llvm.ptr, (!llvm.ptr) -> ()
 // CHECK:   llvm.br ^[[JOIN]](%[[CLONED]] : !llvm.ptr)
 // CHECK: ^[[JOIN]](%[[JOIN_ARG:[0-9]+]]: !llvm.ptr):  // 2 preds: ^bb1, ^bb2

--- a/tests/integration/conversion/rc_ops.mlir
+++ b/tests/integration/conversion/rc_ops.mlir
@@ -39,8 +39,8 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
   // CHECK-LABEL: define ptr @rc_create(fp128 %0)
   // CHECK: %2 = call ptr @__reussir_allocate(i64 16, i64 32)
   // CHECK: %3 = getelementptr { i64, fp128 }, ptr %2, i32 0, i32 0
-  // CHECK: %4 = getelementptr { i64, fp128 }, ptr %2, i32 0, i32 1
   // CHECK: store i64 1, ptr %3, align 8
+  // CHECK: %4 = getelementptr { i64, fp128 }, ptr %2, i32 0, i32 1
   // CHECK: store fp128 %0, ptr %4, align 16
   func.func @rc_create(%value: f128) -> !reussir.rc<f128> {
     %token = reussir.token.alloc : !reussir.token<align: 16, size: 32>

--- a/tests/integration/conversion/record_ops.mlir
+++ b/tests/integration/conversion/record_ops.mlir
@@ -47,8 +47,8 @@ module {
 // CHECK: %[[loaded:[0-9]+]] = load %List, ptr %[[alloca]], align 8
 // CHECK: %[[allocated:[0-9]+]] = call ptr @__reussir_allocate(i64 8, i64 32)
 // CHECK: %[[rc_tag_ptr:[0-9]+]] = getelementptr { i64, %List }, ptr %[[allocated]], i32 0, i32 0
-// CHECK: %[[rc_value_ptr:[0-9]+]] = getelementptr { i64, %List }, ptr %[[allocated]], i32 0, i32 1
 // CHECK: store i64 1, ptr %[[rc_tag_ptr]], align 4
+// CHECK: %[[rc_value_ptr:[0-9]+]] = getelementptr { i64, %List }, ptr %[[allocated]], i32 0, i32 1
 // CHECK: store %List %[[loaded]], ptr %[[rc_value_ptr]], align 8
 // CHECK: ret ptr %[[allocated]]
 


### PR DESCRIPTION
## Summary

- Introduce `reussir.token.launder` op and lower it to `llvm.launder.invariant.group`
- Mark vtable stores/loads and object-field stores with `invariant_group` metadata
- Rework closure transfer to explicitly propagate vtable via `invariant_group` load/store pair
- Pre-mark `ref.load` ops originating from `rc.borrow` or `closure.inspect_payload` with `reussir.invariant_group` attribute

## Analysis

### Motivation

Previously, vtable function pointer loads used LLVM's `!invariant.load` metadata, which asserts that a memory location's value **never changes for the entire program lifetime**. This is unsound when memory is reused: after an object is freed and its token recycled for a new allocation, the same address may hold a different vtable pointer, yet `!invariant.load` would tell LLVM the old value is still valid.

### Approach: `invariant.group` semantics

LLVM's [`invariant.group`](https://llvm.org/docs/LangRef.html#invariant-group-metadata) metadata provides a scoped invariance model that correctly handles memory reuse:

- **`invariant_group` on stores and loads**: Tells LLVM that loads from a pointer return the same value as the corresponding store, *as long as the pointer belongs to the same invariant group*. This allows LLVM to cache and forward vtable/payload values across loads within a single object lifetime.
- **`llvm.launder.invariant.group`**: Returns a pointer that is "aliased but in a new invariant group." When a token is reused (via `token.ensure`'s non-null path), passing it through `launder` creates a new group, preventing LLVM from forwarding stale values from the previous allocation.

This is the standard LLVM mechanism for devirtualization under memory reuse.

### Changes by area

**New IR operation** (`ReussirOps.td`):
- `reussir.token.launder`: Takes a token and returns a "laundered" token in a new invariant group, lowered to `llvm.launder.invariant.group`.

**Lowering pass** (`BasicOpsLowering.cpp`):
- `markInvariantGroup` pre-pass: Walks the IR before conversion and marks `ref.load` ops whose reference chain traces back to `rc.borrow` or `closure.inspect_payload` with a `reussir.invariant_group` unit attribute. These loads are then emitted with LLVM `invariant_group` metadata during conversion.
- **RC create**: Vtable and object-value stores marked `invariant_group`. Store order adjusted (refcount store before element GEP) for better code structure.
- **Closure create**: Vtable store marked `invariant_group`.
- **Closure payload assign**: Payload stores marked `invariant_group`.
- **RC dec / Closure clone / Closure eval**: Vtable loads marked `invariant_group`; vtable entry loads changed from `invariant` to `invariant_group`.
- **Closure transfer**: Reworked to copy the closure box **excluding** the vtable pointer (via pointer arithmetic that skips the first pointer-sized field), then explicitly transfers the vtable through an `invariant_group` load/store pair. This preserves invariant group semantics across ownership transfers.
- New `ReussirTokenLaunderOp` → `llvm.launder.invariant.group` conversion pattern registered.

**SCF lowering** (`SCFOpsLowering.cpp`):
- In `token.ensure` lowering, the non-null (reuse) path now launders the token through `reussir.token.launder` before yielding it. This is the critical correctness point: reused memory gets a fresh invariant group.

### Correctness argument

1. **Object creation**: Vtable/payload stores are `invariant_group` → LLVM knows these values are stable for this group.
2. **Object access**: Loads from borrowed refs / closure payloads are `invariant_group` → LLVM can forward from the creation stores, enabling devirtualization.
3. **Memory reuse**: `token.ensure` launders reused tokens → creates a new invariant group → LLVM will not forward values from the previous allocation.
4. **Closure transfer**: Vtable is explicitly loaded/stored with `invariant_group` → the destination gets proper group membership even though the payload is bulk-copied.

## Test plan

- [ ] Verify `closure_uniqify_2.mlir` checks updated to expect `invariant_group` instead of `invariant`
- [ ] Verify `rc_ops.mlir` checks reflect reordered stores in `rc_create`
- [ ] Verify `record_ops.mlir` checks reflect reordered stores
- [ ] Run full integration test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)