### PR TITLE
Add filesystem-based module system with mod declarations

### DIFF
--- a/frontend/reussir-core/app/Compiler.hs
+++ b/frontend/reussir-core/app/Compiler.hs
@@ -21,7 +21,12 @@ import Reussir.Bridge qualified as B
 import Reussir.Codegen qualified as C
 
 import Reussir.Core (translatePackageToModule, translateProgToModule)
-import Reussir.Core.Module (PackageInfo (..), discoverPackageFiles)
+import Reussir.Core.Module (
+    PackageInfo (..),
+    discoverPackageFiles,
+    renderDiscoveryError,
+    validatePackageInfo,
+ )
 import Reussir.Parser.Types.Lexer (Identifier (..))
 
 data Args = Args
@@ -218,8 +223,14 @@ compileSingleFile args inputFile = do
 
 compilePackage :: Args -> FilePath -> String -> IO ()
 compilePackage args root pkgName = do
-    let pkgInfo = PackageInfo root (Identifier (T.pack pkgName))
-    discoveredFiles <- discoverPackageFiles pkgInfo
+    let rawPkgInfo = PackageInfo root (Identifier (T.pack pkgName))
+    pkgInfo <- case validatePackageInfo rawPkgInfo of
+        Left err -> putStrLn err >> exitFailure
+        Right valid -> return valid
+    discoveryResult <- discoverPackageFiles pkgInfo
+    discoveredFiles <- case discoveryResult of
+        Left err -> putStrLn (renderDiscoveryError err) >> exitFailure
+        Right files -> return files
     when (null discoveredFiles) $ do
         putStrLn $ "Error: no .rr files found in " ++ root
         exitFailure

--- a/frontend/reussir-core/app/Compiler.hs
+++ b/frontend/reussir-core/app/Compiler.hs
@@ -2,6 +2,7 @@
 
 module Main where
 
+import Control.Monad (forM, when)
 import Data.Char (toLower)
 import Effectful (liftIO, runEff)
 import Effectful.Prim (runPrim)
@@ -19,10 +20,12 @@ import Effectful.Log qualified as L
 import Reussir.Bridge qualified as B
 import Reussir.Codegen qualified as C
 
-import Reussir.Core (translateProgToModule)
+import Reussir.Core (translatePackageToModule, translateProgToModule)
+import Reussir.Core.Module (PackageInfo (..), discoverPackageFiles)
+import Reussir.Parser.Types.Lexer (Identifier (..))
 
 data Args = Args
-    { argInputFile :: FilePath
+    { argInputFile :: Maybe FilePath
     , argOutputFile :: FilePath
     , argOptLevel :: B.OptOption
     , argOutputTarget :: OutputTarget
@@ -34,12 +37,14 @@ data Args = Args
     , argRelocationMode :: B.RelocationModel
     , argReuseTokenAcrossCall :: Bool
     , argDisableInvariantAnalysis :: Bool
+    , argPackageRoot :: Maybe FilePath
+    , argPackageName :: Maybe String
     }
 
 argsParser :: Parser Args
 argsParser =
     Args
-        <$> strArgument (metavar "INPUT" <> help "Input file")
+        <$> optional (strArgument (metavar "INPUT" <> help "Input file (single-file mode)"))
         <*> strOption (long "output" <> short 'o' <> metavar "OUTPUT" <> help "Output file")
         <*> option
             parseOptLevel
@@ -84,6 +89,10 @@ argsParser =
             ( long "disable-invariant-analysis"
                 <> help "Disable the invariant group analysis pass in backend lowering"
             )
+        <*> optional
+            (strOption (long "package-root" <> metavar "DIR" <> help "Package root directory (multi-file mode)"))
+        <*> optional
+            (strOption (long "package-name" <> metavar "NAME" <> help "Package name (required with --package-root)"))
 
 parseOptLevel :: ReadM B.OptOption
 parseOptLevel = eitherReader $ \s -> case s of
@@ -127,31 +136,58 @@ parseRelocationMode = eitherReader $ \s -> case map toLower s of
     "ropi_rwpi" -> Right B.RelocationModelROPI_RWPI
     _ -> Left $ "Unknown relocation mode: " ++ s
 
+-- | Build a TargetSpec from the common arguments and a given file path.
+makeTargetSpec :: Args -> FilePath -> TargetSpec
+makeTargetSpec args filePath =
+    TargetSpec
+        { programName = T.pack (argModuleName args)
+        , outputPath = argOutputFile args
+        , optimization = argOptLevel args
+        , outputTarget = case argOutputTarget args of
+            MLIR -> B.OutputObject
+            Backend t -> t
+        , logLevel = argLogLevel args
+        , moduleFilePath = filePath
+        , targetTriple = T.pack <$> argTargetTriple args
+        , targetCPU = T.pack <$> argTargetCPU args
+        , targetFeatures = T.pack <$> argTargetFeatures args
+        }
+
 main :: IO ()
 main = do
     args <- execParser opts
-    content <- TIO.readFile (argInputFile args)
-    case runParser parseProg (argInputFile args) content of
+    case (argPackageRoot args, argPackageName args) of
+        (Just root, Just pkgName) -> compilePackage args root pkgName
+        (Just _, Nothing) -> do
+            putStrLn "Error: --package-name is required when --package-root is specified"
+            exitFailure
+        (Nothing, Just _) -> do
+            putStrLn "Error: --package-root is required when --package-name is specified"
+            exitFailure
+        (Nothing, Nothing) -> case argInputFile args of
+            Just inputFile -> compileSingleFile args inputFile
+            Nothing -> do
+                putStrLn "Error: either INPUT file or --package-root/--package-name must be specified"
+                exitFailure
+  where
+    opts =
+        info
+            (argsParser <**> helper)
+            ( fullDesc
+                <> progDesc "Compile a Reussir file"
+                <> header "reussir-compiler - Reussir Compiler"
+            )
+
+compileSingleFile :: Args -> FilePath -> IO ()
+compileSingleFile args inputFile = do
+    content <- TIO.readFile inputFile
+    case runParser parseProg inputFile content of
         Left err -> do
             putStrLn (errorBundlePretty err)
             exitFailure
         Right prog -> do
             let outputTarget = argOutputTarget args
-            let outputTarget' = case outputTarget of
-                    MLIR -> B.OutputObject
-                    Backend t -> t
-            let spec =
-                    TargetSpec
-                        { programName = T.pack (argModuleName args)
-                        , outputPath = argOutputFile args
-                        , optimization = argOptLevel args
-                        , outputTarget = outputTarget'
-                        , logLevel = argLogLevel args
-                        , moduleFilePath = argInputFile args
-                        , targetTriple = T.pack <$> argTargetTriple args
-                        , targetCPU = T.pack <$> argTargetCPU args
-                        , targetFeatures = T.pack <$> argTargetFeatures args
-                        }
+            let spec = makeTargetSpec args inputFile
 
             B.withReussirLogger (argLogLevel args) "reussir-compiler" $ \logger -> do
                 runEff $ L.runLog "reussir-compiler" logger (toEffLogLevel (argLogLevel args)) $ do
@@ -179,18 +215,58 @@ main = do
                                         (argRelocationMode args)
                                         (argReuseTokenAcrossCall args)
                                         (not (argDisableInvariantAnalysis args))
-  where
-    toEffLogLevel :: B.LogLevel -> LogLevel
-    toEffLogLevel = \case
-        B.LogError -> LogAttention
-        B.LogWarning -> LogAttention
-        B.LogInfo -> LogInfo
-        B.LogDebug -> LogTrace
-        B.LogTrace -> LogTrace
-    opts =
-        info
-            (argsParser <**> helper)
-            ( fullDesc
-                <> progDesc "Compile a Reussir file"
-                <> header "reussir-compiler - Reussir Compiler"
-            )
+
+compilePackage :: Args -> FilePath -> String -> IO ()
+compilePackage args root pkgName = do
+    let pkgInfo = PackageInfo root (Identifier (T.pack pkgName))
+    discoveredFiles <- discoverPackageFiles pkgInfo
+    when (null discoveredFiles) $ do
+        putStrLn $ "Error: no .rr files found in " ++ root
+        exitFailure
+    parsedFiles <- forM discoveredFiles $ \(fp, modPath) -> do
+        content <- TIO.readFile fp
+        case runParser parseProg fp content of
+            Left err -> do
+                putStrLn (errorBundlePretty err)
+                exitFailure
+            Right prog -> return (fp, modPath, prog)
+    let primaryFile = case discoveredFiles of
+            ((fp, _) : _) -> fp
+            [] -> root
+    let outputTarget = argOutputTarget args
+    let spec = makeTargetSpec args primaryFile
+
+    B.withReussirLogger (argLogLevel args) "reussir-compiler" $ \logger -> do
+        runEff $ L.runLog "reussir-compiler" logger (toEffLogLevel (argLogLevel args)) $ do
+            irModule <- runPrim $ translatePackageToModule spec parsedFiles
+            case irModule of
+                Nothing -> liftIO exitFailure
+                Just module' -> case outputTarget of
+                    MLIR -> do
+                        mlirText <- C.emitModuleToText module'
+                        liftIO $ TIO.writeFile (argOutputFile args) mlirText
+                    Backend target -> do
+                        mlirText <- C.emitModuleToText module'
+                        liftIO $
+                            B.compileForTargetWithModels
+                                (TE.encodeUtf8 mlirText)
+                                (argModuleName args)
+                                (argOutputFile args)
+                                target
+                                (argOptLevel args)
+                                (argLogLevel args)
+                                (TE.encodeUtf8 . T.pack <$> argTargetTriple args)
+                                (TE.encodeUtf8 . T.pack <$> argTargetCPU args)
+                                (TE.encodeUtf8 . T.pack <$> argTargetFeatures args)
+                                B.CodeModelDefault
+                                (argRelocationMode args)
+                                (argReuseTokenAcrossCall args)
+                                (not (argDisableInvariantAnalysis args))
+
+toEffLogLevel :: B.LogLevel -> LogLevel
+toEffLogLevel = \case
+    B.LogError -> LogAttention
+    B.LogWarning -> LogAttention
+    B.LogInfo -> LogInfo
+    B.LogDebug -> LogTrace
+    B.LogTrace -> LogTrace

--- a/frontend/reussir-core/app/Elab.hs
+++ b/frontend/reussir-core/app/Elab.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Control.Monad (forM_)
+import Control.Monad (forM, forM_, when)
 import Data.List (nub)
 import Effectful (inject, liftIO, runEff)
 import Effectful.Prim (runPrim)
@@ -12,7 +12,7 @@ import Prettyprinter (hardline, unAnnotate)
 import Prettyprinter.Render.Terminal (putDoc)
 import Reussir.Diagnostic (createRepository, displayReport)
 import Reussir.Parser.Prog (parseProg)
-import Reussir.Parser.Types.Lexer (WithSpan (..))
+import Reussir.Parser.Types.Lexer (Identifier (..), WithSpan (..))
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (hIsTerminalDevice, hPutStrLn, stdout)
 import Text.Megaparsec (errorBundlePretty, runParser)
@@ -31,10 +31,12 @@ import Reussir.Core.Data.Semi.Context (SemiContext (..))
 import Reussir.Core.Data.Semi.Function (FunctionTable (..))
 import Reussir.Core.Full.Context (reportAllErrors)
 import Reussir.Core.Full.Conversion (convertCtx)
+import Reussir.Core.Module (PackageInfo (..), discoverPackageFiles)
 import Reussir.Core.Semi.Context (
     emptySemiContext,
     populateRecordFields,
     scanStmt,
+    withModuleFile,
  )
 import Reussir.Core.Semi.FlowAnalysis (solveAllGenerics)
 import Reussir.Core.Semi.Tyck (checkFuncType)
@@ -48,7 +50,9 @@ data ElabMode = SemiMode | FullMode
 
 data Args = Args
     { elabMode :: ElabMode
-    , inputFile :: FilePath
+    , inputFile :: Maybe FilePath
+    , argPackageRoot :: Maybe FilePath
+    , argPackageName :: Maybe String
     }
 
 elabModeReader :: ReadM ElabMode
@@ -67,7 +71,11 @@ argsParser =
                 <> metavar "MODE"
                 <> help "Elaboration mode: 'semi' or 'full'"
             )
-        <*> strArgument (metavar "FILE" <> help "Input file")
+        <*> optional (strArgument (metavar "FILE" <> help "Input file (single-file mode)"))
+        <*> optional
+            (strOption (long "package-root" <> metavar "DIR" <> help "Package root directory (multi-file mode)"))
+        <*> optional
+            (strOption (long "package-name" <> metavar "NAME" <> help "Package name (required with --package-root)"))
 
 tyckBridgeLogLevel :: B.LogLevel
 tyckBridgeLogLevel = B.LogWarning
@@ -87,14 +95,19 @@ unspanStmt stmt = stmt
 main :: IO ()
 main = do
     args <- execParser opts
-    content <- TIO.readFile (inputFile args)
-    case runParser parseProg (inputFile args) content of
-        Left err -> do
-            putStrLn (errorBundlePretty err)
+    case (argPackageRoot args, argPackageName args) of
+        (Just root, Just pkgName) -> elabPackage args root pkgName
+        (Just _, Nothing) -> do
+            putStrLn "Error: --package-name is required when --package-root is specified"
             exitFailure
-        Right prog -> case elabMode args of
-            SemiMode -> runSemiElab args prog
-            FullMode -> runFullElab args prog
+        (Nothing, Just _) -> do
+            putStrLn "Error: --package-root is required when --package-name is specified"
+            exitFailure
+        (Nothing, Nothing) -> case inputFile args of
+            Just fp -> elabSingleFile args fp
+            Nothing -> do
+                putStrLn "Error: either FILE or --package-root/--package-name must be specified"
+                exitFailure
   where
     opts =
         info
@@ -104,28 +117,70 @@ main = do
                 <> header "reussir-elab - Reussir Elaborator"
             )
 
-runSemiElab :: Args -> [Syn.Stmt] -> IO ()
-runSemiElab args prog = do
-    repository <- runEff $ createRepository [inputFile args]
+elabSingleFile :: Args -> FilePath -> IO ()
+elabSingleFile args fp = do
+    content <- TIO.readFile fp
+    case runParser parseProg fp content of
+        Left err -> do
+            putStrLn (errorBundlePretty err)
+            exitFailure
+        Right prog -> case elabMode args of
+            SemiMode -> runSemiElab args [(fp, [], prog)]
+            FullMode -> runFullElab args [(fp, [], prog)]
+
+elabPackage :: Args -> FilePath -> String -> IO ()
+elabPackage args root pkgName = do
+    let pkgInfo = PackageInfo root (Identifier (T.pack pkgName))
+    discoveredFiles <- discoverPackageFiles pkgInfo
+    when (null discoveredFiles) $ do
+        putStrLn $ "Error: no .rr files found in " ++ root
+        exitFailure
+    parsedFiles <- forM discoveredFiles $ \(fp, modPath) -> do
+        content <- TIO.readFile fp
+        case runParser parseProg fp content of
+            Left err -> do
+                putStrLn (errorBundlePretty err)
+                exitFailure
+            Right prog -> return (fp, modPath, prog)
+    case elabMode args of
+        SemiMode -> runSemiElab args parsedFiles
+        FullMode -> runFullElab args parsedFiles
+
+runSemiElab :: Args -> [(FilePath, [Identifier], [Syn.Stmt])] -> IO ()
+runSemiElab _args files = do
+    let allFilePaths = map (\(fp, _, _) -> fp) files
+    let primaryFilePath = case files of
+            ((fp, _, _) : _) -> fp
+            [] -> "<unknown>"
+    let primaryModPath = case files of
+            ((_, mp, _) : _) -> mp
+            [] -> []
+    repository <- runEff $ createRepository allFilePaths
     ((), finalState) <- L.withStdOutLogger $ \logger -> do
         runEff $ L.runLog (T.pack "reussir-elab") logger (toEffLogLevel tyckBridgeLogLevel) $ do
-            initState <- runPrim $ emptySemiContext tyckBridgeLogLevel (inputFile args)
+            initState <- runPrim $ emptySemiContext tyckBridgeLogLevel primaryFilePath primaryModPath
             runPrim $ runState initState $ do
                 -- Scan all statements
-                forM_ prog $ \stmt -> inject $ scanStmt stmt
+                forM_ files $ \(fp, modPath, prog) ->
+                    inject $ withModuleFile fp modPath $
+                        forM_ prog $ \stmt -> inject $ scanStmt stmt
 
                 -- Populate record fields
-                forM_ prog $ \stmt -> inject $ populateRecordFields stmt
+                forM_ files $ \(fp, modPath, prog) ->
+                    inject $ withModuleFile fp modPath $
+                        forM_ prog $ \stmt -> inject $ populateRecordFields stmt
 
                 -- Elaborate all functions
-                forM_ prog $ \stmt -> do
-                    case unspanStmt stmt of
-                        Syn.FunctionStmt f -> do
-                            _ <- inject $ checkFuncType f
-                            return ()
-                        Syn.ExternTrampolineStmt name abi target args' -> do
-                            inject $ resolveTrampoline name abi target args'
-                        _ -> return ()
+                forM_ files $ \(fp, modPath, prog) ->
+                    inject $ withModuleFile fp modPath $
+                        forM_ prog $ \stmt -> do
+                            case unspanStmt stmt of
+                                Syn.FunctionStmt f -> do
+                                    _ <- inject $ checkFuncType f
+                                    return ()
+                                Syn.ExternTrampolineStmt name abi target args' -> do
+                                    inject $ resolveTrampoline name abi target args'
+                                _ -> return ()
 
                 let putDoc' doc = do
                         isTTy <- liftIO $ hIsTerminalDevice stdout
@@ -168,29 +223,42 @@ runSemiElab args prog = do
         then exitSuccess
         else exitFailure
 
-runFullElab :: Args -> [Syn.Stmt] -> IO ()
-runFullElab args prog = do
-    repository <- runEff $ createRepository [inputFile args]
+runFullElab :: Args -> [(FilePath, [Identifier], [Syn.Stmt])] -> IO ()
+runFullElab _args files = do
+    let allFilePaths = map (\(fp, _, _) -> fp) files
+    let primaryFilePath = case files of
+            ((fp, _, _) : _) -> fp
+            [] -> "<unknown>"
+    let primaryModPath = case files of
+            ((_, mp, _) : _) -> mp
+            [] -> []
+    repository <- runEff $ createRepository allFilePaths
     (result, finalSemiCtx) <- L.withStdOutLogger $ \logger -> do
         runEff $ L.runLog (T.pack "reussir-elab") logger (toEffLogLevel tyckBridgeLogLevel) $ do
             -- 1. Semi Elab
-            initSemiState <- runPrim $ emptySemiContext tyckBridgeLogLevel (inputFile args)
-            ((slns), finalSemiState) <- runPrim $ runState initSemiState $ do
+            initSemiState <- runPrim $ emptySemiContext tyckBridgeLogLevel primaryFilePath primaryModPath
+            (slns, finalSemiState) <- runPrim $ runState initSemiState $ do
                 -- Scan all statements
-                forM_ prog $ \stmt -> inject $ scanStmt stmt
+                forM_ files $ \(fp, modPath, prog) ->
+                    inject $ withModuleFile fp modPath $
+                        forM_ prog $ \stmt -> inject $ scanStmt stmt
 
                 -- Populate record fields
-                forM_ prog $ \stmt -> inject $ populateRecordFields stmt
+                forM_ files $ \(fp, modPath, prog) ->
+                    inject $ withModuleFile fp modPath $
+                        forM_ prog $ \stmt -> inject $ populateRecordFields stmt
 
                 -- Elaborate all functions
-                forM_ prog $ \stmt -> do
-                    case unspanStmt stmt of
-                        Syn.FunctionStmt f -> do
-                            _ <- inject $ checkFuncType f
-                            return ()
-                        Syn.ExternTrampolineStmt name abi target args' -> do
-                            inject $ resolveTrampoline name abi target args'
-                        _ -> return ()
+                forM_ files $ \(fp, modPath, prog) ->
+                    inject $ withModuleFile fp modPath $
+                        forM_ prog $ \stmt -> do
+                            case unspanStmt stmt of
+                                Syn.FunctionStmt f -> do
+                                    _ <- inject $ checkFuncType f
+                                    return ()
+                                Syn.ExternTrampolineStmt name abi target args' -> do
+                                    inject $ resolveTrampoline name abi target args'
+                                _ -> return ()
 
                 -- Solve generics
                 inject solveAllGenerics

--- a/frontend/reussir-core/app/Elab.hs
+++ b/frontend/reussir-core/app/Elab.hs
@@ -31,7 +31,12 @@ import Reussir.Core.Data.Semi.Context (SemiContext (..))
 import Reussir.Core.Data.Semi.Function (FunctionTable (..))
 import Reussir.Core.Full.Context (reportAllErrors)
 import Reussir.Core.Full.Conversion (convertCtx)
-import Reussir.Core.Module (PackageInfo (..), discoverPackageFiles)
+import Reussir.Core.Module (
+    PackageInfo (..),
+    discoverPackageFiles,
+    renderDiscoveryError,
+    validatePackageInfo,
+ )
 import Reussir.Core.Semi.Context (
     emptySemiContext,
     populateRecordFields,
@@ -130,8 +135,14 @@ elabSingleFile args fp = do
 
 elabPackage :: Args -> FilePath -> String -> IO ()
 elabPackage args root pkgName = do
-    let pkgInfo = PackageInfo root (Identifier (T.pack pkgName))
-    discoveredFiles <- discoverPackageFiles pkgInfo
+    let rawPkgInfo = PackageInfo root (Identifier (T.pack pkgName))
+    pkgInfo <- case validatePackageInfo rawPkgInfo of
+        Left err -> putStrLn err >> exitFailure
+        Right valid -> return valid
+    discoveryResult <- discoverPackageFiles pkgInfo
+    discoveredFiles <- case discoveryResult of
+        Left err -> putStrLn (renderDiscoveryError err) >> exitFailure
+        Right files -> return files
     when (null discoveredFiles) $ do
         putStrLn $ "Error: no .rr files found in " ++ root
         exitFailure

--- a/frontend/reussir-core/reussir-core.cabal
+++ b/frontend/reussir-core/reussir-core.cabal
@@ -85,6 +85,7 @@ library
                       text,
                       unordered-containers,
                       containers,
+                      transformers,
                       hashable,
                       xxhash-ffi,
                       scientific,
@@ -155,6 +156,7 @@ test-suite reussir-core-test
         Test.Reussir.Core.Class
         Test.Reussir.Core.String
         Test.Reussir.Core.Semi.Mangle
+        Test.Reussir.Core.Semi.ModuleResolution
         Test.Reussir.Core.Semi.PatternMatch
         Test.Reussir.Core.Semi.TyckSpec
     build-depends:

--- a/frontend/reussir-core/reussir-core.cabal
+++ b/frontend/reussir-core/reussir-core.cabal
@@ -71,6 +71,7 @@ library
         Reussir.Core.Lowering.Type
         Reussir.Core.Lowering.Record
         Reussir.Core.Lowering.Module
+        Reussir.Core.Module
     other-modules:
         Reussir.Core.Uitls.HashTable
     build-depends:    base ^>=4.20.2.0,
@@ -99,7 +100,8 @@ library
                       idn,
                       vector,
                       sort,
-                      rrb-vector
+                      rrb-vector,
+                      megaparsec
     hs-source-dirs:   src
     default-language: GHC2024
 

--- a/frontend/reussir-core/src/Reussir/Core.hs
+++ b/frontend/reussir-core/src/Reussir/Core.hs
@@ -2,6 +2,7 @@
 
 module Reussir.Core (
     translateProgToModule,
+    translatePackageToModule,
 ) where
 
 import Control.Monad (forM, forM_)
@@ -11,7 +12,7 @@ import Effectful.Prim.IORef.Strict (Prim)
 import Effectful.State.Static.Local (runState)
 import Reussir.Diagnostic.Display (displayReport)
 import Reussir.Diagnostic.Repository (createRepository)
-import Reussir.Parser.Types.Lexer (WithSpan (..))
+import Reussir.Parser.Types.Lexer (Identifier, WithSpan (..))
 import System.IO (stderr)
 
 import Data.Text qualified as T
@@ -30,6 +31,7 @@ import Reussir.Core.Semi.Context (
     emptySemiContext,
     populateRecordFields,
     scanStmt,
+    withModuleFile,
  )
 import Reussir.Core.Semi.FlowAnalysis (solveAllGenerics)
 import Reussir.Core.Semi.Trampoline (resolveTrampoline)
@@ -39,33 +41,68 @@ unspanStmt :: Syn.Stmt -> Syn.Stmt
 unspanStmt (Syn.SpannedStmt (WithSpan s _ _)) = unspanStmt s
 unspanStmt stmt = stmt
 
+-- | Compile a single source file to an IR module (backward compatible entry point).
 translateProgToModule ::
     (IOE :> es, Prim :> es, L.Log :> es) =>
     IR.TargetSpec -> Syn.Prog -> Eff es (Maybe IR.Module)
-translateProgToModule spec prog = do
-    let filePath = IR.moduleFilePath spec
+translateProgToModule spec prog =
+    translatePackageToModule spec [(IR.moduleFilePath spec, [], prog)]
+
+{- | Compile multiple source files (a package) to a single IR module.
+
+Each entry in the list is a @(filePath, modulePath, parsedProgram)@ triple.
+The @modulePath@ is the list of module segments for that file (e.g.,
+@[\"mylib\", \"utils\"]@ for @mylib::utils@). For single-file mode, pass
+an empty module path.
+
+All files are scanned into a shared symbol table, then type-checked together,
+allowing cross-file references to resolve naturally.
+-}
+translatePackageToModule ::
+    (IOE :> es, Prim :> es, L.Log :> es) =>
+    IR.TargetSpec ->
+    [(FilePath, [Identifier], Syn.Prog)] ->
+    Eff es (Maybe IR.Module)
+translatePackageToModule spec files = do
+    let allFilePaths = map (\(fp, _, _) -> fp) files
+    let primaryFilePath = case files of
+            ((fp, _, _) : _) -> fp
+            [] -> IR.moduleFilePath spec
+    let primaryModPath = case files of
+            ((_, mp, _) : _) -> mp
+            [] -> []
+
     L.logTrace_ $
-        T.pack "translateProgToModule: scanning statements for " <> T.pack filePath
-    repository <- createRepository [filePath]
+        T.pack ("translatePackageToModule: scanning "
+            <> show (length files)
+            <> " file(s)")
+
+    repository <- createRepository allFilePaths
     (elaborated, finalSemiCtx) <- do
         -- 1. Semi Elab
-        initSemiState <- runPrim $ emptySemiContext (IR.logLevel spec) filePath
+        initSemiState <- runPrim $ emptySemiContext (IR.logLevel spec) primaryFilePath primaryModPath
         (slns, finalSemiState) <- runPrim $ runState initSemiState $ do
-            -- Scan all statements
-            forM_ prog $ \stmt -> inject $ scanStmt stmt
+            -- Scan all statements from all files
+            forM_ files $ \(fp, modPath, prog) ->
+                inject $ withModuleFile fp modPath $
+                    forM_ prog $ \stmt -> inject $ scanStmt stmt
 
-            -- Populate record fields
-            forM_ prog $ \stmt -> inject $ populateRecordFields stmt
+            -- Populate record fields from all files
+            forM_ files $ \(fp, modPath, prog) ->
+                inject $ withModuleFile fp modPath $
+                    forM_ prog $ \stmt -> inject $ populateRecordFields stmt
 
-            -- Elaborate all functions
-            forM_ prog $ \stmt -> do
-                case unspanStmt stmt of
-                    Syn.FunctionStmt f -> do
-                        _ <- inject $ checkFuncType f
-                        return ()
-                    Syn.ExternTrampolineStmt name abi target args -> do
-                        inject $ resolveTrampoline name abi target args
-                    _ -> return ()
+            -- Elaborate all functions from all files
+            forM_ files $ \(fp, modPath, prog) ->
+                inject $ withModuleFile fp modPath $
+                    forM_ prog $ \stmt -> do
+                        case unspanStmt stmt of
+                            Syn.FunctionStmt f -> do
+                                _ <- inject $ checkFuncType f
+                                return ()
+                            Syn.ExternTrampolineStmt name abi target args -> do
+                                inject $ resolveTrampoline name abi target args
+                            _ -> return ()
 
             -- Solve generics
             inject solveAllGenerics
@@ -83,7 +120,7 @@ translateProgToModule spec prog = do
 
     forM elaborated $ \FullContext{..} -> do
         L.logTrace_ $
-            T.pack "translateProgToModule: lowering module for " <> T.pack filePath
+            T.pack "translatePackageToModule: lowering module"
         loweringCtx <-
             inject $
                 createLoweringContext

--- a/frontend/reussir-core/src/Reussir/Core.hs
+++ b/frontend/reussir-core/src/Reussir/Core.hs
@@ -6,6 +6,8 @@ module Reussir.Core (
 ) where
 
 import Control.Monad (forM, forM_)
+import Data.List (find, minimumBy)
+import Data.Ord (comparing)
 import Effectful (Eff, IOE, inject, (:>))
 import Effectful.Prim (runPrim)
 import Effectful.Prim.IORef.Strict (Prim)
@@ -21,6 +23,7 @@ import Reussir.Codegen qualified as IR
 import Reussir.Codegen.Context qualified as IR
 import Reussir.Parser.Prog qualified as Syn
 import Reussir.Parser.Types.Stmt qualified as Syn
+import System.FilePath (takeFileName)
 
 import Reussir.Core.Data.Full.Context (FullContext (..))
 import Reussir.Core.Data.Semi.Context (SemiContext (translationReports))
@@ -65,12 +68,7 @@ translatePackageToModule ::
     Eff es (Maybe IR.Module)
 translatePackageToModule spec files = do
     let allFilePaths = map (\(fp, _, _) -> fp) files
-    let primaryFilePath = case files of
-            ((fp, _, _) : _) -> fp
-            [] -> IR.moduleFilePath spec
-    let primaryModPath = case files of
-            ((_, mp, _) : _) -> mp
-            [] -> []
+    let (primaryFilePath, primaryModPath) = selectPrimaryModule spec files
 
     L.logTrace_ $
         T.pack ("translatePackageToModule: scanning "
@@ -131,3 +129,21 @@ translatePackageToModule spec files = do
                     ctxTrampolines
                     spec
         runLoweringToModule loweringCtx lowerModule
+
+selectPrimaryModule ::
+    IR.TargetSpec ->
+    [(FilePath, [Identifier], Syn.Prog)] ->
+    (FilePath, [Identifier])
+selectPrimaryModule spec files =
+    case find isCrateRoot files of
+        Just (fp, modPath, _) -> (fp, modPath)
+        Nothing -> case files of
+            [] -> (IR.moduleFilePath spec, [])
+            _ ->
+                let (fp, modPath, _) =
+                        minimumBy
+                            (comparing (\(path, mp, _) -> (length mp, path)))
+                            files
+                 in (fp, modPath)
+  where
+    isCrateRoot (fp, _modPath, _) = takeFileName fp == "lib.rr"

--- a/frontend/reussir-core/src/Reussir/Core/Data/Semi/Context.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Data/Semi/Context.hs
@@ -45,6 +45,7 @@ data LocalSemiContext = LocalSemiContext
 -}
 data SemiContext = SemiContext
     { currentFile :: FilePath
+    , currentModulePath :: [Identifier]
     , translationLogLevel :: B.LogLevel
     , stringUniqifier :: StringUniqifier
     , translationReports :: [Report]

--- a/frontend/reussir-core/src/Reussir/Core/Data/Semi/Function.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Data/Semi/Function.hs
@@ -18,6 +18,7 @@ import Reussir.Core.Data.Semi.Type qualified as Semi
 data FunctionProto = FunctionProto
     { funcVisibility :: Visibility
     , funcName :: Identifier
+    , funcPath :: Path
     , funcGenerics :: [(Identifier, GenericID)]
     , funcParams :: [(Identifier, Semi.Type)]
     , funcReturnType :: Semi.Type

--- a/frontend/reussir-core/src/Reussir/Core/Full/Function.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Full/Function.hs
@@ -10,7 +10,6 @@ import Data.Traversable (for)
 import Effectful (inject, liftIO)
 import Effectful.Prim.IORef.Strict (readIORef')
 import Reussir.Codegen.Context.Symbol (verifiedSymbol)
-import Reussir.Parser.Types.Lexer (Path (..))
 import Prelude hiding (span)
 
 import Data.HashTable.IO qualified as H
@@ -42,7 +41,7 @@ convertSemiFunction ::
     GlobalFullEff (Maybe Function)
 convertSemiFunction proto genericMap typeArgs = do
     let span = fromMaybe (0, 0) (Semi.funcSpan proto)
-    let funcPath = Path (Semi.funcName proto) [] -- TODO: Module handling
+    let funcPath = Semi.funcPath proto
     let mangledName = mangleABIName (Semi.TypeRecord funcPath typeArgs Semi.Irrelevant) -- Abuse Record mangle for now as it contains Path and Args
     let symbol = verifiedSymbol mangledName
 

--- a/frontend/reussir-core/src/Reussir/Core/Module.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Module.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Reussir.Core.Module
+Description : Declaration-driven module resolution for packages.
+
+This module implements Rust-like module resolution driven by @mod@ declarations
+in the source code. Given a package root and name, it parses the root @lib.rr@,
+collects @mod@ declarations, resolves them to file paths, and recursively
+processes sub-modules.
+
+== Module Path Convention
+
+@
+\/root\/lib.rr            → [pkgName]          (root file, always included)
+mod math;  in lib.rr      → [pkgName, "math"]  (resolves math.rr or math\/mod.rr)
+mod utils; in lib.rr      → [pkgName, "utils"] (resolves utils.rr or utils\/mod.rr)
+mod sub;   in utils/mod.rr→ [pkgName, "utils", "sub"]
+@
+-}
+module Reussir.Core.Module (
+    PackageInfo (..),
+    computeModulePath,
+    discoverPackageFiles,
+) where
+
+import Data.List (sort)
+import Reussir.Parser.Prog (parseProg)
+import Reussir.Parser.Types.Lexer (Identifier (..), WithSpan (..))
+import Reussir.Parser.Types.Stmt qualified as Syn
+import System.Directory (
+    canonicalizePath,
+    doesFileExist,
+ )
+import System.FilePath (
+    dropExtension,
+    makeRelative,
+    splitDirectories,
+    takeDirectory,
+    (</>),
+ )
+import Text.Megaparsec (runParser)
+
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+
+-- | Information about a package being compiled.
+data PackageInfo = PackageInfo
+    { packageRoot :: FilePath
+    -- ^ Absolute path to the package root directory
+    , packageName :: Identifier
+    -- ^ The root name of the package (e.g., "mylib")
+    }
+
+{- | Compute the module path segments for a source file given its package context.
+
+The mapping from filesystem to module path follows Rust conventions:
+
+  * @lib.rr@ at the root maps to @[packageName]@ (crate root)
+  * @foo.rr@ at the root maps to @[packageName, "foo"]@
+  * @foo\/mod.rr@ maps to @[packageName, "foo"]@
+  * @foo\/bar.rr@ maps to @[packageName, "foo", "bar"]@
+
+Both @filePath@ and @packageRoot@ should be canonicalized before calling.
+-}
+computeModulePath :: PackageInfo -> FilePath -> [Identifier]
+computeModulePath pkg filePath =
+    let rel = makeRelative (packageRoot pkg) filePath
+        parts = splitDirectories (dropExtension rel)
+        -- Filter out "." from splitDirectories output
+        cleanParts = filter (/= ".") parts
+        -- Convert to identifiers, handling mod.rr convention
+        moduleSegs = case cleanParts of
+            -- lib.rr at root → just package name
+            ["lib"] -> []
+            -- mod.rr in a subdir → use the directory as the module name
+            segs
+                | not (null segs) && last segs == "mod" -> init segs
+                | otherwise -> segs
+     in packageName pkg : map (Identifier . T.pack) moduleSegs
+
+{- | Discover package files by following @mod@ declarations starting from @lib.rr@.
+
+Parses the root file, collects @mod name;@ statements, resolves each to
+@name.rr@ or @name\/mod.rr@ relative to the declaring file, and recurses.
+Returns pairs of @(absoluteFilePath, modulePath)@ sorted by file path.
+-}
+discoverPackageFiles :: PackageInfo -> IO [(FilePath, [Identifier])]
+discoverPackageFiles pkg = do
+    root <- canonicalizePath (packageRoot pkg)
+    let pkg' = pkg{packageRoot = root}
+    let rootFile = root </> "lib.rr"
+    rootExists <- doesFileExist rootFile
+    if rootExists
+        then do
+            rootCanon <- canonicalizePath rootFile
+            children <- resolveModDecls pkg' rootCanon
+            let all' = (rootCanon, computeModulePath pkg' rootCanon) : children
+            return $ sort all'
+        else return []
+
+{- | Parse a file and recursively resolve its @mod@ declarations.
+
+For each @mod name;@ found, tries @name.rr@ then @name\/mod.rr@ relative
+to the declaring file's directory. Successfully resolved modules are
+recursively processed for their own @mod@ declarations.
+-}
+resolveModDecls :: PackageInfo -> FilePath -> IO [(FilePath, [Identifier])]
+resolveModDecls pkg filePath = do
+    content <- TIO.readFile filePath
+    case runParser parseProg filePath content of
+        Left _ -> return []
+        Right stmts -> do
+            let modNames = collectModDecls stmts
+            let parentDir = takeDirectory filePath
+            concat <$> mapM (resolveOneModule pkg parentDir) modNames
+
+-- | Extract module names from @mod@ declarations in a list of statements.
+collectModDecls :: [Syn.Stmt] -> [Identifier]
+collectModDecls = concatMap go
+  where
+    go (Syn.ModStmt _vis name) = [name]
+    go (Syn.SpannedStmt (WithSpan s _ _)) = go s
+    go _ = []
+
+{- | Resolve a single @mod name;@ declaration to a file path.
+
+Tries @parentDir\/name.rr@ first, then @parentDir\/name\/mod.rr@.
+If found, computes the module path and recurses into the resolved file.
+-}
+resolveOneModule :: PackageInfo -> FilePath -> Identifier -> IO [(FilePath, [Identifier])]
+resolveOneModule pkg parentDir (Identifier name) = do
+    let nameStr = T.unpack name
+    let fileCandidate = parentDir </> nameStr ++ ".rr"
+    let dirCandidate = parentDir </> nameStr </> "mod.rr"
+    fileExists <- doesFileExist fileCandidate
+    if fileExists
+        then do
+            canon <- canonicalizePath fileCandidate
+            let modPath = computeModulePath pkg canon
+            children <- resolveModDecls pkg canon
+            return $ (canon, modPath) : children
+        else do
+            dirExists <- doesFileExist dirCandidate
+            if dirExists
+                then do
+                    canon <- canonicalizePath dirCandidate
+                    let modPath = computeModulePath pkg canon
+                    children <- resolveModDecls pkg canon
+                    return $ (canon, modPath) : children
+                else return []

--- a/frontend/reussir-core/src/Reussir/Core/Module.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Module.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 {- |
 Module      : Reussir.Core.Module
@@ -19,12 +20,20 @@ mod sub;   in utils/mod.rr→ [pkgName, "utils", "sub"]
 @
 -}
 module Reussir.Core.Module (
+    DiscoveryError (..),
     PackageInfo (..),
+    renderDiscoveryError,
+    validatePackageInfo,
     computeModulePath,
     discoverPackageFiles,
 ) where
 
-import Data.List (sort)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
+import Control.Monad.Trans.State.Strict (StateT, evalStateT, get, modify')
+import Data.Int (Int64)
+import Data.List (intercalate, sort)
+import Data.Set qualified as Set
 import Reussir.Parser.Prog (parseProg)
 import Reussir.Parser.Types.Lexer (Identifier (..), WithSpan (..))
 import Reussir.Parser.Types.Stmt qualified as Syn
@@ -39,7 +48,7 @@ import System.FilePath (
     takeDirectory,
     (</>),
  )
-import Text.Megaparsec (runParser)
+import Text.Megaparsec (errorBundlePretty, runParser)
 
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
@@ -51,6 +60,44 @@ data PackageInfo = PackageInfo
     , packageName :: Identifier
     -- ^ The root name of the package (e.g., "mylib")
     }
+
+data DiscoveryError
+    = MissingModuleFile
+        { missingModuleName :: Identifier
+        , missingModuleDeclaringFile :: FilePath
+        , missingModuleDeclaringSpan :: Maybe (Int64, Int64)
+        , missingModuleCandidates :: [FilePath]
+        }
+    | ModuleParseError
+        { moduleParseFile :: FilePath
+        , moduleParseDetails :: String
+        }
+
+renderDiscoveryError :: DiscoveryError -> String
+renderDiscoveryError MissingModuleFile{..} =
+    "Error: module '"
+        <> T.unpack (unIdentifier missingModuleName)
+        <> "' declared in "
+        <> missingModuleDeclaringFile
+        <> spanSuffix
+        <> " has no source file. Expected one of: "
+        <> intercalate ", " missingModuleCandidates
+  where
+    spanSuffix = case missingModuleDeclaringSpan of
+        Just (start, end) -> " (byte offsets " <> show start <> "-" <> show end <> ")"
+        Nothing -> ""
+renderDiscoveryError ModuleParseError{..} =
+    "Error: failed to parse discovered module file "
+        <> moduleParseFile
+        <> "\n"
+        <> moduleParseDetails
+
+-- | Reject package names that would collide with compiler-defined absolute paths.
+validatePackageInfo :: PackageInfo -> Either String PackageInfo
+validatePackageInfo pkg
+    | packageName pkg == "core" =
+        Left "Error: package name 'core' is reserved for the built-in core package"
+    | otherwise = Right pkg
 
 {- | Compute the module path segments for a source file given its package context.
 
@@ -67,25 +114,25 @@ computeModulePath :: PackageInfo -> FilePath -> [Identifier]
 computeModulePath pkg filePath =
     let rel = makeRelative (packageRoot pkg) filePath
         parts = splitDirectories (dropExtension rel)
-        -- Filter out "." from splitDirectories output
         cleanParts = filter (/= ".") parts
-        -- Convert to identifiers, handling mod.rr convention
         moduleSegs = case cleanParts of
-            -- lib.rr at root → just package name
             ["lib"] -> []
-            -- mod.rr in a subdir → use the directory as the module name
             segs
                 | not (null segs) && last segs == "mod" -> init segs
                 | otherwise -> segs
      in packageName pkg : map (Identifier . T.pack) moduleSegs
 
+type DiscoveryM = StateT (Set.Set FilePath) (ExceptT DiscoveryError IO)
+
 {- | Discover package files by following @mod@ declarations starting from @lib.rr@.
 
 Parses the root file, collects @mod name;@ statements, resolves each to
-@name.rr@ or @name\/mod.rr@ relative to the declaring file, and recurses.
-Returns pairs of @(absoluteFilePath, modulePath)@ sorted by file path.
+@name.rr@ or @name\/mod.rr@ relative to the declaring file's directory, and
+recurses. Canonical file paths are tracked during discovery so duplicate
+declarations and import cycles do not recurse forever or produce duplicate
+entries.
 -}
-discoverPackageFiles :: PackageInfo -> IO [(FilePath, [Identifier])]
+discoverPackageFiles :: PackageInfo -> IO (Either DiscoveryError [(FilePath, [Identifier])])
 discoverPackageFiles pkg = do
     root <- canonicalizePath (packageRoot pkg)
     let pkg' = pkg{packageRoot = root}
@@ -94,10 +141,15 @@ discoverPackageFiles pkg = do
     if rootExists
         then do
             rootCanon <- canonicalizePath rootFile
-            children <- resolveModDecls pkg' rootCanon
-            let all' = (rootCanon, computeModulePath pkg' rootCanon) : children
-            return $ sort all'
-        else return []
+            runExceptT $
+                evalStateT
+                    (do
+                        children <- resolveModDecls pkg' rootCanon
+                        let all' = (rootCanon, computeModulePath pkg' rootCanon) : children
+                        return $ sort all'
+                    )
+                    (Set.singleton rootCanon)
+        else return $ Right []
 
 {- | Parse a file and recursively resolve its @mod@ declarations.
 
@@ -105,47 +157,70 @@ For each @mod name;@ found, tries @name.rr@ then @name\/mod.rr@ relative
 to the declaring file's directory. Successfully resolved modules are
 recursively processed for their own @mod@ declarations.
 -}
-resolveModDecls :: PackageInfo -> FilePath -> IO [(FilePath, [Identifier])]
+resolveModDecls :: PackageInfo -> FilePath -> DiscoveryM [(FilePath, [Identifier])]
 resolveModDecls pkg filePath = do
-    content <- TIO.readFile filePath
+    content <- lift $ lift $ TIO.readFile filePath
     case runParser parseProg filePath content of
-        Left _ -> return []
+        Left err ->
+            lift $
+                throwE
+                    ModuleParseError
+                        { moduleParseFile = filePath
+                        , moduleParseDetails = errorBundlePretty err
+                        }
         Right stmts -> do
             let modNames = collectModDecls stmts
             let parentDir = takeDirectory filePath
-            concat <$> mapM (resolveOneModule pkg parentDir) modNames
+            concat <$> mapM (resolveOneModule pkg filePath parentDir) modNames
 
 -- | Extract module names from @mod@ declarations in a list of statements.
-collectModDecls :: [Syn.Stmt] -> [Identifier]
-collectModDecls = concatMap go
+collectModDecls :: [Syn.Stmt] -> [(Identifier, Maybe (Int64, Int64))]
+collectModDecls = concatMap (go Nothing)
   where
-    go (Syn.ModStmt _vis name) = [name]
-    go (Syn.SpannedStmt (WithSpan s _ _)) = go s
-    go _ = []
+    go span' (Syn.ModStmt _vis name) = [(name, span')]
+    go _ (Syn.SpannedStmt (WithSpan s start end)) = go (Just (start, end)) s
+    go _ _ = []
 
 {- | Resolve a single @mod name;@ declaration to a file path.
 
 Tries @parentDir\/name.rr@ first, then @parentDir\/name\/mod.rr@.
 If found, computes the module path and recurses into the resolved file.
 -}
-resolveOneModule :: PackageInfo -> FilePath -> Identifier -> IO [(FilePath, [Identifier])]
-resolveOneModule pkg parentDir (Identifier name) = do
+resolveOneModule ::
+    PackageInfo ->
+    FilePath ->
+    FilePath ->
+    (Identifier, Maybe (Int64, Int64)) ->
+    DiscoveryM [(FilePath, [Identifier])]
+resolveOneModule pkg declaringFile parentDir (modName@(Identifier name), declSpan) = do
     let nameStr = T.unpack name
     let fileCandidate = parentDir </> nameStr ++ ".rr"
     let dirCandidate = parentDir </> nameStr </> "mod.rr"
-    fileExists <- doesFileExist fileCandidate
+    fileExists <- lift $ lift $ doesFileExist fileCandidate
     if fileExists
-        then do
-            canon <- canonicalizePath fileCandidate
+        then resolveResolvedModule pkg fileCandidate
+        else do
+            dirExists <- lift $ lift $ doesFileExist dirCandidate
+            if dirExists
+                then resolveResolvedModule pkg dirCandidate
+                else
+                    lift $
+                        throwE
+                            MissingModuleFile
+                                { missingModuleName = modName
+                                , missingModuleDeclaringFile = declaringFile
+                                , missingModuleDeclaringSpan = declSpan
+                                , missingModuleCandidates = [fileCandidate, dirCandidate]
+                                }
+
+resolveResolvedModule :: PackageInfo -> FilePath -> DiscoveryM [(FilePath, [Identifier])]
+resolveResolvedModule pkg candidate = do
+    canon <- lift $ lift $ canonicalizePath candidate
+    visited <- get
+    if Set.member canon visited
+        then return []
+        else do
+            modify' (Set.insert canon)
             let modPath = computeModulePath pkg canon
             children <- resolveModDecls pkg canon
             return $ (canon, modPath) : children
-        else do
-            dirExists <- doesFileExist dirCandidate
-            if dirExists
-                then do
-                    canon <- canonicalizePath dirCandidate
-                    let modPath = computeModulePath pkg canon
-                    children <- resolveModDecls pkg canon
-                    return $ (canon, modPath) : children
-                else return []

--- a/frontend/reussir-core/src/Reussir/Core/REPL.hs
+++ b/frontend/reussir-core/src/Reussir/Core/REPL.hs
@@ -171,7 +171,7 @@ initReplState logLevel filePath = do
     loggerName <- uniqueLoggerName
     B.withReussirLogger logLevel loggerName $ \logger -> do
         runEff $ L.runLog "REPL" logger (toEffLogLevel logLevel) $ runPrim $ do
-            semiCtx <- emptySemiContext logLevel filePath
+            semiCtx <- emptySemiContext logLevel filePath []
             compiledFuncs <- liftIO H.new
             genericSol <- liftIO H.new
             return

--- a/frontend/reussir-core/src/Reussir/Core/Semi/Context.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Semi/Context.hs
@@ -19,6 +19,7 @@ module Reussir.Core.Semi.Context (
     addErrReportMsgSeq,
     withVariable,
     withModuleFile,
+    resolveSpecialRelativePath,
     resolveFunctionPath,
     resolveRecordPath,
 ) where
@@ -28,6 +29,7 @@ import Data.Function ((&))
 import Data.Int (Int64)
 import Data.Maybe (isJust)
 import Effectful (Eff, IOE, inject, (:>))
+import Effectful.Exception (finally)
 import Effectful.Prim.IORef (Prim)
 import Effectful.Prim.IORef.Strict (newIORef', writeIORef')
 import Effectful.Reader.Static (runReader)
@@ -530,9 +532,22 @@ withModuleFile file modPath action = do
     oldFile <- State.gets currentFile
     oldModPath <- State.gets currentModulePath
     State.modify $ \st -> st{currentFile = file, currentModulePath = modPath}
-    result <- action
-    State.modify $ \st -> st{currentFile = oldFile, currentModulePath = oldModPath}
-    return result
+    action `finally` State.modify (\st -> st{currentFile = oldFile, currentModulePath = oldModPath})
+
+resolveSpecialRelativePath :: [Identifier] -> [Identifier] -> Maybe [Identifier]
+resolveSpecialRelativePath modulePath segments =
+    case segments of
+        ("root" : rest) -> case modulePath of
+            (pkgRoot : _) -> Just (pkgRoot : rest)
+            [] -> Nothing
+        _ ->
+            let (supers, rest) = span (== "super") segments
+             in case length supers of
+                    0 -> Nothing
+                    upCount
+                        | upCount < length modulePath ->
+                            Just (take (length modulePath - upCount) modulePath ++ rest)
+                        | otherwise -> Nothing
 
 {- | Resolve a parsed path to a fully qualified function path.
 
@@ -558,23 +573,29 @@ resolveFunctionPath parsedPath = do
                     rootResult <- getFunctionProto parsedPath functionTable
                     return $ fmap (parsedPath,) rootResult
         segs -> do
-            -- Qualified path: try as-is first (absolute)
-            result <- getFunctionProto parsedPath functionTable
-            case result of
-                Just proto -> return $ Just (parsedPath, proto)
+            case resolveSpecialRelativePath modulePath segs of
+                Just specialSegs -> do
+                    let specialPath = Path (pathBasename parsedPath) specialSegs
+                    specialResult <- getFunctionProto specialPath functionTable
+                    return $ fmap (specialPath,) specialResult
                 Nothing -> do
-                    -- Try relative to current module
-                    let relativePath = Path (pathBasename parsedPath) (modulePath ++ segs)
-                    relResult <- getFunctionProto relativePath functionTable
-                    case relResult of
-                        Just proto -> return $ Just (relativePath, proto)
-                        Nothing -> case modulePath of
-                            (pkgRoot : _) -> do
-                                -- Try relative to package root
-                                let pkgRelPath = Path (pathBasename parsedPath) (pkgRoot : segs)
-                                pkgResult <- getFunctionProto pkgRelPath functionTable
-                                return $ fmap (pkgRelPath,) pkgResult
-                            [] -> return Nothing
+                    -- Qualified path: try as-is first (absolute)
+                    result <- getFunctionProto parsedPath functionTable
+                    case result of
+                        Just proto -> return $ Just (parsedPath, proto)
+                        Nothing -> do
+                            -- Try relative to current module
+                            let relativePath = Path (pathBasename parsedPath) (modulePath ++ segs)
+                            relResult <- getFunctionProto relativePath functionTable
+                            case relResult of
+                                Just proto -> return $ Just (relativePath, proto)
+                                Nothing -> case modulePath of
+                                    (pkgRoot : _) -> do
+                                        -- Try relative to package root
+                                        let pkgRelPath = Path (pathBasename parsedPath) (pkgRoot : segs)
+                                        pkgResult <- getFunctionProto pkgRelPath functionTable
+                                        return $ fmap (pkgRelPath,) pkgResult
+                                    [] -> return Nothing
 
 {- | Resolve a parsed path to a fully qualified record path.
 
@@ -600,20 +621,26 @@ resolveRecordPath parsedPath = do
                     rootResult <- HU.lookup records parsedPath
                     return $ fmap (parsedPath,) rootResult
         segs -> do
-            -- Qualified path: try as-is first (absolute)
-            result <- HU.lookup records parsedPath
-            case result of
-                Just record -> return $ Just (parsedPath, record)
+            case resolveSpecialRelativePath modulePath segs of
+                Just specialSegs -> do
+                    let specialPath = Path (pathBasename parsedPath) specialSegs
+                    specialResult <- HU.lookup records specialPath
+                    return $ fmap (specialPath,) specialResult
                 Nothing -> do
-                    -- Try relative to current module
-                    let relativePath = Path (pathBasename parsedPath) (modulePath ++ segs)
-                    relResult <- HU.lookup records relativePath
-                    case relResult of
-                        Just record -> return $ Just (relativePath, record)
-                        Nothing -> case modulePath of
-                            (pkgRoot : _) -> do
-                                -- Try relative to package root
-                                let pkgRelPath = Path (pathBasename parsedPath) (pkgRoot : segs)
-                                pkgResult <- HU.lookup records pkgRelPath
-                                return $ fmap (pkgRelPath,) pkgResult
-                            [] -> return Nothing
+                    -- Qualified path: try as-is first (absolute)
+                    result <- HU.lookup records parsedPath
+                    case result of
+                        Just record -> return $ Just (parsedPath, record)
+                        Nothing -> do
+                            -- Try relative to current module
+                            let relativePath = Path (pathBasename parsedPath) (modulePath ++ segs)
+                            relResult <- HU.lookup records relativePath
+                            case relResult of
+                                Just record -> return $ Just (relativePath, record)
+                                Nothing -> case modulePath of
+                                    (pkgRoot : _) -> do
+                                        -- Try relative to package root
+                                        let pkgRelPath = Path (pathBasename parsedPath) (pkgRoot : segs)
+                                        pkgResult <- HU.lookup records pkgRelPath
+                                        return $ fmap (pkgRelPath,) pkgResult
+                                    [] -> return Nothing

--- a/frontend/reussir-core/src/Reussir/Core/Semi/Context.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Semi/Context.hs
@@ -18,6 +18,9 @@ module Reussir.Core.Semi.Context (
     withGenericContext,
     addErrReportMsgSeq,
     withVariable,
+    withModuleFile,
+    resolveFunctionPath,
+    resolveRecordPath,
 ) where
 
 import Control.Monad (forM_, unless)
@@ -70,7 +73,7 @@ import Reussir.Core.Data.Semi.Unification (UnificationEff)
 import Reussir.Core.Data.String (StringUniqifier (StringUniqifier))
 import Reussir.Core.Data.UniqueID (ExprID (..), GenericID (..), VarID)
 import Reussir.Core.Generic (emptyGenericState, newGenericVar)
-import Reussir.Core.Semi.Function (newFunctionTable)
+import Reussir.Core.Semi.Function (getFunctionProto, newFunctionTable)
 import Reussir.Core.Semi.Type (addClassToType, emptyTypeClassTable)
 import Reussir.Core.Semi.Unification (newHoleTable)
 import Reussir.Core.Semi.Variable (newVariable, newVariableTable, rollbackVar)
@@ -172,10 +175,10 @@ populatePrimitives typeClassTable typeClassDAG = do
     forM_ intTypes $ \it ->
         addClassToType typeClassTable (TypeIntegral it) intClass
 
--- | Initialize the semi context with the given log level and file path
+-- | Initialize the semi context with the given log level, file path, and module path
 emptySemiContext ::
-    (IOE :> es, Prim :> es) => B.LogLevel -> FilePath -> Eff es SemiContext
-emptySemiContext translationLogLevel currentFile = do
+    (IOE :> es, Prim :> es) => B.LogLevel -> FilePath -> [Identifier] -> Eff es SemiContext
+emptySemiContext translationLogLevel currentFile currentModulePath = do
     table <- HU.new
     let stringUniqifier = StringUniqifier table
     typeClassDAG <- newDAG
@@ -187,6 +190,7 @@ emptySemiContext translationLogLevel currentFile = do
     return $
         SemiContext
             { currentFile
+            , currentModulePath
             , translationLogLevel
             , stringUniqifier
             , translationReports = []
@@ -264,18 +268,17 @@ evalType (Syn.TypeExpr path args) = do
                         <> " cannot have type arguments"
             return $ TypeGeneric gid
         Nothing -> do
-            knownRecords <- State.gets knownRecords
-            HU.lookup knownRecords path >>= \case
-                Just record -> case recordDefaultCap record of
-                    Syn.Value -> return $ TypeRecord path args' Irrelevant
-                    Syn.Shared -> return $ TypeRecord path args' Irrelevant
-                    Syn.Regional -> return $ TypeRecord path args' Regional
+            resolveRecordPath path >>= \case
+                Just (resolvedPath, record) -> case recordDefaultCap record of
+                    Syn.Value -> return $ TypeRecord resolvedPath args' Irrelevant
+                    Syn.Shared -> return $ TypeRecord resolvedPath args' Irrelevant
+                    Syn.Regional -> return $ TypeRecord resolvedPath args' Regional
                     cap -> do
                         addErrReportMsg $
                             "Unsupported capability "
                                 <> T.pack (show cap)
                                 <> " for record "
-                                <> T.pack (show path)
+                                <> T.pack (show resolvedPath)
                         return TypeBottom
                 Nothing -> do
                     addErrReportMsg $ "Unknown type: " <> T.pack (show path)
@@ -326,9 +329,11 @@ scanStmtImpl (Syn.SpannedStmt s) = do
     scanStmtImpl (spanValue s)
     State.modify $ \st -> st{currentSpan = backup}
 scanStmtImpl (Syn.ExternTrampolineStmt {}) = pure ()
+scanStmtImpl (Syn.ModStmt _ _) = pure ()
 scanStmtImpl (Syn.RecordStmt record) = do
     let name = Syn.recordName record
     let tyParams = Syn.recordTyParams record
+    moduleSegs <- State.gets currentModulePath
     -- Translate generics
     genericsList <- mapM translateGeneric tyParams
 
@@ -341,9 +346,10 @@ scanStmtImpl (Syn.RecordStmt record) = do
             Syn.StructKind -> StructKind
             Syn.EnumKind -> EnumKind
 
+    let recordPath = Path name moduleSegs
     let semRecord =
             Record
-                { recordName = Path name [] -- TODO: handle module path
+                { recordName = recordPath
                 , recordTyParams = genericsList
                 , recordFields = fieldsRef
                 , recordKind = kind
@@ -356,14 +362,14 @@ scanStmtImpl (Syn.RecordStmt record) = do
     case Syn.recordFields record of
         Syn.Variants vs -> do
             V.iforM_ vs $ \variantIdx (WithSpan (variantName, _) s e) -> do
-                let variantPath = Path variantName [name] -- TODO: handle module path
+                let variantPath = Path variantName (moduleSegs ++ [name])
                 variantFieldsRef <- newIORef' Nothing
                 let variantRecord =
                         Record
                             { recordName = variantPath
                             , recordTyParams = genericsList -- share same generics as parent
                             , recordFields = variantFieldsRef
-                            , recordKind = EnumVariant{variantParent = Path name [], variantIdx}
+                            , recordKind = EnumVariant{variantParent = recordPath, variantIdx}
                             , recordVisibility = Syn.recordVisibility record
                             , recordDefaultCap = Syn.Value
                             , recordSpan = Just (s, e)
@@ -371,8 +377,7 @@ scanStmtImpl (Syn.RecordStmt record) = do
                 addRecordDefinition variantPath variantRecord
         _ -> return ()
 
-    let path = Path name [] -- TODO: handle module path
-    addRecordDefinition path semRecord
+    addRecordDefinition recordPath semRecord
 scanStmtImpl
     ( Syn.FunctionStmt
             Syn.Function
@@ -384,6 +389,7 @@ scanStmtImpl
                 , Syn.funcIsRegional = funcIsRegional
                 }
         ) = do
+        moduleSegs <- State.gets currentModulePath
         genericsList <- mapM translateGeneric funcGenerics
         withGenericContext genericsList $ do
             paramsList <- mapM translateParam funcParams
@@ -396,10 +402,12 @@ scanStmtImpl
                     Nothing -> TypeUnit
             pendingFuncBody <- newIORef' Nothing
             funcSpan <- State.gets currentSpan
+            let qualifiedPath = Path funcName moduleSegs
             let proto =
                     FunctionProto
                         { funcVisibility = funcVisibility
                         , funcName = funcName
+                        , funcPath = qualifiedPath
                         , funcGenerics = genericsList
                         , funcParams = paramsList
                         , funcReturnType = returnTy
@@ -407,16 +415,14 @@ scanStmtImpl
                         , funcBody = pendingFuncBody
                         , funcSpan = funcSpan
                         }
-            -- TODO: handle module path
-            let funcPath = Path funcName []
             functionTable <- State.gets functions
             existed <-
-                isJust <$> HU.lookup (functionProtos functionTable) funcPath
+                isJust <$> HU.lookup (functionProtos functionTable) qualifiedPath
             if existed
                 then
                     addErrReportMsg $
                         "Function already defined: " <> unIdentifier funcName
-                else HU.insert (functionProtos functionTable) funcPath proto
+                else HU.insert (functionProtos functionTable) qualifiedPath proto
       where
         translateParam ::
             (Identifier, Syn.Type, Syn.FlexFlag) -> SemiEff (Identifier, Type)
@@ -436,7 +442,8 @@ populateRecordFieldsImpl (Syn.SpannedStmt s) = do
         populateRecordFieldsImpl (spanValue s)
 populateRecordFieldsImpl (Syn.RecordStmt record) = do
     let name = Syn.recordName record
-    let path = Path name [] -- TODO: handle module path
+    moduleSegs <- State.gets currentModulePath
+    let path = Path name moduleSegs
     knownRecords <- State.gets knownRecords
     mRecord <- HU.lookup knownRecords path
 
@@ -478,7 +485,7 @@ populateRecordFieldsImpl (Syn.RecordStmt record) = do
                 case variants of
                     Just vs -> do
                         V.forM_ vs $ \(WithSpan (variantName, variantFields) s e) -> do
-                            let variantPath = Path variantName [name]
+                            let variantPath = Path variantName (moduleSegs ++ [name])
                             mVariantRecord <- HU.lookup knownRecords variantPath
                             case mVariantRecord of
                                 Nothing ->
@@ -515,3 +522,98 @@ withVariable varName varSpan varType cont = do
     result <- cont varID
     rollbackVar changeLog vt
     pure result
+
+-- | Temporarily set the current file and module path for multi-file processing.
+-- Restores the previous values after the computation completes.
+withModuleFile :: FilePath -> [Identifier] -> GlobalSemiEff a -> GlobalSemiEff a
+withModuleFile file modPath action = do
+    oldFile <- State.gets currentFile
+    oldModPath <- State.gets currentModulePath
+    State.modify $ \st -> st{currentFile = file, currentModulePath = modPath}
+    result <- action
+    State.modify $ \st -> st{currentFile = oldFile, currentModulePath = oldModPath}
+    return result
+
+{- | Resolve a parsed path to a fully qualified function path.
+
+For bare names (no segments), tries the current module first, then root.
+For qualified names, tries:
+  1. As-is (absolute)
+  2. Relative to the current module (prepend currentModulePath)
+  3. Relative to the package root (prepend just the package name)
+-}
+resolveFunctionPath :: Path -> SemiEff (Maybe (Path, FunctionProto))
+resolveFunctionPath parsedPath = do
+    functionTable <- State.gets functions
+    modulePath <- State.gets currentModulePath
+    case pathSegments parsedPath of
+        [] -> do
+            -- Bare name: try current module first
+            let localPath = Path (pathBasename parsedPath) modulePath
+            localResult <- getFunctionProto localPath functionTable
+            case localResult of
+                Just proto -> return $ Just (localPath, proto)
+                Nothing -> do
+                    -- Fall back to root (empty segments)
+                    rootResult <- getFunctionProto parsedPath functionTable
+                    return $ fmap (parsedPath,) rootResult
+        segs -> do
+            -- Qualified path: try as-is first (absolute)
+            result <- getFunctionProto parsedPath functionTable
+            case result of
+                Just proto -> return $ Just (parsedPath, proto)
+                Nothing -> do
+                    -- Try relative to current module
+                    let relativePath = Path (pathBasename parsedPath) (modulePath ++ segs)
+                    relResult <- getFunctionProto relativePath functionTable
+                    case relResult of
+                        Just proto -> return $ Just (relativePath, proto)
+                        Nothing -> case modulePath of
+                            (pkgRoot : _) -> do
+                                -- Try relative to package root
+                                let pkgRelPath = Path (pathBasename parsedPath) (pkgRoot : segs)
+                                pkgResult <- getFunctionProto pkgRelPath functionTable
+                                return $ fmap (pkgRelPath,) pkgResult
+                            [] -> return Nothing
+
+{- | Resolve a parsed path to a fully qualified record path.
+
+For bare names (no segments), tries the current module first, then root.
+For qualified names, tries:
+  1. As-is (absolute)
+  2. Relative to the current module (prepend currentModulePath)
+  3. Relative to the package root (prepend just the package name)
+-}
+resolveRecordPath :: Path -> SemiEff (Maybe (Path, Record))
+resolveRecordPath parsedPath = do
+    records <- State.gets knownRecords
+    modulePath <- State.gets currentModulePath
+    case pathSegments parsedPath of
+        [] -> do
+            -- Bare name: try current module first
+            let localPath = Path (pathBasename parsedPath) modulePath
+            localResult <- HU.lookup records localPath
+            case localResult of
+                Just record -> return $ Just (localPath, record)
+                Nothing -> do
+                    -- Fall back to root (empty segments)
+                    rootResult <- HU.lookup records parsedPath
+                    return $ fmap (parsedPath,) rootResult
+        segs -> do
+            -- Qualified path: try as-is first (absolute)
+            result <- HU.lookup records parsedPath
+            case result of
+                Just record -> return $ Just (parsedPath, record)
+                Nothing -> do
+                    -- Try relative to current module
+                    let relativePath = Path (pathBasename parsedPath) (modulePath ++ segs)
+                    relResult <- HU.lookup records relativePath
+                    case relResult of
+                        Just record -> return $ Just (relativePath, record)
+                        Nothing -> case modulePath of
+                            (pkgRoot : _) -> do
+                                -- Try relative to package root
+                                let pkgRelPath = Path (pathBasename parsedPath) (pkgRoot : segs)
+                                pkgResult <- HU.lookup records pkgRelPath
+                                return $ fmap (pkgRelPath,) pkgResult
+                            [] -> return Nothing

--- a/frontend/reussir-core/src/Reussir/Core/Semi/Pretty.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Semi/Pretty.hs
@@ -461,7 +461,7 @@ instance PrettyColored Record where
         prettyFieldFlag True = pure $ brackets (keyword "field") <> space
 
 instance PrettyColored FunctionProto where
-    prettyColored (FunctionProto vis name generics params retType isRegional bodyRef _span) = do
+    prettyColored (FunctionProto vis name _path generics params retType isRegional bodyRef _span) = do
         visDoc <- prettyColored vis
         nameDoc <- prettyColored name
         genericsDoc <- prettyGenerics generics

--- a/frontend/reussir-core/src/Reussir/Core/Semi/Trampoline.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Semi/Trampoline.hs
@@ -6,9 +6,8 @@ import Data.Text qualified as T
 import Effectful.State.Static.Local qualified as State
 
 import Reussir.Core.Data.Semi.Context (SemiContext (..), GlobalSemiEff)
-import Reussir.Core.Data.Semi.Function (FunctionProto (..))
-import Reussir.Core.Semi.Context (addErrReportMsg, evalType, withFreshLocalContext)
-import Reussir.Core.Semi.Function (getFunctionProto)
+import Reussir.Core.Data.Semi.Function (FunctionProto(funcGenerics))
+import Reussir.Core.Semi.Context (addErrReportMsg, evalType, resolveFunctionPath, withFreshLocalContext)
 
 import Reussir.Parser.Types.Lexer (Identifier, Path)
 import Reussir.Parser.Types.Type qualified as Syn
@@ -24,12 +23,11 @@ resolveTrampoline name abi target tyArgs = withFreshLocalContext $ do
 
     tyArgs' <- mapM evalType tyArgs
 
-    -- 2. Lookup target function
-    funcTable <- State.gets functions
-    getFunctionProto target funcTable >>= \case
+    -- 2. Lookup target function via module-aware resolution
+    resolveFunctionPath target >>= \case
         Nothing ->
              addErrReportMsg $ "Trampoline target function not found: " <> T.pack (show target)
-        Just proto -> do
+        Just (resolvedTarget, proto) -> do
             let generics = funcGenerics proto
 
             -- 3. Check type argument count
@@ -41,6 +39,6 @@ resolveTrampoline name abi target tyArgs = withFreshLocalContext $ do
                             <> ", got "
                             <> T.pack (show (length tyArgs'))
                 else do
-                    -- 4. Register trampoline
+                    -- 4. Register trampoline with the resolved target path
                     State.modify $ \ctx ->
-                        ctx { trampolines = HashMap.insert name (target, abi, tyArgs') (trampolines ctx) }
+                        ctx { trampolines = HashMap.insert name (resolvedTarget, abi, tyArgs') (trampolines ctx) }

--- a/frontend/reussir-core/src/Reussir/Core/Semi/Tyck.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Semi/Tyck.hs
@@ -90,6 +90,8 @@ import Reussir.Core.Semi.Context (
     evalType,
     evalTypeWithFlexivity,
     exprWithSpan,
+    resolveFunctionPath,
+    resolveRecordPath,
     runUnification,
     withFreshLocalContext,
     withGenericContext,
@@ -97,7 +99,6 @@ import Reussir.Core.Semi.Context (
     withSpan,
     withVariable,
  )
-import Reussir.Core.Semi.Function (getFunctionProto)
 import Reussir.Core.Semi.PatternMatch (
     TyckCPS (TyckCPS),
     initializePMMatrix,
@@ -408,7 +409,8 @@ checkFuncType :: Syn.Function -> GlobalSemiEff Expr
 checkFuncType func = withFreshLocalContext $ do
     L.logTrace_ $ "Tyck: checking function " <> unIdentifier (Syn.funcName func)
     let name = Syn.funcName func
-    let path = Path name [] -- TODO: handle module prefix later on
+    moduleSegs <- State.gets currentModulePath
+    let path = Path name moduleSegs
     funcTable <- State.gets functions
     varTable <- State.gets varTable
     liftIO (H.lookup (functionProtos funcTable) path) >>= \case
@@ -599,11 +601,10 @@ inferType (Syn.Var varName) = do
                 Just (varId, varType) -> exprWithSpan varType $ Var varId
                 Nothing -> do
                     -- Try lifting a named function to a closure
-                    functionTable <- State.gets functions
-                    getFunctionProto varName functionTable >>= \case
-                        Just proto
+                    resolveFunctionPath varName >>= \case
+                        Just (resolvedPath, proto)
                             | not (funcIsRegional proto) ->
-                                liftFunctionToClosure proto varName
+                                liftFunctionToClosure proto resolvedPath
                             | otherwise -> do
                                 addErrReportMsg "Cannot lift regional function to closure"
                                 exprWithSpan TypeBottom Poison
@@ -611,16 +612,15 @@ inferType (Syn.Var varName) = do
                             addErrReportMsg "Variable not found"
                             exprWithSpan TypeBottom Poison
         _ -> do
-            records <- State.gets knownRecords
-            liftIO (H.lookup records varName) >>= \case
-                Just record -> do
+            resolveRecordPath varName >>= \case
+                Just (resolvedPath, record) -> do
                     fieldsMaybe <- readIORef' (recordFields record)
                     case (recordKind record, fieldsMaybe) of
                         (EnumVariant _ _, Just (Unnamed fs))
                             | V.null fs ->
                                 inferTypeForNormalCtorCall
                                     Syn.CtorCall
-                                        { Syn.ctorName = varName
+                                        { Syn.ctorName = resolvedPath
                                         , Syn.ctorTyArgs = []
                                         , Syn.ctorArgs = []
                                         }
@@ -629,8 +629,17 @@ inferType (Syn.Var varName) = do
                                 "Qualified path is not a nullary variant: " <> T.pack (show varName)
                             exprWithSpan TypeBottom Poison
                 Nothing -> do
-                    addErrReportMsg $ "Qualified variable not found: " <> T.pack (show varName)
-                    exprWithSpan TypeBottom Poison
+                    -- Also try as a function reference with qualified path
+                    resolveFunctionPath varName >>= \case
+                        Just (resolvedPath, proto)
+                            | not (funcIsRegional proto) ->
+                                liftFunctionToClosure proto resolvedPath
+                            | otherwise -> do
+                                addErrReportMsg "Cannot lift regional function to closure"
+                                exprWithSpan TypeBottom Poison
+                        Nothing -> do
+                            addErrReportMsg $ "Qualified variable not found: " <> T.pack (show varName)
+                            exprWithSpan TypeBottom Poison
 
 -- Project:
 --     C, record R, I : T, I in R |- R <- e
@@ -1054,10 +1063,9 @@ inferTypeForNormalCall
         , Syn.funcCallArgs = argExprs
         } = do
         L.logTrace_ $ "Tyck: infer func call " <> T.pack (show path)
-        -- Lookup function
-        functionTable <- State.gets functions
-        getFunctionProto path functionTable >>= \case
-            Just proto -> do
+        -- Lookup function via module-aware resolution
+        resolveFunctionPath path >>= \case
+            Just (resolvedPath, proto) -> do
                 let numGenerics = length (funcGenerics proto)
                 -- Allow empty type argument list as syntax sugar for all holes
                 let paddedTyArgs =
@@ -1073,7 +1081,7 @@ inferTypeForNormalCall
                     tyArgs' <- zipWithM tyArgOrMetaHole paddedTyArgs bounds
                     L.logTrace_ $
                         "Tyck: instantiated call generics for "
-                            <> T.pack (show path)
+                            <> T.pack (show resolvedPath)
                             <> ": "
                             <> T.pack (show tyArgs')
                     let genericMap = functionGenericMap proto tyArgs'
@@ -1084,7 +1092,7 @@ inferTypeForNormalCall
                         then do
                             addErrReportMsg $
                                 "Function "
-                                    <> T.pack (show path)
+                                    <> T.pack (show resolvedPath)
                                     <> " expects "
                                     <> T.pack (show expectedNumParams)
                                     <> " arguments, but got "
@@ -1096,7 +1104,7 @@ inferTypeForNormalCall
                                 let instantiatedRetType = substituteGenericMap (funcReturnType proto) genericMap
                                 exprWithSpan instantiatedRetType $
                                     FuncCall
-                                        { funcCallTarget = path
+                                        { funcCallTarget = resolvedPath
                                         , funcCallArgs = argExprs'
                                         , funcCallTyArgs = tyArgs'
                                         , funcCallRegional = funcIsRegional proto
@@ -1118,7 +1126,7 @@ inferTypeForNormalCall
                                             Nothing -> error "unreachable: partial application arg"
                                     let allArgExprs = checkedArgs ++ remainingArgExprs
                                     exprWithSpan instantiatedRetType $ FuncCall
-                                        { funcCallTarget = path
+                                        { funcCallTarget = resolvedPath
                                         , funcCallArgs = allArgExprs
                                         , funcCallTyArgs = tyArgs'
                                         , funcCallRegional = funcIsRegional proto
@@ -1291,12 +1299,11 @@ inferTypeForNormalCtorCall
         , Syn.ctorTyArgs = ctorTyArgs
         } = do
         L.logTrace_ $ "Tyck: infer ctor call " <> T.pack (show ctorCallTarget)
-        records <- State.gets knownRecords
-        liftIO (H.lookup records ctorCallTarget) >>= \case
+        resolveRecordPath ctorCallTarget >>= \case
             Nothing -> do
                 addErrReportMsg $ "Record not found: " <> T.pack (show ctorCallTarget)
                 exprWithSpan TypeBottom Poison
-            Just record -> do
+            Just (resolvedCtorTarget, record) -> do
                 let numGenerics = length (recordTyParams record)
                 -- Allow empty type argument list as syntax sugar for all holes
                 let paddedTyArgs =
@@ -1400,14 +1407,14 @@ inferTypeForNormalCtorCall
                                 else return Irrelevant
                         let recordTy = case variantInfo of
                                 Just (parent, _) -> TypeRecord parent tyArgs' flexivity
-                                Nothing -> TypeRecord ctorCallTarget tyArgs' flexivity
+                                Nothing -> TypeRecord resolvedCtorTarget tyArgs' flexivity
                         case variantInfo of
                             Just (parentPath, idx) -> do
-                                let innerTy = TypeRecord ctorCallTarget tyArgs' Irrelevant
+                                let innerTy = TypeRecord resolvedCtorTarget tyArgs' Irrelevant
                                 innerExpr <-
                                     exprWithSpan innerTy $
                                         CompoundCall
-                                            { compoundCallTarget = ctorCallTarget
+                                            { compoundCallTarget = resolvedCtorTarget
                                             , compoundCallTyArgs = tyArgs'
                                             , compoundCallArgs = argExprs'
                                             }
@@ -1421,7 +1428,7 @@ inferTypeForNormalCtorCall
                             Nothing ->
                                 exprWithSpan recordTy $
                                     CompoundCall
-                                        { compoundCallTarget = ctorCallTarget
+                                        { compoundCallTarget = resolvedCtorTarget
                                         , compoundCallTyArgs = tyArgs'
                                         , compoundCallArgs = argExprs'
                                         }

--- a/frontend/reussir-core/test/Main.hs
+++ b/frontend/reussir-core/test/Main.hs
@@ -6,6 +6,7 @@ import Test.Tasty.Hspec (testSpec)
 import Test.Reussir.Core.Class qualified as Class
 import Test.Reussir.Core.Generic qualified as Generic
 import Test.Reussir.Core.Semi.Mangle qualified as Mangle
+import Test.Reussir.Core.Semi.ModuleResolution qualified as ModuleResolution
 import Test.Reussir.Core.Semi.PatternMatch qualified as PatternMatch
 import Test.Reussir.Core.Semi.TyckSpec qualified as TyckSpec
 import Test.Reussir.Core.String qualified as String
@@ -23,6 +24,7 @@ tests tyckSpec =
         , Class.tests
         , String.tests
         , Mangle.tests
+        , ModuleResolution.tests
         , PatternMatch.tests
         , tyckSpec
         ]

--- a/frontend/reussir-core/test/Test/Reussir/Core/Semi/ModuleResolution.hs
+++ b/frontend/reussir-core/test/Test/Reussir/Core/Semi/ModuleResolution.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Reussir.Core.Semi.ModuleResolution (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Reussir.Core.Module (PackageInfo (..), validatePackageInfo)
+import Reussir.Core.Semi.Context (resolveSpecialRelativePath)
+
+tests :: TestTree
+tests =
+    testGroup
+        "Reussir.Core.Semi.ModuleResolution"
+        [ testGroup
+            "validatePackageInfo"
+            [ testCase "accepts non-reserved package names" testValidateNormalPackage
+            , testCase "rejects the reserved core package name" testValidateReservedPackage
+            ]
+        , testGroup
+            "resolveSpecialRelativePath"
+            [ testCase "ignores non-special leading segments" testNonSpecialPath
+            , testCase "root resolves from any nested module to the package root" testRootPath
+            , testCase "super resolves to the parent module" testSuperPath
+            , testCase "multiple supers climb multiple module levels" testNestedSuperPath
+            , testCase "super cannot escape the package root" testInvalidSuperPath
+            , testCase "root requires a package-qualified module path" testRootWithoutPackagePath
+            ]
+        ]
+
+testValidateNormalPackage :: Assertion
+testValidateNormalPackage =
+    case validatePackageInfo (PackageInfo "/tmp/mypkg" "mypkg") of
+        Right _ -> pure ()
+        Left err -> assertFailure err
+
+testValidateReservedPackage :: Assertion
+testValidateReservedPackage =
+    case validatePackageInfo (PackageInfo "/tmp/core" "core") of
+        Left err ->
+            err @?= "Error: package name 'core' is reserved for the built-in core package"
+        Right _ -> assertFailure "expected the reserved core package name to be rejected"
+
+testNonSpecialPath :: Assertion
+testNonSpecialPath =
+    resolveSpecialRelativePath ["mypkg", "utils"] ["math"]
+        @?= Nothing
+
+testRootPath :: Assertion
+testRootPath =
+    resolveSpecialRelativePath ["mypkg", "utils", "nested"] ["root", "models"]
+        @?= Just ["mypkg", "models"]
+
+testSuperPath :: Assertion
+testSuperPath =
+    resolveSpecialRelativePath ["mypkg", "utils", "nested"] ["super"]
+        @?= Just ["mypkg", "utils"]
+
+testNestedSuperPath :: Assertion
+testNestedSuperPath =
+    resolveSpecialRelativePath ["mypkg", "utils", "nested"] ["super", "super", "models"]
+        @?= Just ["mypkg", "models"]
+
+testInvalidSuperPath :: Assertion
+testInvalidSuperPath =
+    resolveSpecialRelativePath ["mypkg"] ["super"]
+        @?= Nothing
+
+testRootWithoutPackagePath :: Assertion
+testRootWithoutPackagePath =
+    resolveSpecialRelativePath [] ["root", "models"]
+        @?= Nothing

--- a/frontend/reussir-core/test/Test/Reussir/Core/Semi/PatternMatch.hs
+++ b/frontend/reussir-core/test/Test/Reussir/Core/Semi/PatternMatch.hs
@@ -84,7 +84,7 @@ runSemi :: String -> SemiEff a -> IO a
 runSemi name action = do
     B.withReussirLogger B.LogError name $ \logger -> do
         runEff $ runPrim $ runLog (Data.Text.pack name) logger LogAttention $ do
-            semiCtx <- emptySemiContext B.LogError "test.reussir"
+            semiCtx <- emptySemiContext B.LogError "test.reussir" []
             locCtx <- emptyLocalSemiContext
             State.evalState semiCtx $ State.evalState locCtx $ inject action
 

--- a/frontend/reussir-lsp/src/Reussir/LSP/Diagnostics.hs
+++ b/frontend/reussir-lsp/src/Reussir/LSP/Diagnostics.hs
@@ -54,7 +54,7 @@ elaborateFile filePath content =
         Left err -> return $ Left (T.pack $ errorBundlePretty err)
         Right prog -> do
             (_, finalState) <- do
-                initState <- emptySemiContext B.LogWarning filePath
+                initState <- emptySemiContext B.LogWarning filePath []
                 runState initState $ do
                     forM_ prog $ \stmt -> inject $ scanStmt stmt
                     forM_ prog $ \stmt -> inject $ populateRecordFields stmt

--- a/frontend/reussir-lsp/src/Reussir/LSP/SemanticTokens.hs
+++ b/frontend/reussir-lsp/src/Reussir/LSP/SemanticTokens.hs
@@ -60,6 +60,7 @@ collectStmt content (Syn.FunctionStmt f) = collectFunction content f
 collectStmt content (Syn.RecordStmt r) = collectRecord content r
 collectStmt content (Syn.ExternTrampolineStmt _ _ _ tyArgs) =
     concatMap (collectType content) tyArgs
+collectStmt _ (Syn.ModStmt _ _) = []
 
 -- | Collect tokens from a function definition.
 collectFunction :: T.Text -> Syn.Function -> [SemanticTokenAbsolute]

--- a/frontend/reussir-parser/src/Reussir/Parser/Pretty.hs
+++ b/frontend/reussir-parser/src/Reussir/Parser/Pretty.hs
@@ -289,6 +289,8 @@ instance PrettyColored Stmt where
         prettyUnnamedField (t, fld) = prettyFieldFlag fld <> prettyColored t
         prettyFieldFlag False = emptyDoc
         prettyFieldFlag True = brackets (keyword "field") <> space
+    prettyColored (ModStmt vis name) =
+        prettyColored vis <> keyword "mod" <+> prettyColored name <> operator ";"
     prettyColored (SpannedStmt w) = prettyColored (spanValue w)
     prettyColored (ExternTrampolineStmt (Identifier sym) abi func tys) =
         keyword "extern"

--- a/frontend/reussir-parser/src/Reussir/Parser/Stmt.hs
+++ b/frontend/reussir-parser/src/Reussir/Parser/Stmt.hs
@@ -148,5 +148,12 @@ parseStmtInner = do
         [ parseFuncDefRest vis <?> "function definition"
         , parseStructDecRest vis <?> "struct declaration"
         , parseEnumDecRest vis <?> "enum declaration"
+        , parseModDeclRest vis <?> "module declaration"
         , parseExternTrampoline <?> "extern trampoline"
         ]
+
+parseModDeclRest :: Visibility -> Parser Stmt
+parseModDeclRest vis = do
+    _ <- string "mod" *> space
+    name <- parseIdentifier <* semicolon
+    return $ ModStmt vis name

--- a/frontend/reussir-parser/src/Reussir/Parser/Types/Stmt.hs
+++ b/frontend/reussir-parser/src/Reussir/Parser/Types/Stmt.hs
@@ -51,5 +51,6 @@ data Stmt
         etsFunc :: Path,
         etsFuncTyArgs :: [Type]
     }
+    | ModStmt Visibility Identifier
     | SpannedStmt (WithSpan Stmt)
     deriving (Show, Eq)

--- a/frontend/reussir-parser/test/Reussir/Parser/StmtSpec.hs
+++ b/frontend/reussir-parser/test/Reussir/Parser/StmtSpec.hs
@@ -39,6 +39,7 @@ stripStmtSpans (RecordStmt r) = RecordStmt (r{recordFields = stripFields (record
     stripFields (Named fs) = Named (V.map (\(WithSpan (n, t, f) _ _) -> WithSpan (n, t, f) 0 0) fs)
     stripFields (Unnamed fs) = Unnamed (V.map (\(WithSpan (t, f) _ _) -> WithSpan (t, f) 0 0) fs)
     stripFields (Variants vs) = Variants (V.map (\(WithSpan (n, ts) _ _) -> WithSpan (n, ts) 0 0) vs)
+stripStmtSpans (ModStmt vis name) = ModStmt vis name
 stripStmtSpans (ExternTrampolineStmt n a f tys) = ExternTrampolineStmt n a f tys
 
 dummyWithSpan :: a -> WithSpan a
@@ -256,3 +257,12 @@ spec = do
                     "C"
                     (Path (Identifier "foo") [])
                     []
+
+    describe "parseStmt module declarations" $ do
+        it "parses a private module declaration" $
+            (stripStmtSpans <$> parse parseStmt "" "mod math;")
+                `shouldParse` ModStmt Private (Identifier "math")
+
+        it "parses a public module declaration" $
+            (stripStmtSpans <$> parse parseStmt "" "pub mod math;")
+                `shouldParse` ModStmt Public (Identifier "math")

--- a/tests/integration/frontend/module_basic.rr
+++ b/tests/integration/frontend/module_basic.rr
@@ -1,0 +1,5 @@
+// RUN: %reussir-elab --mode semi --package-root %S/module_basic --package-name mylib
+// RUN: %reussir-elab --mode full --package-root %S/module_basic --package-name mylib
+// RUN: %reussir-compiler --package-root %S/module_basic --package-name mylib -o %t.o
+// RUN: %cc %t.o %S/module_basic/driver.c -o %t.exe
+// RUN: %t.exe

--- a/tests/integration/frontend/module_basic/driver.c
+++ b/tests/integration/frontend/module_basic/driver.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+extern uint64_t entry_ffi(uint64_t n);
+
+int main() {
+  if (entry_ffi(5) != 15)
+    abort();
+  if (entry_ffi(0) != 10)
+    abort();
+  if (entry_ffi(100) != 110)
+    abort();
+  return 0;
+}

--- a/tests/integration/frontend/module_basic/lib.rr
+++ b/tests/integration/frontend/module_basic/lib.rr
@@ -1,0 +1,7 @@
+mod math;
+
+pub fn entry(n: u64) -> u64 {
+    math::add(n, 10)
+}
+
+extern "C" trampoline "entry_ffi" = entry;

--- a/tests/integration/frontend/module_basic/lit.local.cfg
+++ b/tests/integration/frontend/module_basic/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/module_basic/math.rr
+++ b/tests/integration/frontend/module_basic/math.rr
@@ -1,0 +1,3 @@
+pub fn add(a: u64, b: u64) -> u64 {
+    a + b
+}

--- a/tests/integration/frontend/module_cycle_duplicate.rr
+++ b/tests/integration/frontend/module_cycle_duplicate.rr
@@ -1,0 +1,5 @@
+// RUN: %reussir-elab --mode semi --package-root %S/module_cycle_duplicate --package-name mypkg
+// RUN: %reussir-elab --mode full --package-root %S/module_cycle_duplicate --package-name mypkg
+// RUN: %reussir-compiler --package-root %S/module_cycle_duplicate --package-name mypkg -o %t.o
+// RUN: %cc %t.o %S/module_cycle_duplicate/driver.c -o %t.exe
+// RUN: %t.exe

--- a/tests/integration/frontend/module_cycle_duplicate/a.rr
+++ b/tests/integration/frontend/module_cycle_duplicate/a.rr
@@ -1,0 +1,5 @@
+mod b;
+
+pub fn entry(n: u64) -> u64 {
+    b::twice(n) + 1
+}

--- a/tests/integration/frontend/module_cycle_duplicate/b.rr
+++ b/tests/integration/frontend/module_cycle_duplicate/b.rr
@@ -1,0 +1,5 @@
+mod a;
+
+pub fn twice(n: u64) -> u64 {
+    n + n
+}

--- a/tests/integration/frontend/module_cycle_duplicate/driver.c
+++ b/tests/integration/frontend/module_cycle_duplicate/driver.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+uint64_t entry_ffi(uint64_t);
+
+int main(void) {
+  uint64_t result = entry_ffi(7);
+  if (result != 15) {
+    fprintf(stderr, "unexpected result: %llu\n", (unsigned long long)result);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/module_cycle_duplicate/lib.rr
+++ b/tests/integration/frontend/module_cycle_duplicate/lib.rr
@@ -1,0 +1,8 @@
+mod a;
+mod a;
+
+pub fn entry(n: u64) -> u64 {
+    a::entry(n)
+}
+
+extern "C" trampoline "entry_ffi" = entry;

--- a/tests/integration/frontend/module_cycle_duplicate/lit.local.cfg
+++ b/tests/integration/frontend/module_cycle_duplicate/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/module_missing_file.rr
+++ b/tests/integration/frontend/module_missing_file.rr
@@ -1,0 +1,8 @@
+// RUN: %not %reussir-elab --mode semi --package-root %S/module_missing_file --package-name mypkg 2>&1 | %FileCheck %s --check-prefix=ERR
+// RUN: %not %reussir-elab --mode full --package-root %S/module_missing_file --package-name mypkg 2>&1 | %FileCheck %s --check-prefix=ERR
+// RUN: %not %reussir-compiler --package-root %S/module_missing_file --package-name mypkg -o %t.o 2>&1 | %FileCheck %s --check-prefix=ERR
+
+// ERR: Error: module 'missing'
+// ERR: has no source file
+// ERR: missing.rr
+// ERR: missing/mod.rr

--- a/tests/integration/frontend/module_missing_file.rr
+++ b/tests/integration/frontend/module_missing_file.rr
@@ -5,4 +5,4 @@
 // ERR: Error: module 'missing'
 // ERR: has no source file
 // ERR: missing.rr
-// ERR: missing/mod.rr
+// ERR: missing{{[/\\]}}mod.rr

--- a/tests/integration/frontend/module_missing_file/lib.rr
+++ b/tests/integration/frontend/module_missing_file/lib.rr
@@ -1,0 +1,5 @@
+mod missing;
+
+pub fn entry(n: u64) -> u64 {
+    n
+}

--- a/tests/integration/frontend/module_missing_file/lit.local.cfg
+++ b/tests/integration/frontend/module_missing_file/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/module_nested.rr
+++ b/tests/integration/frontend/module_nested.rr
@@ -1,0 +1,5 @@
+// RUN: %reussir-elab --mode semi --package-root %S/module_nested --package-name mypkg
+// RUN: %reussir-elab --mode full --package-root %S/module_nested --package-name mypkg
+// RUN: %reussir-compiler --package-root %S/module_nested --package-name mypkg -o %t.o
+// RUN: %cc %t.o %S/module_nested/driver.c -o %t.exe
+// RUN: %t.exe

--- a/tests/integration/frontend/module_nested/driver.c
+++ b/tests/integration/frontend/module_nested/driver.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+extern uint64_t nested_entry_ffi(uint64_t n);
+
+int main() {
+  // double(5) + offset() = 10 + 42 = 52
+  if (nested_entry_ffi(5) != 52)
+    abort();
+  // double(0) + offset() = 0 + 42 = 42
+  if (nested_entry_ffi(0) != 42)
+    abort();
+  // double(100) + offset() = 200 + 42 = 242
+  if (nested_entry_ffi(100) != 242)
+    abort();
+  return 0;
+}

--- a/tests/integration/frontend/module_nested/lib.rr
+++ b/tests/integration/frontend/module_nested/lib.rr
@@ -1,0 +1,7 @@
+mod utils;
+
+pub fn entry(n: u64) -> u64 {
+    utils::math::double(n) + utils::offset()
+}
+
+extern "C" trampoline "nested_entry_ffi" = entry;

--- a/tests/integration/frontend/module_nested/lit.local.cfg
+++ b/tests/integration/frontend/module_nested/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/module_nested/utils/math.rr
+++ b/tests/integration/frontend/module_nested/utils/math.rr
@@ -1,0 +1,3 @@
+pub fn double(x: u64) -> u64 {
+    x + x
+}

--- a/tests/integration/frontend/module_nested/utils/mod.rr
+++ b/tests/integration/frontend/module_nested/utils/mod.rr
@@ -1,0 +1,5 @@
+mod math;
+
+pub fn offset() -> u64 {
+    42
+}

--- a/tests/integration/frontend/module_relative_paths.rr
+++ b/tests/integration/frontend/module_relative_paths.rr
@@ -1,0 +1,5 @@
+// RUN: %reussir-elab --mode semi --package-root %S/module_relative_paths --package-name mypkg
+// RUN: %reussir-elab --mode full --package-root %S/module_relative_paths --package-name mypkg
+// RUN: %reussir-compiler --package-root %S/module_relative_paths --package-name mypkg -o %t.o
+// RUN: %cc %t.o %S/module_relative_paths/driver.c -o %t.exe
+// RUN: %t.exe

--- a/tests/integration/frontend/module_relative_paths/driver.c
+++ b/tests/integration/frontend/module_relative_paths/driver.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+uint64_t entry_ffi(uint64_t);
+
+int main(void) {
+  uint64_t result = entry_ffi(7);
+  if (result != 39) {
+    fprintf(stderr, "unexpected result: %llu\n", (unsigned long long)result);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/module_relative_paths/lib.rr
+++ b/tests/integration/frontend/module_relative_paths/lib.rr
@@ -1,0 +1,8 @@
+mod models;
+mod utils;
+
+pub fn entry(n: u64) -> u64 {
+    root::utils::nested::compute(n) + root::models::seed()
+}
+
+extern "C" trampoline "entry_ffi" = entry;

--- a/tests/integration/frontend/module_relative_paths/lit.local.cfg
+++ b/tests/integration/frontend/module_relative_paths/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/module_relative_paths/models.rr
+++ b/tests/integration/frontend/module_relative_paths/models.rr
@@ -1,0 +1,7 @@
+pub fn seed() -> u64 {
+    5
+}
+
+pub fn scale(x: u64) -> u64 {
+    x + seed()
+}

--- a/tests/integration/frontend/module_relative_paths/utils/math.rr
+++ b/tests/integration/frontend/module_relative_paths/utils/math.rr
@@ -1,0 +1,7 @@
+pub fn double_with_offset(x: u64) -> u64 {
+    x + x + super::offset()
+}
+
+pub fn scaled_offset(x: u64) -> u64 {
+    root::models::scale(double_with_offset(x))
+}

--- a/tests/integration/frontend/module_relative_paths/utils/mod.rr
+++ b/tests/integration/frontend/module_relative_paths/utils/mod.rr
@@ -1,0 +1,6 @@
+mod math;
+mod nested;
+
+pub fn offset() -> u64 {
+    10
+}

--- a/tests/integration/frontend/module_relative_paths/utils/nested.rr
+++ b/tests/integration/frontend/module_relative_paths/utils/nested.rr
@@ -1,0 +1,3 @@
+pub fn compute(x: u64) -> u64 {
+    super::math::scaled_offset(x) + super::super::models::seed()
+}

--- a/tests/integration/frontend/module_reserved_package.rr
+++ b/tests/integration/frontend/module_reserved_package.rr
@@ -1,0 +1,5 @@
+// RUN: %not %reussir-elab --mode semi --package-root %S/module_reserved_package --package-name core 2>&1 | %FileCheck %s --check-prefix=ERR
+// RUN: %not %reussir-elab --mode full --package-root %S/module_reserved_package --package-name core 2>&1 | %FileCheck %s --check-prefix=ERR
+// RUN: %not %reussir-compiler --package-root %S/module_reserved_package --package-name core -o %t.o 2>&1 | %FileCheck %s --check-prefix=ERR
+
+// ERR: Error: package name 'core' is reserved for the built-in core package

--- a/tests/integration/frontend/module_reserved_package/lib.rr
+++ b/tests/integration/frontend/module_reserved_package/lib.rr
@@ -1,0 +1,3 @@
+pub fn entry(n: u64) -> u64 {
+    n
+}

--- a/tests/integration/frontend/module_reserved_package/lit.local.cfg
+++ b/tests/integration/frontend/module_reserved_package/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []


### PR DESCRIPTION
## Summary

- Implement Rust-like module system driven by `mod name;` / `pub mod name;` declarations in source files
- Compiler resolves modules from filesystem layout (`name.rr` or `name/mod.rr`) starting from `lib.rr`, qualifies all symbols with their module path, and compiles into a single object file
- Cross-module references resolve via 3-level lookup: absolute → current-module-relative → package-root-relative

### Changes

**Parser:** New `ModStmt` variant and `mod name;` syntax parsing

**`Reussir.Core.Module` (new):** Declaration-driven file discovery — parses `lib.rr`, follows `mod` declarations recursively to resolve file paths and compute module paths

**`SemiContext`:** Added `currentModulePath` field, `withModuleFile` for file/module context switching, `resolveFunctionPath`/`resolveRecordPath` with multi-level resolution

**`FunctionProto`:** Added `funcPath :: Path` — fully qualified paths stored at registration time, used in `Full/Function.hs` instead of constructing `Path name []`

**Core pipeline:** New `translatePackageToModule` multi-file entry point; `translateProgToModule` delegates to it for backward compatibility

**CLI:** `--package-root DIR --package-name NAME` arguments for both `reussir-compiler` and `reussir-elab`

**LSP/REPL:** Updated pattern matches for new `ModStmt` constructor

### Usage

```bash
# Single file (unchanged)
reussir-compiler input.rr -o output.o

# Package mode
reussir-compiler --package-root ./mylib --package-name mylib -o output.o
```

Where `mylib/lib.rr` contains:
```rust
mod math;

pub fn entry(n: u64) -> u64 {
    math::add(n, 10)
}
```

## Test plan

- [x] `ninja check` — all 227 existing tests pass (backward compatible)
- [x] `cabal test reussir-core-test` — all 45 unit tests pass
- [x] `module_basic.rr` — cross-module function call (lib.rr → math.rr) with C driver E2E
- [x] `module_nested.rr` — nested modules (lib.rr → utils/mod.rr → utils/math.rr) with C driver E2E
- [x] `reussir-lsp` builds clean with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)