### PR TITLE
[frontend] reussir-core: Semi → Full monomorphization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "blake3",
  "ena",
  "ftree",
+ "lasso",
  "rapidhash",
  "reussir-syntax",
  "rustc-hash",

--- a/crates/reussir-core/Cargo.toml
+++ b/crates/reussir-core/Cargo.toml
@@ -12,6 +12,7 @@ name = "reussir_core"
 blake3.workspace = true
 ena.workspace = true
 ftree.workspace = true
+lasso.workspace = true
 rapidhash.workspace = true
 rustc-hash.workspace = true
 smallvec.workspace = true

--- a/crates/reussir-core/src/full.rs
+++ b/crates/reussir-core/src/full.rs
@@ -14,5 +14,6 @@
 //! [`semi`]: crate::semi
 
 pub mod mangle;
+pub mod mir;
 pub mod mono;
 pub mod subst;

--- a/crates/reussir-core/src/full.rs
+++ b/crates/reussir-core/src/full.rs
@@ -14,3 +14,5 @@
 //! [`semi`]: crate::semi
 
 pub mod mangle;
+pub mod mono;
+pub mod subst;

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -1,0 +1,205 @@
+//! The Full *MIR*: the monomorphized, symbol-indexed mid-level IR.
+//!
+//! Where the Semi [`hir`](crate::semi::hir) keeps generics open and dispatches
+//! calls by `(DefId, ty_args)`, the MIR is **fully ground and generics-erased**:
+//! every call names its callee by an interned [`Symbol`] (the v0 mangled name),
+//! no node carries type arguments, and no type contains a `Generic`/`Hole`.
+//! Types survive only as ground [`Ty`] layout data on nodes, never as a dispatch
+//! key. This is the representation the backend lowers from — `call @symbol` is a
+//! direct read — and the one the ownership pass will thread its inc/dec/drop/
+//! reuse operations through.
+//!
+//! The node tree is **arena-allocated and `Copy`**, like the type interner:
+//! children are `&'tcx Expr` and lists are `&'tcx [Expr]` / `&'tcx [u32]`,
+//! allocated through [`TyCtxt::alloc`](crate::semi::ty::TyCtxt::alloc). Produced
+//! by [`crate::full::mono`], which *lowers* the Semi HIR into it (it is not the
+//! HIR with ground types — it is a distinct tree).
+
+use lasso::{Rodeo, Spur};
+use reussir_syntax::kind::TokenKey;
+
+use crate::semi::hir::{ArithOp, CmpOp, VarId};
+use crate::semi::ty::Ty;
+use crate::surface::{Span, Visibility};
+use crate::utils::string::StringToken;
+
+/// An interned linker symbol (a v0 mangled name). `Copy`; resolve it to text via
+/// [`Program::symbol`].
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct Symbol(pub Spur);
+
+/// A path from a scrutinee to a sub-value: a sequence of field indices,
+/// arena-allocated (the MIR counterpart of [`crate::semi::hir::PatVarRef`]).
+pub type Path<'tcx> = &'tcx [u32];
+
+/// The whole monomorphized program: ground functions, the ground record
+/// instances their layouts need, and exported trampolines — all keyed by
+/// [`Symbol`]. The owning [`Rodeo`] resolves those symbols back to text.
+pub struct Program<'tcx> {
+    pub functions: Vec<Function<'tcx>>,
+    pub records: Vec<RecordInstance<'tcx>>,
+    pub trampolines: Vec<Trampoline>,
+    /// Interner backing every [`Symbol`] in this program.
+    pub symbols: Rodeo,
+}
+
+impl<'tcx> Program<'tcx> {
+    /// Resolve an interned symbol to its mangled text.
+    pub fn symbol(&self, sym: Symbol) -> &str {
+        self.symbols.resolve(&sym.0)
+    }
+}
+
+/// A monomorphized function: a ground signature and body under its v0 symbol.
+#[derive(Clone, Debug)]
+pub struct Function<'tcx> {
+    pub symbol: Symbol,
+    pub visibility: Visibility,
+    pub is_regional: bool,
+    pub params: Vec<Param<'tcx>>,
+    pub return_ty: Ty<'tcx>,
+    /// `None` for a declared-but-undefined function.
+    pub body: Option<&'tcx Expr<'tcx>>,
+}
+
+/// A function parameter: source name, local variable, and ground type.
+#[derive(Clone, Copy, Debug)]
+pub struct Param<'tcx> {
+    pub name: TokenKey,
+    pub var: VarId,
+    pub ty: Ty<'tcx>,
+}
+
+/// A ground record instance whose layout the backend must materialize. Keyed by
+/// [`Symbol`]; the ground type carries the fields needed to compute that layout.
+#[derive(Clone, Copy, Debug)]
+pub struct RecordInstance<'tcx> {
+    pub symbol: Symbol,
+    /// The ground record type (`def` + args + capability) for layout.
+    pub ty: Ty<'tcx>,
+}
+
+/// An exported C-ABI trampoline aliasing a concrete function instance.
+#[derive(Clone, Debug)]
+pub struct Trampoline {
+    pub export: Symbol,
+    pub abi: String,
+    pub target: Symbol,
+}
+
+/// A monomorphized expression: a ground type, the structure, and a source span.
+#[derive(Clone, Copy, Debug)]
+pub struct Expr<'tcx> {
+    pub kind: ExprKind<'tcx>,
+    pub ty: Ty<'tcx>,
+    pub span: Option<Span>,
+}
+
+/// The closure form; see [`crate::semi::hir::ClosureExpr`] for the
+/// captures-as-leading-inputs lowering convention, which the MIR preserves.
+#[derive(Clone, Copy, Debug)]
+pub struct ClosureExpr<'tcx> {
+    pub captures: &'tcx [(VarId, Ty<'tcx>)],
+    pub params: &'tcx [(VarId, Ty<'tcx>)],
+    pub body: &'tcx Expr<'tcx>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ExprKind<'tcx> {
+    GlobalStr(StringToken),
+    ConstInt(i128),
+    ConstFloat(f64),
+    ConstBool(bool),
+    Var(VarId),
+    Negate(&'tcx Expr<'tcx>),
+    Not(&'tcx Expr<'tcx>),
+    Arith(&'tcx Expr<'tcx>, ArithOp, &'tcx Expr<'tcx>),
+    Cmp(&'tcx Expr<'tcx>, CmpOp, &'tcx Expr<'tcx>),
+    Cast(&'tcx Expr<'tcx>, Ty<'tcx>),
+    If(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>, &'tcx Expr<'tcx>),
+    /// A `region-run` body; its result has been frozen to a rigid capability.
+    RegionRun(&'tcx Expr<'tcx>),
+    /// A nested field projection (a path of field indices).
+    Proj(&'tcx Expr<'tcx>, Path<'tcx>),
+    /// Assign `src` into field `field` of the flex record `dst`.
+    Assign(&'tcx Expr<'tcx>, u32, &'tcx Expr<'tcx>),
+    Let {
+        var: VarId,
+        name: TokenKey,
+        value: &'tcx Expr<'tcx>,
+    },
+    Seq(&'tcx [Expr<'tcx>]),
+    /// A direct call to a ground function instance, by interned symbol.
+    Call {
+        callee: Symbol,
+        args: &'tcx [Expr<'tcx>],
+        regional: bool,
+    },
+    /// A struct (compound) constructor for a ground record instance.
+    Ctor {
+        record: Symbol,
+        args: &'tcx [Expr<'tcx>],
+    },
+    /// An enum variant constructor for a ground record instance.
+    Variant {
+        record: Symbol,
+        variant: usize,
+        args: &'tcx [Expr<'tcx>],
+    },
+    /// `Nullable::NonNull{e}` (Some) or `Nullable::Null` (None).
+    NullableCall(Option<&'tcx Expr<'tcx>>),
+    Closure(ClosureExpr<'tcx>),
+    ClosureCall {
+        target: &'tcx Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    },
+    Match(&'tcx Expr<'tcx>, DecisionTree<'tcx>),
+    /// Error-recovery placeholder.
+    Poison,
+}
+
+/// A pattern binding: a local variable bound to a scrutinee [`Path`].
+pub type Binding<'tcx> = (VarId, Path<'tcx>);
+
+/// A compiled pattern match, mirroring [`crate::semi::hir::DecisionTree`] but
+/// arena-allocated over MIR expressions.
+#[derive(Clone, Copy, Debug)]
+pub enum DecisionTree<'tcx> {
+    Uncovered,
+    Unreachable,
+    Leaf {
+        body: &'tcx Expr<'tcx>,
+        bindings: &'tcx [Binding<'tcx>],
+    },
+    Guard {
+        bindings: &'tcx [Binding<'tcx>],
+        guard: &'tcx Expr<'tcx>,
+        success: &'tcx DecisionTree<'tcx>,
+        failure: &'tcx DecisionTree<'tcx>,
+    },
+    Switch {
+        scrutinee: Path<'tcx>,
+        cases: SwitchCases<'tcx>,
+    },
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum SwitchCases<'tcx> {
+    Int {
+        cases: &'tcx [(i128, DecisionTree<'tcx>)],
+        default: &'tcx DecisionTree<'tcx>,
+    },
+    Bool {
+        if_true: &'tcx DecisionTree<'tcx>,
+        if_false: &'tcx DecisionTree<'tcx>,
+    },
+    Ctor(&'tcx [DecisionTree<'tcx>]),
+    String {
+        cases: &'tcx [(StringToken, DecisionTree<'tcx>)],
+        default: &'tcx DecisionTree<'tcx>,
+    },
+    Nullable {
+        non_null: &'tcx DecisionTree<'tcx>,
+        null: &'tcx DecisionTree<'tcx>,
+    },
+}

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -156,8 +156,8 @@ pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> (mir::Program<'tcx
         .collect();
 
     // Deterministic output: sort by mangled text.
-    functions.sort_by_cached_key(|f| driver.symbols.resolve(&f.symbol.0).to_string());
-    records.sort_by_cached_key(|r| driver.symbols.resolve(&r.symbol.0).to_string());
+    functions.sort_by_cached_key(|f| driver.symbols.resolve(&f.symbol.0));
+    records.sort_by_cached_key(|r| driver.symbols.resolve(&r.symbol.0));
 
     let Driver {
         symbols, reports, ..

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -1,40 +1,50 @@
-//! Monomorphization: the Semi → Full driver.
+//! Monomorphization: the Semi → Full lowering driver.
 //!
-//! Elaboration leaves functions polymorphic. Monomorphization specializes them:
-//! starting from a set of **roots**, it instantiates each reachable function at
-//! every concrete type-argument tuple it is used with, substitutes the generics
-//! away (see [`crate::full::subst`]), and assigns each instance its v0 symbol
-//! (see [`crate::full::mangle`]). The result is a flat list of ground functions
-//! plus the set of ground record instances their layouts require.
+//! Elaboration leaves functions polymorphic. Monomorphization specializes them
+//! and **lowers** them into the [`crate::full::mir`]: starting from a set of
+//! **roots**, it instantiates each reachable function at every concrete
+//! type-argument tuple it is used with, grounds its types (see
+//! [`crate::full::subst`]), resolves every callee to its v0 [`mir::Symbol`] (see
+//! [`crate::full::mangle`]), and **erases the generic apparatus** — the MIR has
+//! no type arguments on any node and dispatches purely by interned symbol.
 //!
 //! # Roots
 //!
-//! The roots are **every non-generic function** plus **every trampoline target**
-//! (an exported C-ABI alias instantiated at concrete arguments). A non-generic
-//! function is emitted even if nothing calls it — whole-program dead-code
-//! elimination is the backend's job, not the frontend's — which matches the
-//! observable behavior of the existing frontend. Generic functions are emitted
-//! once per distinct instantiation discovered from a reachable body.
+//! Every non-generic function (emitted even if uncalled — whole-program DCE is
+//! the backend's job) plus every trampoline target. Generic functions are
+//! emitted once per distinct instantiation discovered from a reachable body.
 //!
 //! # Worklist
 //!
 //! An [`Instance`] is `(DefId, &[Ty])`; its interned type-argument slice compares
 //! by element pointer-identity, so structurally-equal instantiations collapse to
-//! one worklist entry. We pop an instance, substitute its body to ground form,
-//! then scan that ground body (and signature) for further instances — function
-//! calls seed new function instances; every record type seeds a record instance.
+//! one entry. Popping an instance lowers its body to MIR; each `FuncCall` found
+//! there resolves to a callee symbol *and* enqueues that callee instance, so
+//! discovery and symbol resolution happen in the same pass.
+//!
+//! # Capability re-validation
+//!
+//! Semi leaves generics *uncolored* — a value of generic type has no flex/rigid
+//! capability, so the flex-escape rules are vacuously skipped for it. Once an
+//! instance is ground those capabilities are known, so lowering re-checks them
+//! (flex capture / flex return) and reports any instantiation that lets a flex
+//! value escape its region. This is a **latent** hook today: the elaborator drops
+//! flexivity through generic inference and there is no surface syntax for a flex
+//! type argument, so no instance currently reaches it with a flex generic — it
+//! becomes live once capability-as-a-bound lets flexivity flow into instances.
 
 use std::collections::VecDeque;
 
-use reussir_syntax::kind::TokenKey;
+use lasso::Rodeo;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::full::mangle::Mangler;
-use crate::full::subst::{Subst, subst_expr, subst_ty};
-use crate::semi::ctxt::Elaborator;
-use crate::semi::hir::{DecisionTree, Expr, ExprKind, Function, SwitchCases, VarId};
-use crate::semi::ty::{DefId, Ty, TyCtxt, TyKind};
-use crate::surface::Visibility;
+use crate::full::mir;
+use crate::full::subst::{Subst, subst_ty};
+use crate::semi::ctxt::{Elaborator, Report, Severity};
+use crate::semi::hir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
+use crate::semi::ty::{Capability, DefId, Ty, TyCtxt, TyKind};
+use crate::surface::Span;
 
 /// A ground instantiation of a top-level item: its [`DefId`] applied to an
 /// interned tuple of concrete type arguments (empty for a non-generic item).
@@ -44,54 +54,21 @@ pub struct Instance<'tcx> {
     pub ty_args: &'tcx [Ty<'tcx>],
 }
 
-/// A monomorphized function: a ground signature and body with its v0 symbol.
-#[derive(Clone, Debug)]
-pub struct FullFunction<'tcx> {
-    pub instance: Instance<'tcx>,
-    /// The v0 linker symbol for this instance.
-    pub symbol: String,
-    pub visibility: Visibility,
-    pub is_regional: bool,
-    /// `(source name, variable, ground type)` in declaration order.
-    pub params: Vec<(TokenKey, VarId, Ty<'tcx>)>,
-    pub return_ty: Ty<'tcx>,
-    /// `None` for a declared-but-undefined function.
-    pub body: Option<Expr<'tcx>>,
-}
-
-/// An exported C-ABI trampoline aliasing a concrete function instance.
-#[derive(Clone, Debug)]
-pub struct Trampoline {
-    /// The exported C symbol.
-    pub export: String,
-    /// The C ABI string (e.g. `"C"`).
-    pub abi: String,
-    /// The v0 symbol of the aliased function instance.
-    pub target_symbol: String,
-}
-
-/// The whole monomorphized program: ground functions, the ground record
-/// instances their layouts need, and the exported trampolines. Functions and
-/// record instances are sorted by symbol for deterministic output.
-#[derive(Debug)]
-pub struct FullProgram<'tcx> {
-    pub functions: Vec<FullFunction<'tcx>>,
-    pub records: Vec<Instance<'tcx>>,
-    pub trampolines: Vec<Trampoline>,
-}
-
-/// Monomorphize an elaborated program into its ground Full form.
-pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> FullProgram<'tcx> {
+/// Monomorphize an elaborated program into its ground Full MIR, alongside any
+/// diagnostics raised by capability re-validation.
+pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> (mir::Program<'tcx>, Vec<Report>) {
     let tcx: &'a TyCtxt<'tcx> = elab.tcx;
     let by_def: FxHashMap<DefId, &Function<'tcx>> =
         elab.elaborated.iter().map(|f| (f.def, f)).collect();
-    let mangler = Mangler::new(&elab.defs, elab.resolver);
 
     let mut driver = Driver {
         tcx,
+        mangler: Mangler::new(&elab.defs, elab.resolver),
+        symbols: Rodeo::default(),
         queue: VecDeque::new(),
         seen: FxHashSet::default(),
         records: FxHashSet::default(),
+        reports: Vec::new(),
     };
 
     // Seed roots: every non-generic function, then every trampoline target.
@@ -107,36 +84,36 @@ pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> FullProgram<'tcx> 
     let mut functions = Vec::new();
     while let Some(inst) = driver.queue.pop_front() {
         let Some(func) = by_def.get(&inst.def) else {
-            // No body/prototype recorded (e.g. an item that failed to elaborate);
-            // nothing to instantiate.
+            // No body/prototype recorded (e.g. an item that failed to elaborate).
             continue;
         };
 
-        // Bind this instance's generics, then specialize the signature and body.
+        // Bind this instance's generics, then ground the signature and lower the
+        // body into the MIR.
         let mut subst = Subst::default();
         for ((_, gid), &ty) in func.generics.iter().zip(inst.ty_args.iter()) {
             subst.insert(*gid, ty);
         }
-        let params: Vec<(TokenKey, VarId, Ty<'tcx>)> = func
+        let params: Vec<mir::Param<'tcx>> = func
             .params
             .iter()
-            .map(|(name, var, ty)| (*name, *var, subst_ty(tcx, *ty, &subst)))
+            .map(|(name, var, ty)| {
+                let ty = subst_ty(tcx, *ty, &subst);
+                driver.note_records(ty);
+                mir::Param {
+                    name: *name,
+                    var: *var,
+                    ty,
+                }
+            })
             .collect();
         let return_ty = subst_ty(tcx, func.return_ty, &subst);
-        let body = func.body.as_ref().map(|b| subst_expr(tcx, b, &subst));
+        driver.note_records(return_ty);
+        let body = func.body.as_ref().map(|b| driver.lower_ref(b, &subst));
 
-        // Discover further instances from the ground signature and body.
-        for (_, _, ty) in &params {
-            driver.scan_ty(*ty);
-        }
-        driver.scan_ty(return_ty);
-        if let Some(body) = &body {
-            driver.scan_expr(body);
-        }
-
-        functions.push(FullFunction {
-            instance: inst,
-            symbol: mangler.mangle_instance(inst.def, inst.ty_args),
+        let symbol = driver.symbol_of(inst.def, inst.ty_args);
+        functions.push(mir::Function {
+            symbol,
             visibility: func.visibility,
             is_regional: func.is_regional,
             params,
@@ -145,35 +122,50 @@ pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> FullProgram<'tcx> 
         });
     }
 
-    functions.sort_by(|a, b| a.symbol.cmp(&b.symbol));
-
-    let mut records: Vec<Instance<'tcx>> = driver.records.into_iter().collect();
-    records.sort_by_cached_key(|r| mangler.mangle_instance(r.def, r.ty_args));
-
-    let trampolines = elab
-        .trampolines
-        .iter()
-        .map(|t| Trampoline {
-            export: t.name.clone(),
-            abi: t.abi.clone(),
-            target_symbol: mangler.mangle_instance(t.target, tcx.intern_tys(&t.ty_args)),
+    // Resolve the discovered record instances to symbols. Collect the keys first
+    // so the interner can be borrowed mutably while we map them.
+    let record_keys: Vec<(DefId, &'tcx [Ty<'tcx>])> = driver.records.iter().copied().collect();
+    let mut records: Vec<mir::RecordInstance<'tcx>> = record_keys
+        .into_iter()
+        .map(|(def, args)| mir::RecordInstance {
+            symbol: driver.symbol_of(def, args),
+            // Layout is capability-independent, so canonicalize the coloring.
+            ty: tcx.mk_record(def, args, Capability::Irrelevant),
         })
         .collect();
 
-    FullProgram {
-        functions,
-        records,
-        trampolines,
-    }
+    let trampolines: Vec<mir::Trampoline> = elab
+        .trampolines
+        .iter()
+        .map(|t| mir::Trampoline {
+            export: mir::Symbol(driver.symbols.get_or_intern(&t.name)),
+            abi: t.abi.clone(),
+            target: driver.symbol_of(t.target, tcx.intern_tys(&t.ty_args)),
+        })
+        .collect();
+
+    // Deterministic output: sort by mangled text.
+    functions.sort_by_cached_key(|f| driver.symbols.resolve(&f.symbol.0).to_string());
+    records.sort_by_cached_key(|r| driver.symbols.resolve(&r.symbol.0).to_string());
+
+    let Driver {
+        symbols, reports, ..
+    } = driver;
+    (
+        mir::Program {
+            functions,
+            records,
+            trampolines,
+            symbols,
+        },
+        reports,
+    )
 }
 
 /// The maximum type-argument nesting depth monomorphization will instantiate
 /// before treating the chain as non-terminating — in the spirit of rustc's
 /// `recursion_limit`. Deep but finite generic nesting stays well under it; the
 /// unbounded type growth of polymorphic recursion blows straight past it.
-///
-/// TODO: surface as a proper diagnostic (naming the offending instance) once
-/// mono gains a report sink, instead of panicking.
 const RECURSION_LIMIT: usize = 128;
 
 /// The structural nesting depth of a ground type: `1` for a scalar, one more
@@ -204,17 +196,60 @@ fn ty_depth(ty: Ty<'_>) -> usize {
     }
 }
 
-/// Mutable worklist state shared across the instantiation walk.
+/// Whether `ty`'s head (peeling `Nullable`) is a flex regional record — a value
+/// that cannot be materialized, hence cannot escape its region. Mirrors the Semi
+/// checker's `is_flex`, but on ground types, so it fires for the generic
+/// instantiations the checker could not colour.
+fn is_flex(ty: Ty<'_>) -> bool {
+    match *ty.kind() {
+        TyKind::Record {
+            flex: Capability::Flex,
+            ..
+        } => true,
+        TyKind::Nullable(inner) => is_flex(inner),
+        _ => false,
+    }
+}
+
+/// Mutable worklist + lowering state.
 struct Driver<'a, 'tcx> {
     tcx: &'a TyCtxt<'tcx>,
+    mangler: Mangler<'a>,
+    /// Interner for every mangled symbol; moved into the final `mir::Program`.
+    symbols: Rodeo,
     queue: VecDeque<Instance<'tcx>>,
     /// Function instances already enqueued (so each is emitted once).
     seen: FxHashSet<Instance<'tcx>>,
-    /// Record instances whose layout is needed.
-    records: FxHashSet<Instance<'tcx>>,
+    /// Ground record instances whose layout is needed (keyed flex-independently).
+    records: FxHashSet<(DefId, &'tcx [Ty<'tcx>])>,
+    reports: Vec<Report>,
 }
 
 impl<'a, 'tcx> Driver<'a, 'tcx> {
+    /// Intern a mangled instance symbol (deduping so a callee and its definition
+    /// share one [`mir::Symbol`]).
+    fn symbol_of(&mut self, def: DefId, ty_args: &'tcx [Ty<'tcx>]) -> mir::Symbol {
+        mir::Symbol(
+            self.symbols
+                .get_or_intern(self.mangler.mangle_instance(def, ty_args)),
+        )
+    }
+
+    /// Record a ground record instance (for layout) and return its symbol.
+    fn record_symbol(&mut self, def: DefId, args: &'tcx [Ty<'tcx>]) -> mir::Symbol {
+        self.records.insert((def, args));
+        self.symbol_of(def, args)
+    }
+
+    /// Push an `Error` diagnostic.
+    fn error(&mut self, span: Option<Span>, message: impl Into<String>) {
+        self.reports.push(Report {
+            severity: Severity::Error,
+            message: message.into(),
+            span,
+        });
+    }
+
     /// Enqueue a function instance if it has not been seen.
     fn enqueue(&mut self, def: DefId, ty_args: &'tcx [Ty<'tcx>]) {
         let inst = Instance { def, ty_args };
@@ -235,124 +270,319 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         }
     }
 
-    /// Record a ground record instance and recurse into its arguments.
-    fn record(&mut self, def: DefId, args: &'tcx [Ty<'tcx>]) {
-        self.records.insert(Instance { def, ty_args: args });
-        for &arg in args {
-            self.scan_ty(arg);
-        }
-    }
-
     /// Collect every record instance reachable from a ground type.
-    fn scan_ty(&mut self, ty: Ty<'tcx>) {
+    fn note_records(&mut self, ty: Ty<'tcx>) {
         match *ty.kind() {
-            TyKind::Record { def, args, .. } => self.record(def, args),
+            TyKind::Record { def, args, .. } => {
+                self.records.insert((def, args));
+                for &arg in args {
+                    self.note_records(arg);
+                }
+            }
             TyKind::Closure { params, ret } => {
                 for &p in params {
-                    self.scan_ty(p);
+                    self.note_records(p);
                 }
-                self.scan_ty(ret);
+                self.note_records(ret);
             }
-            TyKind::Nullable(inner) => self.scan_ty(inner),
-            TyKind::Int(_)
-            | TyKind::Fp(_)
-            | TyKind::Bool
-            | TyKind::Str
-            | TyKind::Unit
-            | TyKind::Bottom => {}
-            TyKind::Generic(_) | TyKind::Hole(_) => {
-                panic!("monomorphize: non-ground type {ty:?} reached instance scan")
+            TyKind::Nullable(inner) => self.note_records(inner),
+            _ => {}
+        }
+    }
+
+    /// Ground a slice of type arguments and re-intern it.
+    fn ground_args(&self, ty_args: &[Ty<'tcx>], subst: &Subst<'tcx>) -> &'tcx [Ty<'tcx>] {
+        let grounded: Vec<Ty<'tcx>> = ty_args
+            .iter()
+            .map(|&t| subst_ty(self.tcx, t, subst))
+            .collect();
+        self.tcx.intern_tys(&grounded)
+    }
+
+    /// Lower an expression and arena-allocate it, returning a shared reference.
+    fn lower_ref(&mut self, e: &Expr<'tcx>, subst: &Subst<'tcx>) -> &'tcx mir::Expr<'tcx> {
+        let lowered = self.lower_expr(e, subst);
+        self.tcx.alloc(lowered)
+    }
+
+    /// Lower a list of expressions into an arena slice.
+    fn lower_slice(&mut self, es: &[Expr<'tcx>], subst: &Subst<'tcx>) -> &'tcx [mir::Expr<'tcx>] {
+        let lowered: Vec<mir::Expr<'tcx>> = es.iter().map(|e| self.lower_expr(e, subst)).collect();
+        self.tcx.alloc_slice(&lowered)
+    }
+
+    /// Lower one Semi expression into a ground MIR expression.
+    fn lower_expr(&mut self, e: &Expr<'tcx>, subst: &Subst<'tcx>) -> mir::Expr<'tcx> {
+        let ty = subst_ty(self.tcx, e.ty, subst);
+        self.note_records(ty);
+        let kind = self.lower_kind(&e.kind, subst, e.span);
+        mir::Expr {
+            kind,
+            ty,
+            span: e.span,
+        }
+    }
+
+    fn lower_kind(
+        &mut self,
+        kind: &ExprKind<'tcx>,
+        subst: &Subst<'tcx>,
+        span: Option<Span>,
+    ) -> mir::ExprKind<'tcx> {
+        use mir::ExprKind as M;
+        match kind {
+            ExprKind::GlobalStr(s) => M::GlobalStr(*s),
+            ExprKind::ConstInt(n) => M::ConstInt(*n),
+            ExprKind::ConstFloat(f) => M::ConstFloat(*f),
+            ExprKind::ConstBool(b) => M::ConstBool(*b),
+            ExprKind::Var(v) => M::Var(*v),
+            ExprKind::Poison => M::Poison,
+            ExprKind::Negate(e) => M::Negate(self.lower_ref(e, subst)),
+            ExprKind::Not(e) => M::Not(self.lower_ref(e, subst)),
+            ExprKind::Arith(l, op, r) => {
+                M::Arith(self.lower_ref(l, subst), *op, self.lower_ref(r, subst))
+            }
+            ExprKind::Cmp(l, op, r) => {
+                M::Cmp(self.lower_ref(l, subst), *op, self.lower_ref(r, subst))
+            }
+            ExprKind::Cast(e, t) => {
+                let t = subst_ty(self.tcx, *t, subst);
+                self.note_records(t);
+                M::Cast(self.lower_ref(e, subst), t)
+            }
+            ExprKind::If(c, t, f) => M::If(
+                self.lower_ref(c, subst),
+                self.lower_ref(t, subst),
+                self.lower_ref(f, subst),
+            ),
+            ExprKind::RegionRun(e) => M::RegionRun(self.lower_ref(e, subst)),
+            ExprKind::Proj(e, idx) => {
+                let base = self.lower_ref(e, subst);
+                M::Proj(base, self.tcx.alloc_slice(idx))
+            }
+            ExprKind::Assign(d, i, s) => {
+                M::Assign(self.lower_ref(d, subst), *i, self.lower_ref(s, subst))
+            }
+            ExprKind::Let {
+                var, name, value, ..
+            } => M::Let {
+                var: *var,
+                name: *name,
+                value: self.lower_ref(value, subst),
+            },
+            ExprKind::Seq(es) => M::Seq(self.lower_slice(es, subst)),
+            ExprKind::FuncCall {
+                target,
+                ty_args,
+                args,
+                regional,
+            } => {
+                let ty_args = self.ground_args(ty_args, subst);
+                self.enqueue(*target, ty_args);
+                let callee = self.symbol_of(*target, ty_args);
+                M::Call {
+                    callee,
+                    args: self.lower_slice(args, subst),
+                    regional: *regional,
+                }
+            }
+            ExprKind::CompoundCall {
+                target,
+                ty_args,
+                args,
+            } => {
+                let ty_args = self.ground_args(ty_args, subst);
+                let record = self.record_symbol(*target, ty_args);
+                M::Ctor {
+                    record,
+                    args: self.lower_slice(args, subst),
+                }
+            }
+            ExprKind::VariantCall {
+                target,
+                ty_args,
+                variant,
+                args,
+            } => {
+                let ty_args = self.ground_args(ty_args, subst);
+                let record = self.record_symbol(*target, ty_args);
+                M::Variant {
+                    record,
+                    variant: *variant,
+                    args: self.lower_slice(args, subst),
+                }
+            }
+            ExprKind::NullableCall(opt) => {
+                M::NullableCall(opt.as_ref().map(|e| self.lower_ref(e, subst)))
+            }
+            ExprKind::ClosureCall { target, args } => M::ClosureCall {
+                target: self.lower_ref(target, subst),
+                args: self.lower_slice(args, subst),
+            },
+            ExprKind::Closure(c) => M::Closure(self.lower_closure(c, subst, span)),
+            ExprKind::Match(scrut, tree) => {
+                M::Match(self.lower_ref(scrut, subst), self.lower_tree(tree, subst))
             }
         }
     }
 
-    /// Collect instances from a ground expression: the node's type, any callee
-    /// instance, and recursively all children (including decision-tree arms).
-    fn scan_expr(&mut self, e: &Expr<'tcx>) {
-        use ExprKind::*;
-        self.scan_ty(e.ty);
-        if let FuncCall {
-            target, ty_args, ..
-        } = &e.kind
-        {
-            self.enqueue(*target, self.tcx.intern_tys(ty_args));
-            for &t in ty_args {
-                self.scan_ty(t);
+    fn lower_closure(
+        &mut self,
+        c: &hir::ClosureExpr<'tcx>,
+        subst: &Subst<'tcx>,
+        span: Option<Span>,
+    ) -> mir::ClosureExpr<'tcx> {
+        let captures = self.lower_var_tys(&c.captures, subst);
+        let params = self.lower_var_tys(&c.params, subst);
+        let body = self.lower_ref(&c.body, subst);
+
+        // Capability re-validation: at Semi these values had generic (uncolored)
+        // types, so the flex-escape rules were skipped. Now they are ground, so we
+        // re-run them on the concrete capabilities. NOTE: this is currently a
+        // *latent* hook — the elaborator drops flexivity through generic inference
+        // (`unify` ignores it) and there is no way to spell a flex type argument,
+        // so no instance reaches here with a flex generic *yet*. It fires once
+        // capability-as-a-bound lands and flexivity flows into instantiations.
+        for &(_, ty) in captures {
+            if is_flex(ty) {
+                self.error(
+                    span,
+                    "closure cannot capture a flex value: a flex value cannot escape its region",
+                );
             }
         }
-        for child in children(e) {
-            self.scan_expr(child);
+        if is_flex(body.ty) {
+            self.error(
+                span,
+                "closure cannot return a flex value: a flex value cannot escape its region",
+            );
         }
-        if let Match(_, tree) = &e.kind {
-            self.scan_tree(tree);
+
+        mir::ClosureExpr {
+            captures,
+            params,
+            body,
         }
     }
 
-    /// Collect instances from a decision tree's arm bodies, guards, and subtrees.
-    fn scan_tree(&mut self, tree: &DecisionTree<'tcx>) {
-        use DecisionTree::*;
+    /// Ground a `(var, type)` list (closure captures/params) into an arena slice.
+    fn lower_var_tys(
+        &mut self,
+        vars: &[(hir::VarId, Ty<'tcx>)],
+        subst: &Subst<'tcx>,
+    ) -> &'tcx [(hir::VarId, Ty<'tcx>)] {
+        let grounded: Vec<(hir::VarId, Ty<'tcx>)> = vars
+            .iter()
+            .map(|(v, t)| {
+                let t = subst_ty(self.tcx, *t, subst);
+                self.note_records(t);
+                (*v, t)
+            })
+            .collect();
+        self.tcx.alloc_slice(&grounded)
+    }
+
+    /// Lower a decision tree and arena-allocate it.
+    fn lower_tree_ref(
+        &mut self,
+        tree: &DecisionTree<'tcx>,
+        subst: &Subst<'tcx>,
+    ) -> &'tcx mir::DecisionTree<'tcx> {
+        let lowered = self.lower_tree(tree, subst);
+        self.tcx.alloc(lowered)
+    }
+
+    /// Copy pattern bindings into the arena (each scrutinee path is its own slice).
+    fn lower_bindings(
+        &self,
+        bindings: &[(hir::VarId, hir::PatVarRef)],
+    ) -> &'tcx [mir::Binding<'tcx>] {
+        let copied: Vec<mir::Binding<'tcx>> = bindings
+            .iter()
+            .map(|(var, path)| (*var, self.tcx.alloc_slice(&path.0)))
+            .collect();
+        self.tcx.alloc_slice(&copied)
+    }
+
+    fn lower_tree(
+        &mut self,
+        tree: &DecisionTree<'tcx>,
+        subst: &Subst<'tcx>,
+    ) -> mir::DecisionTree<'tcx> {
+        use mir::DecisionTree as M;
         match tree {
-            Uncovered | Unreachable => {}
-            Leaf { body, .. } => self.scan_expr(body),
-            Guard {
+            DecisionTree::Uncovered => M::Uncovered,
+            DecisionTree::Unreachable => M::Unreachable,
+            DecisionTree::Leaf { body, bindings } => M::Leaf {
+                body: self.lower_ref(body, subst),
+                bindings: self.lower_bindings(bindings),
+            },
+            DecisionTree::Guard {
+                bindings,
                 guard,
                 success,
                 failure,
-                ..
             } => {
-                self.scan_expr(guard);
-                self.scan_tree(success);
-                self.scan_tree(failure);
+                let bindings = self.lower_bindings(bindings);
+                M::Guard {
+                    bindings,
+                    guard: self.lower_ref(guard, subst),
+                    success: self.lower_tree_ref(success, subst),
+                    failure: self.lower_tree_ref(failure, subst),
+                }
             }
-            Switch { cases, .. } => match cases {
-                SwitchCases::Int { cases, default } => {
-                    for (_, t) in cases {
-                        self.scan_tree(t);
-                    }
-                    self.scan_tree(default);
+            DecisionTree::Switch { scrutinee, cases } => {
+                let scrutinee = self.tcx.alloc_slice(&scrutinee.0);
+                M::Switch {
+                    scrutinee,
+                    cases: self.lower_cases(cases, subst),
                 }
-                SwitchCases::Bool { if_true, if_false } => {
-                    self.scan_tree(if_true);
-                    self.scan_tree(if_false);
-                }
-                SwitchCases::Ctor(arms) => {
-                    for t in arms {
-                        self.scan_tree(t);
-                    }
-                }
-                SwitchCases::String { cases, default } => {
-                    for (_, t) in cases {
-                        self.scan_tree(t);
-                    }
-                    self.scan_tree(default);
-                }
-                SwitchCases::Nullable { non_null, null } => {
-                    self.scan_tree(non_null);
-                    self.scan_tree(null);
-                }
-            },
+            }
         }
     }
-}
 
-/// The immediate sub-expressions of `e` (its scrutinee/operands/arguments), used
-/// to drive the instance scan. Decision-tree arms are walked separately.
-fn children<'a, 'tcx>(e: &'a Expr<'tcx>) -> Vec<&'a Expr<'tcx>> {
-    use ExprKind::*;
-    match &e.kind {
-        GlobalStr(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_) | Poison => Vec::new(),
-        Negate(e) | Not(e) | Cast(e, _) | RegionRun(e) | Proj(e, _) => vec![e],
-        Arith(l, _, r) | Cmp(l, _, r) | Assign(l, _, r) => vec![l, r],
-        If(c, t, f) => vec![c, t, f],
-        Let { value, .. } => vec![value],
-        Seq(es) => es.iter().collect(),
-        FuncCall { args, .. } | CompoundCall { args, .. } | VariantCall { args, .. } => {
-            args.iter().collect()
+    /// Lower a list of `(key, sub-tree)` arms into an arena slice.
+    fn lower_keyed<K: Copy>(
+        &mut self,
+        arms: &[(K, DecisionTree<'tcx>)],
+        subst: &Subst<'tcx>,
+    ) -> &'tcx [(K, mir::DecisionTree<'tcx>)] {
+        let lowered: Vec<(K, mir::DecisionTree<'tcx>)> = arms
+            .iter()
+            .map(|(k, t)| (*k, self.lower_tree(t, subst)))
+            .collect();
+        self.tcx.alloc_slice(&lowered)
+    }
+
+    fn lower_cases(
+        &mut self,
+        cases: &SwitchCases<'tcx>,
+        subst: &Subst<'tcx>,
+    ) -> mir::SwitchCases<'tcx> {
+        use mir::SwitchCases as M;
+        match cases {
+            SwitchCases::Int { cases, default } => M::Int {
+                cases: self.lower_keyed(cases, subst),
+                default: self.lower_tree_ref(default, subst),
+            },
+            SwitchCases::Bool { if_true, if_false } => M::Bool {
+                if_true: self.lower_tree_ref(if_true, subst),
+                if_false: self.lower_tree_ref(if_false, subst),
+            },
+            SwitchCases::Ctor(arms) => {
+                let lowered: Vec<mir::DecisionTree<'tcx>> =
+                    arms.iter().map(|t| self.lower_tree(t, subst)).collect();
+                M::Ctor(self.tcx.alloc_slice(&lowered))
+            }
+            SwitchCases::String { cases, default } => M::String {
+                cases: self.lower_keyed(cases, subst),
+                default: self.lower_tree_ref(default, subst),
+            },
+            SwitchCases::Nullable { non_null, null } => M::Nullable {
+                non_null: self.lower_tree_ref(non_null, subst),
+                null: self.lower_tree_ref(null, subst),
+            },
         }
-        NullableCall(e) => e.iter().map(|e| &**e).collect(),
-        ClosureCall { target, args } => std::iter::once(&**target).chain(args.iter()).collect(),
-        Closure(c) => vec![&c.body],
-        Match(scrut, _) => vec![scrut],
     }
 }
 
@@ -362,8 +592,9 @@ mod tests {
     use crate::semi::elaborate;
     use crate::{surface, with_tcx};
 
-    /// Elaborate `source`, monomorphize it, and hand the program to `f`.
-    fn with_full<R>(source: &str, f: impl FnOnce(&FullProgram<'_>) -> R) -> R {
+    /// Elaborate `source`, monomorphize it (asserting no diagnostics), and hand
+    /// the program to `f`.
+    fn with_full<R>(source: &str, f: impl FnOnce(&mir::Program<'_>) -> R) -> R {
         with_tcx(|tcx| {
             let parse = reussir_syntax::parse(source);
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
@@ -374,13 +605,57 @@ mod tests {
                 "elaboration errors: {:#?}",
                 elab.reports
             );
-            let full = monomorphize(&elab);
+            let (full, reports) = monomorphize(&elab);
+            assert!(
+                reports.is_empty(),
+                "unexpected mono diagnostics: {reports:#?}"
+            );
             f(&full)
         })
     }
 
-    fn symbols(full: &FullProgram<'_>) -> Vec<String> {
-        full.functions.iter().map(|f| f.symbol.clone()).collect()
+    fn symbols(full: &mir::Program<'_>) -> Vec<String> {
+        full.functions
+            .iter()
+            .map(|f| full.symbol(f.symbol).to_string())
+            .collect()
+    }
+
+    fn is_ground(ty: Ty<'_>) -> bool {
+        match *ty.kind() {
+            TyKind::Generic(_) | TyKind::Hole(_) => false,
+            TyKind::Record { args, .. } => args.iter().all(|&a| is_ground(a)),
+            TyKind::Closure { params, ret } => {
+                params.iter().all(|&p| is_ground(p)) && is_ground(ret)
+            }
+            TyKind::Nullable(inner) => is_ground(inner),
+            _ => true,
+        }
+    }
+
+    /// The immediate sub-expressions of a MIR node (decision-tree arms aside).
+    fn children<'tcx>(e: &mir::Expr<'tcx>) -> Vec<&'tcx mir::Expr<'tcx>> {
+        use mir::ExprKind::*;
+        match e.kind {
+            GlobalStr(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_) | Poison => vec![],
+            Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],
+            Arith(l, _, r) | Cmp(l, _, r) | Assign(l, _, r) => vec![l, r],
+            If(c, t, f) => vec![c, t, f],
+            Let { value, .. } => vec![value],
+            Seq(es) => es.iter().collect(),
+            Call { args, .. } | Ctor { args, .. } | Variant { args, .. } => args.iter().collect(),
+            NullableCall(opt) => opt.into_iter().collect(),
+            ClosureCall { target, args } => std::iter::once(target).chain(args.iter()).collect(),
+            Closure(c) => vec![c.body],
+            Match(scrut, _) => vec![scrut],
+        }
+    }
+
+    fn assert_ground(e: &mir::Expr<'_>) {
+        assert!(is_ground(e.ty), "non-ground expr type: {:?}", e.ty);
+        for child in children(e) {
+            assert_ground(child);
+        }
     }
 
     #[test]
@@ -399,8 +674,7 @@ mod tests {
 
     #[test]
     fn instantiates_a_generic_at_each_use() {
-        // `id<T>` is generic, so it is emitted once per distinct instantiation
-        // discovered from the (non-generic, hence root) callers.
+        // `id<T>` is emitted once per distinct instantiation; calls are by symbol.
         let src = r#"
             fn id<T>(x: T) -> T { x }
             pub fn use_i32(n: i32) -> i32 { id(n) }
@@ -408,12 +682,10 @@ mod tests {
         "#;
         with_full(src, |full| {
             let syms = symbols(full);
-            // The generic instances mangle with their type argument.
             assert!(syms.contains(&"_RIC2idlE".to_string()), "{syms:?}");
             assert!(syms.contains(&"_RIC2idbE".to_string()), "{syms:?}");
             assert!(syms.contains(&"_RC7use_i32".to_string()), "{syms:?}");
             assert!(syms.contains(&"_RC8use_bool".to_string()), "{syms:?}");
-            // No leftover polymorphic `id` and no duplicate instances.
             let mut sorted = syms.clone();
             sorted.dedup();
             assert_eq!(sorted.len(), syms.len(), "duplicate instances: {syms:?}");
@@ -428,39 +700,94 @@ mod tests {
         "#;
         with_full(src, |full| {
             for func in &full.functions {
-                if let Some(body) = &func.body {
+                if let Some(body) = func.body {
                     assert_ground(body);
                 }
-                for (_, _, ty) in &func.params {
-                    assert!(is_ground(*ty), "non-ground param in {}", func.symbol);
+                for p in &func.params {
+                    assert!(
+                        is_ground(p.ty),
+                        "non-ground param in {}",
+                        full.symbol(func.symbol)
+                    );
                 }
             }
         });
     }
 
-    fn is_ground(ty: Ty<'_>) -> bool {
-        match *ty.kind() {
-            TyKind::Generic(_) | TyKind::Hole(_) => false,
-            TyKind::Record { args, .. } => args.iter().all(|&a| is_ground(a)),
-            TyKind::Closure { params, ret } => {
-                params.iter().all(|&p| is_ground(p)) && is_ground(ret)
-            }
-            TyKind::Nullable(inner) => is_ground(inner),
-            _ => true,
-        }
+    #[test]
+    fn calls_are_resolved_to_callee_symbols() {
+        // The MIR dispatches by interned symbol: the body of `use_i32` calls the
+        // ground `id<i32>` instance directly by its mangled name.
+        let src = r#"
+            fn id<T>(x: T) -> T { x }
+            pub fn use_i32(n: i32) -> i32 { id(n) }
+        "#;
+        with_full(src, |full| {
+            let user = full
+                .functions
+                .iter()
+                .find(|f| full.symbol(f.symbol) == "_RC7use_i32")
+                .expect("use_i32 emitted");
+            let body = user.body.expect("use_i32 has a body");
+            // The body is a `Seq` whose tail expression is the `id(n)` call.
+            let mir::ExprKind::Seq(stmts) = body.kind else {
+                panic!("expected a Seq body, got {:?}", body.kind);
+            };
+            let mir::ExprKind::Call { callee, .. } = stmts.last().expect("non-empty seq").kind
+            else {
+                panic!("expected a Call, got {:?}", stmts.last().unwrap().kind);
+            };
+            assert_eq!(full.symbol(callee), "_RIC2idlE");
+        });
     }
 
-    fn assert_ground(e: &Expr<'_>) {
-        assert!(is_ground(e.ty), "non-ground expr type: {:?}", e.ty);
-        for child in children(e) {
-            assert_ground(child);
-        }
+    #[test]
+    fn multiple_type_params_instantiate_per_ordering() {
+        let src = r#"
+            fn pick<A, B>(a: A, b: B) -> A { a }
+            fn use_ib(n: i32, b: bool) -> i32 { pick(n, b) }
+            fn use_bi(b: bool, n: i32) -> bool { pick(b, n) }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.contains(&"_RIC4picklbE".to_string()), "{syms:?}");
+            assert!(syms.contains(&"_RIC4pickblE".to_string()), "{syms:?}");
+            let picks = syms.iter().filter(|s| s.contains("pick")).count();
+            assert_eq!(picks, 2, "{syms:?}");
+        });
+    }
+
+    #[test]
+    fn permuting_type_params_terminates() {
+        let src = r#"
+            fn swap<A, B>(a: A, b: B) -> i32 { swap(b, a) }
+            fn main(n: i32, b: bool) -> i32 { swap(n, b) }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.contains(&"_RIC4swaplbE".to_string()), "{syms:?}");
+            assert!(syms.contains(&"_RIC4swapblE".to_string()), "{syms:?}");
+            let swaps = syms.iter().filter(|s| s.contains("swap")).count();
+            assert_eq!(swaps, 2, "{syms:?}");
+        });
+    }
+
+    #[test]
+    fn mutual_recursion_at_fixed_type_terminates() {
+        let src = r#"
+            fn ping<T>(x: T) -> i32 { pong(x) }
+            fn pong<T>(x: T) -> i32 { ping(x) }
+            fn main(n: i32) -> i32 { ping(n) }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.contains(&"_RIC4pinglE".to_string()), "{syms:?}");
+            assert!(syms.contains(&"_RIC4ponglE".to_string()), "{syms:?}");
+        });
     }
 
     #[test]
     fn monomorphic_recursion_terminates() {
-        // Self-recursion at a *fixed* type is a single instance — the depth guard
-        // must not mistake ordinary recursion for a runaway.
         let src = r#"
             fn rec(n: i32) -> i32 { rec(n) }
             fn main(n: i32) -> i32 { rec(n) }
@@ -474,10 +801,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "recursion limit")]
     fn detects_polymorphic_recursion() {
-        // `rec<T>` calls itself at `Wrap<T>`, so each instance is one level deeper
-        // than the last: `rec<i32>`, `rec<Wrap<i32>>`, `rec<Wrap<Wrap<i32>>>`, …
-        // This never converges, so mono must abort at the recursion limit instead
-        // of looping forever.
         let src = r#"
             struct Wrap<T> { value: T }
             fn rec<T>(x: T) -> i32 { rec(Wrap { value: x }) }
@@ -487,68 +810,8 @@ mod tests {
     }
 
     #[test]
-    fn multiple_type_params_instantiate_per_ordering() {
-        // `pick<A, B>` is generic in two parameters; the type arguments mangle in
-        // declaration order, so distinct orderings are distinct instances.
-        let src = r#"
-            fn pick<A, B>(a: A, b: B) -> A { a }
-            fn use_ib(n: i32, b: bool) -> i32 { pick(n, b) }
-            fn use_bi(b: bool, n: i32) -> bool { pick(b, n) }
-        "#;
-        with_full(src, |full| {
-            let syms = symbols(full);
-            assert!(syms.contains(&"_RIC4picklbE".to_string()), "{syms:?}"); // pick<i32, bool>
-            assert!(syms.contains(&"_RIC4pickblE".to_string()), "{syms:?}"); // pick<bool, i32>
-            // Exactly two `pick` instances — the two orderings, no duplicates.
-            let picks = syms.iter().filter(|s| s.contains("pick")).count();
-            assert_eq!(picks, 2, "{syms:?}");
-            for func in &full.functions {
-                if let Some(body) = &func.body {
-                    assert_ground(body);
-                }
-            }
-        });
-    }
-
-    #[test]
-    fn permuting_type_params_terminates() {
-        // `swap<A, B>` recurses as `swap<B, A>`: the arguments permute but the
-        // reachable set is finite ({<i32, bool>, <bool, i32>}), so mono converges
-        // without tripping the depth guard.
-        let src = r#"
-            fn swap<A, B>(a: A, b: B) -> i32 { swap(b, a) }
-            fn main(n: i32, b: bool) -> i32 { swap(n, b) }
-        "#;
-        with_full(src, |full| {
-            let syms = symbols(full);
-            assert!(syms.contains(&"_RIC4swaplbE".to_string()), "{syms:?}"); // swap<i32, bool>
-            assert!(syms.contains(&"_RIC4swapblE".to_string()), "{syms:?}"); // swap<bool, i32>
-            let swaps = syms.iter().filter(|s| s.contains("swap")).count();
-            assert_eq!(swaps, 2, "{syms:?}");
-        });
-    }
-
-    #[test]
-    fn mutual_recursion_at_fixed_type_terminates() {
-        // `ping`/`pong` call each other at the *same* type argument, so the cycle
-        // closes after one instance of each.
-        let src = r#"
-            fn ping<T>(x: T) -> i32 { pong(x) }
-            fn pong<T>(x: T) -> i32 { ping(x) }
-            fn main(n: i32) -> i32 { ping(n) }
-        "#;
-        with_full(src, |full| {
-            let syms = symbols(full);
-            assert!(syms.contains(&"_RIC4pinglE".to_string()), "{syms:?}"); // ping<i32>
-            assert!(syms.contains(&"_RIC4ponglE".to_string()), "{syms:?}"); // pong<i32>
-        });
-    }
-
-    #[test]
     #[should_panic(expected = "recursion limit")]
     fn detects_polymorphic_recursion_in_one_of_several_params() {
-        // Only `A` grows; `B` stays fixed. The depth guard takes the max over all
-        // type arguments, so a runaway in any single parameter is still caught.
         let src = r#"
             struct Wrap<T> { value: T }
             fn rec2<A, B>(a: A, b: B) -> i32 { rec2(Wrap { value: a }, b) }
@@ -560,8 +823,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "recursion limit")]
     fn detects_mutual_polymorphic_recursion() {
-        // The growth is split across the cycle: each hop wraps the argument once,
-        // so `ping`/`pong` together drive unbounded instantiation.
         let src = r#"
             struct Wrap<T> { value: T }
             fn ping<T>(x: T) -> i32 { pong(Wrap { value: x }) }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -167,6 +167,43 @@ pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> FullProgram<'tcx> 
     }
 }
 
+/// The maximum type-argument nesting depth monomorphization will instantiate
+/// before treating the chain as non-terminating — in the spirit of rustc's
+/// `recursion_limit`. Deep but finite generic nesting stays well under it; the
+/// unbounded type growth of polymorphic recursion blows straight past it.
+///
+/// TODO: surface as a proper diagnostic (naming the offending instance) once
+/// mono gains a report sink, instead of panicking.
+const RECURSION_LIMIT: usize = 128;
+
+/// The structural nesting depth of a ground type: `1` for a scalar, one more
+/// than its deepest argument for a constructor. Polymorphic recursion grows this
+/// without bound (each `f<T>` → `f<Wrap<T>>` step adds a level), which is what
+/// the recursion-limit guard in [`Driver::enqueue`] watches.
+fn ty_depth(ty: Ty<'_>) -> usize {
+    match *ty.kind() {
+        TyKind::Nullable(inner) => 1 + ty_depth(inner),
+        TyKind::Record { args, .. } => 1 + args.iter().map(|&a| ty_depth(a)).max().unwrap_or(0),
+        TyKind::Closure { params, ret } => {
+            1 + params
+                .iter()
+                .copied()
+                .chain(std::iter::once(ret))
+                .map(ty_depth)
+                .max()
+                .unwrap_or(0)
+        }
+        TyKind::Int(_)
+        | TyKind::Fp(_)
+        | TyKind::Bool
+        | TyKind::Str
+        | TyKind::Unit
+        | TyKind::Bottom
+        | TyKind::Generic(_)
+        | TyKind::Hole(_) => 1,
+    }
+}
+
 /// Mutable worklist state shared across the instantiation walk.
 struct Driver<'a, 'tcx> {
     tcx: &'a TyCtxt<'tcx>,
@@ -182,6 +219,18 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
     fn enqueue(&mut self, def: DefId, ty_args: &'tcx [Ty<'tcx>]) {
         let inst = Instance { def, ty_args };
         if self.seen.insert(inst) {
+            // Bound the queue by type-argument depth. The queue is the only thing
+            // that grows, and polymorphic recursion makes each instance one level
+            // deeper than the last, so an unbounded chain trips this rather than
+            // looping forever. Ground types of depth <= the limit over a finite
+            // set of `DefId`s are a finite set, so this guarantees termination.
+            let depth = ty_args.iter().map(|&t| ty_depth(t)).max().unwrap_or(0);
+            assert!(
+                depth <= RECURSION_LIMIT,
+                "monomorphize: type-argument nesting depth {depth} exceeds the \
+                 recursion limit ({RECURSION_LIMIT}); this is almost certainly \
+                 unbounded instantiation from polymorphic recursion"
+            );
             self.queue.push_back(inst);
         }
     }
@@ -406,5 +455,34 @@ mod tests {
         for child in children(e) {
             assert_ground(child);
         }
+    }
+
+    #[test]
+    fn monomorphic_recursion_terminates() {
+        // Self-recursion at a *fixed* type is a single instance — the depth guard
+        // must not mistake ordinary recursion for a runaway.
+        let src = r#"
+            fn rec(n: i32) -> i32 { rec(n) }
+            fn main(n: i32) -> i32 { rec(n) }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.contains(&"_RC3rec".to_string()), "{syms:?}");
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "recursion limit")]
+    fn detects_polymorphic_recursion() {
+        // `rec<T>` calls itself at `Wrap<T>`, so each instance is one level deeper
+        // than the last: `rec<i32>`, `rec<Wrap<i32>>`, `rec<Wrap<Wrap<i32>>>`, …
+        // This never converges, so mono must abort at the recursion limit instead
+        // of looping forever.
+        let src = r#"
+            struct Wrap<T> { value: T }
+            fn rec<T>(x: T) -> i32 { rec(Wrap { value: x }) }
+            fn main(n: i32) -> i32 { rec(n) }
+        "#;
+        with_full(src, |_| {});
     }
 }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -22,16 +22,16 @@
 //! there resolves to a callee symbol *and* enqueues that callee instance, so
 //! discovery and symbol resolution happen in the same pass.
 //!
-//! # Capability re-validation
+//! # Regional check at the call boundary
 //!
-//! Semi leaves generics *uncolored* — a value of generic type has no flex/rigid
-//! capability, so the flex-escape rules are vacuously skipped for it. Once an
-//! instance is ground those capabilities are known, so lowering re-checks them
-//! (flex capture / flex return) and reports any instantiation that lets a flex
-//! value escape its region. This is a **latent** hook today: the elaborator drops
-//! flexivity through generic inference and there is no surface syntax for a flex
-//! type argument, so no instance currently reaches it with a flex generic — it
-//! becomes live once capability-as-a-bound lets flexivity flow into instances.
+//! A generic used at a `[flex]` position (e.g. `bar: [flex] T`) requires its
+//! instantiating type to be a *regional* record — only regional records can be
+//! flex. The `[flex]` coloring itself is dropped on a bare generic (as in the
+//! reference); the elaborator records the implied requirement in
+//! `Function::regional_generics`, and mono verifies it here when an instance is
+//! popped, reporting any non-regional (value/shared) instantiation. The
+//! *flexivity* rules (flex capture/return/assign) are a separate concern enforced
+//! at the Semi stage on concrete records, not here.
 
 use std::collections::VecDeque;
 
@@ -55,7 +55,7 @@ pub struct Instance<'tcx> {
 }
 
 /// Monomorphize an elaborated program into its ground Full MIR, alongside any
-/// diagnostics raised by capability re-validation.
+/// diagnostics raised by the call-boundary regional check.
 pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> (mir::Program<'tcx>, Vec<Report>) {
     let tcx: &'a TyCtxt<'tcx> = elab.tcx;
     let by_def: FxHashMap<DefId, &Function<'tcx>> =
@@ -93,6 +93,17 @@ pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> (mir::Program<'tcx
         let mut subst = Subst::default();
         for ((_, gid), &ty) in func.generics.iter().zip(inst.ty_args.iter()) {
             subst.insert(*gid, ty);
+            // Call-boundary check: a generic used at a `[flex]` position must be
+            // instantiated with a regional record (only regional records can be
+            // flex). Value/shared records and scalars are rejected.
+            if func.regional_generics.contains(gid) && !is_regional_arg(ty) {
+                driver.error(
+                    func.span,
+                    "a `[flex]` type parameter requires a regional record, but this \
+                     instantiation supplied a non-regional (value/shared) type"
+                        .to_string(),
+                );
+            }
         }
         let params: Vec<mir::Param<'tcx>> = func
             .params
@@ -196,19 +207,14 @@ fn ty_depth(ty: Ty<'_>) -> usize {
     }
 }
 
-/// Whether `ty`'s head (peeling `Nullable`) is a flex regional record — a value
-/// that cannot be materialized, hence cannot escape its region. Mirrors the Semi
-/// checker's `is_flex`, but on ground types, so it fires for the generic
-/// instantiations the checker could not colour.
-fn is_flex(ty: Ty<'_>) -> bool {
-    match *ty.kind() {
-        TyKind::Record {
-            flex: Capability::Flex,
-            ..
-        } => true,
-        TyKind::Nullable(inner) => is_flex(inner),
-        _ => false,
-    }
+/// Whether a ground type argument is a regional record. Only regional records
+/// carry a `Regional`/`Flex`/`Rigid` capability; value/shared records are
+/// `Irrelevant` and scalars carry none.
+fn is_regional_arg(ty: Ty<'_>) -> bool {
+    matches!(
+        ty.capability(),
+        Some(Capability::Regional | Capability::Flex | Capability::Rigid)
+    )
 }
 
 /// Mutable worklist + lowering state.
@@ -315,7 +321,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
     fn lower_expr(&mut self, e: &Expr<'tcx>, subst: &Subst<'tcx>) -> mir::Expr<'tcx> {
         let ty = subst_ty(self.tcx, e.ty, subst);
         self.note_records(ty);
-        let kind = self.lower_kind(&e.kind, subst, e.span);
+        let kind = self.lower_kind(&e.kind, subst);
         mir::Expr {
             kind,
             ty,
@@ -323,12 +329,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         }
     }
 
-    fn lower_kind(
-        &mut self,
-        kind: &ExprKind<'tcx>,
-        subst: &Subst<'tcx>,
-        span: Option<Span>,
-    ) -> mir::ExprKind<'tcx> {
+    fn lower_kind(&mut self, kind: &ExprKind<'tcx>, subst: &Subst<'tcx>) -> mir::ExprKind<'tcx> {
         use mir::ExprKind as M;
         match kind {
             ExprKind::GlobalStr(s) => M::GlobalStr(*s),
@@ -419,7 +420,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 target: self.lower_ref(target, subst),
                 args: self.lower_slice(args, subst),
             },
-            ExprKind::Closure(c) => M::Closure(self.lower_closure(c, subst, span)),
+            ExprKind::Closure(c) => M::Closure(self.lower_closure(c, subst)),
             ExprKind::Match(scrut, tree) => {
                 M::Match(self.lower_ref(scrut, subst), self.lower_tree(tree, subst))
             }
@@ -430,34 +431,14 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         &mut self,
         c: &hir::ClosureExpr<'tcx>,
         subst: &Subst<'tcx>,
-        span: Option<Span>,
     ) -> mir::ClosureExpr<'tcx> {
+        // Flex-escape rules (a flex value may not be captured/returned) are a
+        // *flexivity* concern and are enforced at the Semi stage on concrete
+        // records; monomorphization only verifies the regional requirement at the
+        // call boundary (see the worklist loop).
         let captures = self.lower_var_tys(&c.captures, subst);
         let params = self.lower_var_tys(&c.params, subst);
         let body = self.lower_ref(&c.body, subst);
-
-        // Capability re-validation: at Semi these values had generic (uncolored)
-        // types, so the flex-escape rules were skipped. Now they are ground, so we
-        // re-run them on the concrete capabilities. NOTE: this is currently a
-        // *latent* hook — the elaborator drops flexivity through generic inference
-        // (`unify` ignores it) and there is no way to spell a flex type argument,
-        // so no instance reaches here with a flex generic *yet*. It fires once
-        // capability-as-a-bound lands and flexivity flows into instantiations.
-        for &(_, ty) in captures {
-            if is_flex(ty) {
-                self.error(
-                    span,
-                    "closure cannot capture a flex value: a flex value cannot escape its region",
-                );
-            }
-        }
-        if is_flex(body.ty) {
-            self.error(
-                span,
-                "closure cannot return a flex value: a flex value cannot escape its region",
-            );
-        }
-
         mir::ClosureExpr {
             captures,
             params,
@@ -830,5 +811,50 @@ mod tests {
             fn main(n: i32) -> i32 { ping(n) }
         "#;
         with_full(src, |_| {});
+    }
+
+    #[test]
+    fn flex_generic_accepts_regional_instantiation() {
+        // `foo<T>(bar: [flex] T)` requires T to be regional; instantiating it at a
+        // regional record is accepted (no diagnostic).
+        let src = r#"
+            struct [regional] Cell<T> { v: T, next: [field] Cell<T> }
+            regional fn foo<T>(bar: [flex] T) -> i32 { 0 }
+            regional fn use_ok(c: [flex] Cell<i32>) -> i32 { foo(c) }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.iter().any(|s| s.contains("foo")), "{syms:?}");
+        });
+    }
+
+    #[test]
+    fn flex_generic_rejects_non_regional_instantiation() {
+        // The same `[flex] T` parameter instantiated at a value record is rejected
+        // at the call boundary — only regional records may be flex.
+        let src = r#"
+            struct [regional] Cell<T> { v: T, next: [field] Cell<T> }
+            struct Pair { a: i32 }
+            regional fn foo<T>(bar: [flex] T) -> i32 { 0 }
+            regional fn use_bad(p: Pair) -> i32 { foo(p) }
+        "#;
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(
+                !elab.has_errors(),
+                "elaboration errors: {:#?}",
+                elab.reports
+            );
+            let (_full, reports) = monomorphize(&elab);
+            assert!(
+                reports
+                    .iter()
+                    .any(|r| r.message.contains("regional record")),
+                "expected a regionality diagnostic, got {reports:#?}"
+            );
+        });
     }
 }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -1,0 +1,410 @@
+//! Monomorphization: the Semi → Full driver.
+//!
+//! Elaboration leaves functions polymorphic. Monomorphization specializes them:
+//! starting from a set of **roots**, it instantiates each reachable function at
+//! every concrete type-argument tuple it is used with, substitutes the generics
+//! away (see [`crate::full::subst`]), and assigns each instance its v0 symbol
+//! (see [`crate::full::mangle`]). The result is a flat list of ground functions
+//! plus the set of ground record instances their layouts require.
+//!
+//! # Roots
+//!
+//! The roots are **every non-generic function** plus **every trampoline target**
+//! (an exported C-ABI alias instantiated at concrete arguments). A non-generic
+//! function is emitted even if nothing calls it — whole-program dead-code
+//! elimination is the backend's job, not the frontend's — which matches the
+//! observable behavior of the existing frontend. Generic functions are emitted
+//! once per distinct instantiation discovered from a reachable body.
+//!
+//! # Worklist
+//!
+//! An [`Instance`] is `(DefId, &[Ty])`; its interned type-argument slice compares
+//! by element pointer-identity, so structurally-equal instantiations collapse to
+//! one worklist entry. We pop an instance, substitute its body to ground form,
+//! then scan that ground body (and signature) for further instances — function
+//! calls seed new function instances; every record type seeds a record instance.
+
+use std::collections::VecDeque;
+
+use reussir_syntax::kind::TokenKey;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::full::mangle::Mangler;
+use crate::full::subst::{Subst, subst_expr, subst_ty};
+use crate::semi::ctxt::Elaborator;
+use crate::semi::hir::{DecisionTree, Expr, ExprKind, Function, SwitchCases, VarId};
+use crate::semi::ty::{DefId, Ty, TyCtxt, TyKind};
+use crate::surface::Visibility;
+
+/// A ground instantiation of a top-level item: its [`DefId`] applied to an
+/// interned tuple of concrete type arguments (empty for a non-generic item).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct Instance<'tcx> {
+    pub def: DefId,
+    pub ty_args: &'tcx [Ty<'tcx>],
+}
+
+/// A monomorphized function: a ground signature and body with its v0 symbol.
+#[derive(Clone, Debug)]
+pub struct FullFunction<'tcx> {
+    pub instance: Instance<'tcx>,
+    /// The v0 linker symbol for this instance.
+    pub symbol: String,
+    pub visibility: Visibility,
+    pub is_regional: bool,
+    /// `(source name, variable, ground type)` in declaration order.
+    pub params: Vec<(TokenKey, VarId, Ty<'tcx>)>,
+    pub return_ty: Ty<'tcx>,
+    /// `None` for a declared-but-undefined function.
+    pub body: Option<Expr<'tcx>>,
+}
+
+/// An exported C-ABI trampoline aliasing a concrete function instance.
+#[derive(Clone, Debug)]
+pub struct Trampoline {
+    /// The exported C symbol.
+    pub export: String,
+    /// The C ABI string (e.g. `"C"`).
+    pub abi: String,
+    /// The v0 symbol of the aliased function instance.
+    pub target_symbol: String,
+}
+
+/// The whole monomorphized program: ground functions, the ground record
+/// instances their layouts need, and the exported trampolines. Functions and
+/// record instances are sorted by symbol for deterministic output.
+#[derive(Debug)]
+pub struct FullProgram<'tcx> {
+    pub functions: Vec<FullFunction<'tcx>>,
+    pub records: Vec<Instance<'tcx>>,
+    pub trampolines: Vec<Trampoline>,
+}
+
+/// Monomorphize an elaborated program into its ground Full form.
+pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> FullProgram<'tcx> {
+    let tcx: &'a TyCtxt<'tcx> = elab.tcx;
+    let by_def: FxHashMap<DefId, &Function<'tcx>> =
+        elab.elaborated.iter().map(|f| (f.def, f)).collect();
+    let mangler = Mangler::new(&elab.defs, elab.resolver);
+
+    let mut driver = Driver {
+        tcx,
+        queue: VecDeque::new(),
+        seen: FxHashSet::default(),
+        records: FxHashSet::default(),
+    };
+
+    // Seed roots: every non-generic function, then every trampoline target.
+    for f in &elab.elaborated {
+        if f.generics.is_empty() {
+            driver.enqueue(f.def, tcx.intern_tys(&[]));
+        }
+    }
+    for t in &elab.trampolines {
+        driver.enqueue(t.target, tcx.intern_tys(&t.ty_args));
+    }
+
+    let mut functions = Vec::new();
+    while let Some(inst) = driver.queue.pop_front() {
+        let Some(func) = by_def.get(&inst.def) else {
+            // No body/prototype recorded (e.g. an item that failed to elaborate);
+            // nothing to instantiate.
+            continue;
+        };
+
+        // Bind this instance's generics, then specialize the signature and body.
+        let mut subst = Subst::default();
+        for ((_, gid), &ty) in func.generics.iter().zip(inst.ty_args.iter()) {
+            subst.insert(*gid, ty);
+        }
+        let params: Vec<(TokenKey, VarId, Ty<'tcx>)> = func
+            .params
+            .iter()
+            .map(|(name, var, ty)| (*name, *var, subst_ty(tcx, *ty, &subst)))
+            .collect();
+        let return_ty = subst_ty(tcx, func.return_ty, &subst);
+        let body = func.body.as_ref().map(|b| subst_expr(tcx, b, &subst));
+
+        // Discover further instances from the ground signature and body.
+        for (_, _, ty) in &params {
+            driver.scan_ty(*ty);
+        }
+        driver.scan_ty(return_ty);
+        if let Some(body) = &body {
+            driver.scan_expr(body);
+        }
+
+        functions.push(FullFunction {
+            instance: inst,
+            symbol: mangler.mangle_instance(inst.def, inst.ty_args),
+            visibility: func.visibility,
+            is_regional: func.is_regional,
+            params,
+            return_ty,
+            body,
+        });
+    }
+
+    functions.sort_by(|a, b| a.symbol.cmp(&b.symbol));
+
+    let mut records: Vec<Instance<'tcx>> = driver.records.into_iter().collect();
+    records.sort_by_cached_key(|r| mangler.mangle_instance(r.def, r.ty_args));
+
+    let trampolines = elab
+        .trampolines
+        .iter()
+        .map(|t| Trampoline {
+            export: t.name.clone(),
+            abi: t.abi.clone(),
+            target_symbol: mangler.mangle_instance(t.target, tcx.intern_tys(&t.ty_args)),
+        })
+        .collect();
+
+    FullProgram {
+        functions,
+        records,
+        trampolines,
+    }
+}
+
+/// Mutable worklist state shared across the instantiation walk.
+struct Driver<'a, 'tcx> {
+    tcx: &'a TyCtxt<'tcx>,
+    queue: VecDeque<Instance<'tcx>>,
+    /// Function instances already enqueued (so each is emitted once).
+    seen: FxHashSet<Instance<'tcx>>,
+    /// Record instances whose layout is needed.
+    records: FxHashSet<Instance<'tcx>>,
+}
+
+impl<'a, 'tcx> Driver<'a, 'tcx> {
+    /// Enqueue a function instance if it has not been seen.
+    fn enqueue(&mut self, def: DefId, ty_args: &'tcx [Ty<'tcx>]) {
+        let inst = Instance { def, ty_args };
+        if self.seen.insert(inst) {
+            self.queue.push_back(inst);
+        }
+    }
+
+    /// Record a ground record instance and recurse into its arguments.
+    fn record(&mut self, def: DefId, args: &'tcx [Ty<'tcx>]) {
+        self.records.insert(Instance { def, ty_args: args });
+        for &arg in args {
+            self.scan_ty(arg);
+        }
+    }
+
+    /// Collect every record instance reachable from a ground type.
+    fn scan_ty(&mut self, ty: Ty<'tcx>) {
+        match *ty.kind() {
+            TyKind::Record { def, args, .. } => self.record(def, args),
+            TyKind::Closure { params, ret } => {
+                for &p in params {
+                    self.scan_ty(p);
+                }
+                self.scan_ty(ret);
+            }
+            TyKind::Nullable(inner) => self.scan_ty(inner),
+            TyKind::Int(_)
+            | TyKind::Fp(_)
+            | TyKind::Bool
+            | TyKind::Str
+            | TyKind::Unit
+            | TyKind::Bottom => {}
+            TyKind::Generic(_) | TyKind::Hole(_) => {
+                panic!("monomorphize: non-ground type {ty:?} reached instance scan")
+            }
+        }
+    }
+
+    /// Collect instances from a ground expression: the node's type, any callee
+    /// instance, and recursively all children (including decision-tree arms).
+    fn scan_expr(&mut self, e: &Expr<'tcx>) {
+        use ExprKind::*;
+        self.scan_ty(e.ty);
+        if let FuncCall {
+            target, ty_args, ..
+        } = &e.kind
+        {
+            self.enqueue(*target, self.tcx.intern_tys(ty_args));
+            for &t in ty_args {
+                self.scan_ty(t);
+            }
+        }
+        for child in children(e) {
+            self.scan_expr(child);
+        }
+        if let Match(_, tree) = &e.kind {
+            self.scan_tree(tree);
+        }
+    }
+
+    /// Collect instances from a decision tree's arm bodies, guards, and subtrees.
+    fn scan_tree(&mut self, tree: &DecisionTree<'tcx>) {
+        use DecisionTree::*;
+        match tree {
+            Uncovered | Unreachable => {}
+            Leaf { body, .. } => self.scan_expr(body),
+            Guard {
+                guard,
+                success,
+                failure,
+                ..
+            } => {
+                self.scan_expr(guard);
+                self.scan_tree(success);
+                self.scan_tree(failure);
+            }
+            Switch { cases, .. } => match cases {
+                SwitchCases::Int { cases, default } => {
+                    for (_, t) in cases {
+                        self.scan_tree(t);
+                    }
+                    self.scan_tree(default);
+                }
+                SwitchCases::Bool { if_true, if_false } => {
+                    self.scan_tree(if_true);
+                    self.scan_tree(if_false);
+                }
+                SwitchCases::Ctor(arms) => {
+                    for t in arms {
+                        self.scan_tree(t);
+                    }
+                }
+                SwitchCases::String { cases, default } => {
+                    for (_, t) in cases {
+                        self.scan_tree(t);
+                    }
+                    self.scan_tree(default);
+                }
+                SwitchCases::Nullable { non_null, null } => {
+                    self.scan_tree(non_null);
+                    self.scan_tree(null);
+                }
+            },
+        }
+    }
+}
+
+/// The immediate sub-expressions of `e` (its scrutinee/operands/arguments), used
+/// to drive the instance scan. Decision-tree arms are walked separately.
+fn children<'a, 'tcx>(e: &'a Expr<'tcx>) -> Vec<&'a Expr<'tcx>> {
+    use ExprKind::*;
+    match &e.kind {
+        GlobalStr(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_) | Poison => Vec::new(),
+        Negate(e) | Not(e) | Cast(e, _) | RegionRun(e) | Proj(e, _) => vec![e],
+        Arith(l, _, r) | Cmp(l, _, r) | Assign(l, _, r) => vec![l, r],
+        If(c, t, f) => vec![c, t, f],
+        Let { value, .. } => vec![value],
+        Seq(es) => es.iter().collect(),
+        FuncCall { args, .. } | CompoundCall { args, .. } | VariantCall { args, .. } => {
+            args.iter().collect()
+        }
+        NullableCall(e) => e.iter().map(|e| &**e).collect(),
+        ClosureCall { target, args } => std::iter::once(&**target).chain(args.iter()).collect(),
+        Closure(c) => vec![&c.body],
+        Match(scrut, _) => vec![scrut],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::semi::elaborate;
+    use crate::{surface, with_tcx};
+
+    /// Elaborate `source`, monomorphize it, and hand the program to `f`.
+    fn with_full<R>(source: &str, f: impl FnOnce(&FullProgram<'_>) -> R) -> R {
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(
+                !elab.has_errors(),
+                "elaboration errors: {:#?}",
+                elab.reports
+            );
+            let full = monomorphize(&elab);
+            f(&full)
+        })
+    }
+
+    fn symbols(full: &FullProgram<'_>) -> Vec<String> {
+        full.functions.iter().map(|f| f.symbol.clone()).collect()
+    }
+
+    #[test]
+    fn emits_every_non_generic_function_even_if_uncalled() {
+        // `never_called` is dead, yet still emitted (DCE is the backend's job).
+        let src = r#"
+            pub fn used(n: i32) -> i32 { n }
+            fn never_called(n: i32) -> i32 { n }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.contains(&"_RC4used".to_string()), "{syms:?}");
+            assert!(syms.contains(&"_RC12never_called".to_string()), "{syms:?}");
+        });
+    }
+
+    #[test]
+    fn instantiates_a_generic_at_each_use() {
+        // `id<T>` is generic, so it is emitted once per distinct instantiation
+        // discovered from the (non-generic, hence root) callers.
+        let src = r#"
+            fn id<T>(x: T) -> T { x }
+            pub fn use_i32(n: i32) -> i32 { id(n) }
+            pub fn use_bool(b: bool) -> bool { id(b) }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            // The generic instances mangle with their type argument.
+            assert!(syms.contains(&"_RIC2idlE".to_string()), "{syms:?}");
+            assert!(syms.contains(&"_RIC2idbE".to_string()), "{syms:?}");
+            assert!(syms.contains(&"_RC7use_i32".to_string()), "{syms:?}");
+            assert!(syms.contains(&"_RC8use_bool".to_string()), "{syms:?}");
+            // No leftover polymorphic `id` and no duplicate instances.
+            let mut sorted = syms.clone();
+            sorted.dedup();
+            assert_eq!(sorted.len(), syms.len(), "duplicate instances: {syms:?}");
+        });
+    }
+
+    #[test]
+    fn bodies_are_ground_after_monomorphization() {
+        let src = r#"
+            fn id<T>(x: T) -> T { x }
+            pub fn use_i32(n: i32) -> i32 { id(n) }
+        "#;
+        with_full(src, |full| {
+            for func in &full.functions {
+                if let Some(body) = &func.body {
+                    assert_ground(body);
+                }
+                for (_, _, ty) in &func.params {
+                    assert!(is_ground(*ty), "non-ground param in {}", func.symbol);
+                }
+            }
+        });
+    }
+
+    fn is_ground(ty: Ty<'_>) -> bool {
+        match *ty.kind() {
+            TyKind::Generic(_) | TyKind::Hole(_) => false,
+            TyKind::Record { args, .. } => args.iter().all(|&a| is_ground(a)),
+            TyKind::Closure { params, ret } => {
+                params.iter().all(|&p| is_ground(p)) && is_ground(ret)
+            }
+            TyKind::Nullable(inner) => is_ground(inner),
+            _ => true,
+        }
+    }
+
+    fn assert_ground(e: &Expr<'_>) {
+        assert!(is_ground(e.ty), "non-ground expr type: {:?}", e.ty);
+        for child in children(e) {
+            assert_ground(child);
+        }
+    }
+}

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -485,4 +485,89 @@ mod tests {
         "#;
         with_full(src, |_| {});
     }
+
+    #[test]
+    fn multiple_type_params_instantiate_per_ordering() {
+        // `pick<A, B>` is generic in two parameters; the type arguments mangle in
+        // declaration order, so distinct orderings are distinct instances.
+        let src = r#"
+            fn pick<A, B>(a: A, b: B) -> A { a }
+            fn use_ib(n: i32, b: bool) -> i32 { pick(n, b) }
+            fn use_bi(b: bool, n: i32) -> bool { pick(b, n) }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.contains(&"_RIC4picklbE".to_string()), "{syms:?}"); // pick<i32, bool>
+            assert!(syms.contains(&"_RIC4pickblE".to_string()), "{syms:?}"); // pick<bool, i32>
+            // Exactly two `pick` instances — the two orderings, no duplicates.
+            let picks = syms.iter().filter(|s| s.contains("pick")).count();
+            assert_eq!(picks, 2, "{syms:?}");
+            for func in &full.functions {
+                if let Some(body) = &func.body {
+                    assert_ground(body);
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn permuting_type_params_terminates() {
+        // `swap<A, B>` recurses as `swap<B, A>`: the arguments permute but the
+        // reachable set is finite ({<i32, bool>, <bool, i32>}), so mono converges
+        // without tripping the depth guard.
+        let src = r#"
+            fn swap<A, B>(a: A, b: B) -> i32 { swap(b, a) }
+            fn main(n: i32, b: bool) -> i32 { swap(n, b) }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.contains(&"_RIC4swaplbE".to_string()), "{syms:?}"); // swap<i32, bool>
+            assert!(syms.contains(&"_RIC4swapblE".to_string()), "{syms:?}"); // swap<bool, i32>
+            let swaps = syms.iter().filter(|s| s.contains("swap")).count();
+            assert_eq!(swaps, 2, "{syms:?}");
+        });
+    }
+
+    #[test]
+    fn mutual_recursion_at_fixed_type_terminates() {
+        // `ping`/`pong` call each other at the *same* type argument, so the cycle
+        // closes after one instance of each.
+        let src = r#"
+            fn ping<T>(x: T) -> i32 { pong(x) }
+            fn pong<T>(x: T) -> i32 { ping(x) }
+            fn main(n: i32) -> i32 { ping(n) }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.contains(&"_RIC4pinglE".to_string()), "{syms:?}"); // ping<i32>
+            assert!(syms.contains(&"_RIC4ponglE".to_string()), "{syms:?}"); // pong<i32>
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "recursion limit")]
+    fn detects_polymorphic_recursion_in_one_of_several_params() {
+        // Only `A` grows; `B` stays fixed. The depth guard takes the max over all
+        // type arguments, so a runaway in any single parameter is still caught.
+        let src = r#"
+            struct Wrap<T> { value: T }
+            fn rec2<A, B>(a: A, b: B) -> i32 { rec2(Wrap { value: a }, b) }
+            fn main(n: i32, b: bool) -> i32 { rec2(n, b) }
+        "#;
+        with_full(src, |_| {});
+    }
+
+    #[test]
+    #[should_panic(expected = "recursion limit")]
+    fn detects_mutual_polymorphic_recursion() {
+        // The growth is split across the cycle: each hop wraps the argument once,
+        // so `ping`/`pong` together drive unbounded instantiation.
+        let src = r#"
+            struct Wrap<T> { value: T }
+            fn ping<T>(x: T) -> i32 { pong(Wrap { value: x }) }
+            fn pong<T>(x: T) -> i32 { ping(Wrap { value: x }) }
+            fn main(n: i32) -> i32 { ping(n) }
+        "#;
+        with_full(src, |_| {});
+    }
 }

--- a/crates/reussir-core/src/full/subst.rs
+++ b/crates/reussir-core/src/full/subst.rs
@@ -1,0 +1,216 @@
+//! Type substitution: instantiate a Semi HIR tree at a ground type assignment.
+//!
+//! Monomorphization specializes a polymorphic function by mapping each of its
+//! generic parameters ([`GenericId`]) to a concrete type and rewriting every
+//! type in the body accordingly. Because Full types *are* Semi [`Ty`]s (just
+//! ground), substitution re-interns through the same [`TyCtxt`], so the result
+//! keeps pointer-identity equality and feeds straight into mangling and
+//! lowering.
+//!
+//! The expression walk mirrors [`crate::semi::check`]'s zonking walk one-for-one
+//! — same structure, but resolving against a generic→type map instead of the
+//! inference table.
+
+use rustc_hash::FxHashMap;
+
+use crate::semi::hir::{ClosureExpr, DecisionTree, Expr, ExprKind, SwitchCases};
+use crate::semi::ty::{GenericId, Ty, TyCtxt, TyKind};
+
+/// A ground assignment for a function's generic parameters.
+pub type Subst<'tcx> = FxHashMap<GenericId, Ty<'tcx>>;
+
+/// Substitute generics in a type, re-interning into `tcx`. An empty `subst`
+/// short-circuits (the type is already ground).
+pub fn subst_ty<'tcx>(tcx: &TyCtxt<'tcx>, ty: Ty<'tcx>, subst: &Subst<'tcx>) -> Ty<'tcx> {
+    if subst.is_empty() {
+        return ty;
+    }
+    match *ty.kind() {
+        TyKind::Generic(id) => *subst
+            .get(&id)
+            .unwrap_or_else(|| panic!("subst: generic {id:?} is not bound by this instance")),
+        TyKind::Record { def, args, flex } => {
+            let args: Vec<Ty<'tcx>> = args.iter().map(|&a| subst_ty(tcx, a, subst)).collect();
+            tcx.mk_record(def, &args, flex)
+        }
+        TyKind::Closure { params, ret } => {
+            let params: Vec<Ty<'tcx>> = params.iter().map(|&p| subst_ty(tcx, p, subst)).collect();
+            tcx.mk_closure(&params, subst_ty(tcx, ret, subst))
+        }
+        TyKind::Nullable(inner) => tcx.mk_nullable(subst_ty(tcx, inner, subst)),
+        TyKind::Int(_)
+        | TyKind::Fp(_)
+        | TyKind::Bool
+        | TyKind::Str
+        | TyKind::Unit
+        | TyKind::Bottom => ty,
+        TyKind::Hole(_) => panic!("subst: an inference hole survived zonking"),
+    }
+}
+
+/// Substitute generics throughout an expression tree.
+pub fn subst_expr<'tcx>(tcx: &TyCtxt<'tcx>, e: &Expr<'tcx>, subst: &Subst<'tcx>) -> Expr<'tcx> {
+    Expr {
+        kind: subst_kind(tcx, &e.kind, subst),
+        ty: subst_ty(tcx, e.ty, subst),
+        span: e.span,
+        id: e.id,
+    }
+}
+
+fn subst_kind<'tcx>(
+    tcx: &TyCtxt<'tcx>,
+    kind: &ExprKind<'tcx>,
+    subst: &Subst<'tcx>,
+) -> ExprKind<'tcx> {
+    use ExprKind::*;
+    let sb = |e: &Expr<'tcx>| Box::new(subst_expr(tcx, e, subst));
+    let sv = |es: &[Expr<'tcx>]| es.iter().map(|e| subst_expr(tcx, e, subst)).collect();
+    match kind {
+        // Leaves: nothing to substitute.
+        GlobalStr(s) => GlobalStr(*s),
+        ConstInt(n) => ConstInt(*n),
+        ConstFloat(f) => ConstFloat(*f),
+        ConstBool(b) => ConstBool(*b),
+        Var(v) => Var(*v),
+        Poison => Poison,
+
+        Negate(e) => Negate(sb(e)),
+        Not(e) => Not(sb(e)),
+        Arith(l, op, r) => Arith(sb(l), *op, sb(r)),
+        Cmp(l, op, r) => Cmp(sb(l), *op, sb(r)),
+        Cast(e, t) => Cast(sb(e), subst_ty(tcx, *t, subst)),
+        If(c, t, f) => If(sb(c), sb(t), sb(f)),
+        RegionRun(e) => RegionRun(sb(e)),
+        Proj(e, idx) => Proj(sb(e), idx.clone()),
+        Assign(d, i, s) => Assign(sb(d), *i, sb(s)),
+        Let {
+            var,
+            name,
+            span,
+            value,
+        } => Let {
+            var: *var,
+            name: *name,
+            span: *span,
+            value: sb(value),
+        },
+        Seq(es) => Seq(sv(es)),
+        FuncCall {
+            target,
+            ty_args,
+            args,
+            regional,
+        } => FuncCall {
+            target: *target,
+            ty_args: ty_args.iter().map(|&t| subst_ty(tcx, t, subst)).collect(),
+            args: sv(args),
+            regional: *regional,
+        },
+        CompoundCall {
+            target,
+            ty_args,
+            args,
+        } => CompoundCall {
+            target: *target,
+            ty_args: ty_args.iter().map(|&t| subst_ty(tcx, t, subst)).collect(),
+            args: sv(args),
+        },
+        VariantCall {
+            target,
+            ty_args,
+            variant,
+            args,
+        } => VariantCall {
+            target: *target,
+            ty_args: ty_args.iter().map(|&t| subst_ty(tcx, t, subst)).collect(),
+            variant: *variant,
+            args: sv(args),
+        },
+        NullableCall(e) => NullableCall(e.as_ref().map(|e| sb(e))),
+        ClosureCall { target, args } => ClosureCall {
+            target: sb(target),
+            args: sv(args),
+        },
+        Closure(c) => Closure(ClosureExpr {
+            captures: c
+                .captures
+                .iter()
+                .map(|(v, t)| (*v, subst_ty(tcx, *t, subst)))
+                .collect(),
+            params: c
+                .params
+                .iter()
+                .map(|(v, t)| (*v, subst_ty(tcx, *t, subst)))
+                .collect(),
+            body: sb(&c.body),
+        }),
+        Match(scrut, tree) => Match(sb(scrut), subst_tree(tcx, tree, subst)),
+    }
+}
+
+/// Substitute generics throughout a compiled decision tree.
+fn subst_tree<'tcx>(
+    tcx: &TyCtxt<'tcx>,
+    tree: &DecisionTree<'tcx>,
+    subst: &Subst<'tcx>,
+) -> DecisionTree<'tcx> {
+    use DecisionTree::*;
+    match tree {
+        Uncovered => Uncovered,
+        Unreachable => Unreachable,
+        Leaf { body, bindings } => Leaf {
+            body: Box::new(subst_expr(tcx, body, subst)),
+            bindings: bindings.clone(),
+        },
+        Guard {
+            bindings,
+            guard,
+            success,
+            failure,
+        } => Guard {
+            bindings: bindings.clone(),
+            guard: Box::new(subst_expr(tcx, guard, subst)),
+            success: Box::new(subst_tree(tcx, success, subst)),
+            failure: Box::new(subst_tree(tcx, failure, subst)),
+        },
+        Switch { scrutinee, cases } => Switch {
+            scrutinee: scrutinee.clone(),
+            cases: subst_cases(tcx, cases, subst),
+        },
+    }
+}
+
+fn subst_cases<'tcx>(
+    tcx: &TyCtxt<'tcx>,
+    cases: &SwitchCases<'tcx>,
+    subst: &Subst<'tcx>,
+) -> SwitchCases<'tcx> {
+    use SwitchCases::*;
+    let st = |t: &DecisionTree<'tcx>| Box::new(subst_tree(tcx, t, subst));
+    match cases {
+        Int { cases, default } => Int {
+            cases: cases
+                .iter()
+                .map(|(n, t)| (*n, subst_tree(tcx, t, subst)))
+                .collect(),
+            default: st(default),
+        },
+        Bool { if_true, if_false } => Bool {
+            if_true: st(if_true),
+            if_false: st(if_false),
+        },
+        Ctor(arms) => Ctor(arms.iter().map(|t| subst_tree(tcx, t, subst)).collect()),
+        String { cases, default } => String {
+            cases: cases
+                .iter()
+                .map(|(s, t)| (*s, subst_tree(tcx, t, subst)))
+                .collect(),
+            default: st(default),
+        },
+        Nullable { non_null, null } => Nullable {
+            non_null: st(non_null),
+            null: st(null),
+        },
+    }
+}

--- a/crates/reussir-core/src/full/subst.rs
+++ b/crates/reussir-core/src/full/subst.rs
@@ -1,19 +1,16 @@
-//! Type substitution: instantiate a Semi HIR tree at a ground type assignment.
+//! Type substitution: ground a Semi [`Ty`] at a generic→type assignment.
 //!
-//! Monomorphization specializes a polymorphic function by mapping each of its
-//! generic parameters ([`GenericId`]) to a concrete type and rewriting every
-//! type in the body accordingly. Because Full types *are* Semi [`Ty`]s (just
-//! ground), substitution re-interns through the same [`TyCtxt`], so the result
-//! keeps pointer-identity equality and feeds straight into mangling and
-//! lowering.
+//! Monomorphization specializes a polymorphic function by mapping each generic
+//! parameter ([`GenericId`]) to a concrete type. Because Full types *are* Semi
+//! [`Ty`]s (just ground), substitution re-interns through the same [`TyCtxt`], so
+//! the result keeps pointer-identity equality and feeds straight into mangling.
 //!
-//! The expression walk mirrors [`crate::semi::check`]'s zonking walk one-for-one
-//! — same structure, but resolving against a generic→type map instead of the
-//! inference table.
+//! Only *types* are substituted here; the expression tree is not rewritten in
+//! place — [`crate::full::mono`] *lowers* it into the [`crate::full::mir`],
+//! grounding each node's type with [`subst_ty`] as it goes.
 
 use rustc_hash::FxHashMap;
 
-use crate::semi::hir::{ClosureExpr, DecisionTree, Expr, ExprKind, SwitchCases};
 use crate::semi::ty::{GenericId, Ty, TyCtxt, TyKind};
 
 /// A ground assignment for a function's generic parameters.
@@ -45,172 +42,5 @@ pub fn subst_ty<'tcx>(tcx: &TyCtxt<'tcx>, ty: Ty<'tcx>, subst: &Subst<'tcx>) -> 
         | TyKind::Unit
         | TyKind::Bottom => ty,
         TyKind::Hole(_) => panic!("subst: an inference hole survived zonking"),
-    }
-}
-
-/// Substitute generics throughout an expression tree.
-pub fn subst_expr<'tcx>(tcx: &TyCtxt<'tcx>, e: &Expr<'tcx>, subst: &Subst<'tcx>) -> Expr<'tcx> {
-    Expr {
-        kind: subst_kind(tcx, &e.kind, subst),
-        ty: subst_ty(tcx, e.ty, subst),
-        span: e.span,
-        id: e.id,
-    }
-}
-
-fn subst_kind<'tcx>(
-    tcx: &TyCtxt<'tcx>,
-    kind: &ExprKind<'tcx>,
-    subst: &Subst<'tcx>,
-) -> ExprKind<'tcx> {
-    use ExprKind::*;
-    let sb = |e: &Expr<'tcx>| Box::new(subst_expr(tcx, e, subst));
-    let sv = |es: &[Expr<'tcx>]| es.iter().map(|e| subst_expr(tcx, e, subst)).collect();
-    match kind {
-        // Leaves: nothing to substitute.
-        GlobalStr(s) => GlobalStr(*s),
-        ConstInt(n) => ConstInt(*n),
-        ConstFloat(f) => ConstFloat(*f),
-        ConstBool(b) => ConstBool(*b),
-        Var(v) => Var(*v),
-        Poison => Poison,
-
-        Negate(e) => Negate(sb(e)),
-        Not(e) => Not(sb(e)),
-        Arith(l, op, r) => Arith(sb(l), *op, sb(r)),
-        Cmp(l, op, r) => Cmp(sb(l), *op, sb(r)),
-        Cast(e, t) => Cast(sb(e), subst_ty(tcx, *t, subst)),
-        If(c, t, f) => If(sb(c), sb(t), sb(f)),
-        RegionRun(e) => RegionRun(sb(e)),
-        Proj(e, idx) => Proj(sb(e), idx.clone()),
-        Assign(d, i, s) => Assign(sb(d), *i, sb(s)),
-        Let {
-            var,
-            name,
-            span,
-            value,
-        } => Let {
-            var: *var,
-            name: *name,
-            span: *span,
-            value: sb(value),
-        },
-        Seq(es) => Seq(sv(es)),
-        FuncCall {
-            target,
-            ty_args,
-            args,
-            regional,
-        } => FuncCall {
-            target: *target,
-            ty_args: ty_args.iter().map(|&t| subst_ty(tcx, t, subst)).collect(),
-            args: sv(args),
-            regional: *regional,
-        },
-        CompoundCall {
-            target,
-            ty_args,
-            args,
-        } => CompoundCall {
-            target: *target,
-            ty_args: ty_args.iter().map(|&t| subst_ty(tcx, t, subst)).collect(),
-            args: sv(args),
-        },
-        VariantCall {
-            target,
-            ty_args,
-            variant,
-            args,
-        } => VariantCall {
-            target: *target,
-            ty_args: ty_args.iter().map(|&t| subst_ty(tcx, t, subst)).collect(),
-            variant: *variant,
-            args: sv(args),
-        },
-        NullableCall(e) => NullableCall(e.as_ref().map(|e| sb(e))),
-        ClosureCall { target, args } => ClosureCall {
-            target: sb(target),
-            args: sv(args),
-        },
-        Closure(c) => Closure(ClosureExpr {
-            captures: c
-                .captures
-                .iter()
-                .map(|(v, t)| (*v, subst_ty(tcx, *t, subst)))
-                .collect(),
-            params: c
-                .params
-                .iter()
-                .map(|(v, t)| (*v, subst_ty(tcx, *t, subst)))
-                .collect(),
-            body: sb(&c.body),
-        }),
-        Match(scrut, tree) => Match(sb(scrut), subst_tree(tcx, tree, subst)),
-    }
-}
-
-/// Substitute generics throughout a compiled decision tree.
-fn subst_tree<'tcx>(
-    tcx: &TyCtxt<'tcx>,
-    tree: &DecisionTree<'tcx>,
-    subst: &Subst<'tcx>,
-) -> DecisionTree<'tcx> {
-    use DecisionTree::*;
-    match tree {
-        Uncovered => Uncovered,
-        Unreachable => Unreachable,
-        Leaf { body, bindings } => Leaf {
-            body: Box::new(subst_expr(tcx, body, subst)),
-            bindings: bindings.clone(),
-        },
-        Guard {
-            bindings,
-            guard,
-            success,
-            failure,
-        } => Guard {
-            bindings: bindings.clone(),
-            guard: Box::new(subst_expr(tcx, guard, subst)),
-            success: Box::new(subst_tree(tcx, success, subst)),
-            failure: Box::new(subst_tree(tcx, failure, subst)),
-        },
-        Switch { scrutinee, cases } => Switch {
-            scrutinee: scrutinee.clone(),
-            cases: subst_cases(tcx, cases, subst),
-        },
-    }
-}
-
-fn subst_cases<'tcx>(
-    tcx: &TyCtxt<'tcx>,
-    cases: &SwitchCases<'tcx>,
-    subst: &Subst<'tcx>,
-) -> SwitchCases<'tcx> {
-    use SwitchCases::*;
-    let st = |t: &DecisionTree<'tcx>| Box::new(subst_tree(tcx, t, subst));
-    match cases {
-        Int { cases, default } => Int {
-            cases: cases
-                .iter()
-                .map(|(n, t)| (*n, subst_tree(tcx, t, subst)))
-                .collect(),
-            default: st(default),
-        },
-        Bool { if_true, if_false } => Bool {
-            if_true: st(if_true),
-            if_false: st(if_false),
-        },
-        Ctor(arms) => Ctor(arms.iter().map(|t| subst_tree(tcx, t, subst)).collect()),
-        String { cases, default } => String {
-            cases: cases
-                .iter()
-                .map(|(s, t)| (*s, subst_tree(tcx, t, subst)))
-                .collect(),
-            default: st(default),
-        },
-        Nullable { non_null, null } => Nullable {
-            non_null: st(non_null),
-            null: st(null),
-        },
     }
 }

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -47,6 +47,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             name: proto.name,
             visibility: proto.visibility,
             generics: proto.generics,
+            regional_generics: proto.regional_generics,
             params,
             return_ty,
             is_regional: proto.is_regional,

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -45,6 +45,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.elaborated.push(Function {
             def: proto.def,
             name: proto.name,
+            visibility: proto.visibility,
             generics: proto.generics,
             params,
             return_ty,

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -8,7 +8,7 @@ use crate::semi::infer::InferCtxt;
 use crate::semi::resolve::DefTable;
 use crate::semi::traits::builtins::Builtins;
 use crate::semi::traits::{TraitDb, TraitId};
-use crate::semi::ty::{DefId, GenericId, Ty, TyCtxt};
+use crate::semi::ty::{DefId, GenericId, Ty, TyCtxt, TyKind};
 use crate::surface::{self, Span};
 use crate::utils::string::StringUniqifier;
 
@@ -80,11 +80,32 @@ pub struct FuncProto<'tcx> {
     pub name: TokenKey,
     pub visibility: surface::Visibility,
     pub generics: Vec<(TokenKey, GenericId)>,
+    /// Generics used at a `[flex]` position (e.g. `bar: [flex] T`). A `[flex]`
+    /// use of a bare generic requires the instantiating type to be a regional
+    /// record — checked at the monomorphization call boundary. (The `[flex]`
+    /// coloring itself is dropped on a generic, exactly as in the reference; this
+    /// records the *requirement* it implies.)
+    pub regional_generics: Vec<GenericId>,
     /// `(name, colored type)`.
     pub params: Vec<(TokenKey, Ty<'tcx>)>,
     pub return_ty: Ty<'tcx>,
     pub is_regional: bool,
     pub span: Option<Span>,
+}
+
+/// Records the generic at the head of a `[flex]`-annotated type (peeling
+/// `Nullable`): a `[flex]` use of a bare generic means that generic must be
+/// instantiated with a regional record.
+fn collect_regional_generic(t: Ty<'_>, out: &mut Vec<GenericId>) {
+    match *t.kind() {
+        TyKind::Generic(id) => {
+            if !out.contains(&id) {
+                out.push(id);
+            }
+        }
+        TyKind::Nullable(inner) => collect_regional_generic(inner, out),
+        _ => {}
+    }
 }
 
 /// A resolved `extern "<abi>" trampoline "<name>" = target::func<TyArgs>;`.
@@ -377,13 +398,25 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let generics = self.collect_generics(&func.generics, span);
         self.generic_names = generics.iter().map(|(n, id)| (*n, *id)).collect();
 
-        let params = func
-            .params
-            .iter()
-            .map(|(name, ty, flex)| (*name, self.eval_type_flex(ty, *flex)))
-            .collect();
+        // A `[flex]` annotation on a bare generic (its coloring is dropped, as in
+        // the reference) records that the generic must be instantiated regional.
+        let mut regional_generics: Vec<GenericId> = Vec::new();
+        let mut params = Vec::new();
+        for (name, ty, flex) in &func.params {
+            let t = self.eval_type_flex(ty, *flex);
+            if *flex {
+                collect_regional_generic(t, &mut regional_generics);
+            }
+            params.push((*name, t));
+        }
         let return_ty = match &func.return_type {
-            Some((ty, flex)) => self.eval_type_flex(ty, *flex),
+            Some((ty, flex)) => {
+                let t = self.eval_type_flex(ty, *flex);
+                if *flex {
+                    collect_regional_generic(t, &mut regional_generics);
+                }
+                t
+            }
             None => self.tcx.mk_unit(),
         };
         self.generic_names.clear();
@@ -401,6 +434,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             name,
             visibility: func.visibility,
             generics,
+            regional_generics,
             params,
             return_ty,
             is_regional: func.is_regional,

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -78,6 +78,7 @@ pub struct Record<'tcx> {
 pub struct FuncProto<'tcx> {
     pub def: DefId,
     pub name: TokenKey,
+    pub visibility: surface::Visibility,
     pub generics: Vec<(TokenKey, GenericId)>,
     /// `(name, colored type)`.
     pub params: Vec<(TokenKey, Ty<'tcx>)>,
@@ -398,6 +399,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let proto = FuncProto {
             def,
             name,
+            visibility: func.visibility,
             generics,
             params,
             return_ty,

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -186,6 +186,9 @@ pub enum SwitchCases<'tcx> {
 pub struct Function<'tcx> {
     pub def: DefId,
     pub name: TokenKey,
+    /// Source visibility; carried so the Full phase can give exported (`pub`)
+    /// instances external linkage and keep internal ones private.
+    pub visibility: crate::surface::Visibility,
     pub generics: Vec<(TokenKey, GenericId)>,
     pub params: Vec<(TokenKey, VarId, Ty<'tcx>)>,
     pub return_ty: Ty<'tcx>,

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -190,6 +190,10 @@ pub struct Function<'tcx> {
     /// instances external linkage and keep internal ones private.
     pub visibility: crate::surface::Visibility,
     pub generics: Vec<(TokenKey, GenericId)>,
+    /// Generics used at a `[flex]` position; their instantiations must be
+    /// regional records (checked at monomorphization). See
+    /// [`crate::semi::ctxt::FuncProto::regional_generics`].
+    pub regional_generics: Vec<GenericId>,
     pub params: Vec<(TokenKey, VarId, Ty<'tcx>)>,
     pub return_ty: Ty<'tcx>,
     pub is_regional: bool,

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -216,4 +216,19 @@ impl<'tcx> TyCtxt<'tcx> {
         let params = self.intern_tys(params);
         self.mk(TyKind::Closure { params, ret })
     }
+
+    /// Allocate a value into the arena, returning a shared arena reference. Used
+    /// by the Full MIR to keep its (arena-allocated, `Copy`) node tree alongside
+    /// the types it references — these are *not* interned, just arena-owned.
+    pub fn alloc<T>(&self, value: T) -> &'tcx T {
+        self.arena.alloc(value)
+    }
+
+    /// Allocate a slice of `Copy` values into the arena.
+    pub fn alloc_slice<T: Copy>(&self, slice: &[T]) -> &'tcx [T] {
+        if slice.is_empty() {
+            return &[];
+        }
+        self.arena.alloc_slice_copy(slice)
+    }
 }


### PR DESCRIPTION
Stacked on #264. Second PR in the Haskell→Rust frontend port: turns the
polymorphic Semi HIR into ground Full instances.

## What

- `full::subst` — type substitution over the Semi HIR (`subst_ty` / `subst_expr`
  / decision-tree walk). Maps a function's generics to concrete types and
  re-interns through the same `TyCtxt`, so Full types remain pointer-identity
  Semi `Ty`s. The expression walk mirrors the checker's zonking walk one-for-one.
- `full::mono` — the worklist driver:
  - Roots = every non-generic function (emitted even if uncalled — DCE is the
    backend's job, matching the existing frontend) + every trampoline target.
  - `Instance = (DefId, interned &[Ty])`; the interned slice compares by element
    pointer-identity, so structurally-equal instantiations dedup to one entry.
  - Popping an instance substitutes its body to ground form, then scans the
    ground signature + body (**including decision-tree arms**) for further
    function and record instances.
  - `FullProgram` = ground functions (v0 symbol + visibility), the record
    instances their layouts require, and exported trampolines; sorted by symbol.
- Thread source `pub` visibility through semi (`FuncProto` / `hir::Function`).

## Tests
`id<T>` used at `i32` and `bool` → two distinct ground instances (`_RIC2idlE`,
`_RIC2idbE`); an uncalled non-generic function is still emitted; all bodies are
ground after mono. `cargo test -p reussir-core`: 71 → 74; clippy clean.

## Next in stack
Perceus-style ownership analysis (early drop / drop-guided reuse), then MLIR
lowering, CLI drivers, lit repoint, ASAN, Haskell removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)