### PR TITLE
[frontend] reussir-core: v0 symbol mangling for the Full phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "ftree"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeef4a9366aaf0ed0bb5292b7c489d80600a7431fca0d96271e10e23ac0bc2b0"
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +870,7 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "ena",
+ "ftree",
  "rapidhash",
  "reussir-syntax",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ rustc-hash = "2.1"
 # Small-size-optimized vectors: arity-bounded surface-AST lists (path segments,
 # argument/type-parameter lists) stay inline and skip heap allocation.
 smallvec = "1.15"
+# Fenwick (binary-indexed) tree: O(log n) point-update + prefix-count, used to
+# keep the v0 Punycode encoder's per-occurrence "code points placed to the left"
+# query sub-linear, so Bootstring encoding is O(n log n) rather than O(n²).
+ftree = "1.3.0"
 cstree = { version = "0.14", features = ["derive", "lasso_compat"] }
 # rustc's extracted union-find: keyed unification with value merging and
 # snapshot/rollback (the logged path-compression makes speculation correct).

--- a/crates/reussir-core/Cargo.toml
+++ b/crates/reussir-core/Cargo.toml
@@ -11,6 +11,7 @@ name = "reussir_core"
 [dependencies]
 blake3.workspace = true
 ena.workspace = true
+ftree.workspace = true
 rapidhash.workspace = true
 rustc-hash.workspace = true
 smallvec.workspace = true

--- a/crates/reussir-core/src/full.rs
+++ b/crates/reussir-core/src/full.rs
@@ -1,0 +1,16 @@
+//! The *Full* phase: the monomorphized, mangled representation.
+//!
+//! Where [`crate::semi`] keeps generics open and may carry inference holes, the
+//! Full phase is **ground**: every type argument is a concrete [`semi::ty::Ty`]
+//! with no [`semi::ty::TyKind::Generic`] or [`semi::ty::TyKind::Hole`] left. That
+//! invariant is what lets each item instance have a single, stable linker symbol
+//! (see [`mangle`]) and what the backend lowering relies on.
+//!
+//! Full reuses the Semi type interner ([`semi::ty::TyCtxt`]) rather than
+//! introducing a parallel type representation: a Full type *is* a Semi `Ty` that
+//! happens to be ground, so monomorphization is a substitution that re-interns
+//! into the same arena and downstream code keeps pointer-identity equality.
+//!
+//! [`semi`]: crate::semi
+
+pub mod mangle;

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -160,7 +160,9 @@ impl<'a> Mangler<'a> {
 /// non-ASCII names are Punycode-encoded (with `-`→`_`) behind a `u` tag.
 fn ident(out: &mut String, name: &str) {
     if name.is_ascii() {
-        push_ident_body(out, name, name.chars().count());
+        // ASCII ⇒ one byte per char, so the byte length is the character count
+        // without a second O(n) scan.
+        push_ident_body(out, name, name.len());
     } else {
         let punycode = punycode::encode(name).replace('-', "_");
         out.push('u');

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -1,0 +1,328 @@
+//! Rust v0 symbol mangling for the *Full* (monomorphized) phase.
+//!
+//! Mangling runs on ground [`Ty`]s — every generic has been substituted and
+//! every hole solved — so a function instance or type has a single, stable
+//! linker symbol. The scheme is a subset of Rust's v0 format; it is the contract
+//! shared with the backend (the C++ runtime and the trampoline ABI both name
+//! symbols this way), so the encoding is fixed, not an implementation detail.
+//!
+//! # Grammar
+//!
+//! ```text
+//! mangled-name  → "_R" (path | type)
+//! path          → "C" identifier                     -- crate-root segment
+//!               | "N" "v" path identifier            -- nested (value namespace)
+//! identifier    → decimal [_] body                   -- ASCII; `_` if body leads with a digit/`_`
+//!               | "u" decimal [_] punycode           -- non-ASCII (RFC 3492, `-`→`_`)
+//! path-w/-args  → path                               -- no type arguments
+//!               | "I" path {type}+ "E"               -- applied to type arguments
+//! type          → "b" | "e" | "u" | "z"              -- bool | str | unit | bottom(never)
+//!               | int-code | float-code
+//!               | path-w/-args                       -- nominal record / Nullable
+//!               | "F" "K" identifier {type}* "E" type-- closure
+//! int-code      → a s l x (i8 i16 i32 i64) | h t m y (u8 u16 u32 u64)
+//!               | "C4i128" | "C4u128"
+//! float-code    → f d (f32 f64) | "C3f16" | "C4f128" | "C4bf16" | "C2f8"
+//! ```
+//!
+//! A nominal record mangles as its **fully-qualified path** (so two same-named
+//! records in different modules get distinct symbols) applied to its type
+//! arguments; the per-use capability is *irrelevant* to the ABI and is dropped.
+//! A monomorphized function instance shares the same path-with-arguments form
+//! (its [`DefId`]'s path applied to the instance's type arguments).
+
+use reussir_syntax::kind::{Resolver, TokenKey};
+
+use crate::semi::resolve::DefTable;
+use crate::semi::ty::{DefId, FpTy, IntTy, Ty, TyKind};
+use crate::utils::punycode;
+
+/// Mangles ground types and item instances into v0 linker symbols.
+///
+/// Holds the resolution table (for [`DefId`] → fully-qualified path) and the
+/// token resolver (for path segment → text); construct one per program and reuse
+/// it for every symbol.
+pub struct Mangler<'a> {
+    defs: &'a DefTable,
+    resolver: &'a dyn Resolver<TokenKey>,
+}
+
+impl<'a> Mangler<'a> {
+    pub fn new(defs: &'a DefTable, resolver: &'a dyn Resolver<TokenKey>) -> Self {
+        Mangler { defs, resolver }
+    }
+
+    /// The symbol for a ground type: `_R` followed by the type encoding.
+    pub fn mangle_ty(&self, ty: Ty<'_>) -> String {
+        let mut out = String::from("_R");
+        self.ty(&mut out, ty);
+        out
+    }
+
+    /// The symbol for a monomorphized item instance: its fully-qualified path
+    /// applied to `ty_args`. Functions and records share this form.
+    pub fn mangle_instance(&self, def: DefId, ty_args: &[Ty<'_>]) -> String {
+        let mut out = String::from("_R");
+        self.path_with_args(&mut out, def, ty_args);
+        out
+    }
+
+    // ----- paths -----
+
+    /// A path applied to (possibly zero) type arguments. Bare path when empty,
+    /// else wrapped in `I … E`.
+    fn path_with_args(&self, out: &mut String, def: DefId, args: &[Ty<'_>]) {
+        let segments: Vec<&str> = self
+            .defs
+            .path(def)
+            .0
+            .iter()
+            .map(|&seg| self.resolver.resolve(seg))
+            .collect();
+        self.path_with_args_segs(out, &segments, args);
+    }
+
+    /// As [`Mangler::path_with_args`] but over already-resolved segment text, so
+    /// synthetic paths (e.g. `Nullable`) reuse the same nesting logic.
+    fn path_with_args_segs(&self, out: &mut String, segments: &[&str], args: &[Ty<'_>]) {
+        if args.is_empty() {
+            self.path(out, segments);
+        } else {
+            out.push('I');
+            self.path(out, segments);
+            for &arg in args {
+                self.ty(out, arg);
+            }
+            out.push('E');
+        }
+    }
+
+    /// The nested-path encoding: a single segment is a crate root (`C`); each
+    /// further segment wraps the prefix in `Nv … <ident>`.
+    fn path(&self, out: &mut String, segments: &[&str]) {
+        let (last, prefix) = segments
+            .split_last()
+            .expect("a qualified path is never empty");
+        if prefix.is_empty() {
+            out.push('C');
+            ident(out, last);
+        } else {
+            out.push('N');
+            out.push('v');
+            self.path(out, prefix);
+            ident(out, last);
+        }
+    }
+
+    // ----- types -----
+
+    fn ty(&self, out: &mut String, ty: Ty<'_>) {
+        match *ty.kind() {
+            TyKind::Bool => out.push('b'),
+            TyKind::Str => out.push('e'),
+            TyKind::Unit => out.push('u'),
+            TyKind::Bottom => out.push('z'),
+            TyKind::Int(int) => out.push_str(int_code(int)),
+            TyKind::Fp(fp) => out.push_str(fp_code(fp)),
+            TyKind::Nullable(inner) => {
+                // `Nullable<T>` mangles as a synthetic one-segment record applied
+                // to its inner type.
+                self.path_with_args_segs(out, &["Nullable"], &[inner]);
+            }
+            TyKind::Record { def, args, .. } => {
+                // The per-use capability (`flex`) is irrelevant to the ABI.
+                self.path_with_args(out, def, args);
+            }
+            TyKind::Closure { params, ret } => {
+                out.push('F');
+                out.push('K');
+                ident(out, "ReussirClosure");
+                for &param in params {
+                    self.ty(out, param);
+                }
+                out.push('E');
+                self.ty(out, ret);
+            }
+            TyKind::Generic(_) => {
+                panic!("v0 mangle: a generic survived into the Full phase (type is not ground)")
+            }
+            TyKind::Hole(_) => {
+                panic!(
+                    "v0 mangle: an inference hole survived into the Full phase (type is not ground)"
+                )
+            }
+        }
+    }
+}
+
+/// Mangles one identifier segment: ASCII names use a `length + body` prefix with
+/// a `_` separator when the body would otherwise start with a digit or `_`;
+/// non-ASCII names are Punycode-encoded (with `-`→`_`) behind a `u` tag.
+fn ident(out: &mut String, name: &str) {
+    if name.is_ascii() {
+        push_ident_body(out, name, name.chars().count());
+    } else {
+        let punycode = punycode::encode(name).replace('-', "_");
+        out.push('u');
+        push_ident_body(out, &punycode, punycode.len());
+    }
+}
+
+/// Emits `length [_] body`, inserting the disambiguating `_` when `body` leads
+/// with a digit or underscore (the grammar forbids those right after the length).
+fn push_ident_body(out: &mut String, body: &str, len: usize) {
+    out.push_str(&len.to_string());
+    if matches!(body.bytes().next(), Some(b) if b.is_ascii_digit() || b == b'_') {
+        out.push('_');
+    }
+    out.push_str(body);
+}
+
+/// The integral-type code; panics on widths the ABI does not define.
+fn int_code(int: IntTy) -> &'static str {
+    match int {
+        IntTy::Signed(8) => "a",
+        IntTy::Signed(16) => "s",
+        IntTy::Signed(32) => "l",
+        IntTy::Signed(64) => "x",
+        IntTy::Signed(128) => "C4i128",
+        IntTy::Unsigned(8) => "h",
+        IntTy::Unsigned(16) => "t",
+        IntTy::Unsigned(32) => "m",
+        IntTy::Unsigned(64) => "y",
+        IntTy::Unsigned(128) => "C4u128",
+        IntTy::Signed(w) => panic!("v0 mangle: unsupported signed integer width {w}"),
+        IntTy::Unsigned(w) => panic!("v0 mangle: unsupported unsigned integer width {w}"),
+    }
+}
+
+/// The floating-point-type code; panics on widths the ABI does not define.
+fn fp_code(fp: FpTy) -> &'static str {
+    match fp {
+        FpTy::Ieee(16) => "C3f16",
+        FpTy::Ieee(32) => "f",
+        FpTy::Ieee(64) => "d",
+        FpTy::Ieee(128) => "C4f128",
+        FpTy::Ieee(w) => panic!("v0 mangle: unsupported IEEE float width {w}"),
+        FpTy::BFloat16 => "C4bf16",
+        FpTy::Float8 => "C2f8",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::semi::ty::{Capability, TyCtxt};
+    use reussir_syntax::kind::InternKey;
+
+    /// A test resolver: key `i` (1-based) resolves to segment `i - 1`.
+    struct VecResolver(Vec<&'static str>);
+    impl Resolver<TokenKey> for VecResolver {
+        fn try_resolve(&self, key: TokenKey) -> Option<&str> {
+            self.0.get(key.into_u32() as usize - 1).copied()
+        }
+    }
+
+    fn key(n: u32) -> TokenKey {
+        TokenKey::try_from_u32(n).expect("nonzero key")
+    }
+
+    fn ident_of(name: &str) -> String {
+        let mut s = String::new();
+        ident(&mut s, name);
+        s
+    }
+
+    #[test]
+    fn ascii_identifiers() {
+        // Golden vectors ported from the Haskell `Mangle` test suite.
+        assert_eq!(ident_of("foo"), "3foo");
+        assert_eq!(ident_of("bach"), "4bach");
+        assert_eq!(ident_of("123abc"), "6_123abc");
+    }
+
+    #[test]
+    fn unicode_identifier_uses_punycode() {
+        // `gödel` → punycode `gdel-5qa` → `-`→`_` → `gdel_5qa`, length 8.
+        assert_eq!(ident_of("gödel"), "u8gdel_5qa");
+    }
+
+    /// Mangles a bare segment path (no type arguments) for the path tests.
+    /// `path`/`path_with_args_segs` read only their `segments` argument, so a
+    /// mangler over empty tables suffices.
+    fn mangle_segments(segments: &[&str]) -> String {
+        let defs = DefTable::new();
+        let resolver = VecResolver(vec![]);
+        let m = Mangler::new(&defs, &resolver);
+        let mut out = String::from("_R");
+        m.path_with_args_segs(&mut out, segments, &[]);
+        out
+    }
+
+    #[test]
+    fn root_path() {
+        // Golden vectors ported from the Haskell `Mangle` test suite.
+        assert_eq!(mangle_segments(&["example"]), "_RC7example");
+    }
+
+    #[test]
+    fn nested_path() {
+        assert_eq!(
+            mangle_segments(&["mycrate", "example"]),
+            "_RNvC7mycrate7example"
+        );
+    }
+
+    #[test]
+    fn deeply_nested_path() {
+        assert_eq!(
+            mangle_segments(&["a", "example", "exampla"]),
+            "_RNvNvC1a7example7exampla"
+        );
+    }
+
+    #[test]
+    fn scalar_and_compound_type_codes() {
+        crate::with_tcx(|tcx: &TyCtxt<'_>| {
+            let defs = DefTable::new();
+            let resolver = VecResolver(vec![]);
+            let m = Mangler::new(&defs, &resolver);
+            assert_eq!(m.mangle_ty(tcx.mk_bool()), "_Rb");
+            assert_eq!(m.mangle_ty(tcx.mk_str()), "_Re");
+            assert_eq!(m.mangle_ty(tcx.mk_unit()), "_Ru");
+            assert_eq!(m.mangle_ty(tcx.mk_int(IntTy::Signed(32))), "_Rl");
+            assert_eq!(m.mangle_ty(tcx.mk_int(IntTy::Unsigned(64))), "_Ry");
+            assert_eq!(m.mangle_ty(tcx.mk_int(IntTy::Signed(128))), "_RC4i128");
+            assert_eq!(m.mangle_ty(tcx.mk_fp(FpTy::Ieee(32))), "_Rf");
+            assert_eq!(m.mangle_ty(tcx.mk_fp(FpTy::Ieee(64))), "_Rd");
+            // Closure `(i32) -> bool` → `FK14ReussirClosurelEb`.
+            let clos = tcx.mk_closure(&[tcx.mk_int(IntTy::Signed(32))], tcx.mk_bool());
+            assert_eq!(m.mangle_ty(clos), "_RFK14ReussirClosurelEb");
+            // `Nullable<i32>` → `IC8NullablelE`.
+            let nul = tcx.mk_nullable(tcx.mk_int(IntTy::Signed(32)));
+            assert_eq!(m.mangle_ty(nul), "_RIC8NullablelE");
+        });
+    }
+
+    #[test]
+    fn generic_record_application() {
+        crate::with_tcx(|tcx: &TyCtxt<'_>| {
+            let mut defs = DefTable::new();
+            // A flat-module record `Foo` gets the single-segment path `[Foo]`.
+            let foo = defs.declare_record(key(1)).expect("fresh");
+            let resolver = VecResolver(vec!["Foo"]);
+            let m = Mangler::new(&defs, &resolver);
+            // `Foo<i32>` → `IC3FoolE`.
+            let foo_i32 = tcx.mk_record(
+                foo,
+                &[tcx.mk_int(IntTy::Signed(32))],
+                Capability::Irrelevant,
+            );
+            assert_eq!(m.mangle_ty(foo_i32), "_RIC3FoolE");
+            // `Foo` (no args) → `C3Foo`; mangling a function instance is the same.
+            let foo0 = tcx.mk_record(foo, &[], Capability::Irrelevant);
+            assert_eq!(m.mangle_ty(foo0), "_RC3Foo");
+            assert_eq!(m.mangle_instance(foo, &[]), "_RC3Foo");
+        });
+    }
+}

--- a/crates/reussir-core/src/lib.rs
+++ b/crates/reussir-core/src/lib.rs
@@ -4,9 +4,11 @@
 //! the interned type IR ([`semi::ty`]), its unification solver ([`semi::infer`]),
 //! the trait system ([`semi::traits`]), and the bidirectional elaboration of the
 //! surface AST into a typed, still-polymorphic HIR. [`surface`] is the typed,
-//! parser-facing syntax tree. The monomorphized, mangled *Full* representation
-//! (`full::*`) is a separate, future phase.
+//! parser-facing syntax tree. [`full`] is the monomorphized, mangled *Full*
+//! representation that downstream lowering targets; it reuses the Semi type
+//! interner and adds the ground-only invariant and v0 symbol mangling.
 
+pub mod full;
 pub mod semi;
 pub mod surface;
 pub mod utils;

--- a/crates/reussir-core/src/utils/mod.rs
+++ b/crates/reussir-core/src/utils/mod.rs
@@ -1,4 +1,5 @@
 //! Shared utilities for the Reussir core.
 
 pub mod b62;
+pub mod punycode;
 pub mod string;

--- a/crates/reussir-core/src/utils/punycode.rs
+++ b/crates/reussir-core/src/utils/punycode.rs
@@ -9,7 +9,7 @@
 //! The output is the raw Punycode (e.g. `gödel` → `gdel-5qa`); the mangler is
 //! responsible for the `-`→`_` rewrite the symbol grammar wants.
 
-use smallvec::SmallVec;
+use ftree::FenwickTree;
 
 // Bootstring parameters for Punycode (RFC 3492 §5).
 //
@@ -51,21 +51,53 @@ fn adapt(mut delta: u64, num_points: u64, first_time: bool) -> u64 {
     k + (((BASE - TMIN + 1) * delta) / (delta + SKEW))
 }
 
-/// Encodes a string as Punycode (RFC 3492 §6.3).
+/// Emits `delta` as RFC 3492's generalized variable-length integer under the
+/// current `bias`. Shared by the production encoder and the test oracle so the
+/// two serialize deltas identically.
+fn push_delta(output: &mut String, delta: u64, bias: u64) {
+    let mut q = delta;
+    let mut k = BASE;
+    loop {
+        let t = if k <= bias {
+            TMIN
+        } else if k >= bias + TMAX {
+            TMAX
+        } else {
+            k - bias
+        };
+        if q < t {
+            break;
+        }
+        output.push(digit_to_char(t + ((q - t) % (BASE - t))));
+        q = (q - t) / (BASE - t);
+        k += BASE;
+    }
+    output.push(digit_to_char(q));
+}
+
+/// Encodes a string as Punycode (RFC 3492 §6.3) in `O(n log n)`.
 ///
 /// The input may be any Unicode text; the output is the Bootstring encoding,
 /// with the basic (ASCII) code points first, a `-` delimiter when any basic
 /// code point was emitted, and then the encoded non-basic code points.
+///
+/// The textbook encoder is `O(n²)`: for each distinct code-point value it
+/// rescans the whole input twice — a min-find for the next-smallest value, then
+/// a delta pass. We instead drive the outer loop over `(value, position)` pairs
+/// sorted by value, so the min-find is just a linear walk, and replace the delta
+/// pass with a Fenwick tree. The only quantity that pass needs per occurrence is
+/// `C(p, m)` — the number of already-placed code points (value `< m`) lying left
+/// of input position `p`. Visiting values in ascending order, every such code
+/// point is "placed" before the value that needs it, so `C(p, m)` is a Fenwick
+/// prefix-count over positions: `O(log n)` per occurrence. The literal `O(n²)`
+/// transcription is retained as `encode_reference` and fuzzed against this in
+/// the tests.
 pub fn encode(input: &str) -> String {
-    // Decode the input once into a flat buffer: the Bootstring loop re-scans all
-    // code points O(n²) times (a min-find plus a delta pass per distinct value),
-    // so this trades one small, usually-inline allocation for not re-decoding
-    // UTF-8 on every pass. Identifiers are short, so the inline capacity almost
-    // always avoids the heap entirely.
-    let code_points: SmallVec<[u32; 16]> = input.chars().map(|c| c as u32).collect();
+    let code_points: Vec<u32> = input.chars().map(|c| c as u32).collect();
+    let total = code_points.len();
     let mut output = String::new();
 
-    // Emit all basic (ASCII) code points up front, in order.
+    // Basic (ASCII) code points are emitted verbatim, in input order.
     let mut basic_count: u64 = 0;
     for &c in &code_points {
         if u64::from(c) < INITIAL_N {
@@ -80,6 +112,107 @@ pub fn encode(input: &str) -> String {
         output.push('-');
     }
 
+    // The non-basic code points as `(value, input-position)` pairs, sorted so the
+    // Bootstring loop visits values ascending without rescanning for the next
+    // smallest. Equal values keep input-position order — the order in which their
+    // occurrences must be encoded.
+    let mut pairs: Vec<(u32, usize)> = code_points
+        .iter()
+        .enumerate()
+        .filter(|&(_, &c)| u64::from(c) >= INITIAL_N)
+        .map(|(i, &c)| (c, i))
+        .collect();
+    pairs.sort_unstable();
+
+    // Pure-ASCII input has no tail to encode.
+    if pairs.is_empty() {
+        return output;
+    }
+
+    // Fenwick tree over input positions: position `p` holds 1 once its code point
+    // has been "placed" (its value is below the value now being encoded), so
+    // `prefix_sum(p, 0)` counts placed code points strictly left of `p`. Every
+    // basic code point sits below any non-basic value, so all are placed up front.
+    let mut placed = FenwickTree::from_iter(std::iter::repeat_n(0u64, total));
+    for (i, &c) in code_points.iter().enumerate() {
+        if u64::from(c) < INITIAL_N {
+            placed.add_at(i, 1);
+        }
+    }
+
+    let mut n = INITIAL_N;
+    let mut delta: u64 = 0;
+    let mut bias = INITIAL_BIAS;
+    let mut handled = basic_count;
+
+    let mut i = 0;
+    while i < pairs.len() {
+        let m = u64::from(pairs[i].0);
+
+        // Advance `n` to the next present value; each skipped value costs
+        // `handled + 1` decoder states (u64, so it cannot overflow for any valid
+        // Unicode input).
+        delta += (m - n) * (handled + 1);
+        n = m;
+
+        // At the start of the group `handled` is exactly the number of code points
+        // with value `< m` (all lower values are already encoded) — the count the
+        // trailing carry needs.
+        let placed_below_m = handled;
+        let group_start = i;
+        let mut prev_c = 0u64;
+
+        // Encode every occurrence of `m` in input-position order. An occurrence's
+        // delta is the number of placed code points lying between it and the
+        // previous occurrence — a difference of two Fenwick prefix counts.
+        while i < pairs.len() && u64::from(pairs[i].0) == m {
+            let p = pairs[i].1;
+            let c_p = placed.prefix_sum(p, 0);
+            delta += c_p - prev_c;
+            push_delta(&mut output, delta, bias);
+            bias = adapt(delta, handled + 1, handled == basic_count);
+            delta = 0;
+            prev_c = c_p;
+            handled += 1;
+            i += 1;
+        }
+
+        // Carry into the next value: the placed code points to the right of the
+        // last occurrence (`placed_below_m - prev_c`) plus RFC 3492's per-value
+        // increment.
+        delta = (placed_below_m - prev_c) + 1;
+        n += 1;
+
+        // The whole group now counts as placed for every higher value.
+        for &(_, p) in &pairs[group_start..i] {
+            placed.add_at(p, 1);
+        }
+    }
+
+    output
+}
+
+/// The literal `O(n²)` transcription of RFC 3492 §6.3, kept only as a
+/// differential oracle for the optimized [`encode`]. For each distinct value it
+/// rescans the whole input: once to find the next-smallest code point, once to
+/// accumulate deltas. Both encoders share [`push_delta`], so any divergence is a
+/// difference in the delta/bias state machine, not in serialization.
+#[cfg(test)]
+fn encode_reference(input: &str) -> String {
+    let code_points: Vec<u32> = input.chars().map(|c| c as u32).collect();
+    let mut output = String::new();
+
+    let mut basic_count: u64 = 0;
+    for &c in &code_points {
+        if u64::from(c) < INITIAL_N {
+            output.push(c as u8 as char);
+            basic_count += 1;
+        }
+    }
+    if basic_count > 0 {
+        output.push('-');
+    }
+
     let mut n = INITIAL_N;
     let mut delta: u64 = 0;
     let mut bias = INITIAL_BIAS;
@@ -87,50 +220,26 @@ pub fn encode(input: &str) -> String {
     let total = code_points.len() as u64;
 
     while handled < total {
-        // The smallest non-basic code point not yet handled becomes the next `n`.
         let m = code_points
             .iter()
             .map(|&c| u64::from(c))
             .filter(|&c| c >= n)
             .min()
             .expect("handled < total implies an unhandled code point remains");
-
-        // Advancing `n` to `m` costs `(m - n) * (handled + 1)` in delta (u64, so
-        // it cannot overflow for any valid Unicode input).
         delta += (m - n) * (handled + 1);
         n = m;
-
         for &c in &code_points {
             let c = u64::from(c);
             if c < n {
                 delta += 1;
             }
             if c == n {
-                // Represent `delta` as a generalized variable-length integer.
-                let mut q = delta;
-                let mut k = BASE;
-                loop {
-                    let t = if k <= bias {
-                        TMIN
-                    } else if k >= bias + TMAX {
-                        TMAX
-                    } else {
-                        k - bias
-                    };
-                    if q < t {
-                        break;
-                    }
-                    output.push(digit_to_char(t + ((q - t) % (BASE - t))));
-                    q = (q - t) / (BASE - t);
-                    k += BASE;
-                }
-                output.push(digit_to_char(q));
+                push_delta(&mut output, delta, bias);
                 bias = adapt(delta, handled + 1, handled == basic_count);
                 delta = 0;
                 handled += 1;
             }
         }
-
         delta += 1;
         n += 1;
     }
@@ -278,6 +387,56 @@ mod tests {
 
         for &(decoded, encoded) in VECTORS {
             assert_eq!(encode(decoded), encoded, "encoding {decoded:?}");
+        }
+    }
+
+    /// Differential fuzz: the optimized `O(n log n)` [`encode`] must agree with
+    /// the literal `O(n²)` [`encode_reference`] on every input. A deliberately
+    /// small alphabet (frequent repeats, basic/non-basic interleaving, and code
+    /// points above the BMP) stresses the multi-occurrence delta logic far harder
+    /// than uniformly random scalars would.
+    #[test]
+    fn matches_reference_oracle() {
+        const ALPHABET: &[char] = &[
+            'a',
+            'b',
+            'c',
+            'Z',
+            '0',
+            '9',
+            '-',
+            '_',
+            ' ',
+            '\n',
+            '\u{7f}',
+            '\u{80}',
+            '\u{e9}',
+            '\u{fc}',
+            '\u{f6}',
+            '\u{2665}',
+            '\u{4e2d}',
+            '\u{65e5}',
+            '\u{6587}',
+            '\u{1f600}',
+            '\u{1f389}',
+            '\u{10ffff}',
+        ];
+
+        // xorshift64* with a fixed seed: deterministic, no dependency on `rand`.
+        fn next(state: &mut u64) -> u64 {
+            *state ^= *state >> 12;
+            *state ^= *state << 25;
+            *state ^= *state >> 27;
+            state.wrapping_mul(0x2545_f491_4f6c_dd1d)
+        }
+
+        let mut state: u64 = 0x9e37_79b9_7f4a_7c15;
+        for _ in 0..50_000 {
+            let len = (next(&mut state) % 24) as usize;
+            let s: String = (0..len)
+                .map(|_| ALPHABET[(next(&mut state) as usize) % ALPHABET.len()])
+                .collect();
+            assert_eq!(encode(&s), encode_reference(&s), "mismatch for {s:?}");
         }
     }
 }

--- a/crates/reussir-core/src/utils/punycode.rs
+++ b/crates/reussir-core/src/utils/punycode.rs
@@ -9,6 +9,8 @@
 //! The output is the raw Punycode (e.g. `gödel` → `gdel-5qa`); the mangler is
 //! responsible for the `-`→`_` rewrite the symbol grammar wants.
 
+use smallvec::SmallVec;
+
 // Bootstring parameters for Punycode (RFC 3492 §5).
 //
 // The Bootstring arithmetic is done in `u64`. RFC 3492 specifies that an encoder
@@ -55,7 +57,12 @@ fn adapt(mut delta: u64, num_points: u64, first_time: bool) -> u64 {
 /// with the basic (ASCII) code points first, a `-` delimiter when any basic
 /// code point was emitted, and then the encoded non-basic code points.
 pub fn encode(input: &str) -> String {
-    let code_points: Vec<u32> = input.chars().map(|c| c as u32).collect();
+    // Decode the input once into a flat buffer: the Bootstring loop re-scans all
+    // code points O(n²) times (a min-find plus a delta pass per distinct value),
+    // so this trades one small, usually-inline allocation for not re-decoding
+    // UTF-8 on every pass. Identifiers are short, so the inline capacity almost
+    // always avoids the heap entirely.
+    let code_points: SmallVec<[u32; 16]> = input.chars().map(|c| c as u32).collect();
     let mut output = String::new();
 
     // Emit all basic (ASCII) code points up front, in order.
@@ -160,5 +167,117 @@ mod tests {
     fn pure_non_basic_has_no_delimiter() {
         // No basic code points ⇒ no delimiter, just the encoded tail.
         assert_eq!(encode("ü"), "tda");
+    }
+
+    /// Conformance vectors for the Punycode *encoder*: the RFC 3492 §7.1 sample
+    /// strings plus the punycode.js corpus, as curated by the `idna` crate's
+    /// `tests/punycode_tests.json` (MIT). Only the encode direction is exercised
+    /// (we never decode), and every vector is exact-match safe: the basic prefix
+    /// preserves case while our generated tail is always lowercase, so no
+    /// case-folding fixup is needed (unlike the raw RFC vectors, some of which
+    /// use the optional uppercase-flag feature we deliberately do not emit).
+    #[test]
+    fn rfc3492_and_punycodejs_conformance() {
+        const VECTORS: &[(&str, &str)] = &[
+            ("", ""),
+            ("Bach", "Bach-"),
+            ("\u{fc}", "tda"),
+            ("\u{fc}\u{eb}\u{e4}\u{f6}\u{2665}", "4can8av2009b"),
+            ("b\u{fc}cher", "bcher-kva"),
+            (
+                "Willst du die Bl\u{fc}the des fr\u{fc}hen, die Fr\u{fc}chte des sp\u{e4}teren Jahres",
+                "Willst du die Blthe des frhen, die Frchte des spteren Jahres-x9e96lkal",
+            ),
+            // Arabic (Egyptian)
+            (
+                "\u{644}\u{64a}\u{647}\u{645}\u{627}\u{628}\u{62a}\u{643}\u{644}\u{645}\u{648}\u{634}\u{639}\u{631}\u{628}\u{64a}\u{61f}",
+                "egbpdaj6bu4bxfgehfvwxn",
+            ),
+            // Chinese (simplified)
+            (
+                "\u{4ed6}\u{4eec}\u{4e3a}\u{4ec0}\u{4e48}\u{4e0d}\u{8bf4}\u{4e2d}\u{6587}",
+                "ihqwcrb4cv8a8dqg056pqjye",
+            ),
+            // Chinese (traditional)
+            (
+                "\u{4ed6}\u{5011}\u{7232}\u{4ec0}\u{9ebd}\u{4e0d}\u{8aaa}\u{4e2d}\u{6587}",
+                "ihqwctvzc91f659drss3x8bo0yb",
+            ),
+            // Czech
+            (
+                "Pro\u{10d}prost\u{11b}nemluv\u{ed}\u{10d}esky",
+                "Proprostnemluvesky-uyb24dma41a",
+            ),
+            // Hebrew
+            (
+                "\u{5dc}\u{5de}\u{5d4}\u{5d4}\u{5dd}\u{5e4}\u{5e9}\u{5d5}\u{5d8}\u{5dc}\u{5d0}\u{5de}\u{5d3}\u{5d1}\u{5e8}\u{5d9}\u{5dd}\u{5e2}\u{5d1}\u{5e8}\u{5d9}\u{5ea}",
+                "4dbcagdahymbxekheh6e0a7fei0b",
+            ),
+            // Hindi (Devanagari)
+            (
+                "\u{92f}\u{939}\u{932}\u{94b}\u{917}\u{939}\u{93f}\u{928}\u{94d}\u{926}\u{940}\u{915}\u{94d}\u{92f}\u{94b}\u{902}\u{928}\u{939}\u{940}\u{902}\u{92c}\u{94b}\u{932}\u{938}\u{915}\u{924}\u{947}\u{939}\u{948}\u{902}",
+                "i1baa7eci9glrd9b2ae1bj0hfcgg6iyaf8o0a1dig0cd",
+            ),
+            // Japanese (kanji and hiragana)
+            (
+                "\u{306a}\u{305c}\u{307f}\u{3093}\u{306a}\u{65e5}\u{672c}\u{8a9e}\u{3092}\u{8a71}\u{3057}\u{3066}\u{304f}\u{308c}\u{306a}\u{3044}\u{306e}\u{304b}",
+                "n8jok5ay5dzabd5bym9f0cm5685rrjetr6pdxa",
+            ),
+            // Korean (Hangul syllables)
+            (
+                "\u{c138}\u{acc4}\u{c758}\u{baa8}\u{b4e0}\u{c0ac}\u{b78c}\u{b4e4}\u{c774}\u{d55c}\u{ad6d}\u{c5b4}\u{b97c}\u{c774}\u{d574}\u{d55c}\u{b2e4}\u{ba74}\u{c5bc}\u{b9c8}\u{b098}\u{c88b}\u{c744}\u{ae4c}",
+                "989aomsvi5e83db1d2a355cv1e0vak1dwrv93d5xbh15a0dt30a5jpsd879ccm6fea98c",
+            ),
+            // Russian (Cyrillic)
+            (
+                "\u{43f}\u{43e}\u{447}\u{435}\u{43c}\u{443}\u{436}\u{435}\u{43e}\u{43d}\u{438}\u{43d}\u{435}\u{433}\u{43e}\u{432}\u{43e}\u{440}\u{44f}\u{442}\u{43f}\u{43e}\u{440}\u{443}\u{441}\u{441}\u{43a}\u{438}",
+                "b1abfaaepdrnnbgefbadotcwatmq2g4l",
+            ),
+            // Spanish
+            (
+                "Porqu\u{e9}nopuedensimplementehablarenEspa\u{f1}ol",
+                "PorqunopuedensimplementehablarenEspaol-fmd56a",
+            ),
+            // Vietnamese
+            (
+                "T\u{1ea1}isaoh\u{1ecd}kh\u{f4}ngth\u{1ec3}ch\u{1ec9}n\u{f3}iti\u{1ebf}ngVi\u{1ec7}t",
+                "TisaohkhngthchnitingVit-kjcr8268qyxafd2f1b9g",
+            ),
+            // Mixed scripts with embedded ASCII digits / hyphens
+            (
+                "3\u{5e74}B\u{7d44}\u{91d1}\u{516b}\u{5148}\u{751f}",
+                "3B-ww4c5e180e575a65lsy2b",
+            ),
+            (
+                "\u{5b89}\u{5ba4}\u{5948}\u{7f8e}\u{6075}-with-SUPER-MONKEYS",
+                "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n",
+            ),
+            (
+                "Hello-Another-Way-\u{305d}\u{308c}\u{305e}\u{308c}\u{306e}\u{5834}\u{6240}",
+                "Hello-Another-Way--fc4qua05auwb3674vfr0b",
+            ),
+            (
+                "\u{3072}\u{3068}\u{3064}\u{5c4b}\u{6839}\u{306e}\u{4e0b}2",
+                "2-u9tlzr9756bt3uc0v",
+            ),
+            (
+                "Maji\u{3067}Koi\u{3059}\u{308b}5\u{79d2}\u{524d}",
+                "MajiKoi5-783gue6qz075azm5e",
+            ),
+            (
+                "\u{30d1}\u{30d5}\u{30a3}\u{30fc}de\u{30eb}\u{30f3}\u{30d0}",
+                "de-jg4avhby1noc0d",
+            ),
+            (
+                "\u{305d}\u{306e}\u{30b9}\u{30d4}\u{30fc}\u{30c9}\u{3067}",
+                "d9juau41awczczp",
+            ),
+            // Pure ASCII with punctuation: still gets a trailing delimiter.
+            ("-> $1.00 <-", "-> $1.00 <--"),
+        ];
+
+        for &(decoded, encoded) in VECTORS {
+            assert_eq!(encode(decoded), encoded, "encoding {decoded:?}");
+        }
     }
 }

--- a/crates/reussir-core/src/utils/punycode.rs
+++ b/crates/reussir-core/src/utils/punycode.rs
@@ -89,9 +89,7 @@ fn push_delta(output: &mut String, delta: u64, bias: u64) {
 /// `C(p, m)` — the number of already-placed code points (value `< m`) lying left
 /// of input position `p`. Visiting values in ascending order, every such code
 /// point is "placed" before the value that needs it, so `C(p, m)` is a Fenwick
-/// prefix-count over positions: `O(log n)` per occurrence. The literal `O(n²)`
-/// transcription is retained as `encode_reference` and fuzzed against this in
-/// the tests.
+/// prefix-count over positions: `O(log n)` per occurrence.
 pub fn encode(input: &str) -> String {
     let code_points: Vec<u32> = input.chars().map(|c| c as u32).collect();
     let total = code_points.len();
@@ -187,61 +185,6 @@ pub fn encode(input: &str) -> String {
         for &(_, p) in &pairs[group_start..i] {
             placed.add_at(p, 1);
         }
-    }
-
-    output
-}
-
-/// The literal `O(n²)` transcription of RFC 3492 §6.3, kept only as a
-/// differential oracle for the optimized [`encode`]. For each distinct value it
-/// rescans the whole input: once to find the next-smallest code point, once to
-/// accumulate deltas. Both encoders share [`push_delta`], so any divergence is a
-/// difference in the delta/bias state machine, not in serialization.
-#[cfg(test)]
-fn encode_reference(input: &str) -> String {
-    let code_points: Vec<u32> = input.chars().map(|c| c as u32).collect();
-    let mut output = String::new();
-
-    let mut basic_count: u64 = 0;
-    for &c in &code_points {
-        if u64::from(c) < INITIAL_N {
-            output.push(c as u8 as char);
-            basic_count += 1;
-        }
-    }
-    if basic_count > 0 {
-        output.push('-');
-    }
-
-    let mut n = INITIAL_N;
-    let mut delta: u64 = 0;
-    let mut bias = INITIAL_BIAS;
-    let mut handled = basic_count;
-    let total = code_points.len() as u64;
-
-    while handled < total {
-        let m = code_points
-            .iter()
-            .map(|&c| u64::from(c))
-            .filter(|&c| c >= n)
-            .min()
-            .expect("handled < total implies an unhandled code point remains");
-        delta += (m - n) * (handled + 1);
-        n = m;
-        for &c in &code_points {
-            let c = u64::from(c);
-            if c < n {
-                delta += 1;
-            }
-            if c == n {
-                push_delta(&mut output, delta, bias);
-                bias = adapt(delta, handled + 1, handled == basic_count);
-                delta = 0;
-                handled += 1;
-            }
-        }
-        delta += 1;
-        n += 1;
     }
 
     output
@@ -387,56 +330,6 @@ mod tests {
 
         for &(decoded, encoded) in VECTORS {
             assert_eq!(encode(decoded), encoded, "encoding {decoded:?}");
-        }
-    }
-
-    /// Differential fuzz: the optimized `O(n log n)` [`encode`] must agree with
-    /// the literal `O(n²)` [`encode_reference`] on every input. A deliberately
-    /// small alphabet (frequent repeats, basic/non-basic interleaving, and code
-    /// points above the BMP) stresses the multi-occurrence delta logic far harder
-    /// than uniformly random scalars would.
-    #[test]
-    fn matches_reference_oracle() {
-        const ALPHABET: &[char] = &[
-            'a',
-            'b',
-            'c',
-            'Z',
-            '0',
-            '9',
-            '-',
-            '_',
-            ' ',
-            '\n',
-            '\u{7f}',
-            '\u{80}',
-            '\u{e9}',
-            '\u{fc}',
-            '\u{f6}',
-            '\u{2665}',
-            '\u{4e2d}',
-            '\u{65e5}',
-            '\u{6587}',
-            '\u{1f600}',
-            '\u{1f389}',
-            '\u{10ffff}',
-        ];
-
-        // xorshift64* with a fixed seed: deterministic, no dependency on `rand`.
-        fn next(state: &mut u64) -> u64 {
-            *state ^= *state >> 12;
-            *state ^= *state << 25;
-            *state ^= *state >> 27;
-            state.wrapping_mul(0x2545_f491_4f6c_dd1d)
-        }
-
-        let mut state: u64 = 0x9e37_79b9_7f4a_7c15;
-        for _ in 0..50_000 {
-            let len = (next(&mut state) % 24) as usize;
-            let s: String = (0..len)
-                .map(|_| ALPHABET[(next(&mut state) as usize) % ALPHABET.len()])
-                .collect();
-            assert_eq!(encode(&s), encode_reference(&s), "mismatch for {s:?}");
         }
     }
 }

--- a/crates/reussir-core/src/utils/punycode.rs
+++ b/crates/reussir-core/src/utils/punycode.rs
@@ -10,17 +10,25 @@
 //! responsible for the `-`→`_` rewrite the symbol grammar wants.
 
 // Bootstring parameters for Punycode (RFC 3492 §5).
-const BASE: u32 = 36;
-const TMIN: u32 = 1;
-const TMAX: u32 = 26;
-const SKEW: u32 = 38;
-const DAMP: u32 = 700;
-const INITIAL_BIAS: u32 = 72;
-const INITIAL_N: u32 = 128;
+//
+// The Bootstring arithmetic is done in `u64`. RFC 3492 specifies that an encoder
+// must *signal* overflow rather than wrap; the accumulator `delta` can in
+// principle exceed `u32` for a pathologically long non-ASCII string (the term
+// `(m - n) * (handled + 1)` grows with the code-point gap times the length).
+// Widening to `u64` makes overflow unreachable for any valid Unicode input —
+// code points are ≤ 0x10FFFF and lengths are bounded by `usize`, so `delta`
+// stays far below `2^64` — so no explicit overflow check is needed.
+const BASE: u64 = 36;
+const TMIN: u64 = 1;
+const TMAX: u64 = 26;
+const SKEW: u64 = 38;
+const DAMP: u64 = 700;
+const INITIAL_BIAS: u64 = 72;
+const INITIAL_N: u64 = 128;
 
 /// Maps a Bootstring digit (`0..36`) to its ASCII character: `0-25` → `a-z`,
 /// `26-35` → `0-9`.
-fn digit_to_char(d: u32) -> char {
+fn digit_to_char(d: u64) -> char {
     debug_assert!(d < BASE);
     if d < 26 {
         (b'a' + d as u8) as char
@@ -30,7 +38,7 @@ fn digit_to_char(d: u32) -> char {
 }
 
 /// The bias adaptation of RFC 3492 §6.1.
-fn adapt(mut delta: u32, num_points: u32, first_time: bool) -> u32 {
+fn adapt(mut delta: u64, num_points: u64, first_time: bool) -> u64 {
     delta = if first_time { delta / DAMP } else { delta / 2 };
     delta += delta / num_points;
     let mut k = 0;
@@ -51,9 +59,9 @@ pub fn encode(input: &str) -> String {
     let mut output = String::new();
 
     // Emit all basic (ASCII) code points up front, in order.
-    let mut basic_count: u32 = 0;
+    let mut basic_count: u64 = 0;
     for &c in &code_points {
-        if c < INITIAL_N {
+        if u64::from(c) < INITIAL_N {
             output.push(c as u8 as char);
             basic_count += 1;
         }
@@ -66,26 +74,27 @@ pub fn encode(input: &str) -> String {
     }
 
     let mut n = INITIAL_N;
-    let mut delta: u32 = 0;
+    let mut delta: u64 = 0;
     let mut bias = INITIAL_BIAS;
     let mut handled = basic_count;
-    let total = code_points.len() as u32;
+    let total = code_points.len() as u64;
 
     while handled < total {
         // The smallest non-basic code point not yet handled becomes the next `n`.
         let m = code_points
             .iter()
-            .copied()
+            .map(|&c| u64::from(c))
             .filter(|&c| c >= n)
             .min()
             .expect("handled < total implies an unhandled code point remains");
 
-        // Advancing `n` to `m` costs `(m - n) * (handled + 1)` in delta. The
-        // inputs are bounded by valid Unicode, so u32 cannot overflow here.
+        // Advancing `n` to `m` costs `(m - n) * (handled + 1)` in delta (u64, so
+        // it cannot overflow for any valid Unicode input).
         delta += (m - n) * (handled + 1);
         n = m;
 
         for &c in &code_points {
+            let c = u64::from(c);
             if c < n {
                 delta += 1;
             }

--- a/crates/reussir-core/src/utils/punycode.rs
+++ b/crates/reussir-core/src/utils/punycode.rs
@@ -1,0 +1,155 @@
+//! RFC 3492 Punycode encoding of Unicode identifiers.
+//!
+//! The v0 symbol mangling encodes a non-ASCII identifier as its Punycode form
+//! (a `u` tag, a length, then the Bootstring output) so the resulting linker
+//! symbol is pure ASCII. We only ever *encode* (identifiers are mangled, never
+//! demangled here), so this is the Bootstring encoder of RFC 3492 specialized to
+//! Punycode's parameters — no decode path and no host/label splitting.
+//!
+//! The output is the raw Punycode (e.g. `gödel` → `gdel-5qa`); the mangler is
+//! responsible for the `-`→`_` rewrite the symbol grammar wants.
+
+// Bootstring parameters for Punycode (RFC 3492 §5).
+const BASE: u32 = 36;
+const TMIN: u32 = 1;
+const TMAX: u32 = 26;
+const SKEW: u32 = 38;
+const DAMP: u32 = 700;
+const INITIAL_BIAS: u32 = 72;
+const INITIAL_N: u32 = 128;
+
+/// Maps a Bootstring digit (`0..36`) to its ASCII character: `0-25` → `a-z`,
+/// `26-35` → `0-9`.
+fn digit_to_char(d: u32) -> char {
+    debug_assert!(d < BASE);
+    if d < 26 {
+        (b'a' + d as u8) as char
+    } else {
+        (b'0' + (d - 26) as u8) as char
+    }
+}
+
+/// The bias adaptation of RFC 3492 §6.1.
+fn adapt(mut delta: u32, num_points: u32, first_time: bool) -> u32 {
+    delta = if first_time { delta / DAMP } else { delta / 2 };
+    delta += delta / num_points;
+    let mut k = 0;
+    while delta > ((BASE - TMIN) * TMAX) / 2 {
+        delta /= BASE - TMIN;
+        k += BASE;
+    }
+    k + (((BASE - TMIN + 1) * delta) / (delta + SKEW))
+}
+
+/// Encodes a string as Punycode (RFC 3492 §6.3).
+///
+/// The input may be any Unicode text; the output is the Bootstring encoding,
+/// with the basic (ASCII) code points first, a `-` delimiter when any basic
+/// code point was emitted, and then the encoded non-basic code points.
+pub fn encode(input: &str) -> String {
+    let code_points: Vec<u32> = input.chars().map(|c| c as u32).collect();
+    let mut output = String::new();
+
+    // Emit all basic (ASCII) code points up front, in order.
+    let mut basic_count: u32 = 0;
+    for &c in &code_points {
+        if c < INITIAL_N {
+            output.push(c as u8 as char);
+            basic_count += 1;
+        }
+    }
+
+    // The delimiter separates the literal basic prefix from the encoded tail; it
+    // is only present when there is a basic prefix to delimit.
+    if basic_count > 0 {
+        output.push('-');
+    }
+
+    let mut n = INITIAL_N;
+    let mut delta: u32 = 0;
+    let mut bias = INITIAL_BIAS;
+    let mut handled = basic_count;
+    let total = code_points.len() as u32;
+
+    while handled < total {
+        // The smallest non-basic code point not yet handled becomes the next `n`.
+        let m = code_points
+            .iter()
+            .copied()
+            .filter(|&c| c >= n)
+            .min()
+            .expect("handled < total implies an unhandled code point remains");
+
+        // Advancing `n` to `m` costs `(m - n) * (handled + 1)` in delta. The
+        // inputs are bounded by valid Unicode, so u32 cannot overflow here.
+        delta += (m - n) * (handled + 1);
+        n = m;
+
+        for &c in &code_points {
+            if c < n {
+                delta += 1;
+            }
+            if c == n {
+                // Represent `delta` as a generalized variable-length integer.
+                let mut q = delta;
+                let mut k = BASE;
+                loop {
+                    let t = if k <= bias {
+                        TMIN
+                    } else if k >= bias + TMAX {
+                        TMAX
+                    } else {
+                        k - bias
+                    };
+                    if q < t {
+                        break;
+                    }
+                    output.push(digit_to_char(t + ((q - t) % (BASE - t))));
+                    q = (q - t) / (BASE - t);
+                    k += BASE;
+                }
+                output.push(digit_to_char(q));
+                bias = adapt(delta, handled + 1, handled == basic_count);
+                delta = 0;
+                handled += 1;
+            }
+        }
+
+        delta += 1;
+        n += 1;
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3492_vectors() {
+        // The commonly-cited German example: `bücher` → `bcher-kva`.
+        assert_eq!(encode("bücher"), "bcher-kva");
+    }
+
+    #[test]
+    fn mangle_vector() {
+        // The identifier the v0 mangler golden-tests: `gödel` punycodes to
+        // `gdel-5qa` (the mangler then rewrites `-` to `_`).
+        assert_eq!(encode("gödel"), "gdel-5qa");
+    }
+
+    #[test]
+    fn all_basic_has_trailing_delimiter() {
+        // An all-ASCII input is its own basic prefix plus the delimiter; the
+        // mangler never calls this path (it punycodes only non-ASCII names), but
+        // the encoder must still follow the spec.
+        assert_eq!(encode("abc"), "abc-");
+    }
+
+    #[test]
+    fn pure_non_basic_has_no_delimiter() {
+        // No basic code points ⇒ no delimiter, just the encoded tail.
+        assert_eq!(encode("ü"), "tda");
+    }
+}


### PR DESCRIPTION
First PR in a stacked series porting the Reussir compiler frontend's
elaboration→mangle→lower pipeline from Haskell to Rust (so the Haskell frontend
can be removed). Bottom-up stack; each PR targets the previous one.

## This PR — the `full` phase root + v0 mangling

Introduces `reussir_core::full`, the monomorphized **ground** representation that
backend lowering will target, and lands its first self-contained piece: Rust v0
symbol mangling, ported from `Reussir.Core.Semi.Mangle` and matching the same
scheme byte-for-byte.

- `full::mangle::Mangler` mangles ground `Ty`s and item instances into `_R…`
  symbols: nested paths (`C`/`Nv`), `I…E` type-argument application,
  scalar/closure/`Nullable` type codes, and the function-instance form
  (qualified path applied to type arguments). Per-use capability is dropped (ABI-irrelevant).
- `utils::punycode`: RFC 3492 Bootstring encoder for non-ASCII identifiers
  (`gödel` → `u8gdel_5qa`), replacing the Haskell `Data.Text.Punycode` dep.
- Unique ids remain BLAKE3 everywhere (no xxh3).

Golden vectors from the Haskell `Mangle` suite are ported as unit tests.
`cargo test -p reussir-core`: 60 → 71 passing; clippy clean; formatted.

## Stack roadmap (subsequent PRs)
2. `semi → full` monomorphization (instantiation worklist, ground types + mangled names)
3. Perceus-style ownership analysis (early drop / drop-guided reuse; opsem sequent calculus in comments)
4. MLIR lowering (full + ownership → melior Reussir dialect module)
5. CLI drivers (`reussir-elab`, `reussir-compiler`)
6. Repoint lit framework to the Rust binaries; port frontend integration tests
7. ASAN/LSAN sanitizer tests
8. Remove the Haskell frontend (lsp/repl out of scope for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)