### PR TITLE
[frontend] semi: a freshly-constructed regional record is born flex

### DIFF
--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -857,4 +857,35 @@ mod tests {
             );
         });
     }
+
+    #[test]
+    fn generic_assigned_into_link_must_be_regional() {
+        // Assigning a `Nullable<T>` into a flex link records that `T` must be
+        // regional (a body-discovered requirement, not just `[flex] T` params).
+        // Instantiating at a non-regional type is rejected at the call boundary.
+        let src = r#"
+            struct Pair { a: i32 }
+            struct [regional] Box<T> { item: [field] T }
+            regional fn store<T>(b: [flex] Box<T>, z: Nullable<T>) -> i32 { b->item := z; 0 }
+            regional fn use_bad(b: [flex] Box<Pair>, z: Nullable<Pair>) -> i32 { store(b, z) }
+        "#;
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(
+                !elab.has_errors(),
+                "elaboration errors: {:#?}",
+                elab.reports
+            );
+            let (_full, reports) = monomorphize(&elab);
+            assert!(
+                reports
+                    .iter()
+                    .any(|r| r.message.contains("regional record")),
+                "expected a regionality diagnostic, got {reports:#?}"
+            );
+        });
+    }
 }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -24,14 +24,20 @@
 //!
 //! # Regional check at the call boundary
 //!
-//! A generic used at a `[flex]` position (e.g. `bar: [flex] T`) requires its
-//! instantiating type to be a *regional* record — only regional records can be
-//! flex. The `[flex]` coloring itself is dropped on a bare generic (as in the
-//! reference); the elaborator records the implied requirement in
-//! `Function::regional_generics`, and mono verifies it here when an instance is
-//! popped, reporting any non-regional (value/shared) instantiation. The
-//! *flexivity* rules (flex capture/return/assign) are a separate concern enforced
-//! at the Semi stage on concrete records, not here.
+//! Some generics must be instantiated *regional* — only regional records can be
+//! flex or occupy a `[field]` link. The elaborator records these requirements
+//! (the `[flex]`/`[field]` colorings are dropped on a bare generic, as in the
+//! reference, but the implied requirement is kept):
+//!
+//! * `Function::regional_generics` — a generic used at a `[flex]` position
+//!   (`bar: [flex] T`) or assigned into a flex link in the body;
+//! * `Record::regional_generics` — a generic at the head of a `[field]` link
+//!   (`inner: [field] T`).
+//!
+//! Mono verifies them here — when a function instance is popped, and when a
+//! record instance is finalized — reporting any non-regional (value/shared)
+//! instantiation. The *flexivity* rules (flex capture/return/assign) are a
+//! separate concern enforced at the Semi stage on concrete records, not here.
 
 use std::collections::VecDeque;
 
@@ -136,6 +142,27 @@ pub fn monomorphize<'a, 'tcx>(elab: &Elaborator<'a, 'tcx>) -> (mir::Program<'tcx
     // Resolve the discovered record instances to symbols. Collect the keys first
     // so the interner can be borrowed mutably while we map them.
     let record_keys: Vec<(DefId, &'tcx [Ty<'tcx>])> = driver.records.iter().copied().collect();
+    // Call-boundary regional check for records: a `[field] T` link requires `T`
+    // regional, so a record instance must supply a regional type for each such
+    // generic parameter.
+    for &(def, args) in &record_keys {
+        let Some(record) = elab.records.get(&def) else {
+            continue;
+        };
+        for &gid in &record.regional_generics {
+            let Some(pos) = record.ty_params.iter().position(|(_, g)| *g == gid) else {
+                continue;
+            };
+            if matches!(args.get(pos), Some(&ty) if !is_regional_arg(ty)) {
+                driver.error(
+                    record.span,
+                    "a `[field]` link requires a regional record, but this record was \
+                     instantiated at a non-regional (value/shared) type"
+                        .to_string(),
+                );
+            }
+        }
+    }
     let mut records: Vec<mir::RecordInstance<'tcx>> = record_keys
         .into_iter()
         .map(|(def, args)| mir::RecordInstance {
@@ -854,6 +881,48 @@ mod tests {
                     .iter()
                     .any(|r| r.message.contains("regional record")),
                 "expected a regionality diagnostic, got {reports:#?}"
+            );
+        });
+    }
+
+    #[test]
+    fn field_link_generic_accepts_regional() {
+        // `Wrapper<T>` with `[field] T` instantiated at a regional record is fine.
+        let src = r#"
+            struct [regional] Cell<T> { v: T, next: [field] Cell<T> }
+            struct [regional] Wrapper<T> { inner: [field] T }
+            regional fn use_ok(w: [flex] Wrapper<Cell<i32>>) -> i32 { 0 }
+        "#;
+        with_full(src, |full| {
+            let syms = symbols(full);
+            assert!(syms.iter().any(|s| s.contains("use_ok")), "{syms:?}");
+        });
+    }
+
+    #[test]
+    fn field_link_generic_must_be_regional() {
+        // `struct [regional] Wrapper<T> { inner: [field] T }` requires `T` to be
+        // regional. Instantiating `Wrapper` at a value record is rejected at the
+        // call boundary, even with no function-body assignment.
+        let src = r#"
+            struct Pair { a: i32 }
+            struct [regional] Wrapper<T> { inner: [field] T }
+            regional fn use_bad(w: [flex] Wrapper<Pair>) -> i32 { 0 }
+        "#;
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(
+                !elab.has_errors(),
+                "elaboration errors: {:#?}",
+                elab.reports
+            );
+            let (_full, reports) = monomorphize(&elab);
+            assert!(
+                reports.iter().any(|r| r.message.contains("`[field]` link")),
+                "expected a `[field]` regionality diagnostic, got {reports:#?}"
             );
         });
     }

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -176,6 +176,27 @@ mod tests {
     }
 
     #[test]
+    fn value_record_construction_is_not_flex() {
+        // The fix is scoped to regional records: a value/shared record is never
+        // flex (it carries no regional capability).
+        check(
+            "struct Pair { a: i32 }\n\
+             fn build(n: i32) -> i32 { let p = Pair { a: n }; 0 }",
+            |elab, _tcx| {
+                let f = function(elab, "build");
+                let body = f.body.as_ref().expect("build has a body");
+                let crate::semi::hir::ExprKind::Seq(stmts) = &body.kind else {
+                    panic!("expected a Seq body, got {:?}", body.kind);
+                };
+                let crate::semi::hir::ExprKind::Let { value, .. } = &stmts[0].kind else {
+                    panic!("expected a `let` binding first, got {:?}", stmts[0].kind);
+                };
+                assert_eq!(value.ty.capability(), Some(Capability::Irrelevant));
+            },
+        );
+    }
+
+    #[test]
     fn reports_type_mismatch() {
         with_tcx(|tcx| {
             let source = "fn bad() -> bool { 1 }";

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -223,6 +223,26 @@ mod tests {
     }
 
     #[test]
+    fn rejects_field_link_to_non_regional_record() {
+        with_tcx(|tcx| {
+            // A `[field]` link's element must be a regional record; a concrete
+            // value record is rejected right at the declaration.
+            let source = "struct Pair { a: i32 }\n\
+                          struct [regional] Holder { item: [field] Pair }";
+            let parse = reussir_syntax::parse(source);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(
+                elab.reports
+                    .iter()
+                    .any(|r| r.message.contains("`[field]` link element")),
+                "expected a `[field]` element error: {:#?}",
+                elab.reports
+            );
+        });
+    }
+
+    #[test]
     fn rejects_capturing_a_flex_value() {
         with_tcx(|tcx| {
             // `c` is a flex regional value; a closure cannot capture it (a flex

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -145,6 +145,37 @@ mod tests {
     }
 
     #[test]
+    fn fresh_regional_construction_is_flex_and_assignable() {
+        // A regional record constructed inside a region is born `Flex`, so it can
+        // be assigned into directly — no `[flex]` binding annotation required.
+        // Before the fix the construction was `Regional`, and the assignment was
+        // rejected with "assignment target must be a flex record".
+        check(
+            "struct [regional] Cell<T> { v: T, next: [field] Cell<T> }\n\
+             regional fn build(seed: i32) -> i32 {\n\
+                 let c = Cell { v: seed, next: Nullable::Null };\n\
+                 c->next := Nullable::NonNull{c};\n\
+                 0\n\
+             }",
+            |elab, _tcx| {
+                let f = function(elab, "build");
+                let body = f.body.as_ref().expect("build has a body");
+                let crate::semi::hir::ExprKind::Seq(stmts) = &body.kind else {
+                    panic!("expected a Seq body, got {:?}", body.kind);
+                };
+                let crate::semi::hir::ExprKind::Let { value, .. } = &stmts[0].kind else {
+                    panic!("expected a `let` binding first, got {:?}", stmts[0].kind);
+                };
+                assert_eq!(
+                    value.ty.capability(),
+                    Some(Capability::Flex),
+                    "a fresh regional construction should be flex"
+                );
+            },
+        );
+    }
+
+    #[test]
     fn reports_type_mismatch() {
         with_tcx(|tcx| {
             let source = "fn bad() -> bool { 1 }";

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -27,6 +27,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // parameters may already be flex and it may construct regional records
         // directly, so the body is checked with the region context active.
         self.inside_region = proto.is_regional;
+        // Seed the regional-requirement set from the prototype's `[flex]`-position
+        // generics; the body may add more (e.g. a generic assigned into a link).
+        self.regional_generics = proto.regional_generics.clone();
 
         let mut params = Vec::new();
         for (name, ty) in &proto.params {
@@ -47,7 +50,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             name: proto.name,
             visibility: proto.visibility,
             generics: proto.generics,
-            regional_generics: proto.regional_generics,
+            regional_generics: std::mem::take(&mut self.regional_generics),
             params,
             return_ty,
             is_regional: proto.is_regional,
@@ -582,6 +585,39 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
         // A mutable field's type is already the nullable link type.
         let src = self.check_expr(src, field_ty);
+        // The assigned value must be a `Nullable<R>` whose element `R` is a
+        // regional record — only a regional value belongs in a flex record's
+        // mutable link. If `R` is concrete it must be regional here; if `R` is a
+        // generic, record the requirement for the monomorphization call-boundary
+        // check (the same `regional_generics` channel as a `[flex] T` parameter).
+        let resolved = self.infer.shallow_resolve(src.ty);
+        if let TyKind::Nullable(inner) = resolved.kind() {
+            let inner = self.infer.shallow_resolve(*inner);
+            match inner.kind() {
+                TyKind::Generic(g) => {
+                    if !self.regional_generics.contains(g) {
+                        self.regional_generics.push(*g);
+                    }
+                }
+                _ if matches!(
+                    inner.capability(),
+                    Some(
+                        crate::semi::ty::Capability::Regional
+                            | crate::semi::ty::Capability::Flex
+                            | crate::semi::ty::Capability::Rigid
+                    )
+                ) => {}
+                _ => self.error(
+                    span,
+                    "assignment source must be a `Nullable` of a regional record",
+                ),
+            }
+        } else {
+            self.error(
+                span,
+                "assignment source must be a `Nullable` of a regional record",
+            );
+        }
         let unit = self.tcx.mk_unit();
         self.mk_expr(
             ExprKind::Assign(Box::new(dst), idx, Box::new(src)),

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -896,8 +896,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .iter()
             .map(|(_, g)| inst.get(*g).unwrap_or_else(|| self.tcx.mk_generic(*g)))
             .collect();
+        // A freshly-constructed regional record is a live, region-local value, so
+        // it is born `Flex` (mutable, not yet frozen) — matching the reference
+        // (`Tyck.hs`). This is what lets the result be assigned into or frozen on
+        // region exit; binding it under a `[rigid]`/`[flex]` annotation just
+        // re-reads the head (`unify` ignores flexivity). Construction outside a
+        // region is reported separately by the caller.
         let flex = match record.default_cap {
-            super::ctxt::DefaultCap::Regional => crate::semi::ty::Capability::Regional,
+            super::ctxt::DefaultCap::Regional => crate::semi::ty::Capability::Flex,
             _ => crate::semi::ty::Capability::Irrelevant,
         };
         self.tcx.mk_record(record.def, &args, flex)

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -202,6 +202,11 @@ pub struct Elaborator<'a, 'tcx> {
     pub vars: VarEnv<'tcx>,
     pub generic_names: FxHashMap<TokenKey, GenericId>,
     pub inside_region: bool,
+    /// Generics required to be regional, accumulated while checking the current
+    /// function body (e.g. a generic assigned into a flex link). Seeded from the
+    /// prototype's `[flex]`-position generics and folded into the elaborated
+    /// [`Function`]. See [`FuncProto::regional_generics`].
+    pub regional_generics: Vec<GenericId>,
     pub fulfill: FulfillCtxt<'tcx>,
     expr_counter: u32,
 }
@@ -238,6 +243,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             vars: VarEnv::default(),
             generic_names: FxHashMap::default(),
             inside_region: false,
+            regional_generics: Vec::new(),
             fulfill: FulfillCtxt::default(),
             expr_counter: 0,
         }

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -70,6 +70,10 @@ pub struct Record<'tcx> {
     pub kind: surface::RecordKind,
     pub default_cap: DefaultCap,
     pub fields: Option<RecordFields<'tcx>>,
+    /// Generics that must be instantiated regional because they appear as the
+    /// element of a `[field]` link (e.g. `inner: [field] T`). Checked at the
+    /// monomorphization call boundary, like a function's `regional_generics`.
+    pub regional_generics: Vec<GenericId>,
     pub span: Option<Span>,
 }
 
@@ -395,6 +399,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             kind: rec.kind,
             default_cap,
             fields: None,
+            regional_generics: Vec::new(),
             span,
         };
         self.records.insert(def, record);
@@ -477,12 +482,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let default_cap = record.default_cap;
         self.generic_names = ty_params.iter().map(|(n, id)| (*n, *id)).collect();
 
+        // A generic at the head of a `[field]` link (`inner: [field] T`) must be
+        // instantiated regional; record the requirement for the mono check.
+        let mut regional_generics: Vec<GenericId> = Vec::new();
         let fields = match &rec.fields {
             surface::RecordFields::Named(fs) => RecordFields::Named(
                 fs.iter()
                     .map(|f| {
                         let (name, ty, mutable) = &f.value;
-                        (*name, self.field_ty(ty, *mutable), *mutable)
+                        let fty = self.field_ty(ty, *mutable);
+                        if *mutable {
+                            collect_regional_generic(fty, &mut regional_generics);
+                        }
+                        (*name, fty, *mutable)
                     })
                     .collect(),
             ),
@@ -490,7 +502,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 fs.iter()
                     .map(|f| {
                         let (ty, mutable) = &f.value;
-                        (self.field_ty(ty, *mutable), *mutable)
+                        let fty = self.field_ty(ty, *mutable);
+                        if *mutable {
+                            collect_regional_generic(fty, &mut regional_generics);
+                        }
+                        (fty, *mutable)
                     })
                     .collect(),
             ),
@@ -525,6 +541,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
         if let Some(r) = self.records.get_mut(&def) {
             r.fields = Some(fields);
+            r.regional_generics = regional_generics;
         }
     }
 

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -8,7 +8,7 @@ use crate::semi::infer::InferCtxt;
 use crate::semi::resolve::DefTable;
 use crate::semi::traits::builtins::Builtins;
 use crate::semi::traits::{TraitDb, TraitId};
-use crate::semi::ty::{DefId, GenericId, Ty, TyCtxt, TyKind};
+use crate::semi::ty::{Capability, DefId, GenericId, Ty, TyCtxt, TyKind};
 use crate::surface::{self, Span};
 use crate::utils::string::StringUniqifier;
 
@@ -492,7 +492,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         let (name, ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
                         if *mutable {
-                            collect_regional_generic(fty, &mut regional_generics);
+                            self.note_link_element(fty, &mut regional_generics, span);
                         }
                         (*name, fty, *mutable)
                     })
@@ -504,7 +504,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         let (ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
                         if *mutable {
-                            collect_regional_generic(fty, &mut regional_generics);
+                            self.note_link_element(fty, &mut regional_generics, span);
                         }
                         (fty, *mutable)
                     })
@@ -605,6 +605,36 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     fn field_ty(&mut self, ty: &surface::Type, mutable: bool) -> Ty<'tcx> {
         let t = self.eval_type(ty);
         if mutable { self.tcx.mk_nullable(t) } else { t }
+    }
+
+    /// Enforce that a `[field]` link's element is regional. The element (peeled
+    /// from the `Nullable` link) must be a regional record: a concrete
+    /// value/shared element is rejected here; a generic element records a
+    /// requirement checked at the monomorphization call boundary.
+    fn note_link_element(
+        &mut self,
+        field_ty: Ty<'tcx>,
+        regional: &mut Vec<GenericId>,
+        span: Option<Span>,
+    ) {
+        let elem = match field_ty.kind() {
+            TyKind::Nullable(inner) => *inner,
+            _ => field_ty,
+        };
+        match elem.kind() {
+            TyKind::Generic(g) => {
+                if !regional.contains(g) {
+                    regional.push(*g);
+                }
+            }
+            TyKind::Record {
+                flex: Capability::Irrelevant,
+                ..
+            } => self.error(span, "a `[field]` link element must be a regional record"),
+            // Regional records are fine; non-record elements are already rejected
+            // by the `Nullable` pointer-like check.
+            _ => {}
+        }
     }
 }
 

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -23,12 +23,16 @@
 //!
 //! Lifecycle: create ⟶ Flex ──(freeze on escape)──▶ Rigid (materializable).
 //!
-//! Representation note: `eval_type` leaves a regional record's type *unpinned*
-//! at [`Capability::Regional`]; [`Elaborator::eval_type_flex`] pins a binding's
-//! head to Flex (`[flex]`) or Rigid; [`Elaborator::freeze_region`] freezes an
-//! escaping value. Because `unify` ignores flexivity, a constructor's unpinned
-//! `Regional` result flows into a `[flex]` binding/return and is read as Flex
-//! there. A `[field]` mutable link is wrapped in `Nullable` (nullable, and
+//! Representation note: a regional record's *type annotation* is evaluated by
+//! `eval_type` to an unpinned [`Capability::Regional`], which
+//! [`Elaborator::eval_type_flex`] then pins to Flex (`[flex]`) or Rigid. A
+//! freshly *constructed* regional record is different: it is born Flex directly
+//! (the checker's `record_ty`) — the live, region-local form, so it is
+//! immediately assignable and freezes to Rigid on region exit
+//! ([`Elaborator::freeze_region`] maps Flex/Regional → Rigid). Because `unify`
+//! ignores flexivity, that Flex value still flows into a binding/return annotated
+//! otherwise (e.g. `[rigid]`), where the annotation's coloring is what is read. A
+//! `[field]` mutable link is wrapped in `Nullable` (nullable, and
 //! reassignable in-region), so *assembling* (assigning) and *projecting*
 //! (reading) those fields ride the `Nullable` machinery — and so
 //! [`Elaborator::refine_flex`] looks through a `Nullable` head when pinning a


### PR DESCRIPTION
## What

A freshly-constructed regional record was colored `Regional` (unpinned) by `record_ty`, relying on a `[flex]` binding annotation to pin it to `Flex`. The reference (`Tyck.hs`) instead colors a fresh regional construction `Flex` directly — a live, region-local value.

The divergence was observable: assigning into a freshly-constructed regional record bound by a plain `let` was rejected with *"assignment target must be a flex record"* (the target resolved to `Regional`, but `infer_assign` requires `Flex`).

## Fix

`record_ty` now colors a constructed regional record `Flex` (value/shared stay `Irrelevant`). Binding under a `[rigid]`/`[flex]` annotation just re-reads the head (`unify` ignores flexivity), and freeze-on-region-exit still turns `Flex` into `Rigid`. Construction outside a region is still reported by the caller.

This keeps the flexivity discipline at the Semi stage (per the agreed split: Semi owns flexivity, mono only verifies regional).

## Test

A regional record built in a region and assigned into — without a `[flex]` annotation — now elaborates, and the construction's type is asserted `Flex`. `cargo test -p reussir-core`: 85 → 86; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)