### PR TITLE
Add JSON serialization for all frontend pipeline contexts

### DIFF
--- a/frontend/reussir-core/reussir-core.cabal
+++ b/frontend/reussir-core/reussir-core.cabal
@@ -39,6 +39,10 @@ library
         Reussir.Core.Data.Operator
         Reussir.Core.Data.Generic
         Reussir.Core.Data.UniqueID
+        Reussir.Core.Serialization
+        Reussir.Core.Serialization.Orphans
+        Reussir.Core.Serialization.Semi
+        Reussir.Core.Serialization.Full
         Reussir.Core.Generic
         Reussir.Core.Class
         Reussir.Core.String
@@ -75,6 +79,8 @@ library
     other-modules:
         Reussir.Core.Uitls.HashTable
     build-depends:    base ^>=4.20.2.0,
+                      aeson,
+                      colour,
                       reussir-bridge,
                       reussir-parser,
                       reussir-diagnostic,
@@ -159,8 +165,13 @@ test-suite reussir-core-test
         Test.Reussir.Core.Semi.ModuleResolution
         Test.Reussir.Core.Semi.PatternMatch
         Test.Reussir.Core.Semi.TyckSpec
+        Test.Reussir.Core.SerializationSpec
     build-depends:
         base ^>=4.20.2.0,
+        aeson,
+        directory,
+        megaparsec,
+        xxhash-ffi,
         reussir-core,
         tasty,
         tasty-hspec,

--- a/frontend/reussir-core/src/Reussir/Core/Data/Full/Error.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Data/Full/Error.hs
@@ -14,6 +14,7 @@ data Error = Error
     { errorSpan :: (Int64, Int64)
     , errorKind :: ErrorKind
     }
+    deriving (Show, Eq)
 
 data ErrorKind
     = InvalidRecordField
@@ -28,3 +29,4 @@ data ErrorKind
       InvalidAssignSourceCapability
     | -- | Source of assignment inner type is not a regional record
       InvalidAssignSourceNotRegional
+    deriving (Show, Eq)

--- a/frontend/reussir-core/src/Reussir/Core/Data/Full/Function.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Data/Full/Function.hs
@@ -21,5 +21,6 @@ data Function = Function
     , funcBody :: Maybe Full.Expr
     , funcSpan :: Maybe (Int64, Int64)
     }
+    deriving (Show, Eq)
 
 type FunctionTable = H.CuckooHashTable Symbol Function

--- a/frontend/reussir-core/src/Reussir/Core/Serialization.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Serialization.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+{- | Suspend/recover support for the frontend pipeline.
+
+Every stage of the frontend can be serialized to JSON and recovered later:
+
+* __Surface syntax__: the parsed program ('SurfaceProgram', one
+  'SurfaceModule' per source file).
+* __Semi syntax__: the global semi-elaboration context ('SemiContext'),
+  suspendable after any semi step (statement scanning, record field
+  population, function elaboration, generic solving), plus the
+  'GenericSolution' produced by flow analysis.
+* __Full syntax__: the global full-elaboration context ('FullContext')
+  produced by the semi-to-full conversion.
+
+For each stage there are @encode@/@decode@ (in-memory 'BSL.ByteString') and
+@suspend@/@recover@ (file based) functions. Decoding rebuilds fully
+functional, mutable contexts so the pipeline can continue from the recovered
+state.
+-}
+module Reussir.Core.Serialization (
+    -- * Surface syntax
+    SurfaceModule (..),
+    SurfaceProgram,
+    encodeSurfaceProgram,
+    decodeSurfaceProgram,
+    suspendSurfaceProgram,
+    recoverSurfaceProgram,
+
+    -- * Semi syntax
+    encodeSemiContext,
+    decodeSemiContext,
+    suspendSemiContext,
+    recoverSemiContext,
+    encodeGenericSolution,
+    decodeGenericSolution,
+    suspendGenericSolution,
+    recoverGenericSolution,
+
+    -- * Full syntax
+    encodeFullContext,
+    decodeFullContext,
+    suspendFullContext,
+    recoverFullContext,
+
+    -- * Snapshots
+    module Reussir.Core.Serialization.Semi,
+    module Reussir.Core.Serialization.Full,
+) where
+
+import Data.Aeson (eitherDecode, encode)
+import Data.Aeson.TH (deriveJSON)
+import Effectful (Eff, IOE, liftIO, (:>))
+import Effectful.Prim (Prim)
+import Reussir.Parser.Serialization ()
+import Reussir.Parser.Types.Lexer (Identifier)
+import Reussir.Parser.Types.Stmt (Stmt)
+
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BSL
+
+import Reussir.Core.Data.Full.Context (FullContext)
+import Reussir.Core.Data.Generic (GenericSolution)
+import Reussir.Core.Data.Semi.Context (SemiContext)
+import Reussir.Core.Serialization.Full
+import Reussir.Core.Serialization.Orphans ()
+import Reussir.Core.Serialization.Semi
+
+-- | A parsed source file together with its module path inside the package.
+data SurfaceModule = SurfaceModule
+    { surfaceFile :: FilePath
+    , surfaceModPath :: [Identifier]
+    , surfaceStmts :: [Stmt]
+    }
+    deriving (Show, Eq)
+
+$(deriveJSON Aeson.defaultOptions ''SurfaceModule)
+
+-- | A whole parsed package: the input of the semi-elaboration phase.
+type SurfaceProgram = [SurfaceModule]
+
+encodeSurfaceProgram :: SurfaceProgram -> BSL.ByteString
+encodeSurfaceProgram = encode
+
+decodeSurfaceProgram :: BSL.ByteString -> Either String SurfaceProgram
+decodeSurfaceProgram = eitherDecode
+
+suspendSurfaceProgram :: (IOE :> es) => FilePath -> SurfaceProgram -> Eff es ()
+suspendSurfaceProgram path = liftIO . Aeson.encodeFile path
+
+recoverSurfaceProgram ::
+    (IOE :> es) => FilePath -> Eff es (Either String SurfaceProgram)
+recoverSurfaceProgram = liftIO . Aeson.eitherDecodeFileStrict
+
+encodeSemiContext ::
+    (IOE :> es, Prim :> es) => SemiContext -> Eff es BSL.ByteString
+encodeSemiContext = fmap encode . snapshotSemiContext
+
+decodeSemiContext ::
+    (IOE :> es, Prim :> es) => BSL.ByteString -> Eff es (Either String SemiContext)
+decodeSemiContext bytes = traverse restoreSemiContext (eitherDecode bytes)
+
+suspendSemiContext ::
+    (IOE :> es, Prim :> es) => FilePath -> SemiContext -> Eff es ()
+suspendSemiContext path ctx = do
+    snap <- snapshotSemiContext ctx
+    liftIO $ Aeson.encodeFile path snap
+
+recoverSemiContext ::
+    (IOE :> es, Prim :> es) => FilePath -> Eff es (Either String SemiContext)
+recoverSemiContext path = do
+    snap <- liftIO $ Aeson.eitherDecodeFileStrict path
+    traverse restoreSemiContext snap
+
+encodeGenericSolution ::
+    (IOE :> es) => GenericSolution -> Eff es BSL.ByteString
+encodeGenericSolution = fmap encode . snapshotGenericSolution
+
+decodeGenericSolution ::
+    (IOE :> es) => BSL.ByteString -> Eff es (Either String GenericSolution)
+decodeGenericSolution bytes = traverse restoreGenericSolution (eitherDecode bytes)
+
+suspendGenericSolution ::
+    (IOE :> es) => FilePath -> GenericSolution -> Eff es ()
+suspendGenericSolution path sol = do
+    snap <- snapshotGenericSolution sol
+    liftIO $ Aeson.encodeFile path snap
+
+recoverGenericSolution ::
+    (IOE :> es) => FilePath -> Eff es (Either String GenericSolution)
+recoverGenericSolution path = do
+    snap <- liftIO $ Aeson.eitherDecodeFileStrict path
+    traverse restoreGenericSolution snap
+
+encodeFullContext ::
+    (IOE :> es, Prim :> es) => FullContext -> Eff es BSL.ByteString
+encodeFullContext = fmap encode . snapshotFullContext
+
+decodeFullContext ::
+    (IOE :> es, Prim :> es) => BSL.ByteString -> Eff es (Either String FullContext)
+decodeFullContext bytes = traverse restoreFullContext (eitherDecode bytes)
+
+suspendFullContext ::
+    (IOE :> es, Prim :> es) => FilePath -> FullContext -> Eff es ()
+suspendFullContext path ctx = do
+    snap <- snapshotFullContext ctx
+    liftIO $ Aeson.encodeFile path snap
+
+recoverFullContext ::
+    (IOE :> es, Prim :> es) => FilePath -> Eff es (Either String FullContext)
+recoverFullContext path = do
+    snap <- liftIO $ Aeson.eitherDecodeFileStrict path
+    traverse restoreFullContext snap

--- a/frontend/reussir-core/src/Reussir/Core/Serialization/Full.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Serialization/Full.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | JSON serialization for the full syntax and the global full-elaboration
+context.
+
+Unlike the semi phase, almost all full-phase data ('Full.Function',
+'Full.Record', 'Full.Expr', errors) is already pure, so it receives direct
+'ToJSON'/'FromJSON' instances. Only the context's hash tables need to be
+mirrored: 'snapshotFullContext' captures a 'FullContext' into a pure
+'FullContextSnapshot' and 'restoreFullContext' rebuilds a functional context
+from it. Semi records referenced by the full context are snapshotted via
+"Reussir.Core.Serialization.Semi".
+
+All hash table dumps are sorted by key (symbols by their text) so snapshots
+of structurally equal contexts compare equal and serialize identically.
+-}
+module Reussir.Core.Serialization.Full (
+    FullContextSnapshot (..),
+    snapshotFullContext,
+    restoreFullContext,
+) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), defaultOptions)
+import Data.Aeson.TH (deriveJSON)
+import Data.List (sortOn)
+import Effectful (Eff, IOE, liftIO, (:>))
+import Effectful.Prim (Prim)
+import Reussir.Codegen.Context.Symbol (Symbol, symbolText)
+import Reussir.Parser.Serialization ()
+import Reussir.Parser.Types.Lexer (Path)
+
+import Data.HashMap.Strict qualified as HashMap
+import Data.HashTable.IO qualified as H
+import Data.Text qualified as T
+
+import Reussir.Core.Data.Full.Context (FullContext (..))
+import Reussir.Core.Data.Full.Error (Error, ErrorKind)
+import Reussir.Core.Data.Full.Expr (
+    ClosureExpr,
+    DTSwitchCases,
+    DecisionTree,
+    Expr,
+    ExprKind,
+    PatternVarRef (..),
+ )
+import Reussir.Core.Data.Full.Function (Function)
+import Reussir.Core.Data.Full.Record (Record, RecordFields, RecordKind)
+import Reussir.Core.Data.Full.Type (Type)
+import Reussir.Core.Serialization.Orphans ()
+import Reussir.Core.Serialization.Semi (
+    SemiRecordSnapshot,
+    StringUniqifierSnapshot,
+    restoreSemiRecord,
+    restoreStringUniqifier,
+    snapshotSemiRecord,
+    snapshotStringUniqifier,
+ )
+
+instance ToJSON PatternVarRef where
+    toJSON = toJSON . unPatternVarRef
+    toEncoding = toEncoding . unPatternVarRef
+
+instance FromJSON PatternVarRef where
+    parseJSON = fmap PatternVarRef . parseJSON
+
+$(deriveJSON defaultOptions ''Type)
+
+-- The expression types are mutually recursive, so they are derived in a
+-- single declaration group.
+$( concat
+    <$> traverse
+        (deriveJSON defaultOptions)
+        [ ''ExprKind
+        , ''Expr
+        , ''DecisionTree
+        , ''DTSwitchCases
+        , ''ClosureExpr
+        ]
+ )
+
+$(deriveJSON defaultOptions ''RecordKind)
+$(deriveJSON defaultOptions ''RecordFields)
+$(deriveJSON defaultOptions ''Record)
+$(deriveJSON defaultOptions ''Function)
+$(deriveJSON defaultOptions ''ErrorKind)
+$(deriveJSON defaultOptions ''Error)
+
+{- | Pure snapshot of the whole global full-elaboration context. This is the
+unit of suspension between the full conversion and lowering.
+-}
+data FullContextSnapshot = FullContextSnapshot
+    { fcFunctions :: [(Symbol, Function)]
+    , fcRecords :: [(Symbol, Record)]
+    , fcSemiRecords :: [(Path, SemiRecordSnapshot)]
+    , fcErrors :: [Error]
+    , fcStrings :: StringUniqifierSnapshot
+    , fcFilePath :: FilePath
+    , fcFlexible :: Bool
+    , fcTrampolines :: [(Symbol, (T.Text, Symbol))]
+    }
+    deriving (Show, Eq)
+
+$(deriveJSON defaultOptions ''FullContextSnapshot)
+
+-- | Capture the whole global full context into a pure snapshot.
+snapshotFullContext ::
+    (IOE :> es, Prim :> es) => FullContext -> Eff es FullContextSnapshot
+snapshotFullContext ctx = do
+    functions <- liftIO $ H.toList (ctxFunctions ctx)
+    records <- liftIO $ H.toList (ctxRecords ctx)
+    semiRecords <- liftIO $ H.toList (ctxSemiRecords ctx)
+    semiRecordSnaps <-
+        traverse (\(path, r) -> (path,) <$> snapshotSemiRecord r) semiRecords
+    strings <- snapshotStringUniqifier (ctxStringUniqifier ctx)
+    pure
+        FullContextSnapshot
+            { fcFunctions = sortOn (symbolText . fst) functions
+            , fcRecords = sortOn (symbolText . fst) records
+            , fcSemiRecords = sortOn fst semiRecordSnaps
+            , fcErrors = ctxErrors ctx
+            , fcStrings = strings
+            , fcFilePath = ctxFilePath ctx
+            , fcFlexible = ctxFlexible ctx
+            , fcTrampolines =
+                sortOn (symbolText . fst) (HashMap.toList (ctxTrampolines ctx))
+            }
+
+-- | Rebuild a fully functional full context from a pure snapshot.
+restoreFullContext ::
+    (IOE :> es, Prim :> es) => FullContextSnapshot -> Eff es FullContext
+restoreFullContext snap = do
+    functionTable <- liftIO $ H.fromList (fcFunctions snap)
+    recordTable <- liftIO $ H.fromList (fcRecords snap)
+    semiRecords <-
+        traverse (\(path, r) -> (path,) <$> restoreSemiRecord r) (fcSemiRecords snap)
+    semiRecordTable <- liftIO $ H.fromList semiRecords
+    uniqifier <- restoreStringUniqifier (fcStrings snap)
+    pure
+        FullContext
+            { ctxFunctions = functionTable
+            , ctxRecords = recordTable
+            , ctxSemiRecords = semiRecordTable
+            , ctxErrors = fcErrors snap
+            , ctxStringUniqifier = uniqifier
+            , ctxFilePath = fcFilePath snap
+            , ctxFlexible = fcFlexible snap
+            , ctxTrampolines = HashMap.fromList (fcTrampolines snap)
+            }

--- a/frontend/reussir-core/src/Reussir/Core/Serialization/Orphans.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Serialization/Orphans.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | Shared orphan 'ToJSON'/'FromJSON' instances for the building blocks used
+by both the semi and the full syntax: unique identifiers, operators, interned
+symbols, string tokens, diagnostic reports and the bridge log level.
+
+See "Reussir.Parser.Serialization" for the encoding conventions shared by all
+frontend serialization modules.
+-}
+module Reussir.Core.Serialization.Orphans () where
+
+import Data.Aeson (
+    FromJSON (..),
+    FromJSONKey (..),
+    FromJSONKeyFunction (..),
+    ToJSON (..),
+    ToJSONKey (..),
+    defaultOptions,
+    withText,
+ )
+import Data.Aeson.TH (deriveJSON)
+import Data.Aeson.Types (toJSONKeyText)
+import Data.Colour (Colour)
+import Data.Colour.RGBSpace (RGB (..))
+import Data.Digest.XXHash.FFI (XXH3 (..))
+import Reussir.Codegen.Context.Symbol (Symbol, symbolText, verifiedSymbol)
+import Reussir.Diagnostic.Report (
+    CodeReference,
+    Label,
+    Report,
+    TextWithFormat,
+ )
+import Reussir.Parser.Serialization ()
+
+import Data.Colour.SRGB.Linear qualified as Linear
+import Data.Text qualified as T
+import Reussir.Bridge qualified as B
+import Reussir.Codegen.Type.Data qualified as IR
+import System.Console.ANSI.Types qualified as ANSI
+
+import Reussir.Core.Data.Class (Class, ClassNode)
+import Reussir.Core.Data.FP (FloatingPointType)
+import Reussir.Core.Data.Integral (IntegralType)
+import Reussir.Core.Data.Operator (ArithOp, CmpOp)
+import Reussir.Core.Data.String (StringToken (..))
+import Reussir.Core.Data.UniqueID (
+    ExprID (..),
+    GenericID (..),
+    HoleID (..),
+    VarID (..),
+ )
+
+instance ToJSON GenericID where
+    toJSON = toJSON . genericIDValue
+    toEncoding = toEncoding . genericIDValue
+
+instance FromJSON GenericID where
+    parseJSON = fmap GenericID . parseJSON
+
+instance ToJSON VarID where
+    toJSON = toJSON . unVarID
+    toEncoding = toEncoding . unVarID
+
+instance FromJSON VarID where
+    parseJSON = fmap VarID . parseJSON
+
+instance ToJSON ExprID where
+    toJSON = toJSON . unExprID
+    toEncoding = toEncoding . unExprID
+
+instance FromJSON ExprID where
+    parseJSON = fmap ExprID . parseJSON
+
+instance ToJSON HoleID where
+    toJSON = toJSON . holeIDValue
+    toEncoding = toEncoding . holeIDValue
+
+instance FromJSON HoleID where
+    parseJSON = fmap HoleID . parseJSON
+
+instance ToJSON StringToken where
+    toJSON (StringToken ws) = toJSON ws
+    toEncoding (StringToken ws) = toEncoding ws
+
+instance FromJSON StringToken where
+    parseJSON = fmap StringToken . parseJSON
+
+instance ToJSON Symbol where
+    toJSON = toJSON . symbolText
+    toEncoding = toEncoding . symbolText
+
+instance FromJSON Symbol where
+    parseJSON = withText "Symbol" (pure . verifiedSymbol)
+
+instance ToJSONKey Symbol where
+    toJSONKey = toJSONKeyText symbolText
+
+instance FromJSONKey Symbol where
+    fromJSONKey = FromJSONKeyText verifiedSymbol
+
+instance ToJSON (XXH3 T.Text) where
+    toJSON (XXH3 t) = toJSON t
+    toEncoding (XXH3 t) = toEncoding t
+
+instance FromJSON (XXH3 T.Text) where
+    parseJSON = fmap XXH3 . parseJSON
+
+instance ToJSONKey (XXH3 T.Text) where
+    toJSONKey = toJSONKeyText (\(XXH3 t) -> t)
+
+instance FromJSONKey (XXH3 T.Text) where
+    fromJSONKey = FromJSONKeyText XXH3
+
+-- Colours are stored by their linear RGB channels, which is the internal
+-- representation of 'Colour' and therefore roundtrips exactly.
+instance ToJSON (Colour Float) where
+    toJSON c = let RGB r g b = Linear.toRGB c in toJSON (r, g, b)
+    toEncoding c = let RGB r g b = Linear.toRGB c in toEncoding (r, g, b)
+
+instance FromJSON (Colour Float) where
+    parseJSON v = do
+        (r, g, b) <- parseJSON v
+        pure (Linear.rgb r g b)
+
+$(deriveJSON defaultOptions ''ArithOp)
+$(deriveJSON defaultOptions ''CmpOp)
+$(deriveJSON defaultOptions ''IntegralType)
+$(deriveJSON defaultOptions ''FloatingPointType)
+$(deriveJSON defaultOptions ''Class)
+$(deriveJSON defaultOptions ''ClassNode)
+$(deriveJSON defaultOptions ''B.LogLevel)
+$(deriveJSON defaultOptions ''IR.Capability)
+
+$(deriveJSON defaultOptions ''ANSI.Color)
+$(deriveJSON defaultOptions ''ANSI.ColorIntensity)
+$(deriveJSON defaultOptions ''ANSI.ConsoleLayer)
+$(deriveJSON defaultOptions ''ANSI.ConsoleIntensity)
+$(deriveJSON defaultOptions ''ANSI.Underlining)
+$(deriveJSON defaultOptions ''ANSI.BlinkSpeed)
+$(deriveJSON defaultOptions ''ANSI.SGR)
+
+$(deriveJSON defaultOptions ''Label)
+$(deriveJSON defaultOptions ''TextWithFormat)
+$(deriveJSON defaultOptions ''CodeReference)
+$(deriveJSON defaultOptions ''Report)

--- a/frontend/reussir-core/src/Reussir/Core/Serialization/Semi.hs
+++ b/frontend/reussir-core/src/Reussir/Core/Serialization/Semi.hs
@@ -1,0 +1,439 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | JSON serialization for the semi syntax and the global semi-elaboration
+context.
+
+The pure parts of the semi syntax ('Semi.Type', 'Semi.Expr', decision trees,
+record fields, ...) receive direct 'ToJSON'/'FromJSON' instances. The mutable
+parts of 'SemiContext' (hash tables, @IORef'@s) are mirrored by pure
+@*Snapshot@ types: 'snapshotSemiContext' captures the full context into a
+'SemiContextSnapshot' (which has JSON instances and structural equality) and
+'restoreSemiContext' rebuilds a fresh, fully functional 'SemiContext' from a
+snapshot. This is what allows the pipeline to be suspended after any semi
+phase step and recovered later.
+
+All hash table dumps are sorted by key so that snapshots taken from
+structurally equal contexts compare equal and serialize identically.
+-}
+module Reussir.Core.Serialization.Semi (
+    SemiFunctionSnapshot (..),
+    SemiRecordSnapshot (..),
+    ClassDAGSnapshot (..),
+    GenericVarSnapshot (..),
+    GenericStateSnapshot (..),
+    StringUniqifierSnapshot,
+    GenericSolutionSnapshot,
+    SemiContextSnapshot (..),
+    snapshotStringUniqifier,
+    restoreStringUniqifier,
+    snapshotClassDAG,
+    restoreClassDAG,
+    snapshotGenericState,
+    restoreGenericState,
+    snapshotGenericSolution,
+    restoreGenericSolution,
+    snapshotSemiRecord,
+    restoreSemiRecord,
+    snapshotSemiFunction,
+    restoreSemiFunction,
+    snapshotSemiContext,
+    restoreSemiContext,
+) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), defaultOptions)
+import Data.Aeson.TH (deriveJSON)
+import Data.Array (bounds, elems, listArray)
+import Data.Digest.XXHash.FFI (XXH3 (..))
+import Data.Foldable (toList)
+import Data.Int (Int64)
+import Data.List (sort, sortOn)
+import Effectful (Eff, IOE, liftIO, (:>))
+import Effectful.Prim (Prim)
+import Effectful.Prim.IORef.Strict (newIORef', readIORef')
+import Reussir.Diagnostic.Report (Report)
+import Reussir.Parser.Serialization ()
+import Reussir.Parser.Types.Capability (Capability)
+import Reussir.Parser.Types.Lexer (Identifier, Path)
+import Reussir.Parser.Types.Stmt (Visibility)
+
+import Data.HashMap.Strict qualified as HashMap
+import Data.HashSet qualified as HashSet
+import Data.HashTable.IO qualified as H
+import Data.Sequence qualified as Seq
+import Data.Text qualified as T
+import Reussir.Bridge qualified as B
+
+import Reussir.Core.Data.Class (
+    ChainID,
+    Class,
+    ClassDAG (..),
+    ClassNode,
+ )
+import Reussir.Core.Data.Generic (
+    GenericSolution,
+    GenericState (..),
+    GenericVar (..),
+ )
+import Reussir.Core.Data.Semi.Context (SemiContext (..))
+import Reussir.Core.Data.Semi.Expr (
+    ClosureExpr,
+    DTSwitchCases,
+    DecisionTree,
+    Expr,
+    ExprKind,
+    PatternVarRef (..),
+ )
+import Reussir.Core.Data.Semi.Function (
+    FunctionProto (..),
+    FunctionTable (..),
+ )
+import Reussir.Core.Data.Semi.Record (Record (..), RecordFields, RecordKind)
+import Reussir.Core.Data.Semi.Type (
+    Flexivity,
+    Type,
+    TypeClassTable (..),
+ )
+import Reussir.Core.Data.String (StringToken, StringUniqifier (..))
+import Reussir.Core.Data.UniqueID (GenericID)
+import Reussir.Core.Serialization.Orphans ()
+import Reussir.Core.String (getAllStrings)
+
+instance ToJSON PatternVarRef where
+    toJSON = toJSON . unPatternVarRef
+    toEncoding = toEncoding . unPatternVarRef
+
+instance FromJSON PatternVarRef where
+    parseJSON = fmap PatternVarRef . parseJSON
+
+$(deriveJSON defaultOptions ''Flexivity)
+$(deriveJSON defaultOptions ''Type)
+
+-- The expression types are mutually recursive, so they are derived in a
+-- single declaration group.
+$( concat
+    <$> traverse
+        (deriveJSON defaultOptions)
+        [ ''ExprKind
+        , ''Expr
+        , ''DecisionTree
+        , ''DTSwitchCases
+        , ''ClosureExpr
+        ]
+ )
+
+$(deriveJSON defaultOptions ''RecordKind)
+$(deriveJSON defaultOptions ''RecordFields)
+
+-- | Pure snapshot of a semi-phase 'FunctionProto' (body pulled out of its ref).
+data SemiFunctionSnapshot = SemiFunctionSnapshot
+    { sfVisibility :: Visibility
+    , sfName :: Identifier
+    , sfPath :: Path
+    , sfGenerics :: [(Identifier, GenericID)]
+    , sfParams :: [(Identifier, Type)]
+    , sfReturnType :: Type
+    , sfIsRegional :: Bool
+    , sfBody :: Maybe Expr
+    , sfSpan :: Maybe (Int64, Int64)
+    }
+    deriving (Show, Eq)
+
+-- | Pure snapshot of a semi-phase 'Record' (fields pulled out of their ref).
+data SemiRecordSnapshot = SemiRecordSnapshot
+    { srName :: Path
+    , srTyParams :: [(Identifier, GenericID)]
+    , srFields :: Maybe RecordFields
+    , srKind :: RecordKind
+    , srVisibility :: Visibility
+    , srDefaultCap :: Capability
+    , srSpan :: Maybe (Int64, Int64)
+    }
+    deriving (Show, Eq)
+
+-- | Pure snapshot of the type class DAG.
+data ClassDAGSnapshot = ClassDAGSnapshot
+    { cdNameMap :: [(Class, Int)]
+    , cdIdMap :: [(Int, Class)]
+    , cdNodeMap :: [(Int, ClassNode)]
+    , cdChainHeadMap :: [(ChainID, Int)]
+    , cdCounter :: Int
+    , cdFinalizedGraph :: Maybe ((Int, Int), [ClassNode])
+    }
+    deriving (Show, Eq)
+
+-- | Pure snapshot of a generic variable, including its flow links.
+data GenericVarSnapshot = GenericVarSnapshot
+    { gvName :: Identifier
+    , gvSpan :: Maybe (Int64, Int64)
+    , gvLinks :: [(GenericID, Maybe Type)]
+    , gvBounds :: [Path]
+    }
+    deriving (Show, Eq)
+
+{- | Pure snapshot of the generic instantiation state. The position of each
+variable in 'gsVars' is its 'GenericID', so the sequence order is preserved.
+-}
+data GenericStateSnapshot = GenericStateSnapshot
+    { gsVars :: [GenericVarSnapshot]
+    , gsConcreteFlow :: [(GenericID, [Type])]
+    }
+    deriving (Show, Eq)
+
+-- | The interned strings, sorted by string content.
+type StringUniqifierSnapshot = [(T.Text, StringToken)]
+
+-- | Pure form of 'GenericSolution', sorted by generic ID.
+type GenericSolutionSnapshot = [(GenericID, [Type])]
+
+{- | Pure snapshot of the whole global semi-elaboration context. This is the
+unit of suspension between pipeline steps of the semi phase.
+-}
+data SemiContextSnapshot = SemiContextSnapshot
+    { scFile :: FilePath
+    , scModulePath :: [Identifier]
+    , scLogLevel :: B.LogLevel
+    , scStrings :: StringUniqifierSnapshot
+    , scReports :: [Report]
+    , scHasFailed :: Bool
+    , scClassDAG :: ClassDAGSnapshot
+    , scTypeClassTable :: [(Type, [Class])]
+    , scRecords :: [(Path, SemiRecordSnapshot)]
+    , scFunctions :: [(Path, SemiFunctionSnapshot)]
+    , scGenerics :: GenericStateSnapshot
+    , scTrampolines :: [(Identifier, (Path, T.Text, [Type]))]
+    }
+    deriving (Show, Eq)
+
+$(deriveJSON defaultOptions ''SemiFunctionSnapshot)
+$(deriveJSON defaultOptions ''SemiRecordSnapshot)
+$(deriveJSON defaultOptions ''ClassDAGSnapshot)
+$(deriveJSON defaultOptions ''GenericVarSnapshot)
+$(deriveJSON defaultOptions ''GenericStateSnapshot)
+$(deriveJSON defaultOptions ''SemiContextSnapshot)
+
+snapshotStringUniqifier ::
+    (IOE :> es) => StringUniqifier -> Eff es StringUniqifierSnapshot
+snapshotStringUniqifier = fmap (sortOn fst) . getAllStrings
+
+restoreStringUniqifier ::
+    (IOE :> es) => StringUniqifierSnapshot -> Eff es StringUniqifier
+restoreStringUniqifier entries =
+    StringUniqifier
+        <$> liftIO (H.fromList [(XXH3 str, token) | (str, token) <- entries])
+
+snapshotClassDAG ::
+    (IOE :> es, Prim :> es) => ClassDAG -> Eff es ClassDAGSnapshot
+snapshotClassDAG dag = do
+    names <- liftIO $ H.toList (nameMap dag)
+    ids <- liftIO $ H.toList (idMap dag)
+    nodes <- liftIO $ H.toList (nodeMap dag)
+    chainHeads <- liftIO $ H.toList (chainHeadMap dag)
+    counterVal <- readIORef' (counter dag)
+    finalized <- readIORef' (finalizedGraph dag)
+    pure
+        ClassDAGSnapshot
+            { cdNameMap = sortOn snd names
+            , cdIdMap = sortOn fst ids
+            , cdNodeMap = sortOn fst nodes
+            , cdChainHeadMap = sortOn fst chainHeads
+            , cdCounter = counterVal
+            , cdFinalizedGraph = fmap (\arr -> (bounds arr, elems arr)) finalized
+            }
+
+restoreClassDAG ::
+    (IOE :> es, Prim :> es) => ClassDAGSnapshot -> Eff es ClassDAG
+restoreClassDAG snap = do
+    names <- liftIO $ H.fromList (cdNameMap snap)
+    ids <- liftIO $ H.fromList (cdIdMap snap)
+    nodes <- liftIO $ H.fromList (cdNodeMap snap)
+    chainHeads <- liftIO $ H.fromList (cdChainHeadMap snap)
+    counterRef <- newIORef' (cdCounter snap)
+    finalizedRef <-
+        newIORef' (fmap (\(bnds, xs) -> listArray bnds xs) (cdFinalizedGraph snap))
+    pure
+        ClassDAG
+            { nameMap = names
+            , idMap = ids
+            , nodeMap = nodes
+            , chainHeadMap = chainHeads
+            , counter = counterRef
+            , finalizedGraph = finalizedRef
+            }
+
+snapshotGenericVar :: (IOE :> es) => GenericVar -> Eff es GenericVarSnapshot
+snapshotGenericVar var = do
+    links <- liftIO $ H.toList (genericLinks var)
+    pure
+        GenericVarSnapshot
+            { gvName = genericName var
+            , gvSpan = genericSpan var
+            , gvLinks = sortOn fst links
+            , gvBounds = genericBounds var
+            }
+
+restoreGenericVar :: (IOE :> es) => GenericVarSnapshot -> Eff es GenericVar
+restoreGenericVar snap = do
+    links <- liftIO $ H.fromList (gvLinks snap)
+    pure
+        GenericVar
+            { genericName = gvName snap
+            , genericSpan = gvSpan snap
+            , genericLinks = links
+            , genericBounds = gvBounds snap
+            }
+
+snapshotGenericState ::
+    (IOE :> es, Prim :> es) => GenericState -> Eff es GenericStateSnapshot
+snapshotGenericState st = do
+    vars <- readIORef' (getStateRef st)
+    varSnaps <- traverse snapshotGenericVar (toList vars)
+    flows <- liftIO $ H.toList (concreteFlow st)
+    pure
+        GenericStateSnapshot
+            { gsVars = varSnaps
+            , gsConcreteFlow = sortOn fst flows
+            }
+
+restoreGenericState ::
+    (IOE :> es, Prim :> es) => GenericStateSnapshot -> Eff es GenericState
+restoreGenericState snap = do
+    vars <- traverse restoreGenericVar (gsVars snap)
+    varsRef <- newIORef' (Seq.fromList vars)
+    flows <- liftIO $ H.fromList (gsConcreteFlow snap)
+    pure GenericState{getStateRef = varsRef, concreteFlow = flows}
+
+snapshotGenericSolution ::
+    (IOE :> es) => GenericSolution -> Eff es GenericSolutionSnapshot
+snapshotGenericSolution sol = sortOn fst <$> liftIO (H.toList sol)
+
+restoreGenericSolution ::
+    (IOE :> es) => GenericSolutionSnapshot -> Eff es GenericSolution
+restoreGenericSolution = liftIO . H.fromList
+
+snapshotSemiFunction ::
+    (Prim :> es) => FunctionProto -> Eff es SemiFunctionSnapshot
+snapshotSemiFunction proto = do
+    body <- readIORef' (funcBody proto)
+    pure
+        SemiFunctionSnapshot
+            { sfVisibility = funcVisibility proto
+            , sfName = funcName proto
+            , sfPath = funcPath proto
+            , sfGenerics = funcGenerics proto
+            , sfParams = funcParams proto
+            , sfReturnType = funcReturnType proto
+            , sfIsRegional = funcIsRegional proto
+            , sfBody = body
+            , sfSpan = funcSpan proto
+            }
+
+restoreSemiFunction ::
+    (Prim :> es) => SemiFunctionSnapshot -> Eff es FunctionProto
+restoreSemiFunction snap = do
+    bodyRef <- newIORef' (sfBody snap)
+    pure
+        FunctionProto
+            { funcVisibility = sfVisibility snap
+            , funcName = sfName snap
+            , funcPath = sfPath snap
+            , funcGenerics = sfGenerics snap
+            , funcParams = sfParams snap
+            , funcReturnType = sfReturnType snap
+            , funcIsRegional = sfIsRegional snap
+            , funcBody = bodyRef
+            , funcSpan = sfSpan snap
+            }
+
+snapshotSemiRecord :: (Prim :> es) => Record -> Eff es SemiRecordSnapshot
+snapshotSemiRecord record = do
+    fields <- readIORef' (recordFields record)
+    pure
+        SemiRecordSnapshot
+            { srName = recordName record
+            , srTyParams = recordTyParams record
+            , srFields = fields
+            , srKind = recordKind record
+            , srVisibility = recordVisibility record
+            , srDefaultCap = recordDefaultCap record
+            , srSpan = recordSpan record
+            }
+
+restoreSemiRecord :: (Prim :> es) => SemiRecordSnapshot -> Eff es Record
+restoreSemiRecord snap = do
+    fieldsRef <- newIORef' (srFields snap)
+    pure
+        Record
+            { recordName = srName snap
+            , recordTyParams = srTyParams snap
+            , recordFields = fieldsRef
+            , recordKind = srKind snap
+            , recordVisibility = srVisibility snap
+            , recordDefaultCap = srDefaultCap snap
+            , recordSpan = srSpan snap
+            }
+
+-- | Capture the whole global semi context into a pure snapshot.
+snapshotSemiContext ::
+    (IOE :> es, Prim :> es) => SemiContext -> Eff es SemiContextSnapshot
+snapshotSemiContext ctx = do
+    strings <- snapshotStringUniqifier (stringUniqifier ctx)
+    dag <- snapshotClassDAG (typeClassDAG ctx)
+    typeClasses <- liftIO $ H.toList (unTypeClassTable (typeClassTable ctx))
+    records <- liftIO (H.toList (knownRecords ctx))
+    recordSnaps <- traverse (\(path, r) -> (path,) <$> snapshotSemiRecord r) records
+    protos <- liftIO $ H.toList (functionProtos (functions ctx))
+    protoSnaps <- traverse (\(path, p) -> (path,) <$> snapshotSemiFunction p) protos
+    genericSnap <- snapshotGenericState (generics ctx)
+    pure
+        SemiContextSnapshot
+            { scFile = currentFile ctx
+            , scModulePath = currentModulePath ctx
+            , scLogLevel = translationLogLevel ctx
+            , scStrings = strings
+            , scReports = translationReports ctx
+            , scHasFailed = translationHasFailed ctx
+            , scClassDAG = dag
+            , scTypeClassTable =
+                sortOn
+                    (show . fst)
+                    (map (fmap (sort . HashSet.toList)) typeClasses)
+            , scRecords = sortOn fst recordSnaps
+            , scFunctions = sortOn fst protoSnaps
+            , scGenerics = genericSnap
+            , scTrampolines = sortOn fst (HashMap.toList (trampolines ctx))
+            }
+
+-- | Rebuild a fully functional semi context from a pure snapshot.
+restoreSemiContext ::
+    (IOE :> es, Prim :> es) => SemiContextSnapshot -> Eff es SemiContext
+restoreSemiContext snap = do
+    uniqifier <- restoreStringUniqifier (scStrings snap)
+    dag <- restoreClassDAG (scClassDAG snap)
+    typeClasses <-
+        liftIO $
+            H.fromList
+                [(ty, HashSet.fromList classes) | (ty, classes) <- scTypeClassTable snap]
+    records <-
+        traverse (\(path, r) -> (path,) <$> restoreSemiRecord r) (scRecords snap)
+    recordTable <- liftIO $ H.fromList records
+    protos <-
+        traverse (\(path, p) -> (path,) <$> restoreSemiFunction p) (scFunctions snap)
+    protoTable <- liftIO $ H.fromList protos
+    genericState <- restoreGenericState (scGenerics snap)
+    pure
+        SemiContext
+            { currentFile = scFile snap
+            , currentModulePath = scModulePath snap
+            , translationLogLevel = scLogLevel snap
+            , stringUniqifier = uniqifier
+            , translationReports = scReports snap
+            , translationHasFailed = scHasFailed snap
+            , typeClassDAG = dag
+            , typeClassTable = TypeClassTable typeClasses
+            , knownRecords = recordTable
+            , functions = FunctionTable protoTable
+            , generics = genericState
+            , trampolines = HashMap.fromList (scTrampolines snap)
+            }

--- a/frontend/reussir-core/test/Main.hs
+++ b/frontend/reussir-core/test/Main.hs
@@ -9,15 +9,18 @@ import Test.Reussir.Core.Semi.Mangle qualified as Mangle
 import Test.Reussir.Core.Semi.ModuleResolution qualified as ModuleResolution
 import Test.Reussir.Core.Semi.PatternMatch qualified as PatternMatch
 import Test.Reussir.Core.Semi.TyckSpec qualified as TyckSpec
+import Test.Reussir.Core.SerializationSpec qualified as SerializationSpec
 import Test.Reussir.Core.String qualified as String
 
 main :: IO ()
 main = do
     tyckSpec <- testSpec "Reussir.Core.Semi.Tyck" TyckSpec.spec
-    defaultMain (tests tyckSpec)
+    serializationSpec <-
+        testSpec "Reussir.Core.Serialization" SerializationSpec.spec
+    defaultMain (tests tyckSpec serializationSpec)
 
-tests :: TestTree -> TestTree
-tests tyckSpec =
+tests :: TestTree -> TestTree -> TestTree
+tests tyckSpec serializationSpec =
     testGroup
         "Reussir.Core"
         [ Generic.tests
@@ -27,4 +30,5 @@ tests tyckSpec =
         , ModuleResolution.tests
         , PatternMatch.tests
         , tyckSpec
+        , serializationSpec
         ]

--- a/frontend/reussir-core/test/Test/Reussir/Core/SerializationSpec.hs
+++ b/frontend/reussir-core/test/Test/Reussir/Core/SerializationSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultilineStrings #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {- | Roundtrip tests for the JSON serialization of the semi and full syntax.
@@ -55,24 +56,26 @@ import Reussir.Core.Data.Semi.Type qualified as Semi
 
 sampleProgram :: T.Text
 sampleProgram =
-    "enum List<T> {\n\
-    \    Nil,\n\
-    \    Cons(T, List<T>)\n\
-    \}\n\
-    \struct Pair { first: i32, second: i32 }\n\
-    \fn append(a : List<i32>, b : List<i32>) -> List<i32> {\n\
-    \    match a {\n\
-    \        List::Nil => b,\n\
-    \        List::Cons(x, xs) => List::Cons{x, append(xs, b)}\n\
-    \    }\n\
-    \}\n\
-    \fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }\n\
-    \fn inc(x: i32) -> i32 {\n\
-    \    apply(|v: i32| v + 1, x)\n\
-    \}\n\
-    \fn choose(b: bool) -> str {\n\
-    \    if (b) { \"yes\" } else { \"no\" }\n\
-    \}"
+    """
+    enum List<T> {
+        Nil,
+        Cons(T, List<T>)
+    }
+    struct Pair { first: i32, second: i32 }
+    fn append(a : List<i32>, b : List<i32>) -> List<i32> {
+        match a {
+            List::Nil => b,
+            List::Cons(x, xs) => List::Cons{x, append(xs, b)}
+        }
+    }
+    fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }
+    fn inc(x: i32) -> i32 {
+        apply(|v: i32| v + 1, x)
+    }
+    fn choose(b: bool) -> str {
+        if (b) { "yes" } else { "no" }
+    }
+    """
 
 unspanStmt :: Syn.Stmt -> Syn.Stmt
 unspanStmt (Syn.SpannedStmt (WithSpan s _ _)) = unspanStmt s

--- a/frontend/reussir-core/test/Test/Reussir/Core/SerializationSpec.hs
+++ b/frontend/reussir-core/test/Test/Reussir/Core/SerializationSpec.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Roundtrip tests for the JSON serialization of the semi and full syntax.
+
+The tests run the real elaboration pipeline on a sample program, snapshot the
+resulting contexts, and check that
+
+* decoding the JSON encoding of a snapshot yields the same snapshot, and
+* restoring a context from a snapshot and re-snapshotting it yields the same
+  snapshot (i.e. suspend/recover loses no information).
+-}
+module Test.Reussir.Core.SerializationSpec (spec) where
+
+import Control.Monad (forM_)
+import Data.Aeson (eitherDecode, encode)
+import Data.Digest.XXHash.FFI (XXH3 (..))
+import Effectful (inject, liftIO, runEff)
+import Effectful.Prim (runPrim)
+import Effectful.State.Static.Local (runState)
+import Log (LogLevel (..))
+import Reussir.Parser.Prog (Prog, parseProg)
+import Reussir.Parser.Types.Lexer (WithSpan (..))
+import System.Directory (getTemporaryDirectory, removeFile)
+import Test.Hspec
+import Text.Megaparsec (errorBundlePretty, runParser)
+
+import Data.HashMap.Strict qualified as HashMap
+import Data.Sequence qualified as Seq
+import Data.Text qualified as T
+import Effectful.Log qualified as L
+import Log.Backend.StandardOutput qualified as L
+import Reussir.Bridge qualified as B
+import Reussir.Parser.Types.Stmt qualified as Syn
+
+import Reussir.Core.Data.Semi.Expr (
+    DTSwitchCases (..),
+    DecisionTree (..),
+    Expr (..),
+    ExprKind (..),
+    PatternVarRef (..),
+ )
+import Reussir.Core.Data.UniqueID (ExprID (..), VarID (..))
+import Reussir.Core.Full.Conversion (convertCtx)
+import Reussir.Core.Semi.Context (
+    emptySemiContext,
+    populateRecordFields,
+    scanStmt,
+    withModuleFile,
+ )
+import Reussir.Core.Semi.FlowAnalysis (solveAllGenerics)
+import Reussir.Core.Semi.Tyck (checkFuncType)
+import Reussir.Core.Serialization
+
+import Reussir.Core.Data.Semi.Type qualified as Semi
+
+sampleProgram :: T.Text
+sampleProgram =
+    "enum List<T> {\n\
+    \    Nil,\n\
+    \    Cons(T, List<T>)\n\
+    \}\n\
+    \struct Pair { first: i32, second: i32 }\n\
+    \fn append(a : List<i32>, b : List<i32>) -> List<i32> {\n\
+    \    match a {\n\
+    \        List::Nil => b,\n\
+    \        List::Cons(x, xs) => List::Cons{x, append(xs, b)}\n\
+    \    }\n\
+    \}\n\
+    \fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }\n\
+    \fn inc(x: i32) -> i32 {\n\
+    \    apply(|v: i32| v + 1, x)\n\
+    \}\n\
+    \fn choose(b: bool) -> str {\n\
+    \    if (b) { \"yes\" } else { \"no\" }\n\
+    \}"
+
+unspanStmt :: Syn.Stmt -> Syn.Stmt
+unspanStmt (Syn.SpannedStmt (WithSpan s _ _)) = unspanStmt s
+unspanStmt stmt = stmt
+
+parseSample :: T.Text -> IO Prog
+parseSample src = case runParser parseProg "<test>" src of
+    Left err -> fail (errorBundlePretty err)
+    Right prog -> pure prog
+
+{- | Run the semi and full elaboration pipeline on a program and snapshot the
+context after each stage.
+-}
+elaborateSnapshots ::
+    T.Text ->
+    IO (SemiContextSnapshot, GenericSolutionSnapshot, FullContextSnapshot)
+elaborateSnapshots src = do
+    prog <- parseSample src
+    L.withStdOutLogger $ \logger ->
+        runEff $ L.runLog "serialization-test" logger LogAttention $ do
+            initState <- runPrim $ emptySemiContext B.LogWarning "<test>" []
+            (slns, finalSemi) <- runPrim $ runState initState $ do
+                inject $
+                    withModuleFile "<test>" [] $
+                        forM_ prog $
+                            \stmt -> inject $ scanStmt stmt
+                inject $
+                    withModuleFile "<test>" [] $
+                        forM_ prog $
+                            \stmt -> inject $ populateRecordFields stmt
+                inject $
+                    withModuleFile "<test>" [] $
+                        forM_ prog $ \stmt ->
+                            case unspanStmt stmt of
+                                Syn.FunctionStmt f -> do
+                                    _ <- inject $ checkFuncType f
+                                    return ()
+                                _ -> return ()
+                inject solveAllGenerics
+            solutions <- maybe (liftIO $ fail "generic solving failed") pure slns
+            fullCtx <- runPrim $ convertCtx finalSemi solutions
+            runPrim $ do
+                semiSnap <- snapshotSemiContext finalSemi
+                slnSnap <- snapshotGenericSolution solutions
+                fullSnap <- snapshotFullContext fullCtx
+                pure (semiSnap, slnSnap, fullSnap)
+
+spec :: Spec
+spec = do
+    (semiSnap, slnSnap, fullSnap) <- runIO (elaborateSnapshots sampleProgram)
+
+    describe "sample elaboration" $ do
+        it "elaborates without failures" $ do
+            scHasFailed semiSnap `shouldBe` False
+            scReports semiSnap `shouldBe` []
+            fcErrors fullSnap `shouldBe` []
+
+        it "produces a non-trivial context" $ do
+            scFunctions semiSnap `shouldNotBe` []
+            scRecords semiSnap `shouldNotBe` []
+            fcFunctions fullSnap `shouldNotBe` []
+            fcRecords fullSnap `shouldNotBe` []
+            scStrings semiSnap `shouldNotBe` []
+
+    describe "surface program suspension" $ do
+        it "roundtrips through JSON" $ do
+            prog <- parseSample sampleProgram
+            let surface = [SurfaceModule "<test>" [] prog]
+            decodeSurfaceProgram (encodeSurfaceProgram surface)
+                `shouldBe` Right surface
+
+    describe "semi context suspension" $ do
+        it "snapshot roundtrips through JSON" $
+            eitherDecode (encode semiSnap) `shouldBe` Right semiSnap
+
+        it "restore/re-snapshot is lossless" $ do
+            resnap <-
+                runEff . runPrim $
+                    restoreSemiContext semiSnap >>= snapshotSemiContext
+            resnap `shouldBe` semiSnap
+
+        it "suspends to and recovers from a file" $ do
+            tmpDir <- getTemporaryDirectory
+            let path = tmpDir <> "/reussir-semi-suspend-test.json"
+            recovered <- runEff . runPrim $ do
+                ctx <- restoreSemiContext semiSnap
+                suspendSemiContext path ctx
+                recoverSemiContext path
+            resnap <-
+                either
+                    (fail . ("recovery failed: " <>))
+                    (runEff . runPrim . snapshotSemiContext)
+                    recovered
+            removeFile path
+            resnap `shouldBe` semiSnap
+
+    describe "generic solution suspension" $ do
+        it "snapshot roundtrips through JSON" $
+            eitherDecode (encode slnSnap) `shouldBe` Right slnSnap
+
+        it "restore/re-snapshot is lossless" $ do
+            resnap <-
+                runEff . runPrim $
+                    restoreGenericSolution slnSnap >>= snapshotGenericSolution
+            resnap `shouldBe` slnSnap
+
+    describe "full context suspension" $ do
+        it "snapshot roundtrips through JSON" $
+            eitherDecode (encode fullSnap) `shouldBe` Right fullSnap
+
+        it "restore/re-snapshot is lossless" $ do
+            resnap <-
+                runEff . runPrim $
+                    restoreFullContext fullSnap >>= snapshotFullContext
+            resnap `shouldBe` fullSnap
+
+    describe "pipeline continuation after recovery" $ do
+        it "full conversion from a recovered semi context matches the original" $ do
+            fullResnap <- L.withStdOutLogger $ \logger ->
+                runEff $ L.runLog "serialization-test" logger LogAttention $ runPrim $ do
+                    ctx <- restoreSemiContext semiSnap
+                    solutions <- restoreGenericSolution slnSnap
+                    fullCtx <- convertCtx ctx solutions
+                    snapshotFullContext fullCtx
+            fullResnap `shouldBe` fullSnap
+
+    describe "semi expression corner cases" $ do
+        it "roundtrips decision trees with string switches" $ do
+            let leaf = mkSemiExpr (Constant 1)
+                tree =
+                    DTSwitch
+                        { dtSwitchVarRef = PatternVarRef (Seq.fromList [0, 1])
+                        , dtSwitchCases =
+                            DTSwitchString
+                                { dtSwitchStringMap =
+                                    HashMap.fromList
+                                        [ (XXH3 "hello", DTLeaf leaf mempty)
+                                        , (XXH3 "world", DTUnreachable)
+                                        ]
+                                , dtSwitchStringDefault = DTUncovered
+                                }
+                        }
+                expr = mkSemiExpr (Match (mkSemiExpr (Var (VarID 0))) tree)
+            eitherDecode (encode expr) `shouldBe` Right expr
+
+mkSemiExpr :: ExprKind -> Expr
+mkSemiExpr kind =
+    Expr
+        { exprKind = kind
+        , exprSpan = Just (3, 14)
+        , exprType = Semi.TypeStr
+        , exprID = ExprID 42
+        }

--- a/frontend/reussir-parser/reussir-parser.cabal
+++ b/frontend/reussir-parser/reussir-parser.cabal
@@ -70,6 +70,7 @@ library
                       Reussir.Parser.Types.Lexer
                       Reussir.Parser.Types.Capability
                       Reussir.Parser.Pretty
+                      Reussir.Parser.Serialization
 
     -- Modules included in this library but not exported.
     -- other-modules:
@@ -79,6 +80,7 @@ library
 
     -- Other library packages from which modules are imported.
     build-depends:    base ^>=4.20.0.0,
+                      aeson,
                       megaparsec,
                       parser-combinators,
                       scientific,
@@ -145,10 +147,12 @@ test-suite reussir-parser-test
                       Reussir.Parser.TypeSpec
                       Reussir.Parser.StmtSpec
                       Reussir.Parser.ExprSpec
+                      Reussir.Parser.SerializationSpec
 
     -- Test dependencies.
     build-depends:
         base ^>=4.20.0.0,
+        aeson,
         tasty,
         tasty-hspec,
         hspec,

--- a/frontend/reussir-parser/src/Reussir/Parser/Serialization.hs
+++ b/frontend/reussir-parser/src/Reussir/Parser/Serialization.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | JSON serialization for the surface syntax.
+
+This module provides 'ToJSON'/'FromJSON' instances for every type that makes
+up the surface syntax (the direct output of the parser). Together with the
+serialization modules in @reussir-core@ this allows any step of the frontend
+pipeline to be suspended to a JSON document and recovered later, which is the
+foundation for testing the frontend against other implementations (e.g. the
+planned Rust frontend).
+
+Encoding conventions (shared by all serialization modules):
+
+* Sum types use aeson's default tagged-object encoding:
+  @{"tag": "Ctor", "contents": ...}@, with record constructors inlining
+  their fields next to the @"tag"@ key.
+* Sum types whose constructors are all nullary are encoded as plain strings.
+* 'Identifier' is encoded as a plain JSON string.
+* Strict boxed vectors are encoded as JSON arrays (orphans provided here
+  because aeson does not yet ship instances for "Data.Vector.Strict").
+-}
+module Reussir.Parser.Serialization () where
+
+import Data.Aeson (
+    FromJSON (..),
+    FromJSONKey (..),
+    FromJSONKeyFunction (..),
+    ToJSON (..),
+    ToJSONKey (..),
+    defaultOptions,
+ )
+import Data.Aeson.TH (deriveJSON)
+import Data.Aeson.Types (toJSONKeyText)
+
+import Data.Vector.Strict qualified as VS
+
+import Reussir.Parser.Types.Capability (Capability)
+import Reussir.Parser.Types.Expr (
+    Access,
+    BinaryOp,
+    Constant,
+    CtorCall,
+    Expr,
+    FuncCall,
+    LambdaExpr,
+    Pattern,
+    PatternCtorArg,
+    PatternKind,
+    UnaryOp,
+ )
+import Reussir.Parser.Types.Lexer (Identifier (..), Path, WithSpan)
+import Reussir.Parser.Types.Stmt (
+    Function,
+    Record,
+    RecordFields,
+    RecordKind,
+    Stmt,
+    Visibility,
+ )
+import Reussir.Parser.Types.Type (FloatingPointType, IntegralType, Type)
+
+instance ToJSON Identifier where
+    toJSON = toJSON . unIdentifier
+    toEncoding = toEncoding . unIdentifier
+
+instance FromJSON Identifier where
+    parseJSON = fmap Identifier . parseJSON
+
+instance ToJSONKey Identifier where
+    toJSONKey = toJSONKeyText unIdentifier
+
+instance FromJSONKey Identifier where
+    fromJSONKey = FromJSONKeyText Identifier
+
+instance (ToJSON a) => ToJSON (VS.Vector a) where
+    toJSON = toJSON . VS.toList
+    toEncoding = toEncoding . VS.toList
+
+instance (FromJSON a) => FromJSON (VS.Vector a) where
+    parseJSON = fmap VS.fromList . parseJSON
+
+$(deriveJSON defaultOptions ''Path)
+$(deriveJSON defaultOptions ''WithSpan)
+$(deriveJSON defaultOptions ''Capability)
+$(deriveJSON defaultOptions ''IntegralType)
+$(deriveJSON defaultOptions ''FloatingPointType)
+$(deriveJSON defaultOptions ''Type)
+
+-- The expression types are mutually recursive, so they are derived in a
+-- single declaration group.
+$( concat
+    <$> traverse
+        (deriveJSON defaultOptions)
+        [ ''Constant
+        , ''BinaryOp
+        , ''UnaryOp
+        , ''Access
+        , ''PatternCtorArg
+        , ''PatternKind
+        , ''Pattern
+        , ''CtorCall
+        , ''FuncCall
+        , ''LambdaExpr
+        , ''Expr
+        ]
+ )
+
+$( concat
+    <$> traverse
+        (deriveJSON defaultOptions)
+        [ ''Visibility
+        , ''RecordKind
+        , ''RecordFields
+        , ''Record
+        , ''Function
+        , ''Stmt
+        ]
+ )

--- a/frontend/reussir-parser/test/Main.hs
+++ b/frontend/reussir-parser/test/Main.hs
@@ -5,6 +5,7 @@ import Test.Tasty.Hspec
 
 import Reussir.Parser.ExprSpec qualified as ExprSpec
 import Reussir.Parser.LexerSpec qualified as LexerSpec
+import Reussir.Parser.SerializationSpec qualified as SerializationSpec
 import Reussir.Parser.StmtSpec qualified as StmtSpec
 import Reussir.Parser.TypeSpec qualified as TypeSpec
 
@@ -14,5 +15,10 @@ main = do
     typeSpec <- testSpec "Reussir.Parser.Type" TypeSpec.spec
     stmtSpec <- testSpec "Reussir.Parser.Stmt" StmtSpec.spec
     exprSpec <- testSpec "Reussir.Parser.Expr" ExprSpec.spec
+    serializationSpec <-
+        testSpec "Reussir.Parser.Serialization" SerializationSpec.spec
     defaultMain
-        (testGroup "Reussir Parser Tests" [lexerSpec, typeSpec, stmtSpec, exprSpec])
+        ( testGroup
+            "Reussir Parser Tests"
+            [lexerSpec, typeSpec, stmtSpec, exprSpec, serializationSpec]
+        )

--- a/frontend/reussir-parser/test/Reussir/Parser/SerializationSpec.hs
+++ b/frontend/reussir-parser/test/Reussir/Parser/SerializationSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultilineStrings #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Roundtrip tests for the JSON serialization of the surface syntax.
@@ -25,76 +26,90 @@ spec = do
     describe "surface syntax JSON roundtrip" $ do
         it "roundtrips functions with let/if and operators" $
             roundtrips
-                "fn f(x: i32, y: i32) -> i32 {\n\
-                \    let z = x * 2 + y % 3;\n\
-                \    if (z >= 0 && !(z == 4)) { z } else { -z }\n\
-                \}"
+                """
+                fn f(x: i32, y: i32) -> i32 {
+                    let z = x * 2 + y % 3;
+                    if (z >= 0 && !(z == 4)) { z } else { -z }
+                }
+                """
 
         it "roundtrips generic records, enums and pattern matching" $
             roundtrips
-                "enum List<T> {\n\
-                \    Nil,\n\
-                \    Cons(T, List<T>)\n\
-                \}\n\
-                \struct Pair<A, B> { first: A, second: B }\n\
-                \fn append(a : List<i32>, b : List<i32>) -> List<i32> {\n\
-                \    match a {\n\
-                \        List::Nil => b,\n\
-                \        List::Cons(x, xs) => List::Cons{x, append(xs, b)}\n\
-                \    }\n\
-                \}"
+                """
+                enum List<T> {
+                    Nil,
+                    Cons(T, List<T>)
+                }
+                struct Pair<A, B> { first: A, second: B }
+                fn append(a : List<i32>, b : List<i32>) -> List<i32> {
+                    match a {
+                        List::Nil => b,
+                        List::Cons(x, xs) => List::Cons{x, append(xs, b)}
+                    }
+                }
+                """
 
         it "roundtrips closures and closure calls" $
             roundtrips
-                "fn abstract() -> bool -> u64 {\n\
-                \    let u = 1;\n\
-                \    |x| if (x) { 0 } else { u }\n\
-                \}\n\
-                \fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }"
+                """
+                fn abstract() -> bool -> u64 {
+                    let u = 1;
+                    |x| if (x) { 0 } else { u }
+                }
+                fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }
+                """
 
         it "roundtrips regional records and assignments" $
             roundtrips
-                "struct [regional] DLLink<T> {\n\
-                \    val: T,\n\
-                \    next: [field] DLLink<T>,\n\
-                \    prev: [field] DLLink<T>\n\
-                \}\n\
-                \regional fn new<T>(val: T) -> [flex] DLLink<T> {\n\
-                \    DLLink { val: val, next: Nullable::Null {}, prev: Nullable::Null {} }\n\
-                \}\n\
-                \fn foo() -> DLLink<i32> {\n\
-                \    regional {\n\
-                \        let a = new(1);\n\
-                \        a->next := Nullable::NonNull{a};\n\
-                \        a\n\
-                \    }\n\
-                \}"
+                """
+                struct [regional] DLLink<T> {
+                    val: T,
+                    next: [field] DLLink<T>,
+                    prev: [field] DLLink<T>
+                }
+                regional fn new<T>(val: T) -> [flex] DLLink<T> {
+                    DLLink { val: val, next: Nullable::Null {}, prev: Nullable::Null {} }
+                }
+                fn foo() -> DLLink<i32> {
+                    regional {
+                        let a = new(1);
+                        a->next := Nullable::NonNull{a};
+                        a
+                    }
+                }
+                """
 
         it "roundtrips extern trampolines and module statements" $
             roundtrips
-                "pub mod utils;\n\
-                \fn fibonacci<T>(n: T) -> T { n }\n\
-                \extern \"C\" trampoline \"fibonacci_ffi\" = fibonacci<u64>;"
+                """
+                pub mod utils;
+                fn fibonacci<T>(n: T) -> T { n }
+                extern "C" trampoline "fibonacci_ffi" = fibonacci<u64>;
+                """
 
         it "roundtrips constants, casts, strings and access chains" $
             roundtrips
-                "fn g(b: bool) -> str {\n\
-                \    match b {\n\
-                \        true => \"yes\",\n\
-                \        false => \"no\"\n\
-                \    }\n\
-                \}\n\
-                \fn h(p: Pair<i32, f64>) -> f64 {\n\
-                \    let x = p.first;\n\
-                \    (x as f64) + 1.5\n\
-                \}"
+                """
+                fn g(b: bool) -> str {
+                    match b {
+                        true => "yes",
+                        false => "no"
+                    }
+                }
+                fn h(p: Pair<i32, f64>) -> f64 {
+                    let x = p.first;
+                    (x as f64) + 1.5
+                }
+                """
 
         it "roundtrips patterns with guards, wildcards and ellipsis" $
             roundtrips
-                "fn classify(p: Pair<i32, i32>) -> i32 {\n\
-                \    match p {\n\
-                \        Pair { first: 0, .. } => 0,\n\
-                \        Pair { first: x, second: y } if x > y => 1,\n\
-                \        _ => 2\n\
-                \    }\n\
-                \}"
+                """
+                fn classify(p: Pair<i32, i32>) -> i32 {
+                    match p {
+                        Pair { first: 0, .. } => 0,
+                        Pair { first: x, second: y } if x > y => 1,
+                        _ => 2
+                    }
+                }
+                """

--- a/frontend/reussir-parser/test/Reussir/Parser/SerializationSpec.hs
+++ b/frontend/reussir-parser/test/Reussir/Parser/SerializationSpec.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Roundtrip tests for the JSON serialization of the surface syntax.
+module Reussir.Parser.SerializationSpec (spec) where
+
+import Data.Aeson (eitherDecode, encode)
+import Test.Hspec
+import Text.Megaparsec (errorBundlePretty, runParser)
+
+import Data.Text qualified as T
+
+import Reussir.Parser.Prog (parseProg)
+import Reussir.Parser.Serialization ()
+
+{- | Parse a program and require that decoding its JSON encoding yields the
+exact same AST (spans included).
+-}
+roundtrips :: T.Text -> Expectation
+roundtrips src = case runParser parseProg "<test>" src of
+    Left err -> expectationFailure (errorBundlePretty err)
+    Right prog -> eitherDecode (encode prog) `shouldBe` Right prog
+
+spec :: Spec
+spec = do
+    describe "surface syntax JSON roundtrip" $ do
+        it "roundtrips functions with let/if and operators" $
+            roundtrips
+                "fn f(x: i32, y: i32) -> i32 {\n\
+                \    let z = x * 2 + y % 3;\n\
+                \    if (z >= 0 && !(z == 4)) { z } else { -z }\n\
+                \}"
+
+        it "roundtrips generic records, enums and pattern matching" $
+            roundtrips
+                "enum List<T> {\n\
+                \    Nil,\n\
+                \    Cons(T, List<T>)\n\
+                \}\n\
+                \struct Pair<A, B> { first: A, second: B }\n\
+                \fn append(a : List<i32>, b : List<i32>) -> List<i32> {\n\
+                \    match a {\n\
+                \        List::Nil => b,\n\
+                \        List::Cons(x, xs) => List::Cons{x, append(xs, b)}\n\
+                \    }\n\
+                \}"
+
+        it "roundtrips closures and closure calls" $
+            roundtrips
+                "fn abstract() -> bool -> u64 {\n\
+                \    let u = 1;\n\
+                \    |x| if (x) { 0 } else { u }\n\
+                \}\n\
+                \fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }"
+
+        it "roundtrips regional records and assignments" $
+            roundtrips
+                "struct [regional] DLLink<T> {\n\
+                \    val: T,\n\
+                \    next: [field] DLLink<T>,\n\
+                \    prev: [field] DLLink<T>\n\
+                \}\n\
+                \regional fn new<T>(val: T) -> [flex] DLLink<T> {\n\
+                \    DLLink { val: val, next: Nullable::Null {}, prev: Nullable::Null {} }\n\
+                \}\n\
+                \fn foo() -> DLLink<i32> {\n\
+                \    regional {\n\
+                \        let a = new(1);\n\
+                \        a->next := Nullable::NonNull{a};\n\
+                \        a\n\
+                \    }\n\
+                \}"
+
+        it "roundtrips extern trampolines and module statements" $
+            roundtrips
+                "pub mod utils;\n\
+                \fn fibonacci<T>(n: T) -> T { n }\n\
+                \extern \"C\" trampoline \"fibonacci_ffi\" = fibonacci<u64>;"
+
+        it "roundtrips constants, casts, strings and access chains" $
+            roundtrips
+                "fn g(b: bool) -> str {\n\
+                \    match b {\n\
+                \        true => \"yes\",\n\
+                \        false => \"no\"\n\
+                \    }\n\
+                \}\n\
+                \fn h(p: Pair<i32, f64>) -> f64 {\n\
+                \    let x = p.first;\n\
+                \    (x as f64) + 1.5\n\
+                \}"
+
+        it "roundtrips patterns with guards, wildcards and ellipsis" $
+            roundtrips
+                "fn classify(p: Pair<i32, i32>) -> i32 {\n\
+                \    match p {\n\
+                \        Pair { first: 0, .. } => 0,\n\
+                \        Pair { first: x, second: y } if x > y => 1,\n\
+                \        _ => 2\n\
+                \    }\n\
+                \}"


### PR DESCRIPTION
## Summary

First step toward migrating the Haskell frontend to Rust: every stage of the frontend pipeline can now be suspended to JSON and recovered losslessly, so an alternative (Rust) implementation can later be tested against any pipeline step in isolation. No Rust involved yet.

- **`Reussir.Parser.Serialization`** — `ToJSON`/`FromJSON` for the entire surface syntax (`Stmt`, `Expr`, `Pattern`, `Type`, paths, spans), plus orphans for strict boxed vectors (not shipped by aeson 2.2.3).
- **`Reussir.Core.Serialization.Orphans`** — shared instances: unique IDs as plain numbers, interned `Symbol`s as strings, `StringToken`, operators, `Class`/`ClassNode`, bridge `LogLevel`, and full diagnostic `Report` support (ANSI colours stored as linear RGB channels so they roundtrip exactly).
- **`Reussir.Core.Serialization.Semi`** — instances for the semi syntax plus pure `*Snapshot` mirrors of everything mutable in `SemiContext` (function/record tables with their `IORef'` contents, class DAG, generic state with flow links, string uniqifier, trampolines), with `snapshot*`/`restore*` in both directions; same for `GenericSolution`.
- **`Reussir.Core.Serialization.Full`** — instances for the full syntax (`Function`/`Record`/`Expr`/`Error` are already pure) and `FullContextSnapshot` with snapshot/restore.
- **`Reussir.Core.Serialization`** — the suspend/recover API: in-memory `encode*`/`decode*` and file-based `suspend*`/`recover*` for `SurfaceProgram`, `SemiContext`, `GenericSolution`, and `FullContext`.

Encoding uses aeson's default tagged-object convention uniformly (nullary-only sums as plain strings), so the schema is mechanical to mirror with serde later. Hash table dumps are sorted by key, making snapshots of structurally equal contexts compare equal and serialize deterministically. `deriving (Show, Eq)` was added to `Full.Function` and `Full.Error` for snapshot equality.

Global contexts (the state at step boundaries) are serialized; `LocalSemiContext`/`LocalFullContext` are transient per-function state that never crosses a step, so they are intentionally out of scope.

## Test plan

- 7 surface-syntax roundtrip tests over parsed programs covering generics, enums, match guards/ellipsis, closures, regional records with assignment, trampolines, and modules.
- Core spec runs the real pipeline (scan → populate fields → typecheck → solve generics → full conversion) on a sample program and verifies, for each stage: JSON encode/decode is identity, restore + re-snapshot is lossless, and file-based suspend/recover works.
- Continuation test: a `SemiContext` recovered from JSON is fed through `convertCtx` and produces a `FullContext` snapshot identical to the original.
- `cabal test all`: all 6 suites pass (92 parser + 65 core tests). `ninja check`: 234/238 passed, 4 unsupported, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)