### PR TITLE
[backend] reussir-compiler: standalone AOT object/asm/llvm-ir compiler

### DIFF
--- a/.github/workflows/mlir-cpp-test.yml
+++ b/.github/workflows/mlir-cpp-test.yml
@@ -129,3 +129,6 @@ jobs:
 
       - name: Build and Test reussir-codegen
         run: cmake --build build --target reussir-codegen-test
+
+      - name: Build and Test reussir-compiler
+        run: cmake --build build --target reussir-compiler-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ add_subdirectory(crates/reussir-syntax)
 add_subdirectory(crates/reussir-backend)
 add_subdirectory(crates/reussir-jit)
 add_subdirectory(crates/reussir-codegen)
+add_subdirectory(crates/reussir-compiler)
 add_subdirectory(frontend)
 
 if (REUSSIR_ENABLE_TESTS)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "reussir-compiler"
+version = "0.1.0"
+dependencies = [
+ "llvm-sys",
+ "melior",
+ "mlir-sys",
+ "palc",
+ "reussir-backend",
+ "reussir-backend-sys",
+ "reussir-codegen",
+ "reussir-core",
+ "reussir-syntax",
+]
+
+[[package]]
 name = "reussir-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 name = "reussir-backend"
 version = "0.1.0"
 dependencies = [
+ "llvm-sys",
  "melior",
+ "mlir-sys",
  "reussir-backend-sys",
  "tracing",
 ]
@@ -1129,7 +1131,6 @@ version = "0.1.0"
 dependencies = [
  "llvm-sys",
  "melior",
- "mlir-sys",
  "reussir-backend",
  "reussir-backend-sys",
  "reussir-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/reussir-backend",
     "crates/reussir-jit",
     "crates/reussir-codegen",
+    "crates/reussir-compiler",
 ]
 # The backend crates (and reussir-codegen, which depends on them) link against
 # MLIR and the staged Reussir C API, so they are excluded from the default

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -70,10 +70,16 @@ pub struct LlvmOpaqueModule {
 pub struct LlvmOpaqueContext {
     _private: [u8; 0],
 }
+#[repr(C)]
+pub struct LlvmOpaqueMemoryBuffer {
+    _private: [u8; 0],
+}
 /// Mirrors `LLVMModuleRef`.
 pub type LLVMModuleRef = *mut LlvmOpaqueModule;
 /// Mirrors `LLVMContextRef`.
 pub type LLVMContextRef = *mut LlvmOpaqueContext;
+/// Mirrors `LLVMMemoryBufferRef`.
+pub type LLVMMemoryBufferRef = *mut LlvmOpaqueMemoryBuffer;
 
 unsafe extern "C" {
     //==-- Dialect registration --==//
@@ -141,6 +147,22 @@ unsafe extern "C" {
 
     /// Reports whether TPDE support was compiled into the backend.
     pub fn reussirHasTPDE() -> c_int;
+
+    //==-- LLVM-side codegen helpers (Jit.h) --==//
+
+    /// Runs the Reussir LLVM optimization pipeline on `module` in place at the
+    /// requested level (a no-op for `None`/`Tpde`). `opt` mirrors the backend's
+    /// `ReussirOptOption`/`ReussirJitOptLevel` C enum.
+    pub fn reussirRunBackendLLVMPipeline(module: LLVMModuleRef, opt: c_int);
+
+    /// Compiles `module` to an ELF object with TPDE after stamping the given data
+    /// layout and triple on it. Returns null if TPDE is unavailable or
+    /// compilation fails; otherwise the caller owns the returned memory buffer.
+    pub fn reussirTpdeCompileToObject(
+        module: LLVMModuleRef,
+        data_layout: *const c_char,
+        triple: *const c_char,
+    ) -> LLVMMemoryBufferRef;
 
     //==-- Reussir type constructors --==//
     //

--- a/crates/reussir-backend/CMakeLists.txt
+++ b/crates/reussir-backend/CMakeLists.txt
@@ -25,6 +25,9 @@ set(REUSSIR_BACKEND_CARGO_ENV
     MLIR_SYS_210_PREFIX=${REUSSIR_LLVM_PREFIX}
     TABLEGEN_220_PREFIX=${REUSSIR_LLVM_PREFIX}
     LLVM_SYS_220_PREFIX=${REUSSIR_LLVM_PREFIX}
+    # `llvm-sys` 221 (the shared LLVM-IR boundary: translate, the backend LLVM
+    # pipeline, polyffi gather/link) discovers LLVM through the 221 variable.
+    LLVM_SYS_221_PREFIX=${REUSSIR_LLVM_PREFIX}
     REUSSIR_CAPI_LIB_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     REUSSIR_INCLUDE_DIR=${CMAKE_SOURCE_DIR}/include
     RUSTFLAGS=-Awarnings)

--- a/crates/reussir-backend/Cargo.toml
+++ b/crates/reussir-backend/Cargo.toml
@@ -19,4 +19,10 @@ doctest = false
 # typestate markers. `helpers` enables melior's higher-level convenience APIs.
 melior = { workspace = true, features = ["ods-dialects", "helpers"] }
 reussir-backend-sys = { path = "../reussir-backend-sys" }
+# The LLVM-IR boundary shared by the JIT and the AOT compiler: `mlir-sys` for
+# MLIR→LLVM-IR translation, `llvm-sys` for module linking and disposal. Both
+# resolve to the same LLVM the dialect statically links (LLVM_SYS_221_PREFIX set
+# by CMake), so `LLVMModuleRef`s cross the boundary safely.
+mlir-sys.workspace = true
+llvm-sys.workspace = true
 tracing.workspace = true

--- a/crates/reussir-backend/src/lib.rs
+++ b/crates/reussir-backend/src/lib.rs
@@ -18,6 +18,7 @@ use reussir_backend_sys as sys;
 
 pub mod builders;
 pub mod dialect;
+pub mod llvm;
 pub mod pipeline;
 
 /// Returns the [`DialectHandle`] for the Reussir dialect.

--- a/crates/reussir-backend/src/llvm.rs
+++ b/crates/reussir-backend/src/llvm.rs
@@ -1,0 +1,164 @@
+//! The LLVM-IR boundary shared by the JIT (`reussir-jit`) and the AOT compiler
+//! (`reussir-compiler`): translating a lowered MLIR module to LLVM IR, running
+//! the backend LLVM pass pipeline, and the polymorphic-FFI gather/link.
+//!
+//! Polymorphic FFI straddles the MLIR lowering pipeline. The `reussir.polyffi`
+//! templates are compiled to LLVM bitcode and gathered *before* the pipeline
+//! erases them, but the gathered module is linked into the main module *after*
+//! it is translated to LLVM IR. [`LlvmLowering`] is the handle carried across
+//! the caller's [`run_lowering_pipeline`](crate::pipeline::run_lowering_pipeline)
+//! call to bracket those two halves; it also owns the `LLVMContext` both modules
+//! live in, so they can be linked.
+//!
+//! These helpers operate on raw `llvm-sys` handles (and pass them to the Reussir
+//! CAPI, whose mirror types are pointer-cast across) so callers keep driving the
+//! ORC session / target-machine emission through `llvm-sys` directly. All LLVM
+//! handles here resolve to the one statically linked LLVM, so the casts are
+//! sound.
+
+use std::ffi::CString;
+
+use llvm_sys::core::{LLVMContextCreate, LLVMContextDispose, LLVMDisposeModule, LLVMSetDataLayout};
+use llvm_sys::linker::LLVMLinkModules2;
+use llvm_sys::prelude::{LLVMContextRef, LLVMModuleRef};
+
+use melior::ir::Module;
+
+use reussir_backend_sys as sys;
+
+use crate::pipeline::OptLevel;
+
+/// Translates a lowered MLIR `module` to an LLVM IR module created in `context`.
+///
+/// The returned module is owned alongside `context`. Returns an error if MLIR
+/// translation fails.
+///
+/// # Safety
+/// `context` must be a valid `LLVMContextRef`, and `module` must already be
+/// lowered to the LLVM dialect.
+pub unsafe fn translate_to_llvm_ir(
+    module: &Module,
+    context: LLVMContextRef,
+) -> Result<LLVMModuleRef, String> {
+    unsafe {
+        let operation = mlir_sys::mlirModuleGetOperation(module.to_raw());
+        let llvm_module =
+            mlir_sys::mlirTranslateModuleToLLVMIR(operation, context as mlir_sys::LLVMContextRef)
+                as LLVMModuleRef;
+        if llvm_module.is_null() {
+            return Err("failed to translate MLIR module to LLVM IR".into());
+        }
+        Ok(llvm_module)
+    }
+}
+
+/// Runs the Reussir backend LLVM pass pipeline on `module` in place (a no-op for
+/// [`OptLevel::None`]/[`OptLevel::Tpde`], matching the C++ backend).
+///
+/// # Safety
+/// `module` must be a valid `LLVMModuleRef`.
+pub unsafe fn run_backend_llvm_pipeline(module: LLVMModuleRef, opt: OptLevel) {
+    unsafe {
+        sys::reussirRunBackendLLVMPipeline(
+            module as sys::LLVMModuleRef,
+            opt.as_reussir_opt_option(),
+        );
+    }
+}
+
+/// Polymorphic-FFI lowering bracketing the MLIR lowering pipeline.
+///
+/// Construct it with [`prepare`](Self::prepare) before running the lowering
+/// pipeline, then [`finish`](Self::finish) afterwards. It owns the `LLVMContext`
+/// the gathered and (eventually) main modules share.
+pub struct LlvmLowering {
+    context: LLVMContextRef,
+    /// The gathered FFI bitcode (an empty module when there is no polyffi).
+    /// Null after [`finish`](Self::finish) consumes it via the linker.
+    gathered: LLVMModuleRef,
+    data_layout: CString,
+}
+
+impl LlvmLowering {
+    /// Phase 1 — run *before* the MLIR lowering pipeline. Creates the LLVM
+    /// context, compiles the module's `reussir.polyffi` templates, and gathers
+    /// their bitcode (an empty module when there is none, so the scalar path is
+    /// unaffected). `data_layout` stamps the gathered module — and later the main
+    /// module — so the eventual link is layout-consistent.
+    ///
+    /// Gathering erases the polyffi ops, so the lowering pipeline's own
+    /// `CompilePolymorphicFFIPass` then sees nothing to do.
+    pub fn prepare(module: &Module, data_layout: &str, optimized: bool) -> Result<Self, String> {
+        let data_layout =
+            CString::new(data_layout).map_err(|_| "data layout contains a NUL byte".to_string())?;
+        unsafe {
+            if !sys::reussirCompilePolymorphicFFI(module.to_raw(), optimized) {
+                return Err("failed to compile polymorphic FFI".into());
+            }
+            let context = LLVMContextCreate();
+            let gathered = sys::reussirGatherCompiledModules(
+                module.to_raw(),
+                context as sys::LLVMContextRef,
+                data_layout.as_ptr(),
+            ) as LLVMModuleRef;
+            if gathered.is_null() {
+                LLVMContextDispose(context);
+                return Err("failed to gather compiled polymorphic-FFI modules".into());
+            }
+            Ok(Self {
+                context,
+                gathered,
+                data_layout,
+            })
+        }
+    }
+
+    /// Phase 3 — run *after* the MLIR lowering pipeline. Translates the lowered
+    /// `module` into the prepared context, stamps the shared data layout, and
+    /// links the gathered FFI bitcode into it. Returns the finalized LLVM IR
+    /// module (and the context that owns it) for the caller to optimize and
+    /// either JIT or emit.
+    pub fn finish(mut self, module: &Module) -> Result<Finalized, String> {
+        unsafe {
+            let main = translate_to_llvm_ir(module, self.context)?;
+            LLVMSetDataLayout(main, self.data_layout.as_ptr());
+            // `LLVMLinkModules2` consumes (disposes) the source module, even on
+            // failure — so null our handle either way to keep `Drop` correct.
+            let gathered = std::mem::replace(&mut self.gathered, std::ptr::null_mut());
+            if LLVMLinkModules2(main, gathered) != 0 {
+                LLVMDisposeModule(main);
+                return Err("failed to link polymorphic-FFI modules into the main module".into());
+            }
+            // Hand the context off to `Finalized`; null it so our `Drop` is inert.
+            let context = std::mem::replace(&mut self.context, std::ptr::null_mut());
+            Ok(Finalized {
+                context,
+                module: main,
+            })
+        }
+    }
+}
+
+impl Drop for LlvmLowering {
+    fn drop(&mut self) {
+        // Only disposes anything when `finish` was *not* called (e.g. an error
+        // between `prepare` and `finish`); `finish` nulls both handles.
+        unsafe {
+            if !self.gathered.is_null() {
+                LLVMDisposeModule(self.gathered);
+            }
+            if !self.context.is_null() {
+                LLVMContextDispose(self.context);
+            }
+        }
+    }
+}
+
+/// A finalized LLVM IR module and the `LLVMContext` that owns it. The caller is
+/// responsible for the handles: run [`run_backend_llvm_pipeline`] over `module`,
+/// then either hand `module`/`context` to the ORC JIT or emit `module` and
+/// dispose both.
+pub struct Finalized {
+    pub context: LLVMContextRef,
+    pub module: LLVMModuleRef,
+}

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -33,6 +33,20 @@ impl OptLevel {
     fn runs_optimization(self) -> bool {
         !matches!(self, OptLevel::None)
     }
+
+    /// This level as its matching `ReussirOptOption` C enum value — the contract
+    /// the LLVM-IR-level backend pipeline (`reussirRunBackendLLVMPipeline`)
+    /// expects. Owned here so callers (the JIT, the AOT compiler) need not
+    /// re-encode it.
+    pub fn as_reussir_opt_option(self) -> core::ffi::c_int {
+        match self {
+            OptLevel::None => 0,
+            OptLevel::Default => 1,
+            OptLevel::Aggressive => 2,
+            OptLevel::Size => 3,
+            OptLevel::Tpde => 4,
+        }
+    }
 }
 
 /// Knobs for [`run_lowering_pipeline`].

--- a/crates/reussir-backend/tests/polyffi_link.rs
+++ b/crates/reussir-backend/tests/polyffi_link.rs
@@ -1,0 +1,72 @@
+//! Exercises the polymorphic-FFI gather/link step shared by the JIT and the AOT
+//! compiler: a `reussir.polyffi` template is compiled to LLVM bitcode, gathered
+//! ([`LlvmLowering::prepare`]), and linked into the finalized module
+//! ([`LlvmLowering::finish`]) so its function ends up *defined* — not merely
+//! declared — in the resulting LLVM IR. Without the gather/link, the symbol would
+//! remain an undefined external and fail to link.
+//!
+//! Ignored by default: it shells out to `rustc` to compile the embedded Rust
+//! (needs `REUSSIR_RUSTC`/`rustc` on a known path, and a `REUSSIR_RUSTC_DEPS`
+//! directory for its `-L`). Run explicitly with:
+//!
+//! ```text
+//! cargo test -p reussir-backend --test polyffi_link -- --ignored
+//! ```
+
+use std::ffi::CString;
+
+use reussir_backend::context;
+use reussir_backend::llvm::LlvmLowering;
+use reussir_backend::melior::ir::Module;
+use reussir_backend::pipeline::{LoweringOptions, run_lowering_pipeline};
+
+// A self-contained polyffi template (no `extern crate reussir_rt`, so the
+// `-L` deps dir only has to exist) defining one `extern "C"` function, plus a
+// caller that references it through a `func.func` declaration.
+const MODULE: &str = r##"
+module {
+  reussir.polyffi texture("#[no_mangle] pub unsafe extern \"C\" fn __reussir_polyffi_answer() -> i64 { 42 }")
+  func.func private @__reussir_polyffi_answer() -> i64
+  func.func @entry() -> i64 {
+    %0 = func.call @__reussir_polyffi_answer() : () -> i64
+    func.return %0 : i64
+  }
+}
+"##;
+
+#[test]
+#[ignore = "requires rustc + a REUSSIR_RUSTC_DEPS directory for the polyffi bitcode compile"]
+fn polyffi_function_is_linked_in() {
+    // The Rust-compiler helper requires a non-empty deps directory even when the
+    // template pulls in no external crates; any existing directory will do.
+    if std::env::var_os("REUSSIR_RUSTC_DEPS").is_none() {
+        unsafe { std::env::set_var("REUSSIR_RUSTC_DEPS", env!("CARGO_MANIFEST_DIR")) };
+    }
+
+    let context = context();
+    let mut module = Module::parse(&context, MODULE).expect("polyffi module parses");
+
+    // Gather (compiles the template + collects its bitcode) must run before the
+    // lowering pipeline erases the polyffi op; the link happens in `finish`.
+    let prepared =
+        LlvmLowering::prepare(&module, "", false).expect("polyffi compile + gather succeeds");
+    run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
+        .expect("lowering pipeline succeeds");
+    let finalized = prepared.finish(&module).expect("translate + link succeeds");
+
+    unsafe {
+        let name = CString::new("__reussir_polyffi_answer").unwrap();
+        let function = llvm_sys::core::LLVMGetNamedFunction(finalized.module, name.as_ptr());
+        assert!(
+            !function.is_null(),
+            "polyffi function missing from the linked module"
+        );
+        assert_eq!(
+            llvm_sys::core::LLVMIsDeclaration(function),
+            0,
+            "polyffi function is only declared, not defined — gather/link did not run"
+        );
+        llvm_sys::core::LLVMDisposeModule(finalized.module);
+        llvm_sys::core::LLVMContextDispose(finalized.context);
+    }
+}

--- a/crates/reussir-compiler/CMakeLists.txt
+++ b/crates/reussir-compiler/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Builds the reussir-compiler Rust crate (the AOT driver: Reussir source ->
+# native object / assembly / LLVM IR) with cargo.
+#
+# Like reussir-backend / reussir-jit / reussir-codegen, these targets are NOT
+# part of the default `ALL` build. Invoke them explicitly:
+#   ninja -C build reussir-compiler         # compile the crate + binary
+#   ninja -C build reussir-compiler-test    # run the crate's tests
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(REUSSIR_COMPILER_CARGO_PROFILE "dev")
+else()
+    set(REUSSIR_COMPILER_CARGO_PROFILE "release")
+endif()
+
+# The same environment as reussir-codegen: the crate pulls in reussir-backend
+# (mlir-sys / melior / the staged Reussir archives) and links LLVM via llvm-sys
+# 221, all discovered through these prefixes.
+set(REUSSIR_COMPILER_CARGO_ENV
+    CARGO_TARGET_DIR=${CMAKE_BINARY_DIR}/target
+    MLIR_SYS_220_PREFIX=${REUSSIR_LLVM_PREFIX}
+    MLIR_SYS_210_PREFIX=${REUSSIR_LLVM_PREFIX}
+    TABLEGEN_220_PREFIX=${REUSSIR_LLVM_PREFIX}
+    LLVM_SYS_220_PREFIX=${REUSSIR_LLVM_PREFIX}
+    LLVM_SYS_221_PREFIX=${REUSSIR_LLVM_PREFIX}
+    REUSSIR_CAPI_LIB_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    REUSSIR_INCLUDE_DIR=${CMAKE_SOURCE_DIR}/include
+    RUSTFLAGS=-Awarnings)
+
+add_custom_target(reussir-compiler
+    COMMAND ${CMAKE_COMMAND} -E env ${REUSSIR_COMPILER_CARGO_ENV}
+        cargo build --locked --profile ${REUSSIR_COMPILER_CARGO_PROFILE}
+        --package reussir-compiler --quiet
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS ReussirCAPI MLIRReussir
+    COMMENT "Building reussir-compiler with cargo (${REUSSIR_COMPILER_CARGO_PROFILE} profile)"
+    USES_TERMINAL
+)
+
+add_custom_target(reussir-compiler-test
+    COMMAND ${CMAKE_COMMAND} -E env ${REUSSIR_COMPILER_CARGO_ENV}
+        cargo test --locked --profile ${REUSSIR_COMPILER_CARGO_PROFILE}
+        --package reussir-compiler
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS ReussirCAPI MLIRReussir
+    COMMENT "Testing reussir-compiler with cargo"
+    USES_TERMINAL
+)

--- a/crates/reussir-compiler/Cargo.toml
+++ b/crates/reussir-compiler/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "reussir-compiler"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Ahead-of-time Reussir compiler: source → native object / assembly / LLVM IR"
+
+[lib]
+name = "reussir_compiler"
+
+[dependencies]
+# `melior` for the lowered `Module` type; `mlir-sys` for the MLIR→LLVM-IR
+# translation; `llvm-sys` for the host `TargetMachine` emission. llvm-sys
+# discovers LLVM via LLVM_SYS_221_PREFIX (set by CMake).
+melior.workspace = true
+mlir-sys.workspace = true
+llvm-sys.workspace = true
+# The MLIR foundation: the lowering `pipeline` and its `OptLevel`, plus `context()`.
+reussir-backend = { path = "../reussir-backend" }
+# Links libReussirCAPI (the custom Reussir LLVM passes) and the staged archives
+# into the final binary, and supplies `reussirRunBackendLLVMPipeline`; see its
+# build.rs. No JIT engine and no runtime are linked into the AOT compiler.
+reussir-backend-sys = { path = "../reussir-backend-sys" }
+# Full MIR → MLIR lowering.
+reussir-codegen = { path = "../reussir-codegen" }
+# The frontend: parse → elaborate → monomorphize.
+reussir-core = { path = "../reussir-core" }
+reussir-syntax = { path = "../reussir-syntax" }
+palc.workspace = true

--- a/crates/reussir-compiler/src/lib.rs
+++ b/crates/reussir-compiler/src/lib.rs
@@ -1,42 +1,39 @@
-//! Ahead-of-time compilation: a lowered MLIR module → an object file, assembly,
-//! or LLVM IR on disk.
+//! Ahead-of-time compilation: a finalized LLVM IR module → an object file,
+//! assembly, or LLVM IR on disk.
 //!
-//! This is the AOT counterpart to `reussir-jit`: instead of adding the
-//! translated LLVM IR to an ORC JIT session, it runs the backend LLVM pass
-//! pipeline and emits a file with a host (or cross) `TargetMachine`. It links neither the
-//! JIT engine nor the Reussir runtime — an emitted object is linked against
-//! `reussir-rt` later by the C toolchain. The `reussir-compiler` binary drives
-//! the whole frontend → lowering → [`compile_to_file`] path.
+//! This is the AOT counterpart to `reussir-jit`: instead of adding the finalized
+//! LLVM IR to an ORC JIT session, it emits a file with a host (or cross)
+//! `TargetMachine`. It links neither the JIT engine nor the Reussir runtime — an
+//! emitted object is linked against `reussir-rt` later by the C toolchain.
+//!
+//! The `reussir-compiler` binary drives the shared lowering in
+//! [`reussir_backend::llvm`] — build a [`TargetMachine`] (its data layout feeds
+//! the polymorphic-FFI gather), run the lowering pipeline, finalize, then hand
+//! the [`Finalized`] module to [`emit_to_file`].
 
-use std::ffi::{CString, c_char, c_int};
+use std::ffi::{CString, c_char};
 use std::path::Path;
-use std::sync::Once;
 
 use llvm_sys::core::{
-    LLVMContextCreate, LLVMContextDispose, LLVMDisposeMessage, LLVMDisposeModule,
-    LLVMPrintModuleToString, LLVMSetTarget,
+    LLVMContextDispose, LLVMDisposeMessage, LLVMDisposeModule, LLVMPrintModuleToString,
+    LLVMSetTarget,
 };
-use llvm_sys::prelude::{LLVMContextRef, LLVMModuleRef};
+use llvm_sys::prelude::LLVMModuleRef;
 use llvm_sys::target::{
-    LLVM_InitializeNativeAsmParser, LLVM_InitializeNativeAsmPrinter, LLVM_InitializeNativeTarget,
+    LLVM_InitializeAllAsmParsers, LLVM_InitializeAllAsmPrinters, LLVM_InitializeAllTargetInfos,
+    LLVM_InitializeAllTargetMCs, LLVM_InitializeAllTargets, LLVM_InitializeNativeAsmParser,
+    LLVM_InitializeNativeAsmPrinter, LLVM_InitializeNativeTarget, LLVMCopyStringRepOfTargetData,
     LLVMDisposeTargetData, LLVMSetModuleDataLayout,
 };
 use llvm_sys::target_machine::{
     LLVMCodeGenFileType, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMCreateTargetDataLayout,
     LLVMCreateTargetMachine, LLVMDisposeTargetMachine, LLVMGetDefaultTargetTriple,
     LLVMGetHostCPUFeatures, LLVMGetHostCPUName, LLVMGetTargetFromTriple, LLVMRelocMode,
-    LLVMTargetMachineEmitToFile, LLVMTargetRef,
+    LLVMTargetMachineEmitToFile, LLVMTargetMachineRef, LLVMTargetRef,
 };
 
-use melior::ir::Module;
-
+use reussir_backend::llvm::{Finalized, run_backend_llvm_pipeline};
 use reussir_backend::pipeline::OptLevel;
-
-// LLVM-side codegen helper from libReussirCAPI: the custom Reussir LLVM passes,
-// the same pipeline the JIT runs.
-unsafe extern "C" {
-    fn reussirRunBackendLLVMPipeline(module: LLVMModuleRef, opt: c_int);
-}
 
 /// What `reussir-compiler` writes out.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -75,15 +72,30 @@ pub struct TargetSpec {
     pub features: Option<String>,
 }
 
-fn init_native() {
-    static ONCE: Once = Once::new();
-    ONCE.call_once(|| unsafe {
-        // A non-zero return means the target is unavailable; codegen then fails
-        // loudly at `LLVMGetTargetFromTriple`, so there is nothing to recover here.
-        LLVM_InitializeNativeTarget();
-        LLVM_InitializeNativeAsmPrinter();
-        LLVM_InitializeNativeAsmParser();
-    });
+/// Registers LLVM targets before codegen. A host compile needs only the native
+/// target; a custom triple may name any architecture, so register them all —
+/// otherwise `LLVMGetTargetFromTriple` would not find a foreign target's backend.
+///
+/// No `Once` guard: LLVM's `TargetRegistry::RegisterTarget` early-returns once a
+/// target is registered (`if (T.Name) return;`), and `TargetSelect.h` documents
+/// that "it is legal for a client to make multiple calls to this function", so
+/// these are idempotent on every compile.
+fn init_targets(cross: bool) {
+    unsafe {
+        if cross {
+            LLVM_InitializeAllTargetInfos();
+            LLVM_InitializeAllTargets();
+            LLVM_InitializeAllTargetMCs();
+            LLVM_InitializeAllAsmPrinters();
+            LLVM_InitializeAllAsmParsers();
+        } else {
+            // A non-zero return means the target is unavailable; codegen then
+            // fails loudly at `LLVMGetTargetFromTriple`, so nothing to recover.
+            LLVM_InitializeNativeTarget();
+            LLVM_InitializeNativeAsmPrinter();
+            LLVM_InitializeNativeAsmParser();
+        }
+    }
 }
 
 fn codegen_level(opt: OptLevel) -> LLVMCodeGenOptLevel {
@@ -127,49 +139,114 @@ unsafe fn take_llvm_string(ptr: *mut c_char) -> CString {
     }
 }
 
-/// Compile a lowered (LLVM-dialect) MLIR `module` to `out_path`.
+/// A host or cross `TargetMachine` plus the triple and data layout it implies.
 ///
-/// The module must already have been through
-/// [`crate::pipeline`](reussir_backend::pipeline)-equivalent lowering to the LLVM
-/// dialect; this translates it to LLVM IR, runs the backend LLVM pipeline, and
-/// emits the requested artifact for `target` (the native host by default).
-pub fn compile_to_file(
-    module: &Module,
+/// Built up front (before the lowering pipeline) because the data layout must be
+/// known before polymorphic-FFI gathering; the same machine then emits the file.
+pub struct TargetMachine {
+    machine: LLVMTargetMachineRef,
+    triple: CString,
+    data_layout: CString,
+}
+
+impl TargetMachine {
+    /// Resolves `spec` (host by default), creates the target machine at the given
+    /// optimization and relocation model, and queries its data layout.
+    pub fn new(spec: &TargetSpec, opt: OptLevel, reloc_mode: RelocMode) -> Result<Self, String> {
+        init_targets(spec.triple.is_some());
+        unsafe {
+            // A custom triple defaults CPU/features to empty (architecture
+            // defaults); the host's would crash LLVM against a foreign triple.
+            let foreign = spec.triple.is_some();
+            let triple = match spec.triple.as_deref() {
+                Some(t) => {
+                    CString::new(t).map_err(|_| "target triple contains a NUL byte".to_string())?
+                }
+                None => take_llvm_string(LLVMGetDefaultTargetTriple()),
+            };
+            let cpu = match spec.cpu.as_deref() {
+                Some(c) => {
+                    CString::new(c).map_err(|_| "target CPU contains a NUL byte".to_string())?
+                }
+                None if foreign => CString::default(),
+                None => take_llvm_string(LLVMGetHostCPUName()),
+            };
+            let features = match spec.features.as_deref() {
+                Some(f) => {
+                    CString::new(f).map_err(|_| "target features contain a NUL byte".to_string())?
+                }
+                None if foreign => CString::default(),
+                None => take_llvm_string(LLVMGetHostCPUFeatures()),
+            };
+
+            let mut target: LLVMTargetRef = std::ptr::null_mut();
+            let mut err: *mut c_char = std::ptr::null_mut();
+            if LLVMGetTargetFromTriple(triple.as_ptr(), &mut target, &mut err) != 0 {
+                let msg = c_str(err);
+                LLVMDisposeMessage(err);
+                return Err(format!(
+                    "no target for triple `{}`: {msg}",
+                    triple.to_string_lossy()
+                ));
+            }
+            let machine = LLVMCreateTargetMachine(
+                target,
+                triple.as_ptr(),
+                cpu.as_ptr(),
+                features.as_ptr(),
+                codegen_level(opt),
+                reloc(reloc_mode),
+                LLVMCodeModel::LLVMCodeModelDefault,
+            );
+            if machine.is_null() {
+                return Err("failed to create the target machine".to_string());
+            }
+            let target_data = LLVMCreateTargetDataLayout(machine);
+            let data_layout = take_llvm_string(LLVMCopyStringRepOfTargetData(target_data));
+            LLVMDisposeTargetData(target_data);
+            Ok(TargetMachine {
+                machine,
+                triple,
+                data_layout,
+            })
+        }
+    }
+
+    /// The target's data layout string — feed this to
+    /// [`reussir_backend::llvm::LlvmLowering::prepare`].
+    pub fn data_layout(&self) -> &str {
+        self.data_layout.to_str().unwrap_or("")
+    }
+}
+
+impl Drop for TargetMachine {
+    fn drop(&mut self) {
+        unsafe { LLVMDisposeTargetMachine(self.machine) }
+    }
+}
+
+/// Runs the backend LLVM pass pipeline over a [`Finalized`] module, emits the
+/// requested artifact for `machine`, and disposes the module and its context.
+pub fn emit_to_file(
+    finalized: Finalized,
+    machine: &TargetMachine,
     opt: OptLevel,
     kind: OutputKind,
-    reloc_mode: RelocMode,
-    target: &TargetSpec,
     out_path: &Path,
 ) -> Result<(), String> {
-    init_native();
     unsafe {
-        let context: LLVMContextRef = LLVMContextCreate();
-        let operation = mlir_sys::mlirModuleGetOperation(module.to_raw());
-        let llvm_module =
-            mlir_sys::mlirTranslateModuleToLLVMIR(operation, context as mlir_sys::LLVMContextRef)
-                as LLVMModuleRef;
-        if llvm_module.is_null() {
-            LLVMContextDispose(context);
-            return Err("failed to translate MLIR module to LLVM IR".into());
-        }
-
-        // The custom Reussir LLVM passes + standard optimization.
-        reussirRunBackendLLVMPipeline(llvm_module, opt.as_reussir_opt_option());
-
-        let result = emit(llvm_module, opt, kind, reloc_mode, target, out_path);
-
-        LLVMDisposeModule(llvm_module);
-        LLVMContextDispose(context);
+        run_backend_llvm_pipeline(finalized.module, opt);
+        let result = emit(finalized.module, machine, kind, out_path);
+        LLVMDisposeModule(finalized.module);
+        LLVMContextDispose(finalized.context);
         result
     }
 }
 
 unsafe fn emit(
     llvm_module: LLVMModuleRef,
-    opt: OptLevel,
+    machine: &TargetMachine,
     kind: OutputKind,
-    reloc_mode: RelocMode,
-    target_spec: &TargetSpec,
     out_path: &Path,
 ) -> Result<(), String> {
     unsafe {
@@ -182,57 +259,14 @@ unsafe fn emit(
                 .map_err(|e| format!("failed to write {}: {e}", out_path.display()));
         }
 
-        // Resolve the triple/CPU/features into owned C strings. A custom triple
-        // makes CPU/features default to empty (LLVM picks architecture defaults)
-        // rather than the host's, which would crash for a foreign triple.
-        let foreign = target_spec.triple.is_some();
-        let triple = match target_spec.triple.as_deref() {
-            Some(t) => {
-                CString::new(t).map_err(|_| "target triple contains a NUL byte".to_string())?
-            }
-            None => take_llvm_string(LLVMGetDefaultTargetTriple()),
-        };
-        let cpu = match target_spec.cpu.as_deref() {
-            Some(c) => CString::new(c).map_err(|_| "target CPU contains a NUL byte".to_string())?,
-            None if foreign => CString::default(),
-            None => take_llvm_string(LLVMGetHostCPUName()),
-        };
-        let features = match target_spec.features.as_deref() {
-            Some(f) => {
-                CString::new(f).map_err(|_| "target features contain a NUL byte".to_string())?
-            }
-            None if foreign => CString::default(),
-            None => take_llvm_string(LLVMGetHostCPUFeatures()),
-        };
-
-        let mut target: LLVMTargetRef = std::ptr::null_mut();
-        let mut err: *mut c_char = std::ptr::null_mut();
-        if LLVMGetTargetFromTriple(triple.as_ptr(), &mut target, &mut err) != 0 {
-            let msg = c_str(err);
-            LLVMDisposeMessage(err);
-            return Err(format!(
-                "no target for triple `{}`: {msg}",
-                triple.to_string_lossy()
-            ));
-        }
-        let machine = LLVMCreateTargetMachine(
-            target,
-            triple.as_ptr(),
-            cpu.as_ptr(),
-            features.as_ptr(),
-            codegen_level(opt),
-            reloc(reloc_mode),
-            LLVMCodeModel::LLVMCodeModelDefault,
-        );
-
         // Stamp the module with the target triple and data layout so the emitted
         // object's ABI matches the target (and so `%cc` can link it).
-        LLVMSetTarget(llvm_module, triple.as_ptr());
-        let data_layout = LLVMCreateTargetDataLayout(machine);
+        LLVMSetTarget(llvm_module, machine.triple.as_ptr());
+        let target_data = LLVMCreateTargetDataLayout(machine.machine);
         // `LLVMSetModuleDataLayout` copies the layout into the module, so the
         // target-data handle is ours to dispose.
-        LLVMSetModuleDataLayout(llvm_module, data_layout);
-        LLVMDisposeTargetData(data_layout);
+        LLVMSetModuleDataLayout(llvm_module, target_data);
+        LLVMDisposeTargetData(target_data);
 
         let file_type = match kind {
             OutputKind::Object => LLVMCodeGenFileType::LLVMObjectFile,
@@ -243,13 +277,12 @@ unsafe fn emit(
             .map_err(|_| "output path contains a NUL byte".to_string())?;
         let mut emit_err: *mut c_char = std::ptr::null_mut();
         let failed = LLVMTargetMachineEmitToFile(
-            machine,
+            machine.machine,
             llvm_module,
             path.as_ptr() as *mut c_char,
             file_type,
             &mut emit_err,
         );
-        LLVMDisposeTargetMachine(machine);
         if failed != 0 {
             let msg = c_str(emit_err);
             LLVMDisposeMessage(emit_err);

--- a/crates/reussir-compiler/src/lib.rs
+++ b/crates/reussir-compiler/src/lib.rs
@@ -1,0 +1,260 @@
+//! Ahead-of-time compilation: a lowered MLIR module → an object file, assembly,
+//! or LLVM IR on disk.
+//!
+//! This is the AOT counterpart to `reussir-jit`: instead of adding the
+//! translated LLVM IR to an ORC JIT session, it runs the backend LLVM pass
+//! pipeline and emits a file with a host (or cross) `TargetMachine`. It links neither the
+//! JIT engine nor the Reussir runtime — an emitted object is linked against
+//! `reussir-rt` later by the C toolchain. The `reussir-compiler` binary drives
+//! the whole frontend → lowering → [`compile_to_file`] path.
+
+use std::ffi::{CString, c_char, c_int};
+use std::path::Path;
+use std::sync::Once;
+
+use llvm_sys::core::{
+    LLVMContextCreate, LLVMContextDispose, LLVMDisposeMessage, LLVMDisposeModule,
+    LLVMPrintModuleToString, LLVMSetTarget,
+};
+use llvm_sys::prelude::{LLVMContextRef, LLVMModuleRef};
+use llvm_sys::target::{
+    LLVM_InitializeNativeAsmParser, LLVM_InitializeNativeAsmPrinter, LLVM_InitializeNativeTarget,
+    LLVMDisposeTargetData, LLVMSetModuleDataLayout,
+};
+use llvm_sys::target_machine::{
+    LLVMCodeGenFileType, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMCreateTargetDataLayout,
+    LLVMCreateTargetMachine, LLVMDisposeTargetMachine, LLVMGetDefaultTargetTriple,
+    LLVMGetHostCPUFeatures, LLVMGetHostCPUName, LLVMGetTargetFromTriple, LLVMRelocMode,
+    LLVMTargetMachineEmitToFile, LLVMTargetRef,
+};
+
+use melior::ir::Module;
+
+use reussir_backend::pipeline::OptLevel;
+
+// LLVM-side codegen helper from libReussirCAPI: the custom Reussir LLVM passes,
+// the same pipeline the JIT runs.
+unsafe extern "C" {
+    fn reussirRunBackendLLVMPipeline(module: LLVMModuleRef, opt: c_int);
+}
+
+/// What `reussir-compiler` writes out.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputKind {
+    /// A relocatable object file (`.o`).
+    Object,
+    /// Target assembly (`.s`).
+    Assembly,
+    /// LLVM IR text (`.ll`).
+    LlvmIr,
+}
+
+/// Position-independence of the emitted code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum RelocMode {
+    /// The target default.
+    #[default]
+    Default,
+    /// Position-independent code.
+    Pic,
+    /// Non-PIC.
+    Static,
+}
+
+/// Which machine to emit for. A `None` field falls back to the native host —
+/// except that, for a custom `triple`, `cpu`/`features` fall back to *empty*
+/// (LLVM's architecture defaults) rather than the host's: feeding the host CPU
+/// or feature string to a foreign triple makes LLVM crash.
+#[derive(Clone, Debug, Default)]
+pub struct TargetSpec {
+    /// Target triple; `None` = the native host triple.
+    pub triple: Option<String>,
+    /// Target CPU; `None` = the native host CPU (generic for a custom triple).
+    pub cpu: Option<String>,
+    /// Target features; `None` = the native host features (none for a custom triple).
+    pub features: Option<String>,
+}
+
+fn init_native() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| unsafe {
+        // A non-zero return means the target is unavailable; codegen then fails
+        // loudly at `LLVMGetTargetFromTriple`, so there is nothing to recover here.
+        LLVM_InitializeNativeTarget();
+        LLVM_InitializeNativeAsmPrinter();
+        LLVM_InitializeNativeAsmParser();
+    });
+}
+
+fn codegen_level(opt: OptLevel) -> LLVMCodeGenOptLevel {
+    match opt {
+        OptLevel::None => LLVMCodeGenOptLevel::LLVMCodeGenLevelNone,
+        OptLevel::Size | OptLevel::Default => LLVMCodeGenOptLevel::LLVMCodeGenLevelDefault,
+        OptLevel::Aggressive | OptLevel::Tpde => LLVMCodeGenOptLevel::LLVMCodeGenLevelAggressive,
+    }
+}
+
+fn reloc(mode: RelocMode) -> LLVMRelocMode {
+    match mode {
+        RelocMode::Default => LLVMRelocMode::LLVMRelocDefault,
+        RelocMode::Pic => LLVMRelocMode::LLVMRelocPIC,
+        RelocMode::Static => LLVMRelocMode::LLVMRelocStatic,
+    }
+}
+
+unsafe fn c_str(ptr: *const c_char) -> String {
+    if ptr.is_null() {
+        String::new()
+    } else {
+        unsafe { std::ffi::CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+/// Takes ownership of an LLVM-allocated C string (e.g. from
+/// `LLVMGetDefaultTargetTriple`), copying it into an owned [`CString`] and
+/// freeing the original with `LLVMDisposeMessage`. A null pointer yields an
+/// empty string.
+unsafe fn take_llvm_string(ptr: *mut c_char) -> CString {
+    if ptr.is_null() {
+        return CString::default();
+    }
+    unsafe {
+        let owned = std::ffi::CStr::from_ptr(ptr).to_owned();
+        LLVMDisposeMessage(ptr);
+        owned
+    }
+}
+
+/// Compile a lowered (LLVM-dialect) MLIR `module` to `out_path`.
+///
+/// The module must already have been through
+/// [`crate::pipeline`](reussir_backend::pipeline)-equivalent lowering to the LLVM
+/// dialect; this translates it to LLVM IR, runs the backend LLVM pipeline, and
+/// emits the requested artifact for `target` (the native host by default).
+pub fn compile_to_file(
+    module: &Module,
+    opt: OptLevel,
+    kind: OutputKind,
+    reloc_mode: RelocMode,
+    target: &TargetSpec,
+    out_path: &Path,
+) -> Result<(), String> {
+    init_native();
+    unsafe {
+        let context: LLVMContextRef = LLVMContextCreate();
+        let operation = mlir_sys::mlirModuleGetOperation(module.to_raw());
+        let llvm_module =
+            mlir_sys::mlirTranslateModuleToLLVMIR(operation, context as mlir_sys::LLVMContextRef)
+                as LLVMModuleRef;
+        if llvm_module.is_null() {
+            LLVMContextDispose(context);
+            return Err("failed to translate MLIR module to LLVM IR".into());
+        }
+
+        // The custom Reussir LLVM passes + standard optimization.
+        reussirRunBackendLLVMPipeline(llvm_module, opt.as_reussir_opt_option());
+
+        let result = emit(llvm_module, opt, kind, reloc_mode, target, out_path);
+
+        LLVMDisposeModule(llvm_module);
+        LLVMContextDispose(context);
+        result
+    }
+}
+
+unsafe fn emit(
+    llvm_module: LLVMModuleRef,
+    opt: OptLevel,
+    kind: OutputKind,
+    reloc_mode: RelocMode,
+    target_spec: &TargetSpec,
+    out_path: &Path,
+) -> Result<(), String> {
+    unsafe {
+        // LLVM IR text needs no target machine.
+        if kind == OutputKind::LlvmIr {
+            let s = LLVMPrintModuleToString(llvm_module);
+            let text = c_str(s);
+            LLVMDisposeMessage(s);
+            return std::fs::write(out_path, text)
+                .map_err(|e| format!("failed to write {}: {e}", out_path.display()));
+        }
+
+        // Resolve the triple/CPU/features into owned C strings. A custom triple
+        // makes CPU/features default to empty (LLVM picks architecture defaults)
+        // rather than the host's, which would crash for a foreign triple.
+        let foreign = target_spec.triple.is_some();
+        let triple = match target_spec.triple.as_deref() {
+            Some(t) => {
+                CString::new(t).map_err(|_| "target triple contains a NUL byte".to_string())?
+            }
+            None => take_llvm_string(LLVMGetDefaultTargetTriple()),
+        };
+        let cpu = match target_spec.cpu.as_deref() {
+            Some(c) => CString::new(c).map_err(|_| "target CPU contains a NUL byte".to_string())?,
+            None if foreign => CString::default(),
+            None => take_llvm_string(LLVMGetHostCPUName()),
+        };
+        let features = match target_spec.features.as_deref() {
+            Some(f) => {
+                CString::new(f).map_err(|_| "target features contain a NUL byte".to_string())?
+            }
+            None if foreign => CString::default(),
+            None => take_llvm_string(LLVMGetHostCPUFeatures()),
+        };
+
+        let mut target: LLVMTargetRef = std::ptr::null_mut();
+        let mut err: *mut c_char = std::ptr::null_mut();
+        if LLVMGetTargetFromTriple(triple.as_ptr(), &mut target, &mut err) != 0 {
+            let msg = c_str(err);
+            LLVMDisposeMessage(err);
+            return Err(format!(
+                "no target for triple `{}`: {msg}",
+                triple.to_string_lossy()
+            ));
+        }
+        let machine = LLVMCreateTargetMachine(
+            target,
+            triple.as_ptr(),
+            cpu.as_ptr(),
+            features.as_ptr(),
+            codegen_level(opt),
+            reloc(reloc_mode),
+            LLVMCodeModel::LLVMCodeModelDefault,
+        );
+
+        // Stamp the module with the target triple and data layout so the emitted
+        // object's ABI matches the target (and so `%cc` can link it).
+        LLVMSetTarget(llvm_module, triple.as_ptr());
+        let data_layout = LLVMCreateTargetDataLayout(machine);
+        // `LLVMSetModuleDataLayout` copies the layout into the module, so the
+        // target-data handle is ours to dispose.
+        LLVMSetModuleDataLayout(llvm_module, data_layout);
+        LLVMDisposeTargetData(data_layout);
+
+        let file_type = match kind {
+            OutputKind::Object => LLVMCodeGenFileType::LLVMObjectFile,
+            OutputKind::Assembly => LLVMCodeGenFileType::LLVMAssemblyFile,
+            OutputKind::LlvmIr => unreachable!("handled above"),
+        };
+        let path = CString::new(out_path.as_os_str().to_string_lossy().as_bytes())
+            .map_err(|_| "output path contains a NUL byte".to_string())?;
+        let mut emit_err: *mut c_char = std::ptr::null_mut();
+        let failed = LLVMTargetMachineEmitToFile(
+            machine,
+            llvm_module,
+            path.as_ptr() as *mut c_char,
+            file_type,
+            &mut emit_err,
+        );
+        LLVMDisposeTargetMachine(machine);
+        if failed != 0 {
+            let msg = c_str(emit_err);
+            LLVMDisposeMessage(emit_err);
+            return Err(format!("failed to emit {}: {msg}", out_path.display()));
+        }
+        Ok(())
+    }
+}

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -1,0 +1,196 @@
+//! `reussir-compiler`: compile a Reussir source file to native code.
+//!
+//! Runs the whole pipeline — parse, elaborate, monomorphize, lower to MLIR, run
+//! the Reussir lowering pipeline, then emit an object file, assembly, or LLVM IR
+//! for the selected target (the native host by default, or `--target-triple`).
+//! Exit 0 on success, 1 on a frontend (syntax/elaboration) or lowering error, 2
+//! on usage or I/O error.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use palc::Parser;
+
+use reussir_backend::pipeline::{self, LoweringOptions, OptLevel};
+use reussir_codegen::lower::lower_program;
+use reussir_compiler::{OutputKind, RelocMode, TargetSpec, compile_to_file};
+use reussir_core::full::mono::monomorphize;
+use reussir_core::semi::{Report, Severity, elaborate};
+use reussir_core::{in_arena, surface};
+
+/// Reussir ahead-of-time compiler.
+#[derive(Parser)]
+#[command(name = "reussir-compiler", version)]
+struct Cli {
+    /// Input source file (`-` reads from stdin).
+    input: PathBuf,
+
+    /// Output file. The artifact kind is inferred from its extension unless
+    /// `--emit` is given.
+    #[arg(short = 'o', long)]
+    output: PathBuf,
+
+    /// Artifact to emit: `obj`, `asm`, or `llvm-ir`. Defaults to the output
+    /// extension (`.o`/`.s`/`.ll`), else `obj`.
+    #[arg(short = 't', long = "emit")]
+    emit: Option<String>,
+
+    /// Optimization level: `none`, `default`, `aggressive`, or `size`.
+    #[arg(short = 'O', long = "opt", default_value = "default")]
+    opt: String,
+
+    /// Relocation model: `default`, `pic`, or `static`.
+    #[arg(long = "relocation-mode", default_value = "default")]
+    relocation_mode: String,
+
+    /// Target triple to compile for. Defaults to the native host.
+    #[arg(long = "target-triple")]
+    target_triple: Option<String>,
+
+    /// Target CPU. Defaults to the native host CPU (generic for a custom triple).
+    #[arg(long = "target-cpu")]
+    target_cpu: Option<String>,
+
+    /// Target features. Defaults to the native host features (none for a custom triple).
+    #[arg(long = "target-features")]
+    target_features: Option<String>,
+
+    /// Let the token-reuse pass reuse tokens across function calls.
+    #[arg(long = "reuse-across-call")]
+    reuse_across_call: bool,
+}
+
+fn parse_emit(cli: &Cli) -> Result<OutputKind, String> {
+    if let Some(e) = &cli.emit {
+        return match e.as_str() {
+            "obj" | "object" => Ok(OutputKind::Object),
+            "asm" | "assembly" => Ok(OutputKind::Assembly),
+            "llvm-ir" | "llvmir" | "ll" => Ok(OutputKind::LlvmIr),
+            other => Err(format!("unknown --emit `{other}`")),
+        };
+    }
+    Ok(match cli.output.extension().and_then(|e| e.to_str()) {
+        Some("s") => OutputKind::Assembly,
+        Some("ll") => OutputKind::LlvmIr,
+        _ => OutputKind::Object,
+    })
+}
+
+fn parse_opt(s: &str) -> Result<OptLevel, String> {
+    match s {
+        "none" => Ok(OptLevel::None),
+        "default" => Ok(OptLevel::Default),
+        "aggressive" => Ok(OptLevel::Aggressive),
+        "size" => Ok(OptLevel::Size),
+        other => Err(format!("unknown -O level `{other}`")),
+    }
+}
+
+fn parse_reloc(s: &str) -> Result<RelocMode, String> {
+    match s {
+        "default" => Ok(RelocMode::Default),
+        "pic" => Ok(RelocMode::Pic),
+        "static" => Ok(RelocMode::Static),
+        other => Err(format!("unknown --relocation-mode `{other}`")),
+    }
+}
+
+fn read_input(path: &PathBuf) -> Result<(String, String), String> {
+    use std::io::Read;
+    if path.as_os_str() == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| format!("failed to read stdin: {e}"))?;
+        Ok(("<stdin>".to_owned(), buf))
+    } else {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        Ok((path.display().to_string(), text))
+    }
+}
+
+/// Prints `reports` to stderr, each labelled with its severity, and returns
+/// whether any was an error. Warnings alone do not fail the compile.
+fn report_diagnostics(name: &str, reports: &[Report]) -> bool {
+    let mut had_error = false;
+    for report in reports {
+        let label = match report.severity {
+            Severity::Error => {
+                had_error = true;
+                "error"
+            }
+            Severity::Warning => "warning",
+        };
+        eprintln!("{name}: {label}: {}", report.message);
+    }
+    had_error
+}
+
+fn run(cli: &Cli) -> Result<bool, String> {
+    let kind = parse_emit(cli)?;
+    let opt = parse_opt(&cli.opt)?;
+    let reloc = parse_reloc(&cli.relocation_mode)?;
+    let (name, source) = read_input(&cli.input)?;
+
+    let parse = reussir_syntax::parse(&source);
+    if !parse.ok() {
+        for err in &parse.errors {
+            eprintln!("{name}: error: {err:?}");
+        }
+        return Ok(false);
+    }
+    let prog = surface::program(&parse.root);
+
+    let context = reussir_backend::context();
+    // Frontend + lowering inside the arena scope; the lowered module borrows the
+    // context, not the arena, so it outlives `tcx`.
+    let module = in_arena(|tcx| {
+        let elab = elaborate(tcx, &prog, parse.resolver());
+        if report_diagnostics(&name, &elab.reports) {
+            return Err(String::new());
+        }
+        let (full, reports) = monomorphize(&elab.mono_input());
+        if report_diagnostics(&name, &reports) {
+            return Err(String::new());
+        }
+        lower_program(&context, &full).map_err(|e| format!("{name}: {e}"))
+    });
+    let mut module = match module {
+        Ok(module) => module,
+        Err(msg) => {
+            if !msg.is_empty() {
+                eprintln!("{msg}");
+            }
+            return Ok(false);
+        }
+    };
+
+    let options = LoweringOptions {
+        opt,
+        reuse_token_across_call: cli.reuse_across_call,
+        ..LoweringOptions::default()
+    };
+    pipeline::run_lowering_pipeline(&context, &mut module, &options)
+        .map_err(|e| format!("lowering pipeline failed: {e:?}"))?;
+
+    let target = TargetSpec {
+        triple: cli.target_triple.clone(),
+        cpu: cli.target_cpu.clone(),
+        features: cli.target_features.clone(),
+    };
+    compile_to_file(&module, opt, kind, reloc, &target, &cli.output)?;
+    Ok(true)
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match run(&cli) {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::FAILURE,
+        Err(message) => {
+            eprintln!("error: {message}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -11,9 +11,10 @@ use std::process::ExitCode;
 
 use palc::Parser;
 
+use reussir_backend::llvm::LlvmLowering;
 use reussir_backend::pipeline::{self, LoweringOptions, OptLevel};
 use reussir_codegen::lower::lower_program;
-use reussir_compiler::{OutputKind, RelocMode, TargetSpec, compile_to_file};
+use reussir_compiler::{OutputKind, RelocMode, TargetMachine, TargetSpec, emit_to_file};
 use reussir_core::full::mono::monomorphize;
 use reussir_core::semi::{Report, Severity, elaborate};
 use reussir_core::{in_arena, surface};
@@ -142,10 +143,28 @@ fn run(cli: &Cli) -> Result<bool, String> {
     }
     let prog = surface::program(&parse.root);
 
+    // The target machine is built first: its data layout feeds the polymorphic
+    // FFI gather, which must run before the lowering pipeline erases those ops.
+    let spec = TargetSpec {
+        triple: cli.target_triple.clone(),
+        cpu: cli.target_cpu.clone(),
+        features: cli.target_features.clone(),
+    };
+    let machine = TargetMachine::new(&spec, opt, reloc)?;
+
+    let options = LoweringOptions {
+        opt,
+        reuse_token_across_call: cli.reuse_across_call,
+        ..LoweringOptions::default()
+    };
+    let optimize_ffi = !matches!(opt, OptLevel::None);
+
     let context = reussir_backend::context();
-    // Frontend + lowering inside the arena scope; the lowered module borrows the
-    // context, not the arena, so it outlives `tcx`.
-    let module = in_arena(|tcx| {
+    // Frontend + lowering inside the arena scope. Polymorphic FFI is compiled and
+    // gathered before the pipeline (which erases the polyffi ops) and linked in
+    // after translation; the finalized LLVM module borrows neither the arena nor
+    // the MLIR context, so it outlives `tcx`.
+    let finalized = in_arena(|tcx| {
         let elab = elaborate(tcx, &prog, parse.resolver());
         if report_diagnostics(&name, &elab.reports) {
             return Err(String::new());
@@ -154,10 +173,15 @@ fn run(cli: &Cli) -> Result<bool, String> {
         if report_diagnostics(&name, &reports) {
             return Err(String::new());
         }
-        lower_program(&context, &full).map_err(|e| format!("{name}: {e}"))
+        let mut module = lower_program(&context, &full).map_err(|e| format!("{name}: {e}"))?;
+        let prepared = LlvmLowering::prepare(&module, machine.data_layout(), optimize_ffi)
+            .map_err(|e| format!("{name}: {e}"))?;
+        pipeline::run_lowering_pipeline(&context, &mut module, &options)
+            .map_err(|e| format!("lowering pipeline failed: {e:?}"))?;
+        prepared.finish(&module).map_err(|e| format!("{name}: {e}"))
     });
-    let mut module = match module {
-        Ok(module) => module,
+    let finalized = match finalized {
+        Ok(finalized) => finalized,
         Err(msg) => {
             if !msg.is_empty() {
                 eprintln!("{msg}");
@@ -166,20 +190,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
         }
     };
 
-    let options = LoweringOptions {
-        opt,
-        reuse_token_across_call: cli.reuse_across_call,
-        ..LoweringOptions::default()
-    };
-    pipeline::run_lowering_pipeline(&context, &mut module, &options)
-        .map_err(|e| format!("lowering pipeline failed: {e:?}"))?;
-
-    let target = TargetSpec {
-        triple: cli.target_triple.clone(),
-        cpu: cli.target_cpu.clone(),
-        features: cli.target_features.clone(),
-    };
-    compile_to_file(&module, opt, kind, reloc, &target, &cli.output)?;
+    emit_to_file(finalized, &machine, opt, kind, &cli.output)?;
     Ok(true)
 }
 

--- a/crates/reussir-jit/Cargo.toml
+++ b/crates/reussir-jit/Cargo.toml
@@ -9,12 +9,13 @@ description = "JIT execution engine for Reussir, built on the reussir-backend lo
 name = "reussir_jit"
 
 [dependencies]
-# `melior` for the lowered `Module` type; `mlir-sys` for MLIR->LLVM IR
-# translation; `llvm-sys` for the ORC/LLJIT engine (not bound by mlir-sys).
+# `melior` for the lowered `Module` type; `llvm-sys` for the ORC/LLJIT engine.
 # llvm-sys discovers LLVM via LLVM_SYS_221_PREFIX (set by CMake).
 melior.workspace = true
-mlir-sys.workspace = true
 llvm-sys.workspace = true
+# The shared LLVM-IR boundary: MLIR→LLVM-IR translation, the backend LLVM pass
+# pipeline, and the pipeline `OptLevel` the JIT re-exports.
+reussir-backend = { path = "../reussir-backend" }
 # Links libReussirCAPI (the JIT codegen helper: custom LLVM passes + TPDE) and
 # its TPDE/pass archives into the final binary; see its build.rs.
 reussir-backend-sys = { path = "../reussir-backend-sys" }
@@ -25,7 +26,3 @@ reussir-backend-sys = { path = "../reussir-backend-sys" }
 # allocator of anything that links the JIT.
 reussir-rt = { path = "../reussir-rt", default-features = false }
 tracing.workspace = true
-
-[dev-dependencies]
-# Tests build and lower Reussir IR through reussir-backend, then execute it.
-reussir-backend = { path = "../reussir-backend" }

--- a/crates/reussir-jit/src/orc.rs
+++ b/crates/reussir-jit/src/orc.rs
@@ -40,46 +40,20 @@ use llvm_sys::target_machine::LLVMGetDefaultTargetTriple;
 
 use melior::ir::Module;
 
-// LLVM-side codegen helpers provided by libReussirCAPI (lib/CAPI/Jit.cpp): the
-// custom Reussir LLVM passes and TPDE, which cannot be reached through the
-// LLVM-C ORC API. Linked via the reussir-backend-sys dependency.
+// The MLIR→LLVM-IR translation and the backend LLVM pass pipeline are shared with
+// the AOT compiler; `OptLevel` is the backend's pipeline level.
+use reussir_backend::llvm::{run_backend_llvm_pipeline, translate_to_llvm_ir};
+pub use reussir_backend::pipeline::OptLevel;
+
+// TPDE object compilation is JIT-specific (libReussirCAPI / lib/CAPI/Jit.cpp); it
+// cannot be reached through the LLVM-C ORC API. Linked via reussir-backend-sys.
 unsafe extern "C" {
-    fn reussirRunBackendLLVMPipeline(module: LLVMModuleRef, opt: c_int);
     fn reussirTpdeCompileToObject(
         module: LLVMModuleRef,
         data_layout: *const c_char,
         triple: *const c_char,
     ) -> LLVMMemoryBufferRef;
     fn reussirHasTPDE() -> c_int;
-}
-
-/// Optimization / codegen level for [`OrcJit::add_module`], mirroring the
-/// backend's `ReussirOptOption`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
-pub enum OptLevel {
-    /// No LLVM optimization.
-    None,
-    /// Default optimization (`-O2`).
-    #[default]
-    Default,
-    /// Aggressive optimization (`-O3`).
-    Aggressive,
-    /// Optimize for size (`-Os`).
-    Size,
-    /// Compile with the TPDE fast back end instead of the LLVM code generator.
-    Tpde,
-}
-
-impl OptLevel {
-    fn as_c(self) -> c_int {
-        match self {
-            OptLevel::None => 0,
-            OptLevel::Default => 1,
-            OptLevel::Aggressive => 2,
-            OptLevel::Size => 3,
-            OptLevel::Tpde => 4,
-        }
-    }
 }
 
 /// Reports whether TPDE support was compiled into the backend. [`OptLevel::Tpde`]
@@ -301,21 +275,28 @@ impl OrcJit {
     /// For [`OptLevel::Tpde`] the module is compiled to an object file by TPDE
     /// and added directly; otherwise the Reussir LLVM pass pipeline runs and the
     /// IR module is handed to the default `LLJIT` compiler.
+    ///
+    /// TODO(polyffi): this path does not gather/link polymorphic FFI. The module
+    /// arrives already lowered, but `reussir_backend::llvm::LlvmLowering::prepare`
+    /// (compile + gather) must run *before* the lowering pipeline erases the
+    /// `reussir.polyffi` ops, and `finish` (translate + link) after — see the AOT
+    /// compiler's flow. A polyffi-capable JIT entry would orchestrate
+    /// `prepare → run_lowering_pipeline → finish` and add the resulting
+    /// [`reussir_backend::llvm::Finalized`] here. Until then a module containing
+    /// `reussir.polyffi` fails loudly at `run_lowering_pipeline`, not silently.
     pub fn add_module(&self, module: &Module, opt: OptLevel) -> Result<(), String> {
         let _span = tracing::debug_span!("orcjit_add_module", opt = ?opt).entered();
         unsafe {
-            let context = LLVMContextCreate();
-            let operation = mlir_sys::mlirModuleGetOperation(module.to_raw());
             // The translated module is created in (and owned alongside) `context`.
-            let llvm_module = mlir_sys::mlirTranslateModuleToLLVMIR(
-                operation,
-                context as mlir_sys::LLVMContextRef,
-            ) as LLVMModuleRef;
-            if llvm_module.is_null() {
-                LLVMContextDispose(context);
-                tracing::error!("failed to translate MLIR module to LLVM IR");
-                return Err("failed to translate MLIR module to LLVM IR".into());
-            }
+            let context = LLVMContextCreate();
+            let llvm_module = match translate_to_llvm_ir(module, context) {
+                Ok(llvm_module) => llvm_module,
+                Err(message) => {
+                    LLVMContextDispose(context);
+                    tracing::error!("{message}");
+                    return Err(message);
+                }
+            };
             tracing::trace!("translated MLIR module to LLVM IR");
 
             if opt == OptLevel::Tpde {
@@ -329,7 +310,7 @@ impl OrcJit {
 
             // Run the Reussir LLVM passes in place, then add the IR module.
             tracing::trace!("running backend LLVM pass pipeline");
-            reussirRunBackendLLVMPipeline(llvm_module, opt.as_c());
+            run_backend_llvm_pipeline(llvm_module, opt);
             self.add_owned_module(context, llvm_module)?;
             tracing::debug!("added LLVM-IR module to the JIT");
             Ok(())


### PR DESCRIPTION
Stacked on #267. Adds the ahead-of-time compiler so Reussir source compiles to a
native object that links and runs through the C ABI — no Haskell in the pipeline.

## What
- `reussir_jit::compile` — lowered (LLVM-dialect) MLIR module → object / asm /
  LLVM-IR on disk: translate to LLVM IR (mlir-sys), run the backend LLVM pass
  pipeline, emit via a host `TargetMachine` (llvm-sys) with a selectable
  relocation model.
- `reussir-compiler` (palc CLI): parse → elaborate → monomorphize → lower →
  pipeline → emit. Flags `-o`, `--emit`, `-O`, `--relocation-mode`,
  `--reuse-across-call`.
- reussir-jit gains reussir-backend/-core/-syntax + palc as normal deps.

## Verified end-to-end (no Haskell)
```
reussir-compiler fibonacci.rr -o fib.o --relocation-mode pic
cc fib.o fibonacci.c -o fib && ./fib   # exit 0: fib(10)=55, fib(42)=267914296
```
`-t llvm-ir` emits optimized IR (the backend even applies tail-recursion to the
iterative helper).

## Next in stack
Perceus-style ownership analysis + rc/record/closure/match lowering (validated
under ASAN/LSAN), repoint the lit suite to these binaries, then remove Haskell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)