### PR TITLE
[frontend][codegen] value records and expression revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1107,8 @@ dependencies = [
  "reussir-jit",
  "reussir-syntax",
  "rustc-hash",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1288,6 +1299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1537,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1569,6 +1624,12 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -65,3 +65,41 @@ pub fn trampoline_export<'c>(
         .build()
         .expect("valid reussir.trampoline")
 }
+
+/// `reussir.record.compound (<fields> : <types>) : <result_type>` — construct a
+/// compound record value from its (declaration-ordered) field operands.
+///
+/// melior has no generated builder for the Reussir dialect, so the op is built
+/// raw; the result type (the compound record type) must be supplied explicitly.
+pub fn record_compound<'c>(
+    fields: &[Value<'c, '_>],
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.record.compound", location)
+        .add_operands(fields)
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.record.compound")
+}
+
+/// `reussir.record.extract (<record> : <type>) [<index>] : <field_type>` —
+/// project a field out of a record value.
+///
+/// The field selector is an `index`-typed `IndexAttr`; the result type is the
+/// projected field's type.
+pub fn record_extract<'c>(
+    context: &'c Context,
+    record: Value<'c, '_>,
+    index: usize,
+    field_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let index_attr = IntegerAttribute::new(Type::index(context), index as i64).into();
+    OperationBuilder::new("reussir.record.extract", location)
+        .add_operands(&[record])
+        .add_attributes(&[(Identifier::new(context, "index"), index_attr)])
+        .add_results(&[field_type])
+        .build()
+        .expect("valid reussir.record.extract")
+}

--- a/crates/reussir-codegen/Cargo.toml
+++ b/crates/reussir-codegen/Cargo.toml
@@ -15,9 +15,11 @@ reussir-core = { path = "../reussir-core" }
 reussir-backend = { path = "../reussir-backend" }
 # The fast map for the per-function SSA environment.
 rustc-hash.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 # End-to-end tests: source → elaborate → monomorphize → lower → run.
 reussir-syntax = { path = "../reussir-syntax" }
 # JIT-execute the lowered module to check the compiled program's meaning.
 reussir-jit = { path = "../reussir-jit" }
+tracing-subscriber = "0.3.23"

--- a/crates/reussir-codegen/src/lib.rs
+++ b/crates/reussir-codegen/src/lib.rs
@@ -8,3 +8,13 @@
 //! of any MLIR dependency.
 
 pub mod lower;
+
+#[cfg(test)]
+pub(crate) mod test {
+    pub(crate) fn init_tracing() {
+        static TRACING_INIT: std::sync::Once = std::sync::Once::new();
+        TRACING_INIT.call_once(|| {
+            tracing_subscriber::fmt().init();
+        });
+    }
+}

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -25,26 +25,33 @@ use reussir_backend::melior::ir::{
 };
 
 use reussir_core::full::mir::{self, Expr, ExprKind};
+use reussir_core::semi::ctxt::DefaultCap;
 use reussir_core::semi::hir::{ArithOp, CmpOp, VarId};
 use reussir_core::semi::ty::{IntTy, Ty, TyKind};
 use reussir_core::surface::Visibility;
 
-use super::ty::{is_unit, mlir_ty, num_class};
+use super::ty::{TypeCtx, is_unit, num_class};
 use super::{LoweringError, Result, err};
 
 /// The variable → SSA-value environment for one block scope.
 type Env<'c, 'b> = FxHashMap<VarId, Value<'c, 'b>>;
 
-/// Per-program lowering state: the context to build in and the program whose
-/// symbol table resolves callee/trampoline names. Reused across functions.
+/// Per-program lowering state: the context to build in, the program whose symbol
+/// table resolves callee/trampoline names, and the [`TypeCtx`] that lowers types
+/// and resolves record layouts. Reused across functions.
 pub(super) struct Lowerer<'c, 'p, 'tcx> {
     context: &'c Context,
     program: &'p mir::Program<'tcx>,
+    tys: TypeCtx<'c, 'p, 'tcx>,
 }
 
 impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
     pub(super) fn new(context: &'c Context, program: &'p mir::Program<'tcx>) -> Self {
-        Lowerer { context, program }
+        Lowerer {
+            context,
+            program,
+            tys: TypeCtx::new(context, program),
+        }
     }
 
     fn loc(&self) -> Location<'c> {
@@ -57,13 +64,13 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let param_tys = func
             .params
             .iter()
-            .map(|p| mlir_ty(self.context, p.ty))
+            .map(|p| self.tys.mlir_ty(p.ty))
             .collect::<Result<Vec<_>>>()?;
         let ret = func.return_ty;
         let result_tys = if is_unit(ret) {
             Vec::new()
         } else {
-            vec![mlir_ty(self.context, ret)?]
+            vec![self.tys.mlir_ty(ret)?]
         };
         let fn_ty = FunctionType::new(self.context, &param_tys, &result_tys);
 
@@ -123,7 +130,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let loc = self.loc();
         match &e.kind {
             ConstInt(n) => {
-                let attr = IntegerAttribute::new(mlir_ty(self.context, e.ty)?, *n as i64).into();
+                let attr = IntegerAttribute::new(self.tys.mlir_ty(e.ty)?, *n as i64).into();
                 Ok(Some(
                     self.append(block, arith::constant(self.context, attr, loc)),
                 ))
@@ -136,8 +143,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 ))
             }
             ConstFloat(f) => {
-                let attr =
-                    FloatAttribute::new(self.context, mlir_ty(self.context, e.ty)?, *f).into();
+                let attr = FloatAttribute::new(self.context, self.tys.mlir_ty(e.ty)?, *f).into();
                 Ok(Some(
                     self.append(block, arith::constant(self.context, attr, loc)),
                 ))
@@ -185,7 +191,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 let result_tys = if is_unit(e.ty) {
                     Vec::new()
                 } else {
-                    vec![mlir_ty(self.context, e.ty)?]
+                    vec![self.tys.mlir_ty(e.ty)?]
                 };
                 let symbol =
                     FlatSymbolRefAttribute::new(self.context, self.program.symbol(*callee));
@@ -203,16 +209,75 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 }
             }
             RegionRun(_) => err("region-run lowering not yet implemented"),
-            Proj(..) => err("projection lowering not yet implemented"),
+            Proj(base, path) => self.proj(block, env, base, path).map(Some),
             Assign(..) => err("assignment lowering not yet implemented"),
             Match(..) => err("match lowering not yet implemented"),
-            Ctor { .. } | Variant { .. } | NullableCall(_) => {
-                err("constructor lowering not yet implemented")
-            }
+            Ctor { args, .. } => self.compound(block, env, e, args).map(Some),
+            Variant { .. } | NullableCall(_) => err("enum/nullable lowering not yet implemented"),
             Closure(_) | ClosureCall { .. } => err("closure lowering not yet implemented"),
             GlobalStr(_) => err("string literal lowering not yet implemented"),
             Poison => err("poison expression reached lowering"),
         }
+    }
+
+    /// Construct a `[value]` record from its (declaration-ordered) field args via
+    /// `reussir.record.compound`.
+    fn compound<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        e: &Expr<'tcx>,
+        args: &[Expr<'tcx>],
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        // `record_type` also enforces the value-only restriction.
+        let record_ty = self.tys.record_type(e.ty)?;
+        let mut operands = Vec::with_capacity(args.len());
+        for a in args.iter() {
+            operands.push(
+                self.expr(block, env, a)?
+                    .ok_or_else(|| LoweringError("record field is unit".into()))?,
+            );
+        }
+        Ok(self.append(block, builders::record_compound(&operands, record_ty, loc)))
+    }
+
+    /// Project a chain of fields out of a `[value]` record value with a sequence
+    /// of `reussir.record.extract` ops.
+    fn proj<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        base: &Expr<'tcx>,
+        path: &[u32],
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let mut cur_val = self
+            .expr(block, env, base)?
+            .ok_or_else(|| LoweringError("projection base is unit".into()))?;
+        let mut cur_ty = base.ty;
+        for &idx in path.iter() {
+            let rec = self
+                .tys
+                .record_of(cur_ty)
+                .ok_or_else(|| LoweringError("projection base is not a record".into()))?;
+            if rec.default_cap != DefaultCap::Value {
+                return err("projection of shared/regional records not yet implemented");
+            }
+            let members = match rec.layout {
+                mir::RecordLayout::Compound(ms) => ms,
+                mir::RecordLayout::Variant(_) => return err("projection of an enum value"),
+            };
+            let field = members
+                .get(idx as usize)
+                .ok_or_else(|| LoweringError(format!("field index {idx} out of range")))?;
+            let field_ty = field.ty;
+            let field_mlir = self.tys.mlir_ty(field_ty)?;
+            let op = builders::record_extract(self.context, cur_val, idx as usize, field_mlir, loc);
+            cur_val = self.append(block, op);
+            cur_ty = field_ty;
+        }
+        Ok(cur_val)
     }
 
     /// Append `op` to `block` and return its single result as a value.
@@ -233,7 +298,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         match x.ty.kind() {
             TyKind::Fp(_) => Ok(self.append(block, arith::negf(xv, loc))),
             TyKind::Int(_) => {
-                let ty = mlir_ty(self.context, x.ty)?;
+                let ty = self.tys.mlir_ty(x.ty)?;
                 let zero = self.append(
                     block,
                     arith::constant(self.context, IntegerAttribute::new(ty, 0).into(), loc),
@@ -362,7 +427,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             .ok_or_else(|| LoweringError("cast operand is unit".into()))?;
         let src = num_class(x.ty)?;
         let dst = num_class(to)?;
-        let to_ty = mlir_ty(self.context, to)?;
+        let to_ty = self.tys.mlir_ty(to)?;
         let op = match (src.float, dst.float) {
             (false, false) => {
                 if dst.width == src.width {
@@ -419,7 +484,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let result_tys = if is_unit(ty) {
             Vec::new()
         } else {
-            vec![mlir_ty(self.context, ty)?]
+            vec![self.tys.mlir_ty(ty)?]
         };
         let then_region = self.branch_region(env, t, ty)?;
         let else_region = self.branch_region(env, f, ty)?;

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -83,7 +83,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             for (i, p) in func.params.iter().enumerate() {
                 let arg = block
                     .argument(i)
-                    .map_err(|e| LoweringError(format!("missing block argument: {e}")))?;
+                    .map_err(|e| LoweringError(format!("missing block argument: {e}").into()))?;
                 env.insert(p.var, arg.into());
             }
             let value = self.expr(&block, &mut env, body)?;
@@ -158,7 +158,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     env.get(v)
                         .copied()
                         .map(Some)
-                        .ok_or_else(|| LoweringError(format!("unbound variable {v:?}")))
+                        .ok_or_else(|| LoweringError(format!("unbound variable {v:?}").into()))
                 }
             }
             Negate(x) => self.negate(block, env, x).map(Some),
@@ -270,7 +270,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             };
             let field = members
                 .get(idx as usize)
-                .ok_or_else(|| LoweringError(format!("field index {idx} out of range")))?;
+                .ok_or_else(|| LoweringError(format!("field index {idx} out of range").into()))?;
             let field_ty = field.ty;
             let field_mlir = self.tys.mlir_ty(field_ty)?;
             let op = builders::record_extract(self.context, cur_val, idx as usize, field_mlir, loc);

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -86,6 +86,7 @@ mod tests {
     /// Elaborate + monomorphize + lower `source`, checking the module verifies
     /// and returning its printed text for assertions.
     fn lower_source(source: &str) -> String {
+        crate::test::init_tracing();
         let context = reussir_backend::context();
         in_arena(|tcx| {
             let parse = reussir_syntax::parse(source);
@@ -101,6 +102,7 @@ mod tests {
                 "module verifies:\n{}",
                 module.as_operation()
             );
+            tracing::info!("IR lowered successfully:\n{}", module.as_operation());
             module.as_operation().to_string()
         })
     }

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -13,13 +13,14 @@
 //!
 //! # Scope
 //!
-//! This is the **scalar / control-flow subset**: integer and floating-point
-//! values, arithmetic and comparison, `if`, `let`/sequencing, direct calls, and
-//! exported trampolines — enough to compile and run reference programs like
-//! `fibonacci.rr` end-to-end. Reference-counted constructs (records, closures,
-//! `match`, regions, strings) are not yet lowered and surface as an explicit
-//! [`LoweringError`] rather than wrong code; they arrive with the ownership
-//! analysis in a later change.
+//! Currently lowered: the **scalar / control-flow subset** (integer and
+//! floating-point values, arithmetic and comparison, `if`, `let`/sequencing,
+//! direct calls, exported trampolines) and **by-value (`[value]`) records**
+//! (construction via `reussir.record.compound` and field projection via
+//! `reussir.record.extract`). Reference-counted constructs (shared/regional
+//! records, enums/`match`, closures, regions, strings) are not yet lowered and
+//! surface as an explicit [`LoweringError`] rather than wrong code; they arrive
+//! with the ownership analysis in later changes.
 //!
 //! Every callee/trampoline target in the MIR is already resolved to an interned
 //! [`mir::Symbol`](reussir_core::full::mir::Symbol) (mono did the mangling), so
@@ -118,6 +119,22 @@ mod tests {
         assert!(mlir.contains("scf.if"), "{mlir}");
         assert!(mlir.contains("call @_RC9fibonacci"), "{mlir}");
         assert!(mlir.contains("reussir.trampoline"), "{mlir}");
+    }
+
+    #[test]
+    fn lowers_value_records_to_verifiable_mlir() {
+        // A `[value]` record is a by-value aggregate: construction lowers to
+        // `reussir.record.compound` and field access to `reussir.record.extract`.
+        let src = r#"
+            struct [value] Point { x: i64, y: i64 }
+            pub fn dot(a: Point, b: Point) -> i64 { a.x * b.x + a.y * b.y }
+            pub fn mk(x: i64, y: i64) -> Point { Point { x: x, y: y } }
+            extern "C" trampoline "dot_ffi" = dot;
+        "#;
+        let mlir = lower_source(src);
+        assert!(mlir.contains("reussir.record.compound"), "{mlir}");
+        assert!(mlir.contains("reussir.record.extract"), "{mlir}");
+        assert!(mlir.contains("!reussir.record<"), "{mlir}");
     }
 
     #[test]

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -30,6 +30,8 @@
 mod expr;
 mod ty;
 
+use std::borrow::Cow;
+
 use reussir_backend::builders;
 use reussir_backend::melior::Context;
 use reussir_backend::melior::ir::{BlockLike, Location, Module};
@@ -40,7 +42,7 @@ use expr::Lowerer;
 
 /// A construct the current lowering subset does not handle.
 #[derive(Debug, Clone)]
-pub struct LoweringError(pub String);
+pub struct LoweringError(pub Cow<'static, str>);
 
 impl std::fmt::Display for LoweringError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -52,7 +54,7 @@ impl std::error::Error for LoweringError {}
 
 type Result<T> = std::result::Result<T, LoweringError>;
 
-fn err<T>(msg: impl Into<String>) -> Result<T> {
+fn err<T>(msg: impl Into<Cow<'static, str>>) -> Result<T> {
     Err(LoweringError(msg.into()))
 }
 

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -1,21 +1,117 @@
-//! Type lowering: ground scalar Reussir types → MLIR types, plus the numeric
-//! classification [`expr`](super::expr) uses to choose the right cast op.
+//! Type lowering: ground Reussir types → MLIR types.
+//!
+//! Scalars map directly to builtin MLIR types. A record has no `DefTable` here,
+//! so it resolves through a layout table ([`TypeCtx`]) keyed by its `(def, args)`
+//! identity — the ground layout `mono` baked into the MIR. `[value]` records
+//! build an identified `!reussir.record<…>`; shared/regional records and enums
+//! arrive with the rc lowering. This module also holds the numeric classification
+//! [`expr`](super::expr) uses to choose the right cast op.
 
+use rustc_hash::FxHashMap;
+
+use reussir_backend::dialect::ty::{ReussirCapability, ReussirRecordKind, record_complete};
 use reussir_backend::melior::Context;
 use reussir_backend::melior::ir::Type;
+use reussir_backend::melior::ir::attribute::StringAttribute;
 use reussir_backend::melior::ir::r#type::IntegerType;
 
-use reussir_core::semi::ty::{FpTy, IntTy, Ty, TyKind};
+use reussir_core::full::mir;
+use reussir_core::semi::ctxt::DefaultCap;
+use reussir_core::semi::ty::{DefId, FpTy, IntTy, Ty, TyKind};
 
-use super::{Result, err};
+use super::{LoweringError, Result, err};
+
+/// The identity of a record instance — its definition and ground type arguments
+/// (capability-canonicalized) — used to match a record-typed value to its layout.
+type RecordInstanceKey<'tcx> = (DefId, &'tcx [Ty<'tcx>]);
+
+/// Type-lowering state: the MLIR context to build types in, the program (whose
+/// symbol table names record types), and the record instances indexed by their
+/// `(def, args)` identity so a record-typed value can find its ground layout.
+pub(super) struct TypeCtx<'c, 'p, 'tcx> {
+    context: &'c Context,
+    program: &'p mir::Program<'tcx>,
+    records: FxHashMap<RecordInstanceKey<'tcx>, &'p mir::RecordInstance<'tcx>>,
+}
+
+impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
+    pub(super) fn new(context: &'c Context, program: &'p mir::Program<'tcx>) -> Self {
+        let records = program
+            .records
+            .iter()
+            .filter_map(|r| match *r.ty.kind() {
+                TyKind::Record { def, args, .. } => Some(((def, args), r)),
+                _ => None,
+            })
+            .collect();
+        TypeCtx {
+            context,
+            program,
+            records,
+        }
+    }
+
+    /// The record instance for a nominal record type, if known.
+    pub(super) fn record_of(&self, ty: Ty<'tcx>) -> Option<&'p mir::RecordInstance<'tcx>> {
+        match *ty.kind() {
+            TyKind::Record { def, args, .. } => self.records.get(&(def, args)).copied(),
+            _ => None,
+        }
+    }
+
+    /// Lower a ground type to MLIR: records resolve through the layout table,
+    /// everything else is a scalar.
+    pub(super) fn mlir_ty(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
+        match *ty.kind() {
+            TyKind::Record { .. } => self.record_type(ty),
+            _ => scalar_ty(self.context, ty),
+        }
+    }
+
+    /// Build the MLIR record type for a record instance. Only `[value]` records
+    /// lower today; shared/regional records arrive with the rc lowering.
+    pub(super) fn record_type(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
+        let rec = self
+            .record_of(ty)
+            .ok_or_else(|| LoweringError("record instance has no resolved layout".into()))?;
+        match rec.default_cap {
+            DefaultCap::Value => {}
+            DefaultCap::Shared => return err("shared (rc) record lowering not yet implemented"),
+            DefaultCap::Regional => return err("regional record lowering not yet implemented"),
+        }
+        let members = match rec.layout {
+            mir::RecordLayout::Compound(ms) => ms,
+            mir::RecordLayout::Variant(_) => return err("a `[value]` record cannot be an enum"),
+        };
+        let mut member_tys = Vec::with_capacity(members.len());
+        let mut member_is_field = Vec::with_capacity(members.len());
+        for m in members {
+            member_tys.push(self.mlir_ty(m.ty)?);
+            member_is_field.push(m.is_field);
+        }
+        // Identify the record by its unique v0 symbol so distinct generic
+        // instances stay distinct MLIR types.
+        let name = StringAttribute::new(self.context, self.program.symbol(rec.symbol));
+        Ok(record_complete(
+            self.context,
+            &member_tys,
+            &member_is_field,
+            Some(name),
+            ReussirRecordKind::Compound,
+            ReussirCapability::Value,
+        ))
+    }
+}
 
 /// Whether `ty` is the unit type (which carries no MLIR SSA value).
 pub(super) fn is_unit(ty: Ty<'_>) -> bool {
     matches!(ty.kind(), TyKind::Unit)
 }
 
-/// The MLIR type for a ground scalar Reussir type.
-pub(super) fn mlir_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
+/// The MLIR type for a ground scalar Reussir type. Records are handled by
+/// [`TypeCtx::record_type`], which intercepts them before this fallback; reaching
+/// the `Record` arm here is a bug.
+fn scalar_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
     match *ty.kind() {
         TyKind::Int(IntTy::Signed(w)) | TyKind::Int(IntTy::Unsigned(w)) => {
             Ok(IntegerType::new(context, u32::from(w)).into())
@@ -29,7 +125,7 @@ pub(super) fn mlir_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> 
         TyKind::Bool => Ok(IntegerType::new(context, 1).into()),
         TyKind::Unit => err("unit has no MLIR value type"),
         TyKind::Str => err("string type lowering not yet implemented"),
-        TyKind::Record { .. } => err("record type lowering not yet implemented"),
+        TyKind::Record { .. } => err("record type reached scalar lowering without a layout"),
         TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),
         TyKind::Closure { .. } => err("closure type lowering not yet implemented"),
         TyKind::Bottom => err("bottom type reached lowering"),

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -61,6 +61,31 @@ fn runs_recursive_fibonacci() {
 }
 
 #[test]
+fn runs_value_record_construction_and_projection() {
+    // `[value]` records are by-value aggregates: no heap, no rc. Build a point,
+    // pass it by value across internal calls, and project its fields —
+    // exercising `reussir.record.compound` / `record.extract` and the
+    // record-by-value function ABI end-to-end. The records stay internal; only
+    // two scalars cross the trampoline (the Reussir C ABI packs ≥4 args behind a
+    // pointer, an orthogonal concern, so we keep the entry point at two args).
+    let src = r#"
+        struct [value] Point { x: i64, y: i64 }
+        fn mk(x: i64, y: i64) -> Point { Point { x: x, y: y } }
+        fn dot(a: Point, b: Point) -> i64 { a.x * b.x + a.y * b.y }
+        pub fn sq_norm(x: i64, y: i64) -> i64 { dot(mk(x, y), mk(x, y)) }
+        extern "C" trampoline "sq_norm_ffi" = sq_norm;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("sq_norm_ffi").expect("lookup sq_norm_ffi");
+        let sq_norm: extern "C" fn(i64, i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        // |(3,4)|² = 3*3 + 4*4 = 25
+        assert_eq!(sq_norm(3, 4), 25);
+        // |(5,6)|² = 25 + 36 = 61
+        assert_eq!(sq_norm(5, 6), 61);
+    });
+}
+
+#[test]
 fn runs_iterative_helper_and_signed_arithmetic() {
     let src = r#"
         fn iter_impl(n: u64, a: u64, b: u64) -> u64 {

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -59,6 +59,12 @@ struct Cli {
     /// Let the token-reuse pass reuse tokens across function calls.
     #[arg(long = "reuse-across-call")]
     reuse_across_call: bool,
+
+    /// Run the MLIR backend single-threaded (disable its thread pool). Useful for
+    /// deterministic diagnostics and for debugging under tools that dislike the
+    /// backend's worker threads (e.g. some sanitizers/debuggers).
+    #[arg(long = "disable-backend-multithreading")]
+    disable_backend_multithreading: bool,
 }
 
 fn parse_emit(cli: &Cli) -> Result<OutputKind, String> {
@@ -160,6 +166,9 @@ fn run(cli: &Cli) -> Result<bool, String> {
     let optimize_ffi = !matches!(opt, OptLevel::None);
 
     let context = reussir_backend::context();
+    if cli.disable_backend_multithreading {
+        context.enable_multi_threading(false);
+    }
     // Frontend + lowering inside the arena scope. Polymorphic FFI is compiled and
     // gathered before the pipeline (which erases the polyffi ops) and linked in
     // after translation; the finalized LLVM module borrows neither the arena nor

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -315,11 +315,8 @@ mod tests {
             let resolver = VecResolver(vec!["Foo"]);
             let m = Mangler::new(&defs, &resolver);
             // `Foo<i32>` → `IC3FoolE`.
-            let foo_i32 = tcx.mk_record(
-                foo,
-                &[tcx.mk_int(IntTy::Signed(32))],
-                Flexivity::Irrelevant,
-            );
+            let foo_i32 =
+                tcx.mk_record(foo, &[tcx.mk_int(IntTy::Signed(32))], Flexivity::Irrelevant);
             assert_eq!(m.mangle_ty(foo_i32), "_RIC3FoolE");
             // `Foo` (no args) → `C3Foo`; mangling a function instance is the same.
             let foo0 = tcx.mk_record(foo, &[], Flexivity::Irrelevant);

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -18,6 +18,7 @@
 use lasso::{Rodeo, Spur};
 use reussir_syntax::kind::TokenKey;
 
+use crate::semi::ctxt::DefaultCap;
 use crate::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use crate::semi::ty::Ty;
 use crate::surface::{Span, Visibility};
@@ -85,13 +86,44 @@ pub struct Param<'tcx> {
     pub ty: Ty<'tcx>,
 }
 
-/// A ground record instance whose layout the backend must materialize. Keyed by
-/// [`Symbol`]; the ground type carries the fields needed to compute that layout.
+/// A ground record instance whose layout the backend materializes. Keyed by
+/// [`Symbol`]; the [`layout`](Self::layout) carries the ground member types so a
+/// program parsed from textual MIR is lowerable without re-consulting the
+/// elaborator (the [`ty`](Self::ty) is the nominal record handle used to match a
+/// record-typed value back to its instance).
 #[derive(Clone, Copy, Debug)]
 pub struct RecordInstance<'tcx> {
     pub symbol: Symbol,
-    /// The ground record type (`def` + args + capability) for layout.
+    /// The nominal ground record type (`def` + args), capability-canonicalized.
     pub ty: Ty<'tcx>,
+    /// The capability the record declares by default — selects the lowering
+    /// (only `Value` records lower today; `Shared`/`Regional` await the rc work).
+    pub default_cap: DefaultCap,
+    /// The ground field layout.
+    pub layout: RecordLayout<'tcx>,
+}
+
+/// A ground record's shape: a struct's ordered fields, or an enum's variants.
+#[derive(Clone, Copy, Debug)]
+pub enum RecordLayout<'tcx> {
+    Compound(&'tcx [Member<'tcx>]),
+    Variant(&'tcx [VariantDef<'tcx>]),
+}
+
+/// One compound field: its ground type and whether it is a mutable `[field]`
+/// link (only regional records carry these).
+#[derive(Clone, Copy, Debug)]
+pub struct Member<'tcx> {
+    pub ty: Ty<'tcx>,
+    pub is_field: bool,
+}
+
+/// One enum variant: its source name (interned in the program's symbol table)
+/// and ordered field types.
+#[derive(Clone, Copy, Debug)]
+pub struct VariantDef<'tcx> {
+    pub name: Symbol,
+    pub fields: &'tcx [Ty<'tcx>],
 }
 
 /// An exported C-ABI trampoline aliasing a concrete function instance.

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -16,6 +16,7 @@ use rustc_hash::FxHashMap;
 
 use crate::full::mir::{self, grammar as ir, raw};
 use crate::ir_lex::lex;
+use crate::semi::ctxt::DefaultCap;
 use crate::semi::hir::{ArithOp, CmpOp, VarId};
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{Flexivity, FpTy, IntTy, Ty, TyCtxt, TyKind};
@@ -101,15 +102,45 @@ impl<'tcx> Builder<'_, 'tcx> {
         }
     }
 
+    /// Rebuild a record instance (symbol, nominal type, default capability, and
+    /// ground layout) from its parsed declaration.
+    fn record(&mut self, r: &raw::RecordDecl) -> mir::RecordInstance<'tcx> {
+        let layout = match &r.body {
+            raw::RecordBody::Compound(members) => {
+                let ms: Vec<mir::Member<'tcx>> = members
+                    .iter()
+                    .map(|m| mir::Member {
+                        ty: self.ty(&m.ty),
+                        is_field: m.is_field,
+                    })
+                    .collect();
+                mir::RecordLayout::Compound(self.tcx.alloc_slice(&ms))
+            }
+            raw::RecordBody::Variant(variants) => {
+                let vs: Vec<mir::VariantDef<'tcx>> = variants
+                    .iter()
+                    .map(|v| {
+                        let fields: Vec<Ty<'tcx>> = v.fields.iter().map(|t| self.ty(t)).collect();
+                        mir::VariantDef {
+                            name: self.sym(&v.name),
+                            fields: self.tcx.intern_tys(&fields),
+                        }
+                    })
+                    .collect();
+                mir::RecordLayout::Variant(self.tcx.alloc_slice(&vs))
+            }
+        };
+        mir::RecordInstance {
+            symbol: self.sym(&r.symbol),
+            ty: self.ty(&r.ty),
+            default_cap: def_cap(r.default_cap),
+            layout,
+        }
+    }
+
     fn program(&mut self, raw: raw::Program) -> mir::Program<'tcx> {
-        let records: Vec<mir::RecordInstance<'tcx>> = raw
-            .records
-            .iter()
-            .map(|(s, t)| mir::RecordInstance {
-                symbol: self.sym(s),
-                ty: self.ty(t),
-            })
-            .collect();
+        let records: Vec<mir::RecordInstance<'tcx>> =
+            raw.records.iter().map(|r| self.record(r)).collect();
         let trampolines: Vec<mir::Trampoline> = raw
             .trampolines
             .iter()
@@ -406,6 +437,14 @@ fn cap(c: raw::Cap) -> Flexivity {
         raw::Cap::Flex => Flexivity::Flex,
         raw::Cap::Rigid => Flexivity::Rigid,
         raw::Cap::Regional => Flexivity::Regional,
+    }
+}
+
+fn def_cap(c: raw::DefCap) -> DefaultCap {
+    match c {
+        raw::DefCap::Value => DefaultCap::Value,
+        raw::DefCap::Shared => DefaultCap::Shared,
+        raw::DefCap::Regional => DefaultCap::Regional,
     }
 }
 

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -12,11 +12,34 @@ grammar<'input>;
 pub Program: raw::Program = <items:Item*> => raw::Program::from_items(items);
 
 Item: raw::Item = {
-    "record" "@" <s:Sym> ":" <t:Ty> ";" => raw::Item::Record(s, t),
+    "record" "@" <s:Sym> ":" <cap:DefCap> <kind:RecordBody> ";"
+        => raw::Item::Record(raw::RecordDecl { symbol: s, default_cap: cap, ty: kind.0, body: kind.1 }),
     <f:Func> => raw::Item::Func(f),
     "extern" <abi:"quoted"> "trampoline" <export:"quoted"> "=" "@" <target:Sym> ";"
         => raw::Item::Tramp(raw::Tramp { abi: abi.to_string(), export: export.to_string(), target }),
 };
+
+/// The capability a record declares by default.
+DefCap: raw::DefCap = {
+    "value" => raw::DefCap::Value,
+    "shared" => raw::DefCap::Shared,
+    "regional" => raw::DefCap::Regional,
+};
+
+/// A record body: the nominal record type followed by its ground field layout.
+/// Returns `(nominal type, layout)`; `struct`/`enum` pick compound vs variant.
+RecordBody: (raw::Ty, raw::RecordBody) = {
+    "struct" <t:Ty> "{" <ms:Comma<Member>> "}" => (t, raw::RecordBody::Compound(ms)),
+    "enum" <t:Ty> "{" <vs:Comma<Variant>> "}" => (t, raw::RecordBody::Variant(vs)),
+};
+
+/// A compound field: an optional `field` marker (a mutable `[field]` link) and
+/// its ground type.
+Member: raw::Member = <f:"field"?> <t:Ty> => raw::Member { is_field: f.is_some(), ty: t };
+
+/// An enum variant: its source name and ordered field types.
+Variant: raw::Variant =
+    <name:"ident"> "(" <fs:Comma<Ty>> ")" => raw::Variant { name: name.to_string(), fields: fs };
 
 /// A symbol body (after `@`).
 Sym: String = <s:"ident"> => s.to_string();
@@ -210,6 +233,11 @@ extern {
         "regional" => Token::Regional,
         "fn" => Token::Fn,
         "record" => Token::Record,
+        "struct" => Token::Struct,
+        "enum" => Token::Enum,
+        "value" => Token::Value,
+        "shared" => Token::Shared,
+        "field" => Token::Field,
         "extern" => Token::Extern,
         "trampoline" => Token::Trampoline,
         "let" => Token::Let,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -18,6 +18,7 @@ use pprint::{Doc, Printer as PpPrinter, hardline, indent, pprint};
 use reussir_syntax::kind::{Resolver, TokenKey};
 
 use crate::full::mir;
+use crate::semi::ctxt::DefaultCap;
 use crate::semi::hir::{ArithOp, CmpOp, VarId};
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{Flexivity, FpTy, IntTy, Ty, TyKind};
@@ -53,8 +54,7 @@ impl<'a> Printer<'a> {
 
         let mut items: Vec<Doc<'static>> = Vec::new();
         for rec in &program.records {
-            items
-                .push(text(format!("record @{} : ", r.sym(rec.symbol))) + r.ty(rec.ty) + text(";"));
+            items.push(r.record(rec));
         }
         for func in &program.functions {
             items.push(r.function(func));
@@ -93,6 +93,47 @@ struct Render<'a> {
 impl Render<'_> {
     fn sym(&self, s: mir::Symbol) -> &str {
         self.symbols.resolve(&s.0)
+    }
+
+    /// Render a record instance: its symbol, default capability, nominal type,
+    /// and ground field layout (`struct { … }` / `enum { … }`). The nominal type
+    /// reprints capability-canonicalized, so the leading keyword carries the
+    /// default capability instead.
+    fn record(&self, rec: &mir::RecordInstance<'_>) -> Doc<'static> {
+        let cap = match rec.default_cap {
+            DefaultCap::Value => "value",
+            DefaultCap::Shared => "shared",
+            DefaultCap::Regional => "regional",
+        };
+        let head = text(format!("record @{} : {cap} ", self.sym(rec.symbol)));
+        let body = match rec.layout {
+            mir::RecordLayout::Compound(members) => {
+                let parts: Vec<Doc<'static>> = members
+                    .iter()
+                    .map(|m| {
+                        let marker = if m.is_field {
+                            text("field ")
+                        } else {
+                            Doc::Null
+                        };
+                        marker + self.ty(m.ty)
+                    })
+                    .collect();
+                text("struct ") + self.ty(rec.ty) + text(" { ") + comma_sep(parts) + text(" }")
+            }
+            mir::RecordLayout::Variant(variants) => {
+                let parts: Vec<Doc<'static>> = variants
+                    .iter()
+                    .map(|v| {
+                        let fields: Vec<Doc<'static>> =
+                            v.fields.iter().map(|&t| self.ty(t)).collect();
+                        text(format!("{}(", self.sym(v.name))) + comma_sep(fields) + text(")")
+                    })
+                    .collect();
+                text("enum ") + self.ty(rec.ty) + text(" { ") + comma_sep(parts) + text(" }")
+            }
+        };
+        head + body + text(";")
     }
 
     fn function(&self, func: &mir::Function<'_>) -> Doc<'static> {

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -12,11 +12,11 @@
 //! correct by construction. This makes the round trip value-sound, not merely
 //! text-faithful.
 
-/// A whole program: record instances (with their ground type), functions,
+/// A whole program: record instances (with their ground layout), functions,
 /// exported trampolines.
 #[derive(Clone, Debug)]
 pub struct Program {
-    pub records: Vec<(String, Ty)>,
+    pub records: Vec<RecordDecl>,
     pub funcs: Vec<Func>,
     pub trampolines: Vec<Tramp>,
 }
@@ -24,9 +24,54 @@ pub struct Program {
 /// One top-level item, as the grammar yields them before partitioning.
 #[derive(Clone, Debug)]
 pub enum Item {
-    Record(String, Ty),
+    Record(RecordDecl),
     Func(Func),
     Tramp(Tramp),
+}
+
+/// A ground record declaration: its v0 symbol, the capability it declares by
+/// default, the nominal record type (path + ground args), and its field layout.
+/// The layout is what makes the textual MIR self-contained — a parsed program
+/// carries enough to lower records without re-consulting the elaborator.
+#[derive(Clone, Debug)]
+pub struct RecordDecl {
+    pub symbol: String,
+    pub default_cap: DefCap,
+    pub ty: Ty,
+    pub body: RecordBody,
+}
+
+/// A record's ground shape.
+#[derive(Clone, Debug)]
+pub enum RecordBody {
+    /// A struct: ordered fields.
+    Compound(Vec<Member>),
+    /// An enum: one compound sub-record per variant, in declaration order.
+    Variant(Vec<Variant>),
+}
+
+/// One compound field: its ground type, and whether it is a mutable `[field]`
+/// link (only regional records carry these).
+#[derive(Clone, Debug)]
+pub struct Member {
+    pub is_field: bool,
+    pub ty: Ty,
+}
+
+/// One enum variant: its source name and ordered field types.
+#[derive(Clone, Debug)]
+pub struct Variant {
+    pub name: String,
+    pub fields: Vec<Ty>,
+}
+
+/// The capability a record declares by default (mirrors
+/// [`crate::semi::ctxt::DefaultCap`]).
+#[derive(Clone, Copy, Debug)]
+pub enum DefCap {
+    Value,
+    Shared,
+    Regional,
 }
 
 impl Program {
@@ -39,7 +84,7 @@ impl Program {
         };
         for item in items {
             match item {
-                Item::Record(s, ty) => p.records.push((s, ty)),
+                Item::Record(r) => p.records.push(r),
                 Item::Func(f) => p.funcs.push(f),
                 Item::Tramp(t) => p.trampolines.push(t),
             }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -49,7 +49,9 @@ use reussir_syntax::kind::{Resolver, TokenKey};
 use crate::full::mangle::Mangler;
 use crate::full::mir;
 use crate::full::subst::{Subst, subst_ty};
-use crate::semi::ctxt::{Elaborator, Record, Report, Severity, TrampolineRoot};
+use crate::semi::ctxt::{
+    DefaultCap, Elaborator, Record, RecordFields, Report, Severity, TrampolineRoot,
+};
 use crate::semi::hir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{DefId, Flexivity, Ty, TyCtxt, TyKind};
@@ -194,14 +196,24 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             }
         }
     }
-    let mut records: Vec<mir::RecordInstance<'tcx>> = record_keys
-        .into_iter()
-        .map(|(def, args)| mir::RecordInstance {
-            symbol: driver.symbol_of(def, args),
-            // Layout is capability-independent, so canonicalize the coloring.
-            ty: tcx.mk_record(def, args, Flexivity::Irrelevant),
-        })
-        .collect();
+    let mut records: Vec<mir::RecordInstance<'tcx>> = Vec::with_capacity(record_keys.len());
+    for (def, args) in record_keys {
+        let symbol = driver.symbol_of(def, args);
+        // Layout is capability-independent, so canonicalize the coloring.
+        let ty = tcx.mk_record(def, args, Flexivity::Irrelevant);
+        // A record whose definition is missing (it failed to elaborate) gets an
+        // empty value layout so lowering still has a well-formed instance.
+        let (default_cap, layout) = match input.records.get(&def) {
+            Some(record) => resolve_layout(tcx, record, args, input.resolver, &mut driver.symbols),
+            None => (DefaultCap::Value, mir::RecordLayout::Compound(&[])),
+        };
+        records.push(mir::RecordInstance {
+            symbol,
+            ty,
+            default_cap,
+            layout,
+        });
+    }
 
     let trampolines: Vec<mir::Trampoline> = input
         .trampolines
@@ -229,6 +241,63 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         },
         reports,
     )
+}
+
+/// Resolve a record instance to its ground layout: the field types with the
+/// instance's generics substituted away (variants expanded), plus the
+/// default capability that selects the lowering. Variant names are interned into
+/// `symbols` (the program's symbol table).
+fn resolve_layout<'tcx>(
+    tcx: &TyCtxt<'tcx>,
+    record: &Record<'tcx>,
+    args: &'tcx [Ty<'tcx>],
+    resolver: &dyn Resolver<TokenKey>,
+    symbols: &mut Rodeo,
+) -> (DefaultCap, mir::RecordLayout<'tcx>) {
+    let mut subst = Subst::default();
+    for ((_, gid), &ty) in record.ty_params.iter().zip(args.iter()) {
+        subst.insert(*gid, ty);
+    }
+    let layout = match record.fields.as_ref() {
+        Some(RecordFields::Named(fields)) => {
+            let members: Vec<mir::Member<'tcx>> = fields
+                .iter()
+                .map(|(_, ty, is_mut)| mir::Member {
+                    ty: subst_ty(tcx, *ty, &subst),
+                    is_field: *is_mut,
+                })
+                .collect();
+            mir::RecordLayout::Compound(tcx.alloc_slice(&members))
+        }
+        Some(RecordFields::Unnamed(fields)) => {
+            let members: Vec<mir::Member<'tcx>> = fields
+                .iter()
+                .map(|(ty, is_mut)| mir::Member {
+                    ty: subst_ty(tcx, *ty, &subst),
+                    is_field: *is_mut,
+                })
+                .collect();
+            mir::RecordLayout::Compound(tcx.alloc_slice(&members))
+        }
+        Some(RecordFields::Variants(variants)) => {
+            let vdefs: Vec<mir::VariantDef<'tcx>> = variants
+                .iter()
+                .map(|v| {
+                    let fields: Vec<Ty<'tcx>> =
+                        v.fields.iter().map(|&t| subst_ty(tcx, t, &subst)).collect();
+                    mir::VariantDef {
+                        name: mir::Symbol(symbols.get_or_intern(resolver.resolve(v.name))),
+                        fields: tcx.intern_tys(&fields),
+                    }
+                })
+                .collect();
+            mir::RecordLayout::Variant(tcx.alloc_slice(&vdefs))
+        }
+        // A record that failed field population elaborates with no fields; treat
+        // it as an empty compound so lowering still has a well-formed layout.
+        None => mir::RecordLayout::Compound(&[]),
+    };
+    (record.default_cap, layout)
 }
 
 /// The maximum type-argument nesting depth monomorphization will instantiate

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -28,6 +28,8 @@ pub enum Token<'a> {
     Value,
     #[token("shared")]
     Shared,
+    #[token("field")]
+    Field,
     #[token("extern")]
     Extern,
     #[token("trampoline")]

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -492,10 +492,6 @@ mod tests {
         let src = "struct Point { x: i32 }\n\
                    fn f(p: Frobnicate) -> i32 { 0 }";
         assert!(has_error(src, "unknown type"), "{:#?}", reports_of(src));
-        assert!(
-            !has_error(src, "did you mean"),
-            "{:#?}",
-            reports_of(src)
-        );
+        assert!(!has_error(src, "did you mean"), "{:#?}", reports_of(src));
     }
 }

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -828,7 +828,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     ) -> Expr<'tcx> {
         let Some(def) = self.defs.resolve_record(enum_name) else {
             let hint = self.record_suggestion(enum_name);
-            self.error(span, format!("unknown enum `{}`{hint}", self.sym(enum_name)));
+            self.error(
+                span,
+                format!("unknown enum `{}`{hint}", self.sym(enum_name)),
+            );
             return self.poison(span);
         };
         self.record_use(enum_name);

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -8,7 +8,7 @@ use crate::semi::infer::InferCtxt;
 use crate::semi::resolve::DefTable;
 use crate::semi::traits::builtins::Builtins;
 use crate::semi::traits::{TraitDb, TraitId};
-use crate::semi::ty::{Flexivity, DefId, GenericId, Ty, TyCtxt, TyKind};
+use crate::semi::ty::{DefId, Flexivity, GenericId, Ty, TyCtxt, TyKind};
 use crate::surface::{self, Span};
 use crate::utils::frecency::Frecency;
 use crate::utils::fuzzy::FuzzyIndex;
@@ -333,7 +333,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     pub(super) fn variable_suggestion(&self, name: TokenKey) -> String {
         self.fuzzy_hint(
             self.sym(name),
-            self.vars.names().map(|k| (self.sym(k), self.frecency.score(k))),
+            self.vars
+                .names()
+                .map(|k| (self.sym(k), self.frecency.score(k))),
         )
     }
 

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -235,7 +235,7 @@ impl<'tcx> FulfillCtxt<'tcx> {
 mod tests {
     use super::ty_has_hole;
     use crate::semi::infer::InferCtxt;
-    use crate::semi::ty::{Flexivity, DefId, IntTy};
+    use crate::semi::ty::{DefId, Flexivity, IntTy};
     use crate::with_tcx;
 
     #[test]

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -15,7 +15,7 @@ use reussir_syntax::kind::{InternKey, Resolver, TokenKey};
 use rustc_hash::FxHashMap;
 
 use crate::ir_lex::lex;
-use crate::semi::ctxt::{DefaultCap, Record, TrampolineRoot};
+use crate::semi::ctxt::{DefaultCap, Record, RecordFields, TrampolineRoot, Variant};
 use crate::semi::hir::grammar as hir_ir;
 use crate::semi::hir::raw;
 use crate::semi::hir::{
@@ -136,7 +136,9 @@ impl<'tcx> Builder<'_, 'tcx> {
         (ty_params, regional)
     }
 
-    /// Rebuild the `Record` metadata mono reads (no field layouts).
+    /// Rebuild the `Record` metadata mono reads, including the ground field
+    /// layout. Struct field names are not serialized (mono ignores them), so a
+    /// struct's fields rebuild as [`RecordFields::Unnamed`] — layout-equivalent.
     fn record(&mut self, r: &raw::Record) -> (DefId, Record<'tcx>) {
         let def = self.record_def(&r.path);
         let name = self.names.intern(&r.path);
@@ -150,13 +152,30 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::DefaultCap::Shared => DefaultCap::Shared,
             raw::DefaultCap::Regional => DefaultCap::Regional,
         };
+        let fields = match &r.body {
+            raw::RecordBody::Compound(members) => RecordFields::Unnamed(
+                members
+                    .iter()
+                    .map(|m| (self.ty(&m.ty), m.is_field))
+                    .collect(),
+            ),
+            raw::RecordBody::Variant(variants) => RecordFields::Variants(
+                variants
+                    .iter()
+                    .map(|v| Variant {
+                        name: self.names.intern(&v.name),
+                        fields: v.fields.iter().map(|t| self.ty(t)).collect(),
+                    })
+                    .collect(),
+            ),
+        };
         let record = Record {
             def,
             name,
             ty_params,
             kind,
             default_cap,
-            fields: None,
+            fields: Some(fields),
             regional_generics,
             span: None,
         };

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -18,14 +18,26 @@ Item: raw::Item = {
     <f:Func> => raw::Item::Func(f),
 };
 
-RecordDecl: raw::Record =
-    <default_cap:DefaultCap> <kind:RecordKind> "#" <path:"ident"> <generics:Generics?> ";"
+RecordDecl: raw::Record = {
+    <default_cap:DefaultCap> "struct" "#" <path:"ident"> <generics:Generics?>
+    "{" <ms:Comma<Member>> "}" ";"
     => raw::Record {
         default_cap,
-        kind,
+        kind: raw::RecordKind::Struct,
         path: path.to_string(),
         generics: generics.unwrap_or_default(),
-    };
+        body: raw::RecordBody::Compound(ms),
+    },
+    <default_cap:DefaultCap> "enum" "#" <path:"ident"> <generics:Generics?>
+    "{" <vs:Comma<Variant>> "}" ";"
+    => raw::Record {
+        default_cap,
+        kind: raw::RecordKind::Enum,
+        path: path.to_string(),
+        generics: generics.unwrap_or_default(),
+        body: raw::RecordBody::Variant(vs),
+    },
+};
 
 DefaultCap: raw::DefaultCap = {
     "[" "value" "]" => raw::DefaultCap::Value,
@@ -33,10 +45,13 @@ DefaultCap: raw::DefaultCap = {
     "[" "regional" "]" => raw::DefaultCap::Regional,
 };
 
-RecordKind: raw::RecordKind = {
-    "struct" => raw::RecordKind::Struct,
-    "enum" => raw::RecordKind::Enum,
-};
+/// A compound field: an optional `field` marker (a mutable `[field]` link) and
+/// its type.
+Member: raw::Member = <f:"field"?> <t:Ty> => raw::Member { is_field: f.is_some(), ty: t };
+
+/// An enum variant: its source name and ordered field types.
+Variant: raw::Variant =
+    <name:"ident"> "(" <fs:Comma<Ty>> ")" => raw::Variant { name: name.to_string(), fields: fs };
 
 TrampDecl: raw::Tramp =
     "extern" <abi:"quoted"> "trampoline" <name:"quoted"> "=" "#" <target:"ident"> <ta:TyArgs?> ";"
@@ -245,6 +260,7 @@ extern {
         "enum" => Token::Enum,
         "value" => Token::Value,
         "shared" => Token::Shared,
+        "field" => Token::Field,
         "extern" => Token::Extern,
         "trampoline" => Token::Trampoline,
         "quoted" => Token::Quoted(<&'input str>),

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -15,7 +15,7 @@
 use pprint::{Doc, Printer as PpPrinter, hardline, indent, pprint};
 use reussir_syntax::kind::{Resolver, TokenKey};
 
-use crate::semi::ctxt::{DefaultCap, Record, TrampolineRoot};
+use crate::semi::ctxt::{DefaultCap, Record, RecordFields, TrampolineRoot};
 use crate::semi::hir::{
     ArithOp, CmpOp, DecisionTree, Expr, ExprKind, Function, PatVarRef, SwitchCases, VarId,
 };
@@ -114,9 +114,51 @@ impl<'a> Printer<'a> {
             RecordKind::StructKind => "struct #",
             RecordKind::EnumKind => "enum #",
         };
-        text(format!("{cap}{kind}{}", self.path(r.def)))
-            + self.generics_binder(&r.ty_params, &r.regional_generics)
-            + text(";")
+        let head = text(format!("{cap}{kind}{}", self.path(r.def)))
+            + self.generics_binder(&r.ty_params, &r.regional_generics);
+        head + text(" { ") + self.record_body(r) + text(" };")
+    }
+
+    /// The field layout of a record: `field?`-marked member types for a struct,
+    /// `Name(types)` variants for an enum. Struct field names are not emitted —
+    /// mono does not read them, so leaving them out keeps the form minimal and
+    /// the round-trip exact.
+    fn record_body(&self, r: &Record<'_>) -> Doc<'static> {
+        match r.fields.as_ref() {
+            Some(RecordFields::Named(fields)) => {
+                let parts = fields
+                    .iter()
+                    .map(|(_, ty, is_mut)| self.member(*ty, *is_mut))
+                    .collect();
+                comma_sep(parts)
+            }
+            Some(RecordFields::Unnamed(fields)) => {
+                let parts = fields
+                    .iter()
+                    .map(|(ty, is_mut)| self.member(*ty, *is_mut))
+                    .collect();
+                comma_sep(parts)
+            }
+            Some(RecordFields::Variants(variants)) => {
+                let parts = variants
+                    .iter()
+                    .map(|v| {
+                        let fields = v.fields.iter().map(|&t| self.ty(t)).collect();
+                        text(format!("{}(", self.resolver.resolve(v.name)))
+                            + comma_sep(fields)
+                            + text(")")
+                    })
+                    .collect();
+                comma_sep(parts)
+            }
+            // A record that failed field population elaborates with no fields.
+            None => Doc::Null,
+        }
+    }
+
+    fn member(&self, ty: Ty<'_>, is_mut: bool) -> Doc<'static> {
+        let marker = if is_mut { text("field ") } else { Doc::Null };
+        marker + self.ty(ty)
     }
 
     fn trampoline(&self, t: &TrampolineRoot<'_>) -> Doc<'static> {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -43,15 +43,40 @@ impl Program {
     }
 }
 
-/// A record declaration carrying what mono reads: its path/kind/default cap and
-/// its generic parameters (with the `regional` ones marked). Field layouts are
-/// not part of the mono-resumable form.
+/// A record declaration carrying what mono reads: its path/kind/default cap, its
+/// generic parameters (with the `regional` ones marked), and its field layout.
+/// Field types are serialized (struct field *names* are not — mono does not read
+/// them) so the resumed HIR resolves ground record layouts identically.
 #[derive(Clone, Debug)]
 pub struct Record {
     pub default_cap: DefaultCap,
     pub kind: RecordKind,
     pub path: String,
     pub generics: Vec<Generic>,
+    pub body: RecordBody,
+}
+
+/// A record's field layout in the HIR form.
+#[derive(Clone, Debug)]
+pub enum RecordBody {
+    /// A struct's ordered fields (names dropped; mono does not read them).
+    Compound(Vec<Member>),
+    /// An enum's variants, in declaration order.
+    Variant(Vec<Variant>),
+}
+
+/// One compound field: a `[field]`-mutability marker and its type.
+#[derive(Clone, Debug)]
+pub struct Member {
+    pub is_field: bool,
+    pub ty: Ty,
+}
+
+/// One enum variant: its source name and ordered field types.
+#[derive(Clone, Debug)]
+pub struct Variant {
+    pub name: String,
+    pub fields: Vec<Ty>,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -122,7 +122,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // A user record, resolved to its def.
         let Some(def) = self.defs.resolve_record(key) else {
             let hint = self.record_suggestion(key);
-            self.error(Some(span), format!("unknown type `{}`{hint}", self.sym(key)));
+            self.error(
+                Some(span),
+                format!("unknown type `{}`{hint}", self.sym(key)),
+            );
             return self.tcx.mk(TyKind::Bottom);
         };
         self.record_use(key);

--- a/include/Reussir/IR/ReussirTypeDetails.h
+++ b/include/Reussir/IR/ReussirTypeDetails.h
@@ -72,7 +72,16 @@ struct RecordTypeStorage : public mlir::TypeStorage {
 
   static RecordTypeStorage *construct(::mlir::TypeStorageAllocator &allocator,
                                       const KeyTy &key) {
-    return new (allocator.allocate<RecordTypeStorage>()) RecordTypeStorage(key);
+    auto *storage =
+        new (allocator.allocate<RecordTypeStorage>()) RecordTypeStorage(key);
+    // The key's `members`/`memberIsField` point at caller-owned buffers (a
+    // local `SmallVector` in the parser or the C API). Copy them into the
+    // uniquer's allocator so the uniqued storage owns them; otherwise a record
+    // built complete directly via `get` (rather than parsed-then-`mutate`d)
+    // dangles and crashes on first use.
+    storage->members = allocator.copyInto(key.members);
+    storage->memberIsField = allocator.copyInto(key.memberIsField);
+    return storage;
   }
 
   /// Mutates the members and attributes an identified record.


### PR DESCRIPTION
Rebases the *worthy part* of the old #269 (by-value records) onto current `main`. The original commit emitted **textual** MLIR over the Semi-HIR `FullProgram`; `main` has since rewritten codegen into `reussir-codegen` (in-memory melior ODS builders over the new `full::mir`, with no `DefTable`/`Mangler` at lowering time), so this is a re-implementation onto the new substrate, not a cherry-pick. The frontend half of the old PR already landed during that rewrite.

## Commits

1. **reussir dialect: own record members in `RecordTypeStorage::construct`** — a latent bug: `construct` copy-constructed storage from the key, keeping its `members`/`memberIsField` `ArrayRef`s pointing at *caller* buffers. Parse-then-`mutate` survived (mutate copies); a record built **complete directly via `RecordType::get`** (the C API / in-memory codegen) dangled → SIGSEGV on first print. Fixed with `allocator.copyInto`.
2. **reussir-codegen: lower by-value (`[value]`) records** — construction (`reussir.record.compound`) + field projection (`reussir.record.extract`) + the record-by-value function ABI. Shared/regional records and enums still surface an explicit `LoweringError` pending the rc work. New `reussir_backend::builders::{record_compound, record_extract}`.
3. **rrc: add `--disable-backend-multithreading`** — runs the MLIR backend single-threaded for deterministic diagnostics / debugging under sanitizers.

## Self-contained IR

Record field layout is baked into **both** textual forms (MIR and Semi HIR), because `TyKind::Record` is nominal (def/args/flex only) and the MIR parser builds a *fresh* `DefTable` from text — there is no record table at parse time. `mir::RecordInstance` carries `default_cap` + `RecordLayout`; printed as `record @sym : <cap> struct|enum <ty> { … };`. The HIR form serializes record fields too (struct field *names* dropped — mono ignores them — so they rebuild as `RecordFields::Unnamed`), keeping HIR-resume → mono layout-identical to the live elaborator.

## Verification

reussir-core 165 · C++ unit 17/17 · integration lit 237 · reussir-backend 5 · reussir-codegen unit 3 + JIT e2e 3 (`sq_norm(3,4)=25`) · rrc AOT smoke test (`%_RC5Point = type { i64, i64 }`) · clippy + rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)