### PR TITLE
Perceus-style ownership (precise reference-counting) analysis over Full MIR

### DIFF
--- a/.github/workflows/mlir-cpp-test.yml
+++ b/.github/workflows/mlir-cpp-test.yml
@@ -130,5 +130,5 @@ jobs:
       - name: Build and Test reussir-codegen
         run: cmake --build build --target reussir-codegen-test
 
-      - name: Build and Test reussir-compiler
-        run: cmake --build build --target reussir-compiler-test
+      - name: Build and Test rrc
+        run: cmake --build build --target rrc-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,7 @@ dependencies = [
  "atuin-nucleo-matcher",
  "blake3",
  "ena",
+ "fixedbitset",
  "ftree",
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "caseless"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1131,7 @@ dependencies = [
  "pprint",
  "rapidhash",
  "reussir-syntax",
+ "roaring",
  "rustc-hash",
  "smallvec",
  "strsim",
@@ -1161,6 +1174,16 @@ dependencies = [
  "palc",
  "serde_json",
  "stacker",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ blake3 = "1"
 rapidhash = "4.4.1"
 # Fast non-DoS-resistant hasher for interner/compiler-internal maps.
 rustc-hash = "2.1"
+# Compressed (Roaring) bitmaps over u32; back the ownership pass's VarId live-sets.
+roaring = "0.11.4"
 # Small-size-optimized vectors: arity-bounded surface-AST lists (path segments,
 # argument/type-parameter lists) stay inline and skip heap allocation.
 smallvec = "1.15"
@@ -63,7 +65,6 @@ llvm-sys = "221"
 melior = "0.27"
 mlir-sys = "220"
 palc = "0.0.2"
-serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 stacker = "0.1.21"
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,12 @@ blake3 = "1"
 rapidhash = "4.4.1"
 # Fast non-DoS-resistant hasher for interner/compiler-internal maps.
 rustc-hash = "2.1"
-# Compressed (Roaring) bitmaps over u32; back the ownership pass's VarId live-sets.
+# Compressed (Roaring) bitmaps over u32; the sparse backend of the ownership
+# pass's small-set-optimized VarId live-sets (utils::bitset).
 roaring = "0.11.4"
+# Dense word-backed bitset; the small-domain backend of utils::bitset before it
+# promotes to a Roaring bitmap.
+fixedbitset = "0.5.7"
 # Small-size-optimized vectors: arity-bounded surface-AST lists (path segments,
 # argument/type-parameter lists) stay inline and skip heap allocation.
 smallvec = "1.15"

--- a/crates/reussir-compiler/CMakeLists.txt
+++ b/crates/reussir-compiler/CMakeLists.txt
@@ -1,10 +1,15 @@
 # Builds the reussir-compiler Rust crate (the AOT driver: Reussir source ->
 # native object / assembly / LLVM IR) with cargo.
 #
+# The CMake targets and the produced binary are named `rrc`, not
+# `reussir-compiler`: frontend/CMakeLists.txt already registers a
+# `reussir-compiler` custom target, and CMake aborts configuration when two
+# targets share a name.
+#
 # Like reussir-backend / reussir-jit / reussir-codegen, these targets are NOT
 # part of the default `ALL` build. Invoke them explicitly:
-#   ninja -C build reussir-compiler         # compile the crate + binary
-#   ninja -C build reussir-compiler-test    # run the crate's tests
+#   ninja -C build rrc         # compile the crate + binary
+#   ninja -C build rrc-test    # run the crate's tests
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(REUSSIR_COMPILER_CARGO_PROFILE "dev")
@@ -26,22 +31,22 @@ set(REUSSIR_COMPILER_CARGO_ENV
     REUSSIR_INCLUDE_DIR=${CMAKE_SOURCE_DIR}/include
     RUSTFLAGS=-Awarnings)
 
-add_custom_target(reussir-compiler
+add_custom_target(rrc
     COMMAND ${CMAKE_COMMAND} -E env ${REUSSIR_COMPILER_CARGO_ENV}
         cargo build --locked --profile ${REUSSIR_COMPILER_CARGO_PROFILE}
         --package reussir-compiler --quiet
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     DEPENDS ReussirCAPI MLIRReussir
-    COMMENT "Building reussir-compiler with cargo (${REUSSIR_COMPILER_CARGO_PROFILE} profile)"
+    COMMENT "Building rrc with cargo (${REUSSIR_COMPILER_CARGO_PROFILE} profile)"
     USES_TERMINAL
 )
 
-add_custom_target(reussir-compiler-test
+add_custom_target(rrc-test
     COMMAND ${CMAKE_COMMAND} -E env ${REUSSIR_COMPILER_CARGO_ENV}
         cargo test --locked --profile ${REUSSIR_COMPILER_CARGO_PROFILE}
         --package reussir-compiler
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     DEPENDS ReussirCAPI MLIRReussir
-    COMMENT "Testing reussir-compiler with cargo"
+    COMMENT "Testing rrc with cargo"
     USES_TERMINAL
 )

--- a/crates/reussir-compiler/Cargo.toml
+++ b/crates/reussir-compiler/Cargo.toml
@@ -8,6 +8,10 @@ description = "Ahead-of-time Reussir compiler: source → native object / assemb
 [lib]
 name = "reussir_compiler"
 
+[[bin]]
+name = "rrc"
+path = "src/main.rs"
+
 [dependencies]
 # `melior` for the lowered `Module` type; `mlir-sys` for the MLIR→LLVM-IR
 # translation; `llvm-sys` for the host `TargetMachine` emission. llvm-sys

--- a/crates/reussir-core/Cargo.toml
+++ b/crates/reussir-core/Cargo.toml
@@ -40,5 +40,7 @@ lalrpop-util.workspace = true
 pprint.workspace = true
 # The surface AST is a set of typed views over the parser's lossless CST.
 reussir-syntax = { path = "../reussir-syntax" }
-# Compressed bitmaps over u32, used for the ownership pass's VarId live-sets.
+# Backends for utils::bitset's small-set-optimized VarId live-sets: a dense
+# fixedbitset that promotes to a compressed roaring bitmap past 512 bits.
 roaring.workspace = true
+fixedbitset.workspace = true

--- a/crates/reussir-core/Cargo.toml
+++ b/crates/reussir-core/Cargo.toml
@@ -40,3 +40,5 @@ lalrpop-util.workspace = true
 pprint.workspace = true
 # The surface AST is a set of typed views over the parser's lossless CST.
 reussir-syntax = { path = "../reussir-syntax" }
+# Compressed bitmaps over u32, used for the ownership pass's VarId live-sets.
+roaring.workspace = true

--- a/crates/reussir-core/docs/ownership-analysis.md
+++ b/crates/reussir-core/docs/ownership-analysis.md
@@ -43,27 +43,37 @@ refinement.
 ```text
 is_rr(ty) =
   match ty.kind():
-    Record{def, args} =>                                  // capability ignored
+    Record{def, args, flex} =>
         match record_table.shape(def, args).managed:      // Value | Shared | Regional
-            Shared | Regional => true                     // rc-managed
-            Value             => any field is_rr           // transitive
+            Shared   => true                              // always rc-managed
+            Value    => any field is_rr                   // transitive
+            Regional => flex == Rigid                     // rc only when frozen out
     Closure{..}      => true            // owns a captured environment
     Nullable(inner)  => is_rr(inner)
     Int | Float | Bool | …             => false
 ```
 
-- **Two orthogonal axes.** A record's `Ty` *capability* records **regional value
-  coloring** (`Regional`/`Flex`/`Rigid`, or `Irrelevant` for anything that does
-  not participate — i.e. every non-regional record). That is a *different axis*
-  from **rc-management** (is it heap/region reference-counted, or inline by
-  value), which the elaborator stores in `ctxt::Record.default_cap`
-  (`Value | Shared | Regional`). The capability cannot answer "is this rc'd": the
-  dialect's `Capability` has no `Shared`/`Value` variant, and `[value]`/`[shared]`
-  both elaborate to `Irrelevant` (`ty_eval.rs`).
-- **So `is_rr` decides rc-management from the `RecordTable` for *every* record**
-  (regional or not), keyed by the canonical (`Irrelevant`) record type — never
-  from the capability. The table (`canonical-Ty → RecordShape { managed, fields }`)
-  carries `default_cap` forward.
+- **Two axes — management and flexivity.** A record's **rc-management** (is it
+  heap reference-counted, region-allocated, or inline by value) is what the
+  elaborator stores in `ctxt::Record.default_cap` (`Value | Shared | Regional`)
+  and the `RecordTable` carries forward, keyed by the canonical (flexivity-erased)
+  record type. A `Ty`'s **flexivity** (`Regional`/`Flex`/`Rigid`, or `Irrelevant`
+  for any non-regional record) is the orthogonal *regional value coloring*. The
+  flexivity cannot, on its own, say "is this rc'd": `[value]`/`[shared]` both
+  erase to `Irrelevant` (`ty_eval.rs`), so management must come from the table.
+- **The two axes meet in exactly one case: a `Regional` record.** A
+  region-allocated value is freed *en masse* when its region is torn down — no
+  per-object rc — **unless** it has been frozen to `Rigid`, which lifts it into a
+  managed (reference-counted) object that escapes the region. So a `Regional`
+  record is RR iff its flexivity is `Rigid`; a region-local `Flex` (or unrefined
+  `Regional`) value needs no `dup`/`drop`. `Shared` is always RR and `Value` is
+  transitive, independent of flexivity. The table is
+  `canonical-Ty → RecordShape { managed, fields }`.
+  - *Managed fields of a region-local record are still rc'd.* The flex container
+    itself takes no ops, but a `Shared`/`Rigid` field it is assembled from is an
+    ordinary RR value — `dup`'d if the source stays live, moved (ownership
+    transferred to the field, dec'd by region teardown) if it is a last use.
+    Container-unmanaged never means field-unmanaged.
 - Memoized per interned `Ty` (pointer-identity key — types are arena-interned);
   a provisional `false` guards the (illegal but defensively-handled) value-record
   field cycle.
@@ -422,11 +432,11 @@ Then **pm/08:** codegen consumes `OwnershipTable` → emits `rc.inc` / `rc.dec` 
   choke point via a shared `ExprIdGen` (§4). *Locked, landed.*
 - **Owned-only convention** to start (no borrowed-parameter optimization); the
   simplest correct base, refined later. *Resolved.*
-- **RR set:** rc-management (`Shared`/`Regional`) and closures are always rc;
-  `Value` records are rc iff transitively so; `Nullable` follows its inner.
-  Rc-management comes from the `RecordTable` for *every* record — the `Ty`
-  capability (regional coloring) is an orthogonal axis and is not consulted
-  (§3). *Resolved.*
+- **RR set:** `Shared` records and closures are always rc; `Value` records are rc
+  iff transitively so; a `Regional` record is rc iff its flexivity is `Rigid`
+  (frozen out of its region); `Nullable` follows its inner. Management comes from
+  the `RecordTable` for *every* record; the `Ty`'s flexivity (regional coloring)
+  refines only the regional case (§3). *Resolved.*
 - **Increment 1 = linear core + `is_rr` + harness.** *Resolved, landed.*
 
 ## Open questions

--- a/crates/reussir-core/docs/ownership-analysis.md
+++ b/crates/reussir-core/docs/ownership-analysis.md
@@ -381,8 +381,12 @@ table.
    and the **linear core** (`Var` / `Let` / `Seq` / `Call` / `Ctor` / `Variant` /
    `NullableCall`) with the §9.3 corpus. Deferred forms (`If`/`Match`/`Proj`/…)
    `unimplemented!` loudly rather than miscount.
-2. **Control flow:** `If` / `Match` branch reconciliation, multi-use `Dup`,
-   discarded-result drops.
+2. **Control flow — `If` landed.** `If` branch reconciliation (settle one-sided
+   ownership so both arms exit owning the same set), multi-use `Dup` (already in
+   increment 1), and discarded-result drops via `RcOp::DropValue(ExprId)` for an
+   unconsumed non-`let` `Seq` statement. **`Match` reconciliation over decision
+   trees** (switch/guard/bindings) is split into its own follow-up — it overlaps
+   the container increment (destructuring `Proj`/partial moves).
 3. **Containers:** `Proj` borrow-dup, `Nullable`, `Variant`, transitive
    value-records.
 4. **Closures & regions:** capture consumption, region-run lifecycle.

--- a/crates/reussir-core/docs/ownership-analysis.md
+++ b/crates/reussir-core/docs/ownership-analysis.md
@@ -385,22 +385,33 @@ table.
    ownership so both arms exit owning the same set), multi-use `Dup` (already in
    increment 1), and discarded-result drops via `RcOp::DropValue(ExprId)` for an
    unconsumed non-`let` `Seq` statement.
-3. **Pattern matching — landed (no guards yet).** `Match` over `Switch` + `Leaf`,
-   following Perceus/Koka **borrow-dup**: the scrutinee is borrowed; each leaf
-   `dup`s the used RR fields it extracts, drops the consumed scrutinee early (or
-   keeps it if live after), moves a whole-scrutinee binding, and reconciles
+3. **Pattern matching — landed (with guards).** `Match` over `Switch` + `Leaf` +
+   `Guard`, following Perceus/Koka **borrow-dup**: the scrutinee is borrowed; each
+   leaf `dup`s the used RR fields it extracts, drops the consumed scrutinee early
+   (or keeps it if live after), moves a whole-scrutinee binding, and reconciles
    dead-after outer vars N-way across the switch arms. Reuse specialization
    (in-place, uniqueness-guarded) is the backend's job, exactly as Koka separates
-   Perceus from reuse analysis. **Guards** (scrutinee stays live across a
-   re-testable failure path) `unimplemented!` for a follow-up.
+   Perceus from reuse analysis. **Guards** keep the scrutinee live across the
+   re-testable `failure` path (its drop stays in each terminal leaf, not hoisted);
+   bindings are borrow-extracted at the guard, then settled per branch (consumed
+   in the branch that uses them, dropped in the one that does not).
    *Note:* binding-type resolution via an enriched `RecordTable` proved
    **unnecessary** here — an unused binding needs no op (the scrutinee drop frees
-   it), and a used binding's type is on its `Var` node; the enrichment is still
-   wanted for the `Proj` container increment.
-4. **Containers:** `Proj` borrow-dup, `Nullable` payloads, `Variant`, transitive
-   value-records.
-5. **Closures & regions:** capture consumption, region-run lifecycle.
-6. **Drop-specialization** (optional, reuse-targeted).
+   it), and a used binding's type is on its `Var` node.
+4. **Containers — landed.** `Proj` borrow-dup (the extracted field is inc'd while
+   the parent keeps the original; nested projections are pure navigation; the dead
+   base drops early at the projection), `Assign` (`src` moved into the field, `dst`
+   borrowed and dropped if dead — no old-field dec, the link is freed with its
+   parent/region), `Nullable` payloads, `Variant`, transitive value-records.
+5. **Closures & regions — landed.** Closure capture consumption (`dup` a capture
+   still live after; the body is analyzed as its own owned scope — captures +
+   params owned on entry, unused ones dropped), `ClosureCall` (target + args
+   consumed left-to-right), and `RegionRun` (rc-transparent: the body's result is
+   moved straight through; region lifetime is a separate axis).
+6. **Drop-specialization** (optional, reuse-targeted) — still future backend work.
+
+**Every MIR form is now handled — no `unimplemented!` remains; the analysis is
+total over the Full MIR.**
 
 Then **pm/08:** codegen consumes `OwnershipTable` → emits `rc.inc` / `rc.dec` /
 `ref.drop`, gated by ASAN/LSAN execution tests.

--- a/crates/reussir-core/docs/ownership-analysis.md
+++ b/crates/reussir-core/docs/ownership-analysis.md
@@ -384,13 +384,23 @@ table.
 2. **Control flow — `If` landed.** `If` branch reconciliation (settle one-sided
    ownership so both arms exit owning the same set), multi-use `Dup` (already in
    increment 1), and discarded-result drops via `RcOp::DropValue(ExprId)` for an
-   unconsumed non-`let` `Seq` statement. **`Match` reconciliation over decision
-   trees** (switch/guard/bindings) is split into its own follow-up — it overlaps
-   the container increment (destructuring `Proj`/partial moves).
-3. **Containers:** `Proj` borrow-dup, `Nullable`, `Variant`, transitive
+   unconsumed non-`let` `Seq` statement.
+3. **Pattern matching — landed (no guards yet).** `Match` over `Switch` + `Leaf`,
+   following Perceus/Koka **borrow-dup**: the scrutinee is borrowed; each leaf
+   `dup`s the used RR fields it extracts, drops the consumed scrutinee early (or
+   keeps it if live after), moves a whole-scrutinee binding, and reconciles
+   dead-after outer vars N-way across the switch arms. Reuse specialization
+   (in-place, uniqueness-guarded) is the backend's job, exactly as Koka separates
+   Perceus from reuse analysis. **Guards** (scrutinee stays live across a
+   re-testable failure path) `unimplemented!` for a follow-up.
+   *Note:* binding-type resolution via an enriched `RecordTable` proved
+   **unnecessary** here — an unused binding needs no op (the scrutinee drop frees
+   it), and a used binding's type is on its `Var` node; the enrichment is still
+   wanted for the `Proj` container increment.
+4. **Containers:** `Proj` borrow-dup, `Nullable` payloads, `Variant`, transitive
    value-records.
-4. **Closures & regions:** capture consumption, region-run lifecycle.
-5. **Drop-specialization** (optional, reuse-targeted).
+5. **Closures & regions:** capture consumption, region-run lifecycle.
+6. **Drop-specialization** (optional, reuse-targeted).
 
 Then **pm/08:** codegen consumes `OwnershipTable` → emits `rc.inc` / `rc.dec` /
 `ref.drop`, gated by ASAN/LSAN execution tests.

--- a/crates/reussir-core/docs/ownership-analysis.md
+++ b/crates/reussir-core/docs/ownership-analysis.md
@@ -1,0 +1,415 @@
+# Ownership Analysis (Full MIR)
+
+> Status: **design / proposed** (pm/07). This is a fresh Perceus-style analysis,
+> not a port of the Haskell `Reussir.Core.Ownership` (which used a forward
+> ledger + flux). We keep only its vocabulary (RR types, before/after
+> annotations).
+
+## 1. Goal & scope
+
+Insert reference-counting operations — `dup` (`rc.inc`) and `drop`
+(`rc.dec` / `ref.drop`) — onto the Full MIR so that **every resource-relevant
+(RR) value is freed exactly once**, with `drop`s placed **as early as possible**
+so the backend `TokenReuse` pass can pair a freed token with a same-layout
+allocation.
+
+In scope: **shared rc, rigid rc, regional values, closures, and any container
+that transitively holds one of those** (the RR set). Out of scope here:
+
+- emitting MLIR — that is codegen (pm/08), which *consumes* this analysis;
+- the backend reuse pairing — already a backend pass; the frontend only has to
+  emit `drop`s early and near allocations.
+
+## 2. The ownership discipline
+
+- **Owned calling convention.** A function owns its RR parameters (the caller
+  transfers ownership in). It must consume-or-drop each owned RR value exactly
+  once. The return value is moved out — owned by the caller, never dropped.
+- **Last use is the pivot.** For a use of RR variable `x`:
+  - last use → **move** (consume; no `dup`), `x` becomes dead;
+  - non-last use → **`dup x`** before the use, keep ownership;
+  - a var that goes dead without being consumed (bound-but-unused, or dead after
+    a branch) → **`drop x`** at the earliest dead point.
+- **Borrow ≠ own.** Reading a field (`Proj`) borrows from the parent; if the
+  borrowed RR value escapes as owned, **`dup`** it — the parent still owns the
+  original.
+
+We start with the **owned** discipline only (no borrowed-parameter
+optimization). That is the simplest correct base; borrow-passing is a later
+refinement.
+
+## 3. The RR-type predicate
+
+```text
+is_rr(ty) =
+  match ty.kind():
+    Record{def, args} =>                                  // capability ignored
+        match record_table.shape(def, args).managed:      // Value | Shared | Regional
+            Shared | Regional => true                     // rc-managed
+            Value             => any field is_rr           // transitive
+    Closure{..}      => true            // owns a captured environment
+    Nullable(inner)  => is_rr(inner)
+    Int | Float | Bool | …             => false
+```
+
+- **Two orthogonal axes.** A record's `Ty` *capability* records **regional value
+  coloring** (`Regional`/`Flex`/`Rigid`, or `Irrelevant` for anything that does
+  not participate — i.e. every non-regional record). That is a *different axis*
+  from **rc-management** (is it heap/region reference-counted, or inline by
+  value), which the elaborator stores in `ctxt::Record.default_cap`
+  (`Value | Shared | Regional`). The capability cannot answer "is this rc'd": the
+  dialect's `Capability` has no `Shared`/`Value` variant, and `[value]`/`[shared]`
+  both elaborate to `Irrelevant` (`ty_eval.rs`).
+- **So `is_rr` decides rc-management from the `RecordTable` for *every* record**
+  (regional or not), keyed by the canonical (`Irrelevant`) record type — never
+  from the capability. The table (`canonical-Ty → RecordShape { managed, fields }`)
+  carries `default_cap` forward.
+- Memoized per interned `Ty` (pointer-identity key — types are arena-interned);
+  a provisional `false` guards the (illegal but defensively-handled) value-record
+  field cycle.
+- The pass takes the `RecordTable` as an explicit argument
+  (`analyze_function(tcx, &Function, &RecordTable)`); the test harness builds it
+  directly, and the real pipeline will populate it from `mono`'s record table
+  when codegen wires the analysis in (pm/08). The MIR `Program` need not grow new
+  ser/de surface for this.
+
+## 4. Anchors: recording op positions on an immutable MIR
+
+The MIR is immutable and `mir::Expr` (`{kind, ty, span}`) carries no id.
+
+**Decision (locked): add `pub id: ExprId` to `mir::Expr`** (`ExprId(u32)`; the
+type already exists in `semi::hir`).
+
+- Stamped at the two allocation choke points — `mir/build.rs::expr_ref` and
+  `mono.rs` — via a single monotonic counter on the build/mono context. One
+  helper (`mk_expr`) becomes the only site that assigns ids.
+- The textual printer **need not emit ids**; they are regenerated
+  deterministically on parse, so round-trip soundness is preserved (ids are not
+  semantic content).
+
+Alternatives considered and rejected:
+
+- **Arena pointer-identity** (`*const Expr` as key): zero IR change, but
+  unidiomatic, undebuggable, and breaks if a node is ever copied / re-interned.
+- **Traversal-order index** (the i-th visited expr): no field, but couples the
+  analysis and codegen to walk in lock-step — fragile.
+
+Explicit `ExprId` is robust, debuggable (`id → action` is printable), and
+survives traversal changes. The cost is a contained build/mono ripple.
+
+**Non-`Expr` positions.** Match arm bodies and `Let` are `Expr`s, so they anchor
+directly. Operations with no natural `Expr` — dropping a variant shell at a
+switch, dropping an unused parameter — attach to the nearest `Expr`'s
+`before`/`after` list (arm-body `before`, function-body root). Match-internal
+anchoring is resolved in the control-flow increment.
+
+## 5. Output data model
+
+A side-table — the MIR stays immutable; codegen does lookups.
+
+```rust
+pub struct OwnershipTable { actions: HashMap<ExprId, Action> }
+
+pub struct Action { pub before: Vec<RcOp>, pub after: Vec<RcOp> }
+
+pub enum RcOp {
+    Dup(VarId),
+    Drop(VarId),
+    // grows later: DropField(VarId, Path), …
+}
+```
+
+Timeline per expression: `[before ops] → evaluate expr → [after ops]`. Codegen
+(`reussir-codegen::lower`) consults `table.get(expr.id)` around each node.
+
+## 6. The algorithm
+
+Two passes over each function body, pure (no MLIR):
+
+**Pass A — free RR variables (bottom-up).** `free(e): BitSet<VarId>` = the RR
+vars referenced in `e`, memoized per `ExprId`. Drives last-use detection.
+
+**Pass B — placement (top-down, continuation liveness).** Threads `live_after`
+sets through the tree and emits `Dup`/`Drop` per the rules below.
+
+### 6.1 Last-use detection — structured backward liveness, one pass, no fixpoint
+
+**Approach: a structured, syntax-directed backward pass — a *degenerate*
+liveness dataflow that converges in a single sweep — rather than an iterative
+CFG worklist.**
+
+*Why one pass is exact.* A function body is a tree whose only control constructs
+are `Seq`, `Let`, `If`, and `Match`. None of them loop: intra-function iteration
+does not exist in the MIR — repetition is recursion through `Call`, which is a
+dataflow **leaf** (it neither defines nor keeps the caller's locals alive beyond
+its own argument list). The induced control-flow graph is thus a DAG, and
+backward liveness over a DAG is exact after one reverse-topological visit; for a
+structured tree, reverse-topological order *is* right-to-left / post-order. So we
+never build an explicit CFG and never iterate to a fixpoint — distinguishing this
+from general dataflow, which needs a worklist precisely because of back-edges.
+
+*What we track.* Liveness of **named RR variables only** (parameters + `Let`
+bindings). Unnamed intermediate RR values are owned temporaries threaded by the
+tree itself — each is immediately consumed (arg/ctor position), bound (`Let`),
+returned (moved), or discarded (a non-final `Seq` statement → `Drop`) — so they
+never enter the liveness set.
+
+*The quantity.* `live_after(e)` = the set of named RR vars used anywhere in `e`'s
+dynamic continuation (everything that runs after `e`, within the function). A use
+of `x` at `e` is its **last use** ⟺ `x ∉ live_after(e)`.
+
+*Threading rules* (each child's `live_after` is its right-siblings' `free` sets
+∪ the parent's `live_after`):
+
+- `Seq([s₀..sₙ])` under live `L`: `live_after(sₙ) = L`;
+  `live_after(sᵢ) = free(sᵢ₊₁) ∪ … ∪ free(sₙ) ∪ L`.
+- `Let{x, value}` with continuation `k`: `live_after(value) = live(k)`; `x` is
+  granted after `value`, so `x ∈ live(k)` ⟺ used later.
+- `Call`/`Ctor`/`Variant{args=[a₀..aₖ]}` under `L`:
+  `live_after(aᵢ) = free(aᵢ₊₁) ∪ … ∪ free(aₖ) ∪ L`. ⇒ a var reused in a later
+  argument is live after the earlier occurrence, so the earlier one is **not** a
+  last use and gets a `Dup` — the `foo(x, x)` case falls straight out.
+- `If(c, t, e)` under `L`: `live_after(c) = free(t) ∪ free(e) ∪ L`;
+  `live_after(t) = live_after(e) = L`.
+- `Match(scrut, dt)`: like `If` over the arms;
+  `live_after(scrut) = (⋃ free(armᵢ)) ∪ L`.
+
+*Conditional (path-dependent) last use* is handled by branch reconciliation, not
+a separate mechanism. Two canonical cases:
+
+- **Dies on one path.** `let x; if c { use(x) } else { /* x unused */ }` with
+  `x ∉ L`: `x ∈ free(then)`, `x ∉ free(else)` ⇒ `Drop(x)` in the `else` arm; in
+  `then`, `use(x)` sees `x ∉ live_after (= L)` ⇒ move. Both paths leave `x`
+  settled.
+- **Used in a branch *and* after.** `let x; if c { use(x) } else { use(x) };
+  use(x)` with `x ∈ L`: inside each arm `live_after(use x) = L ∋ x` ⇒ **not** a
+  last use ⇒ `Dup(x)`; the trailing `use(x)` has `x ∉ live_after` ⇒ move. The rc
+  stays balanced (enter 1 → arm `dup` 2 → arm-use 1 → trailing-use 0), and only
+  the taken arm's `dup` runs.
+
+*Representation.* `VarId`s are dense per function, so live sets are fixed-width
+**bitsets** (union/diff/membership in O(words)); `free(e)` is computed once
+bottom-up and memoized per `ExprId`; `live_after` is threaded top-down and only
+materialized where an op is emitted.
+
+### 6.2 Placement rules
+
+`place(e, live_after)` reads off the live-after sets above and emits, per MIR
+form:
+
+| Form | Rule |
+| --- | --- |
+| `Var(x)` (RR) | `x ∈ live_after` ⇒ `before: Dup(x)`; else move (last use). |
+| `Seq([s0..sn])` | right-to-left; `live_after(sᵢ) = ⋃_{j>i} free(sⱼ) ∪ outer`. A `Let`-bound `x` unused later ⇒ `Drop(x)` in the let's `after`. A non-final statement producing an unbound/unconsumed RR value ⇒ `Drop` its result. `sn` is moved out. |
+| `Let{x, value}` | `value` placed with `x`'s downstream liveness; binding grants ownership of `x`. |
+| `If(c,t,e)` / `Match` | **branch reconciliation** — both arms must exit owning the same set. Per arm: owned-on-entry but unused-in-arm and not-needed-after ⇒ `Drop` inside that arm; needed-after but consumed-in-arm ⇒ `Dup` as needed. Balanced ownership at the join. |
+| `Call`/`Ctor`/`Variant`/`ClosureCall` args | each arg position consumes its value; a var in ≥2 arg positions ⇒ `Dup` on all but the last occurrence (left-to-right). |
+| `Proj(e, path)` | borrow; if the projected RR field escapes as owned, `before: Dup` it. Parent's drop is unaffected (dropped at its own last use). |
+| `Closure{captures}` | creating the closure consumes its captures (dup any still live afterwards). Closure drop-glue is the backend's. |
+| `RegionRun` / regional | result owned; detailed region lifecycle deferred. |
+
+**Early-drop / reuse.** The rules above already drop at last-use / dead-branch
+(not deferred to function end), which is "early". A dedicated
+**drop-specialization** refinement — push `drop` into match arms and just after a
+destructuring `Proj`, so the freed token sits right before a sibling allocation —
+is staged separately; the backend `TokenReuse` does the actual pairing, so the
+frontend only needs the dec emitted at the destructure point.
+
+## 7. Operational semantics (sequent calculus)
+
+Judgment `L ⊢ e ⤳ 𝒜`: "with continuation-live set `L`, expression `e` annotates
+to actions `𝒜`." Representative rules (the full set ships as module
+doc-comments, one sequent per MIR form, checkable against the code):
+
+```text
+x ∈ L                                   x ∉ L
+─────────────────── [Var-Shared]        ─────────────────── [Var-LastUse]
+L ⊢ x ⤳ {before: dup x}                 L ⊢ x ⤳ {}
+
+L ⊢ e ⤳ 𝒜     x ∉ free(rest)
+──────────────────────────────────────────────── [Let-Dead]
+L ⊢ (let x = e; rest) ⤳ 𝒜 ⊕ {after: drop x}
+
+L_t = L│t     L_e = L│e     Δ owned at join
+──────────────────────────────────────────── [If-Reconcile]
+L ⊢ if c t e ⤳ balance(Δ, t, e)
+```
+
+### 7.1 Relation to Tree Borrows (design inspiration)
+
+Tree Borrows (Villani, Hostert, Dreyer, Jung; PLDI 2025 — the successor to
+Stacked Borrows as Rust's aliasing model) gives each *(location, reference)* a
+**permission state** in a small lattice and transitions it on every access,
+propagating the effect along a **tree of derivations** — each reference is a node
+whose parent is the reference it was derived from. Its states:
+
+- **Reserved** — a fresh `&mut` not yet written; tolerates *foreign* reads.
+- **Active** — written through; enforces uniqueness, so a foreign read demotes it.
+- **Frozen** — read-only (shared).
+- **Disabled** — any further access is undefined behavior.
+
+Transitions: a *child* write `Reserved → Active`; a *foreign* read
+`Active → Frozen`; a *foreign* write `* → Disabled`.
+
+We borrow three *ideas*, not the model:
+
+1. **Per-entity state machine.** Each owned RR variable carries an ownership
+   state, transitioned on *use* events — the analysis analogue of TB
+   transitioning a permission on *access* events.
+2. **Propagation along a tree with reconciliation at joins.** TB propagates an
+   access to a node's relatives; we propagate liveness backward through the
+   expression tree and **reconcile sibling control-flow branches** at each
+   `If`/`Match` join (§6.1).
+3. **Terminal ("settled") states must not be re-used.** TB makes a
+   post-`Disabled` access UB; we make the corresponding situation
+   *unrepresentable* — the analysis guarantees every owned var reaches a settled
+   state exactly once per path, so the runtime is always well-defined.
+
+Our lattice is far simpler than TB (no aliasing, no reborrow stack, no
+protectors, no interior-mutability variants):
+
+```text
+        bind / param-in
+              │
+              ▼
+           Owned ──── non-last use ──▶ dup (rc++), stay Owned
+            │   │
+       last │   │ goes dead
+      use   ▼   ▼ (no further use)
+        Consumed   Dropped          ── both terminal ("settled")
+            ▲
+   return = Consumed (moved to caller, never dropped)
+```
+
+The crucial difference: TB is a **runtime semantics** (it *defines* UB, checked
+dynamically by Miri); ours is a **static rewrite** that *inserts* the rc ops so
+no such UB can arise. There is no "foreign access" notion — we never alias, we
+transfer ownership. (A future borrowed-parameter optimization would add a
+read-only `Borrowed` state, the rough analogue of `Frozen` — no drop
+responsibility.)
+
+## 8. Placement in the tree
+
+`crates/reussir-core/src/full/ownership.rs` — pure, no MLIR dependency (fits the
+`reussir-core::full` "no MLIR" rule). Entry points:
+
+- `ownership::analyze(&mir::Program) -> OwnershipTable`
+- `ownership::analyze_function(&Function, &RecordTable) -> …` (for unit tests)
+
+Methods over free functions where it reads naturally.
+
+## 9. Testing (pure, no execution)
+
+The analysis is a pure `&Program → OwnershipTable`, so it is unit-tested without
+any MLIR or runtime. The framework has three pieces: a way to **construct** MIR,
+a way to **assert** on the result, and a generic **safety-net** property.
+
+### 9.1 Construction — an in-arena `MirBuilder`
+
+A test-support `MirBuilder` builds `mir::Function` / `Program` directly in an
+arena, sharing the production `ExprId`-stamping path so anchors match real
+builds. Fluent constructors mirror the MIR forms:
+
+```rust
+let mut b = MirBuilder::new(&tcx);
+let x = b.param("x", rc_ty);                 // an RR parameter
+let y = b.local();
+let body = b.seq([
+    b.let_(y, b.call(foo, [b.var(x)])),      // let y = foo(x);
+    b.var(y),                                //   y            (returned)
+]);
+let f = b.function("f", [x], rc_ty, body);
+```
+
+Types are **real interned `Ty`s** (`mk_record(.., Shared)` for an rc, `i64` for a
+scalar, `mk_nullable`, …) backed by a minimal record table, so `is_rr` — the
+predicate everything keys off — is exercised for real, not stubbed.
+
+*Why a builder over textual MIR:* it is precise, **parser-independent** (analysis
+tests don't break on unrelated ser/de gaps), and each increment can target
+exactly the forms it adds. Textual-MIR-driven tests are layered on later for
+round-trip coverage once the parser covers every form — at which point the same
+cases can be expressed as `.mir` strings.
+
+### 9.2 Assertion — annotated rendering + structured probes
+
+An **annotated pretty-printer** walks the body together with the
+`OwnershipTable`, weaving each emitted op into the tree:
+
+```text
+fn f(x: Rc) -> Rc {
+  let y = foo(x);     // x: last use → move
+  y                   //    returned → move
+}                     // (no drops: everything moved)
+```
+
+Tests compare this rendering against an inline expected snapshot — readable, and
+doubling as live opsem documentation. Pinpoint cases also use structured probes:
+`table.before(id)` / `table.after(id)` assert the exact `Dup`/`Drop` set at a
+given node.
+
+### 9.3 Corpus
+
+One constructed function per rule, each with its expected annotated body:
+
+1. one use → `Drop` after last use;
+2. two uses → one `Dup` before the first;
+3. `if` / `match` arm reconciliation (var live in one arm only);
+4. borrow-only `Proj` → parent still dropped, field dup'd;
+5. returned var → moved, **no** drop;
+6. nested value-record transitively holding rc → treated RR;
+7. unused RR parameter → dropped at entry.
+
+### 9.4 Property check — a generic safety net
+
+Beyond goldens, a **balanced-rc checker** abstractly interprets the annotated
+tree: along every control path, a `dup` is `+1`, a consuming use or a `drop`
+settles the unit. It asserts that every owned RR variable reaches a settled state
+**exactly once per path** — no double-settle, nothing left live at `return`
+except the moved result. This catches placement bugs the hand-written goldens
+miss, and is cheap to run over every corpus case.
+
+Execution / ASAN-LSAN gating arrives in **pm/08**, when codegen consumes the
+table.
+
+## 10. Incremental stack (bottom-up PRs)
+
+1. **Anchors + foundation — landed (`full::ownership`).** `ExprId` on
+   `mir::Expr` (+ build/mono stamping via a shared `ExprIdGen`, printer
+   unaffected), `is_rr` + `RecordTable`, `OwnershipTable` / `RcOp`, the
+   **`MirBuilder` test harness + annotated renderer + balanced-rc checker** (§9),
+   and the **linear core** (`Var` / `Let` / `Seq` / `Call` / `Ctor` / `Variant` /
+   `NullableCall`) with the §9.3 corpus. Deferred forms (`If`/`Match`/`Proj`/…)
+   `unimplemented!` loudly rather than miscount.
+2. **Control flow:** `If` / `Match` branch reconciliation, multi-use `Dup`,
+   discarded-result drops.
+3. **Containers:** `Proj` borrow-dup, `Nullable`, `Variant`, transitive
+   value-records.
+4. **Closures & regions:** capture consumption, region-run lifecycle.
+5. **Drop-specialization** (optional, reuse-targeted).
+
+Then **pm/08:** codegen consumes `OwnershipTable` → emits `rc.inc` / `rc.dec` /
+`ref.drop`, gated by ASAN/LSAN execution tests.
+
+## Decisions
+
+- **Anchor:** add `ExprId` to `mir::Expr`, stamped at the build/mono allocation
+  choke point via a shared `ExprIdGen` (§4). *Locked, landed.*
+- **Owned-only convention** to start (no borrowed-parameter optimization); the
+  simplest correct base, refined later. *Resolved.*
+- **RR set:** rc-management (`Shared`/`Regional`) and closures are always rc;
+  `Value` records are rc iff transitively so; `Nullable` follows its inner.
+  Rc-management comes from the `RecordTable` for *every* record — the `Ty`
+  capability (regional coloring) is an orthogonal axis and is not consulted
+  (§3). *Resolved.*
+- **Increment 1 = linear core + `is_rr` + harness.** *Resolved, landed.*
+
+## Open questions
+
+1. **`RecordTable` provenance for the real pipeline.** Increment 1's table is
+   built by the test harness. When codegen consumes the analysis (pm/08), build
+   it from `mono`'s `records: &FxHashMap<DefId, Record>` (which has `default_cap`
+   + fields) — confirm that hand-off rather than enriching `mir::Program`.
+2. **Anonymous-result drops.** A non-`let` `Seq` statement of RR type whose
+   result is discarded has no `VarId` to `Drop`; the var-only `RcOp` can't name
+   it. Lands with the control-flow increment (likely a `DropValue(ExprId)` op).

--- a/crates/reussir-core/docs/trait-system.md
+++ b/crates/reussir-core/docs/trait-system.md
@@ -97,7 +97,7 @@ vtable — dynamic dispatch is then an additive feature, not a redesign.
   Super-traits subsume what the DAG did (`Integral: Num`).
 - **D4 — Bounds desugar to obligations.** `<T: Trait>` and `where` clauses are
   sugar for predicates `T: Trait` that the solver must discharge.
-- **D5 — Capability is a bound.** A trait ranges over a value *type*; but a
+- **D5 — Flexivity is a bound.** A trait ranges over a value *type*; but a
   value's `Flexivity` (`Irrelevant | Regional | Flex | Rigid`) is itself
   expressible in bound position: `<T: Flex>`, `where T: Regional`. These are
   *built-in capability predicates*, not traits — the capability lattice is
@@ -153,13 +153,13 @@ pub struct TraitRef { pub trait_id: TraitId, pub args: Vec<Ty> }
 /// A predicate the solver must discharge.
 pub enum Obligation {
     Trait(TraitRef),        // `τ: Trait<…>` — discharged by impl search (§5.1)
-    Cap(Ty, Capability),    // `τ: Flex` etc. — discharged by lattice subsumption
+    Cap(Ty, Flexivity),    // `τ: Flex` etc. — discharged by lattice subsumption
     // later: projection-equality `<T as Trait>::Assoc == U`, etc.
 }
 
-/// The capability lattice (built-in, closed). `Cap(τ, c)` holds when the
-/// capability of τ is at least `c` in this ordering.
-pub enum Capability { Irrelevant, Regional, Flex, Rigid }
+/// The flexivity lattice (built-in, closed). `Cap(τ, c)` holds when the
+/// flexivity of τ is at least `c` in this ordering.
+pub enum Flexivity { Irrelevant, Regional, Flex, Rigid }
 
 /// The proof that an obligation holds — consumed statically now, a vtable later.
 pub enum Evidence {
@@ -309,7 +309,7 @@ idea lifted from single variables to whole substitutions, and it is exactly the
 Monomorphization* (Lutze et al., OOPSLA 2025) draws. We borrow that boundary,
 not its per-variable flow encoding.
 
-### 5.6 Capability obligations
+### 5.6 Flexivity obligations
 
 > **Status (revised): deferred.** This section assumed a *total* capability
 > lattice with a `⊒` subsumption. That is wrong: `Flex` (mutable, but cannot be
@@ -317,7 +317,7 @@ not its per-variable flow encoding.
 > are **incomparable** — different axes, not a chain. Because the subsumption
 > semantics are unsettled, the capability-as-a-bound machinery (`Obligation::Cap`
 > / `Evidence::Cap` / the `satisfies` lattice) has been **removed** from the
-> code for now; `Capability` is just the coloring stored on `Ty::Record`. The
+> code for now; `Flexivity` is just the coloring stored on `Ty::Record`. The
 > design below is retained as a sketch and will be reworked (likely as a partial
 > order, or folded into coloring/region checking) before capability bounds
 > return.
@@ -349,7 +349,7 @@ monomorphized, mangled representation) is its future sibling. As built:
 crates/reussir-core/src/
   surface.rs          typed surface AST + direct CST lowering / aeson serde
   semi/               the whole Semi phase
-    ty.rs             Ty, TyKind, TyCtxt (interned), IntTy, FpTy, Capability, ids
+    ty.rs             Ty, TyKind, TyCtxt (interned), IntTy, FpTy, Flexivity, ids
     infer.rs          ena union-find holes, unify/occurs/zonk, lazy instantiation
     traits.rs         TraitRef, Obligation, Evidence
     traits/db.rs      instance database, select(), super-trait evidence chains
@@ -404,7 +404,7 @@ That is: lexer keywords (`trait`, `impl`, `for`, `where`), grammar rules, CST
 kinds, and AST/JSON lowering in `reussir-syntax`. **Decision: this is in the
 first cut** — user-declared traits from the start, not deferred.
 
-Capability bounds reuse the existing bound position. The names `Irrelevant`,
+Flexivity bounds reuse the existing bound position. The names `Irrelevant`,
 `Regional`, `Flex`, `Rigid` in a bound list are recognized as built-in
 capability predicates (§5.6) rather than trait references; everything else in
 bound position resolves to a `TraitRef`.

--- a/crates/reussir-core/src/full.rs
+++ b/crates/reussir-core/src/full.rs
@@ -16,4 +16,5 @@
 pub mod mangle;
 pub mod mir;
 pub mod mono;
+pub mod ownership;
 pub mod subst;

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -214,7 +214,7 @@ fn fp_code(fp: FpTy) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::semi::ty::{Capability, TyCtxt};
+    use crate::semi::ty::{Flexivity, TyCtxt};
     use reussir_syntax::kind::InternKey;
 
     /// A test resolver: key `i` (1-based) resolves to segment `i - 1`.
@@ -318,11 +318,11 @@ mod tests {
             let foo_i32 = tcx.mk_record(
                 foo,
                 &[tcx.mk_int(IntTy::Signed(32))],
-                Capability::Irrelevant,
+                Flexivity::Irrelevant,
             );
             assert_eq!(m.mangle_ty(foo_i32), "_RIC3FoolE");
             // `Foo` (no args) → `C3Foo`; mangling a function instance is the same.
-            let foo0 = tcx.mk_record(foo, &[], Capability::Irrelevant);
+            let foo0 = tcx.mk_record(foo, &[], Flexivity::Irrelevant);
             assert_eq!(m.mangle_ty(foo0), "_RC3Foo");
             assert_eq!(m.mangle_instance(foo, &[]), "_RC3Foo");
         });

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -18,7 +18,7 @@
 use lasso::{Rodeo, Spur};
 use reussir_syntax::kind::TokenKey;
 
-use crate::semi::hir::{ArithOp, CmpOp, VarId};
+use crate::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use crate::semi::ty::Ty;
 use crate::surface::{Span, Visibility};
 use crate::utils::string::StringToken;
@@ -103,11 +103,38 @@ pub struct Trampoline {
 }
 
 /// A monomorphized expression: a ground type, the structure, and a source span.
+///
+/// The [`id`](Self::id) is a per-program-unique **anchor** the ownership pass
+/// keys its inc/dec/drop placement on (see [`crate::full::ownership`]); the MIR
+/// itself stays immutable, so analyses record their results in side-tables keyed
+/// by this id rather than rewriting the tree.
 #[derive(Clone, Copy, Debug)]
 pub struct Expr<'tcx> {
+    pub id: ExprId,
     pub kind: ExprKind<'tcx>,
     pub ty: Ty<'tcx>,
     pub span: Option<Span>,
+}
+
+/// A monotonic source of fresh [`ExprId`]s, threaded through whichever pass
+/// constructs MIR — monomorphization ([`crate::full::mono`]), textual re-intern
+/// ([`mir::build`](self::build)), or the test-only builder. Centralizing id
+/// assignment here is what makes "one expr, one stable anchor" hold regardless of
+/// who built the tree; ids are *not* printed (they are regenerated
+/// deterministically on parse), so they never enter the textual round-trip.
+#[derive(Default)]
+pub struct ExprIdGen {
+    next: u32,
+}
+
+impl ExprIdGen {
+    /// Hand out the next id. Post-order at the construction site (children are
+    /// built before their parent), but the pass only relies on uniqueness.
+    pub fn fresh(&mut self) -> ExprId {
+        let id = ExprId(self.next);
+        self.next += 1;
+        id
+    }
 }
 
 /// The closure form; see [`crate::semi::hir::ClosureExpr`] for the

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -18,7 +18,7 @@ use crate::full::mir::{self, grammar as ir, raw};
 use crate::ir_lex::lex;
 use crate::semi::hir::{ArithOp, CmpOp, VarId};
 use crate::semi::resolve::DefTable;
-use crate::semi::ty::{Capability, FpTy, IntTy, Ty, TyCtxt, TyKind};
+use crate::semi::ty::{Flexivity, FpTy, IntTy, Ty, TyCtxt, TyKind};
 use crate::utils::string::StringToken;
 
 /// A parsed program plus the fresh tables needed to re-print it.
@@ -400,12 +400,12 @@ impl<'tcx> Builder<'_, 'tcx> {
     }
 }
 
-fn cap(c: raw::Cap) -> Capability {
+fn cap(c: raw::Cap) -> Flexivity {
     match c {
-        raw::Cap::None => Capability::Irrelevant,
-        raw::Cap::Flex => Capability::Flex,
-        raw::Cap::Rigid => Capability::Rigid,
-        raw::Cap::Regional => Capability::Regional,
+        raw::Cap::None => Flexivity::Irrelevant,
+        raw::Cap::Flex => Flexivity::Flex,
+        raw::Cap::Rigid => Flexivity::Rigid,
+        raw::Cap::Regional => Flexivity::Regional,
     }
 }
 

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -66,6 +66,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
         symbols: Rodeo::default(),
         names: Names::default(),
         defs: DefTable::new(),
+        ids: mir::ExprIdGen::default(),
     };
     let program = b.program(raw);
     Ok(Parsed {
@@ -80,6 +81,10 @@ struct Builder<'a, 'tcx> {
     symbols: Rodeo,
     names: Names,
     defs: DefTable,
+    /// Fresh [`mir::ExprId`] anchors, regenerated deterministically on each
+    /// parse. Ids are not part of the textual form, so a freshly re-interned
+    /// tree re-numbers from zero without affecting round-trip text equality.
+    ids: mir::ExprIdGen,
 }
 
 impl<'tcx> Builder<'_, 'tcx> {
@@ -387,6 +392,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             }
         };
         mir::Expr {
+            id: self.ids.fresh(),
             kind,
             ty,
             span: None,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -20,7 +20,7 @@ use reussir_syntax::kind::{Resolver, TokenKey};
 use crate::full::mir;
 use crate::semi::hir::{ArithOp, CmpOp, VarId};
 use crate::semi::resolve::DefTable;
-use crate::semi::ty::{Capability, FpTy, IntTy, Ty, TyKind};
+use crate::semi::ty::{Flexivity, FpTy, IntTy, Ty, TyKind};
 use crate::surface::Visibility;
 
 /// Four-space indentation, 100-column target. Block structure is forced
@@ -141,10 +141,10 @@ impl Render<'_> {
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
             TyKind::Record { def, args, flex } => {
                 let mut d = match flex {
-                    Capability::Flex | Capability::Rigid | Capability::Regional => {
+                    Flexivity::Flex | Flexivity::Rigid | Flexivity::Regional => {
                         text(format!("[{}] ", cap_name(flex)))
                     }
-                    Capability::Irrelevant => Doc::Null,
+                    Flexivity::Irrelevant => Doc::Null,
                 };
                 d = d + text(self.defs.path(def).display(self.resolver));
                 if !args.is_empty() {
@@ -455,12 +455,12 @@ fn comma_sep(docs: Vec<Doc<'static>>) -> Doc<'static> {
     d
 }
 
-fn cap_name(c: Capability) -> &'static str {
+fn cap_name(c: Flexivity) -> &'static str {
     match c {
-        Capability::Flex => "flex",
-        Capability::Rigid => "rigid",
-        Capability::Regional => "regional",
-        Capability::Irrelevant => "",
+        Flexivity::Flex => "flex",
+        Flexivity::Rigid => "rigid",
+        Flexivity::Regional => "regional",
+        Flexivity::Irrelevant => "",
     }
 }
 

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -52,7 +52,7 @@ use crate::full::subst::{Subst, subst_ty};
 use crate::semi::ctxt::{Elaborator, Record, Report, Severity, TrampolineRoot};
 use crate::semi::hir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::resolve::DefTable;
-use crate::semi::ty::{Capability, DefId, Ty, TyCtxt, TyKind};
+use crate::semi::ty::{DefId, Flexivity, Ty, TyCtxt, TyKind};
 use crate::surface::Span;
 
 /// Exactly the part of an [`Elaborator`] that monomorphization reads. Taking
@@ -199,7 +199,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         .map(|(def, args)| mir::RecordInstance {
             symbol: driver.symbol_of(def, args),
             // Layout is capability-independent, so canonicalize the coloring.
-            ty: tcx.mk_record(def, args, Capability::Irrelevant),
+            ty: tcx.mk_record(def, args, Flexivity::Irrelevant),
         })
         .collect();
 
@@ -270,8 +270,8 @@ fn ty_depth(ty: Ty<'_>) -> usize {
 /// `Irrelevant` and scalars carry none.
 fn is_regional_arg(ty: Ty<'_>) -> bool {
     matches!(
-        ty.capability(),
-        Some(Capability::Regional | Capability::Flex | Capability::Rigid)
+        ty.flexivity(),
+        Some(Flexivity::Regional | Flexivity::Flex | Flexivity::Rigid)
     )
 }
 

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -105,6 +105,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         seen: FxHashSet::default(),
         records: FxHashSet::default(),
         reports: Vec::new(),
+        ids: mir::ExprIdGen::default(),
     };
 
     // Seed roots: every non-generic function, then every trampoline target.
@@ -286,6 +287,10 @@ struct Driver<'a, 'tcx> {
     /// Ground record instances whose layout is needed (keyed flex-independently).
     records: FxHashSet<(DefId, &'tcx [Ty<'tcx>])>,
     reports: Vec<Report>,
+    /// Source of fresh [`mir::ExprId`] anchors for every lowered node. A single
+    /// counter across the whole program: one semi expr may lower into many MIR
+    /// exprs (once per instantiation), so semi ids are not reused.
+    ids: mir::ExprIdGen,
 }
 
 impl<'a, 'tcx> Driver<'a, 'tcx> {
@@ -380,6 +385,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         self.note_records(ty);
         let kind = self.lower_kind(&e.kind, subst);
         mir::Expr {
+            id: self.ids.fresh(),
             kind,
             ty,
             span: e.span,

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -49,6 +49,20 @@
 //!  p ∈ params,  is_rr(p),  p ∉ free(body)
 //! ──────────────────────────────────────── [Param-Unused]
 //!  {} ⊢ body ⤳ … ⊕ {root.before: drop p}
+//!
+//!  L ⊢ t ⤳ 𝒜ₜ      L ⊢ e ⤳ 𝒜ₑ      free(c) ∪ free(t) ∪ free(e) ∪ L ⊢ c ⤳ 𝒜_c
+//! ──────────────────────────────────────────────────────────────────────── [If-Reconcile]
+//!  L ⊢ (if c then t else e) ⤳ 𝒜_c ⊕ 𝒜ₜ ⊕ 𝒜ₑ
+//!                ⊕ {t.before: drop x | x ∈ free(e) \ free(t), x ∉ L}
+//!                ⊕ {e.before: drop x | x ∈ free(t) \ free(e), x ∉ L}
+//!   A var owned on entry but used in only one branch and dead afterwards is
+//!   settled (moved) on the branch that uses it and dropped on the branch that
+//!   does not, so both arms exit owning the same set. A var in `L` survives both
+//!   arms (dup'd at any in-arm use); a var used in both arms is moved in each.
+//!
+//!  s is a non-final Seq statement, is_rr(s), s not a `let`
+//! ────────────────────────────────────────────────────────── [Discard]
+//!  … ⊕ {s.after: drop-value s}     (its result is owned but unconsumed)
 //! ```
 //!
 //! # Relation to Tree Borrows
@@ -72,15 +86,19 @@ use crate::semi::ty::{Capability, Ty, TyCtxt, TyKind};
 // Output data model
 // ---------------------------------------------------------------------------
 
-/// A single reference-counting operation the backend must emit. Keyed by
-/// [`VarId`]; richer targets (`DropField(VarId, Path)`, dropping an anonymous
-/// result) arrive with the container and control-flow increments.
+/// A single reference-counting operation the backend must emit. Mostly keyed by
+/// [`VarId`]; richer targets (`DropField(VarId, Path)`) arrive with the container
+/// increment.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum RcOp {
     /// Increment the refcount of `x` (it has another live owner).
     Dup(VarId),
     /// Decrement the refcount of `x` (its last owner here is releasing it).
     Drop(VarId),
+    /// Decrement the refcount of the **anonymous result** of node `id` — a
+    /// statement value that is produced but neither bound nor consumed (a
+    /// discarded non-final `Seq` statement). Recorded in that node's `after`.
+    DropValue(ExprId),
 }
 
 /// The rc ops to run immediately *before* and *after* evaluating one expression.
@@ -290,6 +308,15 @@ impl VarSet {
             *a |= *b;
         }
     }
+
+    /// The members, in ascending `VarId` order (deterministic op emission).
+    fn iter(&self) -> impl Iterator<Item = VarId> + '_ {
+        self.words.iter().enumerate().flat_map(|(w, &word)| {
+            (0..64)
+                .filter(move |b| (word >> b) & 1 == 1)
+                .map(move |b| VarId((w * 64 + b) as u32))
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -389,8 +416,12 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                     s.union_with(&self.free(x));
                 }
             }
-            ExprKind::If(..)
-            | ExprKind::Match(..)
+            ExprKind::If(c, t, e) => {
+                s.union_with(&self.free(c));
+                s.union_with(&self.free(t));
+                s.union_with(&self.free(e));
+            }
+            ExprKind::Match(..)
             | ExprKind::Proj(..)
             | ExprKind::Assign(..)
             | ExprKind::RegionRun(..)
@@ -450,8 +481,8 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                     self.place(x, live_after);
                 }
             }
-            ExprKind::If(..)
-            | ExprKind::Match(..)
+            ExprKind::If(c, t, e) => self.place_if(c, t, e, live_after),
+            ExprKind::Match(..)
             | ExprKind::Proj(..)
             | ExprKind::Assign(..)
             | ExprKind::RegionRun(..)
@@ -461,6 +492,45 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                     "ownership::place: `{}` lands in a later increment (see ownership-analysis.md §10)",
                     kind_name(&e.kind)
                 )
+            }
+        }
+    }
+
+    /// [If-Reconcile]: place the condition (live across both arms), then each arm
+    /// under the shared continuation `L`, then settle one-sided ownership so both
+    /// arms exit owning the same set — a var used in only one arm and dead after
+    /// is moved on the arm that uses it and dropped on the arm that does not.
+    fn place_if(
+        &mut self,
+        c: &'tcx Expr<'tcx>,
+        t: &'tcx Expr<'tcx>,
+        e: &'tcx Expr<'tcx>,
+        live_after: &VarSet,
+    ) {
+        let used_t = self.free(t);
+        let used_e = self.free(e);
+
+        // The condition runs before either arm, so anything an arm needs is live
+        // across it.
+        let mut cond_live = used_t.clone();
+        cond_live.union_with(&used_e);
+        cond_live.union_with(live_after);
+        self.place(c, &cond_live);
+
+        self.place(t, live_after);
+        self.place(e, live_after);
+
+        // Reconciliation drops, ascending var order for determinism. `x ∉ L`
+        // because a var in `L` is owned out of both arms (no drop); a var used in
+        // both arms is moved (settled) in each.
+        for x in used_e.iter() {
+            if !used_t.contains(x) && !live_after.contains(x) {
+                self.add_before(t.id, RcOp::Drop(x));
+            }
+        }
+        for x in used_t.iter() {
+            if !used_e.contains(x) && !live_after.contains(x) {
+                self.add_before(e.id, RcOp::Drop(x));
             }
         }
     }
@@ -486,14 +556,11 @@ impl<'tcx> Analyzer<'_, 'tcx> {
 
     fn place_stmt(&mut self, s: &Expr<'tcx>, after: &VarSet, is_last: bool) {
         self.place(s, after);
-        // A non-final statement whose RR result is neither bound (`Let`) nor
-        // consumed leaves an owned value with no name to drop. Anonymous-result
-        // drops arrive with the control-flow increment.
+        // [Discard]: a non-final statement whose RR result is neither bound
+        // (`Let`) nor consumed leaves an owned value with no name — drop it by
+        // anchor right after the statement.
         if !is_last && !matches!(s.kind, ExprKind::Let { .. }) && self.rr.is_rr(s.ty) {
-            unimplemented!(
-                "ownership: an unconsumed non-`let` statement of RR type needs a \
-                 result-drop (control-flow increment)"
-            );
+            self.add_after(s.id, RcOp::DropValue(s.id));
         }
     }
 

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -107,7 +107,7 @@
 
 use std::cell::RefCell;
 
-use roaring::RoaringBitmap;
+use crate::utils::bitset::HybridBitSet;
 use rustc_hash::FxHashMap;
 
 use crate::full::mir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
@@ -322,12 +322,12 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
 // Live-variable sets
 // ---------------------------------------------------------------------------
 
-/// A set of [`VarId`]s, backed by a [`RoaringBitmap`]. Var ids are dense `u32`s
-/// (allocated per function) — exactly the domain a Roaring bitmap keys on — so no
-/// index mapping is needed. Backs both `free(e)` and the threaded `live_after`
-/// sets.
+/// A set of [`VarId`]s, backed by a [`HybridBitSet`]. Var ids are dense `u32`s
+/// (allocated per function), so a body with a handful of locals stays in the
+/// hybrid's word-backed dense form and only large bodies pay for a compressed
+/// bitmap. Backs both `free(e)` and the threaded `live_after` sets.
 #[derive(Clone, Default, PartialEq, Eq, Debug)]
-struct VarSet(RoaringBitmap);
+struct VarSet(HybridBitSet);
 
 impl VarSet {
     fn insert(&mut self, v: VarId) {
@@ -340,15 +340,15 @@ impl VarSet {
 
     /// In place: `self ← self ∪ other`.
     fn union_with(&mut self, other: &VarSet) {
-        self.0 |= &other.0;
+        self.0.union_with(&other.0);
     }
 
     /// Remove every member of `other` (set difference, in place).
     fn subtract(&mut self, other: &VarSet) {
-        self.0 -= &other.0;
+        self.0.subtract(&other.0);
     }
 
-    /// The members, in ascending `VarId` order (a Roaring bitmap iterates sorted,
+    /// The members, in ascending `VarId` order (the hybrid set iterates sorted,
     /// keeping op emission deterministic).
     fn iter(&self) -> impl Iterator<Item = VarId> + '_ {
         self.0.iter().map(VarId)

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -404,7 +404,6 @@ impl<'tcx> Analyzer<'_, 'tcx> {
     }
 
     // --- Pass A: free RR variables, memoized per anchor ---
-
     fn free(&mut self, e: &Expr<'tcx>) -> VarSet {
         if let Some(s) = self.free_memo.get(&e.id) {
             return s.clone();
@@ -580,7 +579,7 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 }
                 self.navigate_base(base, e.id, live_after);
             }
-            ExprKind::Assign(dst, _, src) => self.place_assign(e.id, dst, src, live_after),
+            ExprKind::Assign(dst, _, src) => self.place_assign(dst, src, live_after),
             // Transparent: a region scope does not change rc ownership (region
             // lifetime is a separate axis); its body's result is moved out.
             ExprKind::RegionRun(x) => self.place(x, live_after),
@@ -612,20 +611,21 @@ impl<'tcx> Analyzer<'_, 'tcx> {
         }
     }
 
-    /// `dst->field := src`: `src` is moved into the field (consumed); `dst` is
-    /// borrowed (mutated in place). The old field value is *not* dropped here —
-    /// flex/regional field links carry `field` capability and are freed with their
-    /// parent / region, not by an individual dec at the store.
-    fn place_assign(
-        &mut self,
-        id: ExprId,
-        dst: &'tcx Expr<'tcx>,
-        src: &'tcx Expr<'tcx>,
-        live_after: &VarSet,
-    ) {
-        // `dst` is evaluated and live across `src`, but only borrowed, so its
-        // root's drop is decided by the assignment's own continuation.
-        self.navigate_base(dst, id, live_after);
+    /// `dst->field := src`: store `src` into a field of `dst`.
+    ///
+    /// An assignment target is always a **flex regional** record — mutation is
+    /// only legal on a mutable, region-local value, and such a value is not RR
+    /// (it is freed with its region, never individually rc'd). So neither `dst`
+    /// nor its root takes any rc op, and the old field value is *not* dropped
+    /// here (flex/regional field links are reclaimed with the parent / region,
+    /// not by a per-store dec). The only work is to place `src`, moved into the
+    /// field: a rigid/managed `src` is inc'd like any other move into an owning
+    /// slot.
+    fn place_assign(&mut self, dst: &'tcx Expr<'tcx>, src: &'tcx Expr<'tcx>, live_after: &VarSet) {
+        debug_assert!(
+            !self.rr.is_rr(dst.ty),
+            "assign dst must be a flex regional (non-RR) record",
+        );
         self.place(src, live_after);
     }
 

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -1,0 +1,551 @@
+//! Ownership analysis: Perceus-style precise reference counting over the Full
+//! MIR.
+//!
+//! The job is to decide, for every resource-relevant (RR) value, *where* the
+//! backend should `dup` (rc++) or `drop` (rc--) it so that each owned value is
+//! released exactly once, with drops placed as early as possible (so the backend
+//! `TokenReuse` pass can pair a freed token with a same-layout allocation). The
+//! MIR is immutable, so the result is a side-table keyed by [`mir::ExprId`]
+//! anchors rather than a rewritten tree — see [`OwnershipTable`].
+//!
+//! This is **increment 1** (see `docs/ownership-analysis.md` §10): the linear
+//! core (`Var` / `Let` / `Seq` / `Call` / `Ctor` / `Variant` / `NullableCall`),
+//! the [`is_rr`](Rr::is_rr) predicate (including transitive value-records), and
+//! the test harness. Control flow (`If` / `Match`), container borrows (`Proj`),
+//! closures, and regions land in later increments; the forms they need
+//! [`unimplemented!`] loudly rather than silently miscounting.
+//!
+//! # Discipline
+//!
+//! - **Owned calling convention.** A function owns its RR parameters; it must
+//!   consume-or-drop each exactly once. The return value is moved out (owned by
+//!   the caller, never dropped here).
+//! - **Last use is the pivot.** A non-last use of an RR var `dup`s it (keeping
+//!   ownership); the last use moves it (consumes, no `dup`); a var that goes dead
+//!   without being consumed is `drop`ped at that dead point.
+//!
+//! # Operational semantics
+//!
+//! Judgment `L ⊢ e ⤳ 𝒜`: "with continuation-live set `L`, expression `e`
+//! annotates to actions `𝒜`". `free(e)` is the set of named RR vars used in `e`;
+//! `L` is the set live in `e`'s continuation. The increment-1 rules:
+//!
+//! ```text
+//! x ∈ L                                   x ∉ L
+//! ─────────────────── [Var-Shared]        ─────────────────── [Var-LastUse]
+//! L ⊢ x ⤳ {before: dup x}                 L ⊢ x ⤳ {}            (move)
+//!
+//!  L ⊢ aₖ ⤳ 𝒜ₖ   with  Lᵢ = free(aᵢ₊₁..aₖ) ∪ L
+//! ─────────────────────────────────────────────── [Args]   (Call/Ctor/Variant)
+//!  L ⊢ f(a₀..aₖ) ⤳ ⊕ᵢ 𝒜ᵢ
+//!  ⇒ a var reused in a later arg is live after the earlier one, so the earlier
+//!    occurrence is not a last use and takes a `dup` (the `f(x, x)` case).
+//!
+//! L ⊢ value ⤳ 𝒜       x ∉ Lᵢ                  L ⊢ value ⤳ 𝒜     x ∈ Lᵢ
+//! ─────────────────────────────────── [Let-Dead]    ──────────────────── [Let-Live]
+//! L ⊢ (let x = value) ⤳ 𝒜 ⊕ {after: drop x}        L ⊢ (let x = value) ⤳ 𝒜
+//!   where, inside Seq([s₀..sₙ]), Lᵢ = free(sᵢ₊₁..sₙ) ∪ L.
+//!
+//!  p ∈ params,  is_rr(p),  p ∉ free(body)
+//! ──────────────────────────────────────── [Param-Unused]
+//!  {} ⊢ body ⤳ … ⊕ {root.before: drop p}
+//! ```
+//!
+//! # Relation to Tree Borrows
+//!
+//! Borrowed as *design inspiration*, not as a model: each owned RR var carries a
+//! per-entity state (`Owned → {Consumed | Dropped}`), transitioned on use events,
+//! and we reconcile sibling control-flow branches at joins. Unlike Tree Borrows —
+//! a *runtime* semantics that defines UB — this is a *static rewrite* that
+//! inserts the rc ops so the corresponding UB is unrepresentable. See
+//! `docs/ownership-analysis.md` §7.1.
+
+use std::cell::RefCell;
+
+use rustc_hash::FxHashMap;
+
+use crate::full::mir::{Expr, ExprKind, Function};
+use crate::semi::hir::{ExprId, VarId};
+use crate::semi::ty::{Capability, Ty, TyCtxt, TyKind};
+
+// ---------------------------------------------------------------------------
+// Output data model
+// ---------------------------------------------------------------------------
+
+/// A single reference-counting operation the backend must emit. Keyed by
+/// [`VarId`]; richer targets (`DropField(VarId, Path)`, dropping an anonymous
+/// result) arrive with the container and control-flow increments.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RcOp {
+    /// Increment the refcount of `x` (it has another live owner).
+    Dup(VarId),
+    /// Decrement the refcount of `x` (its last owner here is releasing it).
+    Drop(VarId),
+}
+
+/// The rc ops to run immediately *before* and *after* evaluating one expression.
+/// Timeline: `[before] → evaluate expr → [after]`.
+#[derive(Clone, Default, Debug)]
+pub struct Action {
+    pub before: Vec<RcOp>,
+    pub after: Vec<RcOp>,
+}
+
+/// The analysis result: a side-table from each [`mir::ExprId`] anchor to the rc
+/// ops surrounding it. The MIR itself is untouched; codegen looks up
+/// `table.before(id)` / `table.after(id)` around each node.
+#[derive(Default, Debug)]
+pub struct OwnershipTable {
+    actions: FxHashMap<ExprId, Action>,
+}
+
+const NO_OPS: &[RcOp] = &[];
+
+impl OwnershipTable {
+    /// The full action recorded at `id`, if any.
+    pub fn get(&self, id: ExprId) -> Option<&Action> {
+        self.actions.get(&id)
+    }
+
+    /// The ops to run before evaluating the node `id` (empty if none).
+    pub fn before(&self, id: ExprId) -> &[RcOp] {
+        self.actions.get(&id).map_or(NO_OPS, |a| &a.before)
+    }
+
+    /// The ops to run after evaluating the node `id` (empty if none).
+    pub fn after(&self, id: ExprId) -> &[RcOp] {
+        self.actions.get(&id).map_or(NO_OPS, |a| &a.after)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Record management classification
+// ---------------------------------------------------------------------------
+
+/// How a record's memory is managed — its [`ctxt::Record.default_cap`] carried
+/// forward. This axis is **orthogonal to the `Ty`'s capability**: the capability
+/// records *regional value coloring* (and is [`Capability::Irrelevant`] for any
+/// record that does not participate in it — i.e. every non-regional record), so
+/// it cannot say whether a record is Rc-managed. That is decided here, from the
+/// record table, for every record (regional or not).
+///
+/// [`ctxt::Record.default_cap`]: crate::semi::ctxt::Record
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Managed {
+    /// Stored inline (by value). Rc-managed only transitively — RR iff a field is.
+    Value,
+    /// Heap-allocated and reference-counted (the default `struct`/`enum`).
+    Shared,
+    /// Region-allocated and reference-counted (a `[regional]` record).
+    Regional,
+}
+
+impl Managed {
+    /// Whether the record itself owns an rc (`Shared`/`Regional`), independent of
+    /// its fields. A `Value` record is rc only through what it transitively holds.
+    pub fn is_rc(self) -> bool {
+        matches!(self, Managed::Shared | Managed::Regional)
+    }
+}
+
+/// The shape of a ground record instance, as the ownership pass needs it: how it
+/// is managed and (for value records) its ground field types, flattened across
+/// all variants, so `is_rr` can decide transitive resource-relevance.
+#[derive(Clone, Debug)]
+pub struct RecordShape<'tcx> {
+    pub managed: Managed,
+    pub fields: Vec<Ty<'tcx>>,
+}
+
+/// How every ground record instance is managed, keyed by its **canonical** record
+/// type (capability normalized to [`Capability::Irrelevant`], matching the
+/// instance types `mono` records, so a record and its regionally-colored variants
+/// share one entry). Built from the elaborated record table by the pipeline;
+/// built directly by the test harness.
+#[derive(Default)]
+pub struct RecordTable<'tcx> {
+    shapes: FxHashMap<Ty<'tcx>, RecordShape<'tcx>>,
+}
+
+impl<'tcx> RecordTable<'tcx> {
+    pub fn new() -> Self {
+        RecordTable {
+            shapes: FxHashMap::default(),
+        }
+    }
+
+    /// Register `canonical_ty`'s shape. `canonical_ty` must carry
+    /// [`Capability::Irrelevant`] (the form `is_rr` looks up).
+    pub fn insert(&mut self, canonical_ty: Ty<'tcx>, shape: RecordShape<'tcx>) {
+        self.shapes.insert(canonical_ty, shape);
+    }
+
+    fn shape(&self, canonical_ty: Ty<'tcx>) -> Option<&RecordShape<'tcx>> {
+        self.shapes.get(&canonical_ty)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The is_rr predicate
+// ---------------------------------------------------------------------------
+
+/// The resource-relevance predicate, with its memo and the record table it
+/// consults. Held by the [`Analyzer`]; also usable standalone (the test harness's
+/// balanced-rc checker borrows one).
+pub(crate) struct Rr<'a, 'tcx> {
+    tcx: &'a TyCtxt<'tcx>,
+    table: &'a RecordTable<'tcx>,
+    /// `Ty` → is_rr, memoized (types are interned, so the pointer key is exact).
+    memo: RefCell<FxHashMap<Ty<'tcx>, bool>>,
+}
+
+impl<'a, 'tcx> Rr<'a, 'tcx> {
+    pub(crate) fn new(tcx: &'a TyCtxt<'tcx>, table: &'a RecordTable<'tcx>) -> Self {
+        Rr {
+            tcx,
+            table,
+            memo: RefCell::new(FxHashMap::default()),
+        }
+    }
+
+    /// Is a value of `ty` reference-counted (needs `dup`/`drop`)?
+    ///
+    /// An Rc-managed record (`Shared`/`Regional`, per the record table) and a
+    /// closure are always RR; a `Value` record is RR iff some field transitively
+    /// is; `Nullable(inner)` follows `inner`; scalars are not. The record's `Ty`
+    /// *capability* is not consulted — it tracks regional value coloring, a
+    /// different axis from rc-management.
+    pub(crate) fn is_rr(&self, ty: Ty<'tcx>) -> bool {
+        if let Some(&b) = self.memo.borrow().get(&ty) {
+            return b;
+        }
+        // Provisional `false` before recursing: a value-record field cycle can
+        // only close through an rc-managed link (which is RR regardless), so
+        // reading `false` for an in-progress value type on the back-edge is
+        // correct (a pure inline cycle would be an illegal infinite-size type).
+        // Overwritten with the real answer below.
+        self.memo.borrow_mut().insert(ty, false);
+        let b = match *ty.kind() {
+            // Rc-management is the record table's call, for every record — the
+            // capability (regional coloring) is canonicalized away for the key.
+            TyKind::Record { def, args, .. } => {
+                let canonical = self.tcx.mk_record(def, args, Capability::Irrelevant);
+                match self.table.shape(canonical) {
+                    Some(shape) if shape.managed.is_rc() => true,
+                    Some(shape) => shape.fields.iter().any(|&f| self.is_rr(f)),
+                    // Unknown record: treat as non-RR. The pipeline populates
+                    // every reachable instance; a miss means a scalar-only type.
+                    None => false,
+                }
+            }
+            TyKind::Closure { .. } => true,
+            TyKind::Nullable(inner) => self.is_rr(inner),
+            TyKind::Int(_)
+            | TyKind::Fp(_)
+            | TyKind::Bool
+            | TyKind::Str
+            | TyKind::Unit
+            | TyKind::Generic(_)
+            | TyKind::Hole(_)
+            | TyKind::Bottom => false,
+        };
+        self.memo.borrow_mut().insert(ty, b);
+        b
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Live-variable sets
+// ---------------------------------------------------------------------------
+
+/// A dense set of [`VarId`]s, a fixed-width bitset (var ids are dense per
+/// function). Backs both `free(e)` and the threaded `live_after` sets.
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+struct VarSet {
+    words: Vec<u64>,
+}
+
+impl VarSet {
+    fn insert(&mut self, v: VarId) {
+        let i = v.0 as usize;
+        let w = i / 64;
+        if w >= self.words.len() {
+            self.words.resize(w + 1, 0);
+        }
+        self.words[w] |= 1u64 << (i % 64);
+    }
+
+    fn contains(&self, v: VarId) -> bool {
+        let i = v.0 as usize;
+        self.words
+            .get(i / 64)
+            .is_some_and(|x| (x >> (i % 64)) & 1 == 1)
+    }
+
+    fn union_with(&mut self, other: &VarSet) {
+        if other.words.len() > self.words.len() {
+            self.words.resize(other.words.len(), 0);
+        }
+        for (a, b) in self.words.iter_mut().zip(other.words.iter()) {
+            *a |= *b;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The analyzer
+// ---------------------------------------------------------------------------
+
+/// Analyze one function body, returning the rc ops it needs. `table` classifies
+/// every ground record the body mentions (value vs shared + value-record fields).
+pub fn analyze_function<'tcx>(
+    tcx: &TyCtxt<'tcx>,
+    func: &Function<'tcx>,
+    table: &RecordTable<'tcx>,
+) -> OwnershipTable {
+    let mut a = Analyzer {
+        rr: Rr::new(tcx, table),
+        free_memo: FxHashMap::default(),
+        actions: FxHashMap::default(),
+    };
+    if let Some(body) = func.body {
+        // Top-level continuation is empty: the return value is moved to the
+        // caller, everything else must be settled within the body.
+        a.place(body, &VarSet::default());
+        // [Param-Unused]: an RR parameter never used anywhere is dead on entry.
+        let body_free = a.free(body);
+        for p in &func.params {
+            if a.rr.is_rr(p.ty) && !body_free.contains(p.var) {
+                a.add_before(body.id, RcOp::Drop(p.var));
+            }
+        }
+    }
+    OwnershipTable { actions: a.actions }
+}
+
+struct Analyzer<'a, 'tcx> {
+    rr: Rr<'a, 'tcx>,
+    /// `free(e)` memoized per anchor (Pass A). Computed bottom-up, read while
+    /// threading `live_after` top-down.
+    free_memo: FxHashMap<ExprId, VarSet>,
+    actions: FxHashMap<ExprId, Action>,
+}
+
+impl<'tcx> Analyzer<'_, 'tcx> {
+    fn add_before(&mut self, id: ExprId, op: RcOp) {
+        self.actions.entry(id).or_default().before.push(op);
+    }
+
+    fn add_after(&mut self, id: ExprId, op: RcOp) {
+        self.actions.entry(id).or_default().after.push(op);
+    }
+
+    // --- Pass A: free RR variables, memoized per anchor ---
+
+    fn free(&mut self, e: &Expr<'tcx>) -> VarSet {
+        if let Some(s) = self.free_memo.get(&e.id) {
+            return s.clone();
+        }
+        let s = self.compute_free(e);
+        self.free_memo.insert(e.id, s.clone());
+        s
+    }
+
+    fn compute_free(&mut self, e: &Expr<'tcx>) -> VarSet {
+        let mut s = VarSet::default();
+        match e.kind {
+            ExprKind::Var(x) => {
+                if self.rr.is_rr(e.ty) {
+                    s.insert(x);
+                }
+            }
+            ExprKind::GlobalStr(_)
+            | ExprKind::ConstInt(_)
+            | ExprKind::ConstFloat(_)
+            | ExprKind::ConstBool(_)
+            | ExprKind::Poison => {}
+            ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => {
+                s.union_with(&self.free(x));
+            }
+            ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
+                s.union_with(&self.free(l));
+                s.union_with(&self.free(r));
+            }
+            ExprKind::Let { value, .. } => s.union_with(&self.free(value)),
+            ExprKind::Seq(es) => {
+                for st in es {
+                    s.union_with(&self.free(st));
+                }
+            }
+            ExprKind::Call { args, .. }
+            | ExprKind::Ctor { args, .. }
+            | ExprKind::Variant { args, .. } => {
+                for arg in args {
+                    s.union_with(&self.free(arg));
+                }
+            }
+            ExprKind::NullableCall(opt) => {
+                if let Some(x) = opt {
+                    s.union_with(&self.free(x));
+                }
+            }
+            ExprKind::If(..)
+            | ExprKind::Match(..)
+            | ExprKind::Proj(..)
+            | ExprKind::Assign(..)
+            | ExprKind::RegionRun(..)
+            | ExprKind::Closure(..)
+            | ExprKind::ClosureCall { .. } => {
+                unimplemented!(
+                    "ownership::free: `{}` lands in a later increment (see ownership-analysis.md §10)",
+                    kind_name(&e.kind)
+                )
+            }
+        }
+        s
+    }
+
+    // --- Pass B: placement, threading continuation liveness top-down ---
+
+    fn place(&mut self, e: &Expr<'tcx>, live_after: &VarSet) {
+        match e.kind {
+            // [Var-Shared] / [Var-LastUse]: dup if still live afterwards, else
+            // this is the last use and the value is moved (consumed) in place.
+            ExprKind::Var(x) => {
+                if self.rr.is_rr(e.ty) && live_after.contains(x) {
+                    self.add_before(e.id, RcOp::Dup(x));
+                }
+            }
+            ExprKind::GlobalStr(_)
+            | ExprKind::ConstInt(_)
+            | ExprKind::ConstFloat(_)
+            | ExprKind::ConstBool(_)
+            | ExprKind::Poison => {}
+            // Scalar unary: the operand never holds an RR value, but recurse for
+            // generality (and to keep liveness threading uniform).
+            ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => {
+                self.place(x, live_after);
+            }
+            // Scalar binary, left-to-right: `l` is live across `r`.
+            ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
+                let mut la = self.free(r);
+                la.union_with(live_after);
+                self.place(l, &la);
+                self.place(r, live_after);
+            }
+            ExprKind::Let { var, value, .. } => {
+                self.place(value, live_after);
+                // [Let-Dead]: bound but not used downstream ⇒ drop right after
+                // binding. `live_after` here is the let's own continuation set.
+                if self.rr.is_rr(value.ty) && !live_after.contains(var) {
+                    self.add_after(e.id, RcOp::Drop(var));
+                }
+            }
+            ExprKind::Seq(es) => self.place_seq(es, live_after),
+            ExprKind::Call { args, .. }
+            | ExprKind::Ctor { args, .. }
+            | ExprKind::Variant { args, .. } => self.place_args(args, live_after),
+            ExprKind::NullableCall(opt) => {
+                if let Some(x) = opt {
+                    self.place(x, live_after);
+                }
+            }
+            ExprKind::If(..)
+            | ExprKind::Match(..)
+            | ExprKind::Proj(..)
+            | ExprKind::Assign(..)
+            | ExprKind::RegionRun(..)
+            | ExprKind::Closure(..)
+            | ExprKind::ClosureCall { .. } => {
+                unimplemented!(
+                    "ownership::place: `{}` lands in a later increment (see ownership-analysis.md §10)",
+                    kind_name(&e.kind)
+                )
+            }
+        }
+    }
+
+    /// `Seq([s₀..sₙ])`: `sₙ` is the moved-out result; earlier statements run for
+    /// effect. Each `sᵢ`'s continuation-live set is `free(sᵢ₊₁..sₙ) ∪ L`.
+    fn place_seq(&mut self, es: &'tcx [Expr<'tcx>], live_after: &VarSet) {
+        let n = es.len();
+        if n == 0 {
+            return;
+        }
+        let mut afters = vec![VarSet::default(); n];
+        afters[n - 1] = live_after.clone();
+        for i in (0..n - 1).rev() {
+            let mut s = self.free(&es[i + 1]);
+            s.union_with(&afters[i + 1]);
+            afters[i] = s;
+        }
+        for (i, st) in es.iter().enumerate() {
+            self.place_stmt(st, &afters[i], i == n - 1);
+        }
+    }
+
+    fn place_stmt(&mut self, s: &Expr<'tcx>, after: &VarSet, is_last: bool) {
+        self.place(s, after);
+        // A non-final statement whose RR result is neither bound (`Let`) nor
+        // consumed leaves an owned value with no name to drop. Anonymous-result
+        // drops arrive with the control-flow increment.
+        if !is_last && !matches!(s.kind, ExprKind::Let { .. }) && self.rr.is_rr(s.ty) {
+            unimplemented!(
+                "ownership: an unconsumed non-`let` statement of RR type needs a \
+                 result-drop (control-flow increment)"
+            );
+        }
+    }
+
+    /// [Args]: each argument is consumed by the call/ctor; a var reused in a
+    /// later argument is live across the earlier occurrence (so it gets a `dup`).
+    fn place_args(&mut self, args: &'tcx [Expr<'tcx>], live_after: &VarSet) {
+        let n = args.len();
+        if n == 0 {
+            return;
+        }
+        let mut afters = vec![VarSet::default(); n];
+        afters[n - 1] = live_after.clone();
+        for i in (0..n - 1).rev() {
+            let mut s = self.free(&args[i + 1]);
+            s.union_with(&afters[i + 1]);
+            afters[i] = s;
+        }
+        for (i, arg) in args.iter().enumerate() {
+            self.place(arg, &afters[i]);
+        }
+    }
+}
+
+/// A short name for an [`ExprKind`], for `unimplemented!` diagnostics.
+fn kind_name(kind: &ExprKind<'_>) -> &'static str {
+    match kind {
+        ExprKind::GlobalStr(_) => "GlobalStr",
+        ExprKind::ConstInt(_) => "ConstInt",
+        ExprKind::ConstFloat(_) => "ConstFloat",
+        ExprKind::ConstBool(_) => "ConstBool",
+        ExprKind::Var(_) => "Var",
+        ExprKind::Negate(_) => "Negate",
+        ExprKind::Not(_) => "Not",
+        ExprKind::Arith(..) => "Arith",
+        ExprKind::Cmp(..) => "Cmp",
+        ExprKind::Cast(..) => "Cast",
+        ExprKind::If(..) => "If",
+        ExprKind::RegionRun(_) => "RegionRun",
+        ExprKind::Proj(..) => "Proj",
+        ExprKind::Assign(..) => "Assign",
+        ExprKind::Let { .. } => "Let",
+        ExprKind::Seq(_) => "Seq",
+        ExprKind::Call { .. } => "Call",
+        ExprKind::Ctor { .. } => "Ctor",
+        ExprKind::Variant { .. } => "Variant",
+        ExprKind::NullableCall(_) => "NullableCall",
+        ExprKind::Closure(_) => "Closure",
+        ExprKind::ClosureCall { .. } => "ClosureCall",
+        ExprKind::Match(..) => "Match",
+        ExprKind::Poison => "Poison",
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -8,11 +8,12 @@
 //! MIR is immutable, so the result is a side-table keyed by [`mir::ExprId`]
 //! anchors rather than a rewritten tree — see [`OwnershipTable`].
 //!
-//! This is **increment 1** (see `docs/ownership-analysis.md` §10): the linear
-//! core (`Var` / `Let` / `Seq` / `Call` / `Ctor` / `Variant` / `NullableCall`),
-//! the [`is_rr`](Rr::is_rr) predicate (including transitive value-records), and
-//! the test harness. Control flow (`If` / `Match`), container borrows (`Proj`),
-//! closures, and regions land in later increments; the forms they need
+//! Implemented so far (see `docs/ownership-analysis.md` §10): the linear core
+//! (`Var` / `Let` / `Seq` / `Call` / `Ctor` / `Variant` / `NullableCall`), the
+//! [`is_rr`](Rr::is_rr) predicate (including transitive value-records), `If`
+//! branch reconciliation, discarded-result drops, and **pattern matching**
+//! (`Match` over `Switch` + `Leaf`, borrow-dup). Still to come: match guards,
+//! container borrows (`Proj`), closures, and regions — the forms they need
 //! [`unimplemented!`] loudly rather than silently miscounting.
 //!
 //! # Discipline
@@ -65,6 +66,30 @@
 //!  … ⊕ {s.after: drop-value s}     (its result is owned but unconsumed)
 //! ```
 //!
+//! # Match (borrow-dup, à la Perceus/Koka)
+//!
+//! A `match` **borrows** its scrutinee to read fields; it does not consume it at
+//! the scrutinee position. Per leaf (the reconciliation join is N-way over the
+//! switch arms, like [If-Reconcile]):
+//!
+//! - a used RR field binding `(y, path≠[])` takes `dup y` (borrow-extract: the
+//!   field is aliased out while the scrutinee still holds its reference);
+//! - the scrutinee is **consumed** iff it is dead after the match (a `Var(s)` with
+//!   `s ∉ free(arms) ∪ L`, or any temporary); a consumed scrutinee is dropped at
+//!   each leaf *after* the field dups (early, so the backend can reuse the token);
+//! - binding the **whole** scrutinee `(y, [])` is an identity, so it follows
+//!   ordinary move/borrow: a consumed scrutinee is *moved* into `y` (no op, no
+//!   drop), a borrowed one is `dup`'d;
+//! - an **unused** binding needs no op at all — a consumed scrutinee's drop
+//!   recursively frees its un-extracted fields, and a borrowed scrutinee is never
+//!   extracted.
+//!
+//! Reuse *specialization* (fusing `dup field; drop parent` into an in-place,
+//! uniqueness-guarded move) is the backend's job, exactly as Koka separates
+//! Perceus from its reuse analysis — the frontend only emits the early drop.
+//! Guards (which keep the scrutinee live across a re-testable failure path) land
+//! in a follow-up.
+//!
 //! # Relation to Tree Borrows
 //!
 //! Borrowed as *design inspiration*, not as a model: each owned RR var carries a
@@ -78,7 +103,7 @@ use std::cell::RefCell;
 
 use rustc_hash::FxHashMap;
 
-use crate::full::mir::{Expr, ExprKind, Function};
+use crate::full::mir::{DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::hir::{ExprId, VarId};
 use crate::semi::ty::{Capability, Ty, TyCtxt, TyKind};
 
@@ -309,6 +334,13 @@ impl VarSet {
         }
     }
 
+    /// Remove every member of `other` (set difference, in place).
+    fn subtract(&mut self, other: &VarSet) {
+        for (a, b) in self.words.iter_mut().zip(other.words.iter()) {
+            *a &= !*b;
+        }
+    }
+
     /// The members, in ascending `VarId` order (deterministic op emission).
     fn iter(&self) -> impl Iterator<Item = VarId> + '_ {
         self.words.iter().enumerate().flat_map(|(w, &word)| {
@@ -421,8 +453,11 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 s.union_with(&self.free(t));
                 s.union_with(&self.free(e));
             }
-            ExprKind::Match(..)
-            | ExprKind::Proj(..)
+            ExprKind::Match(scrut, tree) => {
+                s.union_with(&self.free(scrut));
+                s.union_with(&self.free_tree(&tree));
+            }
+            ExprKind::Proj(..)
             | ExprKind::Assign(..)
             | ExprKind::RegionRun(..)
             | ExprKind::Closure(..)
@@ -431,6 +466,42 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                     "ownership::free: `{}` lands in a later increment (see ownership-analysis.md §10)",
                     kind_name(&e.kind)
                 )
+            }
+        }
+        s
+    }
+
+    /// The free RR variables of a decision tree: vars used in arm bodies (and
+    /// guards), **minus** the variables the patterns bind (those are internal to
+    /// the match, not free in it).
+    fn free_tree(&mut self, tree: &DecisionTree<'tcx>) -> VarSet {
+        let mut free = self.tree_body_free(tree);
+        let bound = tree_bound(tree);
+        free.subtract(&bound);
+        free
+    }
+
+    /// The union of the free sets of every arm body / guard in the tree (still
+    /// including pattern-bound vars; [`free_tree`](Self::free_tree) removes them).
+    fn tree_body_free(&mut self, tree: &DecisionTree<'tcx>) -> VarSet {
+        let mut s = VarSet::default();
+        match *tree {
+            DecisionTree::Uncovered | DecisionTree::Unreachable => {}
+            DecisionTree::Leaf { body, .. } => s.union_with(&self.free(body)),
+            DecisionTree::Guard {
+                guard,
+                success,
+                failure,
+                ..
+            } => {
+                s.union_with(&self.free(guard));
+                s.union_with(&self.tree_body_free(success));
+                s.union_with(&self.tree_body_free(failure));
+            }
+            DecisionTree::Switch { cases, .. } => {
+                for sub in subtrees(&cases) {
+                    s.union_with(&self.tree_body_free(sub));
+                }
             }
         }
         s
@@ -482,8 +553,8 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 }
             }
             ExprKind::If(c, t, e) => self.place_if(c, t, e, live_after),
-            ExprKind::Match(..)
-            | ExprKind::Proj(..)
+            ExprKind::Match(scrut, tree) => self.place_match(scrut, &tree, live_after),
+            ExprKind::Proj(..)
             | ExprKind::Assign(..)
             | ExprKind::RegionRun(..)
             | ExprKind::Closure(..)
@@ -494,6 +565,122 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 )
             }
         }
+    }
+
+    /// Place a `match`. See the module "Match" section for the model. The
+    /// scrutinee is borrowed; each leaf dups its used RR fields, drops the
+    /// scrutinee if it is consumed (dead after the match), and drops any
+    /// dead-after outer var it does not use (N-way [If-Reconcile]).
+    fn place_match(
+        &mut self,
+        scrut: &'tcx Expr<'tcx>,
+        tree: &DecisionTree<'tcx>,
+        live_after: &VarSet,
+    ) {
+        let tree_free = self.free_tree(tree);
+        let mut scrut_after = tree_free.clone();
+        scrut_after.union_with(live_after);
+
+        // Decide how the scrutinee value is settled by the match.
+        let (consumed, held) = match scrut.kind {
+            // A `Var` scrutinee is borrowed in place (no op); it is consumed iff
+            // dead after the whole match.
+            ExprKind::Var(s) if self.rr.is_rr(scrut.ty) => {
+                (!scrut_after.contains(s), Some(RcOp::Drop(s)))
+            }
+            // A non-RR scrutinee (matching an int/bool/…): nothing to settle.
+            ExprKind::Var(_) => (false, None),
+            // A temporary: its internals are placed here; the owned result is
+            // consumed by the match and dropped (by anchor) in each leaf.
+            _ => {
+                self.place(scrut, &scrut_after);
+                let held = self.rr.is_rr(scrut.ty).then_some(RcOp::DropValue(scrut.id));
+                (held.is_some(), held)
+            }
+        };
+
+        // Outer RR vars that die within the match: settled per leaf.
+        let mut must_settle = tree_free;
+        must_settle.subtract(live_after);
+        let must_settle: Vec<VarId> = must_settle.iter().collect();
+
+        self.place_tree(tree, live_after, consumed, held, &must_settle);
+    }
+
+    fn place_tree(
+        &mut self,
+        tree: &DecisionTree<'tcx>,
+        live_after: &VarSet,
+        consumed: bool,
+        held: Option<RcOp>,
+        must_settle: &[VarId],
+    ) {
+        match *tree {
+            DecisionTree::Uncovered | DecisionTree::Unreachable => {}
+            DecisionTree::Leaf { body, bindings } => {
+                self.place_leaf(body, bindings, live_after, consumed, held, must_settle);
+            }
+            DecisionTree::Guard { .. } => unimplemented!(
+                "ownership: `match` guards land in a follow-up increment \
+                 (the scrutinee stays live across a re-testable failure path)"
+            ),
+            DecisionTree::Switch { cases, .. } => {
+                for sub in subtrees(&cases) {
+                    self.place_tree(sub, live_after, consumed, held, must_settle);
+                }
+            }
+        }
+    }
+
+    fn place_leaf(
+        &mut self,
+        body: &'tcx Expr<'tcx>,
+        bindings: &'tcx [(VarId, &'tcx [u32])],
+        live_after: &VarSet,
+        consumed: bool,
+        held: Option<RcOp>,
+        must_settle: &[VarId],
+    ) {
+        let body_free = self.free(body);
+        // A used binding of the whole scrutinee (path `[]`) takes ownership of the
+        // borrowed root: moved if the scrutinee is consumed, else dup'd.
+        let has_whole = bindings
+            .iter()
+            .any(|&(y, path)| path.is_empty() && body_free.contains(y));
+
+        // 1. Field dups / whole-binding dup — used RR bindings only.
+        for &(y, path) in bindings {
+            if !body_free.contains(y) {
+                continue; // unused (or non-RR) binding: no op
+            }
+            if path.is_empty() {
+                if !consumed {
+                    self.add_before(body.id, RcOp::Dup(y)); // borrowed root → alias
+                }
+                // consumed whole binding ⇒ move (no op)
+            } else {
+                self.add_before(body.id, RcOp::Dup(y)); // borrow-extract a field
+            }
+        }
+
+        // 2. Drop the consumed scrutinee (after the field dups), unless a whole
+        //    binding moved it out.
+        if consumed
+            && !has_whole
+            && let Some(op) = held
+        {
+            self.add_before(body.id, op);
+        }
+
+        // 3. Reconciliation: settle dead-after outer vars this path does not use.
+        for &v in must_settle {
+            if !body_free.contains(v) {
+                self.add_before(body.id, RcOp::Drop(v));
+            }
+        }
+
+        // 4. The arm body, under the match's own continuation.
+        self.place(body, live_after);
     }
 
     /// [If-Reconcile]: place the condition (live across both arms), then each arm
@@ -580,6 +767,75 @@ impl<'tcx> Analyzer<'_, 'tcx> {
         }
         for (i, arg) in args.iter().enumerate() {
             self.place(arg, &afters[i]);
+        }
+    }
+}
+
+/// The immediate sub-trees of a switch's cases, in source order.
+fn subtrees<'tcx>(cases: &SwitchCases<'tcx>) -> Vec<&'tcx DecisionTree<'tcx>> {
+    let mut v = Vec::new();
+    match *cases {
+        SwitchCases::Int { cases, default } => {
+            for (_, t) in cases {
+                v.push(t);
+            }
+            v.push(default);
+        }
+        SwitchCases::Bool { if_true, if_false } => {
+            v.push(if_true);
+            v.push(if_false);
+        }
+        SwitchCases::Ctor(arms) => {
+            for t in arms {
+                v.push(t);
+            }
+        }
+        SwitchCases::String { cases, default } => {
+            for (_, t) in cases {
+                v.push(t);
+            }
+            v.push(default);
+        }
+        SwitchCases::Nullable { non_null, null } => {
+            v.push(non_null);
+            v.push(null);
+        }
+    }
+    v
+}
+
+/// Every variable bound by a pattern anywhere in the tree (internal to the match;
+/// excluded from its free set).
+fn tree_bound<'tcx>(tree: &DecisionTree<'tcx>) -> VarSet {
+    let mut s = VarSet::default();
+    collect_bound(tree, &mut s);
+    s
+}
+
+fn collect_bound<'tcx>(tree: &DecisionTree<'tcx>, s: &mut VarSet) {
+    match *tree {
+        DecisionTree::Uncovered | DecisionTree::Unreachable => {}
+        DecisionTree::Leaf { bindings, .. } => {
+            for &(y, _) in bindings {
+                s.insert(y);
+            }
+        }
+        DecisionTree::Guard {
+            bindings,
+            success,
+            failure,
+            ..
+        } => {
+            for &(y, _) in bindings {
+                s.insert(y);
+            }
+            collect_bound(success, s);
+            collect_bound(failure, s);
+        }
+        DecisionTree::Switch { cases, .. } => {
+            for sub in subtrees(&cases) {
+                collect_bound(sub, s);
+            }
         }
     }
 }

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -109,6 +109,7 @@ use std::cell::RefCell;
 
 use crate::utils::bitset::HybridBitSet;
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 
 use crate::full::mir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::hir::{ExprId, VarId};
@@ -936,7 +937,8 @@ impl<'tcx> Analyzer<'_, 'tcx> {
         if n == 0 {
             return;
         }
-        let mut afters = vec![VarSet::default(); n];
+        let mut afters = SmallVec::<[_; 4]>::with_capacity(n);
+        afters.resize_with(n, VarSet::default);
         afters[n - 1] = live_after.clone();
         for i in (0..n - 1).rev() {
             let mut s = self.free(&args[i + 1]);
@@ -950,8 +952,8 @@ impl<'tcx> Analyzer<'_, 'tcx> {
 }
 
 /// The immediate sub-trees of a switch's cases, in source order.
-fn subtrees<'tcx>(cases: &SwitchCases<'tcx>) -> Vec<&'tcx DecisionTree<'tcx>> {
-    let mut v = Vec::new();
+fn subtrees<'tcx>(cases: &SwitchCases<'tcx>) -> SmallVec<[&'tcx DecisionTree<'tcx>; 8]> {
+    let mut v = SmallVec::new();
     match *cases {
         SwitchCases::Int { cases, default } => {
             for (_, t) in cases {

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -176,29 +176,29 @@ impl OwnershipTable {
 // ---------------------------------------------------------------------------
 
 /// How a record's memory is managed — its [`ctxt::Record.default_cap`] carried
-/// forward. This axis is **orthogonal to the `Ty`'s capability**: the capability
-/// records *regional value coloring* (and is [`Flexivity::Irrelevant`] for any
-/// record that does not participate in it — i.e. every non-regional record), so
-/// it cannot say whether a record is Rc-managed. That is decided here, from the
-/// record table, for every record (regional or not).
+/// forward. This is a **different axis from the `Ty`'s [`Flexivity`]**: flexivity
+/// is the *regional value coloring* (and is [`Flexivity::Irrelevant`] for any
+/// non-regional record), while management says how the storage is reclaimed. The
+/// management class comes from the record table, never from the flexivity.
+///
+/// The two axes are independent for `Value`/`Shared`, and meet in exactly one
+/// place: a `Regional` record is rc-managed only when its flexivity is `Rigid`
+/// (see [`Rr::is_rr`]).
 ///
 /// [`ctxt::Record.default_cap`]: crate::semi::ctxt::Record
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Managed {
     /// Stored inline (by value). Rc-managed only transitively — RR iff a field is.
     Value,
-    /// Heap-allocated and reference-counted (the default `struct`/`enum`).
+    /// Heap-allocated and reference-counted (the default `struct`/`enum`). Always
+    /// RR.
     Shared,
-    /// Region-allocated and reference-counted (a `[regional]` record).
+    /// Region-allocated (a `[regional]` record). RR only when the value's
+    /// [`Flexivity`] is `Rigid` (frozen out of its region into a managed object);
+    /// a region-local `Flex` / unrefined value is freed with its region and needs
+    /// no rc. This is the one place the two axes (management vs flexivity) meet —
+    /// see [`Rr::is_rr`].
     Regional,
-}
-
-impl Managed {
-    /// Whether the record itself owns an rc (`Shared`/`Regional`), independent of
-    /// its fields. A `Value` record is rc only through what it transitively holds.
-    pub fn is_rc(self) -> bool {
-        matches!(self, Managed::Shared | Managed::Regional)
-    }
 }
 
 /// The shape of a ground record instance, as the ownership pass needs it: how it
@@ -263,11 +263,12 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
 
     /// Is a value of `ty` reference-counted (needs `dup`/`drop`)?
     ///
-    /// An Rc-managed record (`Shared`/`Regional`, per the record table) and a
-    /// closure are always RR; a `Value` record is RR iff some field transitively
-    /// is; `Nullable(inner)` follows `inner`; scalars are not. The record's `Ty`
-    /// *capability* is not consulted — it tracks regional value coloring, a
-    /// different axis from rc-management.
+    /// A `Shared` record and a closure are always RR; a `Value` record is RR iff
+    /// some field transitively is; a `Regional` record is RR only when its
+    /// [`Flexivity`] is `Rigid` (frozen into a managed object — a `Flex` or
+    /// unrefined-regional value is freed with its region); `Nullable(inner)`
+    /// follows `inner`; scalars are not. Management comes from the record table;
+    /// flexivity is consulted only to settle the regional case.
     pub(crate) fn is_rr(&self, ty: Ty<'tcx>) -> bool {
         if let Some(&b) = self.memo.borrow().get(&ty) {
             return b;
@@ -279,13 +280,22 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
         // Overwritten with the real answer below.
         self.memo.borrow_mut().insert(ty, false);
         let b = match *ty.kind() {
-            // Rc-management is the record table's call, for every record — the
-            // capability (regional coloring) is canonicalized away for the key.
-            TyKind::Record { def, args, .. } => {
+            // The management class is the record table's call (keyed by the
+            // canonical, flexivity-erased type); the per-use flexivity then refines
+            // the one case where it matters — a regional record.
+            TyKind::Record { def, args, flex } => {
                 let canonical = self.tcx.mk_record(def, args, Flexivity::Irrelevant);
                 match self.table.shape(canonical) {
-                    Some(shape) if shape.managed.is_rc() => true,
-                    Some(shape) => shape.fields.iter().any(|&f| self.is_rr(f)),
+                    Some(shape) => match shape.managed {
+                        Managed::Shared => true,
+                        Managed::Value => shape.fields.iter().any(|&f| self.is_rr(f)),
+                        // A region-allocated value is freed en masse when its region
+                        // is torn down — no per-object rc — *unless* it has been
+                        // frozen to `Rigid`, which lifts it to a managed (refcounted)
+                        // object that escapes the region. Flex / unrefined-regional
+                        // values stay region-local, so they need no dup/drop.
+                        Managed::Regional => flex == Flexivity::Rigid,
+                    },
                     // Unknown record: treat as non-RR. The pipeline populates
                     // every reachable instance; a miss means a scalar-only type.
                     None => false,

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -107,6 +107,7 @@
 
 use std::cell::RefCell;
 
+use roaring::RoaringBitmap;
 use rustc_hash::FxHashMap;
 
 use crate::full::mir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
@@ -321,53 +322,36 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
 // Live-variable sets
 // ---------------------------------------------------------------------------
 
-/// A dense set of [`VarId`]s, a fixed-width bitset (var ids are dense per
-/// function). Backs both `free(e)` and the threaded `live_after` sets.
+/// A set of [`VarId`]s, backed by a [`RoaringBitmap`]. Var ids are dense `u32`s
+/// (allocated per function) — exactly the domain a Roaring bitmap keys on — so no
+/// index mapping is needed. Backs both `free(e)` and the threaded `live_after`
+/// sets.
 #[derive(Clone, Default, PartialEq, Eq, Debug)]
-struct VarSet {
-    words: Vec<u64>,
-}
+struct VarSet(RoaringBitmap);
 
 impl VarSet {
     fn insert(&mut self, v: VarId) {
-        let i = v.0 as usize;
-        let w = i / 64;
-        if w >= self.words.len() {
-            self.words.resize(w + 1, 0);
-        }
-        self.words[w] |= 1u64 << (i % 64);
+        self.0.insert(v.0);
     }
 
     fn contains(&self, v: VarId) -> bool {
-        let i = v.0 as usize;
-        self.words
-            .get(i / 64)
-            .is_some_and(|x| (x >> (i % 64)) & 1 == 1)
+        self.0.contains(v.0)
     }
 
+    /// In place: `self ← self ∪ other`.
     fn union_with(&mut self, other: &VarSet) {
-        if other.words.len() > self.words.len() {
-            self.words.resize(other.words.len(), 0);
-        }
-        for (a, b) in self.words.iter_mut().zip(other.words.iter()) {
-            *a |= *b;
-        }
+        self.0 |= &other.0;
     }
 
     /// Remove every member of `other` (set difference, in place).
     fn subtract(&mut self, other: &VarSet) {
-        for (a, b) in self.words.iter_mut().zip(other.words.iter()) {
-            *a &= !*b;
-        }
+        self.0 -= &other.0;
     }
 
-    /// The members, in ascending `VarId` order (deterministic op emission).
+    /// The members, in ascending `VarId` order (a Roaring bitmap iterates sorted,
+    /// keeping op emission deterministic).
     fn iter(&self) -> impl Iterator<Item = VarId> + '_ {
-        self.words.iter().enumerate().flat_map(|(w, &word)| {
-            (0..64)
-                .filter(move |b| (word >> b) & 1 == 1)
-                .map(move |b| VarId((w * 64 + b) as u32))
-        })
+        self.0.iter().map(VarId)
     }
 }
 

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -8,13 +8,13 @@
 //! MIR is immutable, so the result is a side-table keyed by [`mir::ExprId`]
 //! anchors rather than a rewritten tree — see [`OwnershipTable`].
 //!
-//! Implemented so far (see `docs/ownership-analysis.md` §10): the linear core
-//! (`Var` / `Let` / `Seq` / `Call` / `Ctor` / `Variant` / `NullableCall`), the
-//! [`is_rr`](Rr::is_rr) predicate (including transitive value-records), `If`
-//! branch reconciliation, discarded-result drops, and **pattern matching**
-//! (`Match` over `Switch` + `Leaf`, borrow-dup). Still to come: match guards,
-//! container borrows (`Proj`), closures, and regions — the forms they need
-//! [`unimplemented!`] loudly rather than silently miscounting.
+//! Every Full MIR form is handled (see `docs/ownership-analysis.md` §10): the
+//! linear core (`Var` / `Let` / `Seq` / `Call` / `Ctor` / `Variant` /
+//! `NullableCall`), the [`is_rr`](Rr::is_rr) predicate (including transitive
+//! value-records), `If` branch reconciliation, discarded-result drops, **pattern
+//! matching** (`Match` over `Switch` + `Leaf` + `Guard`, borrow-dup), container
+//! borrows (`Proj`, `Assign`), closures (`Closure`, `ClosureCall`), and regions
+//! (`RegionRun`). No form is deferred — the analysis is total over the MIR.
 //!
 //! # Discipline
 //!
@@ -29,7 +29,7 @@
 //!
 //! Judgment `L ⊢ e ⤳ 𝒜`: "with continuation-live set `L`, expression `e`
 //! annotates to actions `𝒜`". `free(e)` is the set of named RR vars used in `e`;
-//! `L` is the set live in `e`'s continuation. The increment-1 rules:
+//! `L` is the set live in `e`'s continuation. The core rules:
 //!
 //! ```text
 //! x ∈ L                                   x ∉ L
@@ -87,8 +87,14 @@
 //! Reuse *specialization* (fusing `dup field; drop parent` into an in-place,
 //! uniqueness-guarded move) is the backend's job, exactly as Koka separates
 //! Perceus from its reuse analysis — the frontend only emits the early drop.
-//! Guards (which keep the scrutinee live across a re-testable failure path) land
-//! in a follow-up.
+//!
+//! A **guard** keeps the scrutinee live across its re-testable `failure` path, so
+//! the scrutinee drop is *not* hoisted above the guard — it stays in each terminal
+//! leaf. The guard's pattern bindings are borrow-extracted (dup at the guard,
+//! before either branch); a binding used only in the guard is consumed there,
+//! while one that survives into a branch is settled there (the branch that uses it
+//! moves it, the branch that does not drops it) — i.e. it joins the sub-trees'
+//! per-leaf settle obligations.
 //!
 //! # Relation to Tree Borrows
 //!
@@ -103,7 +109,7 @@ use std::cell::RefCell;
 
 use rustc_hash::FxHashMap;
 
-use crate::full::mir::{DecisionTree, Expr, ExprKind, Function, SwitchCases};
+use crate::full::mir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::hir::{ExprId, VarId};
 use crate::semi::ty::{Capability, Ty, TyCtxt, TyKind};
 
@@ -111,9 +117,8 @@ use crate::semi::ty::{Capability, Ty, TyCtxt, TyKind};
 // Output data model
 // ---------------------------------------------------------------------------
 
-/// A single reference-counting operation the backend must emit. Mostly keyed by
-/// [`VarId`]; richer targets (`DropField(VarId, Path)`) arrive with the container
-/// increment.
+/// A single reference-counting operation the backend must emit, keyed either by
+/// [`VarId`] (a named owner) or by [`ExprId`] (an anonymous intermediate result).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum RcOp {
     /// Increment the refcount of `x` (it has another live owner).
@@ -122,8 +127,13 @@ pub enum RcOp {
     Drop(VarId),
     /// Decrement the refcount of the **anonymous result** of node `id` — a
     /// statement value that is produced but neither bound nor consumed (a
-    /// discarded non-final `Seq` statement). Recorded in that node's `after`.
+    /// discarded non-final `Seq` statement, or a consumed temporary that was
+    /// projected from). Recorded in that node's `after`.
     DropValue(ExprId),
+    /// Increment the refcount of the **anonymous result** of node `id` — a field
+    /// borrow-extracted by a [`Proj`](ExprKind::Proj): the parent record still
+    /// owns the original, so the extracted owned copy must be inc'd.
+    DupValue(ExprId),
 }
 
 /// The rc ops to run immediately *before* and *after* evaluating one expression.
@@ -457,15 +467,28 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 s.union_with(&self.free(scrut));
                 s.union_with(&self.free_tree(&tree));
             }
-            ExprKind::Proj(..)
-            | ExprKind::Assign(..)
-            | ExprKind::RegionRun(..)
-            | ExprKind::Closure(..)
-            | ExprKind::ClosureCall { .. } => {
-                unimplemented!(
-                    "ownership::free: `{}` lands in a later increment (see ownership-analysis.md §10)",
-                    kind_name(&e.kind)
-                )
+            // A projection reads (borrows) its base: the base's vars are used, so
+            // the enclosing scope keeps them live until the projection.
+            ExprKind::Proj(base, _) => s.union_with(&self.free(base)),
+            ExprKind::Assign(dst, _, src) => {
+                s.union_with(&self.free(dst));
+                s.union_with(&self.free(src));
+            }
+            ExprKind::RegionRun(x) => s.union_with(&self.free(x)),
+            // A closure consumes its captured outer vars; its body is a separate
+            // scope and does not contribute to the enclosing function's free set.
+            ExprKind::Closure(c) => {
+                for &(v, ty) in c.captures {
+                    if self.rr.is_rr(ty) {
+                        s.insert(v);
+                    }
+                }
+            }
+            ExprKind::ClosureCall { target, args } => {
+                s.union_with(&self.free(target));
+                for arg in args {
+                    s.union_with(&self.free(arg));
+                }
             }
         }
         s
@@ -554,15 +577,113 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             }
             ExprKind::If(c, t, e) => self.place_if(c, t, e, live_after),
             ExprKind::Match(scrut, tree) => self.place_match(scrut, &tree, live_after),
-            ExprKind::Proj(..)
-            | ExprKind::Assign(..)
-            | ExprKind::RegionRun(..)
-            | ExprKind::Closure(..)
-            | ExprKind::ClosureCall { .. } => {
-                unimplemented!(
-                    "ownership::place: `{}` lands in a later increment (see ownership-analysis.md §10)",
-                    kind_name(&e.kind)
-                )
+            // Borrow-extract: the result is an owned field copy (inc'd, since the
+            // parent keeps the original); the base is navigated and its root
+            // dropped early if this is its last use.
+            ExprKind::Proj(base, _) => {
+                if self.rr.is_rr(e.ty) {
+                    self.add_after(e.id, RcOp::DupValue(e.id));
+                }
+                self.navigate_base(base, e.id, live_after);
+            }
+            ExprKind::Assign(dst, _, src) => self.place_assign(e.id, dst, src, live_after),
+            // Transparent: a region scope does not change rc ownership (region
+            // lifetime is a separate axis); its body's result is moved out.
+            ExprKind::RegionRun(x) => self.place(x, live_after),
+            ExprKind::Closure(c) => self.place_closure(e.id, &c, live_after),
+            ExprKind::ClosureCall { target, args } => {
+                self.place_closure_call(target, args, live_after)
+            }
+        }
+    }
+
+    /// Navigate the base of a [`Proj`](ExprKind::Proj) / [`Assign`](ExprKind::Assign)
+    /// dst — a borrow, so the root is not consumed in place. Nested projections
+    /// are pure navigation; a `Var` root is dropped (early, at `drop_anchor`) if
+    /// dead after; a temporary root is placed and dropped (consumed).
+    fn navigate_base(&mut self, e: &'tcx Expr<'tcx>, drop_anchor: ExprId, live_after: &VarSet) {
+        match e.kind {
+            ExprKind::Proj(inner, _) => self.navigate_base(inner, drop_anchor, live_after),
+            ExprKind::Var(s) => {
+                if self.rr.is_rr(e.ty) && !live_after.contains(s) {
+                    self.add_after(drop_anchor, RcOp::Drop(s));
+                }
+            }
+            _ => {
+                self.place(e, live_after);
+                if self.rr.is_rr(e.ty) {
+                    self.add_after(drop_anchor, RcOp::DropValue(e.id));
+                }
+            }
+        }
+    }
+
+    /// `dst->field := src`: `src` is moved into the field (consumed); `dst` is
+    /// borrowed (mutated in place). The old field value is *not* dropped here —
+    /// flex/regional field links carry `field` capability and are freed with their
+    /// parent / region, not by an individual dec at the store.
+    fn place_assign(
+        &mut self,
+        id: ExprId,
+        dst: &'tcx Expr<'tcx>,
+        src: &'tcx Expr<'tcx>,
+        live_after: &VarSet,
+    ) {
+        // `dst` is evaluated and live across `src`, but only borrowed, so its
+        // root's drop is decided by the assignment's own continuation.
+        self.navigate_base(dst, id, live_after);
+        self.place(src, live_after);
+    }
+
+    /// Creating a closure consumes its captured outer vars (dup any still live
+    /// after), and analyzes the body as its own owned scope (captures + params
+    /// owned on entry, result moved out).
+    fn place_closure(&mut self, id: ExprId, c: &mir::ClosureExpr<'tcx>, live_after: &VarSet) {
+        for &(v, ty) in c.captures {
+            if self.rr.is_rr(ty) && live_after.contains(v) {
+                self.add_before(id, RcOp::Dup(v));
+            }
+        }
+        let owned = c.captures.iter().chain(c.params.iter());
+        self.analyze_owned_body(c.body, owned);
+    }
+
+    /// `target(args)`: the closure value and every argument are consumed, in
+    /// left-to-right evaluation order (a value reused later is dup'd).
+    fn place_closure_call(
+        &mut self,
+        target: &'tcx Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+        live_after: &VarSet,
+    ) {
+        let mut target_after = self.free_slice(args);
+        target_after.union_with(live_after);
+        self.place(target, &target_after);
+        self.place_args(args, live_after);
+    }
+
+    /// The union of the free sets of a slice of expressions.
+    fn free_slice(&mut self, es: &'tcx [Expr<'tcx>]) -> VarSet {
+        let mut s = VarSet::default();
+        for e in es {
+            s.union_with(&self.free(e));
+        }
+        s
+    }
+
+    /// Place a body whose `owned` vars (function params, or closure captures +
+    /// params) are owned on entry: the body under an empty continuation, then an
+    /// entry drop for any owned RR var the body never uses ([Param-Unused]).
+    fn analyze_owned_body(
+        &mut self,
+        body: &'tcx Expr<'tcx>,
+        owned: impl Iterator<Item = &'tcx (VarId, Ty<'tcx>)>,
+    ) {
+        self.place(body, &VarSet::default());
+        let body_free = self.free(body);
+        for &(v, ty) in owned {
+            if self.rr.is_rr(ty) && !body_free.contains(v) {
+                self.add_before(body.id, RcOp::Drop(v));
             }
         }
     }
@@ -620,9 +741,20 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             DecisionTree::Leaf { body, bindings } => {
                 self.place_leaf(body, bindings, live_after, consumed, held, must_settle);
             }
-            DecisionTree::Guard { .. } => unimplemented!(
-                "ownership: `match` guards land in a follow-up increment \
-                 (the scrutinee stays live across a re-testable failure path)"
+            DecisionTree::Guard {
+                bindings,
+                guard,
+                success,
+                failure,
+            } => self.place_guard(
+                bindings,
+                guard,
+                success,
+                failure,
+                live_after,
+                consumed,
+                held,
+                must_settle,
             ),
             DecisionTree::Switch { cases, .. } => {
                 for sub in subtrees(&cases) {
@@ -630,6 +762,58 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 }
             }
         }
+    }
+
+    /// A guarded arm. The scrutinee stays live across the guard (its `failure`
+    /// branch re-tests it), so the scrutinee drop stays in the terminal leaves.
+    /// The guard's pattern bindings are borrow-extracted (dup at the guard); a
+    /// binding used only in the guard is consumed there, one used in a branch is
+    /// settled in that branch (success consumes, failure drops) — so it joins the
+    /// sub-trees' `must_settle`.
+    #[allow(clippy::too_many_arguments)]
+    fn place_guard(
+        &mut self,
+        bindings: &'tcx [(VarId, &'tcx [u32])],
+        guard: &'tcx Expr<'tcx>,
+        success: &'tcx DecisionTree<'tcx>,
+        failure: &'tcx DecisionTree<'tcx>,
+        live_after: &VarSet,
+        consumed: bool,
+        held: Option<RcOp>,
+        must_settle: &[VarId],
+    ) {
+        let guard_free = self.free(guard);
+        let mut below = self.free_tree(success);
+        below.union_with(&self.free_tree(failure));
+
+        // Extract (dup) each RR binding used in the guard or a branch. Membership
+        // in a free set already implies RR, so no type lookup is needed.
+        let mut extracted = Vec::new();
+        for &(y, _) in bindings {
+            if guard_free.contains(y) || below.contains(y) {
+                self.add_before(guard.id, RcOp::Dup(y));
+                extracted.push(y);
+            }
+        }
+
+        // The guard runs before either branch; everything used below (or in the
+        // match's continuation, or still owed a settle) is live across it.
+        let mut guard_after = below.clone();
+        guard_after.union_with(live_after);
+        for &v in must_settle {
+            guard_after.insert(v);
+        }
+        self.place(guard, &guard_after);
+
+        // Bindings that survive the guard into a branch must be settled there.
+        let mut sub_settle = must_settle.to_vec();
+        for &y in &extracted {
+            if below.contains(y) {
+                sub_settle.push(y);
+            }
+        }
+        self.place_tree(success, live_after, consumed, held, &sub_settle);
+        self.place_tree(failure, live_after, consumed, held, &sub_settle);
     }
 
     fn place_leaf(
@@ -837,36 +1021,6 @@ fn collect_bound<'tcx>(tree: &DecisionTree<'tcx>, s: &mut VarSet) {
                 collect_bound(sub, s);
             }
         }
-    }
-}
-
-/// A short name for an [`ExprKind`], for `unimplemented!` diagnostics.
-fn kind_name(kind: &ExprKind<'_>) -> &'static str {
-    match kind {
-        ExprKind::GlobalStr(_) => "GlobalStr",
-        ExprKind::ConstInt(_) => "ConstInt",
-        ExprKind::ConstFloat(_) => "ConstFloat",
-        ExprKind::ConstBool(_) => "ConstBool",
-        ExprKind::Var(_) => "Var",
-        ExprKind::Negate(_) => "Negate",
-        ExprKind::Not(_) => "Not",
-        ExprKind::Arith(..) => "Arith",
-        ExprKind::Cmp(..) => "Cmp",
-        ExprKind::Cast(..) => "Cast",
-        ExprKind::If(..) => "If",
-        ExprKind::RegionRun(_) => "RegionRun",
-        ExprKind::Proj(..) => "Proj",
-        ExprKind::Assign(..) => "Assign",
-        ExprKind::Let { .. } => "Let",
-        ExprKind::Seq(_) => "Seq",
-        ExprKind::Call { .. } => "Call",
-        ExprKind::Ctor { .. } => "Ctor",
-        ExprKind::Variant { .. } => "Variant",
-        ExprKind::NullableCall(_) => "NullableCall",
-        ExprKind::Closure(_) => "Closure",
-        ExprKind::ClosureCall { .. } => "ClosureCall",
-        ExprKind::Match(..) => "Match",
-        ExprKind::Poison => "Poison",
     }
 }
 

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -111,7 +111,7 @@ use rustc_hash::FxHashMap;
 
 use crate::full::mir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::hir::{ExprId, VarId};
-use crate::semi::ty::{Capability, Ty, TyCtxt, TyKind};
+use crate::semi::ty::{Flexivity, Ty, TyCtxt, TyKind};
 
 // ---------------------------------------------------------------------------
 // Output data model
@@ -177,7 +177,7 @@ impl OwnershipTable {
 
 /// How a record's memory is managed — its [`ctxt::Record.default_cap`] carried
 /// forward. This axis is **orthogonal to the `Ty`'s capability**: the capability
-/// records *regional value coloring* (and is [`Capability::Irrelevant`] for any
+/// records *regional value coloring* (and is [`Flexivity::Irrelevant`] for any
 /// record that does not participate in it — i.e. every non-regional record), so
 /// it cannot say whether a record is Rc-managed. That is decided here, from the
 /// record table, for every record (regional or not).
@@ -211,7 +211,7 @@ pub struct RecordShape<'tcx> {
 }
 
 /// How every ground record instance is managed, keyed by its **canonical** record
-/// type (capability normalized to [`Capability::Irrelevant`], matching the
+/// type (capability normalized to [`Flexivity::Irrelevant`], matching the
 /// instance types `mono` records, so a record and its regionally-colored variants
 /// share one entry). Built from the elaborated record table by the pipeline;
 /// built directly by the test harness.
@@ -228,7 +228,7 @@ impl<'tcx> RecordTable<'tcx> {
     }
 
     /// Register `canonical_ty`'s shape. `canonical_ty` must carry
-    /// [`Capability::Irrelevant`] (the form `is_rr` looks up).
+    /// [`Flexivity::Irrelevant`] (the form `is_rr` looks up).
     pub fn insert(&mut self, canonical_ty: Ty<'tcx>, shape: RecordShape<'tcx>) {
         self.shapes.insert(canonical_ty, shape);
     }
@@ -282,7 +282,7 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
             // Rc-management is the record table's call, for every record — the
             // capability (regional coloring) is canonicalized away for the key.
             TyKind::Record { def, args, .. } => {
-                let canonical = self.tcx.mk_record(def, args, Capability::Irrelevant);
+                let canonical = self.tcx.mk_record(def, args, Flexivity::Irrelevant);
                 match self.table.shape(canonical) {
                     Some(shape) if shape.managed.is_rc() => true,
                     Some(shape) => shape.fields.iter().any(|&f| self.is_rr(f)),

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -18,7 +18,7 @@ use lasso::Rodeo;
 use rustc_hash::FxHashMap;
 
 use super::{Managed, OwnershipTable, RcOp, RecordShape, RecordTable, Rr, analyze_function};
-use crate::full::mir::{self, Expr, ExprKind, Function, Param};
+use crate::full::mir::{self, DecisionTree, Expr, ExprKind, Function, Param, SwitchCases};
 use crate::semi::hir::VarId;
 use crate::semi::ty::{Capability, DefId, IntTy, Ty, TyCtxt};
 use crate::surface::Visibility;
@@ -192,6 +192,33 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
         self.mk(ExprKind::Ctor { record, args }, ty)
     }
 
+    // ----- decision trees -----
+
+    fn leaf(&self, body: Expr<'tcx>, bindings: Vec<(VarId, Vec<u32>)>) -> DecisionTree<'tcx> {
+        let body = self.tcx.alloc(body);
+        let bs: Vec<(VarId, &'tcx [u32])> = bindings
+            .iter()
+            .map(|(y, p)| (*y, self.tcx.alloc_slice(p)))
+            .collect();
+        let bindings = self.tcx.alloc_slice(&bs);
+        DecisionTree::Leaf { body, bindings }
+    }
+
+    /// A variant switch on the value at `path` (root = `[]`), one arm per variant.
+    fn switch_ctor(&self, path: Vec<u32>, arms: Vec<DecisionTree<'tcx>>) -> DecisionTree<'tcx> {
+        let scrutinee = self.tcx.alloc_slice(&path);
+        let arms = self.tcx.alloc_slice(&arms);
+        DecisionTree::Switch {
+            scrutinee,
+            cases: SwitchCases::Ctor(arms),
+        }
+    }
+
+    fn match_(&mut self, scrut: Expr<'tcx>, tree: DecisionTree<'tcx>, ty: Ty<'tcx>) -> Expr<'tcx> {
+        let scrut = self.tcx.alloc(scrut);
+        self.mk(ExprKind::Match(scrut, tree), ty)
+    }
+
     fn param(&mut self, v: VarId, ty: Ty<'tcx>) -> Param<'tcx> {
         Param {
             name: dummy_tok(),
@@ -318,11 +345,39 @@ impl Renderer<'_> {
                 self.line(indent, "else");
                 self.expr(e, indent + 1);
             }
+            ExprKind::Match(scrut, tree) => {
+                self.line(indent, "match");
+                self.expr(scrut, indent + 1);
+                self.tree(&tree, indent + 1);
+            }
             _ => self.line(indent, &format!("<{}>", super::kind_name(&e.kind))),
         }
         let after = self.ot.after(e.id);
         if !after.is_empty() {
             self.line(indent, &format!("« {}", ops_str(after)));
+        }
+    }
+
+    fn tree(&mut self, t: &DecisionTree<'_>, indent: usize) {
+        match *t {
+            DecisionTree::Uncovered => self.line(indent, "uncovered"),
+            DecisionTree::Unreachable => self.line(indent, "unreachable"),
+            DecisionTree::Leaf { body, bindings } => {
+                let bs = bindings
+                    .iter()
+                    .map(|(y, p)| format!("v{}@{p:?}", y.0))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                self.line(indent, &format!("leaf [{bs}]"));
+                self.expr(body, indent + 1);
+            }
+            DecisionTree::Guard { .. } => self.line(indent, "guard <…>"),
+            DecisionTree::Switch { cases, .. } => {
+                self.line(indent, "switch");
+                for sub in super::subtrees(&cases) {
+                    self.tree(sub, indent + 1);
+                }
+            }
         }
     }
 }
@@ -357,12 +412,11 @@ fn render(func: &Function<'_>, ot: &OwnershipTable, syms: &Rodeo) -> String {
 
 fn apply(op: RcOp, rc: &mut FxHashMap<VarId, i32>) {
     match op {
+        // A `dup` on an owned var increments it; a `dup` on an as-yet-untracked
+        // var *establishes* it (this is how a borrow-extracted pattern binding
+        // takes ownership — `bind y = project(scrut, path); rc.inc(y)`).
         RcOp::Dup(x) => {
-            let c = rc
-                .get_mut(&x)
-                .unwrap_or_else(|| panic!("dup of unowned v{}", x.0));
-            assert!(*c >= 1, "dup of settled v{} (rc {c})", x.0);
-            *c += 1;
+            *rc.entry(x).or_insert(0) += 1;
         }
         RcOp::Drop(x) => {
             let c = rc
@@ -440,6 +494,47 @@ fn interp<'tcx>(
             );
             *rc = rc_t;
         }
+        // The scrutinee is borrowed: a `Var` scrutinee is left untouched here (the
+        // leaves settle it via the held drop / whole-move); a temporary's internals
+        // are interpreted, its anonymous result settled by a leaf `drop-value`.
+        // Each leaf is interpreted from the same entry state and must reconcile to
+        // identical ownership; pattern bindings are leaf-local and dropped from the
+        // join.
+        ExprKind::Match(scrut, tree) => {
+            if !matches!(scrut.kind, ExprKind::Var(_)) {
+                interp(scrut, ot, rr, rc);
+            }
+            let entry = rc.clone();
+            let mut join: Option<FxHashMap<VarId, i32>> = None;
+            for (body, bindings) in collect_leaves(&tree) {
+                let mut rcl = entry.clone();
+                // A moved whole-binding has no op: transfer the scrutinee's
+                // ownership to the bound var so it can be consumed in the body.
+                for &(y, path) in bindings {
+                    if path.is_empty() && uses_var(body, y) {
+                        let dup_established = ot.before(body.id).contains(&RcOp::Dup(y));
+                        if !dup_established {
+                            let taken = match scrut.kind {
+                                ExprKind::Var(s) => rcl.remove(&s).unwrap_or(1),
+                                _ => 1,
+                            };
+                            rcl.insert(y, taken);
+                        }
+                    }
+                }
+                interp(body, ot, rr, &mut rcl);
+                for &(y, _) in bindings {
+                    rcl.remove(&y);
+                }
+                match &join {
+                    None => join = Some(rcl),
+                    Some(j) => assert_eq!(*j, rcl, "match arms differ: {j:?} vs {rcl:?}"),
+                }
+            }
+            if let Some(j) = join {
+                *rc = j;
+            }
+        }
         ExprKind::GlobalStr(_)
         | ExprKind::ConstInt(_)
         | ExprKind::ConstFloat(_)
@@ -452,6 +547,67 @@ fn interp<'tcx>(
     }
     for &op in ot.after(e.id) {
         apply(op, rc);
+    }
+}
+
+/// A match leaf: its body and the variables its patterns bind.
+type LeafView<'tcx> = (&'tcx Expr<'tcx>, &'tcx [(VarId, &'tcx [u32])]);
+
+/// Every `(body, bindings)` leaf reachable in the tree, in source order.
+fn collect_leaves<'tcx>(tree: &DecisionTree<'tcx>) -> Vec<LeafView<'tcx>> {
+    let mut out = Vec::new();
+    fn go<'tcx>(t: &DecisionTree<'tcx>, out: &mut Vec<LeafView<'tcx>>) {
+        match *t {
+            DecisionTree::Uncovered | DecisionTree::Unreachable => {}
+            DecisionTree::Leaf { body, bindings } => out.push((body, bindings)),
+            DecisionTree::Guard { .. } => panic!("checker: match guards are not yet supported"),
+            DecisionTree::Switch { cases, .. } => {
+                for sub in super::subtrees(&cases) {
+                    go(sub, out);
+                }
+            }
+        }
+    }
+    go(tree, &mut out);
+    out
+}
+
+/// Whether `e`'s tree contains a use of variable `y`.
+fn uses_var(e: &Expr<'_>, y: VarId) -> bool {
+    let mut found = false;
+    fn go(e: &Expr<'_>, y: VarId, found: &mut bool) {
+        if *found {
+            return;
+        }
+        if let ExprKind::Var(x) = e.kind
+            && x == y
+        {
+            *found = true;
+            return;
+        }
+        for child in children(e) {
+            go(child, y, found);
+        }
+    }
+    go(e, y, &mut found);
+    found
+}
+
+/// The immediate sub-expressions of `e` (decision-tree arms reached separately).
+fn children<'tcx>(e: &Expr<'tcx>) -> Vec<&'tcx Expr<'tcx>> {
+    use ExprKind::*;
+    match e.kind {
+        GlobalStr(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_) | Poison => vec![],
+        Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],
+        Arith(l, _, r) | Cmp(l, _, r) | Assign(l, _, r) => vec![l, r],
+        If(c, t, e) => vec![c, t, e],
+        Let { value, .. } => vec![value],
+        Seq(es) => es.iter().collect(),
+        Call { args, .. } | Ctor { args, .. } | Variant { args, .. } => args.iter().collect(),
+        NullableCall(opt) => opt.into_iter().collect(),
+        ClosureCall { target, args } => std::iter::once(target).chain(args.iter()).collect(),
+        Closure(c) => vec![c.body],
+        Match(scrut, _) => vec![scrut],
     }
 }
 
@@ -832,6 +988,157 @@ fn discarded_rr_statement_gets_drop_value() {
             ot.after(effect_id),
             &[RcOp::DropValue(effect_id)],
             "discarded Rc result is dropped by value"
+        );
+    });
+}
+
+// ----- increment 3: pattern matching (borrow-dup, Perceus-style) -----
+
+#[test]
+fn match_extracts_field_and_drops_scrutinee() {
+    // fn f(e: E) -> i64 { match e { #0 => 0, #1(x) => use(x) } }
+    //   e dies (returns i64) ⇒ consumed: each arm dups the field it extracts, then
+    //   drops the scrutinee shell (which recursively frees what it didn't extract).
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let e_ty = b.shared(); // the enum, rc-managed
+        let rc = b.shared(); // the payload field type
+        let i64t = b.i64();
+        let e = b.fresh_var();
+        let x = b.fresh_var();
+
+        let body0 = b.const_int(0);
+        let body0_id = body0.id;
+        let leaf0 = b.leaf(body0, vec![]);
+
+        let vx = b.var(x, rc);
+        let use_x = b.call("use", vec![vx], i64t);
+        let body1_id = use_x.id;
+        let leaf1 = b.leaf(use_x, vec![(x, vec![0])]);
+
+        let tree = b.switch_ctor(vec![], vec![leaf0, leaf1]);
+        let scrut = b.var(e, e_ty);
+        let body = b.match_(scrut, tree, i64t);
+
+        let params = vec![b.param(e, e_ty)];
+        let func = b.function("f", params, i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(body0_id),
+            &[RcOp::Drop(e)],
+            "empty arm drops the consumed scrutinee"
+        );
+        assert_eq!(
+            ot.before(body1_id),
+            &[RcOp::Dup(x), RcOp::Drop(e)],
+            "extracting arm dups the field, then drops the scrutinee"
+        );
+    });
+}
+
+#[test]
+fn match_whole_scrutinee_moves() {
+    // fn f(e: E) -> i64 { match e { y => use(y) } }
+    //   binding the whole scrutinee is an identity ⇒ a plain move: no inc, no dec.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let e_ty = b.shared();
+        let i64t = b.i64();
+        let e = b.fresh_var();
+        let y = b.fresh_var();
+
+        let vy = b.var(y, e_ty);
+        let use_y = b.call("use", vec![vy], i64t);
+        let use_y_id = use_y.id;
+        let tree = b.leaf(use_y, vec![(y, vec![])]);
+        let scrut = b.var(e, e_ty);
+        let body = b.match_(scrut, tree, i64t);
+
+        let params = vec![b.param(e, e_ty)];
+        let func = b.function("f", params, i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.get(use_y_id).is_none(),
+            "whole-scrutinee bind is a move: no rc.inc on the root, no rc.dec"
+        );
+    });
+}
+
+#[test]
+fn match_unused_binding_freed_by_scrutinee_drop() {
+    // fn f(e: E) -> i64 { match e { #0 => 0, #1(x) => 0 } }  — x bound but unused.
+    //   No dup for x; the scrutinee drop recursively frees the unextracted field.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let e_ty = b.shared();
+        let i64t = b.i64();
+        let e = b.fresh_var();
+        let x = b.fresh_var();
+
+        let body0 = b.const_int(0);
+        let leaf0 = b.leaf(body0, vec![]);
+        let body1 = b.const_int(0);
+        let body1_id = body1.id;
+        let leaf1 = b.leaf(body1, vec![(x, vec![0])]);
+
+        let tree = b.switch_ctor(vec![], vec![leaf0, leaf1]);
+        let scrut = b.var(e, e_ty);
+        let body = b.match_(scrut, tree, i64t);
+
+        let params = vec![b.param(e, e_ty)];
+        let func = b.function("f", params, i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(body1_id),
+            &[RcOp::Drop(e)],
+            "unused binding gets no dup; only the scrutinee drop"
+        );
+    });
+}
+
+#[test]
+fn match_reconciles_an_outer_var() {
+    // fn f(e: E, w: Rc) -> i64 { match e { #0 => use(w), #1(x) => use2(x) } }
+    //   w (an outer var) is used only in arm #0; arm #1 must drop it.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let e_ty = b.shared();
+        let rc = b.shared();
+        let i64t = b.i64();
+        let e = b.fresh_var();
+        let w = b.fresh_var();
+        let x = b.fresh_var();
+
+        let vw = b.var(w, rc);
+        let use_w = b.call("use", vec![vw], i64t);
+        let body0_id = use_w.id;
+        let leaf0 = b.leaf(use_w, vec![]);
+
+        let vx = b.var(x, rc);
+        let use_x = b.call("use2", vec![vx], i64t);
+        let body1_id = use_x.id;
+        let leaf1 = b.leaf(use_x, vec![(x, vec![0])]);
+
+        let tree = b.switch_ctor(vec![], vec![leaf0, leaf1]);
+        let scrut = b.var(e, e_ty);
+        let body = b.match_(scrut, tree, i64t);
+
+        let params = vec![b.param(e, e_ty), b.param(w, rc)];
+        let func = b.function("f", params, i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(body0_id),
+            &[RcOp::Drop(e)],
+            "arm #0 uses w ⇒ only the scrutinee drop"
+        );
+        assert_eq!(
+            ot.before(body1_id),
+            &[RcOp::Dup(x), RcOp::Drop(e), RcOp::Drop(w)],
+            "arm #1 dups x, drops the scrutinee, and reconciles by dropping w"
         );
     });
 }

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -15,6 +15,7 @@
 //!   annotated tree and asserts every owned RR var settles exactly once.
 
 use lasso::Rodeo;
+use pprint::{Doc, Printer as PpPrinter, hardline, indent, pprint};
 use rustc_hash::FxHashMap;
 
 use super::{Managed, OwnershipTable, RcOp, RecordShape, RecordTable, Rr, analyze_function};
@@ -415,133 +416,134 @@ fn kind_name(kind: &ExprKind<'_>) -> &'static str {
     }
 }
 
+/// Two-space block indentation; block structure is forced with `hardline`, so the
+/// width only bounds how wide an op annotation may run before it wraps.
+const ANNO_PRINTER: PpPrinter = PpPrinter {
+    max_width: 100,
+    indent: 2,
+    use_tabs: false,
+};
+
+/// An owned text [`Doc`] node (the renderer never borrows into a `Doc`).
+fn text(s: impl Into<String>) -> Doc<'static> {
+    Doc::from(s.into())
+}
+
+/// `head` followed by each of `children` on its own line, indented one level.
+fn nest(head: Doc<'static>, children: impl IntoIterator<Item = Doc<'static>>) -> Doc<'static> {
+    let mut inner = Doc::Null;
+    for c in children {
+        inner = inner + hardline() + c;
+    }
+    head + indent(inner)
+}
+
+fn binding_list(bindings: &[mir::Binding<'_>]) -> String {
+    bindings
+        .iter()
+        .map(|(y, p)| format!("v{}@{p:?}", y.0))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Renders the analyzed function as a `pprint` [`Doc`] tree with each node's rc
+/// ops woven onto its own header line.
 struct Renderer<'a> {
-    out: String,
     ot: &'a OwnershipTable,
     syms: &'a Rodeo,
 }
 
 impl Renderer<'_> {
-    fn line(&mut self, indent: usize, s: &str) {
-        for _ in 0..indent {
-            self.out.push_str("  ");
-        }
-        self.out.push_str(s);
-        self.out.push('\n');
-    }
-
-    /// Emit a node's header line with its own rc ops woven inline: `before` ops as
-    /// a `»` prefix, `after` ops as a `«` suffix. Keeping the ops on the node's own
-    /// line (rather than on separate lines that visually float between siblings)
-    /// makes it unambiguous *which* node each op belongs to — e.g. a `dup` on the
-    /// first argument of a call reads as the argument's op, not the call's.
-    fn head(&mut self, indent: usize, id: ExprId, text: &str) {
+    /// Weave a node's rc ops onto its header `Doc`: `before` ops as a `»` prefix,
+    /// `after` ops as a `«` suffix. Keeping them on the node's own line makes it
+    /// unambiguous *which* node each op belongs to — a `dup` on a call's first
+    /// argument reads as the argument's op, not the call's.
+    fn anno(&self, id: ExprId, head: Doc<'static>) -> Doc<'static> {
         let before = self.ot.before(id);
         let after = self.ot.after(id);
-        let prefix = if before.is_empty() {
-            String::new()
-        } else {
-            format!("» {}  ", ops_str(before))
-        };
-        let suffix = if after.is_empty() {
-            String::new()
-        } else {
-            format!("  « {}", ops_str(after))
-        };
-        self.line(indent, &format!("{prefix}{text}{suffix}"));
+        let mut d = head;
+        if !before.is_empty() {
+            d = text(format!("» {}  ", ops_str(before))) + d;
+        }
+        if !after.is_empty() {
+            d = d + text(format!("  « {}", ops_str(after)));
+        }
+        d
     }
 
-    fn expr(&mut self, e: &Expr<'_>, indent: usize) {
+    fn exprs(&self, es: &[Expr<'_>]) -> Vec<Doc<'static>> {
+        es.iter().map(|e| self.expr(e)).collect()
+    }
+
+    fn expr(&self, e: &Expr<'_>) -> Doc<'static> {
         match e.kind {
-            ExprKind::Var(x) => self.head(indent, e.id, &format!("var v{}", x.0)),
-            ExprKind::ConstInt(n) => self.head(indent, e.id, &format!("const {n}")),
-            ExprKind::ConstBool(b) => self.head(indent, e.id, &format!("const {b}")),
-            ExprKind::Let { var, value, .. } => {
-                self.head(indent, e.id, &format!("let v{} =", var.0));
-                self.expr(value, indent + 1);
-            }
-            ExprKind::Seq(es) => {
-                self.head(indent, e.id, "seq");
-                for s in es {
-                    self.expr(s, indent + 1);
-                }
-            }
-            ExprKind::Call { callee, args, .. } => {
-                self.head(
-                    indent,
+            ExprKind::Var(x) => self.anno(e.id, text(format!("var v{}", x.0))),
+            ExprKind::ConstInt(n) => self.anno(e.id, text(format!("const {n}"))),
+            ExprKind::ConstBool(b) => self.anno(e.id, text(format!("const {b}"))),
+            ExprKind::Let { var, value, .. } => nest(
+                self.anno(e.id, text(format!("let v{} =", var.0))),
+                [self.expr(value)],
+            ),
+            ExprKind::Seq(es) => nest(self.anno(e.id, text("seq")), self.exprs(es)),
+            ExprKind::Call { callee, args, .. } => nest(
+                self.anno(
                     e.id,
-                    &format!("call @{}", self.syms.resolve(&callee.0)),
-                );
-                for a in args {
-                    self.expr(a, indent + 1);
-                }
-            }
-            ExprKind::Ctor { record, args } => {
-                self.head(
-                    indent,
+                    text(format!("call @{}", self.syms.resolve(&callee.0))),
+                ),
+                self.exprs(args),
+            ),
+            ExprKind::Ctor { record, args } => nest(
+                self.anno(
                     e.id,
-                    &format!("ctor @{}", self.syms.resolve(&record.0)),
-                );
-                for a in args {
-                    self.expr(a, indent + 1);
-                }
-            }
+                    text(format!("ctor @{}", self.syms.resolve(&record.0))),
+                ),
+                self.exprs(args),
+            ),
             ExprKind::Variant {
                 record,
                 variant,
                 args,
-            } => {
-                self.head(
-                    indent,
+            } => nest(
+                self.anno(
                     e.id,
-                    &format!("variant @{}#{variant}", self.syms.resolve(&record.0)),
-                );
-                for a in args {
-                    self.expr(a, indent + 1);
-                }
-            }
+                    text(format!(
+                        "variant @{}#{variant}",
+                        self.syms.resolve(&record.0)
+                    )),
+                ),
+                self.exprs(args),
+            ),
             ExprKind::NullableCall(opt) => match opt {
-                Some(x) => {
-                    self.head(indent, e.id, "nullable");
-                    self.expr(x, indent + 1);
-                }
-                None => self.head(indent, e.id, "null"),
+                Some(x) => nest(self.anno(e.id, text("nullable")), [self.expr(x)]),
+                None => self.anno(e.id, text("null")),
             },
             ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
-                self.head(indent, e.id, "binop");
-                self.expr(l, indent + 1);
-                self.expr(r, indent + 1);
+                nest(self.anno(e.id, text("binop")), [self.expr(l), self.expr(r)])
             }
             ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => {
-                self.head(indent, e.id, "unop");
-                self.expr(x, indent + 1);
+                nest(self.anno(e.id, text("unop")), [self.expr(x)])
             }
-            ExprKind::If(c, t, e2) => {
-                self.head(indent, e.id, "if");
-                self.expr(c, indent + 1);
-                self.line(indent, "then");
-                self.expr(t, indent + 1);
-                self.line(indent, "else");
-                self.expr(e2, indent + 1);
-            }
-            ExprKind::Match(scrut, tree) => {
-                self.head(indent, e.id, "match");
-                self.expr(scrut, indent + 1);
-                self.tree(&tree, indent + 1);
-            }
-            ExprKind::Proj(base, path) => {
-                self.head(indent, e.id, &format!("proj {path:?}"));
-                self.expr(base, indent + 1);
-            }
-            ExprKind::Assign(dst, field, src) => {
-                self.head(indent, e.id, &format!("assign .{field} :="));
-                self.expr(dst, indent + 1);
-                self.expr(src, indent + 1);
-            }
-            ExprKind::RegionRun(x) => {
-                self.head(indent, e.id, "region-run");
-                self.expr(x, indent + 1);
-            }
+            ExprKind::If(c, t, f) => nest(
+                self.anno(e.id, text("if")),
+                [
+                    self.expr(c),
+                    nest(text("then"), [self.expr(t)]),
+                    nest(text("else"), [self.expr(f)]),
+                ],
+            ),
+            ExprKind::Match(scrut, tree) => nest(
+                self.anno(e.id, text("match")),
+                [self.expr(scrut), self.tree(&tree)],
+            ),
+            ExprKind::Proj(base, path) => nest(
+                self.anno(e.id, text(format!("proj {path:?}"))),
+                [self.expr(base)],
+            ),
+            ExprKind::Assign(dst, field, src) => nest(
+                self.anno(e.id, text(format!("assign .{field} :="))),
+                [self.expr(dst), self.expr(src)],
+            ),
+            ExprKind::RegionRun(x) => nest(self.anno(e.id, text("region-run")), [self.expr(x)]),
             ExprKind::Closure(c) => {
                 let caps = c
                     .captures
@@ -549,87 +551,66 @@ impl Renderer<'_> {
                     .map(|(v, _)| format!("v{}", v.0))
                     .collect::<Vec<_>>()
                     .join(", ");
-                self.head(indent, e.id, &format!("closure [{caps}]"));
-                self.expr(c.body, indent + 1);
+                nest(
+                    self.anno(e.id, text(format!("closure [{caps}]"))),
+                    [self.expr(c.body)],
+                )
             }
             ExprKind::ClosureCall { target, args } => {
-                self.head(indent, e.id, "closure-call");
-                self.expr(target, indent + 1);
-                for a in args {
-                    self.expr(a, indent + 1);
-                }
+                let mut kids = vec![self.expr(target)];
+                kids.extend(self.exprs(args));
+                nest(self.anno(e.id, text("closure-call")), kids)
             }
-            _ => self.head(indent, e.id, &format!("<{}>", kind_name(&e.kind))),
+            _ => self.anno(e.id, text(format!("<{}>", kind_name(&e.kind)))),
         }
     }
 
-    fn tree(&mut self, t: &DecisionTree<'_>, indent: usize) {
+    fn tree(&self, t: &DecisionTree<'_>) -> Doc<'static> {
         match *t {
-            DecisionTree::Uncovered => self.line(indent, "uncovered"),
-            DecisionTree::Unreachable => self.line(indent, "unreachable"),
-            DecisionTree::Leaf { body, bindings } => {
-                let bs = bindings
-                    .iter()
-                    .map(|(y, p)| format!("v{}@{p:?}", y.0))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                self.line(indent, &format!("leaf [{bs}]"));
-                self.expr(body, indent + 1);
-            }
+            DecisionTree::Uncovered => text("uncovered"),
+            DecisionTree::Unreachable => text("unreachable"),
+            DecisionTree::Leaf { body, bindings } => nest(
+                text(format!("leaf [{}]", binding_list(bindings))),
+                [self.expr(body)],
+            ),
+            // `if` / `success` / `failure` are the guard's three parts, each
+            // nested under it (and their contents one level deeper still).
             DecisionTree::Guard {
                 bindings,
                 guard,
                 success,
                 failure,
-            } => {
-                let bs = bindings
-                    .iter()
-                    .map(|(y, p)| format!("v{}@{p:?}", y.0))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                // `if` / `success` / `failure` are the guard's three parts, so
-                // indent them under it (and their contents one deeper still),
-                // rather than leaving them flush with the `guard` line.
-                self.line(indent, &format!("guard [{bs}]"));
-                self.line(indent + 1, "if");
-                self.expr(guard, indent + 2);
-                self.line(indent + 1, "success");
-                self.tree(success, indent + 2);
-                self.line(indent + 1, "failure");
-                self.tree(failure, indent + 2);
-            }
-            DecisionTree::Switch { cases, .. } => {
-                self.line(indent, "switch");
-                for sub in super::subtrees(&cases) {
-                    self.tree(sub, indent + 1);
-                }
-            }
+            } => nest(
+                text(format!("guard [{}]", binding_list(bindings))),
+                [
+                    nest(text("if"), [self.expr(guard)]),
+                    nest(text("success"), [self.tree(success)]),
+                    nest(text("failure"), [self.tree(failure)]),
+                ],
+            ),
+            DecisionTree::Switch { cases, .. } => nest(
+                text("switch"),
+                super::subtrees(&cases).into_iter().map(|s| self.tree(s)),
+            ),
         }
     }
 }
 
 /// Render a function body with its inc/dec ops woven in (`»` before, `«` after).
 fn render(func: &Function<'_>, ot: &OwnershipTable, syms: &Rodeo) -> String {
-    let mut r = Renderer {
-        out: String::new(),
-        ot,
-        syms,
-    };
-    let params: Vec<String> = func
+    let r = Renderer { ot, syms };
+    let params = func
         .params
         .iter()
         .map(|p| format!("v{}", p.var.0))
-        .collect();
-    let header = format!(
-        "fn @{}({}):",
-        syms.resolve(&func.symbol.0),
-        params.join(", ")
-    );
-    r.line(0, &header);
-    if let Some(body) = func.body {
-        r.expr(body, 1);
-    }
-    r.out
+        .collect::<Vec<_>>()
+        .join(", ");
+    let header = text(format!("fn @{}({}):", syms.resolve(&func.symbol.0), params));
+    let doc = match func.body {
+        Some(body) => nest(header, [r.expr(body)]),
+        None => header,
+    };
+    pprint(doc, ANNO_PRINTER)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -438,6 +438,22 @@ fn nest(head: Doc<'static>, children: impl IntoIterator<Item = Doc<'static>>) ->
     head + indent(inner)
 }
 
+/// Like [`nest`], but with a blank line between children — for branch contexts
+/// (switch arms, `if` and guard sections) so each branch stands visually apart.
+fn nest_spaced(
+    head: Doc<'static>,
+    children: impl IntoIterator<Item = Doc<'static>>,
+) -> Doc<'static> {
+    let mut inner = Doc::Null;
+    for (i, c) in children.into_iter().enumerate() {
+        if i > 0 {
+            inner = inner + hardline();
+        }
+        inner = inner + hardline() + c;
+    }
+    head + indent(inner)
+}
+
 fn binding_list(bindings: &[mir::Binding<'_>]) -> String {
     bindings
         .iter()
@@ -523,7 +539,7 @@ impl Renderer<'_> {
             ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => {
                 nest(self.anno(e.id, text("unop")), [self.expr(x)])
             }
-            ExprKind::If(c, t, f) => nest(
+            ExprKind::If(c, t, f) => nest_spaced(
                 self.anno(e.id, text("if")),
                 [
                     self.expr(c),
@@ -580,7 +596,7 @@ impl Renderer<'_> {
                 guard,
                 success,
                 failure,
-            } => nest(
+            } => nest_spaced(
                 text(format!("guard [{}]", binding_list(bindings))),
                 [
                     nest(text("if"), [self.expr(guard)]),
@@ -588,7 +604,7 @@ impl Renderer<'_> {
                     nest(text("failure"), [self.tree(failure)]),
                 ],
             ),
-            DecisionTree::Switch { cases, .. } => nest(
+            DecisionTree::Switch { cases, .. } => nest_spaced(
                 text("switch"),
                 super::subtrees(&cases).into_iter().map(|s| self.tree(s)),
             ),

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -22,7 +22,7 @@ use crate::full::mir::{
     self, ClosureExpr, DecisionTree, Expr, ExprKind, Function, Param, SwitchCases,
 };
 use crate::semi::hir::{ExprId, VarId};
-use crate::semi::ty::{Capability, DefId, IntTy, Ty, TyCtxt};
+use crate::semi::ty::{Flexivity, DefId, IntTy, Ty, TyCtxt};
 use crate::surface::Visibility;
 use crate::with_tcx;
 
@@ -83,7 +83,7 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
     /// A heap, reference-counted `Shared` record (the default `struct`/`enum`).
     fn shared(&mut self) -> Ty<'tcx> {
         let def = self.fresh_def();
-        let ty = self.tcx.mk_record(def, &[], Capability::Irrelevant);
+        let ty = self.tcx.mk_record(def, &[], Flexivity::Irrelevant);
         self.table.insert(
             ty,
             RecordShape {
@@ -97,7 +97,7 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
     /// An inline `Value` record with the given ground field types.
     fn value(&mut self, fields: Vec<Ty<'tcx>>) -> Ty<'tcx> {
         let def = self.fresh_def();
-        let ty = self.tcx.mk_record(def, &[], Capability::Irrelevant);
+        let ty = self.tcx.mk_record(def, &[], Flexivity::Irrelevant);
         self.table.insert(
             ty,
             RecordShape {
@@ -113,7 +113,7 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
     /// returned type keeps its `Regional` value coloring.
     fn regional(&mut self) -> Ty<'tcx> {
         let def = self.fresh_def();
-        let canonical = self.tcx.mk_record(def, &[], Capability::Irrelevant);
+        let canonical = self.tcx.mk_record(def, &[], Flexivity::Irrelevant);
         self.table.insert(
             canonical,
             RecordShape {
@@ -121,7 +121,7 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
                 fields: vec![],
             },
         );
-        self.tcx.mk_record(def, &[], Capability::Regional)
+        self.tcx.mk_record(def, &[], Flexivity::Regional)
     }
 
     // ----- expressions (each stamped with a fresh anchor) -----

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -22,7 +22,7 @@ use crate::full::mir::{
     self, ClosureExpr, DecisionTree, Expr, ExprKind, Function, Param, SwitchCases,
 };
 use crate::semi::hir::{ExprId, VarId};
-use crate::semi::ty::{Flexivity, DefId, IntTy, Ty, TyCtxt};
+use crate::semi::ty::{DefId, Flexivity, IntTy, Ty, TyCtxt};
 use crate::surface::Visibility;
 use crate::with_tcx;
 
@@ -108,10 +108,11 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
         ty
     }
 
-    /// A `[regional]` record. It is rc-managed like a shared record; the table
-    /// (keyed by the canonical `Irrelevant` type) records that, while the
-    /// returned type keeps its `Regional` value coloring.
-    fn regional(&mut self) -> Ty<'tcx> {
+    /// A `[regional]` record at the given flexivity. The table (keyed by the
+    /// canonical `Irrelevant` type) records that it is region-managed; the returned
+    /// type carries the requested regional coloring, which is what decides whether
+    /// a value of it is rc-managed: only `Rigid` (frozen) is.
+    fn regional_colored(&mut self, flex: Flexivity) -> Ty<'tcx> {
         let def = self.fresh_def();
         let canonical = self.tcx.mk_record(def, &[], Flexivity::Irrelevant);
         self.table.insert(
@@ -121,7 +122,19 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
                 fields: vec![],
             },
         );
-        self.tcx.mk_record(def, &[], Flexivity::Regional)
+        self.tcx.mk_record(def, &[], flex)
+    }
+
+    /// A region-local `Flex` regional record — freed with its region, *not*
+    /// rc-managed.
+    fn regional_flex(&mut self) -> Ty<'tcx> {
+        self.regional_colored(Flexivity::Flex)
+    }
+
+    /// A frozen `Rigid` regional record — a managed object that escapes its region,
+    /// so it *is* rc-managed.
+    fn regional_rigid(&mut self) -> Ty<'tcx> {
+        self.regional_colored(Flexivity::Rigid)
     }
 
     // ----- expressions (each stamped with a fresh anchor) -----
@@ -927,15 +940,22 @@ fn is_rr_classification() {
         let val_with_rc = b.value(vec![rc]);
         let i64t = b.i64();
         let val_plain = b.value(vec![i64t]);
-        let reg = b.regional();
+        let reg_flex = b.regional_flex();
+        let reg_rigid = b.regional_rigid();
         let rr = Rr::new(tcx, &b.table);
 
         assert!(rr.is_rr(rc), "shared record is rc");
         assert!(rr.is_rr(val_with_rc), "value record holding an rc is RR");
         assert!(!rr.is_rr(val_plain), "scalar-only value record is not RR");
+        // A regional record is rc-managed only when frozen to `Rigid`; a
+        // region-local `Flex` value is freed with its region and needs no rc.
         assert!(
-            rr.is_rr(reg),
-            "regional record is RR (rc-managed, per table)"
+            !rr.is_rr(reg_flex),
+            "region-local flex value is not rc-managed"
+        );
+        assert!(
+            rr.is_rr(reg_rigid),
+            "frozen rigid value is a managed object ⇒ rc"
         );
         assert!(rr.is_rr(tcx.mk_nullable(rc)), "nullable rc is RR");
         assert!(
@@ -1515,14 +1535,16 @@ fn nested_proj_navigates_to_root() {
 }
 
 #[test]
-fn assign_moves_src_and_borrows_dst() {
+fn assign_moves_src_and_borrows_flex_dst() {
     // fn f(c: Flex, x: Rc) -> i64 { c.0 := x; 0 }
-    //   x is moved into the field; c is borrowed (mutated in place) and, being dead
-    //   after, dropped early at the store; the old field link is freed with c.
+    //   You assign into a `flex` (region-local) record. The shared `x` is moved
+    //   into the field; the flex dst `c` is region-managed — *not* rc — so it is
+    //   borrowed in place with no drop (it is freed with its region, and the
+    //   shared value now in its field is reclaimed by the region's drop glue).
     with_tcx(|tcx| {
         let mut b = MirBuilder::new(tcx);
         let rc = b.shared();
-        let flex = b.regional();
+        let flex = b.regional_flex();
         let i64t = b.i64();
         let c = b.fresh_var();
         let x = b.fresh_var();
@@ -1543,10 +1565,9 @@ fn assign_moves_src_and_borrows_dst() {
             ot.before(vx_id).is_empty(),
             "x moved into the field ⇒ no dup"
         );
-        assert_eq!(
-            ot.after(assign_id),
-            &[RcOp::Drop(c)],
-            "dead borrowed dst dropped after the store; no old-field dec"
+        assert!(
+            ot.get(assign_id).is_none(),
+            "flex dst is region-managed ⇒ no drop on it"
         );
     });
 }
@@ -1572,6 +1593,114 @@ fn region_run_is_transparent() {
 
         assert!(ot.get(body_id).is_none(), "region scope adds no ops");
         assert!(ot.get(vx_id).is_none(), "x moved straight through ⇒ no ops");
+    });
+}
+
+#[test]
+fn frozen_rigid_is_managed_across_a_later_region() {
+    // fn f() -> Pair {
+    //     let frozen = region { seed() };        // region 1, frozen to Rigid
+    //     region {                                // region 2
+    //         let local = mk();                   // a region-2-local Flex value
+    //         cons(local, frozen, frozen)         // frozen reused
+    //     }
+    // }
+    //
+    // The first region produces a value frozen to `Rigid` — a managed (refcounted)
+    // object that outlives the region. Inside the second region it is still
+    // rc-managed: reusing it dup's the earlier occurrence and moves the last. The
+    // second region's own `local` is `Flex` — region-allocated, freed when the
+    // region is torn down — so it takes no rc ops at all, even used as an argument.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rigid = b.regional_rigid();
+        let flex = b.regional_flex();
+        let pair = b.shared();
+        let frozen = b.fresh_var();
+        let local = b.fresh_var();
+
+        // region 1: produce the frozen (rigid) value.
+        let seed = b.call("seed", vec![], rigid);
+        let region1 = b.region(seed, rigid);
+        let let_frozen = b.let_(frozen, region1);
+
+        // region 2: a flex local, then reuse the rigid value twice.
+        let mk = b.call("mk", vec![], flex);
+        let let_local = b.let_(local, mk);
+        let a_local = b.var(local, flex);
+        let a_local_id = a_local.id;
+        let a_frozen0 = b.var(frozen, rigid);
+        let a_frozen0_id = a_frozen0.id;
+        let a_frozen1 = b.var(frozen, rigid);
+        let a_frozen1_id = a_frozen1.id;
+        let cons = b.call("cons", vec![a_local, a_frozen0, a_frozen1], pair);
+        let region2_body = b.seq(vec![let_local, cons], pair);
+        let region2 = b.region(region2_body, pair);
+
+        let body = b.seq(vec![let_frozen, region2], pair);
+        let func = b.function("f", vec![], pair, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.get(a_local_id).is_none(),
+            "region-local flex value takes no rc ops, even as an argument"
+        );
+        assert_eq!(
+            ot.before(a_frozen0_id),
+            &[RcOp::Dup(frozen)],
+            "the frozen rigid value is managed ⇒ dup'd across its reuse"
+        );
+        assert!(
+            ot.before(a_frozen1_id).is_empty(),
+            "the last use of the rigid value is moved"
+        );
+    });
+}
+
+#[test]
+fn flex_record_assembly_still_incs_its_rigid_field() {
+    // fn f(r: Rigid) -> Pair {
+    //     let rec = FlexRec { r };   // assemble a region-local flex record from r
+    //     use2(rec, r)               // r is needed again ⇒ the assembly dup's it
+    // }
+    //
+    // The flex record `rec` is region-managed and takes no rc ops of its own — but
+    // the *rigid* (managed) field it is assembled from is an ordinary RR value.
+    // Because r stays live past the constructor, storing it into the field dup's
+    // it; the later use is then the move. Container-unmanaged is not
+    // field-unmanaged.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rigid = b.regional_rigid();
+        let flex = b.regional_flex();
+        let pair = b.shared();
+        let r = b.fresh_var();
+        let rec = b.fresh_var();
+
+        let field_r = b.var(r, rigid);
+        let field_r_id = field_r.id;
+        let ctor = b.ctor("FlexRec", vec![field_r], flex);
+        let let_rec = b.let_(rec, ctor);
+
+        let a_rec = b.var(rec, flex);
+        let a_r = b.var(r, rigid);
+        let a_r_id = a_r.id;
+        let use2 = b.call("use2", vec![a_rec, a_r], pair);
+        let body = b.seq(vec![let_rec, use2], pair);
+
+        let param = b.param(r, rigid);
+        let func = b.function("f", vec![param], pair, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(field_r_id),
+            &[RcOp::Dup(r)],
+            "storing the still-live rigid value into the flex field dup's it"
+        );
+        assert!(
+            ot.before(a_r_id).is_empty(),
+            "the later use of r is its last ⇒ moved"
+        );
     });
 }
 

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -1,0 +1,655 @@
+//! Test harness for the ownership analysis.
+//!
+//! The analysis is a pure `(&Function, &RecordTable) → OwnershipTable`, so it is
+//! exercised without any MLIR or runtime. Three pieces, mirroring
+//! `docs/ownership-analysis.md` §9:
+//!
+//! * [`MirBuilder`] — constructs `mir::Function`s directly in the arena, sharing
+//!   the production [`mir::ExprIdGen`] anchor stamping and using **real interned
+//!   types** so [`Rr::is_rr`] is tested for real, not stubbed.
+//! * [`render`] — an annotated pretty-printer that weaves each emitted
+//!   `dup`/`drop` into the tree. Every corpus test prints its rendering (captured
+//!   by `cargo test`; pass `--nocapture` to watch them), so the placement is
+//!   eyeball-checkable as well as asserted.
+//! * [`check_balanced`] — a generic safety net that abstractly interprets the
+//!   annotated tree and asserts every owned RR var settles exactly once.
+
+use lasso::Rodeo;
+use rustc_hash::FxHashMap;
+
+use super::{Managed, OwnershipTable, RcOp, RecordShape, RecordTable, Rr, analyze_function};
+use crate::full::mir::{self, Expr, ExprKind, Function, Param};
+use crate::semi::hir::VarId;
+use crate::semi::ty::{Capability, DefId, IntTy, Ty, TyCtxt};
+use crate::surface::Visibility;
+use crate::with_tcx;
+
+use reussir_syntax::kind::{InternKey, TokenKey};
+
+/// A name token whose text is irrelevant to the analysis (it keys on `VarId` /
+/// `Symbol`, never source names).
+fn dummy_tok() -> TokenKey {
+    TokenKey::try_from_u32(0).expect("token key")
+}
+
+/// Builds ground `mir::Function`s and their backing [`RecordTable`] in an arena.
+struct MirBuilder<'a, 'tcx> {
+    tcx: &'a TyCtxt<'tcx>,
+    ids: mir::ExprIdGen,
+    next_var: u32,
+    next_def: u32,
+    symbols: Rodeo,
+    table: RecordTable<'tcx>,
+}
+
+impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
+    fn new(tcx: &'a TyCtxt<'tcx>) -> Self {
+        MirBuilder {
+            tcx,
+            ids: mir::ExprIdGen::default(),
+            next_var: 0,
+            next_def: 0,
+            symbols: Rodeo::default(),
+            table: RecordTable::new(),
+        }
+    }
+
+    // ----- ids, vars, symbols -----
+
+    fn fresh_var(&mut self) -> VarId {
+        let v = VarId(self.next_var);
+        self.next_var += 1;
+        v
+    }
+
+    fn sym(&mut self, name: &str) -> mir::Symbol {
+        mir::Symbol(self.symbols.get_or_intern(name))
+    }
+
+    fn fresh_def(&mut self) -> DefId {
+        let d = DefId(self.next_def);
+        self.next_def += 1;
+        d
+    }
+
+    // ----- types (real, interned) -----
+
+    fn i64(&self) -> Ty<'tcx> {
+        self.tcx.mk_int(IntTy::Signed(64))
+    }
+
+    /// A heap, reference-counted `Shared` record (the default `struct`/`enum`).
+    fn shared(&mut self) -> Ty<'tcx> {
+        let def = self.fresh_def();
+        let ty = self.tcx.mk_record(def, &[], Capability::Irrelevant);
+        self.table.insert(
+            ty,
+            RecordShape {
+                managed: Managed::Shared,
+                fields: vec![],
+            },
+        );
+        ty
+    }
+
+    /// An inline `Value` record with the given ground field types.
+    fn value(&mut self, fields: Vec<Ty<'tcx>>) -> Ty<'tcx> {
+        let def = self.fresh_def();
+        let ty = self.tcx.mk_record(def, &[], Capability::Irrelevant);
+        self.table.insert(
+            ty,
+            RecordShape {
+                managed: Managed::Value,
+                fields,
+            },
+        );
+        ty
+    }
+
+    /// A `[regional]` record. It is rc-managed like a shared record; the table
+    /// (keyed by the canonical `Irrelevant` type) records that, while the
+    /// returned type keeps its `Regional` value coloring.
+    fn regional(&mut self) -> Ty<'tcx> {
+        let def = self.fresh_def();
+        let canonical = self.tcx.mk_record(def, &[], Capability::Irrelevant);
+        self.table.insert(
+            canonical,
+            RecordShape {
+                managed: Managed::Regional,
+                fields: vec![],
+            },
+        );
+        self.tcx.mk_record(def, &[], Capability::Regional)
+    }
+
+    // ----- expressions (each stamped with a fresh anchor) -----
+
+    fn mk(&mut self, kind: ExprKind<'tcx>, ty: Ty<'tcx>) -> Expr<'tcx> {
+        Expr {
+            id: self.ids.fresh(),
+            kind,
+            ty,
+            span: None,
+        }
+    }
+
+    fn var(&mut self, v: VarId, ty: Ty<'tcx>) -> Expr<'tcx> {
+        self.mk(ExprKind::Var(v), ty)
+    }
+
+    fn const_int(&mut self, n: i128) -> Expr<'tcx> {
+        let ty = self.i64();
+        self.mk(ExprKind::ConstInt(n), ty)
+    }
+
+    /// `let v = value;` (a Seq statement; its own result type is unit).
+    fn let_(&mut self, v: VarId, value: Expr<'tcx>) -> Expr<'tcx> {
+        let value = self.tcx.alloc(value);
+        let unit = self.tcx.mk_unit();
+        self.mk(
+            ExprKind::Let {
+                var: v,
+                name: dummy_tok(),
+                value,
+            },
+            unit,
+        )
+    }
+
+    fn seq(&mut self, items: Vec<Expr<'tcx>>, ty: Ty<'tcx>) -> Expr<'tcx> {
+        let items = self.tcx.alloc_slice(&items);
+        self.mk(ExprKind::Seq(items), ty)
+    }
+
+    fn call(&mut self, callee: &str, args: Vec<Expr<'tcx>>, ret: Ty<'tcx>) -> Expr<'tcx> {
+        let callee = self.sym(callee);
+        let args = self.tcx.alloc_slice(&args);
+        self.mk(
+            ExprKind::Call {
+                callee,
+                args,
+                regional: false,
+            },
+            ret,
+        )
+    }
+
+    fn ctor(&mut self, record: &str, args: Vec<Expr<'tcx>>, ty: Ty<'tcx>) -> Expr<'tcx> {
+        let record = self.sym(record);
+        let args = self.tcx.alloc_slice(&args);
+        self.mk(ExprKind::Ctor { record, args }, ty)
+    }
+
+    fn param(&mut self, v: VarId, ty: Ty<'tcx>) -> Param<'tcx> {
+        Param {
+            name: dummy_tok(),
+            var: v,
+            ty,
+        }
+    }
+
+    fn function(
+        &mut self,
+        name: &str,
+        params: Vec<Param<'tcx>>,
+        ret: Ty<'tcx>,
+        body: Expr<'tcx>,
+    ) -> Function<'tcx> {
+        let symbol = self.sym(name);
+        let body = self.tcx.alloc(body);
+        Function {
+            symbol,
+            visibility: Visibility::Private,
+            is_regional: false,
+            params,
+            return_ty: ret,
+            body: Some(body),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Annotated rendering
+// ---------------------------------------------------------------------------
+
+fn ops_str(ops: &[RcOp]) -> String {
+    ops.iter()
+        .map(|op| match op {
+            RcOp::Dup(v) => format!("dup v{}", v.0),
+            RcOp::Drop(v) => format!("drop v{}", v.0),
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+struct Renderer<'a> {
+    out: String,
+    ot: &'a OwnershipTable,
+    syms: &'a Rodeo,
+}
+
+impl Renderer<'_> {
+    fn line(&mut self, indent: usize, s: &str) {
+        for _ in 0..indent {
+            self.out.push_str("  ");
+        }
+        self.out.push_str(s);
+        self.out.push('\n');
+    }
+
+    fn expr(&mut self, e: &Expr<'_>, indent: usize) {
+        let before = self.ot.before(e.id);
+        if !before.is_empty() {
+            self.line(indent, &format!("» {}", ops_str(before)));
+        }
+        match e.kind {
+            ExprKind::Var(x) => self.line(indent, &format!("var v{}", x.0)),
+            ExprKind::ConstInt(n) => self.line(indent, &format!("const {n}")),
+            ExprKind::ConstBool(b) => self.line(indent, &format!("const {b}")),
+            ExprKind::Let { var, value, .. } => {
+                self.line(indent, &format!("let v{} =", var.0));
+                self.expr(value, indent + 1);
+            }
+            ExprKind::Seq(es) => {
+                self.line(indent, "seq");
+                for s in es {
+                    self.expr(s, indent + 1);
+                }
+            }
+            ExprKind::Call { callee, args, .. } => {
+                self.line(indent, &format!("call @{}", self.syms.resolve(&callee.0)));
+                for a in args {
+                    self.expr(a, indent + 1);
+                }
+            }
+            ExprKind::Ctor { record, args } => {
+                self.line(indent, &format!("ctor @{}", self.syms.resolve(&record.0)));
+                for a in args {
+                    self.expr(a, indent + 1);
+                }
+            }
+            ExprKind::Variant {
+                record,
+                variant,
+                args,
+            } => {
+                self.line(
+                    indent,
+                    &format!("variant @{}#{variant}", self.syms.resolve(&record.0)),
+                );
+                for a in args {
+                    self.expr(a, indent + 1);
+                }
+            }
+            ExprKind::NullableCall(opt) => match opt {
+                Some(x) => {
+                    self.line(indent, "nullable");
+                    self.expr(x, indent + 1);
+                }
+                None => self.line(indent, "null"),
+            },
+            ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
+                self.line(indent, "binop");
+                self.expr(l, indent + 1);
+                self.expr(r, indent + 1);
+            }
+            ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => {
+                self.line(indent, "unop");
+                self.expr(x, indent + 1);
+            }
+            _ => self.line(indent, &format!("<{}>", super::kind_name(&e.kind))),
+        }
+        let after = self.ot.after(e.id);
+        if !after.is_empty() {
+            self.line(indent, &format!("« {}", ops_str(after)));
+        }
+    }
+}
+
+/// Render a function body with its inc/dec ops woven in (`»` before, `«` after).
+fn render(func: &Function<'_>, ot: &OwnershipTable, syms: &Rodeo) -> String {
+    let mut r = Renderer {
+        out: String::new(),
+        ot,
+        syms,
+    };
+    let params: Vec<String> = func
+        .params
+        .iter()
+        .map(|p| format!("v{}", p.var.0))
+        .collect();
+    let header = format!(
+        "fn @{}({}):",
+        syms.resolve(&func.symbol.0),
+        params.join(", ")
+    );
+    r.line(0, &header);
+    if let Some(body) = func.body {
+        r.expr(body, 1);
+    }
+    r.out
+}
+
+// ---------------------------------------------------------------------------
+// Balanced-rc safety net
+// ---------------------------------------------------------------------------
+
+fn apply(op: RcOp, rc: &mut FxHashMap<VarId, i32>) {
+    match op {
+        RcOp::Dup(x) => {
+            let c = rc
+                .get_mut(&x)
+                .unwrap_or_else(|| panic!("dup of unowned v{}", x.0));
+            assert!(*c >= 1, "dup of settled v{} (rc {c})", x.0);
+            *c += 1;
+        }
+        RcOp::Drop(x) => {
+            let c = rc
+                .get_mut(&x)
+                .unwrap_or_else(|| panic!("drop of unowned v{}", x.0));
+            assert!(*c >= 1, "drop of settled v{} (rc {c})", x.0);
+            *c -= 1;
+        }
+    }
+}
+
+/// Abstractly interpret `e` in evaluation order, applying the surrounding ops and
+/// charging each consuming RR use one owned reference.
+fn interp<'tcx>(
+    e: &Expr<'tcx>,
+    ot: &OwnershipTable,
+    rr: &Rr<'_, 'tcx>,
+    rc: &mut FxHashMap<VarId, i32>,
+) {
+    for &op in ot.before(e.id) {
+        apply(op, rc);
+    }
+    match e.kind {
+        ExprKind::Var(x) => {
+            if rr.is_rr(e.ty) {
+                let c = rc
+                    .get_mut(&x)
+                    .unwrap_or_else(|| panic!("use of unowned v{}", x.0));
+                assert!(*c >= 1, "consuming settled v{} (rc {c})", x.0);
+                *c -= 1;
+            }
+        }
+        ExprKind::Let { var, value, .. } => {
+            interp(value, ot, rr, rc);
+            if rr.is_rr(value.ty) {
+                rc.insert(var, 1);
+            }
+        }
+        ExprKind::Seq(es) => {
+            for s in es {
+                interp(s, ot, rr, rc);
+            }
+        }
+        ExprKind::Call { args, .. }
+        | ExprKind::Ctor { args, .. }
+        | ExprKind::Variant { args, .. } => {
+            for a in args {
+                interp(a, ot, rr, rc);
+            }
+        }
+        ExprKind::NullableCall(opt) => {
+            if let Some(x) = opt {
+                interp(x, ot, rr, rc);
+            }
+        }
+        ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => interp(x, ot, rr, rc),
+        ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
+            interp(l, ot, rr, rc);
+            interp(r, ot, rr, rc);
+        }
+        ExprKind::GlobalStr(_)
+        | ExprKind::ConstInt(_)
+        | ExprKind::ConstFloat(_)
+        | ExprKind::ConstBool(_)
+        | ExprKind::Poison => {}
+        _ => panic!(
+            "checker: unexpected deferred form {}",
+            super::kind_name(&e.kind)
+        ),
+    }
+    for &op in ot.after(e.id) {
+        apply(op, rc);
+    }
+}
+
+/// Every owned RR var must reach a settled state (rc 0) exactly once: nothing is
+/// left live at return except the moved-out result (which the checker does not
+/// track, as it is the caller's to own).
+fn check_balanced<'tcx>(func: &Function<'tcx>, ot: &OwnershipTable, rr: &Rr<'_, 'tcx>) {
+    let mut rc: FxHashMap<VarId, i32> = FxHashMap::default();
+    for p in &func.params {
+        if rr.is_rr(p.ty) {
+            rc.insert(p.var, 1);
+        }
+    }
+    if let Some(body) = func.body {
+        interp(body, ot, rr, &mut rc);
+    }
+    for (v, c) in &rc {
+        assert_eq!(*c, 0, "v{} left unsettled (rc {c})", v.0);
+    }
+}
+
+/// Analyze, print the annotated rendering (for examination), and run the
+/// balanced-rc safety net. Returns the table for pinpoint probes.
+fn run<'tcx>(
+    tcx: &TyCtxt<'tcx>,
+    func: &Function<'tcx>,
+    builder: &MirBuilder<'_, 'tcx>,
+) -> OwnershipTable {
+    let ot = analyze_function(tcx, func, &builder.table);
+    println!("{}", render(func, &ot, &builder.symbols));
+    let rr = Rr::new(tcx, &builder.table);
+    check_balanced(func, &ot, &rr);
+    ot
+}
+
+// ---------------------------------------------------------------------------
+// Corpus
+// ---------------------------------------------------------------------------
+
+#[test]
+fn is_rr_classification() {
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let val_with_rc = b.value(vec![rc]);
+        let i64t = b.i64();
+        let val_plain = b.value(vec![i64t]);
+        let reg = b.regional();
+        let rr = Rr::new(tcx, &b.table);
+
+        assert!(rr.is_rr(rc), "shared record is rc");
+        assert!(rr.is_rr(val_with_rc), "value record holding an rc is RR");
+        assert!(!rr.is_rr(val_plain), "scalar-only value record is not RR");
+        assert!(
+            rr.is_rr(reg),
+            "regional record is RR (rc-managed, per table)"
+        );
+        assert!(rr.is_rr(tcx.mk_nullable(rc)), "nullable rc is RR");
+        assert!(
+            !rr.is_rr(tcx.mk_nullable(i64t)),
+            "nullable scalar is not RR"
+        );
+        assert!(!rr.is_rr(i64t), "scalar is not RR");
+    });
+}
+
+#[test]
+fn case1_dead_let_is_dropped_after_binding() {
+    // fn f(x: Rc) -> i64 { let y = wrap(x); 0 }
+    //   x: last use, moved into `wrap`; y: bound but unused ⇒ drop after the let.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let x = b.fresh_var();
+        let y = b.fresh_var();
+
+        let use_x = b.var(x, rc);
+        let value = b.call("wrap", vec![use_x], rc);
+        let let_stmt = b.let_(y, value);
+        let let_id = let_stmt.id;
+        let zero = b.const_int(0);
+        let i64t = b.i64();
+        let body = b.seq(vec![let_stmt, zero], i64t);
+
+        let p = b.param(x, rc);
+        let func = b.function("f", vec![p], i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.after(let_id),
+            &[RcOp::Drop(y)],
+            "y dropped right after binding"
+        );
+        assert!(
+            ot.before(use_x.id).is_empty(),
+            "x is a last use ⇒ moved, no dup"
+        );
+    });
+}
+
+#[test]
+fn case2_two_uses_dup_all_but_last() {
+    // fn f(x: Rc) -> Pair { mk(x, x) }
+    //   first x is live across the second ⇒ dup; second x is the last use ⇒ move.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let pair = b.value(vec![rc, rc]);
+        let x = b.fresh_var();
+
+        let a0 = b.var(x, rc);
+        let a1 = b.var(x, rc);
+        let (a0_id, a1_id) = (a0.id, a1.id);
+        let body = b.call("mk", vec![a0, a1], pair);
+
+        let p = b.param(x, rc);
+        let func = b.function("f", vec![p], pair, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(ot.before(a0_id), &[RcOp::Dup(x)], "first occurrence dup'd");
+        assert!(ot.before(a1_id).is_empty(), "last occurrence moved");
+    });
+}
+
+#[test]
+fn case5_returned_var_is_moved() {
+    // fn f(x: Rc) -> Rc { x }  — moved to the caller, no dup and no drop.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let x = b.fresh_var();
+        let body = b.var(x, rc);
+        let body_id = body.id;
+
+        let p = b.param(x, rc);
+        let func = b.function("f", vec![p], rc, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(ot.get(body_id).is_none(), "returned var: no ops at all");
+    });
+}
+
+#[test]
+fn case6_transitive_value_record_is_dropped() {
+    // A value record transitively holding an rc is RR.
+    // fn f(v: Box) -> i64 { 0 }  — v unused ⇒ dropped on entry.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let boxed = b.value(vec![rc]); // Box { inner: Rc }
+        let v = b.fresh_var();
+
+        let body = b.const_int(0);
+        let body_id = body.id;
+        let i64t = b.i64();
+        let p = b.param(v, boxed);
+        let func = b.function("f", vec![p], i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(body_id),
+            &[RcOp::Drop(v)],
+            "unused transitively-rc value record dropped on entry"
+        );
+    });
+}
+
+#[test]
+fn case7_unused_param_dropped_on_entry() {
+    // fn f(x: Rc, n: i64) -> i64 { n }  — x never used ⇒ dropped on entry; n scalar.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let i64t = b.i64();
+        let x = b.fresh_var();
+        let n = b.fresh_var();
+
+        let body = b.var(n, i64t);
+        let body_id = body.id;
+        let params = vec![b.param(x, rc), b.param(n, i64t)];
+        let func = b.function("f", params, i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(body_id),
+            &[RcOp::Drop(x)],
+            "unused rc param dropped on entry"
+        );
+    });
+}
+
+#[test]
+fn ctor_consumes_its_rr_field() {
+    // fn f(x: Rc) -> Box { Box { inner: x } }  — x's last use is moved into the
+    // constructor; the resulting (transitively-rc) value record is moved out.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let boxed = b.value(vec![rc]);
+        let x = b.fresh_var();
+
+        let arg = b.var(x, rc);
+        let body = b.ctor("Box", vec![arg], boxed);
+
+        let params = vec![b.param(x, rc)];
+        let func = b.function("f", params, boxed, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.before(arg.id).is_empty(),
+            "x moved into the ctor ⇒ no dup"
+        );
+        assert!(ot.after(arg.id).is_empty(), "no stray drop");
+    });
+}
+
+#[test]
+fn chained_moves_need_no_rc_ops() {
+    // fn f(x: Rc) -> Rc { let y = x; y }  — x moved into y, y moved out. No ops.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let x = b.fresh_var();
+        let y = b.fresh_var();
+
+        let xval = b.var(x, rc);
+        let let_stmt = b.let_(y, xval);
+        let let_id = let_stmt.id;
+        let yval = b.var(y, rc);
+        let body = b.seq(vec![let_stmt, yval], rc);
+
+        let params = vec![b.param(x, rc)];
+        let func = b.function("f", params, rc, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(ot.get(let_id).is_none(), "y is moved out ⇒ no drop");
+        assert!(ot.before(xval.id).is_empty(), "x moved into y ⇒ no dup");
+    });
+}

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -1467,6 +1467,108 @@ fn match_reconciles_an_outer_var() {
     });
 }
 
+#[test]
+fn match_handles_outer_vars_unused_used_and_across() {
+    // fn f(e: E, p: Rc, q: Rc, u: Rc) -> Rc {
+    //     let r = match e { #0 => use0(p, q), #1(x) => use1(p, x) };
+    //     tail(q, r)
+    // }
+    //   Three non-scrutinee RR values, three different fates, all in one match:
+    //     p — used in BOTH arms, dead after → moved in each arm (no dup, no drop).
+    //     q — used in arm #0 AND after the match → live *across*: dup'd at its
+    //         in-arm use, never reconcile-dropped in the arm that skips it, and
+    //         moved at the post-match use.
+    //     u — used nowhere → dead: dropped once on entry (Param-Unused).
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let e_ty = b.shared(); // the enum scrutinee, rc-managed
+        let rc = b.shared(); // the outer values / payload field
+        let e = b.fresh_var();
+        let p = b.fresh_var();
+        let q = b.fresh_var();
+        let u = b.fresh_var();
+        let x = b.fresh_var();
+        let r = b.fresh_var();
+
+        // arm #0: use0(p, q)
+        let vp0 = b.var(p, rc);
+        let vq0 = b.var(q, rc);
+        let (vp0_id, vq0_id) = (vp0.id, vq0.id);
+        let use0 = b.call("use0", vec![vp0, vq0], rc);
+        let body0_id = use0.id;
+        let leaf0 = b.leaf(use0, vec![]);
+
+        // arm #1: use1(p, x), where x is field 0 of the scrutinee
+        let vp1 = b.var(p, rc);
+        let vx = b.var(x, rc);
+        let vp1_id = vp1.id;
+        let use1 = b.call("use1", vec![vp1, vx], rc);
+        let body1_id = use1.id;
+        let leaf1 = b.leaf(use1, vec![(x, vec![0])]);
+
+        let tree = b.switch_ctor(vec![], vec![leaf0, leaf1]);
+        let scrut = b.var(e, e_ty);
+        let matched = b.match_(scrut, tree, rc);
+        let let_r = b.let_(r, matched);
+
+        // tail(q, r): q is used again after the match; r is the match result.
+        let vq_tail = b.var(q, rc);
+        let vq_tail_id = vq_tail.id;
+        let vr = b.var(r, rc);
+        let tail = b.call("tail", vec![vq_tail, vr], rc);
+
+        let body = b.seq(vec![let_r, tail], rc);
+        let body_id = body.id;
+
+        let params = vec![
+            b.param(e, e_ty),
+            b.param(p, rc),
+            b.param(q, rc),
+            b.param(u, rc),
+        ];
+        let func = b.function("f", params, rc, body);
+        let ot = run(tcx, &func, &b);
+
+        // u — wholly unused ⇒ dropped once on entry, at the body root.
+        assert_eq!(
+            ot.before(body_id),
+            &[RcOp::Drop(u)],
+            "the wholly-unused outer var is dropped once on entry"
+        );
+
+        // arm #0 uses both p and q; q is live across, so the leaf carries only the
+        // consumed scrutinee's drop — no reconcile drop of q.
+        assert_eq!(
+            ot.before(body0_id),
+            &[RcOp::Drop(e)],
+            "arm #0: only the scrutinee drop — q is live across, never reconcile-dropped"
+        );
+        // q is used in the arm yet live after the match ⇒ dup at its occurrence.
+        assert_eq!(
+            ot.before(vq0_id),
+            &[RcOp::Dup(q)],
+            "q used in-arm but live across ⇒ dup'd to keep it past the match"
+        );
+        // p is dead after the match and this is its last use here ⇒ moved.
+        assert!(ot.before(vp0_id).is_empty(), "p moved in arm #0 (last use)");
+
+        // arm #1: extract the field then drop the scrutinee; q is NOT dropped here
+        // (still live across) and p is moved.
+        assert_eq!(
+            ot.before(body1_id),
+            &[RcOp::Dup(x), RcOp::Drop(e)],
+            "arm #1: field dup + scrutinee drop; the live-across q is not dropped"
+        );
+        assert!(ot.before(vp1_id).is_empty(), "p moved in arm #1 (last use)");
+
+        // After the match, q's final use is its last ⇒ a plain move.
+        assert!(
+            ot.before(vq_tail_id).is_empty(),
+            "q's post-match use is its last ⇒ moved, no dup"
+        );
+    });
+}
+
 // ----- containers (Proj / Assign) -----
 
 #[test]

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -18,8 +18,10 @@ use lasso::Rodeo;
 use rustc_hash::FxHashMap;
 
 use super::{Managed, OwnershipTable, RcOp, RecordShape, RecordTable, Rr, analyze_function};
-use crate::full::mir::{self, DecisionTree, Expr, ExprKind, Function, Param, SwitchCases};
-use crate::semi::hir::VarId;
+use crate::full::mir::{
+    self, ClosureExpr, DecisionTree, Expr, ExprKind, Function, Param, SwitchCases,
+};
+use crate::semi::hir::{ExprId, VarId};
 use crate::semi::ty::{Capability, DefId, IntTy, Ty, TyCtxt};
 use crate::surface::Visibility;
 use crate::with_tcx;
@@ -192,6 +194,26 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
         self.mk(ExprKind::Ctor { record, args }, ty)
     }
 
+    /// An enum variant constructor (`record#variant(args)`).
+    fn variant(
+        &mut self,
+        record: &str,
+        variant: usize,
+        args: Vec<Expr<'tcx>>,
+        ty: Ty<'tcx>,
+    ) -> Expr<'tcx> {
+        let record = self.sym(record);
+        let args = self.tcx.alloc_slice(&args);
+        self.mk(
+            ExprKind::Variant {
+                record,
+                variant,
+                args,
+            },
+            ty,
+        )
+    }
+
     // ----- decision trees -----
 
     fn leaf(&self, body: Expr<'tcx>, bindings: Vec<(VarId, Vec<u32>)>) -> DecisionTree<'tcx> {
@@ -217,6 +239,92 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
     fn match_(&mut self, scrut: Expr<'tcx>, tree: DecisionTree<'tcx>, ty: Ty<'tcx>) -> Expr<'tcx> {
         let scrut = self.tcx.alloc(scrut);
         self.mk(ExprKind::Match(scrut, tree), ty)
+    }
+
+    // ----- containers / regions / closures -----
+
+    /// A nested field projection `base.<path>`, yielding a value of type `ty`.
+    fn proj(&mut self, base: Expr<'tcx>, path: Vec<u32>, ty: Ty<'tcx>) -> Expr<'tcx> {
+        let base = self.tcx.alloc(base);
+        let path = self.tcx.alloc_slice(&path);
+        self.mk(ExprKind::Proj(base, path), ty)
+    }
+
+    /// `dst->field := src` (result type unit).
+    fn assign(&mut self, dst: Expr<'tcx>, field: u32, src: Expr<'tcx>) -> Expr<'tcx> {
+        let dst = self.tcx.alloc(dst);
+        let src = self.tcx.alloc(src);
+        let unit = self.tcx.mk_unit();
+        self.mk(ExprKind::Assign(dst, field, src), unit)
+    }
+
+    /// A `region-run { body }` scope; its result is moved out as `ty`.
+    fn region(&mut self, body: Expr<'tcx>, ty: Ty<'tcx>) -> Expr<'tcx> {
+        let body = self.tcx.alloc(body);
+        self.mk(ExprKind::RegionRun(body), ty)
+    }
+
+    /// A closure value capturing `captures` and taking `params`, with the given
+    /// closure `ty` (build it with [`closure_ty`](Self::closure_ty)).
+    fn closure(
+        &mut self,
+        captures: Vec<(VarId, Ty<'tcx>)>,
+        params: Vec<(VarId, Ty<'tcx>)>,
+        body: Expr<'tcx>,
+        ty: Ty<'tcx>,
+    ) -> Expr<'tcx> {
+        let captures = self.tcx.alloc_slice(&captures);
+        let params = self.tcx.alloc_slice(&params);
+        let body = self.tcx.alloc(body);
+        self.mk(
+            ExprKind::Closure(ClosureExpr {
+                captures,
+                params,
+                body,
+            }),
+            ty,
+        )
+    }
+
+    fn closure_ty(&self, params: &[Ty<'tcx>], ret: Ty<'tcx>) -> Ty<'tcx> {
+        self.tcx.mk_closure(params, ret)
+    }
+
+    /// `target(args)` — an indirect call through a closure value.
+    fn closure_call(
+        &mut self,
+        target: Expr<'tcx>,
+        args: Vec<Expr<'tcx>>,
+        ty: Ty<'tcx>,
+    ) -> Expr<'tcx> {
+        let target = self.tcx.alloc(target);
+        let args = self.tcx.alloc_slice(&args);
+        self.mk(ExprKind::ClosureCall { target, args }, ty)
+    }
+
+    /// A guarded decision node: bind `bindings`, test `guard`; take `success` if it
+    /// holds, else `failure`.
+    fn guard(
+        &self,
+        bindings: Vec<(VarId, Vec<u32>)>,
+        guard: Expr<'tcx>,
+        success: DecisionTree<'tcx>,
+        failure: DecisionTree<'tcx>,
+    ) -> DecisionTree<'tcx> {
+        let bs: Vec<(VarId, &'tcx [u32])> = bindings
+            .iter()
+            .map(|(y, p)| (*y, self.tcx.alloc_slice(p)))
+            .collect();
+        let bindings = self.tcx.alloc_slice(&bs);
+        let guard = self.tcx.alloc(guard);
+        let success = self.tcx.alloc(success);
+        let failure = self.tcx.alloc(failure);
+        DecisionTree::Guard {
+            bindings,
+            guard,
+            success,
+            failure,
+        }
     }
 
     fn param(&mut self, v: VarId, ty: Ty<'tcx>) -> Param<'tcx> {
@@ -257,9 +365,41 @@ fn ops_str(ops: &[RcOp]) -> String {
             RcOp::Dup(v) => format!("dup v{}", v.0),
             RcOp::Drop(v) => format!("drop v{}", v.0),
             RcOp::DropValue(id) => format!("drop-value #{}", id.0),
+            RcOp::DupValue(id) => format!("dup-value #{}", id.0),
         })
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// A short name for an [`ExprKind`], for the renderer's fallback line (the kinds
+/// without a dedicated arm: `GlobalStr` / `ConstFloat` / `Poison`).
+fn kind_name(kind: &ExprKind<'_>) -> &'static str {
+    match kind {
+        ExprKind::GlobalStr(_) => "GlobalStr",
+        ExprKind::ConstInt(_) => "ConstInt",
+        ExprKind::ConstFloat(_) => "ConstFloat",
+        ExprKind::ConstBool(_) => "ConstBool",
+        ExprKind::Var(_) => "Var",
+        ExprKind::Negate(_) => "Negate",
+        ExprKind::Not(_) => "Not",
+        ExprKind::Arith(..) => "Arith",
+        ExprKind::Cmp(..) => "Cmp",
+        ExprKind::Cast(..) => "Cast",
+        ExprKind::If(..) => "If",
+        ExprKind::RegionRun(_) => "RegionRun",
+        ExprKind::Proj(..) => "Proj",
+        ExprKind::Assign(..) => "Assign",
+        ExprKind::Let { .. } => "Let",
+        ExprKind::Seq(_) => "Seq",
+        ExprKind::Call { .. } => "Call",
+        ExprKind::Ctor { .. } => "Ctor",
+        ExprKind::Variant { .. } => "Variant",
+        ExprKind::NullableCall(_) => "NullableCall",
+        ExprKind::Closure(_) => "Closure",
+        ExprKind::ClosureCall { .. } => "ClosureCall",
+        ExprKind::Match(..) => "Match",
+        ExprKind::Poison => "Poison",
+    }
 }
 
 struct Renderer<'a> {
@@ -277,33 +417,58 @@ impl Renderer<'_> {
         self.out.push('\n');
     }
 
+    /// Emit a node's header line with its own rc ops woven inline: `before` ops as
+    /// a `»` prefix, `after` ops as a `«` suffix. Keeping the ops on the node's own
+    /// line (rather than on separate lines that visually float between siblings)
+    /// makes it unambiguous *which* node each op belongs to — e.g. a `dup` on the
+    /// first argument of a call reads as the argument's op, not the call's.
+    fn head(&mut self, indent: usize, id: ExprId, text: &str) {
+        let before = self.ot.before(id);
+        let after = self.ot.after(id);
+        let prefix = if before.is_empty() {
+            String::new()
+        } else {
+            format!("» {}  ", ops_str(before))
+        };
+        let suffix = if after.is_empty() {
+            String::new()
+        } else {
+            format!("  « {}", ops_str(after))
+        };
+        self.line(indent, &format!("{prefix}{text}{suffix}"));
+    }
+
     fn expr(&mut self, e: &Expr<'_>, indent: usize) {
-        let before = self.ot.before(e.id);
-        if !before.is_empty() {
-            self.line(indent, &format!("» {}", ops_str(before)));
-        }
         match e.kind {
-            ExprKind::Var(x) => self.line(indent, &format!("var v{}", x.0)),
-            ExprKind::ConstInt(n) => self.line(indent, &format!("const {n}")),
-            ExprKind::ConstBool(b) => self.line(indent, &format!("const {b}")),
+            ExprKind::Var(x) => self.head(indent, e.id, &format!("var v{}", x.0)),
+            ExprKind::ConstInt(n) => self.head(indent, e.id, &format!("const {n}")),
+            ExprKind::ConstBool(b) => self.head(indent, e.id, &format!("const {b}")),
             ExprKind::Let { var, value, .. } => {
-                self.line(indent, &format!("let v{} =", var.0));
+                self.head(indent, e.id, &format!("let v{} =", var.0));
                 self.expr(value, indent + 1);
             }
             ExprKind::Seq(es) => {
-                self.line(indent, "seq");
+                self.head(indent, e.id, "seq");
                 for s in es {
                     self.expr(s, indent + 1);
                 }
             }
             ExprKind::Call { callee, args, .. } => {
-                self.line(indent, &format!("call @{}", self.syms.resolve(&callee.0)));
+                self.head(
+                    indent,
+                    e.id,
+                    &format!("call @{}", self.syms.resolve(&callee.0)),
+                );
                 for a in args {
                     self.expr(a, indent + 1);
                 }
             }
             ExprKind::Ctor { record, args } => {
-                self.line(indent, &format!("ctor @{}", self.syms.resolve(&record.0)));
+                self.head(
+                    indent,
+                    e.id,
+                    &format!("ctor @{}", self.syms.resolve(&record.0)),
+                );
                 for a in args {
                     self.expr(a, indent + 1);
                 }
@@ -313,8 +478,9 @@ impl Renderer<'_> {
                 variant,
                 args,
             } => {
-                self.line(
+                self.head(
                     indent,
+                    e.id,
                     &format!("variant @{}#{variant}", self.syms.resolve(&record.0)),
                 );
                 for a in args {
@@ -323,38 +489,64 @@ impl Renderer<'_> {
             }
             ExprKind::NullableCall(opt) => match opt {
                 Some(x) => {
-                    self.line(indent, "nullable");
+                    self.head(indent, e.id, "nullable");
                     self.expr(x, indent + 1);
                 }
-                None => self.line(indent, "null"),
+                None => self.head(indent, e.id, "null"),
             },
             ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
-                self.line(indent, "binop");
+                self.head(indent, e.id, "binop");
                 self.expr(l, indent + 1);
                 self.expr(r, indent + 1);
             }
             ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => {
-                self.line(indent, "unop");
+                self.head(indent, e.id, "unop");
                 self.expr(x, indent + 1);
             }
-            ExprKind::If(c, t, e) => {
-                self.line(indent, "if");
+            ExprKind::If(c, t, e2) => {
+                self.head(indent, e.id, "if");
                 self.expr(c, indent + 1);
                 self.line(indent, "then");
                 self.expr(t, indent + 1);
                 self.line(indent, "else");
-                self.expr(e, indent + 1);
+                self.expr(e2, indent + 1);
             }
             ExprKind::Match(scrut, tree) => {
-                self.line(indent, "match");
+                self.head(indent, e.id, "match");
                 self.expr(scrut, indent + 1);
                 self.tree(&tree, indent + 1);
             }
-            _ => self.line(indent, &format!("<{}>", super::kind_name(&e.kind))),
-        }
-        let after = self.ot.after(e.id);
-        if !after.is_empty() {
-            self.line(indent, &format!("« {}", ops_str(after)));
+            ExprKind::Proj(base, path) => {
+                self.head(indent, e.id, &format!("proj {path:?}"));
+                self.expr(base, indent + 1);
+            }
+            ExprKind::Assign(dst, field, src) => {
+                self.head(indent, e.id, &format!("assign .{field} :="));
+                self.expr(dst, indent + 1);
+                self.expr(src, indent + 1);
+            }
+            ExprKind::RegionRun(x) => {
+                self.head(indent, e.id, "region-run");
+                self.expr(x, indent + 1);
+            }
+            ExprKind::Closure(c) => {
+                let caps = c
+                    .captures
+                    .iter()
+                    .map(|(v, _)| format!("v{}", v.0))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                self.head(indent, e.id, &format!("closure [{caps}]"));
+                self.expr(c.body, indent + 1);
+            }
+            ExprKind::ClosureCall { target, args } => {
+                self.head(indent, e.id, "closure-call");
+                self.expr(target, indent + 1);
+                for a in args {
+                    self.expr(a, indent + 1);
+                }
+            }
+            _ => self.head(indent, e.id, &format!("<{}>", kind_name(&e.kind))),
         }
     }
 
@@ -371,7 +563,28 @@ impl Renderer<'_> {
                 self.line(indent, &format!("leaf [{bs}]"));
                 self.expr(body, indent + 1);
             }
-            DecisionTree::Guard { .. } => self.line(indent, "guard <…>"),
+            DecisionTree::Guard {
+                bindings,
+                guard,
+                success,
+                failure,
+            } => {
+                let bs = bindings
+                    .iter()
+                    .map(|(y, p)| format!("v{}@{p:?}", y.0))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                // `if` / `success` / `failure` are the guard's three parts, so
+                // indent them under it (and their contents one deeper still),
+                // rather than leaving them flush with the `guard` line.
+                self.line(indent, &format!("guard [{bs}]"));
+                self.line(indent + 1, "if");
+                self.expr(guard, indent + 2);
+                self.line(indent + 1, "success");
+                self.tree(success, indent + 2);
+                self.line(indent + 1, "failure");
+                self.tree(failure, indent + 2);
+            }
             DecisionTree::Switch { cases, .. } => {
                 self.line(indent, "switch");
                 for sub in super::subtrees(&cases) {
@@ -425,9 +638,9 @@ fn apply(op: RcOp, rc: &mut FxHashMap<VarId, i32>) {
             assert!(*c >= 1, "drop of settled v{} (rc {c})", x.0);
             *c -= 1;
         }
-        // Settles an anonymous statement result, which this named-var checker
-        // does not track — nothing to charge.
-        RcOp::DropValue(_) => {}
+        // Touch an anonymous result (discarded statement / borrow-extracted
+        // field), which this named-var checker does not track — nothing to charge.
+        RcOp::DropValue(_) | RcOp::DupValue(_) => {}
     }
 }
 
@@ -494,45 +707,52 @@ fn interp<'tcx>(
             );
             *rc = rc_t;
         }
-        // The scrutinee is borrowed: a `Var` scrutinee is left untouched here (the
-        // leaves settle it via the held drop / whole-move); a temporary's internals
-        // are interpreted, its anonymous result settled by a leaf `drop-value`.
-        // Each leaf is interpreted from the same entry state and must reconcile to
-        // identical ownership; pattern bindings are leaf-local and dropped from the
-        // join.
+        // The scrutinee is borrowed; the decision tree is walked path-by-path,
+        // each terminal leaf reconciling to identical ownership (pattern bindings
+        // are dropped from the join).
         ExprKind::Match(scrut, tree) => {
             if !matches!(scrut.kind, ExprKind::Var(_)) {
                 interp(scrut, ot, rr, rc);
             }
-            let entry = rc.clone();
-            let mut join: Option<FxHashMap<VarId, i32>> = None;
-            for (body, bindings) in collect_leaves(&tree) {
-                let mut rcl = entry.clone();
-                // A moved whole-binding has no op: transfer the scrutinee's
-                // ownership to the bound var so it can be consumed in the body.
-                for &(y, path) in bindings {
-                    if path.is_empty() && uses_var(body, y) {
-                        let dup_established = ot.before(body.id).contains(&RcOp::Dup(y));
-                        if !dup_established {
-                            let taken = match scrut.kind {
-                                ExprKind::Var(s) => rcl.remove(&s).unwrap_or(1),
-                                _ => 1,
-                            };
-                            rcl.insert(y, taken);
-                        }
-                    }
-                }
-                interp(body, ot, rr, &mut rcl);
-                for &(y, _) in bindings {
-                    rcl.remove(&y);
-                }
-                match &join {
-                    None => join = Some(rcl),
-                    Some(j) => assert_eq!(*j, rcl, "match arms differ: {j:?} vs {rcl:?}"),
+            let mut states = Vec::new();
+            interp_tree(scrut, &tree, ot, rr, rc.clone(), &[], &mut states);
+            for s in &states[1..] {
+                assert_eq!(
+                    states[0], *s,
+                    "match paths differ: {:?} vs {s:?}",
+                    states[0]
+                );
+            }
+            if let Some(joined) = states.into_iter().next() {
+                *rc = joined;
+            }
+        }
+        // Projection borrows its base (the root is not consumed here; its drop, if
+        // any, is an after-op); a temporary base is consumed.
+        ExprKind::Proj(base, _) => interp_borrow(base, ot, rr, rc),
+        // Assignment: borrow the dst (after-op settles its root), consume the src.
+        ExprKind::Assign(dst, _, src) => {
+            interp_borrow(dst, ot, rr, rc);
+            interp(src, ot, rr, rc);
+        }
+        ExprKind::RegionRun(x) => interp(x, ot, rr, rc),
+        // Creating a closure consumes its RR captures; the body is a separate
+        // scope, validated on its own, not here.
+        ExprKind::Closure(c) => {
+            for &(v, ty) in c.captures {
+                if rr.is_rr(ty) {
+                    let cc = rc
+                        .get_mut(&v)
+                        .unwrap_or_else(|| panic!("capture of unowned v{}", v.0));
+                    assert!(*cc >= 1, "capturing settled v{} (rc {cc})", v.0);
+                    *cc -= 1;
                 }
             }
-            if let Some(j) = join {
-                *rc = j;
+        }
+        ExprKind::ClosureCall { target, args } => {
+            interp(target, ot, rr, rc);
+            for a in args {
+                interp(a, ot, rr, rc);
             }
         }
         ExprKind::GlobalStr(_)
@@ -540,36 +760,88 @@ fn interp<'tcx>(
         | ExprKind::ConstFloat(_)
         | ExprKind::ConstBool(_)
         | ExprKind::Poison => {}
-        _ => panic!(
-            "checker: unexpected deferred form {}",
-            super::kind_name(&e.kind)
-        ),
     }
     for &op in ot.after(e.id) {
         apply(op, rc);
     }
 }
 
-/// A match leaf: its body and the variables its patterns bind.
-type LeafView<'tcx> = (&'tcx Expr<'tcx>, &'tcx [(VarId, &'tcx [u32])]);
+/// Navigate a borrowed base / assign-dst: a `Var` root is left untouched (its
+/// drop, if its last use, is an explicit after-op); nested projections recurse; a
+/// temporary base is consumed (interpreted).
+fn interp_borrow<'tcx>(
+    e: &Expr<'tcx>,
+    ot: &OwnershipTable,
+    rr: &Rr<'_, 'tcx>,
+    rc: &mut FxHashMap<VarId, i32>,
+) {
+    match e.kind {
+        ExprKind::Var(_) => {}
+        ExprKind::Proj(inner, _) => interp_borrow(inner, ot, rr, rc),
+        _ => interp(e, ot, rr, rc),
+    }
+}
 
-/// Every `(body, bindings)` leaf reachable in the tree, in source order.
-fn collect_leaves<'tcx>(tree: &DecisionTree<'tcx>) -> Vec<LeafView<'tcx>> {
-    let mut out = Vec::new();
-    fn go<'tcx>(t: &DecisionTree<'tcx>, out: &mut Vec<LeafView<'tcx>>) {
-        match *t {
-            DecisionTree::Uncovered | DecisionTree::Unreachable => {}
-            DecisionTree::Leaf { body, bindings } => out.push((body, bindings)),
-            DecisionTree::Guard { .. } => panic!("checker: match guards are not yet supported"),
-            DecisionTree::Switch { cases, .. } => {
-                for sub in super::subtrees(&cases) {
-                    go(sub, out);
+/// Walk the decision tree, collecting one terminal ownership state per leaf path.
+/// `bound_above` are the pattern vars bound by enclosing guards (removed from the
+/// state at each leaf, like the leaf's own bindings, since they are match-local).
+fn interp_tree<'tcx>(
+    scrut: &Expr<'tcx>,
+    tree: &DecisionTree<'tcx>,
+    ot: &OwnershipTable,
+    rr: &Rr<'_, 'tcx>,
+    rc: FxHashMap<VarId, i32>,
+    bound_above: &[VarId],
+    states: &mut Vec<FxHashMap<VarId, i32>>,
+) {
+    match *tree {
+        DecisionTree::Uncovered | DecisionTree::Unreachable => {}
+        DecisionTree::Leaf { body, bindings } => {
+            let mut rcl = rc;
+            // A moved whole-binding has no op: transfer the scrutinee's ownership
+            // to the bound var so it can be consumed in the body.
+            for &(y, path) in bindings {
+                if path.is_empty() && uses_var(body, y) {
+                    let dup_established = ot.before(body.id).contains(&RcOp::Dup(y));
+                    if !dup_established {
+                        let taken = match scrut.kind {
+                            ExprKind::Var(s) => rcl.remove(&s).unwrap_or(1),
+                            _ => 1,
+                        };
+                        rcl.insert(y, taken);
+                    }
                 }
             }
+            interp(body, ot, rr, &mut rcl);
+            for &(y, _) in bindings {
+                rcl.remove(&y);
+            }
+            for &y in bound_above {
+                rcl.remove(&y);
+            }
+            states.push(rcl);
+        }
+        DecisionTree::Switch { cases, .. } => {
+            for sub in super::subtrees(&cases) {
+                interp_tree(scrut, sub, ot, rr, rc.clone(), bound_above, states);
+            }
+        }
+        DecisionTree::Guard {
+            bindings,
+            guard,
+            success,
+            failure,
+        } => {
+            let mut rcg = rc;
+            interp(guard, ot, rr, &mut rcg);
+            let mut nested = bound_above.to_vec();
+            for &(y, _) in bindings {
+                nested.push(y);
+            }
+            interp_tree(scrut, success, ot, rr, rcg.clone(), &nested, states);
+            interp_tree(scrut, failure, ot, rr, rcg, &nested, states);
         }
     }
-    go(tree, &mut out);
-    out
 }
 
 /// Whether `e`'s tree contains a use of variable `y`.
@@ -848,7 +1120,7 @@ fn chained_moves_need_no_rc_ops() {
     });
 }
 
-// ----- increment 2: control flow -----
+// ----- control flow (If reconciliation, discarded results) -----
 
 #[test]
 fn case3_if_var_used_in_one_arm_dropped_in_other() {
@@ -992,7 +1264,7 @@ fn discarded_rr_statement_gets_drop_value() {
     });
 }
 
-// ----- increment 3: pattern matching (borrow-dup, Perceus-style) -----
+// ----- pattern matching (borrow-dup, Perceus-style) -----
 
 #[test]
 fn match_extracts_field_and_drops_scrutinee() {
@@ -1139,6 +1411,451 @@ fn match_reconciles_an_outer_var() {
             ot.before(body1_id),
             &[RcOp::Dup(x), RcOp::Drop(e), RcOp::Drop(w)],
             "arm #1 dups x, drops the scrutinee, and reconciles by dropping w"
+        );
+    });
+}
+
+// ----- containers (Proj / Assign) -----
+
+#[test]
+fn proj_extracts_field_and_drops_base() {
+    // fn f(p: Pair) -> Rc { p.0 }
+    //   the projected field is borrow-extracted (inc'd, the parent still owns the
+    //   original); p is dead after ⇒ its root drops early at the projection.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let pair = b.value(vec![rc, rc]);
+        let p = b.fresh_var();
+
+        let vp = b.var(p, pair);
+        let body = b.proj(vp, vec![0], rc);
+        let body_id = body.id;
+
+        let param = b.param(p, pair);
+        let func = b.function("f", vec![param], rc, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(ot.before(body_id).is_empty(), "no op before the projection");
+        assert_eq!(
+            ot.after(body_id),
+            &[RcOp::DupValue(body_id), RcOp::Drop(p)],
+            "extracted field inc'd, dead base dropped early"
+        );
+    });
+}
+
+#[test]
+fn proj_keeps_base_when_still_live() {
+    // fn f(p: Pair) -> Box { mk(p.0, p) }
+    //   p.0 is borrow-extracted, but p itself is used again in the same call ⇒ its
+    //   root is *not* dropped at the projection (it is moved by the later whole use).
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let pair = b.value(vec![rc, rc]);
+        let boxed = b.shared();
+        let p = b.fresh_var();
+
+        let vp_field = b.var(p, pair);
+        let proj = b.proj(vp_field, vec![0], rc);
+        let proj_id = proj.id;
+        let vp_whole = b.var(p, pair);
+        let vp_whole_id = vp_whole.id;
+        let body = b.call("mk", vec![proj, vp_whole], boxed);
+
+        let param = b.param(p, pair);
+        let func = b.function("f", vec![param], boxed, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.after(proj_id),
+            &[RcOp::DupValue(proj_id)],
+            "extracted field inc'd, but the still-live base is not dropped"
+        );
+        assert!(
+            ot.before(vp_whole_id).is_empty(),
+            "the trailing whole use of p is the last ⇒ moved"
+        );
+    });
+}
+
+#[test]
+fn nested_proj_navigates_to_root() {
+    // fn f(p: Outer) -> Rc { p.0.0 }
+    //   only the outermost projection inc's the extracted leaf; the inner one is
+    //   pure navigation (no op); the dead root drops at the outer projection.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let inner_ty = b.value(vec![rc]);
+        let outer_ty = b.value(vec![inner_ty]);
+        let p = b.fresh_var();
+
+        let vp = b.var(p, outer_ty);
+        let inner_proj = b.proj(vp, vec![0], inner_ty);
+        let inner_proj_id = inner_proj.id;
+        let outer_proj = b.proj(inner_proj, vec![0], rc);
+        let outer_proj_id = outer_proj.id;
+
+        let param = b.param(p, outer_ty);
+        let func = b.function("f", vec![param], rc, outer_proj);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.get(inner_proj_id).is_none(),
+            "inner projection is pure navigation: no ops"
+        );
+        assert_eq!(
+            ot.after(outer_proj_id),
+            &[RcOp::DupValue(outer_proj_id), RcOp::Drop(p)],
+            "outer projection inc's the leaf and drops the dead root"
+        );
+    });
+}
+
+#[test]
+fn assign_moves_src_and_borrows_dst() {
+    // fn f(c: Flex, x: Rc) -> i64 { c.0 := x; 0 }
+    //   x is moved into the field; c is borrowed (mutated in place) and, being dead
+    //   after, dropped early at the store; the old field link is freed with c.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let flex = b.regional();
+        let i64t = b.i64();
+        let c = b.fresh_var();
+        let x = b.fresh_var();
+
+        let vc = b.var(c, flex);
+        let vx = b.var(x, rc);
+        let vx_id = vx.id;
+        let assign = b.assign(vc, 0, vx);
+        let assign_id = assign.id;
+        let zero = b.const_int(0);
+        let body = b.seq(vec![assign, zero], i64t);
+
+        let params = vec![b.param(c, flex), b.param(x, rc)];
+        let func = b.function("f", params, i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.before(vx_id).is_empty(),
+            "x moved into the field ⇒ no dup"
+        );
+        assert_eq!(
+            ot.after(assign_id),
+            &[RcOp::Drop(c)],
+            "dead borrowed dst dropped after the store; no old-field dec"
+        );
+    });
+}
+
+// ----- regions -----
+
+#[test]
+fn region_run_is_transparent() {
+    // fn f(x: Rc) -> Rc { region { x } }  — a region scope is rc-transparent.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let x = b.fresh_var();
+
+        let vx = b.var(x, rc);
+        let vx_id = vx.id;
+        let body = b.region(vx, rc);
+        let body_id = body.id;
+
+        let param = b.param(x, rc);
+        let func = b.function("f", vec![param], rc, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(ot.get(body_id).is_none(), "region scope adds no ops");
+        assert!(ot.get(vx_id).is_none(), "x moved straight through ⇒ no ops");
+    });
+}
+
+// ----- closures -----
+
+#[test]
+fn closure_moves_its_capture() {
+    // fn f(x: Rc) -> Clos { || x }  — x is captured at its last use ⇒ moved in.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let clos_ty = b.closure_ty(&[], rc);
+        let x = b.fresh_var();
+
+        let vx = b.var(x, rc);
+        let body = b.closure(vec![(x, rc)], vec![], vx, clos_ty);
+        let body_id = body.id;
+
+        let param = b.param(x, rc);
+        let func = b.function("f", vec![param], clos_ty, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.get(body_id).is_none(),
+            "capture is the last use of x ⇒ moved into the closure, no dup"
+        );
+    });
+}
+
+#[test]
+fn closure_dups_a_still_live_capture() {
+    // fn f(x: Rc) -> Box { mk(|| x, x) }
+    //   x is captured *and* used again in the call ⇒ the closure dup's it.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let boxed = b.shared();
+        let clos_ty = b.closure_ty(&[], rc);
+        let x = b.fresh_var();
+
+        let vx_body = b.var(x, rc);
+        let clos = b.closure(vec![(x, rc)], vec![], vx_body, clos_ty);
+        let clos_id = clos.id;
+        let vx_arg = b.var(x, rc);
+        let vx_arg_id = vx_arg.id;
+        let body = b.call("mk", vec![clos, vx_arg], boxed);
+
+        let param = b.param(x, rc);
+        let func = b.function("f", vec![param], boxed, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(clos_id),
+            &[RcOp::Dup(x)],
+            "x is live after the closure ⇒ dup'd into the capture"
+        );
+        assert!(
+            ot.before(vx_arg_id).is_empty(),
+            "the trailing argument use is the last ⇒ moved"
+        );
+    });
+}
+
+#[test]
+fn closure_call_consumes_target_and_args() {
+    // fn f(g: Clos, x: Rc) -> Rc { g(x) }  — both g and x are at last use ⇒ moved.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let clos_ty = b.closure_ty(&[rc], rc);
+        let g = b.fresh_var();
+        let x = b.fresh_var();
+
+        let vg = b.var(g, clos_ty);
+        let vg_id = vg.id;
+        let vx = b.var(x, rc);
+        let vx_id = vx.id;
+        let body = b.closure_call(vg, vec![vx], rc);
+
+        let params = vec![b.param(g, clos_ty), b.param(x, rc)];
+        let func = b.function("f", params, rc, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.before(vg_id).is_empty(),
+            "target closure moved into the call"
+        );
+        assert!(ot.before(vx_id).is_empty(), "argument moved into the call");
+    });
+}
+
+// ----- match guards -----
+
+#[test]
+fn guard_keeps_scrutinee_until_terminal_leaves() {
+    // fn f(e: E) -> i64 { match e { #_(x) if pred(x) => use(x), _ => 0 } }
+    //   The guard borrow-extracts x (dup at the guard, before either branch). The
+    //   scrutinee stays live across the guard (the failure path re-tests it), so its
+    //   drop lands in *each* terminal leaf. x, surviving into the branches, is moved
+    //   by `use` on success but must be dropped on failure.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let e_ty = b.shared();
+        let rc = b.shared();
+        let i64t = b.i64();
+        let bool_t = b.tcx.mk_bool();
+        let e = b.fresh_var();
+        let x = b.fresh_var();
+
+        let vx_guard = b.var(x, rc);
+        let guard_expr = b.call("pred", vec![vx_guard], bool_t);
+        let guard_id = guard_expr.id;
+
+        let vx_succ = b.var(x, rc);
+        let use_x = b.call("use", vec![vx_succ], i64t);
+        let succ_body_id = use_x.id;
+        let success = b.leaf(use_x, vec![]);
+
+        let zero = b.const_int(0);
+        let fail_body_id = zero.id;
+        let failure = b.leaf(zero, vec![]);
+
+        let tree = b.guard(vec![(x, vec![0])], guard_expr, success, failure);
+        let scrut = b.var(e, e_ty);
+        let body = b.match_(scrut, tree, i64t);
+
+        let param = b.param(e, e_ty);
+        let func = b.function("f", vec![param], i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(guard_id),
+            &[RcOp::Dup(x)],
+            "the guard binding is borrow-extracted before the test"
+        );
+        assert_eq!(
+            ot.before(succ_body_id),
+            &[RcOp::Drop(e)],
+            "success consumes x and drops the now-dead scrutinee"
+        );
+        assert_eq!(
+            ot.before(fail_body_id),
+            &[RcOp::Drop(e), RcOp::Drop(x)],
+            "failure drops the scrutinee and the extracted-but-unused x"
+        );
+    });
+}
+
+// ----- closures are RR: multiple uses follow dup-all-but-last -----
+
+#[test]
+fn closure_value_used_twice_dups_all_but_last() {
+    // fn f(g: Clos) -> Box { mk(g, g) }
+    //   A closure is itself an RR value, so passing it twice follows exactly the
+    //   same rule as any rc (cf. `case2`): the first occurrence is dup'd (live
+    //   across the second), the last is moved.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let i64t = b.i64();
+        let boxed = b.shared();
+        let clos_ty = b.closure_ty(&[], i64t);
+        let g = b.fresh_var();
+
+        let a0 = b.var(g, clos_ty);
+        let a1 = b.var(g, clos_ty);
+        let (a0_id, a1_id) = (a0.id, a1.id);
+        let body = b.call("mk", vec![a0, a1], boxed);
+
+        let param = b.param(g, clos_ty);
+        let func = b.function("f", vec![param], boxed, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(a0_id),
+            &[RcOp::Dup(g)],
+            "first use of the RR closure is dup'd"
+        );
+        assert!(
+            ot.before(a1_id).is_empty(),
+            "last use of the closure is moved"
+        );
+    });
+}
+
+#[test]
+fn closure_called_twice_dups_for_the_earlier_call() {
+    // fn f(x: Rc) -> i64 { let g = || use(x); g(); g() }
+    //   Invoking a closure consumes a reference to it (owned convention), so the
+    //   closure — being RR — is dup'd for the first (non-last) call and moved into
+    //   the second. The capture `x` is consumed once, when the closure is built.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let i64t = b.i64();
+        let clos_ty = b.closure_ty(&[], i64t);
+        let x = b.fresh_var();
+        let g = b.fresh_var();
+
+        let vx = b.var(x, rc);
+        let use_x = b.call("use", vec![vx], i64t);
+        let clos = b.closure(vec![(x, rc)], vec![], use_x, clos_ty);
+        let let_g = b.let_(g, clos);
+
+        let vg1 = b.var(g, clos_ty);
+        let vg1_id = vg1.id;
+        let call1 = b.closure_call(vg1, vec![], i64t);
+        let vg2 = b.var(g, clos_ty);
+        let vg2_id = vg2.id;
+        let call2 = b.closure_call(vg2, vec![], i64t);
+        let body = b.seq(vec![let_g, call1, call2], i64t);
+
+        let param = b.param(x, rc);
+        let func = b.function("f", vec![param], i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(vg1_id),
+            &[RcOp::Dup(g)],
+            "the closure is live across the second call ⇒ dup'd for the first"
+        );
+        assert!(
+            ot.before(vg2_id).is_empty(),
+            "the second call is the closure's last use ⇒ moved"
+        );
+    });
+}
+
+// ----- a realistic function: tail-recursive list reverse -----
+
+#[test]
+fn tail_recursive_list_reverse() {
+    // fn reverse(xs: List, acc: List) -> List {
+    //     match xs {
+    //         Nil        => acc,
+    //         Cons(h, t) => reverse(t, Cons(h, acc)),
+    //     }
+    // }
+    //
+    // `List` is an rc-managed enum (Nil | Cons(head, tail)); the element `head` is
+    // itself an rc. Nil arm: `acc` is moved out as the result and the matched (now
+    // dead) Nil cell is dropped. Cons arm: `h` and `t` are borrow-extracted from
+    // the scrutinee (each dup'd), the consumed Cons cell is dropped, and h / t /
+    // acc are all moved on into the rebuilt `Cons(h, acc)` and the tail call.
+    // Recursion is just a `Call` — a dataflow leaf — so tail position is ordinary.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let list = b.shared(); // List: rc enum
+        let elem = b.shared(); // the element type, also rc
+        let xs = b.fresh_var();
+        let acc = b.fresh_var();
+        let h = b.fresh_var();
+        let t = b.fresh_var();
+
+        // Nil => acc
+        let nil_body = b.var(acc, list);
+        let nil_body_id = nil_body.id;
+        let nil_arm = b.leaf(nil_body, vec![]);
+
+        // Cons(h, t) => reverse(t, Cons(h, acc))
+        let vh = b.var(h, elem);
+        let vacc = b.var(acc, list);
+        let rebuilt = b.variant("List", 1, vec![vh, vacc], list);
+        let vt = b.var(t, list);
+        let rec = b.call("reverse", vec![vt, rebuilt], list);
+        let cons_body_id = rec.id;
+        let cons_arm = b.leaf(rec, vec![(h, vec![0]), (t, vec![1])]);
+
+        let tree = b.switch_ctor(vec![], vec![nil_arm, cons_arm]);
+        let scrut = b.var(xs, list);
+        let body = b.match_(scrut, tree, list);
+
+        let params = vec![b.param(xs, list), b.param(acc, list)];
+        let func = b.function("reverse", params, list, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(nil_body_id),
+            &[RcOp::Drop(xs)],
+            "Nil arm: acc is moved out; the matched Nil cell is dropped"
+        );
+        assert_eq!(
+            ot.before(cons_body_id),
+            &[RcOp::Dup(h), RcOp::Dup(t), RcOp::Drop(xs)],
+            "Cons arm: head & tail borrow-extracted, then the Cons cell dropped"
         );
     });
 }

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -430,7 +430,7 @@ fn text(s: impl Into<String>) -> Doc<'static> {
 }
 
 /// `head` followed by each of `children` on its own line, indented one level.
-fn nest(head: Doc<'static>, children: impl IntoIterator<Item = Doc<'static>>) -> Doc<'static> {
+fn nest(head: Doc<'static>, children: Vec<Doc<'static>>) -> Doc<'static> {
     let mut inner = Doc::Null;
     for c in children {
         inner = inner + hardline() + c;
@@ -440,10 +440,7 @@ fn nest(head: Doc<'static>, children: impl IntoIterator<Item = Doc<'static>>) ->
 
 /// Like [`nest`], but with a blank line between children — for branch contexts
 /// (switch arms, `if` and guard sections) so each branch stands visually apart.
-fn nest_spaced(
-    head: Doc<'static>,
-    children: impl IntoIterator<Item = Doc<'static>>,
-) -> Doc<'static> {
+fn nest_spaced(head: Doc<'static>, children: Vec<Doc<'static>>) -> Doc<'static> {
     let mut inner = Doc::Null;
     for (i, c) in children.into_iter().enumerate() {
         if i > 0 {
@@ -470,11 +467,10 @@ struct Renderer<'a> {
 }
 
 impl Renderer<'_> {
-    /// Weave a node's rc ops onto its header `Doc`: `before` ops as a `»` prefix,
-    /// `after` ops as a `«` suffix. Keeping them on the node's own line makes it
-    /// unambiguous *which* node each op belongs to — a `dup` on a call's first
-    /// argument reads as the argument's op, not the call's.
-    fn anno(&self, id: ExprId, head: Doc<'static>) -> Doc<'static> {
+    /// A **leaf** node (no children): weave its rc ops onto the single line —
+    /// `before` as a `»` prefix, `after` as a `«` suffix. With nothing below it,
+    /// the ops bind unambiguously to this one node (`» dup v0  var v0`).
+    fn leaf(&self, id: ExprId, head: Doc<'static>) -> Doc<'static> {
         let before = self.ot.before(id);
         let after = self.ot.after(id);
         let mut d = head;
@@ -487,79 +483,113 @@ impl Renderer<'_> {
         d
     }
 
+    /// A node **with children**: `head` over its indented `children`, with the rc
+    /// ops on their own lines — `before` above the head, `after` below the
+    /// children. Dedicated lines keep the head label legible (not buried after a
+    /// run of ops), and put an `after` op in its true position (it runs once the
+    /// children are done). `layout` is `nest` or `nest_spaced`.
+    fn block(
+        &self,
+        id: ExprId,
+        head: Doc<'static>,
+        children: Vec<Doc<'static>>,
+        layout: fn(Doc<'static>, Vec<Doc<'static>>) -> Doc<'static>,
+    ) -> Doc<'static> {
+        let before = self.ot.before(id);
+        let after = self.ot.after(id);
+        let mut d = Doc::Null;
+        if !before.is_empty() {
+            d = d + text(format!("» {}", ops_str(before))) + hardline();
+        }
+        d = d + layout(head, children);
+        if !after.is_empty() {
+            d = d + hardline() + text(format!("« {}", ops_str(after)));
+        }
+        d
+    }
+
     fn exprs(&self, es: &[Expr<'_>]) -> Vec<Doc<'static>> {
         es.iter().map(|e| self.expr(e)).collect()
     }
 
     fn expr(&self, e: &Expr<'_>) -> Doc<'static> {
         match e.kind {
-            ExprKind::Var(x) => self.anno(e.id, text(format!("var v{}", x.0))),
-            ExprKind::ConstInt(n) => self.anno(e.id, text(format!("const {n}"))),
-            ExprKind::ConstBool(b) => self.anno(e.id, text(format!("const {b}"))),
-            ExprKind::Let { var, value, .. } => nest(
-                self.anno(e.id, text(format!("let v{} =", var.0))),
-                [self.expr(value)],
+            ExprKind::Var(x) => self.leaf(e.id, text(format!("var v{}", x.0))),
+            ExprKind::ConstInt(n) => self.leaf(e.id, text(format!("const {n}"))),
+            ExprKind::ConstBool(b) => self.leaf(e.id, text(format!("const {b}"))),
+            ExprKind::NullableCall(None) => self.leaf(e.id, text("null")),
+            ExprKind::Let { var, value, .. } => self.block(
+                e.id,
+                text(format!("let v{} =", var.0)),
+                vec![self.expr(value)],
+                nest,
             ),
-            ExprKind::Seq(es) => nest(self.anno(e.id, text("seq")), self.exprs(es)),
-            ExprKind::Call { callee, args, .. } => nest(
-                self.anno(
-                    e.id,
-                    text(format!("call @{}", self.syms.resolve(&callee.0))),
-                ),
+            ExprKind::Seq(es) => self.block(e.id, text("seq"), self.exprs(es), nest),
+            ExprKind::Call { callee, args, .. } => self.block(
+                e.id,
+                text(format!("call @{}", self.syms.resolve(&callee.0))),
                 self.exprs(args),
+                nest,
             ),
-            ExprKind::Ctor { record, args } => nest(
-                self.anno(
-                    e.id,
-                    text(format!("ctor @{}", self.syms.resolve(&record.0))),
-                ),
+            ExprKind::Ctor { record, args } => self.block(
+                e.id,
+                text(format!("ctor @{}", self.syms.resolve(&record.0))),
                 self.exprs(args),
+                nest,
             ),
             ExprKind::Variant {
                 record,
                 variant,
                 args,
-            } => nest(
-                self.anno(
-                    e.id,
-                    text(format!(
-                        "variant @{}#{variant}",
-                        self.syms.resolve(&record.0)
-                    )),
-                ),
+            } => self.block(
+                e.id,
+                text(format!(
+                    "variant @{}#{variant}",
+                    self.syms.resolve(&record.0)
+                )),
                 self.exprs(args),
+                nest,
             ),
-            ExprKind::NullableCall(opt) => match opt {
-                Some(x) => nest(self.anno(e.id, text("nullable")), [self.expr(x)]),
-                None => self.anno(e.id, text("null")),
-            },
+            ExprKind::NullableCall(Some(x)) => {
+                self.block(e.id, text("nullable"), vec![self.expr(x)], nest)
+            }
             ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
-                nest(self.anno(e.id, text("binop")), [self.expr(l), self.expr(r)])
+                self.block(e.id, text("binop"), vec![self.expr(l), self.expr(r)], nest)
             }
             ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => {
-                nest(self.anno(e.id, text("unop")), [self.expr(x)])
+                self.block(e.id, text("unop"), vec![self.expr(x)], nest)
             }
-            ExprKind::If(c, t, f) => nest_spaced(
-                self.anno(e.id, text("if")),
-                [
+            ExprKind::If(c, t, f) => self.block(
+                e.id,
+                text("if"),
+                vec![
                     self.expr(c),
-                    nest(text("then"), [self.expr(t)]),
-                    nest(text("else"), [self.expr(f)]),
+                    nest(text("then"), vec![self.expr(t)]),
+                    nest(text("else"), vec![self.expr(f)]),
                 ],
+                nest_spaced,
             ),
-            ExprKind::Match(scrut, tree) => nest(
-                self.anno(e.id, text("match")),
-                [self.expr(scrut), self.tree(&tree)],
+            ExprKind::Match(scrut, tree) => self.block(
+                e.id,
+                text("match"),
+                vec![self.expr(scrut), self.tree(&tree)],
+                nest,
             ),
-            ExprKind::Proj(base, path) => nest(
-                self.anno(e.id, text(format!("proj {path:?}"))),
-                [self.expr(base)],
+            ExprKind::Proj(base, path) => self.block(
+                e.id,
+                text(format!("proj {path:?}")),
+                vec![self.expr(base)],
+                nest,
             ),
-            ExprKind::Assign(dst, field, src) => nest(
-                self.anno(e.id, text(format!("assign .{field} :="))),
-                [self.expr(dst), self.expr(src)],
+            ExprKind::Assign(dst, field, src) => self.block(
+                e.id,
+                text(format!("assign .{field} :=")),
+                vec![self.expr(dst), self.expr(src)],
+                nest,
             ),
-            ExprKind::RegionRun(x) => nest(self.anno(e.id, text("region-run")), [self.expr(x)]),
+            ExprKind::RegionRun(x) => {
+                self.block(e.id, text("region-run"), vec![self.expr(x)], nest)
+            }
             ExprKind::Closure(c) => {
                 let caps = c
                     .captures
@@ -567,17 +597,19 @@ impl Renderer<'_> {
                     .map(|(v, _)| format!("v{}", v.0))
                     .collect::<Vec<_>>()
                     .join(", ");
-                nest(
-                    self.anno(e.id, text(format!("closure [{caps}]"))),
-                    [self.expr(c.body)],
+                self.block(
+                    e.id,
+                    text(format!("closure [{caps}]")),
+                    vec![self.expr(c.body)],
+                    nest,
                 )
             }
             ExprKind::ClosureCall { target, args } => {
                 let mut kids = vec![self.expr(target)];
                 kids.extend(self.exprs(args));
-                nest(self.anno(e.id, text("closure-call")), kids)
+                self.block(e.id, text("closure-call"), kids, nest)
             }
-            _ => self.anno(e.id, text(format!("<{}>", kind_name(&e.kind)))),
+            _ => self.leaf(e.id, text(format!("<{}>", kind_name(&e.kind)))),
         }
     }
 
@@ -587,7 +619,7 @@ impl Renderer<'_> {
             DecisionTree::Unreachable => text("unreachable"),
             DecisionTree::Leaf { body, bindings } => nest(
                 text(format!("leaf [{}]", binding_list(bindings))),
-                [self.expr(body)],
+                vec![self.expr(body)],
             ),
             // `if` / `success` / `failure` are the guard's three parts, each
             // nested under it (and their contents one level deeper still).
@@ -598,15 +630,18 @@ impl Renderer<'_> {
                 failure,
             } => nest_spaced(
                 text(format!("guard [{}]", binding_list(bindings))),
-                [
-                    nest(text("if"), [self.expr(guard)]),
-                    nest(text("success"), [self.tree(success)]),
-                    nest(text("failure"), [self.tree(failure)]),
+                vec![
+                    nest(text("if"), vec![self.expr(guard)]),
+                    nest(text("success"), vec![self.tree(success)]),
+                    nest(text("failure"), vec![self.tree(failure)]),
                 ],
             ),
             DecisionTree::Switch { cases, .. } => nest_spaced(
                 text("switch"),
-                super::subtrees(&cases).into_iter().map(|s| self.tree(s)),
+                super::subtrees(&cases)
+                    .into_iter()
+                    .map(|s| self.tree(s))
+                    .collect(),
             ),
         }
     }
@@ -623,7 +658,7 @@ fn render(func: &Function<'_>, ot: &OwnershipTable, syms: &Rodeo) -> String {
         .join(", ");
     let header = text(format!("fn @{}({}):", syms.resolve(&func.symbol.0), params));
     let doc = match func.body {
-        Some(body) => nest(header, [r.expr(body)]),
+        Some(body) => nest(header, vec![r.expr(body)]),
         None => header,
     };
     pprint(doc, ANNO_PRINTER)

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -142,6 +142,18 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
         self.mk(ExprKind::ConstInt(n), ty)
     }
 
+    fn const_bool(&mut self, b: bool) -> Expr<'tcx> {
+        let ty = self.tcx.mk_bool();
+        self.mk(ExprKind::ConstBool(b), ty)
+    }
+
+    fn if_(&mut self, c: Expr<'tcx>, t: Expr<'tcx>, e: Expr<'tcx>, ty: Ty<'tcx>) -> Expr<'tcx> {
+        let c = self.tcx.alloc(c);
+        let t = self.tcx.alloc(t);
+        let e = self.tcx.alloc(e);
+        self.mk(ExprKind::If(c, t, e), ty)
+    }
+
     /// `let v = value;` (a Seq statement; its own result type is unit).
     fn let_(&mut self, v: VarId, value: Expr<'tcx>) -> Expr<'tcx> {
         let value = self.tcx.alloc(value);
@@ -217,6 +229,7 @@ fn ops_str(ops: &[RcOp]) -> String {
         .map(|op| match op {
             RcOp::Dup(v) => format!("dup v{}", v.0),
             RcOp::Drop(v) => format!("drop v{}", v.0),
+            RcOp::DropValue(id) => format!("drop-value #{}", id.0),
         })
         .collect::<Vec<_>>()
         .join(", ")
@@ -297,6 +310,14 @@ impl Renderer<'_> {
                 self.line(indent, "unop");
                 self.expr(x, indent + 1);
             }
+            ExprKind::If(c, t, e) => {
+                self.line(indent, "if");
+                self.expr(c, indent + 1);
+                self.line(indent, "then");
+                self.expr(t, indent + 1);
+                self.line(indent, "else");
+                self.expr(e, indent + 1);
+            }
             _ => self.line(indent, &format!("<{}>", super::kind_name(&e.kind))),
         }
         let after = self.ot.after(e.id);
@@ -350,6 +371,9 @@ fn apply(op: RcOp, rc: &mut FxHashMap<VarId, i32>) {
             assert!(*c >= 1, "drop of settled v{} (rc {c})", x.0);
             *c -= 1;
         }
+        // Settles an anonymous statement result, which this named-var checker
+        // does not track — nothing to charge.
+        RcOp::DropValue(_) => {}
     }
 }
 
@@ -401,6 +425,20 @@ fn interp<'tcx>(
         ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
             interp(l, ot, rr, rc);
             interp(r, ot, rr, rc);
+        }
+        // Each arm is interpreted from the same entry state; reconciliation must
+        // leave both with identical ownership (the join is well-defined).
+        ExprKind::If(c, t, e) => {
+            interp(c, ot, rr, rc);
+            let mut rc_t = rc.clone();
+            let mut rc_e = rc.clone();
+            interp(t, ot, rr, &mut rc_t);
+            interp(e, ot, rr, &mut rc_e);
+            assert_eq!(
+                rc_t, rc_e,
+                "if-arms leave different ownership: then={rc_t:?} else={rc_e:?}"
+            );
+            *rc = rc_t;
         }
         ExprKind::GlobalStr(_)
         | ExprKind::ConstInt(_)
@@ -651,5 +689,149 @@ fn chained_moves_need_no_rc_ops() {
 
         assert!(ot.get(let_id).is_none(), "y is moved out ⇒ no drop");
         assert!(ot.before(xval.id).is_empty(), "x moved into y ⇒ no dup");
+    });
+}
+
+// ----- increment 2: control flow -----
+
+#[test]
+fn case3_if_var_used_in_one_arm_dropped_in_other() {
+    // fn f(x: Rc) -> i64 { if c { consume(x) } else { 0 } }
+    //   x dies (returns i64): moved in the `then` arm, dropped in the `else` arm.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let i64t = b.i64();
+        let x = b.fresh_var();
+
+        let xuse = b.var(x, rc);
+        let then = b.call("consume", vec![xuse], i64t);
+        let then_id = then.id;
+        let els = b.const_int(0);
+        let els_id = els.id;
+        let cond = b.const_bool(true);
+        let body = b.if_(cond, then, els, i64t);
+
+        let params = vec![b.param(x, rc)];
+        let func = b.function("f", params, i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(ot.before(then_id).is_empty(), "then moves x ⇒ no drop");
+        assert_eq!(
+            ot.before(els_id),
+            &[RcOp::Drop(x)],
+            "else never uses x ⇒ drop on entry to that arm"
+        );
+    });
+}
+
+#[test]
+fn if_returns_one_of_two_params() {
+    // fn f(x: Rc, y: Rc) -> Rc { if c { x } else { y } }
+    //   each arm moves one and drops the other, so both exit owning nothing.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let x = b.fresh_var();
+        let y = b.fresh_var();
+
+        let then = b.var(x, rc);
+        let then_id = then.id;
+        let els = b.var(y, rc);
+        let els_id = els.id;
+        let cond = b.const_bool(true);
+        let body = b.if_(cond, then, els, rc);
+
+        let params = vec![b.param(x, rc), b.param(y, rc)];
+        let func = b.function("f", params, rc, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(then_id),
+            &[RcOp::Drop(y)],
+            "then drops the unused y"
+        );
+        assert_eq!(
+            ot.before(els_id),
+            &[RcOp::Drop(x)],
+            "else drops the unused x"
+        );
+    });
+}
+
+#[test]
+fn if_var_live_after_dups_in_each_arm() {
+    // fn f(x: Rc) -> Pair { let a = if c { g(x) } else { h(x) }; mk(x, a) }
+    //   x is used in each arm *and* again in `mk`, so each arm dup's it; the
+    //   trailing `mk` is x's last use and moves it.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let pair = b.value(vec![rc, rc]);
+        let x = b.fresh_var();
+        let a = b.fresh_var();
+
+        let xg = b.var(x, rc);
+        let xg_id = xg.id;
+        let gx = b.call("g", vec![xg], rc);
+        let xh = b.var(x, rc);
+        let xh_id = xh.id;
+        let hx = b.call("h", vec![xh], rc);
+        let cond = b.const_bool(true);
+        let iff = b.if_(cond, gx, hx, rc);
+        let let_a = b.let_(a, iff);
+
+        let xm = b.var(x, rc);
+        let xm_id = xm.id;
+        let am = b.var(a, rc);
+        let mk = b.call("mk", vec![xm, am], pair);
+        let body = b.seq(vec![let_a, mk], pair);
+
+        let params = vec![b.param(x, rc)];
+        let func = b.function("f", params, pair, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.before(xg_id),
+            &[RcOp::Dup(x)],
+            "then dup's the still-live x"
+        );
+        assert_eq!(
+            ot.before(xh_id),
+            &[RcOp::Dup(x)],
+            "else dup's the still-live x"
+        );
+        assert!(
+            ot.before(xm_id).is_empty(),
+            "trailing use of x is the last ⇒ move"
+        );
+    });
+}
+
+#[test]
+fn discarded_rr_statement_gets_drop_value() {
+    // fn f(x: Rc) -> i64 { effect(x); 0 }
+    //   `effect(x)` returns an Rc that is discarded ⇒ drop-value its result.
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let rc = b.shared();
+        let i64t = b.i64();
+        let x = b.fresh_var();
+
+        let xuse = b.var(x, rc);
+        let effect = b.call("effect", vec![xuse], rc);
+        let effect_id = effect.id;
+        let zero = b.const_int(0);
+        let body = b.seq(vec![effect, zero], i64t);
+
+        let params = vec![b.param(x, rc)];
+        let func = b.function("f", params, i64t, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.after(effect_id),
+            &[RcOp::DropValue(effect_id)],
+            "discarded Rc result is dropped by value"
+        );
     });
 }

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -52,7 +52,7 @@ pub fn elaborate<'a, 'tcx>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::semi::ty::{Capability, IntTy};
+    use crate::semi::ty::{Flexivity, IntTy};
     use crate::with_tcx;
 
     /// Parse + lower + elaborate, asserting there are no errors, then run `f`
@@ -140,7 +140,7 @@ mod tests {
                 let crate::semi::ty::TyKind::Record { flex, .. } = f.return_ty.kind() else {
                     panic!("expected a record return type, got {:?}", f.return_ty);
                 };
-                assert_eq!(*flex, Capability::Flex);
+                assert_eq!(*flex, Flexivity::Flex);
             },
         );
     }
@@ -168,8 +168,8 @@ mod tests {
                     panic!("expected a `let` binding first, got {:?}", stmts[0].kind);
                 };
                 assert_eq!(
-                    value.ty.capability(),
-                    Some(Capability::Flex),
+                    value.ty.flexivity(),
+                    Some(Flexivity::Flex),
                     "a fresh regional construction should be flex"
                 );
             },
@@ -192,7 +192,7 @@ mod tests {
                 let crate::semi::hir::ExprKind::Let { value, .. } = &stmts[0].kind else {
                     panic!("expected a `let` binding first, got {:?}", stmts[0].kind);
                 };
-                assert_eq!(value.ty.capability(), Some(Capability::Irrelevant));
+                assert_eq!(value.ty.flexivity(), Some(Flexivity::Irrelevant));
             },
         );
     }

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -486,7 +486,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     fn is_flex(&mut self, ty: Ty<'tcx>) -> bool {
         match self.infer.shallow_resolve(ty).kind() {
             TyKind::Record {
-                flex: crate::semi::ty::Capability::Flex,
+                flex: crate::semi::ty::Flexivity::Flex,
                 ..
             } => true,
             TyKind::Nullable(inner) => self.is_flex(*inner),
@@ -582,7 +582,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let TyKind::Record {
             def,
             args,
-            flex: crate::semi::ty::Capability::Flex,
+            flex: crate::semi::ty::Flexivity::Flex,
         } = dty.kind()
         else {
             self.error(span, "assignment target must be a flex record");
@@ -612,11 +612,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     }
                 }
                 _ if matches!(
-                    inner.capability(),
+                    inner.flexivity(),
                     Some(
-                        crate::semi::ty::Capability::Regional
-                            | crate::semi::ty::Capability::Flex
-                            | crate::semi::ty::Capability::Rigid
+                        crate::semi::ty::Flexivity::Regional
+                            | crate::semi::ty::Flexivity::Flex
+                            | crate::semi::ty::Flexivity::Rigid
                     )
                 ) => {}
                 _ => self.error(
@@ -955,8 +955,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // re-reads the head (`unify` ignores flexivity). Construction outside a
         // region is reported separately by the caller.
         let flex = match record.default_cap {
-            super::ctxt::DefaultCap::Regional => crate::semi::ty::Capability::Flex,
-            _ => crate::semi::ty::Capability::Irrelevant,
+            super::ctxt::DefaultCap::Regional => crate::semi::ty::Flexivity::Flex,
+            _ => crate::semi::ty::Flexivity::Irrelevant,
         };
         self.tcx.mk_record(record.def, &args, flex)
     }

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -8,7 +8,7 @@ use crate::semi::infer::InferCtxt;
 use crate::semi::resolve::DefTable;
 use crate::semi::traits::builtins::Builtins;
 use crate::semi::traits::{TraitDb, TraitId};
-use crate::semi::ty::{Capability, DefId, GenericId, Ty, TyCtxt, TyKind};
+use crate::semi::ty::{Flexivity, DefId, GenericId, Ty, TyCtxt, TyKind};
 use crate::surface::{self, Span};
 use crate::utils::frecency::Frecency;
 use crate::utils::fuzzy::FuzzyIndex;
@@ -17,7 +17,7 @@ use crate::utils::string::StringUniqifier;
 use super::fulfill::FulfillCtxt;
 use super::hir::{ExprId, Function, VarId};
 
-/// The capability a record declares by default. (Per-use [`crate::semi::ty::Capability`]
+/// The capability a record declares by default. (Per-use [`crate::semi::ty::Flexivity`]
 /// flexivity is derived from this during coloring.)
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum DefaultCap {
@@ -711,7 +711,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 }
             }
             TyKind::Record {
-                flex: Capability::Irrelevant,
+                flex: Flexivity::Irrelevant,
                 ..
             } => self.error(span, "a `[field]` link element must be a regional record"),
             // Regional records are fine; non-record elements are already rejected

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -235,7 +235,7 @@ impl<'tcx> FulfillCtxt<'tcx> {
 mod tests {
     use super::ty_has_hole;
     use crate::semi::infer::InferCtxt;
-    use crate::semi::ty::{Capability, DefId, IntTy};
+    use crate::semi::ty::{Flexivity, DefId, IntTy};
     use crate::with_tcx;
 
     #[test]
@@ -254,12 +254,12 @@ mod tests {
             assert!(ty_has_hole(tcx.mk_record(
                 DefId(0),
                 &[hole],
-                Capability::Irrelevant
+                Flexivity::Irrelevant
             )));
             assert!(!ty_has_hole(tcx.mk_record(
                 DefId(0),
                 &[ground],
-                Capability::Irrelevant
+                Flexivity::Irrelevant
             )));
             assert!(ty_has_hole(tcx.mk_nullable(hole)));
         });

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -23,7 +23,7 @@ use crate::semi::hir::{
     SwitchCases, VarId,
 };
 use crate::semi::resolve::DefTable;
-use crate::semi::ty::{Capability, DefId, FpTy, GenericId, IntTy, Ty, TyCtxt, TyKind};
+use crate::semi::ty::{DefId, Flexivity, FpTy, GenericId, IntTy, Ty, TyCtxt, TyKind};
 use crate::surface::RecordKind;
 use crate::utils::string::StringToken;
 
@@ -220,7 +220,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::Ty::Record { cap, path, args } => {
                 let def = self.record_def(path);
                 let args: Vec<Ty<'tcx>> = args.iter().map(|a| self.ty(a)).collect();
-                self.tcx.mk_record(def, &args, capability(*cap))
+                self.tcx.mk_record(def, &args, flexivity(*cap))
             }
             raw::Ty::Closure { params, ret } => {
                 let params: Vec<Ty<'tcx>> = params.iter().map(|p| self.ty(p)).collect();
@@ -428,12 +428,12 @@ impl<'tcx> Builder<'_, 'tcx> {
     }
 }
 
-fn capability(c: raw::Cap) -> Capability {
+fn flexivity(c: raw::Cap) -> Flexivity {
     match c {
-        raw::Cap::None => Capability::Irrelevant,
-        raw::Cap::Flex => Capability::Flex,
-        raw::Cap::Rigid => Capability::Rigid,
-        raw::Cap::Regional => Capability::Regional,
+        raw::Cap::None => Flexivity::Irrelevant,
+        raw::Cap::Flex => Flexivity::Flex,
+        raw::Cap::Rigid => Flexivity::Rigid,
+        raw::Cap::Regional => Flexivity::Regional,
     }
 }
 

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -20,7 +20,7 @@ use crate::semi::hir::{
     ArithOp, CmpOp, DecisionTree, Expr, ExprKind, Function, PatVarRef, SwitchCases, VarId,
 };
 use crate::semi::resolve::DefTable;
-use crate::semi::ty::{Capability, DefId, FpTy, GenericId, IntTy, Ty, TyKind};
+use crate::semi::ty::{DefId, Flexivity, FpTy, GenericId, IntTy, Ty, TyKind};
 use crate::surface::{RecordKind, Visibility};
 
 const IR_PRINTER: PpPrinter = PpPrinter {
@@ -176,10 +176,10 @@ impl<'a> Printer<'a> {
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
             TyKind::Record { def, args, flex } => {
                 let mut d = match flex {
-                    Capability::Flex | Capability::Rigid | Capability::Regional => {
+                    Flexivity::Flex | Flexivity::Rigid | Flexivity::Regional => {
                         text(format!("[{}] ", cap_name(flex)))
                     }
-                    Capability::Irrelevant => Doc::Null,
+                    Flexivity::Irrelevant => Doc::Null,
                 };
                 d = d + text(format!("#{}", self.path(def)));
                 if !args.is_empty() {
@@ -505,12 +505,12 @@ fn comma_sep(docs: Vec<Doc<'static>>) -> Doc<'static> {
     d
 }
 
-fn cap_name(c: Capability) -> &'static str {
+fn cap_name(c: Flexivity) -> &'static str {
     match c {
-        Capability::Flex => "flex",
-        Capability::Rigid => "rigid",
-        Capability::Regional => "regional",
-        Capability::Irrelevant => "",
+        Flexivity::Flex => "flex",
+        Flexivity::Rigid => "rigid",
+        Flexivity::Regional => "regional",
+        Flexivity::Irrelevant => "",
     }
 }
 

--- a/crates/reussir-core/src/semi/infer.rs
+++ b/crates/reussir-core/src/semi/infer.rs
@@ -577,12 +577,12 @@ mod tests {
             let a = tcx.mk_record(
                 def(1),
                 &[tcx.mk_int(IntTy::Signed(32))],
-                crate::semi::ty::Capability::Rigid,
+                crate::semi::ty::Flexivity::Rigid,
             );
             let b = tcx.mk_record(
                 def(1),
                 &[tcx.mk_int(IntTy::Signed(32))],
-                crate::semi::ty::Capability::Rigid,
+                crate::semi::ty::Flexivity::Rigid,
             );
             // Structurally equal -> the very same handle.
             assert_eq!(a, b);
@@ -683,7 +683,7 @@ mod tests {
     #[test]
     fn record_head_and_arity_clash() {
         with_tcx(|tcx| {
-            use crate::semi::ty::Capability::Irrelevant;
+            use crate::semi::ty::Flexivity::Irrelevant;
             let mut ic = InferCtxt::new(tcx);
             let i32 = tcx.mk_int(IntTy::Signed(32));
             // Different head constructor.

--- a/crates/reussir-core/src/semi/traits.rs
+++ b/crates/reussir-core/src/semi/traits.rs
@@ -6,7 +6,7 @@
 //! [`Evidence`] returned is a proof tree consumed statically at monomorphization;
 //! its shape is also what a future `dyn` vtable would carry.
 //!
-//! Capability-as-a-bound is deferred (see [`crate::semi::ty::Capability`]); if it
+//! Flexivity-as-a-bound is deferred (see [`crate::semi::ty::Flexivity`]); if it
 //! lands it becomes a second [`Obligation`] variant discharged through the same
 //! [`TraitDb::select`] entry point.
 
@@ -46,8 +46,8 @@ impl<'tcx> TraitRef<'tcx> {
     }
 }
 
-/// A predicate the solver must discharge. (Capability-as-a-bound will join this
-/// once its semantics are settled — see [`crate::semi::ty::Capability`].)
+/// A predicate the solver must discharge. (Flexivity-as-a-bound will join this
+/// once its semantics are settled — see [`crate::semi::ty::Flexivity`].)
 #[derive(Clone, Debug)]
 pub enum Obligation<'tcx> {
     /// `τ : Trait<…>`, discharged by impl search.

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -36,17 +36,24 @@ pub struct GenericId(pub u32);
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct HoleId(pub u32);
 
-/// The per-use memory capability ("flexivity") a value carries: `Flex` is
-/// mutable but cannot be materialized out of its region, `Rigid` is immutable
-/// but materializable (the frozen form that escapes a region), `Regional` is
-/// the unrefined regional form, and `Irrelevant` is the non-regional default.
+/// The per-use *flexivity* a value carries — its regional memory coloring:
+/// `Flex` is mutable but cannot be materialized out of its region, `Rigid` is
+/// immutable but materializable (the frozen form that escapes a region),
+/// `Regional` is the unrefined regional form, and `Irrelevant` is the
+/// non-regional default.
+///
+/// This names the regional-coloring axis **only**; it is deliberately *not*
+/// called a "capability", to keep it distinct from rc-management (value vs
+/// shared vs regional, decided per record from its declaration). The two
+/// interact in exactly one place — a region-managed record needs rc only when
+/// its flexivity is `Rigid` (frozen/escaped); see `full::ownership`.
 ///
 /// These do **not** form a total order — `Flex` and `Rigid` are incomparable
 /// (different axes: mutability vs materializability) — so there is no
-/// subsumption helper. Capability-as-a-bound is deferred until its semantics are
+/// subsumption helper. Flexivity-as-a-bound is deferred until its semantics are
 /// settled; for now this is purely the coloring stored on [`TyKind::Record`].
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum Capability {
+pub enum Flexivity {
     Irrelevant,
     Regional,
     Flex,
@@ -80,7 +87,7 @@ pub enum TyKind<'tcx> {
     Record {
         def: DefId,
         args: &'tcx [Ty<'tcx>],
-        flex: Capability,
+        flex: Flexivity,
     },
     Int(IntTy),
     Fp(FpTy),
@@ -111,9 +118,9 @@ impl<'tcx> Ty<'tcx> {
         self.0
     }
 
-    /// The capability a value of this type carries, if any. Only nominal
-    /// records carry one today.
-    pub fn capability(self) -> Option<Capability> {
+    /// The flexivity (regional coloring) a value of this type carries, if any.
+    /// Only nominal records carry one today.
+    pub fn flexivity(self) -> Option<Flexivity> {
         match self.0 {
             TyKind::Record { flex, .. } => Some(*flex),
             _ => None,
@@ -207,7 +214,7 @@ impl<'tcx> TyCtxt<'tcx> {
         self.mk(TyKind::Nullable(inner))
     }
 
-    pub fn mk_record(&self, def: DefId, args: &[Ty<'tcx>], flex: Capability) -> Ty<'tcx> {
+    pub fn mk_record(&self, def: DefId, args: &[Ty<'tcx>], flex: Flexivity) -> Ty<'tcx> {
         let args = self.intern_tys(args);
         self.mk(TyKind::Record { def, args, flex })
     }

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -2,7 +2,7 @@
 //! ("flexivity") coloring of regional records.
 //!
 //! A `[regional]` record is a type that can be *created locally* inside a region.
-//! Flexivity is the per-use color such a value carries; the four [`Capability`]
+//! Flexivity is the per-use color such a value carries; the four [`Flexivity`]
 //! states mean:
 //!
 //! * **Flex** — a live, freshly created regional object. Its `[field]` links can
@@ -24,7 +24,7 @@
 //! Lifecycle: create ⟶ Flex ──(freeze on escape)──▶ Rigid (materializable).
 //!
 //! Representation note: a regional record's *type annotation* is evaluated by
-//! `eval_type` to an unpinned [`Capability::Regional`], which
+//! `eval_type` to an unpinned [`Flexivity::Regional`], which
 //! [`Elaborator::eval_type_flex`] then pins to Flex (`[flex]`) or Rigid. A
 //! freshly *constructed* regional record is different: it is born Flex directly
 //! (the checker's `record_ty`) — the live, region-local form, so it is
@@ -39,7 +39,7 @@
 //! binding. Generics are left uncolored — their modality is resolved at
 //! monomorphization.
 
-use crate::semi::ty::{Capability, FpTy, IntTy, Ty, TyKind};
+use crate::semi::ty::{Flexivity, FpTy, IntTy, Ty, TyKind};
 use crate::surface::{self, FpType, IntegralType, TypeKind};
 
 use super::ctxt::{DefaultCap, Elaborator};
@@ -129,8 +129,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let default_cap = self.records[&def].default_cap;
         let args: Vec<Ty> = args.iter().map(|a| self.eval_type(a)).collect();
         let flex = match default_cap {
-            DefaultCap::Value | DefaultCap::Shared => Capability::Irrelevant,
-            DefaultCap::Regional => Capability::Regional,
+            DefaultCap::Value | DefaultCap::Shared => Flexivity::Irrelevant,
+            DefaultCap::Regional => Flexivity::Regional,
         };
         self.tcx.mk_record(def, &args, flex)
     }
@@ -145,21 +145,21 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Refine a regional record's flexivity by a `[flex]` flag.
     pub fn refine_flex(&self, t: Ty<'tcx>, is_flex: bool) -> Ty<'tcx> {
         let refined = if is_flex {
-            Capability::Flex
+            Flexivity::Flex
         } else {
-            Capability::Rigid
+            Flexivity::Rigid
         };
         match t.kind() {
             TyKind::Record {
                 def,
                 args,
-                flex: Capability::Regional,
+                flex: Flexivity::Regional,
             } => self.tcx.mk_record(*def, args, refined),
             TyKind::Nullable(inner) => {
                 if let TyKind::Record {
                     def,
                     args,
-                    flex: Capability::Regional,
+                    flex: Flexivity::Regional,
                 } = inner.kind()
                 {
                     let inner = self.tcx.mk_record(*def, args, refined);
@@ -187,8 +187,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             TyKind::Record {
                 def,
                 args,
-                flex: Capability::Regional | Capability::Flex,
-            } => self.tcx.mk_record(*def, args, Capability::Rigid),
+                flex: Flexivity::Regional | Flexivity::Flex,
+            } => self.tcx.mk_record(*def, args, Flexivity::Rigid),
             TyKind::Nullable(inner) => {
                 let inner = self.freeze_region(*inner);
                 self.tcx.mk_nullable(inner)

--- a/crates/reussir-core/src/utils/bitset.rs
+++ b/crates/reussir-core/src/utils/bitset.rs
@@ -1,0 +1,277 @@
+//! A small-set-optimized bitset over `u32`.
+//!
+//! Most live-variable / index sets in a compiler are small and dense (a handful
+//! of low ids), the regime where a flat word bitset is cheapest; a few are large
+//! or sparse, where a compressed bitmap wins. [`HybridBitSet`] starts dense — a
+//! [`FixedBitSet`] sized to one platform register, grown on demand (a register at
+//! a time) up to [`MAX_DENSE_BITS`] — and switches **once** to a [`RoaringBitmap`]
+//! the first time an element at or beyond that bound is inserted. The switch is
+//! one-way: the set never demotes back to dense.
+//!
+//! Equality is by *contents*, independent of representation, so a `HybridBitSet`
+//! can be used as a value in the usual way.
+
+use std::fmt;
+
+use fixedbitset::FixedBitSet;
+use roaring::RoaringBitmap;
+
+/// The dense representation's cap, in bits. Elements `< MAX_DENSE_BITS` live in a
+/// [`FixedBitSet`]; inserting one at or beyond it promotes to a [`RoaringBitmap`].
+/// 512 bits is 8 registers on a 64-bit target — small enough to stay cheap, large
+/// enough to cover the common case without ever allocating a bitmap.
+const MAX_DENSE_BITS: u32 = 512;
+
+/// A set of `u32`s that is dense for small domains and compressed for large ones.
+/// See the module docs.
+#[derive(Clone)]
+pub enum HybridBitSet {
+    /// Every element is `< MAX_DENSE_BITS`. Capacity begins at one platform
+    /// register ([`usize::BITS`]) and grows a register at a time, never past the
+    /// cap.
+    Dense(FixedBitSet),
+    /// At least one element reached `MAX_DENSE_BITS`, so the whole set moved to a
+    /// compressed bitmap.
+    Sparse(RoaringBitmap),
+}
+
+impl HybridBitSet {
+    /// An empty set, dense, sized to one platform register.
+    pub fn new() -> Self {
+        HybridBitSet::Dense(FixedBitSet::with_capacity(usize::BITS as usize))
+    }
+
+    /// Insert `value`. A dense set grows to fit (rounding capacity up to a whole
+    /// platform register, up to [`MAX_DENSE_BITS`]); a `value` at or beyond the cap
+    /// promotes the set to a [`RoaringBitmap`].
+    pub fn insert(&mut self, value: u32) {
+        match self {
+            HybridBitSet::Sparse(bitmap) => {
+                bitmap.insert(value);
+            }
+            HybridBitSet::Dense(dense) if value < MAX_DENSE_BITS => {
+                dense.grow(register_aligned_len(value));
+                dense.insert(value as usize);
+            }
+            // Beyond the cap: promote self by inserting into a bitmap copy.
+            this @ HybridBitSet::Dense(_) => {
+                let mut bitmap = this.to_bitmap();
+                bitmap.insert(value);
+                *this = HybridBitSet::Sparse(bitmap);
+            }
+        }
+    }
+
+    /// Is `value` in the set?
+    pub fn contains(&self, value: u32) -> bool {
+        match self {
+            // `FixedBitSet::contains` treats out-of-capacity bits as unset.
+            HybridBitSet::Dense(dense) => dense.contains(value as usize),
+            HybridBitSet::Sparse(bitmap) => bitmap.contains(value),
+        }
+    }
+
+    /// In place: `self ← self ∪ other`. If `other` is compressed (so it may hold
+    /// elements beyond the cap) `self` is promoted to match.
+    pub fn union_with(&mut self, other: &HybridBitSet) {
+        match (self, other) {
+            (HybridBitSet::Dense(a), HybridBitSet::Dense(b)) => a.union_with(b),
+            (HybridBitSet::Sparse(a), HybridBitSet::Sparse(b)) => *a |= b,
+            (HybridBitSet::Sparse(a), HybridBitSet::Dense(b)) => {
+                a.extend(b.ones().map(|i| i as u32));
+            }
+            // Dense ∪ Sparse: `other` may hold elements past the cap, so promote
+            // self by folding its bits into a copy of the compressed `b`.
+            (this @ HybridBitSet::Dense(_), HybridBitSet::Sparse(b)) => {
+                let mut bitmap = this.to_bitmap();
+                bitmap |= b;
+                *this = HybridBitSet::Sparse(bitmap);
+            }
+        }
+    }
+
+    /// Remove every member of `other` (set difference, in place). Never changes
+    /// representation — a difference only removes elements.
+    pub fn subtract(&mut self, other: &HybridBitSet) {
+        match (self, other) {
+            (HybridBitSet::Dense(a), HybridBitSet::Dense(b)) => a.difference_with(b),
+            (HybridBitSet::Sparse(a), HybridBitSet::Sparse(b)) => *a -= b,
+            (HybridBitSet::Sparse(a), HybridBitSet::Dense(b)) => {
+                for i in b.ones() {
+                    a.remove(i as u32);
+                }
+            }
+            (HybridBitSet::Dense(a), HybridBitSet::Sparse(b)) => {
+                let drop: Vec<usize> = a.ones().filter(|&i| b.contains(i as u32)).collect();
+                for i in drop {
+                    a.remove(i);
+                }
+            }
+        }
+    }
+
+    /// The members in ascending order (both backends iterate sorted, so emission
+    /// order is deterministic).
+    pub fn iter(&self) -> Iter<'_> {
+        match self {
+            HybridBitSet::Dense(dense) => Iter::Dense(dense.ones()),
+            HybridBitSet::Sparse(bitmap) => Iter::Sparse(bitmap.iter()),
+        }
+    }
+
+    /// Materialize the current contents as a [`RoaringBitmap`] (used when a dense
+    /// set has to promote).
+    fn to_bitmap(&self) -> RoaringBitmap {
+        match self {
+            HybridBitSet::Dense(dense) => dense.ones().map(|i| i as u32).collect(),
+            HybridBitSet::Sparse(bitmap) => bitmap.clone(),
+        }
+    }
+}
+
+/// The dense length needed to hold `value`, rounded up to a whole platform
+/// register so growth happens a register at a time rather than bit by bit.
+fn register_aligned_len(value: u32) -> usize {
+    (value + 1).next_multiple_of(usize::BITS) as usize
+}
+
+impl Default for HybridBitSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Contents equality, independent of representation (a dense and a compressed set
+/// holding the same elements compare equal).
+impl PartialEq for HybridBitSet {
+    fn eq(&self, other: &Self) -> bool {
+        self.iter().eq(other.iter())
+    }
+}
+
+impl Eq for HybridBitSet {}
+
+impl fmt::Debug for HybridBitSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+impl FromIterator<u32> for HybridBitSet {
+    fn from_iter<I: IntoIterator<Item = u32>>(iter: I) -> Self {
+        let mut set = HybridBitSet::new();
+        for v in iter {
+            set.insert(v);
+        }
+        set
+    }
+}
+
+/// Ascending iterator over a [`HybridBitSet`]'s members, over whichever backend
+/// the set currently uses.
+pub enum Iter<'a> {
+    Dense(fixedbitset::Ones<'a>),
+    Sparse(roaring::bitmap::Iter<'a>),
+}
+
+impl Iterator for Iter<'_> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<u32> {
+        match self {
+            Iter::Dense(ones) => ones.next().map(|i| i as u32),
+            Iter::Sparse(bitmap) => bitmap.next(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A reference set built straight on a `BTreeSet<u32>` to check against.
+    fn check(values: &[u32]) {
+        use std::collections::BTreeSet;
+        let reference: BTreeSet<u32> = values.iter().copied().collect();
+        let set: HybridBitSet = values.iter().copied().collect();
+        for &v in values {
+            assert!(set.contains(v), "missing {v}");
+        }
+        assert!(!set.contains(99_999));
+        assert_eq!(
+            set.iter().collect::<Vec<_>>(),
+            reference.iter().copied().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn dense_small() {
+        check(&[0, 1, 5, 63, 64, 200, 511]);
+    }
+
+    #[test]
+    fn promotes_past_the_cap() {
+        // 511 stays dense, 512 forces a promotion; both must read back.
+        let mut set = HybridBitSet::new();
+        set.insert(511);
+        assert!(matches!(set, HybridBitSet::Dense(_)));
+        set.insert(512);
+        assert!(matches!(set, HybridBitSet::Sparse(_)));
+        assert!(set.contains(511) && set.contains(512));
+        check(&[1, 511, 512, 1_000, 70_000]);
+    }
+
+    #[test]
+    fn dense_capacity_is_register_aligned() {
+        let reg = usize::BITS as usize;
+        let mut set = HybridBitSet::new();
+        let HybridBitSet::Dense(d) = &set else {
+            unreachable!()
+        };
+        assert_eq!(d.len(), reg); // one register up front
+
+        set.insert(reg as u32); // first bit past the initial register
+        let HybridBitSet::Dense(d) = &set else {
+            unreachable!()
+        };
+        assert_eq!(d.len(), 2 * reg); // grown by exactly one more register
+    }
+
+    #[test]
+    fn union_across_representations() {
+        // dense ∪ sparse must promote and keep both.
+        let mut a: HybridBitSet = [1, 2, 511].into_iter().collect();
+        let b: HybridBitSet = [2, 600].into_iter().collect();
+        a.union_with(&b);
+        assert_eq!(a.iter().collect::<Vec<_>>(), vec![1, 2, 511, 600]);
+
+        // sparse ∪ dense keeps the sparse backing.
+        let mut c: HybridBitSet = [700].into_iter().collect();
+        let d: HybridBitSet = [3, 4].into_iter().collect();
+        c.union_with(&d);
+        assert_eq!(c.iter().collect::<Vec<_>>(), vec![3, 4, 700]);
+    }
+
+    #[test]
+    fn subtract_across_representations() {
+        let mut a: HybridBitSet = [1, 2, 3, 600].into_iter().collect();
+        let b: HybridBitSet = [2, 600].into_iter().collect();
+        a.subtract(&b);
+        assert_eq!(a.iter().collect::<Vec<_>>(), vec![1, 3]);
+
+        let mut c: HybridBitSet = [1, 2, 3].into_iter().collect();
+        let d: HybridBitSet = [2, 900].into_iter().collect();
+        c.subtract(&d);
+        assert_eq!(c.iter().collect::<Vec<_>>(), vec![1, 3]);
+    }
+
+    #[test]
+    fn equality_is_representation_independent() {
+        let dense: HybridBitSet = [1, 2, 3].into_iter().collect();
+        let mut promoted: HybridBitSet = [1, 2, 3, 9_999].into_iter().collect();
+        promoted.subtract(&[9_999].into_iter().collect());
+        // `promoted` is Sparse but holds {1,2,3}, same as the dense set.
+        assert!(matches!(promoted, HybridBitSet::Sparse(_)));
+        assert_eq!(dense, promoted);
+    }
+}

--- a/crates/reussir-core/src/utils/mod.rs
+++ b/crates/reussir-core/src/utils/mod.rs
@@ -1,6 +1,7 @@
 //! Shared utilities for the Reussir core.
 
 pub mod b62;
+pub mod bitset;
 pub mod frecency;
 pub mod fuzzy;
 pub mod punycode;


### PR DESCRIPTION
## Summary

Adds a **Perceus-style precise reference-counting (ownership) analysis** over the Full MIR (`reussir-core/src/full/ownership.rs`). For every resource-relevant (RR) value it decides *where* the backend should `dup`/`drop` so each owned value is released exactly once, with drops placed as early as possible (so the backend's reuse pass can pair a freed token with a same-layout allocation). The MIR is immutable, so the result is a side-table keyed by `ExprId`/`VarId` anchors (`OwnershipTable`) rather than a rewritten tree.

The analysis is **total over the MIR** — no form is deferred:

- **Linear core** — `Var` / `Let` / `Seq` / `Call` / `Ctor` / `Variant` / `NullableCall`, with last-use-is-the-pivot dup/move/drop placement and the owned calling convention.
- **`is_rr` predicate** — `Shared` and closures are always RR; a `Value` record is RR iff some field transitively is; a `Regional` record is RR only when its `Flexivity` is `Rigid` (frozen/escaped) — a region-local `Flex` value needs no rc. Memoized, cycle-guarded.
- **Control flow** — `If` branch reconciliation and discarded-result drops.
- **Pattern matching** — `Match` over `Switch` + `Leaf` + `Guard`, borrow-dup à la Koka (field borrow-extract dups, early scrutinee drop, N-way leaf reconciliation, guards keep the scrutinee live across the re-testable failure path).
- **Containers** — `Proj` (borrow-extract) and `Assign` (store into a flex-regional field).
- **Closures & regions** — `Closure` / `ClosureCall` capture handling, rc-transparent `RegionRun`.

Reuse *specialization* (fusing `dup field; drop parent` into an in-place uniqueness-guarded move) is intentionally left to the backend, exactly as Koka separates Perceus from its reuse analysis.

## Notable design points

- Renamed the type-level `Capability` to **`Flexivity`** (`Irrelevant`/`Regional`/`Flex`/`Rigid`) to disentangle the regional-coloring axis from rc-management; regional rc now gates on `Rigid`.
- `VarSet` live-sets are backed by a new **`utils::bitset::HybridBitSet`** — dense (`FixedBitSet`, one register, grown a register at a time) up to 512 bits, then a one-way switch to a compressed `RoaringBitmap`. Most bodies have a handful of low VarIds and stay in the cheap dense form. Small arg/switch lists stay inline via `SmallVec`.
- `place_assign` is simplified: an assignment target is always a flex-regional (non-RR) record, so its base navigation was dead logic — replaced with a `debug_assert` pinning the invariant.

## Testing

- 31 ownership unit tests built on a self-contained MIR builder + a `pprint`-based tree renderer (the harness prints the annotated tree with rc ops inline). Cases cover the linear core, If/Match reconciliation, guards, containers, closures, regions, regional freeze→Rigid escape, tail-recursive list reverse, and non-scrutinee RR vars used/unused/across a match.
- `utils::bitset` has its own dense/sparse/promotion/union/subtract/equality tests.
- `cargo test -p reussir-core --lib` (164 tests) and `cargo clippy -p reussir-core --lib --tests` both clean.

See `crates/reussir-core/docs/ownership-analysis.md` for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
