### PR TITLE
Redesign trampoline lowering for explicit C ABI boundaries

### DIFF
--- a/frontend/reussir-codegen/src/Reussir/Codegen/Trampoline.hs
+++ b/frontend/reussir-codegen/src/Reussir/Codegen/Trampoline.hs
@@ -16,7 +16,8 @@ data Trampoline = Trampoline {
 trampolineCodegen :: Trampoline -> Codegen ()
 trampolineCodegen (Trampoline name target abi) = emitBuilderLineM $ do
     let opName = "reussir.trampoline"
+    let direction = "export"
     let abi' = TB.fromText $ T.show abi
     name' <- emit name
     target' <- emit target
-    return $ opName <> " " <> abi' <> " @" <> name' <> " = @" <> target' 
+    return $ opName <> " " <> direction <> " " <> abi' <> " @" <> name' <> " = @" <> target'

--- a/frontend/reussir-repl/app/Main.hs
+++ b/frontend/reussir-repl/app/Main.hs
@@ -81,12 +81,6 @@ foreign import ccall "dynamic"
     callU8Func :: FunPtr (IO Word8) -> IO Word8
 
 foreign import ccall "dynamic"
-    callF64Func :: FunPtr (IO Double) -> IO Double
-
-foreign import ccall "dynamic"
-    callF32Func :: FunPtr (IO Float) -> IO Float
-
-foreign import ccall "dynamic"
     callBoolFunc :: FunPtr (IO Word8) -> IO Word8
 
 foreign import ccall "dynamic"
@@ -109,6 +103,12 @@ instance Storable StrResult where
 -- | C helper function to call a JIT function returning a str type
 foreign import capi "Reussir/Bridge.h reussir_bridge_call_str_func"
     c_reussir_bridge_call_str_func :: Ptr () -> Ptr StrResult -> IO ()
+
+foreign import capi "Reussir/Bridge.h reussir_bridge_call_f32_func"
+    c_reussir_bridge_call_f32_func :: Ptr () -> Ptr Float -> IO ()
+
+foreign import capi "Reussir/Bridge.h reussir_bridge_call_f64_func"
+    c_reussir_bridge_call_f64_func :: Ptr () -> Ptr Double -> IO ()
 
 --------------------------------------------------------------------------------
 -- Placeholder callback for lazy module loading
@@ -523,15 +523,21 @@ executeWithResultKind sym resultKind = case resultKind of
         result <- callU64Func (castPtrToFunPtr sym)
         return $ show result ++ " : u64"
     ResultF16 -> do
-        -- F16 is typically not directly supported in C ABI, use F32
-        result <- callF32Func (castPtrToFunPtr sym)
-        return $ show result ++ " : f16"
+        -- F16 is typically not directly supported in C ABI, use F32 storage.
+        alloca $ \resultPtr -> do
+            c_reussir_bridge_call_f32_func sym resultPtr
+            result <- peek resultPtr
+            return $ show result ++ " : f16"
     ResultF32 -> do
-        result <- callF32Func (castPtrToFunPtr sym)
-        return $ show result ++ " : f32"
+        alloca $ \resultPtr -> do
+            c_reussir_bridge_call_f32_func sym resultPtr
+            result <- peek resultPtr
+            return $ show result ++ " : f32"
     ResultF64 -> do
-        result <- callF64Func (castPtrToFunPtr sym)
-        return $ show result ++ " : f64"
+        alloca $ \resultPtr -> do
+            c_reussir_bridge_call_f64_func sym resultPtr
+            result <- peek resultPtr
+            return $ show result ++ " : f64"
     ResultBool -> do
         result <- callBoolFunc (castPtrToFunPtr sym)
         return $ (if result /= 0 then "true" else "false") ++ " : bool"

--- a/frontend/reussir-repl/test/Test/REPL/Expression.hs
+++ b/frontend/reussir-repl/test/Test/REPL/Expression.hs
@@ -33,9 +33,6 @@ foreign import ccall "dynamic"
     callI64Func :: FunPtr (IO Int64) -> IO Int64
 
 foreign import ccall "dynamic"
-    callF64Func :: FunPtr (IO Double) -> IO Double
-
-foreign import ccall "dynamic"
     callBoolFunc :: FunPtr (IO Word8) -> IO Word8
 
 -- | Representation of the str type from Reussir (ptr, len pair)
@@ -55,6 +52,9 @@ instance Storable StrResult where
 -- | C helper function to call a JIT function returning a str type
 foreign import capi "Reussir/Bridge.h reussir_bridge_call_str_func"
     c_reussir_bridge_call_str_func :: Ptr () -> Ptr StrResult -> IO ()
+
+foreign import capi "Reussir/Bridge.h reussir_bridge_call_f64_func"
+    c_reussir_bridge_call_f64_func :: Ptr () -> Ptr Double -> IO ()
 
 -- Placeholder callback for JIT
 placeholderCallback :: () -> IO ByteString
@@ -174,8 +174,10 @@ compileAndExecFloat' input = do
                                 sym <- lookupSymbol jit (fromString funcName) False
                                 if sym /= nullPtr
                                     then do
-                                        val <- callF64Func (castPtrToFunPtr sym)
-                                        return $ Right val
+                                        alloca $ \resultPtr -> do
+                                            c_reussir_bridge_call_f64_func sym resultPtr
+                                            val <- peek resultPtr
+                                            return $ Right val
                                     else return $ Left $ "Symbol not found: " ++ funcName
                             else return $ Left "Failed to add module"
 

--- a/frontend/reussir-repl/test/Test/REPL/Integration.hs
+++ b/frontend/reussir-repl/test/Test/REPL/Integration.hs
@@ -30,9 +30,6 @@ import Data.Text qualified as T
 foreign import ccall "dynamic"
     callI64Func :: FunPtr (IO Int64) -> IO Int64
 
-foreign import ccall "dynamic"
-    callF64Func :: FunPtr (IO Double) -> IO Double
-
 -- | Representation of the str type from Reussir (ptr, len pair)
 data StrResult = StrResult {-# UNPACK #-} !(Ptr CChar) {-# UNPACK #-} !CSize
 
@@ -50,6 +47,9 @@ instance Storable StrResult where
 -- | C helper function to call a JIT function returning a str type
 foreign import capi "Reussir/Bridge.h reussir_bridge_call_str_func"
     c_reussir_bridge_call_str_func :: Ptr () -> Ptr StrResult -> IO ()
+
+foreign import capi "Reussir/Bridge.h reussir_bridge_call_f64_func"
+    c_reussir_bridge_call_f64_func :: Ptr () -> Ptr Double -> IO ()
 
 tests :: TestTree
 tests =
@@ -147,8 +147,10 @@ compileAndExecFloat' input = do
                                 sym <- lookupSymbol jit (fromString funcName) False
                                 if sym /= nullPtr
                                     then do
-                                        val <- callF64Func (castPtrToFunPtr sym)
-                                        return $ Right val
+                                        alloca $ \resultPtr -> do
+                                            c_reussir_bridge_call_f64_func sym resultPtr
+                                            val <- peek resultPtr
+                                            return $ Right val
                                     else return $ Left $ "Symbol not found: " ++ funcName
                             else return $ Left "Failed to add module"
 

--- a/include/Reussir/Bridge.h
+++ b/include/Reussir/Bridge.h
@@ -145,8 +145,10 @@ typedef struct {
   uint64_t len;
 } ReussirStrResult;
 
-// Call a JIT function that returns a str type and capture the result
+// Call JIT functions that use an explicit leading return pointer.
 // The function pointer should be obtained from reussir_bridge_jit_lookup_symbol
+void reussir_bridge_call_f32_func(void *func_ptr, float *result);
+void reussir_bridge_call_f64_func(void *func_ptr, double *result);
 void reussir_bridge_call_str_func(void *func_ptr, ReussirStrResult *result);
 
 #ifdef __cplusplus

--- a/include/Reussir/Conversion/CABISignatureConversion.h
+++ b/include/Reussir/Conversion/CABISignatureConversion.h
@@ -15,44 +15,26 @@
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/TargetParser/Triple.h>
+#include <mlir/Dialect/LLVMIR/LLVMTypes.h>
 #include <mlir/IR/BuiltinTypes.h>
-#include <mlir/Interfaces/DataLayoutInterfaces.h>
 
 namespace reussir {
 
-enum class CABIKind {
-  Win64,
-  SysVAMD64,
-  AArch64AAPCS,
-  Unknown,
-};
-
-enum class CABIParamPassKind {
-  Direct,
-  IndirectByVal,
-  IndirectPointer,
-};
-
-struct CABIParamInfo {
-  mlir::Type originalType;
-  CABIParamPassKind passKind;
-};
-
 struct CABISignature {
+  bool isTrivial = false;
   mlir::Type abiReturnType;
   llvm::SmallVector<mlir::Type> abiParamTypes;
-  llvm::SmallVector<CABIParamInfo> params;
-  bool hasSRet = false;
-  unsigned sretIndex = 0;
-  mlir::Type sretType;
+  bool hasReturnPtr = false;
+  unsigned returnPtrIndex = 0;
+  mlir::Type returnStorageType;
+  bool hasPackedArgs = false;
+  unsigned packedArgsIndex = 0;
+  mlir::LLVM::LLVMStructType packedArgsType;
 };
 
-CABIKind detectCABIKind(const llvm::Triple &triple);
+bool isTrivialFFIType(mlir::Type type);
 
 CABISignature evaluateCABISignatureForC(mlir::Type returnType,
-                                        llvm::ArrayRef<mlir::Type> paramTypes,
-                                        const mlir::DataLayout &dl,
-                                        const llvm::Triple &triple);
+                                        llvm::ArrayRef<mlir::Type> paramTypes);
 
 } // namespace reussir

--- a/include/Reussir/IR/ReussirAttrs.td
+++ b/include/Reussir/IR/ReussirAttrs.td
@@ -71,6 +71,19 @@ def LifeScope
     : I32EnumAttr<"LifeScope", "life scope", [LS_Global, LS_Local]> {
   let cppNamespace = "::reussir";
 }
+
+//===----------------------------------------------------------------------===//
+// Trampoline Attributes
+//===----------------------------------------------------------------------===//
+def TD_Import : I32EnumAttrCase<"Import", 0, "import">;
+def TD_Export : I32EnumAttrCase<"Export", 1, "export">;
+
+def TrampolineDirection
+    : I32EnumAttr<"TrampolineDirection", "trampoline direction",
+                  [TD_Import, TD_Export]> {
+  let cppNamespace = "::reussir";
+}
+
 //===----------------------------------------------------------------------===//
 // Debug Attributes
 //===----------------------------------------------------------------------===//
@@ -168,4 +181,3 @@ def Reussir_DBGFuncArg : ReussirAttr<"DBGFuncArg", "dbg_func_arg"> {
   }];
 }
 #endif // REUSSIR_IR_REUSSIRATTRS_TD
-

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1760,19 +1760,34 @@ def ReussirTrampolineOp : ReussirOp<"trampoline", [
 ]> {
   let summary = "Trampoline for FFI calls";
   let description = [{
-    Interally, Reussir uses MLIR calling convension, which typically aligns with
-    platform ABI. However, for C-FFI, platform ABI is not enough. For example,
-    windows x64 sometimes require hidden pointer to structural return values.
-    `reussir.trampoline` is a trampoline exported to FFI. Currently, only "C" 
-    ABI is supported.
+    `reussir.trampoline` describes an FFI boundary shim. The `direction`
+    attribute distinguishes between:
+
+    - `export`: expose a Reussir-internal function through a C-facing boundary.
+    - `import`: provide a Reussir symbol that forwards to a C-facing target.
+
+    The backend classifies a trampoline as trivial when it accepts fewer than
+    four integral or pointer arguments and returns at most one integral or
+    pointer result. Trivial trampolines forward directly with best-effort
+    minimal overhead.
+
+    Nontrivial trampolines use a backend-defined explicit boundary:
+
+    - nontrivial returns use a leading return pointer parameter;
+    - nontrivial argument lists are packed into a literal LLVM struct passed by
+      pointer in source order.
+
+    Currently only the `"C"` ABI is supported.
   }];
   let arguments = (ins 
+    DefaultValuedAttr<TrampolineDirection,
+                      "::reussir::TrampolineDirection::Export">:$direction,
     Arg<FlatSymbolRefAttr, "Wrapped target function">:$target,
     Arg<StrAttr, "ABI Name">:$abi_name,
-    Arg<SymbolNameAttr, "Exported symbol name">:$sym_name
+    Arg<SymbolNameAttr, "Trampoline symbol name">:$sym_name
   );
   let assemblyFormat = [{
-    $abi_name $sym_name `=` $target attr-dict
+    $direction $abi_name $sym_name `=` $target attr-dict
   }];
 }
 #endif // REUSSIR_IR_REUSSIROPS_TD

--- a/lib/Bridge/JITEngine.cppm
+++ b/lib/Bridge/JITEngine.cppm
@@ -411,12 +411,19 @@ export extern "C" {
     }
     return def->getAddress().toPtr<void *>();
   }
-  // Call a JIT function that returns a str type (struct { ptr, len })
-  // On ARM64 and x86-64, small structs are returned in registers
+  void reussir_bridge_call_f32_func(void *func_ptr, float *result) {
+    using F32FuncType = void (*)(float *);
+    auto func = reinterpret_cast<F32FuncType>(func_ptr);
+    func(result);
+  }
+  void reussir_bridge_call_f64_func(void *func_ptr, double *result) {
+    using F64FuncType = void (*)(double *);
+    auto func = reinterpret_cast<F64FuncType>(func_ptr);
+    func(result);
+  }
   void reussir_bridge_call_str_func(void *func_ptr, ReussirStrResult *result) {
-    // Define the function type that returns the str struct
-    using StrFuncType = ReussirStrResult (*)();
+    using StrFuncType = void (*)(ReussirStrResult *);
     auto func = reinterpret_cast<StrFuncType>(func_ptr);
-    *result = func();
+    func(result);
   }
 }

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -2379,6 +2379,7 @@ struct ReussirTrampolineOpConversionPattern
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::SymbolTable symTable = mlir::SymbolTable::getNearestSymbolTable(op);
     auto converter = static_cast<const mlir::LLVMTypeConverter *> (getTypeConverter());
+    auto ptrType = mlir::LLVM::LLVMPointerType::get(op.getContext());
     mlir::Operation *funcOp = symTable.lookup(op.getTarget());
     if (!funcOp)
       return mlir::failure();
@@ -2386,12 +2387,6 @@ struct ReussirTrampolineOpConversionPattern
     if (op.getAbiName() != "C")
       return mlir::failure();
 
-    auto module = op->getParentOfType<mlir::ModuleOp>();
-    auto tripleAttr = module->getAttrOfType<mlir::StringAttr>(
-        mlir::LLVM::LLVMDialect::getTargetTripleAttrName());
-    if (!tripleAttr)
-      return mlir::failure();
-    auto triple = llvm::Triple(tripleAttr.getValue());
     mlir::LLVM::LLVMFunctionType llvmFuncTy;
     if (auto llvmFuncOp = mlir::dyn_cast<mlir::LLVM::LLVMFuncOp>(funcOp))
       llvmFuncTy = llvmFuncOp.getFunctionType();
@@ -2410,43 +2405,45 @@ struct ReussirTrampolineOpConversionPattern
 
     auto llvmRetTy = llvmFuncTy.getReturnType();
     auto llvmParamTys = llvmFuncTy.getParams();
+    const bool isImport =
+        op.getDirection() == reussir::TrampolineDirection::Import;
+    CABISignature cabiSig;
+    if (isImport) {
+      cabiSig.isTrivial = true;
+      cabiSig.abiReturnType = llvmRetTy;
+      cabiSig.abiParamTypes.append(llvmParamTys.begin(), llvmParamTys.end());
+    } else {
+      cabiSig = evaluateCABISignatureForC(llvmRetTy, llvmParamTys);
+    }
 
-    auto dl = getDataLayout(*converter, op.getOperation());
-    auto cabiSig =
-        evaluateCABISignatureForC(llvmRetTy, llvmParamTys, dl, triple);
-
-    auto trampolineTy = mlir::LLVM::LLVMFunctionType::get(
-        cabiSig.abiReturnType, cabiSig.abiParamTypes);
+    auto trampolineTy =
+        mlir::LLVM::LLVMFunctionType::get(cabiSig.abiReturnType, cabiSig.abiParamTypes);
     auto trampoline = mlir::LLVM::LLVMFuncOp::create(
         rewriter, op.getLoc(), op.getSymName(), trampolineTy);
-
-    // Setup attributes (e.g. sret)
-    if (cabiSig.hasSRet) {
-      trampoline.setArgAttr(cabiSig.sretIndex,
-                            mlir::LLVM::LLVMDialect::getStructRetAttrName(),
-                            mlir::TypeAttr::get(cabiSig.sretType));
-    }
 
     mlir::Block *entry = trampoline.addEntryBlock(rewriter);
     rewriter.setInsertionPointToStart(entry);
 
     llvm::SmallVector<mlir::Value> targetArgs;
-    int trampolineArgIdx = cabiSig.hasSRet ? 1 : 0;
-
-    for (const auto &[paramType, passKind] : cabiSig.params) {
-      const bool isIndirect = passKind != CABIParamPassKind::Direct;
-      if (passKind == CABIParamPassKind::IndirectByVal)
-        trampoline.setArgAttr(trampolineArgIdx,
-                              mlir::LLVM::LLVMDialect::getByValAttrName(),
-                              mlir::TypeAttr::get(paramType));
-
-      auto arg = trampoline.getArgument(trampolineArgIdx++);
-      if (isIndirect) {
+    if (isImport) {
+      targetArgs.append(trampoline.getArguments().begin(),
+                        trampoline.getArguments().end());
+    } else if (cabiSig.hasPackedArgs) {
+      auto packedArgsPtr = trampoline.getArgument(cabiSig.packedArgsIndex);
+      for (const auto &[idx, paramType] : llvm::enumerate(llvmParamTys)) {
+        llvm::SmallVector<mlir::LLVM::GEPArg, 2> gepArgs{
+            0, static_cast<int32_t>(idx)};
+        auto fieldPtr = mlir::LLVM::GEPOp::create(
+            rewriter, op.getLoc(), ptrType, cabiSig.packedArgsType, packedArgsPtr,
+            gepArgs);
         targetArgs.push_back(
-            mlir::LLVM::LoadOp::create(rewriter, op.getLoc(), paramType, arg));
-      } else {
-        targetArgs.push_back(arg);
+            mlir::LLVM::LoadOp::create(rewriter, op.getLoc(), paramType, fieldPtr));
       }
+    } else {
+      auto trampolineArgs = trampoline.getArguments();
+      auto firstTargetArg = cabiSig.hasReturnPtr ? 1u : 0u;
+      targetArgs.append(trampolineArgs.begin() + firstTargetArg,
+                        trampolineArgs.end());
     }
 
     mlir::Operation *callOp;
@@ -2461,10 +2458,10 @@ struct ReussirTrampolineOpConversionPattern
       return mlir::failure();
     }
 
-    if (cabiSig.hasSRet) {
+    if (cabiSig.hasReturnPtr && !isImport) {
       mlir::LLVM::StoreOp::create(rewriter, 
           op.getLoc(), callOp->getResult(0),
-          trampoline.getArgument(cabiSig.sretIndex));
+          trampoline.getArgument(cabiSig.returnPtrIndex));
       mlir::LLVM::ReturnOp::create(rewriter, op.getLoc(), mlir::ValueRange{});
     } else {
       if (llvm::isa<mlir::LLVM::LLVMVoidType>(cabiSig.abiReturnType))

--- a/lib/Conversion/BasicOpsLowering/CABISignatureConversion.cpp
+++ b/lib/Conversion/BasicOpsLowering/CABISignatureConversion.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/CABISignatureConversion.h"
-#include <llvm/Support/ErrorHandling.h>
-#include <mlir/Dialect/LLVMIR/LLVMTypes.h>
 
 namespace reussir {
 namespace {
@@ -18,105 +16,41 @@ static bool isScalarIntegerLike(mlir::Type type) {
          mlir::isa<mlir::LLVM::LLVMPointerType>(type);
 }
 
-static bool isFPScalar(mlir::Type type) { return type.isF32() || type.isF64(); }
-
-static bool isAggregateType(mlir::Type type) {
-  return mlir::isa<mlir::LLVM::LLVMStructType>(type) ||
-         mlir::isa<mlir::LLVM::LLVMArrayType>(type) ||
-         mlir::isa<mlir::VectorType>(type);
-}
-
-static bool isDirectWin64Aggregate(mlir::Type type, const mlir::DataLayout &dl) {
-  const uint64_t size = dl.getTypeSize(type);
-  return size == 1 || size == 2 || size == 4 || size == 8;
-}
-
-static bool shouldPassIndirect(mlir::Type type, const mlir::DataLayout &dl,
-                               CABIKind abiKind) {
-  if (isScalarIntegerLike(type) || isFPScalar(type))
-    return false;
-
-  if (!isAggregateType(type))
-    return true;
-
-  switch (abiKind) {
-  case CABIKind::Win64:
-    return !isDirectWin64Aggregate(type, dl);
-  case CABIKind::SysVAMD64:
-  case CABIKind::AArch64AAPCS:
-  case CABIKind::Unknown:
-    // Large aggregates are passed indirectly in these ABIs.
-    return dl.getTypeSize(type) > 16;
-  }
-
-  llvm_unreachable("unhandled C ABI kind");
-}
-
-static bool shouldReturnIndirect(mlir::Type type, const mlir::DataLayout &dl,
-                                 CABIKind abiKind) {
-  if (mlir::isa<mlir::LLVM::LLVMVoidType>(type))
-    return false;
-
-  if (isScalarIntegerLike(type) || isFPScalar(type))
-    return false;
-
-  if (!isAggregateType(type))
-    return true;
-
-  switch (abiKind) {
-  case CABIKind::Win64:
-    return !isDirectWin64Aggregate(type, dl);
-  case CABIKind::SysVAMD64:
-  case CABIKind::AArch64AAPCS:
-  case CABIKind::Unknown:
-    return dl.getTypeSize(type) > 16;
-  }
-
-  llvm_unreachable("unhandled C ABI kind");
-}
-
 } // namespace
 
-CABIKind detectCABIKind(const llvm::Triple &triple) {
-  if (triple.isOSWindows() && triple.isArch64Bit())
-    return CABIKind::Win64;
-  if (triple.getArch() == llvm::Triple::aarch64 ||
-      triple.getArch() == llvm::Triple::aarch64_be)
-    return CABIKind::AArch64AAPCS;
-  if (triple.getArch() == llvm::Triple::x86_64 && !triple.isOSWindows())
-    return CABIKind::SysVAMD64;
-  return CABIKind::Unknown;
-}
+bool isTrivialFFIType(mlir::Type type) { return isScalarIntegerLike(type); }
 
 CABISignature evaluateCABISignatureForC(mlir::Type returnType,
-                                        llvm::ArrayRef<mlir::Type> paramTypes,
-                                        const mlir::DataLayout &dl,
-                                        const llvm::Triple &triple) {
+                                        llvm::ArrayRef<mlir::Type> paramTypes) {
   CABISignature sig;
   sig.abiReturnType = returnType;
-  sig.sretType = returnType;
-
-  const CABIKind abiKind = detectCABIKind(triple);
+  sig.returnStorageType = returnType;
   auto ptrType = mlir::LLVM::LLVMPointerType::get(returnType.getContext());
+  const bool trivialReturn =
+      mlir::isa<mlir::LLVM::LLVMVoidType>(returnType) || isTrivialFFIType(returnType);
+  const bool trivialParams =
+      paramTypes.size() < 4 &&
+      llvm::all_of(paramTypes, [](mlir::Type type) { return isTrivialFFIType(type); });
 
-  if (shouldReturnIndirect(returnType, dl, abiKind)) {
-    sig.hasSRet = true;
-    sig.sretIndex = 0;
+  sig.isTrivial = trivialReturn && trivialParams;
+  if (sig.isTrivial) {
+    sig.abiParamTypes.append(paramTypes.begin(), paramTypes.end());
+    return sig;
+  }
+
+  if (!mlir::isa<mlir::LLVM::LLVMVoidType>(returnType) && !isTrivialFFIType(returnType)) {
+    sig.hasReturnPtr = true;
+    sig.returnPtrIndex = 0;
     sig.abiReturnType = mlir::LLVM::LLVMVoidType::get(returnType.getContext());
     sig.abiParamTypes.push_back(ptrType);
   }
 
-  for (mlir::Type paramType : paramTypes) {
-    const bool indirect = shouldPassIndirect(paramType, dl, abiKind);
-    CABIParamPassKind passKind = CABIParamPassKind::Direct;
-    if (indirect) {
-      if (abiKind == CABIKind::AArch64AAPCS)
-        passKind = CABIParamPassKind::IndirectPointer;
-      else
-        passKind = CABIParamPassKind::IndirectByVal;
-    }
-    sig.params.push_back(CABIParamInfo{paramType, passKind});
-    sig.abiParamTypes.push_back(indirect ? ptrType : paramType);
+  if (!paramTypes.empty()) {
+    sig.hasPackedArgs = true;
+    sig.packedArgsIndex = sig.abiParamTypes.size();
+    sig.packedArgsType =
+        mlir::LLVM::LLVMStructType::getLiteral(returnType.getContext(), paramTypes);
+    sig.abiParamTypes.push_back(ptrType);
   }
 
   return sig;

--- a/tests/integration/conversion/str_select_e2e.c
+++ b/tests/integration/conversion/str_select_e2e.c
@@ -17,10 +17,14 @@ typedef struct {
   uint8_t found;
 } SelectResult;
 
-extern SelectResult test_basic(ReussirStr str);
-extern SelectResult test_prefix(ReussirStr str);
-extern SelectResult test_long(ReussirStr str);
-extern SelectResult test_many(ReussirStr str);
+typedef struct {
+  ReussirStr str;
+} SelectArgs;
+
+extern void test_basic(SelectResult *out, SelectArgs *args);
+extern void test_prefix(SelectResult *out, SelectArgs *args);
+extern void test_long(SelectResult *out, SelectArgs *args);
+extern void test_many(SelectResult *out, SelectArgs *args);
 
 // Helper to create a ReussirStr from a C string
 static ReussirStr make_str(const char *s) {
@@ -28,6 +32,15 @@ static ReussirStr make_str(const char *s) {
   str.ptr = s;
   str.len = strlen(s);
   return str;
+}
+
+static SelectResult call_select(void (*fn)(SelectResult *, SelectArgs *),
+                                const char *s) {
+  SelectResult out;
+  SelectArgs args;
+  args.str = make_str(s);
+  fn(&out, &args);
+  return out;
 }
 
 // Test assertion macro
@@ -45,65 +58,65 @@ int main() {
   SelectResult r;
 
   // Test basic pattern matching
-  r = test_basic(make_str("foo"));
+  r = call_select(test_basic, "foo");
   ASSERT_MATCH(r, 0);
 
-  r = test_basic(make_str("bar"));
+  r = call_select(test_basic, "bar");
   ASSERT_MATCH(r, 1);
 
-  r = test_basic(make_str("baz"));
+  r = call_select(test_basic, "baz");
   ASSERT_NO_MATCH(r);
 
-  r = test_basic(make_str("foobar"));
+  r = call_select(test_basic, "foobar");
   ASSERT_NO_MATCH(r); // "foobar" is not exactly "foo"
 
-  r = test_basic(make_str(""));
+  r = call_select(test_basic, "");
   ASSERT_NO_MATCH(r);
 
   // Test prefix patterns (distinguishing "abc" vs "abd")
-  r = test_prefix(make_str("abc"));
+  r = call_select(test_prefix, "abc");
   ASSERT_MATCH(r, 0);
 
-  r = test_prefix(make_str("abd"));
+  r = call_select(test_prefix, "abd");
   ASSERT_MATCH(r, 1);
 
-  r = test_prefix(make_str("xyz"));
+  r = call_select(test_prefix, "xyz");
   ASSERT_MATCH(r, 2);
 
-  r = test_prefix(make_str("abz"));
+  r = call_select(test_prefix, "abz");
   ASSERT_NO_MATCH(r);
 
-  r = test_prefix(make_str("ab"));
+  r = call_select(test_prefix, "ab");
   ASSERT_NO_MATCH(r); // prefix of pattern but not full match
 
   // Test long pattern
-  r = test_long(
-      make_str("extremely_long_unique_pattern_that_is_over_32_chars"));
+  r = call_select(test_long,
+                  "extremely_long_unique_pattern_that_is_over_32_chars");
   ASSERT_MATCH(r, 0);
 
-  r = test_long(make_str("extremely_long_unique_pattern"));
+  r = call_select(test_long, "extremely_long_unique_pattern");
   ASSERT_NO_MATCH(r); // partial match
 
-  r = test_long(make_str("short"));
+  r = call_select(test_long, "short");
   ASSERT_NO_MATCH(r);
 
   // Test many patterns
-  r = test_many(make_str("apple"));
+  r = call_select(test_many, "apple");
   ASSERT_MATCH(r, 0);
 
-  r = test_many(make_str("banana"));
+  r = call_select(test_many, "banana");
   ASSERT_MATCH(r, 1);
 
-  r = test_many(make_str("cherry"));
+  r = call_select(test_many, "cherry");
   ASSERT_MATCH(r, 2);
 
-  r = test_many(make_str("date"));
+  r = call_select(test_many, "date");
   ASSERT_MATCH(r, 3);
 
-  r = test_many(make_str("elderberry"));
+  r = call_select(test_many, "elderberry");
   ASSERT_MATCH(r, 4);
 
-  r = test_many(make_str("fig"));
+  r = call_select(test_many, "fig");
   ASSERT_NO_MATCH(r);
 
   return 0;

--- a/tests/integration/conversion/str_select_e2e.mlir
+++ b/tests/integration/conversion/str_select_e2e.mlir
@@ -17,7 +17,7 @@ module {
     return %idx, %found : index, i1
   }
 
-  reussir.trampoline "C" @test_basic = @test_basic_
+  reussir.trampoline export "C" @test_basic = @test_basic_
 
   // Function to test pattern with common prefix: "abc" (0), "abd" (1), "xyz" (2)
   func.func @test_prefix_(%str: !reussir.str<local>) -> (index, i1) {
@@ -25,7 +25,7 @@ module {
     return %idx, %found : index, i1
   }
 
-  reussir.trampoline "C" @test_prefix = @test_prefix_
+  reussir.trampoline export "C" @test_prefix = @test_prefix_
 
   // Function to test long pattern
   func.func @test_long_(%str: !reussir.str<local>) -> (index, i1) {
@@ -33,7 +33,7 @@ module {
     return %idx, %found : index, i1
   }
 
-  reussir.trampoline "C" @test_long = @test_long_
+  reussir.trampoline export "C" @test_long = @test_long_
 
   // Function to test many patterns with various first bytes
   func.func @test_many_(%str: !reussir.str<local>) -> (index, i1) {
@@ -41,5 +41,5 @@ module {
     return %idx, %found : index, i1
   }
 
-  reussir.trampoline "C" @test_many = @test_many_
+  reussir.trampoline export "C" @test_many = @test_many_
 }

--- a/tests/integration/conversion/trampoline_aarch64_large_aggregate.mlir
+++ b/tests/integration/conversion/trampoline_aarch64_large_aggregate.mlir
@@ -7,13 +7,14 @@ module attributes {llvm.target_triple = "aarch64-unknown-linux-gnu"} {
     llvm.return %arg0 : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
   }
 
-  reussir.trampoline "C" @id_huge_ffi = @id_huge
+  reussir.trampoline export "C" @id_huge_ffi = @id_huge
 }
 
 // CHECK-LABEL: llvm.func @id_huge_ffi(
-// CHECK-SAME: !llvm.ptr {llvm.sret = !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>}
 // CHECK-SAME: !llvm.ptr
-// CHECK: %[[V:.*]] = llvm.load %{{.*}} : !llvm.ptr -> !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
+// CHECK-SAME: !llvm.ptr
+// CHECK: %[[FIELD:.*]] = llvm.getelementptr %{{.*}}[0, 0] : (!llvm.ptr) -> !llvm.ptr
+// CHECK: %[[V:.*]] = llvm.load %[[FIELD]] : !llvm.ptr -> !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
 // CHECK: %[[R:.*]] = llvm.call @id_huge(%[[V]]) : (!llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>) -> !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
 // CHECK: llvm.store %[[R]], %{{.*}} : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>, !llvm.ptr
 // CHECK: llvm.return

--- a/tests/integration/conversion/trampoline_import_large_aggregate.mlir
+++ b/tests/integration/conversion/trampoline_import_large_aggregate.mlir
@@ -1,0 +1,15 @@
+// RUN: %reussir-opt %s --convert-to-llvm | %FileCheck %s
+
+module attributes {llvm.target_triple = "x86_64-pc-linux-gnu"} {
+  llvm.func @id_huge_c(
+      %out: !llvm.ptr,
+      %args: !llvm.ptr)
+
+  reussir.trampoline import "C" @id_huge = @id_huge_c
+}
+
+// CHECK-LABEL: llvm.func @id_huge(
+// CHECK-SAME: !llvm.ptr
+// CHECK-SAME: !llvm.ptr
+// CHECK: llvm.call @id_huge_c(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK: llvm.return

--- a/tests/integration/conversion/trampoline_import_scalar.mlir
+++ b/tests/integration/conversion/trampoline_import_scalar.mlir
@@ -1,0 +1,13 @@
+// RUN: %reussir-opt %s --convert-to-llvm | %FileCheck %s
+
+module attributes {llvm.target_triple = "x86_64-pc-linux-gnu"} {
+  llvm.func @id_i64_c(%arg0: i64) -> i64
+
+  reussir.trampoline import "C" @id_i64 = @id_i64_c
+}
+
+// CHECK-LABEL: llvm.func @id_i64(
+// CHECK-SAME: i64
+// CHECK-SAME: -> i64
+// CHECK: %[[R:.*]] = llvm.call @id_i64_c(%{{.*}}) : (i64) -> i64
+// CHECK: llvm.return %[[R]] : i64

--- a/tests/integration/conversion/trampoline_sysv_four_scalar_args.mlir
+++ b/tests/integration/conversion/trampoline_sysv_four_scalar_args.mlir
@@ -1,0 +1,23 @@
+// RUN: %reussir-opt %s --convert-to-llvm | %FileCheck %s
+
+module attributes {llvm.target_triple = "x86_64-pc-linux-gnu"} {
+  llvm.func @pick_last(%arg0: i64, %arg1: i64, %arg2: i64, %arg3: i64) -> i64 {
+    llvm.return %arg3 : i64
+  }
+
+  reussir.trampoline export "C" @pick_last_ffi = @pick_last
+}
+
+// CHECK-LABEL: llvm.func @pick_last_ffi(
+// CHECK-SAME: !llvm.ptr
+// CHECK-SAME: -> i64
+// CHECK: %[[F0:.*]] = llvm.getelementptr %{{.*}}[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, i64, i64, i64)>
+// CHECK: %[[V0:.*]] = llvm.load %[[F0]] : !llvm.ptr -> i64
+// CHECK: %[[F1:.*]] = llvm.getelementptr %{{.*}}[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, i64, i64, i64)>
+// CHECK: %[[V1:.*]] = llvm.load %[[F1]] : !llvm.ptr -> i64
+// CHECK: %[[F2:.*]] = llvm.getelementptr %{{.*}}[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, i64, i64, i64)>
+// CHECK: %[[V2:.*]] = llvm.load %[[F2]] : !llvm.ptr -> i64
+// CHECK: %[[F3:.*]] = llvm.getelementptr %{{.*}}[0, 3] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, i64, i64, i64)>
+// CHECK: %[[V3:.*]] = llvm.load %[[F3]] : !llvm.ptr -> i64
+// CHECK: %[[R:.*]] = llvm.call @pick_last(%[[V0]], %[[V1]], %[[V2]], %[[V3]]) : (i64, i64, i64, i64) -> i64
+// CHECK: llvm.return %[[R]] : i64

--- a/tests/integration/conversion/trampoline_sysv_large_aggregate.mlir
+++ b/tests/integration/conversion/trampoline_sysv_large_aggregate.mlir
@@ -7,13 +7,14 @@ module attributes {llvm.target_triple = "x86_64-pc-linux-gnu"} {
     llvm.return %arg0 : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
   }
 
-  reussir.trampoline "C" @id_huge_ffi = @id_huge
+  reussir.trampoline export "C" @id_huge_ffi = @id_huge
 }
 
 // CHECK-LABEL: llvm.func @id_huge_ffi(
-// CHECK-SAME: !llvm.ptr {llvm.sret = !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>}
-// CHECK-SAME: !llvm.ptr {llvm.byval = !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>}
-// CHECK: %[[V:.*]] = llvm.load %{{.*}} : !llvm.ptr -> !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
+// CHECK-SAME: !llvm.ptr
+// CHECK-SAME: !llvm.ptr
+// CHECK: %[[FIELD:.*]] = llvm.getelementptr %{{.*}}[0, 0] : (!llvm.ptr) -> !llvm.ptr
+// CHECK: %[[V:.*]] = llvm.load %[[FIELD]] : !llvm.ptr -> !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
 // CHECK: %[[R:.*]] = llvm.call @id_huge(%[[V]]) : (!llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>) -> !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
 // CHECK: llvm.store %[[R]], %{{.*}} : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>, !llvm.ptr
 // CHECK: llvm.return

--- a/tests/integration/conversion/trampoline_win64_large_aggregate.mlir
+++ b/tests/integration/conversion/trampoline_win64_large_aggregate.mlir
@@ -7,13 +7,14 @@ module attributes {llvm.target_triple = "x86_64-pc-windows-gnullvm"} {
     llvm.return %arg0 : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
   }
 
-  reussir.trampoline "C" @id_huge_ffi = @id_huge
+  reussir.trampoline export "C" @id_huge_ffi = @id_huge
 }
 
 // CHECK-LABEL: llvm.func @id_huge_ffi(
-// CHECK-SAME: !llvm.ptr {llvm.sret = !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>}
-// CHECK-SAME: !llvm.ptr {llvm.byval = !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>}
-// CHECK: %[[V:.*]] = llvm.load %{{.*}} : !llvm.ptr -> !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
+// CHECK-SAME: !llvm.ptr
+// CHECK-SAME: !llvm.ptr
+// CHECK: %[[FIELD:.*]] = llvm.getelementptr %{{.*}}[0, 0] : (!llvm.ptr) -> !llvm.ptr
+// CHECK: %[[V:.*]] = llvm.load %[[FIELD]] : !llvm.ptr -> !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
 // CHECK: %[[R:.*]] = llvm.call @id_huge(%[[V]]) : (!llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>) -> !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>
 // CHECK: llvm.store %[[R]], %{{.*}} : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64)>, !llvm.ptr
 // CHECK: llvm.return

--- a/tests/integration/conversion/trampoline_win64_scalar.mlir
+++ b/tests/integration/conversion/trampoline_win64_scalar.mlir
@@ -5,7 +5,7 @@ module attributes {llvm.target_triple = "x86_64-pc-windows-gnullvm"} {
     llvm.return %arg0 : i64
   }
 
-  reussir.trampoline "C" @id_i64_ffi = @id_i64
+  reussir.trampoline export "C" @id_i64_ffi = @id_i64
 }
 
 // CHECK: llvm.func @id_i64_ffi({{.*}}i64{{.*}}) -> i64

--- a/tests/integration/frontend/huge_value_struct_call_and_return.c
+++ b/tests/integration/frontend/huge_value_struct_call_and_return.c
@@ -12,7 +12,11 @@ typedef struct {
   uint64_t f7;
 } HugeValue;
 
-extern HugeValue transform_huge_value_ffi(HugeValue input);
+typedef struct {
+  HugeValue input;
+} HugeValueArgs;
+
+extern void transform_huge_value_ffi(HugeValue *out, HugeValueArgs *args);
 
 static void assert_huge_value_eq(HugeValue actual, HugeValue expected) {
   if (actual.f0 != expected.f0 || actual.f1 != expected.f1 ||
@@ -23,14 +27,21 @@ static void assert_huge_value_eq(HugeValue actual, HugeValue expected) {
   }
 }
 
+static HugeValue call_transform_huge_value(HugeValue input) {
+  HugeValue out;
+  HugeValueArgs args = {input};
+  transform_huge_value_ffi(&out, &args);
+  return out;
+}
+
 int main() {
   HugeValue input = {3, 5, 8, 13, 21, 34, 55, 89};
   HugeValue expected = {92, 115, 110, 97, 86, 82, 90, 113};
-  HugeValue output = transform_huge_value_ffi(input);
+  HugeValue output = call_transform_huge_value(input);
   assert_huge_value_eq(output, expected);
 
   HugeValue expected_second = {205, 295, 356, 441, 571, 742, 895, 849};
-  HugeValue output_second = transform_huge_value_ffi(output);
+  HugeValue output_second = call_transform_huge_value(output);
   assert_huge_value_eq(output_second, expected_second);
 
   return 0;

--- a/www/book.typ
+++ b/www/book.typ
@@ -12,6 +12,7 @@
   - #chapter("chapters/development/compilation-process.typ")[Compilation Process]
   - #chapter("chapters/development/closures.typ")[Closures]
   - #chapter("chapters/development/regions.typ")[Regions]
+  - #chapter("chapters/development/trampolines.typ")[Trampolines]
   - #chapter("chapters/development/polymorphic-ffi.typ")[Polymorphic FFI]
 ])
 

--- a/www/chapters/development/trampolines.typ
+++ b/www/chapters/development/trampolines.typ
@@ -1,0 +1,80 @@
+#import "/book.typ": book-page
+
+#show: book-page.with(title: "Trampolines")
+
+== Trampolines
+
+`reussir.trampoline` models the backend FFI boundary for ordinary native calls.
+The operation now carries an explicit direction:
+
+- `reussir.trampoline export "C" @ffi_name = @target`
+- `reussir.trampoline import "C" @reussir_name = @c_target`
+
+`export` exposes an internal Reussir function to C-facing callers. `import`
+defines a Reussir symbol that forwards to a C-facing target already declared in
+the module.
+
+=== Trivial Boundary
+
+A function is *trivial* for the backend trampoline when:
+
+- it accepts fewer than four arguments;
+- every argument is an integral or pointer LLVM value;
+- it returns either no result or exactly one integral or pointer LLVM value.
+
+Trivial trampolines do not need ABI reshaping. The backend therefore lowers
+them as direct forwards with best-effort minimal overhead.
+
+=== Nontrivial Boundary
+
+Any function outside the trivial class uses the explicit trampoline boundary
+below.
+
+For nontrivial returns, the trampoline always uses an explicit leading return
+pointer parameter. The backend does not attach ABI-specific `sret` metadata to
+that parameter. This rule is backend-defined and no longer depends on
+platform-specific C ABI aggregate classification.
+
+For nontrivial calls, the trampoline packs all logical arguments into a literal
+LLVM struct in source order and passes a pointer to that struct. This applies
+even when the original arguments are individually integral or pointer values,
+for example once the arity reaches four.
+
+The resulting exported boundary therefore has one of these shapes:
+
+- trivial call: direct values in, direct value or `void` out;
+- nontrivial return only: `void` return plus leading return pointer;
+- nontrivial arguments only: direct return plus one pointer to the packed
+  argument struct;
+- both nontrivial: leading return pointer plus one pointer to the packed argument
+  struct.
+
+=== Import And Export Responsibilities
+
+The backend now focuses only on lowering the trampoline symbol itself.
+It does *not* synthesize caller-side stack storage for the packed argument
+struct or for the explicit return destination.
+
+That means the caller or callee on the C side is responsible for choosing
+whether it passes direct values or explicit pointers according to the trampoline
+signature. For `export`, the external C caller must obey that ABI shape. For
+`import`, the referenced C target must already be declared with that ABI shape,
+and the Reussir-side caller must provide the corresponding arguments.
+
+=== Operation Shape
+
+The operation now includes an import/export enum attribute in assembly syntax:
+
+```mlir
+reussir.trampoline export "C" @sum_ffi = @sum_internal
+reussir.trampoline import "C" @sum_internal = @sum_c
+```
+
+Currently only the `"C"` ABI is supported.
+
+=== TODO
+
+- The frontend should expose user-facing facilities to import `"C"` functions
+  through `reussir.trampoline`, including helpers for constructing the packed
+  argument struct pointer and any required explicit return storage in
+  JIT-facing flows.


### PR DESCRIPTION

- redesign `reussir.trampoline` around a backend-defined trivial/nontrivial C ABI boundary with import/export direction support
- lower nontrivial returns as explicit leading return pointers and nontrivial argument lists as packed literal structs, without LLVM `sret` attributes
- update the Haskell JIT/REPL call path to marshal nontrivial results with `alloca`, and refresh integration/docs around the new ABI
