### PR TITLE
Add Reussir lowering pipeline via fine-grained CAPI + melior

### DIFF
--- a/crates/reussir-backend-sys/build.rs
+++ b/crates/reussir-backend-sys/build.rs
@@ -2,9 +2,9 @@ use std::env;
 use std::path::PathBuf;
 
 // Locates the directory holding the staged Reussir static archives
-// (libReussirCAPI.a and libMLIRReussir.a). CMake sets REUSSIR_CAPI_LIB_DIR when
-// it drives the build; a direct `cargo` invocation falls back to the in-tree
-// `build/lib` next to the workspace root.
+// (libReussirCAPI.a and the libMLIRReussir* component archives). CMake sets
+// REUSSIR_CAPI_LIB_DIR when it drives the build; a direct `cargo` invocation
+// falls back to the in-tree `build/lib` next to the workspace root.
 fn capi_lib_dir() -> PathBuf {
     if let Ok(dir) = env::var("REUSSIR_CAPI_LIB_DIR") {
         return PathBuf::from(dir);
@@ -13,17 +13,62 @@ fn capi_lib_dir() -> PathBuf {
     manifest.join("../../build/lib")
 }
 
+// Reussir component archives the C API references: the dialect, analyses, the
+// Rust-to-bitcode compiler, and every conversion/transformation pass exposed as
+// a factory. They are whole-archived so registrations are retained and so the
+// link order among them does not matter; their MLIR/LLVM references resolve
+// against mlir-sys' static MLIR/LLVM, which is emitted after these.
+const REUSSIR_ARCHIVES: &[&str] = &[
+    "MLIRReussir",
+    "MLIRReussirAnalysis",
+    "ReussirRustCompiler",
+    "MLIRReussirTypeConverter",
+    "MLIRReussirBasicOpsLowering",
+    "MLIRReussirSCFOpsLowering",
+    "MLIRReussirRegionPatterns",
+    "MLIRReussirAcquireDropExpansion",
+    "MLIRReussirRcDecrementExpansion",
+    "MLIRReussirTokenInstantiation",
+    "MLIRReussirClosureOutlining",
+    "MLIRReussirCompilePolymorphicFFI",
+    "MLIRReussirAttachNativeTarget",
+    "MLIRReussirRcCreateSink",
+    "MLIRReussirRcCreateFusion",
+    "MLIRReussirInferVariantTag",
+    "MLIRReussirIncDecCancellation",
+    "MLIRReussirTokenReuse",
+    "MLIRReussirInvariantGroupAnalysis",
+    "MLIRReussirUniqueCarryingRecursionAnalysis",
+    "MLIRReussirTRMCRecursionAnalysis",
+];
+
 fn main() {
     let lib_dir = capi_lib_dir();
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
 
-    // The Reussir dialect is linked statically into the same binary as mlir-sys'
-    // static MLIR. ReussirCAPI carries the dialect handle; MLIRReussir is whole-
-    // archived so the dialect's op/type/attr registrations are retained even
-    // though only the handle symbol is referenced directly. Both are emitted
-    // before mlir-sys' MLIR archives so their MLIR references resolve.
-    println!("cargo:rustc-link-lib=static=ReussirCAPI");
-    println!("cargo:rustc-link-lib=static:+whole-archive=MLIRReussir");
+    // ReussirCAPI (dialect handle + pass factories + helpers) and the Reussir
+    // component archives are linked statically into the same binary as mlir-sys'
+    // static MLIR, so there is a single MLIR runtime and dialect registry. They
+    // are emitted before mlir-sys' MLIR archives so their references resolve.
+    println!("cargo:rustc-link-lib=static:+whole-archive=ReussirCAPI");
+    for archive in REUSSIR_ARCHIVES {
+        println!("cargo:rustc-link-lib=static:+whole-archive={archive}");
+    }
+
+    // Cargo does not track the contents of native static libraries, so without
+    // this it keeps reusing a binary linked against an out-of-date archive when
+    // only the C++ side (libReussirCAPI.a / the component archives) is rebuilt.
+    // Declaring each archive as a build input forces a relink when it changes.
+    println!(
+        "cargo:rerun-if-changed={}",
+        lib_dir.join("libReussirCAPI.a").display()
+    );
+    for archive in REUSSIR_ARCHIVES {
+        println!(
+            "cargo:rerun-if-changed={}",
+            lib_dir.join(format!("lib{archive}.a")).display()
+        );
+    }
 
     println!("cargo:rerun-if-env-changed=REUSSIR_CAPI_LIB_DIR");
 }

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -9,9 +9,25 @@
 
 pub use mlir_sys;
 
-use core::ffi::c_int;
+use core::ffi::{c_char, c_int};
 
 use mlir_sys::{MlirContext, MlirDialectHandle, MlirDialectRegistry, MlirModule, MlirPass};
+
+// Opaque LLVM-C handles used by the bitcode-gathering helper. The next stage of
+// the port wires in `llvm-sys`; until then these are declared as opaque pointers
+// so the C API surface is complete and linkable, matching `llvm-c/Types.h`.
+#[repr(C)]
+pub struct LlvmOpaqueModule {
+    _private: [u8; 0],
+}
+#[repr(C)]
+pub struct LlvmOpaqueContext {
+    _private: [u8; 0],
+}
+/// Mirrors `LLVMModuleRef`.
+pub type LLVMModuleRef = *mut LlvmOpaqueModule;
+/// Mirrors `LLVMContextRef`.
+pub type LLVMContextRef = *mut LlvmOpaqueContext;
 
 unsafe extern "C" {
     //==-- Dialect registration --==//
@@ -67,6 +83,15 @@ unsafe extern "C" {
     /// Monomorphizes and compiles polymorphic FFI operations in the module.
     /// Returns true on success.
     pub fn reussirCompilePolymorphicFFI(module: MlirModule, optimized: bool) -> bool;
+
+    /// Gathers the LLVM bitcode modules attached to compiled operations into a
+    /// single LLVM module owned by `context`. Returns null on failure; otherwise
+    /// the caller owns the returned module.
+    pub fn reussirGatherCompiledModules(
+        module: MlirModule,
+        context: LLVMContextRef,
+        data_layout: *const c_char,
+    ) -> LLVMModuleRef;
 
     /// Reports whether TPDE support was compiled into the backend.
     pub fn reussirHasTPDE() -> c_int;

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -9,9 +9,13 @@
 
 pub use mlir_sys;
 
-use mlir_sys::{MlirContext, MlirDialectHandle};
+use core::ffi::c_int;
+
+use mlir_sys::{MlirContext, MlirDialectHandle, MlirDialectRegistry, MlirModule, MlirPass};
 
 unsafe extern "C" {
+    //==-- Dialect registration --==//
+
     /// Returns the dialect handle for the Reussir dialect. The handle can be
     /// inserted into a dialect registry or registered into a context.
     pub fn mlirGetDialectHandle__reussir__() -> MlirDialectHandle;
@@ -20,4 +24,50 @@ unsafe extern "C" {
     /// extension and LLVM/builtin translation it relies on into `context`, then
     /// loads all available dialects.
     pub fn reussirRegisterAllDialects(context: MlirContext);
+
+    /// Populates a dialect registry with the Reussir dialect and everything the
+    /// backend pipeline depends on. Build a context from the registry so dialect
+    /// extensions are applied as dialects load.
+    pub fn reussirPopulateRegistry(registry: MlirDialectRegistry);
+
+    //==-- Reussir passes --==//
+
+    pub fn reussirCreateUniqueCarryingRecursionAnalysisPass() -> MlirPass;
+    pub fn reussirCreateTokenInstantiationPass() -> MlirPass;
+    pub fn reussirCreateClosureOutliningPass() -> MlirPass;
+    pub fn reussirCreateRegionPatternsPass() -> MlirPass;
+    pub fn reussirCreateIncDecCancellationPass() -> MlirPass;
+    pub fn reussirCreateRcDecrementExpansionPass() -> MlirPass;
+    pub fn reussirCreateInferVariantTagPass() -> MlirPass;
+    pub fn reussirCreateSCFOpsLoweringPass() -> MlirPass;
+    pub fn reussirCreateRcCreateSinkPass() -> MlirPass;
+    pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
+    pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;
+    pub fn reussirCreateCompilePolymorphicFFIPass(optimized: bool) -> MlirPass;
+    pub fn reussirCreateInvariantGroupAnalysisPass() -> MlirPass;
+    pub fn reussirCreateBasicOpsLoweringPass() -> MlirPass;
+    pub fn reussirCreateAcquireDropExpansionPass(
+        expand_decrement: bool,
+        outline_record: bool,
+    ) -> MlirPass;
+    pub fn reussirCreateTokenReusePass(reuse_across_call: bool) -> MlirPass;
+
+    //==-- Upstream passes used by the pipeline --==//
+
+    pub fn reussirCreateDefaultInlinerPass() -> MlirPass;
+    pub fn reussirCreateCanonicalizerPass() -> MlirPass;
+    pub fn reussirCreateCSEPass() -> MlirPass;
+    pub fn reussirCreateControlFlowSinkPass() -> MlirPass;
+    pub fn reussirCreateSCFToControlFlowPass() -> MlirPass;
+    pub fn reussirCreateConvertToLLVMPass() -> MlirPass;
+    pub fn reussirCreateReconcileUnrealizedCastsPass() -> MlirPass;
+
+    //==-- Standalone helpers --==//
+
+    /// Monomorphizes and compiles polymorphic FFI operations in the module.
+    /// Returns true on success.
+    pub fn reussirCompilePolymorphicFFI(module: MlirModule, optimized: bool) -> bool;
+
+    /// Reports whether TPDE support was compiled into the backend.
+    pub fn reussirHasTPDE() -> c_int;
 }

--- a/crates/reussir-backend/src/lib.rs
+++ b/crates/reussir-backend/src/lib.rs
@@ -12,9 +12,11 @@
 pub use melior;
 
 use melior::Context;
-use melior::dialect::DialectHandle;
+use melior::dialect::{DialectHandle, DialectRegistry};
 
 use reussir_backend_sys as sys;
+
+pub mod pipeline;
 
 /// Returns the [`DialectHandle`] for the Reussir dialect.
 ///
@@ -24,6 +26,26 @@ pub fn reussir_dialect_handle() -> DialectHandle {
     // SAFETY: the handle returned by the C API points at a static registration
     // hook table that lives for the duration of the program.
     unsafe { DialectHandle::from_raw(sys::mlirGetDialectHandle__reussir__()) }
+}
+
+/// Creates a fresh [`Context`] ready to parse and lower Reussir IR.
+///
+/// The context is constructed with the Reussir dialect, its dependent dialects,
+/// and all required extensions and translations already registered, so dialect
+/// extensions (such as the `arith`/`func` ConvertToLLVM interfaces the lowering
+/// pipeline needs) are applied as dialects load. Prefer this over building a
+/// context by hand and calling [`register_all_dialects`].
+pub fn context() -> Context {
+    let registry = DialectRegistry::new();
+    // SAFETY: `registry` is a live melior dialect registry; the C API only
+    // inserts dialects, extensions and translations into it.
+    unsafe { sys::reussirPopulateRegistry(registry.to_raw()) };
+    // Build the context from the populated registry so dialect extensions apply
+    // as dialects load. Dialects load on demand (during parsing and lowering),
+    // matching mlir-opt: eagerly loading every available dialect would pull in
+    // ones (complex, gpu, ...) whose ConvertToLLVM promise the pass would then
+    // check without the conversion ever needing them.
+    Context::new_with_registry(&registry, /* threading */ true)
 }
 
 /// Registers only the Reussir dialect into `context`.

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -1,0 +1,168 @@
+//! The Reussir lowering pipeline.
+//!
+//! Assembles the sequence of Reussir and upstream passes that lowers a Reussir
+//! module down to the LLVM dialect, mirroring the backend's C++ pipeline. Each
+//! pass is created through the Reussir C API and added to a melior pass manager,
+//! with `func.func`-nested passes placed in their original order so the
+//! interleaving with module-level passes is preserved.
+
+use melior::Context;
+use melior::ir::Module;
+use melior::pass::{Pass, PassManager};
+
+use reussir_backend_sys as sys;
+
+/// Optimization level for the lowering pipeline, matching the backend's
+/// `ReussirOptOption` C enum.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OptLevel {
+    /// No optimization; the optimization-only prologue passes are skipped.
+    None,
+    /// Default optimization.
+    Default,
+    /// Aggressive optimization; also runs the unique-carrying recursion analysis.
+    Aggressive,
+    /// Optimize for size.
+    Size,
+    /// Lower for the TPDE fast back end.
+    Tpde,
+}
+
+impl OptLevel {
+    /// Whether the optimization-only prologue (inliner and friends) runs.
+    fn runs_optimization(self) -> bool {
+        !matches!(self, OptLevel::None)
+    }
+}
+
+/// Knobs for [`run_lowering_pipeline`].
+#[derive(Clone, Copy, Debug)]
+pub struct LoweringOptions {
+    /// Optimization level.
+    pub opt: OptLevel,
+    /// Allow the token-reuse pass to reuse tokens across function calls.
+    pub reuse_token_across_call: bool,
+    /// Run the invariant-group analysis pass.
+    pub enable_invariant_analysis: bool,
+}
+
+impl Default for LoweringOptions {
+    fn default() -> Self {
+        Self {
+            opt: OptLevel::Default,
+            reuse_token_across_call: false,
+            enable_invariant_analysis: true,
+        }
+    }
+}
+
+// Wraps a Reussir C API pass factory result as a melior pass.
+fn pass(raw: sys::mlir_sys::MlirPass) -> Pass {
+    // SAFETY: the C API returns a freshly created, owned MlirPass.
+    unsafe { Pass::from_raw(raw) }
+}
+
+/// Runs the full Reussir lowering pipeline on `module`, leaving it in the LLVM
+/// dialect ready for translation to LLVM IR.
+pub fn run_lowering_pipeline(
+    context: &Context,
+    module: &mut Module,
+    options: &LoweringOptions,
+) -> Result<(), melior::Error> {
+    let manager = PassManager::new(context);
+
+    // SAFETY: every factory returns an owned MlirPass handed to the manager.
+    unsafe {
+        if options.opt.runs_optimization() {
+            if options.opt == OptLevel::Aggressive {
+                manager.add_pass(pass(sys::reussirCreateUniqueCarryingRecursionAnalysisPass()));
+            }
+            manager.add_pass(pass(sys::reussirCreateDefaultInlinerPass()));
+        }
+
+        manager
+            .nested_under("func.func")
+            .add_pass(pass(sys::reussirCreateTokenInstantiationPass()));
+        manager.add_pass(pass(sys::reussirCreateClosureOutliningPass()));
+        manager.add_pass(pass(sys::reussirCreateRegionPatternsPass()));
+        manager
+            .nested_under("func.func")
+            .add_pass(pass(sys::reussirCreateIncDecCancellationPass()));
+        manager.add_pass(pass(sys::reussirCreateRcDecrementExpansionPass()));
+        manager
+            .nested_under("func.func")
+            .add_pass(pass(sys::reussirCreateInferVariantTagPass()));
+        manager.add_pass(pass(sys::reussirCreateAcquireDropExpansionPass(
+            false, false,
+        )));
+        manager.add_pass(pass(sys::reussirCreateSCFOpsLoweringPass()));
+        manager
+            .nested_under("func.func")
+            .add_pass(pass(sys::reussirCreateIncDecCancellationPass()));
+
+        // Second acquire/drop expansion phase: expand decrements and outline
+        // record drops.
+        manager.add_pass(pass(sys::reussirCreateAcquireDropExpansionPass(true, true)));
+        manager
+            .nested_under("func.func")
+            .add_pass(pass(sys::reussirCreateTokenReusePass(
+                options.reuse_token_across_call,
+            )));
+        manager.add_pass(pass(sys::reussirCreateSCFOpsLoweringPass()));
+        manager
+            .nested_under("func.func")
+            .add_pass(pass(sys::reussirCreateRcCreateSinkPass()));
+        manager
+            .nested_under("func.func")
+            .add_pass(pass(sys::reussirCreateRcCreateFusionPass()));
+        manager.add_pass(pass(sys::reussirCreateTRMCRecursionAnalysisPass()));
+        manager.add_pass(pass(sys::reussirCreateCompilePolymorphicFFIPass(false)));
+
+        if options.enable_invariant_analysis {
+            manager
+                .nested_under("func.func")
+                .add_pass(pass(sys::reussirCreateInvariantGroupAnalysisPass()));
+        }
+
+        // Lower to the LLVM dialect.
+        manager.add_pass(pass(sys::reussirCreateCanonicalizerPass()));
+        manager.add_pass(pass(sys::reussirCreateControlFlowSinkPass()));
+        manager.add_pass(pass(sys::reussirCreateSCFToControlFlowPass()));
+        manager.add_pass(pass(sys::reussirCreateBasicOpsLoweringPass()));
+        manager.add_pass(pass(sys::reussirCreateConvertToLLVMPass()));
+        manager.add_pass(pass(sys::reussirCreateReconcileUnrealizedCastsPass()));
+        manager.add_pass(pass(sys::reussirCreateCSEPass()));
+        manager.add_pass(pass(sys::reussirCreateCanonicalizerPass()));
+    }
+
+    manager.run(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use melior::ir::operation::OperationLike;
+
+    #[test]
+    fn lowers_simple_module_to_llvm_dialect() {
+        let context = crate::context();
+
+        let source = r#"
+            module {
+              func.func @answer() -> i32 {
+                %0 = arith.constant 42 : i32
+                func.return %0 : i32
+              }
+            }
+        "#;
+        let mut module = Module::parse(&context, source).expect("module should parse");
+
+        run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
+            .expect("pipeline should succeed");
+
+        assert!(module.as_operation().verify());
+        // After lowering, the function is an llvm.func rather than a func.func.
+        let rendered = module.as_operation().to_string();
+        assert!(rendered.contains("llvm.func @answer"), "got:\n{rendered}");
+    }
+}

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -64,6 +64,42 @@ fn pass(raw: sys::mlir_sys::MlirPass) -> Pass {
     unsafe { Pass::from_raw(raw) }
 }
 
+/// A small DSL describing the lowering pipeline as a declarative list of steps,
+/// so the layout reads top-to-bottom instead of being buried in builder calls.
+///
+/// Each step is one of:
+/// * `module: <factory>;` — a module-level pass;
+/// * `func: <factory>;` — a pass nested under `func.func`;
+/// * `if <cond> => { <steps> }` — a group run only when `<cond>` holds.
+///
+/// `<factory>` is a Reussir C API pass factory (an `unsafe` call); the macro
+/// wraps each one and hands the resulting [`Pass`] to the pass manager. The
+/// first argument names the [`PassManager`] to build into.
+macro_rules! lowering_pipeline {
+    // Done.
+    ($pm:ident) => {};
+    ($pm:ident,) => {};
+    // Module-level pass.
+    ($pm:ident, module: $factory:expr; $($rest:tt)*) => {{
+        // SAFETY: each factory returns a freshly created, owned MlirPass.
+        $pm.add_pass(pass(unsafe { $factory }));
+        lowering_pipeline!($pm, $($rest)*);
+    }};
+    // Pass nested under `func.func`.
+    ($pm:ident, func: $factory:expr; $($rest:tt)*) => {{
+        // SAFETY: each factory returns a freshly created, owned MlirPass.
+        $pm.nested_under("func.func").add_pass(pass(unsafe { $factory }));
+        lowering_pipeline!($pm, $($rest)*);
+    }};
+    // Group of steps gated on a condition.
+    ($pm:ident, if $cond:expr => { $($body:tt)* } $($rest:tt)*) => {{
+        if $cond {
+            lowering_pipeline!($pm, $($body)*);
+        }
+        lowering_pipeline!($pm, $($rest)*);
+    }};
+}
+
 /// Runs the full Reussir lowering pipeline on `module`, leaving it in the LLVM
 /// dialect ready for translation to LLVM IR.
 pub fn run_lowering_pipeline(
@@ -73,69 +109,50 @@ pub fn run_lowering_pipeline(
 ) -> Result<(), melior::Error> {
     let manager = PassManager::new(context);
 
-    // SAFETY: every factory returns an owned MlirPass handed to the manager.
-    unsafe {
-        if options.opt.runs_optimization() {
-            if options.opt == OptLevel::Aggressive {
-                manager.add_pass(pass(sys::reussirCreateUniqueCarryingRecursionAnalysisPass()));
+    lowering_pipeline!(manager,
+        // Optimization-only prologue.
+        if options.opt.runs_optimization() => {
+            if options.opt == OptLevel::Aggressive => {
+                module: sys::reussirCreateUniqueCarryingRecursionAnalysisPass();
             }
-            manager.add_pass(pass(sys::reussirCreateDefaultInlinerPass()));
+            module: sys::reussirCreateDefaultInlinerPass();
         }
 
-        manager
-            .nested_under("func.func")
-            .add_pass(pass(sys::reussirCreateTokenInstantiationPass()));
-        manager.add_pass(pass(sys::reussirCreateClosureOutliningPass()));
-        manager.add_pass(pass(sys::reussirCreateRegionPatternsPass()));
-        manager
-            .nested_under("func.func")
-            .add_pass(pass(sys::reussirCreateIncDecCancellationPass()));
-        manager.add_pass(pass(sys::reussirCreateRcDecrementExpansionPass()));
-        manager
-            .nested_under("func.func")
-            .add_pass(pass(sys::reussirCreateInferVariantTagPass()));
-        manager.add_pass(pass(sys::reussirCreateAcquireDropExpansionPass(
-            false, false,
-        )));
-        manager.add_pass(pass(sys::reussirCreateSCFOpsLoweringPass()));
-        manager
-            .nested_under("func.func")
-            .add_pass(pass(sys::reussirCreateIncDecCancellationPass()));
+        // Reussir-level transformation and analysis.
+        func:   sys::reussirCreateTokenInstantiationPass();
+        module: sys::reussirCreateClosureOutliningPass();
+        module: sys::reussirCreateRegionPatternsPass();
+        func:   sys::reussirCreateIncDecCancellationPass();
+        module: sys::reussirCreateRcDecrementExpansionPass();
+        func:   sys::reussirCreateInferVariantTagPass();
+        module: sys::reussirCreateAcquireDropExpansionPass(false, false);
+        module: sys::reussirCreateSCFOpsLoweringPass();
+        func:   sys::reussirCreateIncDecCancellationPass();
 
         // Second acquire/drop expansion phase: expand decrements and outline
         // record drops.
-        manager.add_pass(pass(sys::reussirCreateAcquireDropExpansionPass(true, true)));
-        manager
-            .nested_under("func.func")
-            .add_pass(pass(sys::reussirCreateTokenReusePass(
-                options.reuse_token_across_call,
-            )));
-        manager.add_pass(pass(sys::reussirCreateSCFOpsLoweringPass()));
-        manager
-            .nested_under("func.func")
-            .add_pass(pass(sys::reussirCreateRcCreateSinkPass()));
-        manager
-            .nested_under("func.func")
-            .add_pass(pass(sys::reussirCreateRcCreateFusionPass()));
-        manager.add_pass(pass(sys::reussirCreateTRMCRecursionAnalysisPass()));
-        manager.add_pass(pass(sys::reussirCreateCompilePolymorphicFFIPass(false)));
+        module: sys::reussirCreateAcquireDropExpansionPass(true, true);
+        func:   sys::reussirCreateTokenReusePass(options.reuse_token_across_call);
+        module: sys::reussirCreateSCFOpsLoweringPass();
+        func:   sys::reussirCreateRcCreateSinkPass();
+        func:   sys::reussirCreateRcCreateFusionPass();
+        module: sys::reussirCreateTRMCRecursionAnalysisPass();
+        module: sys::reussirCreateCompilePolymorphicFFIPass(false);
 
-        if options.enable_invariant_analysis {
-            manager
-                .nested_under("func.func")
-                .add_pass(pass(sys::reussirCreateInvariantGroupAnalysisPass()));
+        if options.enable_invariant_analysis => {
+            func: sys::reussirCreateInvariantGroupAnalysisPass();
         }
 
         // Lower to the LLVM dialect.
-        manager.add_pass(pass(sys::reussirCreateCanonicalizerPass()));
-        manager.add_pass(pass(sys::reussirCreateControlFlowSinkPass()));
-        manager.add_pass(pass(sys::reussirCreateSCFToControlFlowPass()));
-        manager.add_pass(pass(sys::reussirCreateBasicOpsLoweringPass()));
-        manager.add_pass(pass(sys::reussirCreateConvertToLLVMPass()));
-        manager.add_pass(pass(sys::reussirCreateReconcileUnrealizedCastsPass()));
-        manager.add_pass(pass(sys::reussirCreateCSEPass()));
-        manager.add_pass(pass(sys::reussirCreateCanonicalizerPass()));
-    }
+        module: sys::reussirCreateCanonicalizerPass();
+        module: sys::reussirCreateControlFlowSinkPass();
+        module: sys::reussirCreateSCFToControlFlowPass();
+        module: sys::reussirCreateBasicOpsLoweringPass();
+        module: sys::reussirCreateConvertToLLVMPass();
+        module: sys::reussirCreateReconcileUnrealizedCastsPass();
+        module: sys::reussirCreateCSEPass();
+        module: sys::reussirCreateCanonicalizerPass();
+    );
 
     manager.run(module)
 }

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -51,7 +51,9 @@ impl Default for LoweringOptions {
         Self {
             opt: OptLevel::Default,
             reuse_token_across_call: false,
-            enable_invariant_analysis: true,
+            // Off by default, mirroring the C++ `createLoweringPipeline`
+            // (`enableInvariantAnalysis = false`).
+            enable_invariant_analysis: false,
         }
     }
 }

--- a/include/Reussir-c/Dialects.h
+++ b/include/Reussir-c/Dialects.h
@@ -33,6 +33,13 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Reussir, reussir);
 // and lower Reussir IR.
 void reussirRegisterAllDialects(MlirContext context);
 
+// Populates the given dialect registry with the Reussir dialect, its dependent
+// dialects, and the extensions and translations the backend pipeline relies on.
+// Building a context from this registry (rather than appending afterward)
+// ensures dialect extensions (e.g. the arith/func ConvertToLLVM interfaces) are
+// applied as dialects load.
+void reussirPopulateRegistry(MlirDialectRegistry registry);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -1,0 +1,91 @@
+//===-- Passes.h - Reussir backend pipeline C API --------------*- C -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// C API for assembling the Reussir lowering pipeline from Rust. Each Reussir
+// (and required upstream) pass is exposed as an MlirPass factory so the Rust
+// backend can build the pipeline step by step with melior's pass manager, plus
+// the standalone helpers the pipeline depends on.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef REUSSIR_C_PASSES_H
+#define REUSSIR_C_PASSES_H
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Pass.h"
+#include "mlir-c/Support.h"
+
+#include "llvm-c/Types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//===----------------------------------------------------------------------===//
+// Reussir passes
+//===----------------------------------------------------------------------===//
+
+MlirPass reussirCreateUniqueCarryingRecursionAnalysisPass(void);
+MlirPass reussirCreateTokenInstantiationPass(void);
+MlirPass reussirCreateClosureOutliningPass(void);
+MlirPass reussirCreateRegionPatternsPass(void);
+MlirPass reussirCreateIncDecCancellationPass(void);
+MlirPass reussirCreateRcDecrementExpansionPass(void);
+MlirPass reussirCreateInferVariantTagPass(void);
+MlirPass reussirCreateSCFOpsLoweringPass(void);
+MlirPass reussirCreateRcCreateSinkPass(void);
+MlirPass reussirCreateRcCreateFusionPass(void);
+MlirPass reussirCreateTRMCRecursionAnalysisPass(void);
+MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized);
+MlirPass reussirCreateInvariantGroupAnalysisPass(void);
+MlirPass reussirCreateBasicOpsLoweringPass(void);
+
+// Acquire/drop expansion has two phases controlled by these options; the
+// pipeline runs it once with both disabled and once with both enabled.
+MlirPass reussirCreateAcquireDropExpansionPass(bool expandDecrement,
+                                               bool outlineRecord);
+// Token reuse can optionally reuse tokens across function calls.
+MlirPass reussirCreateTokenReusePass(bool reuseAcrossCall);
+
+//===----------------------------------------------------------------------===//
+// Upstream passes used by the pipeline
+//===----------------------------------------------------------------------===//
+
+// The default inliner configured with a canonicalizer that does not simplify
+// regions, matching the C++ backend pipeline.
+MlirPass reussirCreateDefaultInlinerPass(void);
+MlirPass reussirCreateCanonicalizerPass(void);
+MlirPass reussirCreateCSEPass(void);
+MlirPass reussirCreateControlFlowSinkPass(void);
+MlirPass reussirCreateSCFToControlFlowPass(void);
+MlirPass reussirCreateConvertToLLVMPass(void);
+MlirPass reussirCreateReconcileUnrealizedCastsPass(void);
+
+//===----------------------------------------------------------------------===//
+// Standalone helpers
+//===----------------------------------------------------------------------===//
+
+// Monomorphizes and compiles polymorphic FFI operations in the module. Returns
+// true on success.
+bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized);
+
+// Gathers the LLVM bitcode modules attached to compiled operations into a
+// single LLVM module owned by `context`. Returns NULL on failure; otherwise the
+// caller owns the returned module.
+LLVMModuleRef reussirGatherCompiledModules(MlirModule module,
+                                           LLVMContextRef context,
+                                           const char *dataLayout);
+
+// Reports whether TPDE support was compiled into the backend.
+int reussirHasTPDE(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // REUSSIR_C_PASSES_H

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -1,13 +1,44 @@
 # C API library consumed by the Rust backend crates (mlir-sys / melior).
 #
 # mlir-sys links MLIR and LLVM statically, so the Reussir dialect registration
-# is shipped as a static archive that is linked into the same Rust binary. That
-# keeps a single copy of the MLIR runtime and dialect registry: the archive's
-# MLIR references resolve against the same static MLIR/LLVM that mlir-sys pulls
-# in. Requires the distro's static MLIR/LLVM development packages (including
-# libpolly-<ver>-dev for the static Polly archives llvm-config references).
-add_library(ReussirCAPI STATIC Dialects.cpp)
-add_dependencies(ReussirCAPI MLIRReussir)
+# and the lowering-pipeline pass factories are shipped as static archives linked
+# into the same Rust binary. That keeps a single copy of the MLIR runtime and
+# dialect registry: the archives' MLIR references resolve against the same static
+# MLIR/LLVM that mlir-sys pulls in. Requires the distro's static MLIR/LLVM
+# development packages (including libpolly-<ver>-dev for the static Polly
+# archives llvm-config references).
+add_library(ReussirCAPI STATIC Dialects.cpp Passes.cpp)
+
+# Reussir component archives whose symbols ReussirCAPI references: per-pass
+# factories plus the standalone helpers (compilePolymorphicFFI via the
+# CompilePolymorphicFFI pass + ReussirRustCompiler, gatherCompiledModules via
+# MLIRReussir). reussir-backend-sys links these into the final Rust binary; here
+# we only ensure they are built first.
+set(REUSSIR_BACKEND_ARCHIVES
+  MLIRReussir
+  MLIRReussirAnalysis
+  ReussirRustCompiler
+  # conversions
+  MLIRReussirTypeConverter
+  MLIRReussirBasicOpsLowering
+  MLIRReussirSCFOpsLowering
+  MLIRReussirRegionPatterns
+  MLIRReussirAcquireDropExpansion
+  MLIRReussirRcDecrementExpansion
+  MLIRReussirTokenInstantiation
+  MLIRReussirClosureOutlining
+  MLIRReussirCompilePolymorphicFFI
+  MLIRReussirAttachNativeTarget
+  # transformations
+  MLIRReussirRcCreateSink
+  MLIRReussirRcCreateFusion
+  MLIRReussirInferVariantTag
+  MLIRReussirIncDecCancellation
+  MLIRReussirTokenReuse
+  MLIRReussirInvariantGroupAnalysis
+  MLIRReussirUniqueCarryingRecursionAnalysis
+  MLIRReussirTRMCRecursionAnalysis)
+add_dependencies(ReussirCAPI ${REUSSIR_BACKEND_ARCHIVES})
 
 # Aggregate target the Rust crates depend on.
-add_custom_target(reussir-capi DEPENDS ReussirCAPI)
+add_custom_target(reussir-capi DEPENDS ReussirCAPI ${REUSSIR_BACKEND_ARCHIVES})

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -10,7 +10,13 @@
 
 #include <mlir/CAPI/IR.h>
 #include <mlir/CAPI/Registration.h>
+#include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
+#include <mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h>
 #include <mlir/Conversion/ConvertToLLVM/ToLLVMPass.h>
+#include <mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h>
+#include <mlir/Conversion/MathToLLVM/MathToLLVM.h>
+#include <mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h>
+#include <mlir/Conversion/UBToLLVM/UBToLLVM.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/DLTI/DLTI.h>
@@ -21,26 +27,56 @@
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/IR/DialectRegistry.h>
-#include <mlir/InitAllExtensions.h>
+#include <mlir/IR/MLIRContext.h>
 #include <mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h>
 #include <mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h>
 
+#include "Reussir/Conversion/Passes.h"
 #include "Reussir/IR/ReussirDialect.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Reussir, reussir, ::reussir::ReussirDialect)
 
-void reussirRegisterAllDialects(MlirContext context) {
-  mlir::DialectRegistry registry;
+namespace {
+// Populates a registry with the Reussir dialect plus the minimal set of
+// upstream dialects, ConvertToLLVM interfaces and translations the lowering
+// pipeline relies on.
+void populateReussirRegistry(mlir::DialectRegistry &registry) {
+  // Only the dialects the Reussir lowering pipeline actually operates on. Using
+  // the minimal set (rather than registerAllDialects/registerAllExtensions)
+  // keeps unrelated dialects such as complex/tensor/bufferization out of the
+  // context, so the ConvertToLLVM pass never trips over their unimplemented
+  // promised interfaces.
   registry.insert<::reussir::ReussirDialect, mlir::DLTIDialect,
                   mlir::LLVM::LLVMDialect, mlir::arith::ArithDialect,
                   mlir::memref::MemRefDialect, mlir::scf::SCFDialect,
                   mlir::math::MathDialect, mlir::ub::UBDialect,
                   mlir::func::FuncDialect, mlir::cf::ControlFlowDialect>();
-  mlir::registerConvertToLLVMDependentDialectLoading(registry);
-  mlir::registerAllExtensions(registry);
+
+  // Register the ConvertToLLVMPatternInterface for exactly the dialects that can
+  // reach the ConvertToLLVM pass, plus Reussir's own lowering interface. These
+  // are the conversion-interface registration APIs (distinct from the dialects
+  // themselves); without them a loaded dialect's promised interface is fatal.
+  ::reussir::registerReussirBasicOpsLoweringInterface(registry);
+  mlir::arith::registerConvertArithToLLVMInterface(registry);
+  mlir::registerConvertFuncToLLVMInterface(registry);
+  mlir::cf::registerConvertControlFlowToLLVMInterface(registry);
+  mlir::registerConvertMathToLLVMInterface(registry);
+  mlir::registerConvertMemRefToLLVMInterface(registry);
+  mlir::ub::registerConvertUBToLLVMInterface(registry);
+
+  // Translations needed to lower the LLVM dialect to LLVM IR.
   mlir::registerLLVMDialectTranslation(registry);
   mlir::registerBuiltinDialectTranslation(registry);
+}
+} // namespace
 
+void reussirPopulateRegistry(MlirDialectRegistry registry) {
+  populateReussirRegistry(*unwrap(registry));
+}
+
+void reussirRegisterAllDialects(MlirContext context) {
+  mlir::DialectRegistry registry;
+  populateReussirRegistry(registry);
   mlir::MLIRContext *ctx = unwrap(context);
   ctx->appendDialectRegistry(registry);
   ctx->loadAllAvailableDialects();

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -10,6 +10,7 @@
 
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
+#include <llvm/Support/CBindingWrapping.h>
 
 #include <mlir/CAPI/IR.h>
 #include <mlir/CAPI/Pass.h>

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -1,0 +1,155 @@
+//===-- Passes.cpp - Reussir backend pipeline C API ----------*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir-c/Passes.h"
+
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+
+#include <mlir/CAPI/IR.h>
+#include <mlir/CAPI/Pass.h>
+#include <mlir/Conversion/ConvertToLLVM/ToLLVMPass.h>
+#include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
+#include <mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+#include <mlir/Transforms/Passes.h>
+
+#include "Reussir/Conversion/BasicOpsLowering.h"
+#include "Reussir/Conversion/Passes.h"
+#include "Reussir/Conversion/SCFOpsLowering.h"
+#include "Reussir/IR/ReussirOps.h"
+#include "Reussir/Transformation/Passes.h"
+
+using namespace mlir;
+
+namespace {
+MlirPass wrapOwned(std::unique_ptr<mlir::Pass> pass) {
+  return wrap(pass.release());
+}
+
+// Canonicalizer with region simplification disabled, used as the inliner's
+// default pipeline so it matches the C++ backend.
+void addCanonicalizerWithoutRegionSimplification(mlir::OpPassManager &pm) {
+  mlir::GreedyRewriteConfig config;
+  config.setRegionSimplificationLevel(mlir::GreedySimplifyRegionLevel::Disabled);
+  pm.addPass(mlir::createCanonicalizerPass(config));
+}
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Reussir passes
+//===----------------------------------------------------------------------===//
+
+MlirPass reussirCreateUniqueCarryingRecursionAnalysisPass(void) {
+  return wrapOwned(reussir::createReussirUniqueCarryingRecursionAnalysisPass());
+}
+MlirPass reussirCreateTokenInstantiationPass(void) {
+  return wrapOwned(reussir::createReussirTokenInstantiationPass());
+}
+MlirPass reussirCreateClosureOutliningPass(void) {
+  return wrapOwned(reussir::createReussirClosureOutliningPass());
+}
+MlirPass reussirCreateRegionPatternsPass(void) {
+  return wrapOwned(reussir::createReussirRegionPatternsPass());
+}
+MlirPass reussirCreateIncDecCancellationPass(void) {
+  return wrapOwned(reussir::createReussirIncDecCancellationPass());
+}
+MlirPass reussirCreateRcDecrementExpansionPass(void) {
+  return wrapOwned(reussir::createReussirRcDecrementExpansionPass());
+}
+MlirPass reussirCreateInferVariantTagPass(void) {
+  return wrapOwned(reussir::createReussirInferVariantTagPass());
+}
+MlirPass reussirCreateSCFOpsLoweringPass(void) {
+  return wrapOwned(reussir::createReussirSCFOpsLoweringPass());
+}
+MlirPass reussirCreateRcCreateSinkPass(void) {
+  return wrapOwned(reussir::createReussirRcCreateSinkPass());
+}
+MlirPass reussirCreateRcCreateFusionPass(void) {
+  return wrapOwned(reussir::createReussirRcCreateFusionPass());
+}
+MlirPass reussirCreateTRMCRecursionAnalysisPass(void) {
+  return wrapOwned(reussir::createReussirTRMCRecursionAnalysisPass());
+}
+MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized) {
+  reussir::ReussirCompilePolymorphicFFIPassOptions options;
+  options.optimized = optimized;
+  return wrapOwned(reussir::createReussirCompilePolymorphicFFIPass(options));
+}
+MlirPass reussirCreateInvariantGroupAnalysisPass(void) {
+  return wrapOwned(reussir::createReussirInvariantGroupAnalysisPass());
+}
+MlirPass reussirCreateBasicOpsLoweringPass(void) {
+  return wrapOwned(reussir::createReussirBasicOpsLoweringPass());
+}
+MlirPass reussirCreateAcquireDropExpansionPass(bool expandDecrement,
+                                               bool outlineRecord) {
+  reussir::ReussirAcquireDropExpansionPassOptions options;
+  options.expandDecrement = expandDecrement;
+  options.outlineRecord = outlineRecord;
+  return wrapOwned(reussir::createReussirAcquireDropExpansionPass(options));
+}
+MlirPass reussirCreateTokenReusePass(bool reuseAcrossCall) {
+  reussir::ReussirTokenReusePassOptions options;
+  options.reuseAcrossCall = reuseAcrossCall;
+  return wrapOwned(reussir::createReussirTokenReusePass(options));
+}
+
+//===----------------------------------------------------------------------===//
+// Upstream passes
+//===----------------------------------------------------------------------===//
+
+MlirPass reussirCreateDefaultInlinerPass(void) {
+  llvm::StringMap<mlir::OpPassManager> pipelines;
+  return wrapOwned(mlir::createInlinerPass(
+      pipelines, addCanonicalizerWithoutRegionSimplification));
+}
+MlirPass reussirCreateCanonicalizerPass(void) {
+  return wrapOwned(mlir::createCanonicalizerPass());
+}
+MlirPass reussirCreateCSEPass(void) { return wrapOwned(mlir::createCSEPass()); }
+MlirPass reussirCreateControlFlowSinkPass(void) {
+  return wrapOwned(mlir::createControlFlowSinkPass());
+}
+MlirPass reussirCreateSCFToControlFlowPass(void) {
+  return wrapOwned(mlir::createSCFToControlFlowPass());
+}
+MlirPass reussirCreateConvertToLLVMPass(void) {
+  return wrapOwned(mlir::createConvertToLLVMPass());
+}
+MlirPass reussirCreateReconcileUnrealizedCastsPass(void) {
+  return wrapOwned(mlir::createReconcileUnrealizedCastsPass());
+}
+
+//===----------------------------------------------------------------------===//
+// Standalone helpers
+//===----------------------------------------------------------------------===//
+
+bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized) {
+  return succeeded(reussir::compilePolymorphicFFI(unwrap(module), optimized));
+}
+
+LLVMModuleRef reussirGatherCompiledModules(MlirModule module,
+                                           LLVMContextRef context,
+                                           const char *dataLayout) {
+  std::unique_ptr<llvm::Module> result = reussir::gatherCompiledModules(
+      unwrap(module), *llvm::unwrap(context), dataLayout);
+  return llvm::wrap(result.release());
+}
+
+int reussirHasTPDE(void) {
+#ifdef REUSSIR_HAS_TPDE
+  return 1;
+#else
+  return 0;
+#endif
+}


### PR DESCRIPTION
## Summary

Second stage of the Rust backend migration (stacked on #254, now merged): the **MLIR lowering half** of the bridge, driven from Rust through melior. Additive — the new crates are still excluded from the default build.

### Fine-grained CAPI
`lib/CAPI/Passes.{h,cpp}` expose each Reussir and required upstream pass as an `MlirPass` factory, plus the standalone helpers (`reussirCompilePolymorphicFFI`, `reussirGatherCompiledModules`, `reussirHasTPDE`). The Reussir dialect/conversion/transformation/analysis archives (and `ReussirRustCompiler`) are linked into the crate.

### Context + dialect/interface registration
`lib/CAPI/Dialects.cpp` adds `reussirPopulateRegistry`, which registers the **minimal** set of dialects, ConvertToLLVM interfaces and translations the pipeline needs — deliberately **not** `registerAllDialects`/`registerAllExtensions`. That keeps unrelated dialects (complex/tensor/bufferization) out of the context, so the generic `ConvertToLLVM` pass never trips over their unimplemented promised interfaces. `reussir_backend::context()` builds a melior `Context` from this registry.

### Pipeline
`reussir_backend::pipeline::run_lowering_pipeline` assembles the lowering passes through melior's `PassManager`, mirroring the C++ `createLoweringPipeline` ordering exactly (the `func.func`-nested passes are interleaved with module-level passes, which MLIR preserves since `nest()` makes a fresh adaptor per call). A test lowers a module to the LLVM dialect and verifies it.

### Build correctness
`reussir-backend-sys` declares each Reussir archive with `cargo:rerun-if-changed`, so cargo relinks the crate/tests when the C++ side is rebuilt. Without this, cargo (which doesn't track native static-lib contents) reuses a binary linked against a stale archive.

### Verification
- `ninja -C build reussir-backend-test` → 3 tests pass: dialect registration, `!reussir.rc<i32>` parse, and the full 25-pass pipeline lowering a module to `llvm.func`.
- `cargo fmt --check` clean.

### Deferred (next stage)
MLIR→LLVM IR translation + LLVM codegen/link via `llvm-sys`, the custom LLVM passes, native target queries, the C ABI cdylib for the Haskell frontend, and `tracing`-based logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
