### PR TITLE
Fix nightly Windows release: pin rustup default-host to gnullvm

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -384,6 +384,14 @@ jobs:
         shell: msys2 {0}
         run: |
           pip install lit
+          # The repo-root rust-toolchain.toml pins only a bare `channel`, which
+          # rustup resolves against the default host triple. On this clang64
+          # image that default is the MSVC host, so the runtime would build as
+          # x86_64-pc-windows-msvc and emit /DEFAULTLIB:oldnames directives that
+          # the gnu clang linker used by the integration tests cannot satisfy
+          # (ld.lld: could not open 'libOLDNAMES.a'). Pin the default host to
+          # gnullvm so the bare channel resolves to the gnu/LLVM toolchain.
+          rustup set default-host x86_64-pc-windows-gnullvm
           rustup target add x86_64-pc-windows-gnullvm
           rustup default nightly-2026-02-15-x86_64-pc-windows-gnullvm
           rustup component add rust-src rustfmt clippy


### PR DESCRIPTION
## Problem

The **Nightly Release** workflow's `build-windows` job is red on `main`. The Windows build itself succeeds, but the **Run Integration Tests** step fails — all 21 tests that link the runtime fail with:

```
ld.lld: error: could not open 'libOLDNAMES.a': No such file or directory
```

## Root cause

The job runs `rustup default nightly-2026-02-15-x86_64-pc-windows-gnullvm`, but the repo-root `rust-toolchain.toml` pins only a **bare** `channel`. An in-repo `cargo` invocation (driven by CMake) lets that toolchain-file override win, and the bare channel resolves against rustup's *default host triple* — which on the clang64 image is the **MSVC** host. So `reussir_rt` builds as `x86_64-pc-windows-msvc` and emits `/DEFAULTLIB:oldnames` directives that the gnu/LLVM clang linker used for the integration-test executables cannot satisfy.

## Fix

Add `rustup set default-host x86_64-pc-windows-gnullvm` so the bare channel resolves to the gnu/LLVM toolchain. This mirrors the already-green **MinGW Clang64 Full Pipeline** workflow (`mlir-cpp-test-windows.yml`), which carries the same fix and comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)