### PR TITLE
[frontend][ownership] fix decision tree branch reconciliation

### DIFF
--- a/frontend/reussir-core/src/Reussir/Core/Ownership.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Ownership.hs
@@ -647,7 +647,21 @@ analyzeExpr tbl expr st = do
             pure (st3, emptyFlux)
         -- If expression: branch reconciliation
         Full.ScfIfExpr condExpr thenExpr elseExpr -> do
-            (st1, _) <- analyzeExpr tbl condExpr st
+            -- Before analyzing the condition, if it's a consuming call,
+            -- emit incs for variables consumed by the condition but also
+            -- needed by the then/else branches.
+            let branchFreeVars = collectFreeVars thenExpr <> collectFreeVars elseExpr
+            st0 <- case Full.exprKind condExpr of
+                Full.FuncCall{} -> emitSequenceLevelIncs condExpr branchFreeVars st
+                Full.IntrinsicCall{} -> emitSequenceLevelIncs condExpr branchFreeVars st
+                Full.CompoundCall{} -> emitSequenceLevelIncs condExpr branchFreeVars st
+                Full.VariantCall{} -> emitSequenceLevelIncs condExpr branchFreeVars st
+                Full.NullableCall{} -> emitSequenceLevelIncs condExpr branchFreeVars st
+                Full.RcWrap{} -> emitSequenceLevelIncs condExpr branchFreeVars st
+                Full.ClosureCall{} -> emitSequenceLevelIncs condExpr branchFreeVars st
+                Full.Closure{} -> emitSequenceLevelIncs condExpr branchFreeVars st
+                _ -> pure st
+            (st1, _) <- analyzeExpr tbl condExpr st0
             -- Save ledger before branches
             let ledgerBefore = asLedger st1
             (st2, thenFlux) <- analyzeExpr tbl thenExpr st1
@@ -1348,33 +1362,79 @@ reconcileBranches branches st =
                     allVars
      in (minCounts, st')
 
--- | Reconcile ownership across decision tree branches
+-- | Reconcile ownership across decision tree branches.
+--
+-- Unlike 'reconcileBranches' which takes pre-extracted ExprIDs,
+-- this function works directly with decision trees. It computes
+-- min counts from ALL branch ledgers (including DTSwitch subtrees),
+-- then emits excess decs at every reachable exit point within each branch.
 reconcileBranchesWithDT ::
     [(IntMap Int, Full.DecisionTree)] ->
     AnalysisState ->
     (IntMap Int, AnalysisState)
 reconcileBranchesWithDT branches st =
     let
-        -- Convert DT branches to ExprID branches where possible
-        exprBranches =
-            [ (ledger, eid, used)
-            | (ledger, dt) <- branches
-            , Just (eid, used) <- [dtExitExprInfo dt]
-            ]
-     in
-        if null exprBranches
-            then
-                -- If no branches have exit ExprIDs, just pick first ledger
-                case branches of
-                    [] -> (asLedger st, st)
-                    ((ledger, _) : _) -> (ledger, st)
-            else reconcileBranches exprBranches st
+        allLedgers = map fst branches
+        allVars = IntSet.unions $ map IntMap.keysSet allLedgers
+        -- For each var, find the minimum count across ALL branches (most consumed)
+        minCounts = IntSet.foldl' findMin IntMap.empty allVars
+          where
+            findMin acc vid =
+                let counts = map (\ledger -> IntMap.findWithDefault 0 vid ledger) allLedgers
+                    minCount = minimum counts
+                 in IntMap.insert vid minCount acc
+        -- Emit decs at every exit point of each branch
+        st' = foldl' reconcileBranch st branches
+          where
+            reconcileBranch s (ledger, dt) =
+                let exitInfos = dtAllExitInfos dt
+                 in foldl' (emitExcessAtExit ledger) s exitInfos
 
--- | Get the exit ExprID and used vars for optimization
-dtExitExprInfo :: Full.DecisionTree -> Maybe (ExprID, IntSet.IntSet)
-dtExitExprInfo (Full.DTLeaf body _) = Just (Full.exprID body, collectFreeVars body)
-dtExitExprInfo (Full.DTGuard _ guardExpr _ _) = Just (Full.exprID guardExpr, collectFreeVars guardExpr)
-dtExitExprInfo _ = Nothing
+            emitExcessAtExit ledger s (eid, usedVars) =
+                IntSet.foldl'
+                    ( \s' vid ->
+                        let branchCount = IntMap.findWithDefault 0 vid ledger
+                            targetCount = IntMap.findWithDefault 0 vid minCounts
+                            excess = branchCount - targetCount
+                         in if excess > 0
+                                then
+                                    let action =
+                                            if vid `IntSet.member` usedVars
+                                                then OwnershipAction [] (replicate excess (ODecVar (VarID vid))) -- Late drop
+                                                else OwnershipAction (replicate excess (ODecVar (VarID vid))) [] -- Early drop
+                                     in annotate eid action s'
+                                else s'
+                    )
+                    s
+                    allVars
+     in
+        if null branches
+            then (asLedger st, st)
+            else (minCounts, st')
+
+-- | Collect all exit-point ExprIDs from a decision tree, recursively.
+--
+-- DTLeaf and DTGuard have a single exit point.  DTSwitch branches
+-- have already been internally reconciled, so all their leaf exit
+-- points share the same ledger — placing the same excess decs at
+-- each one is correct.
+dtAllExitInfos :: Full.DecisionTree -> [(ExprID, IntSet.IntSet)]
+dtAllExitInfos (Full.DTLeaf body _) = [(Full.exprID body, collectFreeVars body)]
+dtAllExitInfos (Full.DTGuard _ guardExpr _ _) = [(Full.exprID guardExpr, collectFreeVars guardExpr)]
+dtAllExitInfos (Full.DTSwitch _ cases) = dtSwitchCasesExitInfos cases
+dtAllExitInfos _ = []
+
+dtSwitchCasesExitInfos :: Full.DTSwitchCases -> [(ExprID, IntSet.IntSet)]
+dtSwitchCasesExitInfos (Full.DTSwitchBool t f) =
+    dtAllExitInfos t ++ dtAllExitInfos f
+dtSwitchCasesExitInfos (Full.DTSwitchCtor cases) =
+    concatMap dtAllExitInfos (V.toList cases)
+dtSwitchCasesExitInfos (Full.DTSwitchInt intMap def) =
+    concatMap dtAllExitInfos (IntMap.elems intMap) ++ dtAllExitInfos def
+dtSwitchCasesExitInfos (Full.DTSwitchString strMap def) =
+    concatMap dtAllExitInfos (HashMap.elems strMap) ++ dtAllExitInfos def
+dtSwitchCasesExitInfos (Full.DTSwitchNullable j n) =
+    dtAllExitInfos j ++ dtAllExitInfos n
 
 -- | Strict left fold for IO
 foldlM' :: (Monad m) => (b -> a -> m b) -> b -> [a] -> m b

--- a/tests/integration/frontend/rbtree.c
+++ b/tests/integration/frontend/rbtree.c
@@ -1,0 +1,41 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct rc_list {
+    int64_t refcount;
+    int64_t tag;
+    int32_t head;
+    int32_t _pad;
+    struct rc_list *tail;
+} rc_list_t;
+
+#define LIST_NIL 0
+#define LIST_CONS 1
+
+extern rc_list_t *make_tree_to_list_ffi(int32_t size);
+
+int main(void) {
+    const int32_t n = 256;
+    rc_list_t *p = make_tree_to_list_ffi(n);
+
+    for (int32_t i = 0; i < n; ++i) {
+        if (p->tag != LIST_CONS) {
+            fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", (int)i);
+            abort();
+        }
+        if (p->head != i) {
+            fprintf(stderr, "FAIL: expected %d at index %d, got %d\n", (int)i, (int)i, (int)p->head);
+            abort();
+        }
+        p = p->tail;
+    }
+
+    if (p->tag != LIST_NIL) {
+        fprintf(stderr, "FAIL: expected Nil terminator, got tag=%ld\n", (long)p->tag);
+        abort();
+    }
+
+    puts("PASS: make_tree_to_list_ffi(256) returned [0..255]");
+    return 0;
+}

--- a/tests/integration/frontend/rbtree.rr
+++ b/tests/integration/frontend/rbtree.rr
@@ -1,0 +1,173 @@
+// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/rbtree.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// Port of Koka rbtree benchmark's make-tree path:
+// build a red-black tree by inserting keys [n-1 .. 0], then
+// expose an FFI that returns the in-order list [0 .. n-1].
+
+enum [value] Color {
+    Red,
+    Black
+}
+
+enum Tree {
+    Branch(Color, Tree, i32, bool, Tree),
+    Leaf
+}
+
+enum List {
+    Nil,
+    Cons(i32, List)
+}
+
+fn is_red(t: Tree) -> bool {
+    match t {
+        Tree::Branch(Color::Red, _, _, _, _) => true,
+        _ => false
+    }
+}
+
+fn balance_left(l: Tree, k: i32, v: bool, r: Tree) -> Tree {
+    match l {
+        Tree::Branch(_, Tree::Branch(Color::Red, lx, kx, vx, rx), ky, vy, ry) =>
+            Tree::Branch{
+                Color::Red,
+                Tree::Branch{Color::Black, lx, kx, vx, rx},
+                ky,
+                vy,
+                Tree::Branch{Color::Black, ry, k, v, r}
+            },
+
+        Tree::Branch(_, ly, ky, vy, Tree::Branch(Color::Red, lx, kx, vx, rx)) =>
+            Tree::Branch{
+                Color::Red,
+                Tree::Branch{Color::Black, ly, ky, vy, lx},
+                kx,
+                vx,
+                Tree::Branch{Color::Black, rx, k, v, r}
+            },
+
+        Tree::Branch(_, lx, kx, vx, rx) =>
+            Tree::Branch{
+                Color::Black,
+                Tree::Branch{Color::Red, lx, kx, vx, rx},
+                k,
+                v,
+                r
+            },
+
+        Tree::Leaf => Tree::Leaf
+    }
+}
+
+fn balance_right(l: Tree, k: i32, v: bool, r: Tree) -> Tree {
+    match r {
+        Tree::Branch(_, Tree::Branch(Color::Red, lx, kx, vx, rx), ky, vy, ry) =>
+            Tree::Branch{
+                Color::Red,
+                Tree::Branch{Color::Black, l, k, v, lx},
+                kx,
+                vx,
+                Tree::Branch{Color::Black, rx, ky, vy, ry}
+            },
+
+        Tree::Branch(_, lx, kx, vx, Tree::Branch(Color::Red, ly, ky, vy, ry)) =>
+            Tree::Branch{
+                Color::Red,
+                Tree::Branch{Color::Black, l, k, v, lx},
+                kx,
+                vx,
+                Tree::Branch{Color::Black, ly, ky, vy, ry}
+            },
+
+        Tree::Branch(_, lx, kx, vx, rx) =>
+            Tree::Branch{
+                Color::Black,
+                l,
+                k,
+                v,
+                Tree::Branch{Color::Red, lx, kx, vx, rx}
+            },
+
+        Tree::Leaf => Tree::Leaf
+    }
+}
+
+fn ins(t: Tree, k: i32, v: bool) -> Tree {
+    match t {
+        Tree::Branch(Color::Red, l, kx, vx, r) =>
+            if k < kx {
+                Tree::Branch{Color::Red, ins(l, k, v), kx, vx, r}
+            } else {
+                if k > kx {
+                    Tree::Branch{Color::Red, l, kx, vx, ins(r, k, v)}
+                } else {
+                    Tree::Branch{Color::Red, l, k, v, r}
+                }
+            },
+
+        Tree::Branch(Color::Black, l, kx, vx, r) =>
+            if k < kx {
+                if is_red(l) {
+                    balance_left(ins(l, k, v), kx, vx, r)
+                } else {
+                    Tree::Branch{Color::Black, ins(l, k, v), kx, vx, r}
+                }
+            } else {
+                if k > kx {
+                    if is_red(r) {
+                        balance_right(l, kx, vx, ins(r, k, v))
+                    } else {
+                        Tree::Branch{Color::Black, l, kx, vx, ins(r, k, v)}
+                    }
+                } else {
+                    Tree::Branch{Color::Black, l, k, v, r}
+                }
+            },
+
+        Tree::Leaf => Tree::Branch{Color::Red, Tree::Leaf, k, v, Tree::Leaf}
+    }
+}
+
+fn set_black(t: Tree) -> Tree {
+    match t {
+        Tree::Branch(_, l, k, v, r) => Tree::Branch{Color::Black, l, k, v, r},
+        Tree::Leaf => Tree::Leaf
+    }
+}
+
+fn insert(t: Tree, k: i32, v: bool) -> Tree {
+    set_black(ins(t, k, v))
+}
+
+fn make_tree_aux(n: i32, t: Tree) -> Tree {
+    if n <= 0 {
+        t
+    } else {
+        let n1 = n - 1;
+        make_tree_aux(n1, insert(t, n1, n1 % 10 == 0))
+    }
+}
+
+fn make_tree(n: i32) -> Tree {
+    make_tree_aux(n, Tree::Leaf)
+}
+
+fn tree_to_list_acc(t: Tree, acc: List) -> List {
+    match t {
+        Tree::Branch(_, l, k, _, r) =>
+            tree_to_list_acc(l, List::Cons{k, tree_to_list_acc(r, acc)}),
+        Tree::Leaf => acc
+    }
+}
+
+fn tree_to_list(t: Tree) -> List {
+    tree_to_list_acc(t, List::Nil)
+}
+
+pub fn make_tree_to_list(size: i32) -> List {
+    tree_to_list(make_tree(size))
+}
+
+extern "C" trampoline "make_tree_to_list_ffi" = make_tree_to_list;


### PR DESCRIPTION
## Summary

- **ScfIfExpr condition consumption**: when the condition of an `if` is a consuming call (e.g. `is_red(l)`), variables consumed by the condition but still needed by the branches were not incremented beforehand, causing use-after-free. Fixed by emitting `rc.inc` via `emitSequenceLevelIncs` before condition analysis.
- **DTSwitch reconciliation exclusion**: `reconcileBranchesWithDT` silently excluded `DTSwitch` branches from ownership reconciliation because `dtExitExprInfo` returned `Nothing` for them. Min counts were computed from only the simple (`DTLeaf`/`DTGuard`) branches, leading to missing `rc.dec` and memory corruption. Fixed by replacing `dtExitExprInfo` with recursive `dtAllExitInfos` that collects all exit ExprIDs from any decision tree, and rewriting `reconcileBranchesWithDT` to compute min counts from ALL branch ledgers.
- Adds red-black tree integration test (`rbtree.rr` + `rbtree.c`) exercising nested pattern matching with consuming if-conditions.

## Test plan

- [x] `ninja check` — all 196 tests pass (previously 195/196 with `rbtree.rr` crashing)
- [x] Verified with `-O none` (no LLVM optimizations) to confirm the fix is in the frontend, not optimizer-dependent

🤖 Generated with [Claude Code](https://claude.com/claude-code)