### PR TITLE
Fix nightly Windows (MSVC) build: suppress snmalloc C4864

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+# snmalloc-sys vendors a copy of snmalloc whose CMake build compiles with
+# `/WX` (warnings-as-errors) under MSVC. Recent MSVC toolchains (VS 2022 17.x /
+# VS 18, 14.5x) emit C4864 ("expected 'template' keyword before dependent
+# template name") inside snmalloc's `corealloc.h`, which `/WX` promotes to a
+# hard error and breaks the Windows (MSVC) build of `reussir-rt`.
+#
+# Disable just that warning for the MSVC target. `/wd<n>` removes the warning
+# entirely, so `/WX` cannot promote it regardless of flag order. The cc/cmake
+# build crates fold these target-prefixed vars into `CMAKE_CXX_FLAGS`, and the
+# target suffix scopes them to MSVC only — the gnu/gnullvm (clang) Windows
+# builds and all other platforms are unaffected.
+[env]
+CFLAGS_x86_64_pc_windows_msvc = "/wd4864"
+CXXFLAGS_x86_64_pc_windows_msvc = "/wd4864"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ crates/**/target
 runtime/target
 rustc-ice-*
 *.profraw
-.cargo
+.cargo/*
+# but keep the checked-in cargo config (build flags for snmalloc on MSVC, etc.)
+!.cargo/config.toml
 
 # Editors / IDEs
 .idea


### PR DESCRIPTION
## Problem

The **Nightly Release** workflow's `build-windows` job fails at the **Build** step:

```
corealloc.h(674,22): warning C4864: expected 'template' keyword before dependent template name
corealloc.h(674,22): error C2220: the following warning is treated as an error
error: failed to run custom build command for `snmalloc-sys v0.7.4`
```

## Root cause

`rust-toolchain.toml` pins only `channel = "nightly-2026-02-15"` with no target, so on Windows it resolves to the host default **`x86_64-pc-windows-msvc`** (overriding the workflow's `rustup default …gnullvm`). `reussir-rt` (default feature `snmalloc`) then builds `snmalloc-sys` with MSVC, and snmalloc's vendored CMake compiles with `/WX` (warnings-as-errors). Recent MSVC toolchains (VS 18 / 14.5x) emit **C4864** inside snmalloc's `corealloc.h`, which `/WX` promotes to a hard error.

snmalloc-rs/sys 0.7.4 is the latest published version, so a dependency bump doesn't help. The MinGW/clang Windows pipeline is unaffected because it doesn't target MSVC.

## Fix

Add a workspace `.cargo/config.toml` that disables just C4864 for the MSVC target:

```toml
[env]
CFLAGS_x86_64_pc_windows_msvc = "/wd4864"
CXXFLAGS_x86_64_pc_windows_msvc = "/wd4864"
```

The `cc`/`cmake` build crates fold these target-prefixed vars into `CMAKE_CXX_FLAGS` (verified in the crate source: `cmake-0.1.58` sets the target on its `cc::Build` then folds `compiler.args()` into `CMAKE_CXX_FLAGS`). `/wd<n>` removes the warning entirely, so `/WX` can't promote it regardless of flag order. The target suffix scopes this to MSVC only — gnu/gnullvm (clang) Windows, Linux, and macOS are untouched.

`.cargo` was gitignored, so `config.toml` is un-ignored via a `.gitignore` exception (`.cargo/*` + `!.cargo/config.toml`).

## Validation

- `cargo build -p reussir-rt` still succeeds locally (Linux; env var is a no-op off-MSVC).
- Triggered the Nightly Release workflow on this branch via `workflow_dispatch` to confirm the Windows MSVC build now passes (run linked in checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)