### PR TITLE
[backend] reussir-codegen: lower the scalar/control-flow Full MIR subset to MLIR + run it

### DIFF
--- a/.github/workflows/mlir-cpp-test.yml
+++ b/.github/workflows/mlir-cpp-test.yml
@@ -126,3 +126,6 @@ jobs:
 
       - name: Build and Test reussir-backend
         run: cmake --build build --target reussir-backend-test
+
+      - name: Build and Test reussir-codegen
+        run: cmake --build build --target reussir-codegen-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ add_subdirectory(crates/reussir-rt)
 add_subdirectory(crates/reussir-syntax)
 add_subdirectory(crates/reussir-backend)
 add_subdirectory(crates/reussir-jit)
+add_subdirectory(crates/reussir-codegen)
 add_subdirectory(frontend)
 
 if (REUSSIR_ENABLE_TESTS)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "reussir-codegen"
+version = "0.1.0"
+dependencies = [
+ "reussir-backend",
+ "reussir-core",
+ "reussir-jit",
+ "reussir-syntax",
+ "rustc-hash",
+]
+
+[[package]]
 name = "reussir-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,12 @@ members = [
     "crates/reussir-backend-sys",
     "crates/reussir-backend",
     "crates/reussir-jit",
+    "crates/reussir-codegen",
 ]
-# The backend crates link against MLIR and the staged Reussir C API, so they are
-# excluded from the default `cargo build`; build them explicitly with
-# `cargo build -p reussir-backend` (the CMake build wires up the needed env).
+# The backend crates (and reussir-codegen, which depends on them) link against
+# MLIR and the staged Reussir C API, so they are excluded from the default
+# `cargo build`; build them explicitly (e.g. `cargo build -p reussir-backend`
+# or `cargo build -p reussir-codegen`) with the CMake build wiring up the env.
 default-members = ["crates/reussir-rt", "crates/reussir-syntax", "crates/reussir-core"]
 
 [workspace.package]

--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -1,0 +1,67 @@
+//! Hand-written op builders for cases melior's generated builders don't cover
+//! well enough.
+//!
+//! melior's ODS/dialect builders are preferred everywhere they fit; this module
+//! holds the few operations whose generated builder is missing a needed
+//! parameter (so the result/attributes can't be set), keeping the raw
+//! [`OperationBuilder`] usage contained in the backend rather than leaking into
+//! downstream code generators.
+
+use melior::Context;
+use melior::ir::attribute::{FlatSymbolRefAttribute, IntegerAttribute, StringAttribute};
+use melior::ir::operation::OperationBuilder;
+use melior::ir::r#type::IntegerType;
+use melior::ir::{Identifier, Location, Operation, Type, Value};
+
+/// `arith.truncf %value : <from> to <result_type>`.
+///
+/// melior's [`arith::truncf`](melior::dialect::arith::truncf) is a plain unary
+/// with no result-type parameter, so it cannot express a float *narrowing* (the
+/// result width must differ from the operand's). This sets the result type
+/// explicitly.
+pub fn truncf<'c>(
+    value: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("arith.truncf", location)
+        .add_operands(&[value])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid arith.truncf")
+}
+
+/// `reussir.trampoline export "<abi>" @<sym_name> = @<target>`.
+///
+/// The op is attribute-only and its `direction` is a `TrampolineDirection`
+/// `I32EnumAttr` for which neither melior nor the Reussir C API exposes a
+/// constructor; the enum is stored as a signless `i32` (`Export` is case `1`).
+/// Building it here keeps that representational detail out of the code
+/// generator.
+pub fn trampoline_export<'c>(
+    context: &'c Context,
+    abi_name: &str,
+    sym_name: &str,
+    target: &str,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let export = IntegerAttribute::new(IntegerType::new(context, 32).into(), 1).into();
+    OperationBuilder::new("reussir.trampoline", location)
+        .add_attributes(&[
+            (Identifier::new(context, "direction"), export),
+            (
+                Identifier::new(context, "target"),
+                FlatSymbolRefAttribute::new(context, target).into(),
+            ),
+            (
+                Identifier::new(context, "abi_name"),
+                StringAttribute::new(context, abi_name).into(),
+            ),
+            (
+                Identifier::new(context, "sym_name"),
+                StringAttribute::new(context, sym_name).into(),
+            ),
+        ])
+        .build()
+        .expect("valid reussir.trampoline")
+}

--- a/crates/reussir-backend/src/lib.rs
+++ b/crates/reussir-backend/src/lib.rs
@@ -16,6 +16,7 @@ use melior::dialect::{DialectHandle, DialectRegistry};
 
 use reussir_backend_sys as sys;
 
+pub mod builders;
 pub mod dialect;
 pub mod pipeline;
 

--- a/crates/reussir-codegen/CMakeLists.txt
+++ b/crates/reussir-codegen/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Builds the reussir-codegen Rust crate (Full MIR -> MLIR lowering) with cargo.
+#
+# Like reussir-backend / reussir-jit, these targets are NOT part of the default
+# `ALL` build. Invoke them explicitly:
+#   ninja -C build reussir-codegen         # compile the crate
+#   ninja -C build reussir-codegen-test    # run the crate's tests
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(REUSSIR_CODEGEN_CARGO_PROFILE "dev")
+else()
+    set(REUSSIR_CODEGEN_CARGO_PROFILE "release")
+endif()
+
+# The union of the reussir-backend and reussir-jit environments: the crate pulls
+# in reussir-backend (mlir-sys / melior / the `dialect!` macro / staged Reussir
+# archives) and, for its end-to-end test, reussir-jit (which links LLVM via
+# llvm-sys 221), all discovered through these prefixes.
+set(REUSSIR_CODEGEN_CARGO_ENV
+    CARGO_TARGET_DIR=${CMAKE_BINARY_DIR}/target
+    MLIR_SYS_220_PREFIX=${REUSSIR_LLVM_PREFIX}
+    MLIR_SYS_210_PREFIX=${REUSSIR_LLVM_PREFIX}
+    TABLEGEN_220_PREFIX=${REUSSIR_LLVM_PREFIX}
+    LLVM_SYS_220_PREFIX=${REUSSIR_LLVM_PREFIX}
+    LLVM_SYS_221_PREFIX=${REUSSIR_LLVM_PREFIX}
+    REUSSIR_CAPI_LIB_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    REUSSIR_INCLUDE_DIR=${CMAKE_SOURCE_DIR}/include
+    RUSTFLAGS=-Awarnings)
+
+add_custom_target(reussir-codegen
+    COMMAND ${CMAKE_COMMAND} -E env ${REUSSIR_CODEGEN_CARGO_ENV}
+        cargo build --locked --profile ${REUSSIR_CODEGEN_CARGO_PROFILE}
+        --package reussir-codegen --quiet
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS ReussirCAPI MLIRReussir
+    COMMENT "Building reussir-codegen with cargo (${REUSSIR_CODEGEN_CARGO_PROFILE} profile)"
+    USES_TERMINAL
+)
+
+add_custom_target(reussir-codegen-test
+    COMMAND ${CMAKE_COMMAND} -E env ${REUSSIR_CODEGEN_CARGO_ENV}
+        cargo test --locked --profile ${REUSSIR_CODEGEN_CARGO_PROFILE}
+        --package reussir-codegen
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS ReussirCAPI MLIRReussir
+    COMMENT "Testing reussir-codegen with cargo"
+    USES_TERMINAL
+)

--- a/crates/reussir-codegen/Cargo.toml
+++ b/crates/reussir-codegen/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "reussir-codegen"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Lowers Reussir's monomorphized Full MIR to MLIR via the reussir-backend ODS builders"
+
+[lib]
+name = "reussir_codegen"
+
+[dependencies]
+# The frontend: lowering consumes its monomorphized Full MIR.
+reussir-core = { path = "../reussir-core" }
+# The MLIR foundation: melior, the Reussir dialect ODS builders, and `context()`.
+reussir-backend = { path = "../reussir-backend" }
+# The fast map for the per-function SSA environment.
+rustc-hash.workspace = true
+
+[dev-dependencies]
+# End-to-end tests: source → elaborate → monomorphize → lower → run.
+reussir-syntax = { path = "../reussir-syntax" }
+# JIT-execute the lowered module to check the compiled program's meaning.
+reussir-jit = { path = "../reussir-jit" }

--- a/crates/reussir-codegen/src/lib.rs
+++ b/crates/reussir-codegen/src/lib.rs
@@ -1,0 +1,10 @@
+//! Code generation: lowering Reussir's monomorphized Full MIR to MLIR.
+//!
+//! This crate sits between the frontend ([`reussir_core`], which produces a
+//! ground [`reussir_core::full::mir::Program`]) and the MLIR foundation
+//! ([`reussir_backend`], which provides [`melior`](reussir_backend::melior), the
+//! Reussir-dialect ODS builders, and the lowering [`pipeline`]). It builds MLIR
+//! in memory through those ODS builders — the frontend crate itself stays free
+//! of any MLIR dependency.
+
+pub mod lower;

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -1,0 +1,462 @@
+//! Function and expression lowering: the per-function recursive tree-walk that
+//! emits MLIR ops for each Full MIR expression.
+//!
+//! # SSA environment
+//!
+//! The variable environment maps each [`VarId`] to the melior [`Value`] that
+//! holds it. melior values borrow the block they were built in, so an `scf.if`
+//! branch — which builds into its own block — gets a fresh environment copied
+//! from its parent (outer values outlive the inner block, so the copy is a plain
+//! lifetime-shortening reborrow). Bindings introduced inside a branch stay
+//! scoped to it.
+
+use rustc_hash::FxHashMap;
+
+use reussir_backend::builders;
+use reussir_backend::melior::Context;
+use reussir_backend::melior::dialect::arith::{self, CmpfPredicate, CmpiPredicate};
+use reussir_backend::melior::dialect::{func, scf};
+use reussir_backend::melior::ir::attribute::{
+    FlatSymbolRefAttribute, FloatAttribute, IntegerAttribute, StringAttribute, TypeAttribute,
+};
+use reussir_backend::melior::ir::r#type::{FunctionType, IntegerType};
+use reussir_backend::melior::ir::{
+    Block, BlockLike, Identifier, Location, Operation, Region, RegionLike, Type, Value,
+};
+
+use reussir_core::full::mir::{self, Expr, ExprKind};
+use reussir_core::semi::hir::{ArithOp, CmpOp, VarId};
+use reussir_core::semi::ty::{IntTy, Ty, TyKind};
+use reussir_core::surface::Visibility;
+
+use super::ty::{is_unit, mlir_ty, num_class};
+use super::{LoweringError, Result, err};
+
+/// The variable → SSA-value environment for one block scope.
+type Env<'c, 'b> = FxHashMap<VarId, Value<'c, 'b>>;
+
+/// Per-program lowering state: the context to build in and the program whose
+/// symbol table resolves callee/trampoline names. Reused across functions.
+pub(super) struct Lowerer<'c, 'p, 'tcx> {
+    context: &'c Context,
+    program: &'p mir::Program<'tcx>,
+}
+
+impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
+    pub(super) fn new(context: &'c Context, program: &'p mir::Program<'tcx>) -> Self {
+        Lowerer { context, program }
+    }
+
+    fn loc(&self) -> Location<'c> {
+        Location::unknown(self.context)
+    }
+
+    /// Lower one MIR function to a `func.func` operation.
+    pub(super) fn function(&self, func: &mir::Function<'tcx>) -> Result<Operation<'c>> {
+        let loc = self.loc();
+        let param_tys = func
+            .params
+            .iter()
+            .map(|p| mlir_ty(self.context, p.ty))
+            .collect::<Result<Vec<_>>>()?;
+        let ret = func.return_ty;
+        let result_tys = if is_unit(ret) {
+            Vec::new()
+        } else {
+            vec![mlir_ty(self.context, ret)?]
+        };
+        let fn_ty = FunctionType::new(self.context, &param_tys, &result_tys);
+
+        let region = Region::new();
+        if let Some(body) = func.body {
+            let block_args: Vec<(Type<'c>, Location<'c>)> =
+                param_tys.iter().map(|t| (*t, loc)).collect();
+            let block = Block::new(&block_args);
+            let mut env: Env<'c, '_> = FxHashMap::default();
+            for (i, p) in func.params.iter().enumerate() {
+                let arg = block
+                    .argument(i)
+                    .map_err(|e| LoweringError(format!("missing block argument: {e}")))?;
+                env.insert(p.var, arg.into());
+            }
+            let value = self.expr(&block, &mut env, body)?;
+            if is_unit(ret) {
+                block.append_operation(func::r#return(&[], loc));
+            } else {
+                let v =
+                    value.ok_or_else(|| LoweringError("non-unit body produced no value".into()))?;
+                block.append_operation(func::r#return(&[v], loc));
+            }
+            region.append_block(block);
+        }
+
+        // A `private` function carries an explicit `sym_visibility` attribute;
+        // the printer renders it as the `private` keyword.
+        let attributes = if func.visibility == Visibility::Private {
+            vec![(
+                Identifier::new(self.context, "sym_visibility"),
+                StringAttribute::new(self.context, "private").into(),
+            )]
+        } else {
+            Vec::new()
+        };
+
+        Ok(func::func(
+            self.context,
+            StringAttribute::new(self.context, self.program.symbol(func.symbol)),
+            TypeAttribute::new(fn_ty.into()),
+            region,
+            &attributes,
+            loc,
+        ))
+    }
+
+    /// Lower an expression into `block`, returning the SSA value holding its
+    /// result (`None` for a unit-typed expression).
+    fn expr<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        e: &Expr<'tcx>,
+    ) -> Result<Option<Value<'c, 'b>>> {
+        use ExprKind::*;
+        let loc = self.loc();
+        match &e.kind {
+            ConstInt(n) => {
+                let attr = IntegerAttribute::new(mlir_ty(self.context, e.ty)?, *n as i64).into();
+                Ok(Some(
+                    self.append(block, arith::constant(self.context, attr, loc)),
+                ))
+            }
+            ConstBool(b) => {
+                let i1 = IntegerType::new(self.context, 1).into();
+                let attr = IntegerAttribute::new(i1, i64::from(*b)).into();
+                Ok(Some(
+                    self.append(block, arith::constant(self.context, attr, loc)),
+                ))
+            }
+            ConstFloat(f) => {
+                let attr =
+                    FloatAttribute::new(self.context, mlir_ty(self.context, e.ty)?, *f).into();
+                Ok(Some(
+                    self.append(block, arith::constant(self.context, attr, loc)),
+                ))
+            }
+            Var(v) => {
+                // A unit-typed variable has no SSA value (e.g. `let x = (); x`),
+                // so it is never stored in `env`; lower it to `None` rather than
+                // reporting it as unbound.
+                if is_unit(e.ty) {
+                    Ok(None)
+                } else {
+                    env.get(v)
+                        .copied()
+                        .map(Some)
+                        .ok_or_else(|| LoweringError(format!("unbound variable {v:?}")))
+                }
+            }
+            Negate(x) => self.negate(block, env, x).map(Some),
+            Not(x) => self.not(block, env, x).map(Some),
+            Arith(l, op, r) => self.arith(block, env, l, *op, r, e.ty).map(Some),
+            Cmp(l, op, r) => self.cmp(block, env, l, *op, r).map(Some),
+            Cast(x, t) => self.cast(block, env, x, *t),
+            If(c, t, f) => self.lower_if(block, env, c, t, f, e.ty),
+            Seq(items) => {
+                let mut last = None;
+                for item in items.iter() {
+                    last = self.expr(block, env, item)?;
+                }
+                Ok(last)
+            }
+            Let { var, value, .. } => {
+                if let Some(v) = self.expr(block, env, value)? {
+                    env.insert(*var, v);
+                }
+                Ok(None)
+            }
+            Call { callee, args, .. } => {
+                let mut operands = Vec::with_capacity(args.len());
+                for a in args.iter() {
+                    operands.push(
+                        self.expr(block, env, a)?
+                            .ok_or_else(|| LoweringError("call argument is unit".into()))?,
+                    );
+                }
+                let result_tys = if is_unit(e.ty) {
+                    Vec::new()
+                } else {
+                    vec![mlir_ty(self.context, e.ty)?]
+                };
+                let symbol =
+                    FlatSymbolRefAttribute::new(self.context, self.program.symbol(*callee));
+                let op = block.append_operation(func::call(
+                    self.context,
+                    symbol,
+                    &operands,
+                    &result_tys,
+                    loc,
+                ));
+                if is_unit(e.ty) {
+                    Ok(None)
+                } else {
+                    Ok(Some(op.result(0).unwrap().into()))
+                }
+            }
+            RegionRun(_) => err("region-run lowering not yet implemented"),
+            Proj(..) => err("projection lowering not yet implemented"),
+            Assign(..) => err("assignment lowering not yet implemented"),
+            Match(..) => err("match lowering not yet implemented"),
+            Ctor { .. } | Variant { .. } | NullableCall(_) => {
+                err("constructor lowering not yet implemented")
+            }
+            Closure(_) | ClosureCall { .. } => err("closure lowering not yet implemented"),
+            GlobalStr(_) => err("string literal lowering not yet implemented"),
+            Poison => err("poison expression reached lowering"),
+        }
+    }
+
+    /// Append `op` to `block` and return its single result as a value.
+    fn append<'b>(&self, block: &'b Block<'c>, op: Operation<'c>) -> Value<'c, 'b> {
+        block.append_operation(op).result(0).unwrap().into()
+    }
+
+    fn negate<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        x: &Expr<'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let xv = self
+            .expr(block, env, x)?
+            .ok_or_else(|| LoweringError("negate on unit".into()))?;
+        match x.ty.kind() {
+            TyKind::Fp(_) => Ok(self.append(block, arith::negf(xv, loc))),
+            TyKind::Int(_) => {
+                let ty = mlir_ty(self.context, x.ty)?;
+                let zero = self.append(
+                    block,
+                    arith::constant(self.context, IntegerAttribute::new(ty, 0).into(), loc),
+                );
+                Ok(self.append(block, arith::subi(zero, xv, loc)))
+            }
+            _ => err("negate on non-numeric type"),
+        }
+    }
+
+    fn not<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        x: &Expr<'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let xv = self
+            .expr(block, env, x)?
+            .ok_or_else(|| LoweringError("not on unit".into()))?;
+        let i1 = IntegerType::new(self.context, 1).into();
+        let one = self.append(
+            block,
+            arith::constant(self.context, IntegerAttribute::new(i1, 1).into(), loc),
+        );
+        Ok(self.append(block, arith::xori(xv, one, loc)))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn arith<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        l: &Expr<'tcx>,
+        op: ArithOp,
+        r: &Expr<'tcx>,
+        ty: Ty<'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let lv = self
+            .expr(block, env, l)?
+            .ok_or_else(|| LoweringError("arith operand is unit".into()))?;
+        let rv = self
+            .expr(block, env, r)?
+            .ok_or_else(|| LoweringError("arith operand is unit".into()))?;
+        let signed = matches!(ty.kind(), TyKind::Int(IntTy::Signed(_)));
+        let float = matches!(ty.kind(), TyKind::Fp(_));
+        let op = match (op, float, signed) {
+            (ArithOp::Add, false, _) => arith::addi(lv, rv, loc),
+            (ArithOp::Add, true, _) => arith::addf(lv, rv, loc),
+            (ArithOp::Sub, false, _) => arith::subi(lv, rv, loc),
+            (ArithOp::Sub, true, _) => arith::subf(lv, rv, loc),
+            (ArithOp::Mul, false, _) => arith::muli(lv, rv, loc),
+            (ArithOp::Mul, true, _) => arith::mulf(lv, rv, loc),
+            (ArithOp::Div, true, _) => arith::divf(lv, rv, loc),
+            (ArithOp::Div, false, true) => arith::divsi(lv, rv, loc),
+            (ArithOp::Div, false, false) => arith::divui(lv, rv, loc),
+            (ArithOp::Mod, true, _) => arith::remf(lv, rv, loc),
+            (ArithOp::Mod, false, true) => arith::remsi(lv, rv, loc),
+            (ArithOp::Mod, false, false) => arith::remui(lv, rv, loc),
+            (ArithOp::And, ..) => arith::andi(lv, rv, loc),
+            (ArithOp::Or, ..) => arith::ori(lv, rv, loc),
+        };
+        Ok(self.append(block, op))
+    }
+
+    fn cmp<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        l: &Expr<'tcx>,
+        op: CmpOp,
+        r: &Expr<'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let operand_ty = l.ty;
+        let lv = self
+            .expr(block, env, l)?
+            .ok_or_else(|| LoweringError("cmp operand is unit".into()))?;
+        let rv = self
+            .expr(block, env, r)?
+            .ok_or_else(|| LoweringError("cmp operand is unit".into()))?;
+        let signed = matches!(operand_ty.kind(), TyKind::Int(IntTy::Signed(_)));
+        let float = matches!(operand_ty.kind(), TyKind::Fp(_));
+        let op = if float {
+            // Ordered relational/equality predicates (NaN operand ⇒ false),
+            // except `!=`, which is unordered so that `NaN != x` is true — the
+            // usual IEEE/C semantics, matching how `==`/`!=` lower elsewhere.
+            let pred = match op {
+                CmpOp::Lt => CmpfPredicate::Olt,
+                CmpOp::Gt => CmpfPredicate::Ogt,
+                CmpOp::Le => CmpfPredicate::Ole,
+                CmpOp::Ge => CmpfPredicate::Oge,
+                CmpOp::Eq => CmpfPredicate::Oeq,
+                CmpOp::Ne => CmpfPredicate::Une,
+            };
+            arith::cmpf(self.context, pred, lv, rv, loc)
+        } else {
+            let pred = match (op, signed) {
+                (CmpOp::Eq, _) => CmpiPredicate::Eq,
+                (CmpOp::Ne, _) => CmpiPredicate::Ne,
+                (CmpOp::Lt, true) => CmpiPredicate::Slt,
+                (CmpOp::Le, true) => CmpiPredicate::Sle,
+                (CmpOp::Gt, true) => CmpiPredicate::Sgt,
+                (CmpOp::Ge, true) => CmpiPredicate::Sge,
+                (CmpOp::Lt, false) => CmpiPredicate::Ult,
+                (CmpOp::Le, false) => CmpiPredicate::Ule,
+                (CmpOp::Gt, false) => CmpiPredicate::Ugt,
+                (CmpOp::Ge, false) => CmpiPredicate::Uge,
+            };
+            arith::cmpi(self.context, pred, lv, rv, loc)
+        };
+        Ok(self.append(block, op))
+    }
+
+    fn cast<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        x: &Expr<'tcx>,
+        to: Ty<'tcx>,
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let loc = self.loc();
+        let xv = self
+            .expr(block, env, x)?
+            .ok_or_else(|| LoweringError("cast operand is unit".into()))?;
+        let src = num_class(x.ty)?;
+        let dst = num_class(to)?;
+        let to_ty = mlir_ty(self.context, to)?;
+        let op = match (src.float, dst.float) {
+            (false, false) => {
+                if dst.width == src.width {
+                    return Ok(Some(xv)); // same integer width, no-op
+                } else if dst.width < src.width {
+                    arith::trunci(xv, to_ty, loc)
+                } else if src.signed {
+                    arith::extsi(xv, to_ty, loc)
+                } else {
+                    arith::extui(xv, to_ty, loc)
+                }
+            }
+            (false, true) => {
+                if src.signed {
+                    arith::sitofp(xv, to_ty, loc)
+                } else {
+                    arith::uitofp(xv, to_ty, loc)
+                }
+            }
+            (true, false) => {
+                if dst.signed {
+                    arith::fptosi(xv, to_ty, loc)
+                } else {
+                    arith::fptoui(xv, to_ty, loc)
+                }
+            }
+            (true, true) => {
+                if dst.width == src.width {
+                    return Ok(Some(xv));
+                } else if dst.width < src.width {
+                    builders::truncf(xv, to_ty, loc)
+                } else {
+                    arith::extf(xv, to_ty, loc)
+                }
+            }
+        };
+        Ok(Some(self.append(block, op)))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn lower_if<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        c: &Expr<'tcx>,
+        t: &Expr<'tcx>,
+        f: &Expr<'tcx>,
+        ty: Ty<'tcx>,
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let loc = self.loc();
+        let cv = self
+            .expr(block, env, c)?
+            .ok_or_else(|| LoweringError("if condition is unit".into()))?;
+        let result_tys = if is_unit(ty) {
+            Vec::new()
+        } else {
+            vec![mlir_ty(self.context, ty)?]
+        };
+        let then_region = self.branch_region(env, t, ty)?;
+        let else_region = self.branch_region(env, f, ty)?;
+        let op = block.append_operation(scf::r#if(cv, &result_tys, then_region, else_region, loc));
+        if is_unit(ty) {
+            Ok(None)
+        } else {
+            Ok(Some(op.result(0).unwrap().into()))
+        }
+    }
+
+    /// Build one `scf.if` branch region: an entry block whose body lowers `e`
+    /// (over a copy of the enclosing environment) and terminates with
+    /// `scf.yield` (yielding its value unless unit-typed).
+    fn branch_region<'b>(
+        &self,
+        env: &Env<'c, 'b>,
+        e: &Expr<'tcx>,
+        ty: Ty<'tcx>,
+    ) -> Result<Region<'c>> {
+        let loc = self.loc();
+        let block = Block::new(&[]);
+        // Reborrow the outer values at the inner block's (shorter) lifetime;
+        // bindings made in the branch stay local to this copy.
+        let mut child: Env<'c, '_> = FxHashMap::default();
+        for (k, v) in env {
+            child.insert(*k, *v);
+        }
+        let value = self.expr(&block, &mut child, e)?;
+        if is_unit(ty) {
+            block.append_operation(scf::r#yield(&[], loc));
+        } else {
+            let v = value.ok_or_else(|| LoweringError("if branch produced no value".into()))?;
+            block.append_operation(scf::r#yield(&[v], loc));
+        }
+        let region = Region::new();
+        region.append_block(block);
+        Ok(region)
+    }
+}

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -1,0 +1,147 @@
+//! Lowering the monomorphized Full MIR to MLIR, built in memory.
+//!
+//! The frontend produces a ground [`mir::Program`]; this module builds the
+//! corresponding MLIR module through the `func`/`arith`/`scf` ODS builders
+//! (melior) and the Reussir-dialect / hand-written builders re-exported by
+//! [`reussir_backend`]. [`reussir_backend::pipeline`] then lowers the result to
+//! the LLVM dialect.
+//!
+//! The work is split across submodules:
+//! * [`ty`] — ground scalar Reussir types → MLIR types, and the numeric
+//!   classification used to pick cast ops;
+//! * [`expr`] — the per-function recursive tree-walk that emits the ops.
+//!
+//! # Scope
+//!
+//! This is the **scalar / control-flow subset**: integer and floating-point
+//! values, arithmetic and comparison, `if`, `let`/sequencing, direct calls, and
+//! exported trampolines — enough to compile and run reference programs like
+//! `fibonacci.rr` end-to-end. Reference-counted constructs (records, closures,
+//! `match`, regions, strings) are not yet lowered and surface as an explicit
+//! [`LoweringError`] rather than wrong code; they arrive with the ownership
+//! analysis in a later change.
+//!
+//! Every callee/trampoline target in the MIR is already resolved to an interned
+//! [`mir::Symbol`](reussir_core::full::mir::Symbol) (mono did the mangling), so
+//! lowering only looks names up in the program's symbol table — it needs no
+//! `DefTable`/resolver/`Mangler`.
+
+mod expr;
+mod ty;
+
+use reussir_backend::builders;
+use reussir_backend::melior::Context;
+use reussir_backend::melior::ir::{BlockLike, Location, Module};
+
+use reussir_core::full::mir;
+
+use expr::Lowerer;
+
+/// A construct the current lowering subset does not handle.
+#[derive(Debug, Clone)]
+pub struct LoweringError(pub String);
+
+impl std::fmt::Display for LoweringError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "lowering error: {}", self.0)
+    }
+}
+
+impl std::error::Error for LoweringError {}
+
+type Result<T> = std::result::Result<T, LoweringError>;
+
+fn err<T>(msg: impl Into<String>) -> Result<T> {
+    Err(LoweringError(msg.into()))
+}
+
+/// Build the MLIR module for a whole program in `context`.
+pub fn lower_program<'c>(context: &'c Context, program: &mir::Program<'_>) -> Result<Module<'c>> {
+    let module = Module::new(Location::unknown(context));
+    let body = module.body();
+    let lowerer = Lowerer::new(context, program);
+    for func in &program.functions {
+        body.append_operation(lowerer.function(func)?);
+    }
+    for t in &program.trampolines {
+        body.append_operation(builders::trampoline_export(
+            context,
+            &t.abi,
+            program.symbol(t.export),
+            program.symbol(t.target),
+            Location::unknown(context),
+        ));
+    }
+    Ok(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reussir_backend::melior::ir::operation::OperationLike;
+    use reussir_core::full::mono::monomorphize;
+    use reussir_core::{in_arena, semi::elaborate, surface};
+
+    /// Elaborate + monomorphize + lower `source`, checking the module verifies
+    /// and returning its printed text for assertions.
+    fn lower_source(source: &str) -> String {
+        let context = reussir_backend::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let module = lower_program(&context, &full).expect("lowering succeeds");
+            assert!(
+                module.as_operation().verify(),
+                "module verifies:\n{}",
+                module.as_operation()
+            );
+            module.as_operation().to_string()
+        })
+    }
+
+    #[test]
+    fn lowers_fibonacci_to_verifiable_mlir() {
+        let src = r#"
+            pub fn fibonacci(n: u64) -> u64 {
+                if n <= 1 { n } else { fibonacci(n - 1) + fibonacci(n - 2) }
+            }
+            extern "C" trampoline "fibonacci_ffi" = fibonacci;
+        "#;
+        let mlir = lower_source(src);
+        assert!(mlir.contains("func.func @_RC9fibonacci"), "{mlir}");
+        assert!(mlir.contains("arith.cmpi ule"), "{mlir}");
+        assert!(mlir.contains("scf.if"), "{mlir}");
+        assert!(mlir.contains("call @_RC9fibonacci"), "{mlir}");
+        assert!(mlir.contains("reussir.trampoline"), "{mlir}");
+    }
+
+    #[test]
+    fn lowers_and_runs_through_the_pipeline() {
+        let src = r#"
+            pub fn add3(a: i32, b: i32, c: i32) -> i32 { a + b + c }
+            extern "C" trampoline "add3_ffi" = add3;
+        "#;
+        let context = reussir_backend::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let mut module = lower_program(&context, &full).expect("lowering succeeds");
+            reussir_backend::pipeline::run_lowering_pipeline(
+                &context,
+                &mut module,
+                &reussir_backend::pipeline::LoweringOptions::default(),
+            )
+            .expect("pipeline lowers the scalar module to LLVM");
+        });
+    }
+}

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -1,0 +1,66 @@
+//! Type lowering: ground scalar Reussir types → MLIR types, plus the numeric
+//! classification [`expr`](super::expr) uses to choose the right cast op.
+
+use reussir_backend::melior::Context;
+use reussir_backend::melior::ir::Type;
+use reussir_backend::melior::ir::r#type::IntegerType;
+
+use reussir_core::semi::ty::{FpTy, IntTy, Ty, TyKind};
+
+use super::{Result, err};
+
+/// Whether `ty` is the unit type (which carries no MLIR SSA value).
+pub(super) fn is_unit(ty: Ty<'_>) -> bool {
+    matches!(ty.kind(), TyKind::Unit)
+}
+
+/// The MLIR type for a ground scalar Reussir type.
+pub(super) fn mlir_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
+    match *ty.kind() {
+        TyKind::Int(IntTy::Signed(w)) | TyKind::Int(IntTy::Unsigned(w)) => {
+            Ok(IntegerType::new(context, u32::from(w)).into())
+        }
+        TyKind::Fp(FpTy::Ieee(16)) => Ok(Type::float16(context)),
+        TyKind::Fp(FpTy::Ieee(32)) => Ok(Type::float32(context)),
+        TyKind::Fp(FpTy::Ieee(64)) => Ok(Type::float64(context)),
+        TyKind::Fp(FpTy::Ieee(_)) => err("unsupported IEEE float width"),
+        TyKind::Fp(FpTy::BFloat16) => Ok(Type::bfloat16(context)),
+        TyKind::Fp(FpTy::Float8) => err("float8 has no standard MLIR builtin type"),
+        TyKind::Bool => Ok(IntegerType::new(context, 1).into()),
+        TyKind::Unit => err("unit has no MLIR value type"),
+        TyKind::Str => err("string type lowering not yet implemented"),
+        TyKind::Record { .. } => err("record type lowering not yet implemented"),
+        TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),
+        TyKind::Closure { .. } => err("closure type lowering not yet implemented"),
+        TyKind::Bottom => err("bottom type reached lowering"),
+        TyKind::Generic(_) | TyKind::Hole(_) => err("non-ground type reached lowering"),
+    }
+}
+
+/// The numeric classification of a scalar type, used to pick the right cast op.
+pub(super) struct NumClass {
+    /// Bit width of the scalar.
+    pub(super) width: u16,
+    /// Whether to treat it as signed — selects `extsi`/`sitofp` over the
+    /// unsigned variants. Floats are signed by convention.
+    pub(super) signed: bool,
+    /// Whether it is a floating-point type (vs. an integer or `bool`).
+    pub(super) float: bool,
+}
+
+/// Classify a numeric scalar for cast selection, or error if it isn't one.
+pub(super) fn num_class(ty: Ty<'_>) -> Result<NumClass> {
+    let (width, signed, float) = match *ty.kind() {
+        TyKind::Int(IntTy::Signed(w)) => (w, true, false),
+        TyKind::Int(IntTy::Unsigned(w)) => (w, false, false),
+        TyKind::Bool => (1, false, false),
+        TyKind::Fp(FpTy::Ieee(w)) => (w, true, true),
+        TyKind::Fp(FpTy::BFloat16) => (16, true, true),
+        _ => return err("cast operand is not a numeric scalar"),
+    };
+    Ok(NumClass {
+        width,
+        signed,
+        float,
+    })
+}

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -1,0 +1,86 @@
+//! End-to-end frontend execution: Reussir source → elaborate → monomorphize →
+//! lower to MLIR → run through the lowering pipeline → JIT-execute.
+//!
+//! This exercises the whole spine for the scalar/control-flow subset: the
+//! result of calling the compiled function through the C ABI must match the
+//! program's meaning.
+
+use reussir_backend::pipeline::{LoweringOptions, run_lowering_pipeline};
+use reussir_codegen::lower::lower_program;
+use reussir_core::full::mono::monomorphize;
+use reussir_core::{in_arena, semi::elaborate, surface};
+use reussir_jit::{OptLevel, OrcJit};
+
+/// Compile `source` to a lowered LLVM-dialect module, then JIT it and hand the
+/// engine to `run` to look up and call entry points.
+fn jit_run<R>(source: &str, run: impl FnOnce(&OrcJit) -> R) -> R {
+    let context = reussir_backend::context();
+    // Frontend + lowering, inside the arena scope; the module outlives it.
+    let mut module = in_arena(|tcx| {
+        let parse = reussir_syntax::parse(source);
+        assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+        let prog = surface::program(&parse.root);
+        let elab = elaborate(tcx, &prog, parse.resolver());
+        assert!(
+            !elab.has_errors(),
+            "elaboration errors: {:#?}",
+            elab.reports
+        );
+        let (full, reports) = monomorphize(&elab.mono_input());
+        assert!(reports.is_empty(), "mono reports: {reports:#?}");
+        lower_program(&context, &full).expect("scalar lowering succeeds")
+    });
+
+    run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
+        .expect("pipeline lowers to LLVM");
+
+    let jit = OrcJit::with_runtime().expect("create JIT");
+    jit.add_module(&module, OptLevel::Default)
+        .expect("add lowered module");
+    run(&jit)
+}
+
+#[test]
+fn runs_recursive_fibonacci() {
+    let src = r#"
+        pub fn fibonacci(n: u64) -> u64 {
+            if n <= 1 { n } else { fibonacci(n - 1) + fibonacci(n - 2) }
+        }
+        extern "C" trampoline "fibonacci_ffi" = fibonacci;
+    "#;
+    jit_run(src, |jit| {
+        // Call through the exported C-ABI trampoline, not the internal symbol.
+        let addr = jit.lookup("fibonacci_ffi").expect("lookup fibonacci_ffi");
+        let fib: extern "C" fn(u64) -> u64 = unsafe { std::mem::transmute(addr as usize) };
+        // 0,1,1,2,3,5,8,13,21,34,55
+        assert_eq!(fib(0), 0);
+        assert_eq!(fib(1), 1);
+        assert_eq!(fib(10), 55);
+        assert_eq!(fib(20), 6765);
+    });
+}
+
+#[test]
+fn runs_iterative_helper_and_signed_arithmetic() {
+    let src = r#"
+        fn iter_impl(n: u64, a: u64, b: u64) -> u64 {
+            if n == 0 { a } else { iter_impl(n - 1, b, a + b) }
+        }
+        pub fn fib_iter(n: u64) -> u64 { iter_impl(n, 0, 1) }
+        pub fn signed_mix(a: i32, b: i32) -> i32 { (a * b - 7) / 2 }
+        extern "C" trampoline "fib_iter_ffi" = fib_iter;
+        extern "C" trampoline "signed_mix_ffi" = signed_mix;
+    "#;
+    jit_run(src, |jit| {
+        // Call through the exported C-ABI trampolines, not the internal symbols.
+        let a = jit.lookup("fib_iter_ffi").expect("lookup fib_iter_ffi");
+        let fib_iter: extern "C" fn(u64) -> u64 = unsafe { std::mem::transmute(a as usize) };
+        assert_eq!(fib_iter(10), 55);
+        assert_eq!(fib_iter(20), 6765);
+
+        let s = jit.lookup("signed_mix_ffi").expect("lookup signed_mix_ffi");
+        let signed_mix: extern "C" fn(i32, i32) -> i32 = unsafe { std::mem::transmute(s as usize) };
+        // (6 * -5 - 7) / 2 = (-30 - 7) / 2 = -37 / 2 = -18 (signed truncation toward zero)
+        assert_eq!(signed_mix(6, -5), -18);
+    });
+}


### PR DESCRIPTION
Reworked onto current `main` (after #266 merged). Connects the Rust frontend to the MLIR backend and proves the whole spine end-to-end for the scalar subset.

## What
- **New `reussir-codegen` crate**, depending on both `reussir-core` (the monomorphized Full MIR) and `reussir-backend` (melior + the Reussir-dialect ODS builders + `context()`/`pipeline`). This keeps `reussir-core` free of any MLIR dependency (it stays a default-member) and avoids a backend↔core cycle. The crate is a workspace member but is excluded from `default-members`.
- `reussir_codegen::lower::lower_program(&Context, &mir::Program) -> Module` builds the MLIR module **in memory** through the melior `func`/`arith`/`scf` ODS builders (no text emission): integer/float values, arithmetic + comparison (signed/unsigned/float), numeric casts, `if` (→ `scf.if` with yields), `let`/sequencing, direct calls, and exported `reussir.trampoline`.
- RC constructs (records, closures, `match`, regions, strings) return an explicit `LoweringError` rather than wrong code — they land with the ownership analysis.

## Notes
- Mono already resolves every callee/trampoline target to an interned `mir::Symbol`, so lowering needs no `DefTable`/resolver/`Mangler` — it looks names up via `program.symbol(sym)`.
- The SSA environment threads melior `Value`s with their real borrow lifetimes (no `unsafe`): an `scf.if` branch builds into its own block over a lifetime-shortened copy of the enclosing environment, so branch-local bindings stay scoped.
- Where a generated ODS/melior builder lacks a needed parameter, the raw `OperationBuilder` usage is encapsulated as a typed util in `reussir_backend::builders` (so the code generator only calls good abstractions): `truncf` (float narrowing needs an explicit result type) and `trampoline_export` (the `TrampolineDirection` `I32EnumAttr` has no melior/CAPI constructor).

## Verification
- Codegen unit tests: emitted MLIR **parses + verifies** and **lowers through `run_lowering_pipeline`** to the LLVM dialect.
- `reussir-codegen/tests/frontend_e2e.rs`: full frontend → lower → **JIT-execute**:
  - recursive `fibonacci` — `fib(10)=55`, `fib(20)=6765`
  - iterative helper with a `private` internal function
  - signed integer arithmetic — `(6*-5-7)/2 = -18`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
