### PR TITLE
Support tensor array views in SCF lowering

### DIFF
--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -49,11 +49,14 @@ def ReussirSCFOpsLoweringPass
     operations.
   }];
   let dependentDialects = ["::mlir::arith::ArithDialect",
+                           "::mlir::bufferization::BufferizationDialect",
+                           "::mlir::func::FuncDialect",
+                           "::mlir::linalg::LinalgDialect",
                            "::reussir::ReussirDialect",
                            "::mlir::math::MathDialect",
                            "::mlir::memref::MemRefDialect",
                            "::mlir::scf::SCFDialect",
-                           "::mlir::func::FuncDialect",
+                           "::mlir::tensor::TensorDialect",
                            "::mlir::ub::UBDialect"];
 }
 

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -857,7 +857,8 @@ def ReussirArrayViewOp : ReussirArrayOp<"view", []> {
   let summary = "Materialize an array view from an array reference";
   let description = [{
     `reussir.array.view` turns a reference to an inline array payload into a
-    statically shaped memref suitable for `memref.load` and `memref.store`.
+    statically shaped memref or tensor suitable for downstream bufferization
+    and lowering.
   }];
   let arguments = (ins Arg<ReussirRefType, "array reference">:$ref);
   let results = (outs Res<AnyType, "materialized view">:$view);
@@ -872,7 +873,7 @@ def ReussirArrayWithUniqueViewOp : ReussirArrayOp<"with_unique_view", []> {
   let description = [{
     `reussir.array.with_unique_view` makes sure the input RC array is unique,
     clones it when needed, then executes the body region with a mutable view of
-    the array payload as a statically shaped memref.
+    the array payload as a statically shaped memref or tensor.
 
     The body region must take exactly one matching view argument and terminate
     with `reussir.scf.yield`.

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -744,7 +744,10 @@ struct ReussirArrayViewConversionPattern
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Location loc = op.getLoc();
     auto converter = static_cast<const LLVMTypeConverter *>(getTypeConverter());
-    auto viewType = llvm::cast<mlir::MemRefType>(op.getView().getType());
+    auto viewType = llvm::dyn_cast<mlir::MemRefType>(op.getView().getType());
+    if (!viewType)
+      return op.emitOpError(
+          "tensor array.view must be bufferized before lowering basic ops");
     ArrayType arrayType =
         llvm::cast<ArrayType>(llvm::cast<RefType>(op.getRef().getType()).getElementType());
     mlir::Type llvmArrayType = converter->convertType(arrayType);

--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -23,12 +23,15 @@
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Bufferization/IR/Bufferization.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>
@@ -611,6 +614,50 @@ static void cloneArrayWithUniqueViewBody(ReussirArrayWithUniqueViewOp op,
   rewriter.create<mlir::scf::YieldOp>(op.getLoc(), yieldedValues);
 }
 
+static mlir::MemRefType getArrayViewMemRefType(ArrayType arrayType) {
+  return mlir::MemRefType::get(arrayType.getShape(), arrayType.getElementType());
+}
+
+static mlir::Value materializeArrayViewValue(mlir::Location loc,
+                                             mlir::PatternRewriter &rewriter,
+                                             ArrayType arrayType,
+                                             mlir::Value ref,
+                                             mlir::Type viewType,
+                                             bool writable) {
+  auto memrefType = getArrayViewMemRefType(arrayType);
+  auto memrefView =
+      rewriter.create<ReussirArrayViewOp>(loc, memrefType, ref).getView();
+  if (llvm::isa<mlir::MemRefType>(viewType))
+    return memrefView;
+
+  auto tensorType = llvm::cast<mlir::RankedTensorType>(viewType);
+  return rewriter
+      .create<mlir::bufferization::ToTensorOp>(loc, tensorType, memrefView,
+                                               /*restrict=*/true, writable)
+      .getResult();
+}
+
+struct ReussirArrayViewOpRewritePattern
+    : public mlir::OpConversionPattern<ReussirArrayViewOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirArrayViewOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto tensorType = llvm::dyn_cast<mlir::RankedTensorType>(op.getView().getType());
+    if (!tensorType)
+      return rewriter.notifyMatchFailure(op, "expected tensor array view");
+
+    auto arrayType =
+        llvm::cast<ArrayType>(llvm::cast<RefType>(op.getRef().getType()).getElementType());
+    auto value = materializeArrayViewValue(op.getLoc(), rewriter, arrayType,
+                                           adaptor.getRef(), tensorType,
+                                           /*writable=*/false);
+    rewriter.replaceOp(op, value);
+    return mlir::success();
+  }
+};
+
 struct ReussirArrayWithUniqueViewOpRewritePattern
     : public mlir::OpConversionPattern<ReussirArrayWithUniqueViewOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -628,9 +675,9 @@ struct ReussirArrayWithUniqueViewOpRewritePattern
       auto borrowedType = RefType::get(rewriter.getContext(), arrayType);
       auto borrowed =
           rewriter.create<ReussirRcBorrowOp>(loc, borrowedType, array);
-      return rewriter
-          .create<ReussirArrayViewOp>(loc, viewType, borrowed.getResult())
-          .getResult();
+      return materializeArrayViewValue(loc, rewriter, arrayType,
+                                       borrowed.getResult(), viewType,
+                                       /*writable=*/true);
     };
 
     auto makeClonedArray =
@@ -677,8 +724,9 @@ struct ReussirArrayWithUniqueViewOpRewritePattern
 
     rewriter.setInsertionPointToStart(&scfIfOp.getElseRegion().front());
     auto [clonedArray, clonedRef] = makeClonedArray();
-    auto clonedView =
-        rewriter.create<ReussirArrayViewOp>(loc, viewType, clonedRef).getView();
+    auto clonedView = materializeArrayViewValue(loc, rewriter, arrayType,
+                                                clonedRef, viewType,
+                                                /*writable=*/true);
     cloneArrayWithUniqueViewBody(op, clonedArray, clonedView, rewriter);
 
     rewriter.replaceOp(op, scfIfOp.getResults());
@@ -876,10 +924,16 @@ struct SCFOpsLoweringPass
 
     populateSCFOpsLoweringConversionPatterns(patterns);
 
-    target.addLegalDialect<mlir::arith::ArithDialect, mlir::memref::MemRefDialect,
-                           mlir::scf::SCFDialect, mlir::math::MathDialect,
-                           mlir::func::FuncDialect, mlir::ub::UBDialect,
-                           reussir::ReussirDialect>();
+    target.addLegalDialect<mlir::arith::ArithDialect,
+                           mlir::bufferization::BufferizationDialect,
+                           mlir::func::FuncDialect, mlir::linalg::LinalgDialect,
+                           mlir::math::MathDialect, mlir::memref::MemRefDialect,
+                           mlir::scf::SCFDialect, mlir::tensor::TensorDialect,
+                           mlir::ub::UBDialect, reussir::ReussirDialect>();
+    target.addDynamicallyLegalOp<ReussirArrayViewOp>(
+        [](ReussirArrayViewOp op) {
+          return llvm::isa<mlir::MemRefType>(op.getView().getType());
+        });
 
     target.addIllegalOp<ReussirNullableDispatchOp, ReussirRecordDispatchOp,
                         ReussirScfYieldOp, ReussirClosureUniqifyOp,
@@ -899,6 +953,7 @@ void populateSCFOpsLoweringConversionPatterns(
   // Add conversion patterns for Reussir SCF operations
   patterns
       .add<ReussirNullableDispatchOpRewritePattern,
+           ReussirArrayViewOpRewritePattern,
            ReussirRecordDispatchOpRewritePattern,
            ReussirClosureUniqifyOpRewritePattern,
            ReussirArrayWithUniqueViewOpRewritePattern,

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -53,6 +53,35 @@ static mlir::MemRefType getArrayViewMemRefType(ArrayType arrayType) {
   return mlir::MemRefType::get(arrayType.getShape(), arrayType.getElementType());
 }
 
+static mlir::RankedTensorType getArrayViewTensorType(ArrayType arrayType) {
+  return mlir::RankedTensorType::get(arrayType.getShape(),
+                                     arrayType.getElementType());
+}
+
+static mlir::LogicalResult verifyArrayViewType(mlir::Operation *op,
+                                               mlir::Type type,
+                                               ArrayType arrayType,
+                                               llvm::StringRef valueName) {
+  if (auto memrefType = llvm::dyn_cast<mlir::MemRefType>(type)) {
+    if (memrefType != getArrayViewMemRefType(arrayType))
+      return op->emitOpError(valueName) << " type mismatch: expected "
+                                        << getArrayViewMemRefType(arrayType)
+                                        << ", got " << memrefType;
+    return mlir::success();
+  }
+
+  if (auto tensorType = llvm::dyn_cast<mlir::RankedTensorType>(type)) {
+    if (tensorType != getArrayViewTensorType(arrayType))
+      return op->emitOpError(valueName) << " type mismatch: expected "
+                                        << getArrayViewTensorType(arrayType)
+                                        << ", got " << tensorType;
+    return mlir::success();
+  }
+
+  return op->emitOpError(valueName)
+         << " must be a statically shaped memref or tensor";
+}
+
 mlir::LogicalResult verifyRcCreateLikeOp(mlir::Operation *op, RcType rcType,
                                          mlir::Type valueType,
                                          mlir::Value token,
@@ -767,13 +796,8 @@ mlir::LogicalResult ReussirArrayViewOp::verify() {
   ArrayType arrayType = llvm::dyn_cast<ArrayType>(refType.getElementType());
   if (!arrayType)
     return emitOpError("array.view input must be a reference to a reussir.array");
-  auto memrefType = llvm::dyn_cast<mlir::MemRefType>(getView().getType());
-  if (!memrefType)
-    return emitOpError("array.view result must be a statically shaped memref");
-  if (memrefType != getArrayViewMemRefType(arrayType))
-    return emitOpError("array.view result type mismatch: expected ")
-           << getArrayViewMemRefType(arrayType) << ", got " << memrefType;
-  return mlir::success();
+  return verifyArrayViewType(getOperation(), getView().getType(), arrayType,
+                             "array.view result");
 }
 
 mlir::LogicalResult ReussirArrayProjectOp::verify() {
@@ -832,12 +856,9 @@ mlir::LogicalResult ReussirArrayWithUniqueViewOp::verify() {
   if (block.empty() || !llvm::isa<ReussirScfYieldOp>(block.getTerminator()))
     return emitOpError("body region must terminate with reussir.scf.yield");
 
-  auto memrefType = llvm::dyn_cast<mlir::MemRefType>(block.getArgument(0).getType());
-  if (!memrefType)
-    return emitOpError("body argument must be a statically shaped memref");
-  if (memrefType != getArrayViewMemRefType(arrayType))
-    return emitOpError("body argument view type mismatch: expected ")
-           << getArrayViewMemRefType(arrayType) << ", got " << memrefType;
+  if (failed(verifyArrayViewType(getOperation(), block.getArgument(0).getType(),
+                                 arrayType, "body argument view")))
+    return mlir::failure();
 
   auto yieldOp = llvm::cast<ReussirScfYieldOp>(block.getTerminator());
   if (getResult() && yieldOp.getNumOperands() == 0 &&

--- a/tests/integration/conversion/array_tensor_view.mlir
+++ b/tests/integration/conversion/array_tensor_view.mlir
@@ -1,0 +1,49 @@
+// RUN: %reussir-opt %s --reussir-lowering-scf-ops | %FileCheck %s
+
+!arr4 = !reussir.array<4 x i8>
+!rc_arr4 = !reussir.rc<!arr4>
+
+module {
+  func.func @borrow_tensor(%xs: !rc_arr4) -> i8 {
+    %borrow = reussir.rc.borrow (%xs : !rc_arr4) : !reussir.ref<!arr4>
+    %view = reussir.array.view(%borrow : !reussir.ref<!arr4>) : tensor<4xi8>
+    %c0 = arith.constant 0 : index
+    %value = tensor.extract %view[%c0] : tensor<4xi8>
+    return %value : i8
+  }
+
+  func.func @update0_tensor(%xs: !rc_arr4) -> i8 {
+    %res = reussir.array.with_unique_view (%xs : !rc_arr4) -> i8 {
+      ^bb0(%view: tensor<4xi8>):
+        %zero = arith.constant 0 : i8
+        %filled = linalg.fill ins(%zero : i8) outs(%view : tensor<4xi8>) -> tensor<4xi8>
+        %c0 = arith.constant 0 : index
+        %loaded = tensor.extract %filled[%c0] : tensor<4xi8>
+        reussir.scf.yield %loaded : i8
+    }
+    return %res : i8
+  }
+}
+
+// CHECK-LABEL: func.func @borrow_tensor(
+// CHECK: %[[BORROW:.+]] = reussir.rc.borrow
+// CHECK: %[[MEMREF:.+]] = reussir.array.view(%[[BORROW]] : !reussir.ref<!reussir.array<4 x i8>>) : memref<4xi8>
+// CHECK: %[[TENSOR:.+]] = bufferization.to_tensor %[[MEMREF]] restrict : memref<4xi8> to tensor<4xi8>
+// CHECK: %[[VALUE:.+]] = tensor.extract %[[TENSOR]]
+// CHECK: return %[[VALUE]] : i8
+
+// CHECK-LABEL: func.func @update0_tensor(
+// CHECK: %[[IS_UNIQUE:.+]] = reussir.rc.is_unique
+// CHECK: %[[RESULT:.+]] = scf.if %[[IS_UNIQUE]] -> (i8) {
+// CHECK: %[[BORROWED:.+]] = reussir.rc.borrow
+// CHECK: %[[VIEW_MEMREF:.+]] = reussir.array.view(%[[BORROWED]] : !reussir.ref<!reussir.array<4 x i8>>) : memref<4xi8>
+// CHECK: %[[VIEW_TENSOR:.+]] = bufferization.to_tensor %[[VIEW_MEMREF]] restrict writable : memref<4xi8> to tensor<4xi8>
+// CHECK: %[[FILLED:.+]] = linalg.fill ins(%{{.+}} : i8) outs(%[[VIEW_TENSOR]] : tensor<4xi8>) -> tensor<4xi8>
+// CHECK: tensor.extract %[[FILLED]]
+// CHECK: } else {
+// CHECK: %[[CLONED_BORROW:.+]] = reussir.rc.borrow(%{{.+}} : !reussir.rc<!reussir.array<4 x i8>>) : !reussir.ref<!reussir.array<4 x i8>>
+// CHECK: %[[CLONED_VIEW_MEMREF:.+]] = reussir.array.view(%{{.+}} : !reussir.ref<!reussir.array<4 x i8>>) : memref<4xi8>
+// CHECK: %[[CLONED_VIEW_TENSOR:.+]] = bufferization.to_tensor %[[CLONED_VIEW_MEMREF]] restrict writable : memref<4xi8> to tensor<4xi8>
+// CHECK: linalg.fill ins(%{{.+}} : i8) outs(%[[CLONED_VIEW_TENSOR]] : tensor<4xi8>) -> tensor<4xi8>
+// CHECK: }
+// CHECK: return %[[RESULT]] : i8

--- a/tests/integration/conversion/array_tensor_view_e2e.mlir
+++ b/tests/integration/conversion/array_tensor_view_e2e.mlir
@@ -1,0 +1,130 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-closure-outlining,reussir-lowering-region-patterns,func.func(reussir-inc-dec-cancellation),reussir-rc-decrement-expansion,func.func(reussir-infer-variant-tag),reussir-acquire-drop-expansion,reussir-lowering-scf-ops,func.func(reussir-inc-dec-cancellation),reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-lowering-scf-ops,func.func(reussir-rc-create-sink),func.func(reussir-rc-create-fusion),reussir-trmc-recursion-analysis,reussir-compile-polymorphic-ffi,canonicalize,cse,one-shot-bufferize{allow-unknown-ops},canonicalize,cse,convert-linalg-to-loops,convert-bufferization-to-memref,canonicalize,cse)' \
+// RUN:   | %FileCheck %s --check-prefix=LOOPS
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-closure-outlining,reussir-lowering-region-patterns,func.func(reussir-inc-dec-cancellation),reussir-rc-decrement-expansion,func.func(reussir-infer-variant-tag),reussir-acquire-drop-expansion,reussir-lowering-scf-ops,func.func(reussir-inc-dec-cancellation),reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-lowering-scf-ops,func.func(reussir-rc-create-sink),func.func(reussir-rc-create-fusion),reussir-trmc-recursion-analysis,reussir-compile-polymorphic-ffi,canonicalize,cse,one-shot-bufferize{allow-unknown-ops},canonicalize,cse,convert-linalg-to-loops,convert-bufferization-to-memref,canonicalize,control-flow-sink,convert-scf-to-cf,reussir-lowering-basic-ops,convert-cf-to-llvm,reconcile-unrealized-casts,cse,canonicalize)' \
+// RUN:   -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O3 -o %t.ll
+// RUN: %llc %t.ll -relocation-model=pic -filetype=obj -o %t.o
+// RUN: %cc %t.o -o %t.exe -L%library_path -lreussir_rt \
+// RUN:   %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+!mat2 = !reussir.array<2 x 2 x i32>
+!rc_mat2 = !reussir.rc<!mat2>
+
+module {
+  func.func private @make_zero_matrix() -> !rc_mat2 attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %poison = ub.poison : !mat2
+    %xs = reussir.rc.create value(%poison : !mat2) : !rc_mat2
+    %zeroed = reussir.array.with_unique_view (%xs : !rc_mat2) -> !rc_mat2 {
+      ^bb0(%view: memref<2x2xi32>):
+        %c0 = arith.constant 0 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        %zero = arith.constant 0 : i32
+        scf.for %i = %c0 to %c2 step %c1 {
+          scf.for %j = %c0 to %c2 step %c1 {
+            memref.store %zero, %view[%i, %j] : memref<2x2xi32>
+          }
+        }
+        reussir.scf.yield
+    }
+    return %zeroed : !rc_mat2
+  }
+
+  func.func private @write_matmul_result(%xs: !rc_mat2) -> !rc_mat2 attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %updated = reussir.array.with_unique_view (%xs : !rc_mat2) -> !rc_mat2 {
+      ^bb0(%view: tensor<2x2xi32>):
+        %lhs = arith.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>
+        %rhs = arith.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi32>
+        %product = linalg.matmul
+          ins(%lhs, %rhs : tensor<2x2xi32>, tensor<2x2xi32>)
+          outs(%view : tensor<2x2xi32>) -> tensor<2x2xi32>
+        %materialized = bufferization.materialize_in_destination %product in %view
+          : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %head = tensor.extract %materialized[%c0, %c0] : tensor<2x2xi32>
+        %tail = tensor.extract %materialized[%c1, %c1] : tensor<2x2xi32>
+        %c19 = arith.constant 19 : i32
+        %c50 = arith.constant 50 : i32
+        %head_failed = arith.cmpi ne, %head, %c19 : i32
+        scf.if %head_failed {
+          reussir.panic "matmul materialization produced the wrong [0,0] entry"
+        }
+        %tail_failed = arith.cmpi ne, %tail, %c50 : i32
+        scf.if %tail_failed {
+          reussir.panic "matmul materialization produced the wrong [1,1] entry"
+        }
+        reussir.scf.yield
+    }
+    return %updated : !rc_mat2
+  }
+
+  func.func private @read00_tensor(%xs: !rc_mat2) -> i32 attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %borrow = reussir.rc.borrow (%xs : !rc_mat2) : !reussir.ref<!mat2>
+    %view = reussir.array.view(%borrow : !reussir.ref<!mat2>) : tensor<2x2xi32>
+    %c0 = arith.constant 0 : index
+    %value = tensor.extract %view[%c0, %c0] : tensor<2x2xi32>
+    return %value : i32
+  }
+
+  func.func private @read11_tensor(%xs: !rc_mat2) -> i32 attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %borrow = reussir.rc.borrow (%xs : !rc_mat2) : !reussir.ref<!mat2>
+    %view = reussir.array.view(%borrow : !reussir.ref<!mat2>) : tensor<2x2xi32>
+    %c1 = arith.constant 1 : index
+    %value = tensor.extract %view[%c1, %c1] : tensor<2x2xi32>
+    return %value : i32
+  }
+
+  func.func @main() -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    %c19 = arith.constant 19 : i32
+    %c50 = arith.constant 50 : i32
+
+    %unique = func.call @make_zero_matrix() : () -> !rc_mat2
+    %unique_updated = func.call @write_matmul_result(%unique) : (!rc_mat2) -> !rc_mat2
+    %unique_head = func.call @read00_tensor(%unique_updated) : (!rc_mat2) -> i32
+    %unique_head_failed = arith.cmpi ne, %unique_head, %c19 : i32
+    scf.if %unique_head_failed {
+      reussir.panic "unique matmul result did not persist at [0,0]"
+    }
+    %unique_tail = func.call @read11_tensor(%unique_updated) : (!rc_mat2) -> i32
+    %unique_tail_failed = arith.cmpi ne, %unique_tail, %c50 : i32
+    scf.if %unique_tail_failed {
+      reussir.panic "unique matmul result did not persist at [1,1]"
+    }
+    reussir.rc.dec (%unique_updated : !rc_mat2)
+
+    %shared = func.call @make_zero_matrix() : () -> !rc_mat2
+    reussir.rc.inc (%shared : !rc_mat2)
+    %shared_updated = func.call @write_matmul_result(%shared) : (!rc_mat2) -> !rc_mat2
+    %shared_original_head = func.call @read00_tensor(%shared) : (!rc_mat2) -> i32
+    %shared_original_failed = arith.cmpi ne, %shared_original_head, %c0_i32 : i32
+    scf.if %shared_original_failed {
+      reussir.panic "shared source matrix was mutated"
+    }
+    %shared_updated_head = func.call @read00_tensor(%shared_updated) : (!rc_mat2) -> i32
+    %shared_updated_head_failed = arith.cmpi ne, %shared_updated_head, %c19 : i32
+    scf.if %shared_updated_head_failed {
+      reussir.panic "shared matmul clone result did not persist at [0,0]"
+    }
+    %shared_updated_tail = func.call @read11_tensor(%shared_updated) : (!rc_mat2) -> i32
+    %shared_updated_tail_failed = arith.cmpi ne, %shared_updated_tail, %c50 : i32
+    scf.if %shared_updated_tail_failed {
+      reussir.panic "shared matmul clone result did not persist at [1,1]"
+    }
+    reussir.rc.dec (%shared : !rc_mat2)
+    reussir.rc.dec (%shared_updated : !rc_mat2)
+
+    return %c0_i32 : i32
+  }
+}
+
+// LOOPS-LABEL: func.func private @write_matmul_result(
+// LOOPS-NOT: linalg.
+// LOOPS-NOT: scf.parallel
+// LOOPS: scf.for
+// LOOPS: memref.load
+// LOOPS: memref.store

--- a/tests/unittest/cases/array.cpp
+++ b/tests/unittest/cases/array.cpp
@@ -1,6 +1,7 @@
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
 #include <gtest/gtest.h>
+#include <mlir/IR/Verifier.h>
 
 import reussir.test;
 import reussir.test.value;
@@ -84,5 +85,41 @@ TEST_F(ReussirValueTransformTest, RefToNestedArrayOfRcAcquisition) {
         EXPECT_EQ(projectCount, 6u);
         EXPECT_EQ(incCount, 4u);
       });
+}
+
+TEST_F(ReussirTest, ArrayViewAllowsTensorResult) {
+  withModule(R"(
+!arr4 = !reussir.array<4 x i8>
+
+module {
+  func.func @borrow_tensor(%xs : !reussir.ref<!arr4>) -> tensor<4xi8> {
+    %view = reussir.array.view(%xs : !reussir.ref<!arr4>) : tensor<4xi8>
+    return %view : tensor<4xi8>
+  }
+}
+)",
+             [](mlir::ModuleOp module) {
+               EXPECT_TRUE(mlir::succeeded(mlir::verify(module)));
+             });
+}
+
+TEST_F(ReussirTest, ArrayWithUniqueViewAllowsTensorBodyArgument) {
+  withModule(R"(
+!arr4 = !reussir.array<4 x i8>
+!rc_arr4 = !reussir.rc<!arr4>
+
+module {
+  func.func @borrow_tensor(%xs : !rc_arr4) -> !rc_arr4 {
+    %updated = reussir.array.with_unique_view (%xs : !rc_arr4) -> !rc_arr4 {
+      ^bb0(%view: tensor<4xi8>):
+        reussir.scf.yield
+    }
+    return %updated : !rc_arr4
+  }
+}
+)",
+             [](mlir::ModuleOp module) {
+               EXPECT_TRUE(mlir::succeeded(mlir::verify(module)));
+             });
 }
 } // namespace reussir


### PR DESCRIPTION
## Summary
- allow reussir.array.view and reussir.array.with_unique_view to expose tensor views by materializing memref views behind bufferization.to_tensor
- make unique tensor views lower through bufferization.to_tensor with restrict writable and guard basic lowering from unbufferized tensor views
- add verifier coverage plus conversion and end-to-end tests, including a linalg.matmul example using bufferization.materialize_in_destination that lowers to single-threaded loops

## Testing
- ninja -C build reussir-opt reussir-ut
- build/bin/reussir-ut (from build/)
- ninja check

## Notes
- ninja check still has existing frontend/repl failures in this environment because reussir-compiler, reussir-elab, and reussir-repl cannot load libLLVM.so.21.1
- the new conversion tests pass: conversion/array_tensor_view.mlir and conversion/array_tensor_view_e2e.mlir