### PR TITLE
Add polymorphic FFI frontend support with extern struct

### DIFF
--- a/frontend/reussir-codegen/src/Reussir/Codegen.hs
+++ b/frontend/reussir-codegen/src/Reussir/Codegen.hs
@@ -36,7 +36,7 @@ import Reussir.Codegen.PolymorphicFFI (
     polyFFICodegen,
  )
 import Reussir.Codegen.Type.Record (Record)
-import Reussir.Codegen.Trampoline
+import Reussir.Codegen.Trampoline (Trampoline, ImportTrampoline, trampolineCodegen, importTrampolineCodegen)
 
 newtype RecordInstance = RecordInstance {unRecordInstance :: (Symbol, Record)}
 data Module = Module
@@ -46,6 +46,7 @@ data Module = Module
     , polymorphicFFIs :: [PolymorphicFFI]
     , globals :: [Global]
     , trampolines :: [Trampoline]
+    , importTrampolines :: [ImportTrampoline]
     }
 
 {- | Create an empty module with the given target specification.
@@ -60,6 +61,7 @@ emptyModule spec =
         , polymorphicFFIs = []
         , globals = []
         , trampolines = []
+        , importTrampolines = []
         }
 
 -- | Emit a complete MLIR module with the given body.
@@ -71,6 +73,7 @@ moduleCodegen m = do
         forM_ (polymorphicFFIs m) polyFFICodegen
         forM_ (moduleFunctions m) functionCodegen
         forM_ (trampolines m) trampolineCodegen
+        forM_ (importTrampolines m) importTrampolineCodegen
 
 -- | Helper function to emit module to a Text
 emitModuleToText :: (IOE :> es, L.Log :> es) => Module -> Eff es T.Text

--- a/frontend/reussir-codegen/src/Reussir/Codegen/Trampoline.hs
+++ b/frontend/reussir-codegen/src/Reussir/Codegen/Trampoline.hs
@@ -1,5 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Reussir.Codegen.Trampoline where
+module Reussir.Codegen.Trampoline (
+    Trampoline(..),
+    ImportTrampoline(..),
+    trampolineCodegen,
+    importTrampolineCodegen,
+) where
 import qualified Data.Text as T
 import Reussir.Codegen.Context.Symbol (Symbol)
 import Reussir.Codegen.Context.Codegen (Codegen)
@@ -7,10 +12,20 @@ import Reussir.Codegen.Context.Emission (emitBuilderLineM)
 import qualified Data.Text.Builder.Linear as TB
 import Reussir.Codegen.Context (Emission(emit))
 
+-- | Export trampoline: wraps a Reussir function for C ABI export.
 data Trampoline = Trampoline {
     trampolineName :: Symbol,
     trampolineTarget :: Symbol,
     trampolineABI :: T.Text
+}
+
+-- | Import trampoline: declares an external C function callable from Reussir.
+-- At MLIR level, this generates:
+--   reussir.import_trampoline "C" @reussir_name = @c_name
+data ImportTrampoline = ImportTrampoline {
+    importTrampolineName :: Symbol,
+    importTrampolineTarget :: Symbol,
+    importTrampolineABI :: T.Text
 }
 
 trampolineCodegen :: Trampoline -> Codegen ()
@@ -19,4 +34,14 @@ trampolineCodegen (Trampoline name target abi) = emitBuilderLineM $ do
     let abi' = TB.fromText $ T.show abi
     name' <- emit name
     target' <- emit target
-    return $ opName <> " " <> abi' <> " @" <> name' <> " = @" <> target' 
+    return $ opName <> " " <> abi' <> " @" <> name' <> " = @" <> target'
+
+-- | Emit an import trampoline operation.
+-- Format: reussir.import_trampoline "C" @reussir_name = @c_name
+importTrampolineCodegen :: ImportTrampoline -> Codegen ()
+importTrampolineCodegen (ImportTrampoline name target abi) = emitBuilderLineM $ do
+    let opName = "reussir.import_trampoline"
+    let abi' = TB.fromText $ T.show abi
+    name' <- emit name
+    target' <- emit target
+    return $ opName <> " " <> abi' <> " @" <> name' <> " = @" <> target'

--- a/frontend/reussir-codegen/src/Reussir/Codegen/Type/Data.hs
+++ b/frontend/reussir-codegen/src/Reussir/Codegen/Type/Data.hs
@@ -27,6 +27,7 @@ where
 import Data.Hashable (Hashable)
 import GHC.Generics (Generic)
 
+import Data.Text qualified as T
 import Reussir.Codegen.Context.Symbol (Symbol)
 
 {- | Integer primitive types for MLIR code generation.
@@ -168,6 +169,8 @@ data Type
     | TypeRc Rc
     | TypeRef Ref
     | TypeExpr Symbol
+    | -- | Opaque FFI object type: @!reussir.ffi_object\<\"foreign_name\", \@dtor\>@
+      TypeFFIObject T.Text Symbol
     | TypeNullable Type
     | TypeRegion -- Region handle
     | TypeStr LifeScope -- String type !reussir.str<global> or !reussir.str<local>

--- a/frontend/reussir-codegen/src/Reussir/Codegen/Type/Emission.hs
+++ b/frontend/reussir-codegen/src/Reussir/Codegen/Type/Emission.hs
@@ -88,6 +88,9 @@ emitTy toplevel (TypeExpr sym) = do
     case record of
         Just r -> emitRecord toplevel (Just sym) r
         Nothing -> error $ "Record not found for expression: " <> show sym
+emitTy _ (TypeFFIObject ffiName dtorSym) = do
+    let ffiName' = TB.fromText ffiName
+    pure $ "!reussir.ffi_object<\"" <> ffiName' <> "\", @" <> symbolBuilder dtorSym <> ">"
 emitTy toplevel (TypeNullable ty) = do
     ty' <- emitTy toplevel ty
     pure $ "!reussir.nullable<" <> ty' <> ">"

--- a/frontend/reussir-core/app/Elab.hs
+++ b/frontend/reussir-core/app/Elab.hs
@@ -48,7 +48,7 @@ import Reussir.Core.Semi.Tyck (checkFuncType)
 
 import Reussir.Core.Full.Pretty qualified as Full
 import Reussir.Core.Semi.Pretty qualified as Semi
-import Reussir.Core.Semi.Trampoline
+import Reussir.Core.Semi.Trampoline (resolveFFI)
 
 data ElabMode = SemiMode | FullMode
     deriving (Eq, Show)
@@ -189,8 +189,13 @@ runSemiElab _args files = do
                                 Syn.FunctionStmt f -> do
                                     _ <- inject $ checkFuncType f
                                     return ()
-                                Syn.ExternTrampolineStmt name abi target args' -> do
-                                    inject $ resolveTrampoline name abi target args'
+                                Syn.ExternFFIStmt{Syn.efsName = name, Syn.efsABI = abi,
+                                                  Syn.efsDirection = direction,
+                                                  Syn.efsGenerics = generics,
+                                                  Syn.efsParams = params,
+                                                  Syn.efsReturnType = retType,
+                                                  Syn.efsBody = body} -> do
+                                    inject $ resolveFFI name abi direction generics params retType body
                                 _ -> return ()
 
                 let putDoc' doc = do
@@ -267,8 +272,13 @@ runFullElab _args files = do
                                 Syn.FunctionStmt f -> do
                                     _ <- inject $ checkFuncType f
                                     return ()
-                                Syn.ExternTrampolineStmt name abi target args' -> do
-                                    inject $ resolveTrampoline name abi target args'
+                                Syn.ExternFFIStmt{Syn.efsName = name, Syn.efsABI = abi,
+                                                  Syn.efsDirection = direction,
+                                                  Syn.efsGenerics = generics,
+                                                  Syn.efsParams = params,
+                                                  Syn.efsReturnType = retType,
+                                                  Syn.efsBody = body} -> do
+                                    inject $ resolveFFI name abi direction generics params retType body
                                 _ -> return ()
 
                 -- Solve generics

--- a/frontend/reussir-core/src/Reussir/Core.hs
+++ b/frontend/reussir-core/src/Reussir/Core.hs
@@ -37,7 +37,7 @@ import Reussir.Core.Semi.Context (
     withModuleFile,
  )
 import Reussir.Core.Semi.FlowAnalysis (solveAllGenerics)
-import Reussir.Core.Semi.Trampoline (resolveTrampoline)
+import Reussir.Core.Semi.Trampoline (resolveFFI)
 import Reussir.Core.Semi.Tyck (checkFuncType)
 
 unspanStmt :: Syn.Stmt -> Syn.Stmt
@@ -98,8 +98,13 @@ translatePackageToModule spec files = do
                             Syn.FunctionStmt f -> do
                                 _ <- inject $ checkFuncType f
                                 return ()
-                            Syn.ExternTrampolineStmt name abi target args -> do
-                                inject $ resolveTrampoline name abi target args
+                            Syn.ExternFFIStmt{Syn.efsName = name, Syn.efsABI = abi,
+                                              Syn.efsDirection = direction,
+                                              Syn.efsGenerics = generics,
+                                              Syn.efsParams = params,
+                                              Syn.efsReturnType = retType,
+                                              Syn.efsBody = body} -> do
+                                inject $ resolveFFI name abi direction generics params retType body
                             _ -> return ()
 
             -- Solve generics
@@ -127,6 +132,8 @@ translatePackageToModule spec files = do
                     ctxRecords
                     ctxStringUniqifier
                     ctxTrampolines
+                    ctxFFIImports
+                    ctxExternStructs
                     spec
         runLoweringToModule loweringCtx lowerModule
 

--- a/frontend/reussir-core/src/Reussir/Core/Data/Full/Context.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Data/Full/Context.hs
@@ -12,8 +12,21 @@ import Reussir.Core.Data.Full.Record (FullRecordTable, SemiRecordTable)
 import Reussir.Core.Data.Full.Type (GenericMap)
 import Reussir.Core.Data.String (StringUniqifier)
 import Reussir.Codegen.Context.Symbol (Symbol)
+import Reussir.Parser.Types.Lexer (Path)
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Text as T
+
+-- | Information about an imported FFI function after full conversion.
+data FullFFIImport = FullFFIImport
+    { fullFFIImportABI :: T.Text
+    , fullFFIImportSymbol :: Symbol
+    -- | The raw function path (for matching against function instances)
+    , fullFFIImportFuncPath :: Path
+    -- | Generic parameter names for template substitution
+    , fullFFIImportGenericNames :: [T.Text]
+    -- | Optional Rust/C template for polymorphic FFI code generation
+    , fullFFIImportTemplate :: Maybe T.Text
+    }
 
 data FullContext = FullContext
     { ctxFunctions :: FunctionTable
@@ -24,6 +37,10 @@ data FullContext = FullContext
     , ctxFilePath :: FilePath
     , ctxFlexible :: Bool
     , ctxTrampolines :: HashMap.HashMap Symbol (T.Text, Symbol)
+    -- | Import FFI declarations: maps mangled function symbol → import info
+    , ctxFFIImports :: HashMap.HashMap Symbol FullFFIImport
+    -- | Extern struct declarations: maps record path → foreign type template
+    , ctxExternStructs :: HashMap.HashMap Path T.Text
     }
 
 data LocalFullContext = LocalFullContext

--- a/frontend/reussir-core/src/Reussir/Core/Data/Full/Record.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Data/Full/Record.hs
@@ -24,6 +24,7 @@ data RecordKind
     = StructKind
     | EnumKind
     | EnumVariant {variantParent :: Symbol, variantIdx :: Int}
+    | ExternStructKind
     deriving (Show, Eq)
 
 data Record = Record

--- a/frontend/reussir-core/src/Reussir/Core/Data/Lowering/Context.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Data/Lowering/Context.hs
@@ -32,6 +32,8 @@ import Reussir.Core.Data.Full.Function qualified as Full
 import Reussir.Core.Data.Full.Record qualified as Full
 import qualified Data.HashMap.Strict as HashMap
 import Reussir.Codegen.Context.Symbol (Symbol)
+import Reussir.Core.Data.Full.Context (FullFFIImport)
+import Reussir.Parser.Types.Lexer (Path)
 
 type BlockBuilder = Seq.Seq IR.Instr
 
@@ -45,6 +47,9 @@ data LoweringContext = LoweringContext
     , targetSpec :: IR.TargetSpec
     , ownershipAnnotations :: OwnershipAnnotations
     , trampolines :: HashMap.HashMap Symbol (T.Text, Symbol)
+    , ffiImports :: HashMap.HashMap Symbol FullFFIImport
+    -- | Extern struct: maps record path → foreign type template
+    , externStructs :: HashMap.HashMap Path T.Text
     }
 
 data LoweringSpan = LoweringSpan

--- a/frontend/reussir-core/src/Reussir/Core/Data/Semi/Context.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Data/Semi/Context.hs
@@ -1,6 +1,7 @@
 module Reussir.Core.Data.Semi.Context (
     SemiContext (..),
     LocalSemiContext (..),
+    FFIImportInfo (..),
     GlobalSemiEff,
     SemiEff,
 ) where
@@ -40,6 +41,16 @@ data LocalSemiContext = LocalSemiContext
     , exprCounter :: Int
     }
 
+-- | Information about an imported FFI function.
+data FFIImportInfo = FFIImportInfo
+    { ffiImportABI :: T.Text
+    -- | The resolved function path (in the function table)
+    , ffiImportFuncPath :: Path
+    -- | Optional template for polymorphic FFI code generation.
+    -- Uses @${T}@ syntax for type parameter substitution.
+    , ffiImportTemplate :: Maybe T.Text
+    }
+
 {- | The context required for semi-elaboration from surface syntax to generic
    constrained semi-abstract syntax.
 -}
@@ -55,7 +66,12 @@ data SemiContext = SemiContext
     , knownRecords :: H.CuckooHashTable Path Record
     , functions :: FunctionTable
     , generics :: GenericState
+    -- | Export trampolines: maps exported symbol → (target func path, ABI, type args)
     , trampolines :: HashMap Identifier (Path, T.Text, [Type])
+    -- | Import FFI declarations: maps function name → import info
+    , ffiImports :: HashMap Identifier FFIImportInfo
+    -- | Extern struct declarations: maps record path → foreign type template
+    , externStructs :: HashMap Path T.Text
     }
 
 type GlobalSemiEff = Eff '[IOE, Prim, Log, State SemiContext]

--- a/frontend/reussir-core/src/Reussir/Core/Data/Semi/Record.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Data/Semi/Record.hs
@@ -23,6 +23,7 @@ data RecordKind
     = StructKind
     | EnumKind
     | EnumVariant {variantParent :: Path, variantIdx :: Int}
+    | ExternStructKind
     deriving (Show, Eq)
 
 data Record = Record

--- a/frontend/reussir-core/src/Reussir/Core/Full/Context.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Full/Context.hs
@@ -75,6 +75,8 @@ emptyFullContext ctxFilePath = do
     let ctxErrors = []
     let ctxFlexible = False
     let ctxTrampolines = HashMap.empty
+    let ctxFFIImports = HashMap.empty
+    let ctxExternStructs = HashMap.empty
     return FullContext{..}
 
 reportAllErrors ::

--- a/frontend/reussir-core/src/Reussir/Core/Full/Conversion.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Full/Conversion.hs
@@ -9,7 +9,7 @@ import Effectful.Prim.IORef.Strict (Prim)
 import Data.HashTable.IO qualified as H
 import Effectful.State.Static.Local qualified as State
 
-import Reussir.Core.Data.Full.Context (FullContext (ctxTrampolines))
+import Reussir.Core.Data.Full.Context (FullContext (ctxTrampolines, ctxFFIImports, ctxExternStructs), FullFFIImport(..))
 import Reussir.Core.Data.Generic (GenericSolution)
 import Reussir.Core.Full.Context (addError, emptyFullContext)
 import Reussir.Core.Full.Function (convertAllSemiFunctions)
@@ -23,6 +23,7 @@ import Reussir.Parser.Types.Lexer (Identifier(Identifier))
 import Reussir.Core.Semi.Mangle (mangleABIName)
 import Reussir.Core.Data.Semi.Type (Type(TypeRecord))
 import qualified Reussir.Core.Data.Semi.Type as Semi
+import qualified Data.Text as T
 
 convertCtx ::
     (IOE :> es, Prim :> es, Log :> es) =>
@@ -35,9 +36,36 @@ convertCtx semiCtx sol = do
         when (null errs) $ do
             funcProtos <- liftIO $ H.toList (Semi.functionProtos $ Semi.functions semiCtx)
             inject $ convertAllSemiFunctions (map snd funcProtos) sol
+
+            -- Convert export trampolines
             forM_ (HashMap.toList (Semi.trampolines semiCtx)) $ \(Identifier name, (path, abi, tyArgs)) -> do
                 let symName = verifiedSymbol name
                 let mangledTarget = mangleABIName $ TypeRecord path tyArgs Semi.Irrelevant
                 let mangledSymbol = verifiedSymbol mangledTarget
-                State.modify $ \ctx -> ctx { 
+                State.modify $ \ctx -> ctx {
                     ctxTrampolines = HashMap.insert symName (abi, mangledSymbol) (ctxTrampolines ctx) }
+
+            -- Convert FFI imports
+            forM_ (HashMap.toList (Semi.ffiImports semiCtx)) $ \(Identifier name, importInfo) -> do
+                let funcPath = Semi.ffiImportFuncPath importInfo
+                -- Look up the function prototype to get its generic parameter names
+                mProto <- liftIO $ H.lookup (Semi.functionProtos $ Semi.functions semiCtx) funcPath
+                let genericNames = case mProto of
+                        Just proto -> map (unIdentifier . fst) (Semi.funcGenerics proto)
+                        Nothing -> []
+                let symName = verifiedSymbol name
+                let fullImport = FullFFIImport
+                        { fullFFIImportABI = Semi.ffiImportABI importInfo
+                        , fullFFIImportSymbol = symName
+                        , fullFFIImportFuncPath = funcPath
+                        , fullFFIImportGenericNames = genericNames
+                        , fullFFIImportTemplate = Semi.ffiImportTemplate importInfo
+                        }
+                State.modify $ \ctx -> ctx {
+                    ctxFFIImports = HashMap.insert symName fullImport (ctxFFIImports ctx) }
+
+            -- Forward extern struct declarations
+            State.modify $ \ctx -> ctx {
+                ctxExternStructs = Semi.externStructs semiCtx }
+  where
+    unIdentifier (Identifier t) = t

--- a/frontend/reussir-core/src/Reussir/Core/Full/Pretty.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Full/Pretty.hs
@@ -339,6 +339,7 @@ instance PrettyColored Record where
                     StructKind -> "struct"
                     EnumKind -> "enum"
                     EnumVariant _ _ -> "enum_variant"
+                    ExternStructKind -> "extern struct"
                 )
                 <+> nameDoc
                 <+> parens ("aka " <> rawPathDoc <> genericsDoc)

--- a/frontend/reussir-core/src/Reussir/Core/Full/Record.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Full/Record.hs
@@ -65,6 +65,7 @@ instantiateRecord tyArgs semiRecords (Semi.Record path tyParams fieldsRef kind _
             Semi.EnumVariant p i ->
                 let parentSymbol = verifiedSymbol $ mangleABIName (Semi.TypeRecord p tyArgs Semi.Irrelevant)
                  in EnumVariant parentSymbol i
+            Semi.ExternStructKind -> ExternStructKind
 
     case instantiatedFields of
         Left errs -> pure $ Left errs

--- a/frontend/reussir-core/src/Reussir/Core/Lowering/Context.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Lowering/Context.hs
@@ -40,14 +40,8 @@ import Reussir.Core.Data.Full.Function qualified as Full
 import Reussir.Core.Data.Full.Record qualified as Full
 import qualified Data.HashMap.Strict as HashMap
 import Reussir.Codegen.Context.Symbol (Symbol)
-
-{-
-, srcRepository :: Repository
-    , functionInstances :: Full.FunctionTable
-    , recordInstances :: Full.FullRecordTable
-    , stringUniqifier :: StringUniqifier
-    , targetSpec :: IR.TargetSpec
--}
+import Reussir.Core.Data.Full.Context (FullFFIImport)
+import Reussir.Parser.Types.Lexer (Path)
 
 createLoweringContext ::
     (IOE :> es, Log :> es, Prim :> es) =>
@@ -56,9 +50,11 @@ createLoweringContext ::
     Full.FullRecordTable ->
     StringUniqifier ->
     HashMap.HashMap Symbol (T.Text, Symbol) ->
+    HashMap.HashMap Symbol FullFFIImport ->
+    HashMap.HashMap Path T.Text ->
     IR.TargetSpec ->
     Eff es LoweringContext
-createLoweringContext repo functions records stringUniqifier trampolines targetSpec = do
+createLoweringContext repo functions records stringUniqifier trampolines ffiImports externStructs targetSpec = do
     (dir, base) <- liftIO $ do
         result <- try @SomeException $ canonicalizePath (IR.moduleFilePath targetSpec)
         case result of
@@ -75,6 +71,8 @@ createLoweringContext repo functions records stringUniqifier trampolines targetS
             , targetSpec = targetSpec
             , ownershipAnnotations = OwnershipAnnotations IntMap.empty
             , trampolines
+            , ffiImports
+            , externStructs
             }
 
 runLoweringToModule ::

--- a/frontend/reussir-core/src/Reussir/Core/Lowering/Module.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Lowering/Module.hs
@@ -4,23 +4,45 @@ module Reussir.Core.Lowering.Module where
 
 import Control.Monad (forM_)
 import Effectful (liftIO)
-import Reussir.Codegen.Context.Symbol (verifiedSymbol)
+import Reussir.Codegen.Context.Symbol (verifiedSymbol, symbolText)
 
 import Data.HashTable.IO qualified as H
 import Effectful.Reader.Static qualified as Reader
 import Effectful.State.Static.Local qualified as State
 import Reussir.Codegen qualified as IR
 import Reussir.Codegen.Global qualified as IR
+import Reussir.Codegen.Type qualified as IR
 
+import Reussir.Core.Data.Full.Context (FullFFIImport(..))
+import Reussir.Core.Data.Full.Function qualified as Full
+import Reussir.Core.Data.Full.Record qualified as Full
+import Reussir.Core.Data.Full.Type qualified as Full
 import Reussir.Core.Data.Lowering.Context (
     GlobalLoweringEff,
     LoweringContext (..),
  )
 import Reussir.Core.Lowering.Function (lowerFunction)
 import Reussir.Core.Lowering.Record (lowerRecord)
+import Reussir.Core.Lowering.Type (convertType)
 import Reussir.Core.String (getAllStrings, mangleStringToken)
 import qualified Data.HashMap.Strict as HashMap
-import qualified Reussir.Codegen.Trampoline as IR
+import Reussir.Codegen.Trampoline qualified as IR
+import qualified Data.Text as T
+
+-- | Convert ${key} template syntax to [:key:] syntax for the MLIR polyffi backend.
+convertTemplateSyntax :: T.Text -> T.Text
+convertTemplateSyntax = go
+  where
+    go t = case T.breakOn "${" t of
+        (before, rest)
+            | T.null rest -> before
+            | otherwise ->
+                let afterDollar = T.drop 2 rest  -- drop "${"
+                in case T.breakOn "}" afterDollar of
+                    (key, rest')
+                        | T.null rest' -> before <> rest  -- malformed, keep as-is
+                        | otherwise ->
+                            before <> "[:" <> key <> ":]" <> go (T.drop 1 rest')
 
 lowerModule :: GlobalLoweringEff ()
 lowerModule = do
@@ -43,9 +65,54 @@ lowerModule = do
         let updatedMod = mod'{IR.globals = global : IR.globals mod'}
         State.put updatedMod
 
-    -- Lower trampolines
+    -- Lower export trampolines
     forM_ (HashMap.toList (trampolines ctx)) $ \(name, (abi, target)) -> do
         let trampoline' = IR.Trampoline name target abi
         mod' <- State.get
         let updatedMod = mod'{IR.trampolines = trampoline' : IR.trampolines mod'}
         State.put updatedMod
+
+    -- Lower import FFI template instantiations.
+    -- For each function instance that corresponds to an FFI import with a template,
+    -- emit a reussir.polyffi op with concrete type substitutions.
+    let ffiImportsByPath = HashMap.fromList
+            [ (fullFFIImportFuncPath info, info)
+            | (_, info) <- HashMap.toList (ffiImports ctx)
+            ]
+    forM_ functionList $ \(_, func) -> do
+        case HashMap.lookup (Full.funcRawPath func) ffiImportsByPath of
+            Just info | Just template <- fullFFIImportTemplate info -> do
+                let converted = convertTemplateSyntax template
+                let genericNames = fullFFIImportGenericNames info
+                let tyArgs = Full.funcInstantiatedTyArgs func
+                -- Convert Full types to IR types for MLIR substitution
+                convertedTyArgs <- mapM convertType tyArgs
+                let attrs = zipWith (\gn ty -> IR.PolyFFITypeParam gn ty) genericNames convertedTyArgs
+                let polyffi = IR.PolymorphicFFI converted attrs
+                mod' <- State.get
+                let updatedMod = mod'{IR.polymorphicFFIs = polyffi : IR.polymorphicFFIs mod'}
+                State.put updatedMod
+            _ -> pure ()
+
+    -- Lower extern struct destructor polyffi ops.
+    -- For each extern struct instantiation, emit a polyffi that generates a drop
+    -- function. We get the concrete Rust type name from convertType.
+    forM_ recordList $ \(_, record) -> do
+        case Full.recordKind record of
+            Full.ExternStructKind -> do
+                irType <- convertType (Full.TypeRecord (Full.recordName record))
+                case irType of
+                    IR.TypeFFIObject ffiName dtorSym -> do
+                        let dtorTemplate =
+                                "#![feature(linkage)]\nextern crate reussir_rt;\n" <>
+                                "use " <> ffiName <> ";\n" <>
+                                "#[linkage = \"weak_odr\"]\n" <>
+                                "#[unsafe(no_mangle)]\n" <>
+                                "pub unsafe extern \"C\" fn " <> symbolText dtorSym <>
+                                "(_: " <> ffiName <> ") {}\n"
+                        let polyffi = IR.PolymorphicFFI dtorTemplate []
+                        mod' <- State.get
+                        let updatedMod = mod'{IR.polymorphicFFIs = polyffi : IR.polymorphicFFIs mod'}
+                        State.put updatedMod
+                    _ -> pure ()
+            _ -> pure ()

--- a/frontend/reussir-core/src/Reussir/Core/Lowering/Record.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Lowering/Record.hs
@@ -16,6 +16,13 @@ import Reussir.Core.Data.Full.Record qualified as Full
 
 lowerRecord :: Full.Record -> GlobalLoweringEff ()
 lowerRecord record = do
+    -- Extern structs are opaque FFI types; they don't produce record instances.
+    case Full.recordKind record of
+        Full.ExternStructKind -> pure ()
+        _ -> lowerRecordImpl record
+
+lowerRecordImpl :: Full.Record -> GlobalLoweringEff ()
+lowerRecordImpl record = do
     let symbol = Full.recordName record
     let semKind = Full.recordKind record
 

--- a/frontend/reussir-core/src/Reussir/Core/Lowering/Type.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Lowering/Type.hs
@@ -1,12 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Reussir.Core.Lowering.Type where
 
+import Effectful (liftIO)
+import Reussir.Codegen.Context.Symbol (verifiedSymbol, symbolText)
 import Reussir.Codegen.Type qualified as IR
 
-import Reussir.Core.Data.Lowering.Context (GlobalLoweringEff)
+import Reussir.Core.Data.Lowering.Context (GlobalLoweringEff, LoweringContext(..))
+
+import Data.HashTable.IO qualified as H
+import Data.HashMap.Strict qualified as HashMap
+import Data.Text qualified as T
+import Effectful.Reader.Static qualified as Reader
 
 import Reussir.Core.Data.FP qualified as FP
+import Reussir.Core.Data.Full.Record qualified as Full
 import Reussir.Core.Data.Full.Type qualified as Full
 import Reussir.Core.Data.Integral qualified as Int
+import Reussir.Core.Data.Semi.Type qualified as Semi
+import Reussir.Core.Semi.Mangle (mangleABIName)
 
 convertType :: Full.Type -> GlobalLoweringEff IR.Type
 convertType Full.TypeBool = pure $ IR.TypePrim IR.PrimBool
@@ -20,7 +32,20 @@ convertType (Full.TypeClosure args ret) = do
     (IR.TypeClosure .) . IR.Closure <$> mapM convertType args <*> convertType ret
 convertType (Full.TypeNullable inner) = IR.TypeNullable <$> convertType inner
 convertType (Full.TypeRecord symbol) = do
-    pure $ IR.TypeExpr symbol
+    ctx <- Reader.ask
+    mRecord <- liftIO $ H.lookup (recordInstances ctx) symbol
+    case mRecord of
+        Just record | Full.ExternStructKind <- Full.recordKind record -> do
+            let rawPath = Full.recordRawPath record
+            case HashMap.lookup rawPath (externStructs ctx) of
+                Just template -> do
+                    let tyArgs = Full.recordSemiTyParams record
+                    let ffiName = substituteTemplate template tyArgs
+                    let dtorName = symbolText symbol <> "$polyffi_drop"
+                    let dtorSym = verifiedSymbol dtorName
+                    pure $ IR.TypeFFIObject ffiName dtorSym
+                Nothing -> pure $ IR.TypeExpr symbol
+        _ -> pure $ IR.TypeExpr symbol
 convertType (Full.TypeRc ty cap) = do
     inner <- convertType ty
     pure $
@@ -50,3 +75,28 @@ convertFloat w = error $ "Unsupported float width: " ++ show w
 
 mkRefType :: IR.Type -> IR.Capability -> IR.Type
 mkRefType ty cap = IR.TypeRef $ IR.Ref ty IR.NonAtomic cap
+
+-- | Substitute ${T}, ${A}, ${B}, ... in a foreign type template with concrete
+-- Rust type names from the instantiated type arguments.
+substituteTemplate :: T.Text -> [Semi.Type] -> T.Text
+substituteTemplate tpl tyArgs =
+    foldl (\t (name, ty) -> T.replace ("${" <> name <> "}") (semiTypeToRustName ty) t)
+        tpl (zip positionalNames tyArgs)
+  where
+    positionalNames :: [T.Text]
+    positionalNames = ["T", "A", "B", "C", "D", "E", "F", "G"]
+
+semiTypeToRustName :: Semi.Type -> T.Text
+semiTypeToRustName (Semi.TypeIntegral (Int.Signed 8)) = "i8"
+semiTypeToRustName (Semi.TypeIntegral (Int.Signed 16)) = "i16"
+semiTypeToRustName (Semi.TypeIntegral (Int.Signed 32)) = "i32"
+semiTypeToRustName (Semi.TypeIntegral (Int.Signed 64)) = "i64"
+semiTypeToRustName (Semi.TypeIntegral (Int.Unsigned 8)) = "u8"
+semiTypeToRustName (Semi.TypeIntegral (Int.Unsigned 16)) = "u16"
+semiTypeToRustName (Semi.TypeIntegral (Int.Unsigned 32)) = "u32"
+semiTypeToRustName (Semi.TypeIntegral (Int.Unsigned 64)) = "u64"
+semiTypeToRustName (Semi.TypeFP (FP.IEEEFloat 32)) = "f32"
+semiTypeToRustName (Semi.TypeFP (FP.IEEEFloat 64)) = "f64"
+semiTypeToRustName Semi.TypeBool = "bool"
+semiTypeToRustName Semi.TypeUnit = "()"
+semiTypeToRustName ty = mangleABIName ty

--- a/frontend/reussir-core/src/Reussir/Core/REPL.hs
+++ b/frontend/reussir-core/src/Reussir/Core/REPL.hs
@@ -473,6 +473,8 @@ generateExpressionModule funcName semiExpr exprType logLevel state = do
                     (ctxRecords finalFullCtx)
                     stringUniq
                     (ctxTrampolines finalFullCtx)
+                    (ctxFFIImports finalFullCtx)
+                    (ctxExternStructs finalFullCtx)
                     targetSpec
 
             -- Lower functions

--- a/frontend/reussir-core/src/Reussir/Core/Semi/Context.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Semi/Context.hs
@@ -203,6 +203,8 @@ emptySemiContext translationLogLevel currentFile currentModulePath = do
             , generics
             , translationHasFailed = False
             , trampolines = mempty
+            , ffiImports = mempty
+            , externStructs = mempty
             }
 
 -- | empty local context
@@ -330,7 +332,59 @@ scanStmtImpl (Syn.SpannedStmt s) = do
     State.modify $ \st -> st{currentSpan = Just (spanStartOffset s, spanEndOffset s)}
     scanStmtImpl (spanValue s)
     State.modify $ \st -> st{currentSpan = backup}
-scanStmtImpl (Syn.ExternTrampolineStmt {}) = pure ()
+scanStmtImpl (Syn.ExternFFIStmt{Syn.efsDirection = Syn.FFIImport,
+                                 Syn.efsName = funcName,
+                                 Syn.efsGenerics = funcGenerics,
+                                 Syn.efsParams = funcParams,
+                                 Syn.efsReturnType = funcReturnType}) = do
+    -- Register FFI imports during scan so they're available for type checking.
+    moduleSegs <- State.gets currentModulePath
+    genericsList <- mapM translateGeneric funcGenerics
+    withGenericContext genericsList $ do
+        paramsList <- mapM (\(pName, ty) -> (pName,) <$> evalType ty) funcParams
+        funcReturnType' <- case funcReturnType of
+            Just ty -> evalType ty
+            Nothing -> return TypeUnit
+        pendingFuncBody <- newIORef' Nothing
+        let qualifiedPath = Path funcName moduleSegs
+        let proto =
+                FunctionProto
+                    { funcVisibility = Syn.Public
+                    , funcName = funcName
+                    , funcPath = qualifiedPath
+                    , funcGenerics = genericsList
+                    , funcParams = paramsList
+                    , funcReturnType = funcReturnType'
+                    , funcIsRegional = False
+                    , funcBody = pendingFuncBody
+                    , funcSpan = Nothing
+                    }
+        functionTable <- State.gets functions
+        existed <- isJust <$> HU.lookup (functionProtos functionTable) qualifiedPath
+        if existed
+            then addErrReportMsg $ "Function already defined: " <> unIdentifier funcName
+            else HU.insert (functionProtos functionTable) qualifiedPath proto
+scanStmtImpl (Syn.ExternFFIStmt {}) = pure ()  -- export trampolines are handled later
+scanStmtImpl (Syn.ExternStructStmt{Syn.essName = name,
+                                    Syn.essGenerics = structGenerics,
+                                    Syn.essForeignType = foreignType}) = do
+    moduleSegs <- State.gets currentModulePath
+    genericsList <- mapM translateGeneric structGenerics
+    recSpan <- State.gets currentSpan
+    fieldsRef <- newIORef' (Just (Named V.empty))  -- opaque: no fields
+    let recordPath = Path name moduleSegs
+    let semRecord =
+            Record
+                { recordName = recordPath
+                , recordTyParams = genericsList
+                , recordFields = fieldsRef
+                , recordKind = ExternStructKind
+                , recordVisibility = Syn.Public
+                , recordDefaultCap = Syn.Shared
+                , recordSpan = recSpan
+                }
+    addRecordDefinition recordPath semRecord
+    State.modify $ \st -> st{externStructs = HashMap.insert recordPath foreignType (externStructs st)}
 scanStmtImpl (Syn.ModStmt _ _) = pure ()
 scanStmtImpl (Syn.RecordStmt record) = do
     let name = Syn.recordName record

--- a/frontend/reussir-core/src/Reussir/Core/Semi/Pretty.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Semi/Pretty.hs
@@ -419,6 +419,7 @@ instance PrettyColored Record where
                         StructKind -> "struct"
                         EnumKind -> "enum"
                         EnumVariant _ _ -> "enum_variant"
+                        ExternStructKind -> "extern struct"
                     )
                 <> (case cap of Cap.Unspecified -> mempty; _ -> space <> brackets capDoc)
                 <+> nameDoc

--- a/frontend/reussir-core/src/Reussir/Core/Semi/Trampoline.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Semi/Trampoline.hs
@@ -1,26 +1,48 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Reussir.Core.Semi.Trampoline where
+module Reussir.Core.Semi.Trampoline (resolveFFI) where
 
 import Data.HashMap.Strict qualified as HashMap
 import Data.Text qualified as T
 import Effectful.State.Static.Local qualified as State
 
-import Reussir.Core.Data.Semi.Context (SemiContext (..), GlobalSemiEff)
+import Reussir.Core.Data.Semi.Context (SemiContext (..), FFIImportInfo (..), GlobalSemiEff)
 import Reussir.Core.Data.Semi.Function (FunctionProto(funcGenerics))
 import Reussir.Core.Semi.Context (addErrReportMsg, evalType, resolveFunctionPath, withFreshLocalContext)
 
-import Reussir.Parser.Types.Lexer (Identifier, Path)
+import Reussir.Parser.Types.Lexer (Identifier (..), Path (..))
+import Reussir.Parser.Types.Stmt (FFIDirection(..), FFIBody(..))
+import Reussir.Parser.Types.Type qualified as Syn
 import Reussir.Parser.Types.Type qualified as Syn
 
-resolveTrampoline ::
+-- | Resolve a unified FFI declaration (both import and export).
+resolveFFI ::
+    Identifier ->
+    T.Text ->
+    FFIDirection ->
+    [(Identifier, [Path])] ->
+    [(Identifier, Syn.Type)] ->
+    Maybe Syn.Type ->
+    FFIBody ->
+    GlobalSemiEff ()
+resolveFFI name abi FFIExport generics _params _retType (FFIAlias target tyArgsSyn) =
+    resolveExportTrampoline name abi target tyArgsSyn
+resolveFFI name abi FFIExport _generics _params _retType body = do
+    withFreshLocalContext $
+        addErrReportMsg $ "Export FFI '" <> unIdentifier name <> "' must use alias syntax (= target<args>), got: "
+            <> T.pack (show body)
+resolveFFI name abi FFIImport generics params retTypeSyn body =
+    resolveImportFFI name abi generics params retTypeSyn body
+
+-- | Resolve an export trampoline (backward-compatible with the old syntax).
+-- Wraps a Reussir function for C ABI export.
+resolveExportTrampoline ::
     Identifier ->
     T.Text ->
     Path ->
     [Syn.Type] ->
     GlobalSemiEff ()
-resolveTrampoline name abi target tyArgs = withFreshLocalContext $ do
+resolveExportTrampoline name abi target tyArgs = withFreshLocalContext $ do
     -- 1. Evaluate type arguments
-
     tyArgs' <- mapM evalType tyArgs
 
     -- 2. Lookup target function via module-aware resolution
@@ -42,3 +64,28 @@ resolveTrampoline name abi target tyArgs = withFreshLocalContext $ do
                     -- 4. Register trampoline with the resolved target path
                     State.modify $ \ctx ->
                         ctx { trampolines = HashMap.insert name (resolvedTarget, abi, tyArgs') (trampolines ctx) }
+
+-- | Resolve an import FFI declaration.
+-- The function prototype was already registered during the scan phase.
+-- This just stores the FFI metadata (ABI, template) for later lowering.
+resolveImportFFI ::
+    Identifier ->
+    T.Text ->
+    [(Identifier, [Path])] ->
+    [(Identifier, Syn.Type)] ->
+    Maybe Syn.Type ->
+    FFIBody ->
+    GlobalSemiEff ()
+resolveImportFFI name abi _generics _params _retTypeSyn body = do
+    moduleSegs <- State.gets currentModulePath
+    let qualifiedPath = Path name moduleSegs
+    let template = case body of
+            FFITemplate t -> Just t
+            _ -> Nothing
+    let importInfo = FFIImportInfo
+            { ffiImportABI = abi
+            , ffiImportFuncPath = qualifiedPath
+            , ffiImportTemplate = template
+            }
+    State.modify $ \ctx ->
+        ctx { ffiImports = HashMap.insert name importInfo (ffiImports ctx) }

--- a/frontend/reussir-core/src/Reussir/Core/Semi/Tyck.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Semi/Tyck.hs
@@ -1341,6 +1341,9 @@ inferTypeForNormalCtorCall
                         (EnumKind, _) -> do
                             addErrReportMsg "Cannot instantiate Enum directly"
                             return ([], Nothing)
+                        (ExternStructKind, _) -> do
+                            addErrReportMsg "Cannot construct extern struct directly"
+                            return ([], Nothing)
                         (_, Nothing) -> do
                             addErrReportMsg "Record fields not populated"
                             return ([], Nothing)

--- a/frontend/reussir-lsp/src/Reussir/LSP/SemanticTokens.hs
+++ b/frontend/reussir-lsp/src/Reussir/LSP/SemanticTokens.hs
@@ -58,8 +58,10 @@ collectStmt :: T.Text -> Syn.Stmt -> [SemanticTokenAbsolute]
 collectStmt content (Syn.SpannedStmt (WithSpan s _ _)) = collectStmt content s
 collectStmt content (Syn.FunctionStmt f) = collectFunction content f
 collectStmt content (Syn.RecordStmt r) = collectRecord content r
-collectStmt content (Syn.ExternTrampolineStmt _ _ _ tyArgs) =
-    concatMap (collectType content) tyArgs
+collectStmt content (Syn.ExternFFIStmt{Syn.efsParams = params, Syn.efsReturnType = retType}) =
+    concatMap (collectType content . snd) params
+        ++ maybe [] (collectType content) retType
+collectStmt _ (Syn.ExternStructStmt{}) = []
 collectStmt _ (Syn.ModStmt _ _) = []
 
 -- | Collect tokens from a function definition.

--- a/frontend/reussir-parser/src/Reussir/Parser/Pretty.hs
+++ b/frontend/reussir-parser/src/Reussir/Parser/Pretty.hs
@@ -292,15 +292,53 @@ instance PrettyColored Stmt where
     prettyColored (ModStmt vis name) =
         prettyColored vis <> keyword "mod" <+> prettyColored name <> operator ";"
     prettyColored (SpannedStmt w) = prettyColored (spanValue w)
-    prettyColored (ExternTrampolineStmt (Identifier sym) abi func tys) =
+    prettyColored (ExternFFIStmt abi direction name generics params retType body) =
         keyword "extern"
             <+> literal (dquotes (pretty abi))
-            <+> keyword "trampoline"
-            <+> literal (dquotes (pretty sym))
+            <+> prettyDir direction
+            <+> keyword "fn"
+            <+> prettyColored name
+            <> prettyGenerics generics
+            <> parens (commaSep (map prettyParam params))
+            <> prettyRet retType
+            <+> prettyBody body
+      where
+        prettyDir FFIExport = keyword "export"
+        prettyDir FFIImport = keyword "import"
+        prettyGenerics [] = emptyDoc
+        prettyGenerics gs = angles (commaSep (map prettyGeneric gs))
+        prettyGeneric (n, bounds) =
+            prettyColored n
+                <> if null bounds
+                    then emptyDoc
+                    else operator ":" <+> concatWith (surround (operator "+")) (map prettyColored bounds)
+        prettyParam (n, t) = prettyColored n <> operator ":" <+> prettyColored t
+        prettyRet Nothing = emptyDoc
+        prettyRet (Just t) = space <> operator "->" <+> prettyColored t
+        prettyBody FFIExtern = operator ";"
+        prettyBody (FFIAlias func tys) =
+            operator "="
+                <+> prettyColored func
+                <> (if null tys then emptyDoc else angles (commaSep (map prettyColored tys)))
+                <> operator ";"
+        prettyBody (FFITemplate tmpl) =
+            braces (nest 4 (hardline <> pretty ("```" :: String) <> hardline <> pretty tmpl <> pretty ("```" :: String)) <> hardline)
+    prettyColored (ExternStructStmt name generics foreignType) =
+        keyword "extern"
+            <+> keyword "struct"
+            <+> prettyColored name
+            <> prettyGenerics generics
             <+> operator "="
-            <+> prettyColored func
-            <> (if null tys then emptyDoc else angles (commaSep (map prettyColored tys)))
+            <+> literal (dquotes (pretty foreignType))
             <> operator ";"
+      where
+        prettyGenerics [] = emptyDoc
+        prettyGenerics gs = angles (commaSep (map prettyGeneric gs))
+        prettyGeneric (n, bounds) =
+            prettyColored n
+                <> if null bounds
+                    then emptyDoc
+                    else operator ":" <+> concatWith (surround (operator "+")) (map prettyColored bounds)
 
 commaSep :: (Foldable t) => t (Doc AnsiStyle) -> Doc AnsiStyle
 commaSep = concatWith (surround (comma <> space))

--- a/frontend/reussir-parser/src/Reussir/Parser/Stmt.hs
+++ b/frontend/reussir-parser/src/Reussir/Parser/Stmt.hs
@@ -2,9 +2,12 @@
 
 module Reussir.Parser.Stmt where
 
+import Control.Monad (join)
 import Data.Maybe
 
 import Data.Vector.Strict qualified as V
+
+import Data.Text qualified as T
 
 import Reussir.Parser.Expr
 import Reussir.Parser.Lexer
@@ -127,6 +130,8 @@ parseEnumDecRest vis = do
     let fields = Variants $ V.fromList body
     return $ RecordStmt $ Record name (fromMaybe [] tyvars) fields EnumKind vis cap
 
+-- | Parse the legacy trampoline syntax, desugaring to ExternFFIStmt.
+-- @extern \"C\" trampoline \"bar\" = foo\<i32\>;@  →  @extern \"C\" export fn bar = foo\<i32\>;@
 parseExternTrampoline :: Parser Stmt
 parseExternTrampoline = do
     _ <- string "extern" *> space
@@ -136,10 +141,111 @@ parseExternTrampoline = do
     _ <- char '=' *> space
     func <- parsePath <* space
     funcTyArgs <- optional (openAngle *> parseType `sepBy` comma <* closeAngle) <* semicolon
-    return $ ExternTrampolineStmt (Identifier sym) abi func $ fromMaybe [] funcTyArgs
+    return $ ExternFFIStmt
+        { efsABI = abi
+        , efsDirection = FFIExport
+        , efsName = Identifier sym
+        , efsGenerics = []
+        , efsParams = []
+        , efsReturnType = Nothing
+        , efsBody = FFIAlias func (fromMaybe [] funcTyArgs)
+        }
+
+-- | Parse a triple-backtick quoted region.
+-- Consumes everything between @\`\`\`@ delimiters as raw text.
+parseQuotedTemplate :: Parser T.Text
+parseQuotedTemplate = do
+    _ <- string "```"
+    -- Only skip the rest of the opening line (not comments inside the template)
+    _ <- takeWhileP Nothing (\c -> c == ' ' || c == '\t')
+    _ <- optional (char '\n')
+    content <- manyTill anySingle (string "```")
+    space
+    return $ T.strip $ T.pack content
+
+-- | Parse a typed parameter for FFI declarations (no flex flag).
+parseFFIParam :: Parser (Identifier, Type)
+parseFFIParam = do
+    name <- parseIdentifier <* char ':' <* space
+    ty <- parseType
+    return (name, ty)
+
+-- | Parse the body of an FFI declaration.
+-- Either an alias (@= path\<args\>@), a quoted template, or just a semicolon.
+parseFFIBody :: FFIDirection -> Parser FFIBody
+parseFFIBody FFIExport = do
+    -- Export must have alias: = path<args>;
+    _ <- char '=' *> space
+    func <- parsePath <* space
+    funcTyArgs <- optional (openAngle *> parseType `sepBy` comma <* closeAngle)
+    semicolon
+    return $ FFIAlias func (fromMaybe [] funcTyArgs)
+parseFFIBody FFIImport = do
+    -- Import: either semicolon (simple extern) or { ```...``` } (template)
+    choice
+        [ FFIExtern <$ semicolon
+        , do
+            openBody
+            template <- parseQuotedTemplate
+            closeBody
+            return $ FFITemplate template
+        ]
+
+-- | Parse a new-style FFI declaration.
+--
+-- @extern \"C\" import fn name\<T\>(params) -> rettype { \`\`\`template\`\`\` }@
+-- @extern \"C\" export fn name = target\<args\>;@
+parseExternFFI :: Parser Stmt
+parseExternFFI = do
+    _ <- string "extern" *> space
+    abi <- parseString <* space
+    direction <- parseDirection <* space
+    _ <- string "fn" *> space
+    name <- parseIdentifier
+    tyargs <- optional $ openAngle *> parseGenericParam `sepBy` comma <* closeAngle
+    params <- case direction of
+        FFIImport -> do
+            ps <- openParen *> optional (parseFFIParam `sepBy` comma)
+            closeParen
+            return $ fromMaybe [] ps
+        FFIExport -> do
+            -- Export may optionally have params for documentation, or omit them
+            ps <- optional (openParen *> optional (parseFFIParam `sepBy` comma) <* closeParen)
+            return $ fromMaybe [] (join ps)
+    ret <- optional (string "->" *> space *> parseType)
+    body <- parseFFIBody direction
+    return $ ExternFFIStmt
+        { efsABI = abi
+        , efsDirection = direction
+        , efsName = name
+        , efsGenerics = fromMaybe [] tyargs
+        , efsParams = params
+        , efsReturnType = ret
+        , efsBody = body
+        }
+  where
+    parseDirection :: Parser FFIDirection
+    parseDirection =
+        (FFIImport <$ string "import")
+            <|> (FFIExport <$ string "export")
 
 parseStmt :: Parser Stmt
 parseStmt = SpannedStmt <$> withSpan parseStmtInner
+
+parseExternStruct :: Parser Stmt
+parseExternStruct = do
+    _ <- string "extern" *> space
+    _ <- string "struct" *> space
+    name <- parseIdentifier
+    tyargs <- optional $ openAngle *> parseGenericParam `sepBy` comma <* closeAngle
+    _ <- char '=' *> space
+    foreignType <- parseString <* space
+    _ <- char ';' *> space
+    return $ ExternStructStmt
+        { essName = name
+        , essGenerics = fromMaybe [] tyargs
+        , essForeignType = foreignType
+        }
 
 parseStmtInner :: Parser Stmt
 parseStmtInner = do
@@ -149,7 +255,9 @@ parseStmtInner = do
         , parseStructDecRest vis <?> "struct declaration"
         , parseEnumDecRest vis <?> "enum declaration"
         , parseModDeclRest vis <?> "module declaration"
-        , parseExternTrampoline <?> "extern trampoline"
+        , try parseExternTrampoline <?> "extern trampoline"
+        , try parseExternStruct <?> "extern struct declaration"
+        , parseExternFFI <?> "extern FFI declaration"
         ]
 
 parseModDeclRest :: Visibility -> Parser Stmt

--- a/frontend/reussir-parser/src/Reussir/Parser/Types/Stmt.hs
+++ b/frontend/reussir-parser/src/Reussir/Parser/Types/Stmt.hs
@@ -42,14 +42,52 @@ data Function = Function
     }
     deriving (Show, Eq)
 
+-- | Direction of an FFI declaration.
+data FFIDirection = FFIExport | FFIImport deriving (Show, Eq)
+
+-- | Body of an FFI declaration.
+data FFIBody
+    = -- | Export alias: @= path\<type_args\>@, wraps an existing Reussir function.
+      FFIAlias Path [Type]
+    | -- | Quoted template: @{ \`\`\`...template...\`\`\` }@, inline foreign source code.
+      FFITemplate T.Text
+    | -- | Simple extern declaration with no body (semicolon-terminated).
+      FFIExtern
+    deriving (Show, Eq)
+
 data Stmt
     = FunctionStmt Function
     | RecordStmt Record
-    | ExternTrampolineStmt {
-        etsName :: Identifier,
-        etsABI :: T.Text,
-        etsFunc :: Path,
-        etsFuncTyArgs :: [Type]
+    | -- | FFI declaration supporting both import and export directions.
+      --
+      -- Syntax examples:
+      --
+      -- Legacy: @extern \"C\" trampoline \"bar\" = foo\<i32\>;@
+      --
+      -- Import: @extern \"C\" import fn strlen(s: i64) -> i64;@
+      --
+      -- Export: @extern \"C\" export fn bar = foo\<i32\>;@
+      --
+      -- Import with template:
+      -- @extern \"C\" import fn push\<T\>(v: Vec\<T\>, e: T) -> Vec\<T\> { \`\`\`...template...\`\`\` }@
+      ExternFFIStmt {
+        efsABI :: T.Text,
+        efsDirection :: FFIDirection,
+        efsName :: Identifier,
+        efsGenerics :: [(Identifier, [Path])],
+        efsParams :: [(Identifier, Type)],
+        efsReturnType :: Maybe Type,
+        efsBody :: FFIBody
+    }
+    | -- | Extern struct declaration for opaque FFI types.
+      --
+      -- Syntax: @extern struct Vec\<T\> = \"::reussir_rt::collections::vec::Vec\<${T}\>\";@
+      --
+      -- Declares an opaque type always behind RC, mapped to a foreign type via template.
+      ExternStructStmt {
+        essName :: Identifier,
+        essGenerics :: [(Identifier, [Path])],
+        essForeignType :: T.Text
     }
     | ModStmt Visibility Identifier
     | SpannedStmt (WithSpan Stmt)

--- a/frontend/reussir-parser/test/Reussir/Parser/StmtSpec.hs
+++ b/frontend/reussir-parser/test/Reussir/Parser/StmtSpec.hs
@@ -40,7 +40,7 @@ stripStmtSpans (RecordStmt r) = RecordStmt (r{recordFields = stripFields (record
     stripFields (Unnamed fs) = Unnamed (V.map (\(WithSpan (t, f) _ _) -> WithSpan (t, f) 0 0) fs)
     stripFields (Variants vs) = Variants (V.map (\(WithSpan (n, ts) _ _) -> WithSpan (n, ts) 0 0) vs)
 stripStmtSpans (ModStmt vis name) = ModStmt vis name
-stripStmtSpans (ExternTrampolineStmt n a f tys) = ExternTrampolineStmt n a f tys
+stripStmtSpans s@(ExternFFIStmt {}) = s
 
 dummyWithSpan :: a -> WithSpan a
 dummyWithSpan x = WithSpan x 0 0
@@ -250,13 +250,16 @@ spec = do
                     )
 
     describe "parseExternTrampoline" $ do
-        it "parses extern trampoline" $
+        it "parses extern trampoline (legacy syntax)" $
             (stripStmtSpans <$> parse parseExternTrampoline "" "extern \"C\" trampoline \"foo_ffi\" = foo;")
-                `shouldParse` ExternTrampolineStmt
-                    (Identifier "foo_ffi")
+                `shouldParse` ExternFFIStmt
                     "C"
-                    (Path (Identifier "foo") [])
+                    FFIExport
+                    (Identifier "foo_ffi")
                     []
+                    []
+                    Nothing
+                    (FFIAlias (Path (Identifier "foo") []) [])
 
     describe "parseStmt module declarations" $ do
         it "parses a private module declaration" $

--- a/tests/integration/frontend/ffi_combined.rr
+++ b/tests/integration/frontend/ffi_combined.rr
@@ -1,0 +1,20 @@
+// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+
+// Test that import and export FFI declarations can coexist in the same module.
+
+// Import: external C function
+extern "C" import fn c_square(x: i32) -> i32;
+
+// Reussir function that uses the imported function
+fn double_square(x: i32) -> i32 {
+    let a = c_square(x);
+    c_square(a)
+}
+
+// Export: expose double_square to C
+extern "C" export fn exported_double_square = double_square;
+
+// CHECK-DAG: func.func private @"_RC8c_square"
+// CHECK-DAG: func.func @"_RC13double_square"
+// CHECK-DAG: reussir.trampoline "C" @exported_double_square = @_RC13double_square

--- a/tests/integration/frontend/ffi_export_new_syntax.c
+++ b/tests/integration/frontend/ffi_export_new_syntax.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <stdint.h>
+
+// Exported trampolines from Reussir
+int32_t add_i32(int32_t x, int32_t y);
+double add_f64(double x, double y);
+
+int main(void) {
+    int32_t r1 = add_i32(20, 22);
+    if (r1 != 42) {
+        printf("FAIL: add_i32(20, 22) = %d, expected 42\n", r1);
+        return 1;
+    }
+
+    double r2 = add_f64(1.5, 2.5);
+    if (r2 < 3.9 || r2 > 4.1) {
+        printf("FAIL: add_f64(1.5, 2.5) = %f, expected 4.0\n", r2);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/integration/frontend/ffi_export_new_syntax.rr
+++ b/tests/integration/frontend/ffi_export_new_syntax.rr
@@ -1,0 +1,13 @@
+// RUN: %reussir-elab --mode semi %s
+// RUN: %reussir-elab --mode full %s
+// RUN: %reussir-compiler %s -o %t.o
+// RUN: %cc %t.o %S/ffi_export_new_syntax.c -o %t.exe
+// RUN: %t.exe
+
+// New-style export syntax (equivalent to legacy trampoline)
+fn add<T : Num>(x: T, y: T) -> T {
+    x + y
+}
+
+extern "C" export fn add_i32 = add<i32>;
+extern "C" export fn add_f64 = add<f64>;

--- a/tests/integration/frontend/ffi_extern_struct_vec.rr
+++ b/tests/integration/frontend/ffi_extern_struct_vec.rr
@@ -1,0 +1,64 @@
+// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+
+// Test extern struct declaration for opaque FFI types.
+// Vec<T> wraps reussir_rt's Vec and is always behind RC.
+
+extern struct Vec<T> = "::reussir_rt::collections::vec::Vec<${T}>";
+
+enum List<T> {
+    Nil,
+    Cons(T, List<T>)
+}
+
+// FFI operations on Vec
+extern "C" import fn vec_new<T>() -> Vec<T> {
+    ```
+    #![feature(linkage)]
+    extern crate reussir_rt;
+    use reussir_rt::collections::vec::Vec;
+    #[linkage = "weak_odr"]
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn vec_new_[:T:]() -> Vec<[:T:]> { Vec::new() }
+    ```
+}
+
+extern "C" import fn vec_push<T>(v: Vec<T>, e: T) -> Vec<T> {
+    ```
+    #![feature(linkage)]
+    extern crate reussir_rt;
+    use reussir_rt::collections::vec::Vec;
+    #[linkage = "weak_odr"]
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn vec_push_[:T:](v: Vec<[:T:]>, e: [:T:]) -> Vec<[:T:]> {
+        Vec::push(v, e)
+    }
+    ```
+}
+
+// Instantiate with primitive type
+fn make_int_vec() -> Vec<i32> {
+    let v = vec_new<i32>();
+    vec_push<i32>(v, 42)
+}
+
+// Instantiate with non-trivial RC type: List<i32>
+fn make_list_vec(elem: List<i32>) -> Vec<List<i32>> {
+    let v = vec_new<List<i32>>();
+    vec_push<List<i32>>(v, elem)
+}
+
+// -- Check ffi_object types --
+
+// Vec<i32> should produce ffi_object with the Rust type name
+// CHECK-DAG: !reussir.ffi_object<"::reussir_rt::collections::vec::Vec<i32>"
+
+// Vec<List<i32>> should produce ffi_object for the List-parameterized Vec
+// CHECK-DAG: !reussir.ffi_object<"::reussir_rt::collections::vec::Vec<
+
+// -- Check polyffi ops --
+// CHECK-DAG: reussir.polyffi texture(
+// CHECK-DAG: substitutions({T = i32})
+
+// -- Check destructor polyffi templates are emitted --
+// CHECK-DAG: polyffi_drop

--- a/tests/integration/frontend/ffi_import_basic.c
+++ b/tests/integration/frontend/ffi_import_basic.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdint.h>
+
+// Provided by the Reussir module
+int32_t _RC11use_add_one(int32_t x);
+
+// Imported by the Reussir module - we provide it here
+int32_t _RC7add_one(int32_t x) {
+    return x + 1;
+}
+
+int main(void) {
+    int32_t result = _RC11use_add_one(41);
+    if (result != 42) {
+        printf("FAIL: expected 42, got %d\n", result);
+        return 1;
+    }
+    return 0;
+}

--- a/tests/integration/frontend/ffi_import_basic.rr
+++ b/tests/integration/frontend/ffi_import_basic.rr
@@ -1,0 +1,12 @@
+// RUN: %reussir-elab --mode semi %s
+// RUN: %reussir-elab --mode full %s
+// RUN: %reussir-compiler %s -o %t.o
+// RUN: %cc %t.o %S/ffi_import_basic.c -o %t.exe
+// RUN: %t.exe
+
+// Basic import FFI: declares a foreign function callable from Reussir.
+extern "C" import fn add_one(x: i32) -> i32;
+
+fn use_add_one(x: i32) -> i32 {
+    add_one(x)
+}

--- a/tests/integration/frontend/ffi_import_basic_mlir.rr
+++ b/tests/integration/frontend/ffi_import_basic_mlir.rr
@@ -1,0 +1,15 @@
+// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+
+// Test that a basic (non-template) FFI import produces an external function
+// declaration with no polyffi op.
+
+extern "C" import fn foreign_add(x: i32, y: i32) -> i32;
+
+fn call_foreign(a: i32, b: i32) -> i32 {
+    foreign_add(a, b)
+}
+
+// CHECK-NOT: reussir.polyffi
+// CHECK: func.func private @"_RC11foreign_add"({{.*}}) -> i32
+// CHECK-SAME: llvm.linkage = #llvm.linkage<external>

--- a/tests/integration/frontend/ffi_import_template.rr
+++ b/tests/integration/frontend/ffi_import_template.rr
@@ -1,0 +1,29 @@
+// RUN: %reussir-elab --mode semi %s
+// RUN: %reussir-elab --mode full %s
+// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+
+// Import FFI with a quoted template for polymorphic code generation.
+// The template uses ${T} syntax for type parameter substitution,
+// which gets converted to [:T:] at the MLIR level.
+
+extern "C" import fn magic_add<T : Num>(x: T, y: T) -> T {
+    ```
+    #![feature(linkage)]
+    #[linkage = "weak_odr"]
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn magic_add_${T}(x: ${T}, y: ${T}) -> ${T} {
+        x + y
+    }
+    ```
+}
+
+fn use_magic(a: i32, b: i32) -> i32 {
+    magic_add<i32>(a, b)
+}
+
+// CHECK: reussir.polyffi
+// CHECK-SAME: texture(
+// CHECK-SAME: [:T:]
+// CHECK-SAME: substitutions({T = i32})
+// CHECK: func.func private @"_RIC9magic_addlE"

--- a/tests/integration/frontend/ffi_import_template_multi_generic.rr
+++ b/tests/integration/frontend/ffi_import_template_multi_generic.rr
@@ -1,0 +1,25 @@
+// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+
+// Test polymorphic FFI with multiple generic parameters.
+// Each generic should get its own substitution entry with concrete types.
+
+extern "C" import fn pair_op<A : Num, B : Num>(x: A, y: B) -> A {
+    ```
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn pair_op_${A}_${B}(x: ${A}, y: ${B}) -> ${A} {
+        x
+    }
+    ```
+}
+
+fn use_pair(a: i32, b: f64) -> i32 {
+    pair_op<i32, f64>(a, b)
+}
+
+// CHECK: reussir.polyffi
+// CHECK-SAME: texture(
+// CHECK-SAME: [:A:]
+// CHECK-SAME: [:B:]
+// CHECK-SAME: substitutions({A = i32, B = f64})
+// CHECK: func.func private @"_RIC7pair_opldE"

--- a/tests/integration/frontend/ffi_polyffi_list_ownership.rr
+++ b/tests/integration/frontend/ffi_polyffi_list_ownership.rr
@@ -1,0 +1,64 @@
+// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+
+// Test polymorphic FFI with List<T> involving non-trivial clone/cleanup
+// and nested type parameters (List<List<i32>>).
+
+enum List<T> {
+    Nil,
+    Cons(T, List<T>)
+}
+
+// Helper: build a single-element list
+fn singleton<T>(x: T) -> List<T> {
+    List::Cons{x, List::Nil{}}
+}
+
+// Helper: append two lists (exercises clone on shared references)
+fn append<T>(a: List<T>, b: List<T>) -> List<T> {
+    match a {
+        List::Nil => b,
+        List::Cons(x, xs) => List::Cons{x, append<T>(xs, b)}
+    }
+}
+
+// FFI with template: polymorphic over T, receiving and returning List<T>
+extern "C" import fn ffi_transform<T>(xs: List<T>) -> List<T> {
+    ```
+    // FFI stub for transforming List<[:T:]>
+    ```
+}
+
+// Instantiate with a simple type
+fn transform_int_list(xs: List<i32>) -> List<i32> {
+    ffi_transform<i32>(xs)
+}
+
+// Instantiate with a nested type: List<List<i32>>
+// This exercises the type system with nested generic parameters.
+fn transform_nested(xs: List<List<i32>>) -> List<List<i32>> {
+    ffi_transform<List<i32>>(xs)
+}
+
+// Build and transform: exercises clone/cleanup with FFI
+fn build_and_transform(x: i32, y: i32) -> List<i32> {
+    let a = singleton<i32>(x);
+    let b = singleton<i32>(y);
+    let combined = append<i32>(a, b);
+    ffi_transform<i32>(combined)
+}
+
+// CHECK-DAG: reussir.polyffi texture({{.*}}) substitutions({T = !reussir.rc<!_RIC4ListlE shared normal>})
+// CHECK-DAG: reussir.polyffi texture({{.*}}) substitutions({T = i32})
+
+// The nested instantiation should use rc type for List<i32> as T
+// CHECK-DAG: func.func private @"_RIC13ffi_transformIC4ListlEE"
+//                             (taking !reussir.rc of List<List<i32>>)
+
+// The simple instantiation
+// CHECK-DAG: func.func private @"_RIC13ffi_transformlE"
+
+// append and singleton should have proper rc ops for cleanup
+// CHECK-DAG: reussir.rc.dec
+// CHECK-DAG: reussir.rc.inc
+// CHECK-DAG: reussir.rc.create

--- a/tests/integration/frontend/ffi_polyffi_nested_types.rr
+++ b/tests/integration/frontend/ffi_polyffi_nested_types.rr
@@ -1,0 +1,35 @@
+// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+
+// Test polymorphic FFI with non-trivial generic types.
+// When instantiated with List<i32>, the template should receive the
+// concrete MLIR type for the List record (an RC pointer type).
+
+enum List<T> {
+    Nil,
+    Cons(T, List<T>)
+}
+
+// Polymorphic FFI import with a template: the generic T will be
+// substituted with the concrete MLIR type for List<i32>.
+extern "C" import fn process_list<T>(xs: T) -> T {
+    ```
+    // placeholder: process [:T:] values
+    ```
+}
+
+fn use_process_with_int(xs: i32) -> i32 {
+    process_list<i32>(xs)
+}
+
+fn use_process_with_list(xs: List<i32>) -> List<i32> {
+    process_list<List<i32>>(xs)
+}
+
+// Two polyffi instantiations: one for i32, one for List<i32>
+// CHECK-DAG: substitutions({T = i32})
+// CHECK-DAG: substitutions({T = !reussir.rc<!_RIC4ListlE shared normal>})
+
+// External function declarations for each monomorphized instance
+// CHECK-DAG: func.func private @"_RIC12process_listlE"
+// CHECK-DAG: func.func private @"_RIC12process_listIC4ListlEE"

--- a/tests/integration/frontend/ffi_polyffi_vec_list.rr
+++ b/tests/integration/frontend/ffi_polyffi_vec_list.rr
@@ -1,0 +1,80 @@
+// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+
+// Test polymorphic FFI with non-trivial types:
+// - List<T> is an enum with Cons/Nil requiring RC clone/cleanup
+// - Vec from reussir_rt stores elements that need clone/drop
+// - Nested poly params: Vec operations on List<i32> elements
+
+enum List<T> {
+    Nil,
+    Cons(T, List<T>)
+}
+
+// Push an element into a Vec<T>. Uses reussir_rt::collections::vec::Vec
+// which wraps Rc<StdVec<T>> and needs proper clone/drop for T.
+extern "C" import fn vec_push<T>(v: T, elem: T) -> T {
+    ```
+    extern crate reussir_rt;
+    use reussir_rt::collections::vec::Vec;
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn vec_push_[:T:](mut v: Vec<[:T:]>, elem: [:T:]) -> Vec<[:T:]> {
+        v.push(elem);
+        v
+    }
+    ```
+}
+
+// Get vector length via FFI
+extern "C" import fn vec_len<T>(v: T) -> i64 {
+    ```
+    extern crate reussir_rt;
+    use reussir_rt::collections::vec::Vec;
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn vec_len_[:T:](v: Vec<[:T:]>) -> i64 {
+        Vec::len(&v) as i64
+    }
+    ```
+}
+
+// Use vec_push with List<i32> -- non-trivial type with RC semantics.
+// The generated Rust code must handle Clone/Drop for the RC'd List type.
+fn push_list_to_vec(v: List<i32>, elem: List<i32>) -> List<i32> {
+    vec_push<List<i32>>(v, elem)
+}
+
+// Use vec_len with List<i32>
+fn get_list_vec_len(v: List<i32>) -> i64 {
+    vec_len<List<i32>>(v)
+}
+
+// Also test with a simple type for comparison
+fn push_int_to_vec(v: i32, elem: i32) -> i32 {
+    vec_push<i32>(v, elem)
+}
+
+// Nested: List<List<i32>> -- doubly-nested RC type
+fn push_nested_to_vec(v: List<List<i32>>, elem: List<List<i32>>) -> List<List<i32>> {
+    vec_push<List<List<i32>>>(v, elem)
+}
+
+// -- polyffi ops with type substitutions --
+
+// Simple i32 instantiation
+// CHECK-DAG: substitutions({T = i32})
+
+// List<i32> instantiation: T becomes an RC pointer to the List variant type
+// CHECK-DAG: substitutions({T = !reussir.rc<!_RIC4ListlE shared normal>})
+
+// List<List<i32>> instantiation: doubly-nested RC type
+// CHECK-DAG: substitutions({T = !reussir.rc<!_RIC4ListIC4ListlEE shared normal>})
+
+// External function declarations for vec_push instantiations
+// CHECK-DAG: func.func private @"_RIC8vec_pushlE"
+// CHECK-DAG: func.func private @"_RIC8vec_pushIC4ListlEE"
+// CHECK-DAG: func.func private @"_RIC8vec_pushIC4ListIC4ListlEEE"
+
+// External function declarations for vec_len instantiations
+// CHECK-DAG: func.func private @"_RIC7vec_lenIC4ListlEE"


### PR DESCRIPTION
## Summary
- Add `extern "C" import/export fn` syntax with triple-backtick Rust templates and `extern struct Name<T> = "rust::Type<${T}>";` for declaring opaque FFI types
- Emit `reussir.polyffi` ops with concrete MLIR type substitutions and auto-generated destructor polyffi templates for extern struct instantiations
- Lower extern structs to `!reussir.ffi_object<"rust_name", @dtor>` types, threading FFI data through the full Semi → Full → Lowering → Codegen pipeline

## Test plan
- [x] 241/241 integration tests pass (`ninja -C build check`)
- [x] `ffi_import_template.rr` — single-generic polyffi with `{T = i32}` substitution
- [x] `ffi_import_template_multi_generic.rr` — multi-generic `{A = i32, B = f64}` substitution
- [x] `ffi_extern_struct_vec.rr` — extern struct `Vec<T>` with `ffi_object` type and destructor polyffi
- [x] `ffi_polyffi_vec_list.rr` — `Vec` operations on `List<i32>` and `List<List<i32>>` with RC semantics
- [x] `ffi_polyffi_list_ownership.rr` — List clone/cleanup through FFI with `rc.dec`/`rc.inc`/`rc.create`
- [x] `ffi_polyffi_nested_types.rr` — nested generic instantiations
- [x] `ffi_combined.rr` — import + export coexistence
- [x] `ffi_import_basic_mlir.rr` — basic import without polyffi template

🤖 Generated with [Claude Code](https://claude.com/claude-code)