### PR TITLE
[backend] reussir-codegen: managed (`[shared]`) records via ownership-driven reference counting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,7 @@ dependencies = [
  "reussir-jit",
  "reussir-syntax",
  "rustc-hash",
+ "smallvec",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -230,4 +230,5 @@ unsafe extern "C" {
         member_is_field: *const bool,
         default_capability: ReussirCapability,
     );
+    pub fn reussirRecordTypeIsComplete(record: MlirType) -> bool;
 }

--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -8,7 +8,9 @@
 //! downstream code generators.
 
 use melior::Context;
-use melior::ir::attribute::{FlatSymbolRefAttribute, IntegerAttribute, StringAttribute};
+use melior::ir::attribute::{
+    DenseI32ArrayAttribute, FlatSymbolRefAttribute, IntegerAttribute, StringAttribute,
+};
 use melior::ir::operation::OperationBuilder;
 use melior::ir::r#type::IntegerType;
 use melior::ir::{Identifier, Location, Operation, Type, Value};
@@ -81,6 +83,33 @@ pub fn record_compound<'c>(
         .add_results(&[result_type])
         .build()
         .expect("valid reussir.record.compound")
+}
+
+/// `reussir.rc.create value(<value> : <type>) : <result_type>` — box a value into
+/// a fresh reference-counted pointer with an initial count of 1.
+///
+/// The op carries `AttrSizedOperandSegments` over its `[value, token, region]`
+/// operand groups, but melior's generated builder leaves the required
+/// `operandSegmentSizes` attribute unset, so it is constructed here with the
+/// single value operand present (`[1, 0, 0]`). The allocation token and any
+/// region are supplied later by the token-instantiation pass; the rc-create
+/// fusion pass then folds an immediately preceding `record.compound` into this
+/// op (`reussir.rc.create_compound`).
+pub fn rc_create<'c>(
+    context: &'c Context,
+    value: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.rc.create", location)
+        .add_operands(&[value])
+        .add_attributes(&[(
+            Identifier::new(context, "operandSegmentSizes"),
+            DenseI32ArrayAttribute::new(context, &[1, 0, 0]).into(),
+        )])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.rc.create")
 }
 
 /// `reussir.record.extract (<record> : <type>) [<index>] : <field_type>` —

--- a/crates/reussir-backend/src/dialect/ty.rs
+++ b/crates/reussir-backend/src/dialect/ty.rs
@@ -193,6 +193,14 @@ pub fn record_incomplete<'c>(
     }
 }
 
+/// Whether an identified record type has had its body filled in. A type from
+/// [`record_incomplete`] reports `false` until [`record_complete_in_place`]
+/// runs, so a caller can look a record up by name and skip rebuilding its
+/// members when it is already complete.
+pub fn record_is_complete(record: Type) -> bool {
+    unsafe { sys::reussirRecordTypeIsComplete(record.to_raw()) }
+}
+
 /// Completes a previously created incomplete record type in place. `members` and
 /// `member_is_field` must have the same length.
 pub fn record_complete_in_place(

--- a/crates/reussir-codegen/Cargo.toml
+++ b/crates/reussir-codegen/Cargo.toml
@@ -16,6 +16,7 @@ reussir-backend = { path = "../reussir-backend" }
 # The fast map for the per-function SSA environment.
 rustc-hash.workspace = true
 tracing.workspace = true
+smallvec.workspace = true
 
 [dev-dependencies]
 # End-to-end tests: source → elaborate → monomorphize → lower → run.

--- a/crates/reussir-codegen/src/lib.rs
+++ b/crates/reussir-codegen/src/lib.rs
@@ -9,12 +9,7 @@
 
 pub mod lower;
 
+// Test-only helpers, shared with the integration tests (which include the same
+// file directly via `#[path]`). Not part of the crate's API.
 #[cfg(test)]
-pub(crate) mod test {
-    pub(crate) fn init_tracing() {
-        static TRACING_INIT: std::sync::Once = std::sync::Once::new();
-        TRACING_INIT.call_once(|| {
-            tracing_subscriber::fmt().init();
-        });
-    }
-}
+pub(crate) mod testing;

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -10,9 +10,12 @@
 //! lifetime-shortening reborrow). Bindings introduced inside a branch stay
 //! scoped to it.
 
+use std::cell::RefCell;
+
 use rustc_hash::FxHashMap;
 
 use reussir_backend::builders;
+use reussir_backend::dialect;
 use reussir_backend::melior::Context;
 use reussir_backend::melior::dialect::arith::{self, CmpfPredicate, CmpiPredicate};
 use reussir_backend::melior::dialect::{func, scf};
@@ -25,9 +28,9 @@ use reussir_backend::melior::ir::{
 };
 
 use reussir_core::full::mir::{self, Expr, ExprKind};
-use reussir_core::semi::ctxt::DefaultCap;
-use reussir_core::semi::hir::{ArithOp, CmpOp, VarId};
-use reussir_core::semi::ty::{IntTy, Ty, TyKind};
+use reussir_core::full::ownership::{OwnershipTable, RcOp, RecordTable, analyze_function};
+use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
+use reussir_core::semi::ty::{IntTy, Ty, TyCtxt, TyKind};
 use reussir_core::surface::Visibility;
 
 use super::ty::{TypeCtx, is_unit, num_class};
@@ -36,26 +39,67 @@ use super::{LoweringError, Result, err};
 /// The variable → SSA-value environment for one block scope.
 type Env<'c, 'b> = FxHashMap<VarId, Value<'c, 'b>>;
 
-/// Per-program lowering state: the context to build in, the program whose symbol
-/// table resolves callee/trampoline names, and the [`TypeCtx`] that lowers types
-/// and resolves record layouts. Reused across functions.
+/// The state threaded through a field-projection walk: either a loaded value or a
+/// borrowed reference into a record, each tagged with its ground MIR type so the
+/// next step can consult the record layout and pick the right op.
+enum Cursor<'c, 'b, 'tcx> {
+    /// A loaded SSA value of record or scalar type `ty`. For a `[value]` record
+    /// this is the inline aggregate; for a `[shared]` record it is the `rc`
+    /// pointer.
+    Value { val: Value<'c, 'b>, ty: Ty<'tcx> },
+    /// A borrowed `!reussir.ref<…>` into a record whose MIR type is `ty`.
+    Ref { val: Value<'c, 'b>, ty: Ty<'tcx> },
+}
+
+/// Per-program lowering state: the context to build in, the type arena, the
+/// program whose symbol table resolves callee/trampoline names, the [`TypeCtx`]
+/// that lowers types and resolves record layouts, and the record table the
+/// ownership analysis consults. Reused across functions.
+///
+/// Two side-tables hold state for the function currently being lowered (reset on
+/// entry to [`function`](Self::function)): the [`OwnershipTable`] that says where
+/// to emit reference-count ops, and the type of each named local (so a `dup`/
+/// `drop` keyed by a variable knows whether to emit an `rc` op or to recurse
+/// through an inline record).
 pub(super) struct Lowerer<'c, 'p, 'tcx> {
     context: &'c Context,
+    tcx: &'p TyCtxt<'tcx>,
     program: &'p mir::Program<'tcx>,
     tys: TypeCtx<'c, 'p, 'tcx>,
+    records: RecordTable<'tcx>,
+    ownership: RefCell<OwnershipTable>,
+    var_tys: RefCell<FxHashMap<VarId, Ty<'tcx>>>,
 }
 
 impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
-    pub(super) fn new(context: &'c Context, program: &'p mir::Program<'tcx>) -> Self {
+    pub(super) fn new(
+        context: &'c Context,
+        tcx: &'p TyCtxt<'tcx>,
+        program: &'p mir::Program<'tcx>,
+    ) -> Self {
         Lowerer {
             context,
+            tcx,
             program,
             tys: TypeCtx::new(context, program),
+            records: RecordTable::from_records(&program.records),
+            ownership: RefCell::new(OwnershipTable::default()),
+            var_tys: RefCell::new(FxHashMap::default()),
         }
     }
 
     fn loc(&self) -> Location<'c> {
         Location::unknown(self.context)
+    }
+
+    /// Record the ground type of a local, so reference-count ops keyed by it can
+    /// pick the right instruction.
+    fn bind_var_ty(&self, var: VarId, ty: Ty<'tcx>) {
+        self.var_tys.borrow_mut().insert(var, ty);
+    }
+
+    fn var_ty(&self, var: VarId) -> Option<Ty<'tcx>> {
+        self.var_tys.borrow().get(&var).copied()
     }
 
     /// Lower one MIR function to a `func.func` operation.
@@ -74,6 +118,11 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         };
         let fn_ty = FunctionType::new(self.context, &param_tys, &result_tys);
 
+        // Reset the per-function side-tables, then run the ownership analysis for
+        // this body so the tree-walk can emit each node's reference-count ops.
+        *self.ownership.borrow_mut() = analyze_function(self.tcx, func, &self.records);
+        self.var_tys.borrow_mut().clear();
+
         let region = Region::new();
         if let Some(body) = func.body {
             let block_args: Vec<(Type<'c>, Location<'c>)> =
@@ -85,6 +134,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     .argument(i)
                     .map_err(|e| LoweringError(format!("missing block argument: {e}").into()))?;
                 env.insert(p.var, arg.into());
+                self.bind_var_ty(p.var, p.ty);
             }
             let value = self.expr(&block, &mut env, body)?;
             if is_unit(ret) {
@@ -120,7 +170,25 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
 
     /// Lower an expression into `block`, returning the SSA value holding its
     /// result (`None` for a unit-typed expression).
+    ///
+    /// Around the node's own ops, this emits the reference-count ops the
+    /// ownership analysis placed at its anchor: the `before` ops first, then the
+    /// node, then the `after` ops (which may reference the node's freshly-produced
+    /// value, e.g. to increment a borrowed field or drop a discarded result).
     fn expr<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        e: &Expr<'tcx>,
+    ) -> Result<Option<Value<'c, 'b>>> {
+        self.emit_rc_before(block, env, e.id)?;
+        let value = self.expr_inner(block, env, e)?;
+        self.emit_rc_after(block, env, e.id, e.ty, value)?;
+        Ok(value)
+    }
+
+    /// Lower the node itself, without its surrounding reference-count ops.
+    fn expr_inner<'b>(
         &self,
         block: &'b Block<'c>,
         env: &mut Env<'c, 'b>,
@@ -175,6 +243,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 Ok(last)
             }
             Let { var, value, .. } => {
+                self.bind_var_ty(*var, value.ty);
                 if let Some(v) = self.expr(block, env, value)? {
                     env.insert(*var, v);
                 }
@@ -220,8 +289,13 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         }
     }
 
-    /// Construct a `[value]` record from its (declaration-ordered) field args via
-    /// `reussir.record.compound`.
+    /// Construct a record from its (declaration-ordered) field args.
+    ///
+    /// The fields are packed into the inline record payload with
+    /// `reussir.record.compound`. A `[value]` record stops there; a `[shared]`
+    /// record then boxes that payload into a fresh reference-counted pointer with
+    /// `reussir.rc.create` (the rc-create fusion pass folds the two into one
+    /// allocation later).
     fn compound<'b>(
         &self,
         block: &'b Block<'c>,
@@ -230,8 +304,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         args: &[Expr<'tcx>],
     ) -> Result<Value<'c, 'b>> {
         let loc = self.loc();
-        // `record_type` also enforces the value-only restriction.
-        let record_ty = self.tys.record_type(e.ty)?;
+        let payload_ty = self.tys.record_inner_of(e.ty)?;
         let mut operands = Vec::with_capacity(args.len());
         for a in args.iter() {
             operands.push(
@@ -239,11 +312,25 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     .ok_or_else(|| LoweringError("record field is unit".into()))?,
             );
         }
-        Ok(self.append(block, builders::record_compound(&operands, record_ty, loc)))
+        let payload = self.append(block, builders::record_compound(&operands, payload_ty, loc));
+        if self.tys.is_shared_record(e.ty) {
+            let rc_ty = self.tys.rc_type(payload_ty);
+            Ok(self.append(block, builders::rc_create(self.context, payload, rc_ty, loc)))
+        } else {
+            Ok(payload)
+        }
     }
 
-    /// Project a chain of fields out of a `[value]` record value with a sequence
-    /// of `reussir.record.extract` ops.
+    /// Project a chain of fields out of a record value.
+    ///
+    /// The walk is type-directed (see [`Cursor`]): an inline `[value]` record is
+    /// read field-by-field with `reussir.record.extract`; a `[shared]` record is
+    /// borrowed (`reussir.rc.borrow`) and then navigated with
+    /// `reussir.ref.project`, loading (`reussir.ref.load`) wherever a value is
+    /// needed — either to cross into a nested `rc` link or to materialize the
+    /// final result. The result is always a loaded value; if it is itself an rc
+    /// resource, the ownership analysis records the matching increment in the
+    /// projection's `after` ops.
     fn proj<'b>(
         &self,
         block: &'b Block<'c>,
@@ -251,38 +338,260 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         base: &Expr<'tcx>,
         path: &[u32],
     ) -> Result<Value<'c, 'b>> {
-        let loc = self.loc();
-        let mut cur_val = self
+        let base_val = self
             .expr(block, env, base)?
             .ok_or_else(|| LoweringError("projection base is unit".into()))?;
-        let mut cur_ty = base.ty;
+        let mut cursor = Cursor::Value {
+            val: base_val,
+            ty: base.ty,
+        };
         for &idx in path.iter() {
-            let rec = self
-                .tys
-                .record_of(cur_ty)
-                .ok_or_else(|| LoweringError("projection base is not a record".into()))?;
-            if rec.default_cap != DefaultCap::Value {
-                return err("projection of shared/regional records not yet implemented");
-            }
-            let members = match rec.layout {
-                mir::RecordLayout::Compound(ms) => ms,
-                mir::RecordLayout::Variant(_) => return err("projection of an enum value"),
-            };
-            let field = members
-                .get(idx as usize)
-                .ok_or_else(|| LoweringError(format!("field index {idx} out of range").into()))?;
-            let field_ty = field.ty;
-            let field_mlir = self.tys.mlir_ty(field_ty)?;
-            let op = builders::record_extract(self.context, cur_val, idx as usize, field_mlir, loc);
-            cur_val = self.append(block, op);
-            cur_ty = field_ty;
+            cursor = self.project_one(block, cursor, idx)?;
         }
-        Ok(cur_val)
+        self.load_cursor(block, cursor)
+    }
+
+    /// Advance the projection [`Cursor`] by one field index.
+    fn project_one<'b>(
+        &self,
+        block: &'b Block<'c>,
+        cursor: Cursor<'c, 'b, 'tcx>,
+        idx: u32,
+    ) -> Result<Cursor<'c, 'b, 'tcx>> {
+        let loc = self.loc();
+        match cursor {
+            // A shared record value is an rc pointer: borrow it to obtain a
+            // reference, then project through that reference.
+            Cursor::Value { val, ty } if self.tys.is_shared_record(ty) => {
+                let inner = self.tys.record_inner_of(ty)?;
+                let ref_ty = self.tys.shared_ref_type(inner);
+                let borrowed =
+                    self.append(block, dialect::rc_borrow(self.context, ref_ty, val, loc).into());
+                self.project_ref(block, borrowed, ty, idx)
+            }
+            // An inline record value: read the field out by value.
+            Cursor::Value { val, ty } => {
+                let (field_ty, _) = self.field_at(ty, idx)?;
+                let field_mlir = self.tys.mlir_ty(field_ty)?;
+                let extracted = self.append(
+                    block,
+                    builders::record_extract(self.context, val, idx as usize, field_mlir, loc),
+                );
+                Ok(Cursor::Value {
+                    val: extracted,
+                    ty: field_ty,
+                })
+            }
+            Cursor::Ref { val, ty } => self.project_ref(block, val, ty, idx),
+        }
+    }
+
+    /// Project field `idx` out of a reference into a record. A shared field is an
+    /// rc link stored inline, so it is loaded to a pointer value (ready to be
+    /// re-borrowed or returned); any other field stays a reference until the walk
+    /// finishes.
+    fn project_ref<'b>(
+        &self,
+        block: &'b Block<'c>,
+        reference: Value<'c, 'b>,
+        record_ty: Ty<'tcx>,
+        idx: u32,
+    ) -> Result<Cursor<'c, 'b, 'tcx>> {
+        let loc = self.loc();
+        let (field_ty, shared) = self.field_at(record_ty, idx)?;
+        let field_mlir = self.tys.mlir_ty(field_ty)?;
+        let proj_ref_ty = self.tys.shared_ref_type(field_mlir);
+        let index = IntegerAttribute::new(Type::index(self.context), i64::from(idx));
+        let projected = self.append(
+            block,
+            dialect::ref_project(self.context, proj_ref_ty, reference, index, loc).into(),
+        );
+        if shared {
+            let loaded = self.append(
+                block,
+                dialect::ref_load(self.context, field_mlir, projected, loc).into(),
+            );
+            Ok(Cursor::Value {
+                val: loaded,
+                ty: field_ty,
+            })
+        } else {
+            Ok(Cursor::Ref {
+                val: projected,
+                ty: field_ty,
+            })
+        }
+    }
+
+    /// The type of field `idx` of a compound record, and whether it is a shared
+    /// (rc-link) field.
+    fn field_at(&self, record_ty: Ty<'tcx>, idx: u32) -> Result<(Ty<'tcx>, bool)> {
+        let rec = self
+            .tys
+            .record_of(record_ty)
+            .ok_or_else(|| LoweringError("projection base is not a record".into()))?;
+        let members = match rec.layout {
+            mir::RecordLayout::Compound(ms) => ms,
+            mir::RecordLayout::Variant(_) => return err("projection of an enum value"),
+        };
+        let field = members
+            .get(idx as usize)
+            .ok_or_else(|| LoweringError(format!("field index {idx} out of range").into()))?;
+        if field.is_field {
+            return err("projection of a regional field link not yet implemented");
+        }
+        Ok((field.ty, self.tys.is_shared_record(field.ty)))
+    }
+
+    /// Materialize a [`Cursor`] as a loaded SSA value, loading through a trailing
+    /// reference if the walk ended on one.
+    fn load_cursor<'b>(
+        &self,
+        block: &'b Block<'c>,
+        cursor: Cursor<'c, 'b, 'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        match cursor {
+            Cursor::Value { val, .. } => Ok(val),
+            Cursor::Ref { val, ty } => {
+                let inner = self.tys.mlir_ty(ty)?;
+                Ok(self.append(
+                    block,
+                    dialect::ref_load(self.context, inner, val, self.loc()).into(),
+                ))
+            }
+        }
     }
 
     /// Append `op` to `block` and return its single result as a value.
     fn append<'b>(&self, block: &'b Block<'c>, op: Operation<'c>) -> Value<'c, 'b> {
         block.append_operation(op).result(0).unwrap().into()
+    }
+
+    // --- Reference-count op emission ----------------------------------------
+
+    /// Emit the reference-count ops the ownership analysis placed *before* node
+    /// `id`. These only ever target named locals here: a `dup`/`drop` of an
+    /// anonymous result before a node would refer to an already-evaluated
+    /// temporary, which the constructs lowered here do not produce.
+    fn emit_rc_before<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &Env<'c, 'b>,
+        id: ExprId,
+    ) -> Result<()> {
+        let ops = self.ownership.borrow().before(id).to_vec();
+        for op in ops {
+            match op {
+                RcOp::Dup(v) => self.emit_inc_var(block, env, v)?,
+                RcOp::Drop(v) => self.emit_dec_var(block, env, v)?,
+                RcOp::DupValue(_) | RcOp::DropValue(_) => {
+                    return err("reference-count op on an unbound temporary is not supported");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Emit the reference-count ops the ownership analysis placed *after* node
+    /// `id`, whose `ty`/`value` are the node's just-produced result. A `DupValue`/
+    /// `DropValue` keyed by `id` acts on that result (a borrowed field to retain,
+    /// or a discarded result to release).
+    fn emit_rc_after<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &Env<'c, 'b>,
+        id: ExprId,
+        ty: Ty<'tcx>,
+        value: Option<Value<'c, 'b>>,
+    ) -> Result<()> {
+        let ops = self.ownership.borrow().after(id).to_vec();
+        for op in ops {
+            match op {
+                RcOp::Dup(v) => self.emit_inc_var(block, env, v)?,
+                RcOp::Drop(v) => self.emit_dec_var(block, env, v)?,
+                RcOp::DupValue(target) if target == id => {
+                    let val = value
+                        .ok_or_else(|| LoweringError("retain of a node with no value".into()))?;
+                    self.emit_inc(block, val, ty)?;
+                }
+                RcOp::DropValue(target) if target == id => {
+                    let val = value
+                        .ok_or_else(|| LoweringError("release of a node with no value".into()))?;
+                    self.emit_dec(block, val, ty)?;
+                }
+                RcOp::DupValue(_) | RcOp::DropValue(_) => {
+                    return err("reference-count op on an unbound temporary is not supported");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Increment the refcount owned by local `v`. A value-less local (e.g. unit)
+    /// holds no resource, so there is nothing to do.
+    fn emit_inc_var<'b>(&self, block: &'b Block<'c>, env: &Env<'c, 'b>, v: VarId) -> Result<()> {
+        match (env.get(&v).copied(), self.var_ty(v)) {
+            (Some(val), Some(ty)) => self.emit_inc(block, val, ty),
+            _ => Ok(()),
+        }
+    }
+
+    /// Decrement the refcount owned by local `v` (see [`emit_inc_var`](Self::emit_inc_var)).
+    fn emit_dec_var<'b>(&self, block: &'b Block<'c>, env: &Env<'c, 'b>, v: VarId) -> Result<()> {
+        match (env.get(&v).copied(), self.var_ty(v)) {
+            (Some(val), Some(ty)) => self.emit_dec(block, val, ty),
+            _ => Ok(()),
+        }
+    }
+
+    /// Increment a value's refcount: an `rc` pointer is incremented directly,
+    /// while an inline record that transitively owns rc fields is acquired through
+    /// a reference (which increments every rc pointer it reaches).
+    fn emit_inc<'b>(&self, block: &'b Block<'c>, val: Value<'c, 'b>, ty: Ty<'tcx>) -> Result<()> {
+        let loc = self.loc();
+        if self.tys.is_shared_record(ty) {
+            block.append_operation(dialect::rc_inc(self.context, val, loc).into());
+            Ok(())
+        } else if matches!(ty.kind(), TyKind::Record { .. }) {
+            let reference = self.spill(block, val, ty)?;
+            block.append_operation(dialect::ref_acquire(self.context, reference, loc).into());
+            Ok(())
+        } else {
+            err("reference-count increment on an unsupported type")
+        }
+    }
+
+    /// Decrement a value's refcount, the dual of [`emit_inc`](Self::emit_inc): an
+    /// `rc` pointer is decremented directly, an inline record is dropped through a
+    /// reference (releasing every rc pointer it reaches).
+    fn emit_dec<'b>(&self, block: &'b Block<'c>, val: Value<'c, 'b>, ty: Ty<'tcx>) -> Result<()> {
+        let loc = self.loc();
+        if self.tys.is_shared_record(ty) {
+            block.append_operation(dialect::rc_dec(self.context, val, loc).into());
+            Ok(())
+        } else if matches!(ty.kind(), TyKind::Record { .. }) {
+            let reference = self.spill(block, val, ty)?;
+            block.append_operation(dialect::ref_drop(self.context, reference, loc).into());
+            Ok(())
+        } else {
+            err("reference-count decrement on an unsupported type")
+        }
+    }
+
+    /// Spill a value to a fresh stack slot and return an (unspecified-capability)
+    /// reference to it, so the recursive acquire/drop ops can walk its fields.
+    fn spill<'b>(
+        &self,
+        block: &'b Block<'c>,
+        val: Value<'c, 'b>,
+        ty: Ty<'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        let inner = self.tys.mlir_ty(ty)?;
+        let ref_ty = self.tys.unspecified_ref_type(inner);
+        Ok(self.append(
+            block,
+            dialect::ref_spilled(self.context, ref_ty, val, self.loc()).into(),
+        ))
     }
 
     fn negate<'b>(

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -32,6 +32,7 @@ use reussir_core::full::ownership::{OwnershipTable, RcOp, RecordTable, analyze_f
 use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use reussir_core::semi::ty::{IntTy, Ty, TyCtxt, TyKind};
 use reussir_core::surface::Visibility;
+use smallvec::SmallVec;
 
 use super::ty::{TypeCtx, is_unit, num_class};
 use super::{LoweringError, Result, err};
@@ -125,7 +126,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
 
         let region = Region::new();
         if let Some(body) = func.body {
-            let block_args: Vec<(Type<'c>, Location<'c>)> =
+            let block_args: SmallVec<[(Type<'c>, Location<'c>); 8]> =
                 param_tys.iter().map(|t| (*t, loc)).collect();
             let block = Block::new(&block_args);
             let mut env: Env<'c, '_> = FxHashMap::default();
@@ -315,7 +316,10 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let payload = self.append(block, builders::record_compound(&operands, payload_ty, loc));
         if self.tys.is_shared_record(e.ty) {
             let rc_ty = self.tys.rc_type(payload_ty);
-            Ok(self.append(block, builders::rc_create(self.context, payload, rc_ty, loc)))
+            Ok(self.append(
+                block,
+                builders::rc_create(self.context, payload, rc_ty, loc),
+            ))
         } else {
             Ok(payload)
         }
@@ -365,8 +369,10 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             Cursor::Value { val, ty } if self.tys.is_shared_record(ty) => {
                 let inner = self.tys.record_inner_of(ty)?;
                 let ref_ty = self.tys.shared_ref_type(inner);
-                let borrowed =
-                    self.append(block, dialect::rc_borrow(self.context, ref_ty, val, loc).into());
+                let borrowed = self.append(
+                    block,
+                    dialect::rc_borrow(self.context, ref_ty, val, loc).into(),
+                );
                 self.project_ref(block, borrowed, ty, idx)
             }
             // An inline record value: read the field out by value.

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -183,6 +183,26 @@ mod tests {
     }
 
     #[test]
+    fn lowers_a_chained_projection_through_shared_records() {
+        // `o.inner.n` is a single projection with a two-element path crossing two
+        // shared records: borrow the outer box, project + load the inner `rc` link,
+        // borrow that, then project the scalar — so the walk emits two `rc.borrow`s.
+        let src = r#"
+            struct [shared] Inner { n: i64 }
+            struct [shared] Outer { inner: Inner }
+            pub fn deep(o: Outer) -> i64 { o.inner.n }
+        "#;
+        let mlir = lower_source(src);
+        assert_eq!(
+            mlir.matches("reussir.rc.borrow").count(),
+            2,
+            "expected two borrows for a two-level shared chain:\n{mlir}"
+        );
+        assert!(mlir.contains("reussir.ref.project"), "{mlir}");
+        assert!(mlir.contains("reussir.rc.dec"), "{mlir}");
+    }
+
+    #[test]
     fn lowers_a_recursive_shared_record() {
         // A `[shared]` record whose field is the record itself is finite — the
         // field is an `rc` pointer, not an inline copy. Lowering its type must

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -13,14 +13,18 @@
 //!
 //! # Scope
 //!
-//! Currently lowered: the **scalar / control-flow subset** (integer and
-//! floating-point values, arithmetic and comparison, `if`, `let`/sequencing,
-//! direct calls, exported trampolines) and **by-value (`[value]`) records**
-//! (construction via `reussir.record.compound` and field projection via
-//! `reussir.record.extract`). Reference-counted constructs (shared/regional
-//! records, enums/`match`, closures, regions, strings) are not yet lowered and
-//! surface as an explicit [`LoweringError`] rather than wrong code; they arrive
-//! with the ownership analysis in later changes.
+//! Currently lowered:
+//! * the **scalar / control-flow subset** — integer and floating-point values,
+//!   arithmetic and comparison, `if`, `let`/sequencing, direct calls, exported
+//!   trampolines;
+//! * **by-value (`[value]`) records** — construction via
+//!   `reussir.record.compound`, field projection via `reussir.record.extract`;
+//! * **shared (`[shared]`) records** — heap-allocated and reference-counted
+//!   (`reussir.rc.create`, borrow/project/load), with the ownership analysis
+//!   placing the `dup`/`drop` reference-count ops (see [`expr`]).
+//!
+//! Regional records, enums/`match`, closures, regions, and strings are not yet
+//! lowered and surface as an explicit [`LoweringError`] rather than wrong code.
 //!
 //! Every callee/trampoline target in the MIR is already resolved to an interned
 //! [`mir::Symbol`](reussir_core::full::mir::Symbol) (mono did the mangling), so
@@ -37,6 +41,7 @@ use reussir_backend::melior::Context;
 use reussir_backend::melior::ir::{BlockLike, Location, Module};
 
 use reussir_core::full::mir;
+use reussir_core::semi::ty::TyCtxt;
 
 use expr::Lowerer;
 
@@ -59,10 +64,17 @@ fn err<T>(msg: impl Into<Cow<'static, str>>) -> Result<T> {
 }
 
 /// Build the MLIR module for a whole program in `context`.
-pub fn lower_program<'c>(context: &'c Context, program: &mir::Program<'_>) -> Result<Module<'c>> {
+///
+/// `tcx` is the type arena the program was monomorphized in; the ownership
+/// analysis that places reference-count ops is run per function against it.
+pub fn lower_program<'c, 'tcx>(
+    context: &'c Context,
+    tcx: &TyCtxt<'tcx>,
+    program: &mir::Program<'tcx>,
+) -> Result<Module<'c>> {
     let module = Module::new(Location::unknown(context));
     let body = module.body();
-    let lowerer = Lowerer::new(context, program);
+    let lowerer = Lowerer::new(context, tcx, program);
     for func in &program.functions {
         body.append_operation(lowerer.function(func)?);
     }
@@ -75,6 +87,7 @@ pub fn lower_program<'c>(context: &'c Context, program: &mir::Program<'_>) -> Re
             Location::unknown(context),
         ));
     }
+    tracing::debug!(mlir = %module.as_operation(), "lowered program to MLIR");
     Ok(module)
 }
 
@@ -88,8 +101,7 @@ mod tests {
     /// Elaborate + monomorphize + lower `source`, checking the module verifies
     /// and returning its printed text for assertions.
     fn lower_source(source: &str) -> String {
-        crate::test::init_tracing();
-        let context = reussir_backend::context();
+        let context = crate::testing::context();
         in_arena(|tcx| {
             let parse = reussir_syntax::parse(source);
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
@@ -98,13 +110,12 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let module = lower_program(&context, &full).expect("lowering succeeds");
+            let module = lower_program(&context, tcx, &full).expect("lowering succeeds");
             assert!(
                 module.as_operation().verify(),
                 "module verifies:\n{}",
                 module.as_operation()
             );
-            tracing::info!("IR lowered successfully:\n{}", module.as_operation());
             module.as_operation().to_string()
         })
     }
@@ -142,6 +153,65 @@ mod tests {
     }
 
     #[test]
+    fn lowers_shared_records_to_reference_counted_mlir() {
+        // A `[shared]` record is heap-allocated and reference-counted. Building
+        // one lowers to `record.compound` + `rc.create`; reading a field borrows
+        // the box (`rc.borrow`) and navigates it (`ref.project` / `ref.load`); and
+        // the ownership analysis surrounds the uses with `rc.inc` / `rc.dec`.
+        //
+        // `Outer` nests a shared `Inner`, so its field is stored as an `rc` link:
+        // projecting it out loads the inner pointer and retains it (`rc.inc`),
+        // while the consumed outer box is released (`rc.dec`).
+        let src = r#"
+            struct [shared] Inner { n: i64 }
+            struct [shared] Outer { inner: Inner }
+            fn mk_inner(n: i64) -> Inner { Inner { n: n } }
+            fn mk_outer(i: Inner) -> Outer { Outer { inner: i } }
+            fn inner_of(o: Outer) -> Inner { o.inner }
+            fn n_of(i: Inner) -> i64 { i.n }
+            pub fn build_and_read(n: i64) -> i64 { n_of(inner_of(mk_outer(mk_inner(n)))) }
+            extern "C" trampoline "build_and_read_ffi" = build_and_read;
+        "#;
+        let mlir = lower_source(src);
+        assert!(mlir.contains("!reussir.rc<"), "{mlir}");
+        assert!(mlir.contains("reussir.rc.create"), "{mlir}");
+        assert!(mlir.contains("reussir.rc.borrow"), "{mlir}");
+        assert!(mlir.contains("reussir.ref.project"), "{mlir}");
+        assert!(mlir.contains("reussir.ref.load"), "{mlir}");
+        assert!(mlir.contains("reussir.rc.inc"), "{mlir}");
+        assert!(mlir.contains("reussir.rc.dec"), "{mlir}");
+    }
+
+    #[test]
+    fn lowers_a_recursive_shared_record() {
+        // A `[shared]` record whose field is the record itself is finite — the
+        // field is an `rc` pointer, not an inline copy. Lowering its type must
+        // terminate: the identified record is published on the construction stack
+        // before its members, so the self-reference on the field resolves to the
+        // in-progress handle instead of recursing forever.
+        let src = r#"
+            struct [shared] Node { next: Node }
+            pub fn forward(n: Node) -> Node { n }
+        "#;
+        let mlir = lower_source(src);
+        // The record's own field is an `rc` link back to itself.
+        assert!(mlir.contains("!reussir.rc<"), "{mlir}");
+        assert!(mlir.contains("Node"), "{mlir}");
+    }
+
+    #[test]
+    fn drops_an_unused_shared_parameter() {
+        // An owned `[shared]` parameter that the body never uses is dead on entry,
+        // so the ownership analysis releases it immediately with `rc.dec`.
+        let src = r#"
+            struct [shared] Box { v: i64 }
+            pub fn ignore(b: Box, fallback: i64) -> i64 { fallback }
+        "#;
+        let mlir = lower_source(src);
+        assert!(mlir.contains("reussir.rc.dec"), "{mlir}");
+    }
+
+    #[test]
     fn lowers_and_runs_through_the_pipeline() {
         let src = r#"
             pub fn add3(a: i32, b: i32, c: i32) -> i32 { a + b + c }
@@ -156,7 +226,7 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let mut module = lower_program(&context, &full).expect("lowering succeeds");
+            let mut module = lower_program(&context, tcx, &full).expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -2,14 +2,28 @@
 //!
 //! Scalars map directly to builtin MLIR types. A record has no `DefTable` here,
 //! so it resolves through a layout table ([`TypeCtx`]) keyed by its `(def, args)`
-//! identity — the ground layout `mono` baked into the MIR. `[value]` records
-//! build an identified `!reussir.record<…>`; shared/regional records and enums
-//! arrive with the rc lowering. This module also holds the numeric classification
-//! [`expr`](super::expr) uses to choose the right cast op.
+//! identity — the ground layout `mono` baked into the MIR.
+//!
+//! Two record flavours lower, selected by the instance's declared capability:
+//! * a **`[value]`** record is an inline aggregate — an identified
+//!   `!reussir.record<…>` held directly by value;
+//! * a **`[shared]`** record is heap-allocated and reference-counted — the same
+//!   identified record type wrapped in a `!reussir.rc<…>` pointer. A shared
+//!   record that appears as a field of another record is therefore stored as an
+//!   `rc` link, which falls out of lowering its field type here.
+//!
+//! Regional records and enum (`variant`) layouts are not lowered yet. This
+//! module also holds the numeric classification [`expr`](super::expr) uses to
+//! choose the right cast op.
 
-use rustc_hash::FxHashMap;
+use std::cell::RefCell;
 
-use reussir_backend::dialect::ty::{ReussirCapability, ReussirRecordKind, record_complete};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use reussir_backend::dialect::ty::{
+    ReussirAtomicKind, ReussirCapability, ReussirRecordKind, rc, record_complete_in_place,
+    record_incomplete, record_is_complete, r#ref,
+};
 use reussir_backend::melior::Context;
 use reussir_backend::melior::ir::Type;
 use reussir_backend::melior::ir::attribute::StringAttribute;
@@ -28,10 +42,18 @@ type RecordInstanceKey<'tcx> = (DefId, &'tcx [Ty<'tcx>]);
 /// Type-lowering state: the MLIR context to build types in, the program (whose
 /// symbol table names record types), and the record instances indexed by their
 /// `(def, args)` identity so a record-typed value can find its ground layout.
+///
+/// The MLIR context already uniques identified record types by name, so it is the
+/// type cache; `building` is just the set of record symbols whose body is
+/// currently being lowered — the construction stack. A record that reaches itself
+/// (directly or through an `rc` field) re-enters lowering on the back-edge, finds
+/// its symbol already on the stack, and hands back the same (still-incomplete)
+/// identified type rather than recursing forever.
 pub(super) struct TypeCtx<'c, 'p, 'tcx> {
     context: &'c Context,
     program: &'p mir::Program<'tcx>,
     records: FxHashMap<RecordInstanceKey<'tcx>, &'p mir::RecordInstance<'tcx>>,
+    building: RefCell<FxHashSet<mir::Symbol>>,
 }
 
 impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
@@ -48,6 +70,7 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             context,
             program,
             records,
+            building: RefCell::new(FxHashSet::default()),
         }
     }
 
@@ -59,6 +82,14 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         }
     }
 
+    /// Whether `ty` is a `[shared]` record — one whose value is represented as an
+    /// `!reussir.rc<…>` pointer rather than held inline. (Regional records are
+    /// also managed, but region-allocated and lowered separately.)
+    pub(super) fn is_shared_record(&self, ty: Ty<'tcx>) -> bool {
+        self.record_of(ty)
+            .is_some_and(|rec| rec.default_cap == DefaultCap::Shared)
+    }
+
     /// Lower a ground type to MLIR: records resolve through the layout table,
     /// everything else is a scalar.
     pub(super) fn mlir_ty(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
@@ -68,20 +99,67 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         }
     }
 
-    /// Build the MLIR record type for a record instance. Only `[value]` records
-    /// lower today; shared/regional records arrive with the rc lowering.
+    /// The MLIR type of a value of record type `ty`: the inline record type for a
+    /// `[value]` record, or an `rc` pointer to it for a `[shared]` record.
     pub(super) fn record_type(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
         let rec = self
             .record_of(ty)
             .ok_or_else(|| LoweringError("record instance has no resolved layout".into()))?;
+        let inner = self.record_inner_type(rec)?;
         match rec.default_cap {
-            DefaultCap::Value => {}
-            DefaultCap::Shared => return err("shared (rc) record lowering not yet implemented"),
-            DefaultCap::Regional => return err("regional record lowering not yet implemented"),
+            DefaultCap::Value => Ok(inner),
+            DefaultCap::Shared => Ok(self.rc_type(inner)),
+            DefaultCap::Regional => err("regional record lowering not yet implemented"),
         }
+    }
+
+    /// The identified `!reussir.record<…>` payload type for a record-typed `ty`
+    /// (the inline layout, before any `rc` wrapping). For a `[shared]` record this
+    /// is the type stored inside its `rc` box, as produced by
+    /// `reussir.record.compound` before `reussir.rc.create`.
+    pub(super) fn record_inner_of(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
+        let rec = self
+            .record_of(ty)
+            .ok_or_else(|| LoweringError("record instance has no resolved layout".into()))?;
+        self.record_inner_type(rec)
+    }
+
+    /// Build the identified `!reussir.record<…>` payload type for a record
+    /// instance (the inline layout, before any `rc` wrapping). Shared record-typed
+    /// members lower to `rc` links through [`mlir_ty`](Self::mlir_ty).
+    ///
+    /// The identified type is obtained by its unique v0 symbol — which is how the
+    /// MLIR context uniques it, so this returns the same handle however many times
+    /// it is called. The body is filled in only when the record is not already
+    /// complete and not already on the construction stack, so each record is
+    /// completed exactly once and a self-referential record's back-edge resolves
+    /// to the still-incomplete handle instead of recursing forever.
+    fn record_inner_type(&self, rec: &mir::RecordInstance<'tcx>) -> Result<Type<'c>> {
+        let name = StringAttribute::new(self.context, self.program.symbol(rec.symbol));
+        let record = record_incomplete(self.context, name, ReussirRecordKind::Compound);
+        // Already built, or currently being built further up the stack (a
+        // recursive reference): hand back the identified handle as-is.
+        if record_is_complete(record) || !self.building.borrow_mut().insert(rec.symbol) {
+            return Ok(record);
+        }
+        let result = self.complete_record(rec, record);
+        self.building.borrow_mut().remove(&rec.symbol);
+        result
+    }
+
+    /// Fill in `record`'s body from `rec`'s layout. The caller has marked
+    /// `rec.symbol` as on the construction stack, so the recursion through
+    /// [`mlir_ty`](Self::mlir_ty) below terminates at any back-edge.
+    fn complete_record(
+        &self,
+        rec: &mir::RecordInstance<'tcx>,
+        record: Type<'c>,
+    ) -> Result<Type<'c>> {
         let members = match rec.layout {
             mir::RecordLayout::Compound(ms) => ms,
-            mir::RecordLayout::Variant(_) => return err("a `[value]` record cannot be an enum"),
+            mir::RecordLayout::Variant(_) => {
+                return err("enum (variant) record lowering not yet implemented");
+            }
         };
         let mut member_tys = Vec::with_capacity(members.len());
         let mut member_is_field = Vec::with_capacity(members.len());
@@ -89,17 +167,41 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             member_tys.push(self.mlir_ty(m.ty)?);
             member_is_field.push(m.is_field);
         }
-        // Identify the record by its unique v0 symbol so distinct generic
-        // instances stay distinct MLIR types.
-        let name = StringAttribute::new(self.context, self.program.symbol(rec.symbol));
-        Ok(record_complete(
-            self.context,
+        record_complete_in_place(
+            record,
             &member_tys,
             &member_is_field,
-            Some(name),
-            ReussirRecordKind::Compound,
-            ReussirCapability::Value,
-        ))
+            capability(rec.default_cap),
+        );
+        Ok(record)
+    }
+
+    /// `!reussir.rc<inner, shared>` — the pointer type for a heap-allocated,
+    /// reference-counted value with the default (non-atomic) box layout.
+    pub(super) fn rc_type(&self, inner: Type<'c>) -> Type<'c> {
+        rc(inner, ReussirCapability::Shared, ReussirAtomicKind::Normal)
+    }
+
+    /// `!reussir.ref<inner, shared>` — a borrowed reference into a shared value,
+    /// as produced by `reussir.rc.borrow` and `reussir.ref.project`.
+    pub(super) fn shared_ref_type(&self, inner: Type<'c>) -> Type<'c> {
+        r#ref(inner, ReussirCapability::Shared, ReussirAtomicKind::Normal)
+    }
+
+    /// `!reussir.ref<inner>` with unspecified capability — the form a spilled
+    /// stack reference takes, used to acquire/drop an inline value in place.
+    pub(super) fn unspecified_ref_type(&self, inner: Type<'c>) -> Type<'c> {
+        r#ref(inner, ReussirCapability::Unspecified, ReussirAtomicKind::Normal)
+    }
+}
+
+/// Map a record's declared management to the MLIR record type's default member
+/// capability.
+fn capability(cap: DefaultCap) -> ReussirCapability {
+    match cap {
+        DefaultCap::Value => ReussirCapability::Value,
+        DefaultCap::Shared => ReussirCapability::Shared,
+        DefaultCap::Regional => ReussirCapability::Regional,
     }
 }
 

--- a/crates/reussir-codegen/src/testing.rs
+++ b/crates/reussir-codegen/src/testing.rs
@@ -1,0 +1,20 @@
+//! Shared helpers for this crate's tests.
+//!
+//! The same file backs both the in-crate unit tests (via `mod testing` under
+//! `#[cfg(test)]`) and the external integration tests (via `#[path]`), so every
+//! test obtains its backend context the same way: through [`context`], which also
+//! installs the `tracing` subscriber. Lowering emits `tracing` events as it builds
+//! the IR, so running a test with `--nocapture` shows exactly what it produced.
+
+/// A fresh backend [`Context`](reussir_backend::melior::Context) with the
+/// `tracing` subscriber installed at `DEBUG` level.
+///
+/// The subscriber is process-global, so it is installed at most once: a second
+/// call (the next test in the same binary) finds it already set and leaves it in
+/// place.
+pub fn context() -> reussir_backend::melior::Context {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .try_init();
+    reussir_backend::context()
+}

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -11,10 +11,15 @@ use reussir_core::full::mono::monomorphize;
 use reussir_core::{in_arena, semi::elaborate, surface};
 use reussir_jit::{OptLevel, OrcJit};
 
+// Share the crate's test helpers (a tracing-enabled backend context) by
+// including the same source the unit tests use.
+#[path = "../src/testing.rs"]
+mod testing;
+
 /// Compile `source` to a lowered LLVM-dialect module, then JIT it and hand the
 /// engine to `run` to look up and call entry points.
 fn jit_run<R>(source: &str, run: impl FnOnce(&OrcJit) -> R) -> R {
-    let context = reussir_backend::context();
+    let context = testing::context();
     // Frontend + lowering, inside the arena scope; the module outlives it.
     let mut module = in_arena(|tcx| {
         let parse = reussir_syntax::parse(source);
@@ -28,7 +33,7 @@ fn jit_run<R>(source: &str, run: impl FnOnce(&OrcJit) -> R) -> R {
         );
         let (full, reports) = monomorphize(&elab.mono_input());
         assert!(reports.is_empty(), "mono reports: {reports:#?}");
-        lower_program(&context, &full).expect("scalar lowering succeeds")
+        lower_program(&context, tcx, &full).expect("scalar lowering succeeds")
     });
 
     run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
@@ -82,6 +87,54 @@ fn runs_value_record_construction_and_projection() {
         assert_eq!(sq_norm(3, 4), 25);
         // |(5,6)|² = 25 + 36 = 61
         assert_eq!(sq_norm(5, 6), 61);
+    });
+}
+
+#[test]
+fn runs_shared_record_construction_and_projection() {
+    // `[shared]` records are heap-allocated and reference-counted. `Outer` nests a
+    // shared `Inner`, so the whole spine — allocate (`rc.create`), borrow + project
+    // + load a field, retain a borrowed `rc` field (`rc.inc`), and release consumed
+    // boxes (`rc.dec`) — runs through the runtime allocator. The records stay
+    // internal; only a scalar crosses the trampoline.
+    let src = r#"
+        struct [shared] Inner { n: i64 }
+        struct [shared] Outer { inner: Inner }
+        fn mk_inner(n: i64) -> Inner { Inner { n: n } }
+        fn mk_outer(i: Inner) -> Outer { Outer { inner: i } }
+        fn inner_of(o: Outer) -> Inner { o.inner }
+        fn n_of(i: Inner) -> i64 { i.n }
+        pub fn build_and_read(n: i64) -> i64 { n_of(inner_of(mk_outer(mk_inner(n)))) }
+        extern "C" trampoline "build_and_read_ffi" = build_and_read;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("build_and_read_ffi").expect("lookup build_and_read_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        assert_eq!(f(5), 5);
+        assert_eq!(f(42), 42);
+    });
+}
+
+#[test]
+fn runs_shared_record_with_aliasing_and_release() {
+    // Passing the same shared box to both parameters of `sum` aliases it, so the
+    // ownership analysis inserts one `rc.inc` before the call; `sum` then releases
+    // each parameter, so the box is freed exactly once. A wrong reference count
+    // would double-free (crash) or leak — the arithmetic result pins correctness.
+    let src = r#"
+        struct [shared] Box { v: i64 }
+        fn mk(v: i64) -> Box { Box { v: v } }
+        fn sum(a: Box, b: Box) -> i64 { a.v + b.v }
+        fn use_twice(b: Box) -> i64 { sum(b, b) }
+        pub fn run(n: i64) -> i64 { use_twice(mk(n)) }
+        extern "C" trampoline "run_ffi" = run;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("run_ffi").expect("lookup run_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        // use_twice(mk(7)) = 7 + 7 = 14
+        assert_eq!(f(7), 14);
+        assert_eq!(f(21), 42);
     });
 }
 

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -116,6 +116,30 @@ fn runs_shared_record_construction_and_projection() {
 }
 
 #[test]
+fn runs_shared_record_deep_projection() {
+    // A single chained field access `o.inner.n` crosses two shared records in one
+    // projection: borrow the outer box, project + load the inner `rc` link, borrow
+    // *that*, project + load the scalar. Exercises the multi-step projection walk
+    // (path length > 1) and that the transient inner borrow is neither retained nor
+    // double-freed (the consumed outer box is released once).
+    let src = r#"
+        struct [shared] Inner { n: i64 }
+        struct [shared] Outer { inner: Inner }
+        fn mk_inner(n: i64) -> Inner { Inner { n: n } }
+        fn mk_outer(n: i64) -> Outer { Outer { inner: mk_inner(n) } }
+        fn deep(o: Outer) -> i64 { o.inner.n }
+        pub fn run(n: i64) -> i64 { deep(mk_outer(n)) }
+        extern "C" trampoline "deep_ffi" = run;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("deep_ffi").expect("lookup deep_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        assert_eq!(f(9), 9);
+        assert_eq!(f(-3), -3);
+    });
+}
+
+#[test]
 fn runs_shared_record_with_aliasing_and_release() {
     // Passing the same shared box to both parameters of `sum` aliases it, so the
     // ownership analysis inserts one `rc.inc` before the call; `sum` then releases

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -182,7 +182,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
         if report_diagnostics(&name, &reports) {
             return Err(String::new());
         }
-        let mut module = lower_program(&context, &full).map_err(|e| format!("{name}: {e}"))?;
+        let mut module = lower_program(&context, tcx, &full).map_err(|e| format!("{name}: {e}"))?;
         let prepared = LlvmLowering::prepare(&module, machine.data_layout(), optimize_ffi)
             .map_err(|e| format!("{name}: {e}"))?;
         pipeline::run_lowering_pipeline(&context, &mut module, &options)

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -172,6 +172,11 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         });
     }
 
+    // Close the record set over fields before resolving layouts: a record used
+    // only as another record's field is otherwise never collected, leaving its
+    // layout unresolved.
+    driver.close_records_over_fields(input.records, tcx);
+
     // Resolve the discovered record instances to symbols. Collect the keys first
     // so the interner can be borrowed mutably while we map them.
     let record_keys: Vec<(DefId, &'tcx [Ty<'tcx>])> = driver.records.iter().copied().collect();
@@ -424,6 +429,79 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             }
             TyKind::Nullable(inner) => self.note_records(inner),
             _ => {}
+        }
+    }
+
+    /// Collect the records reachable from a ground type, pushing each *newly*
+    /// discovered instance onto `worklist` (and into [`records`](Self::records)).
+    /// Used to close the record set over fields; bounds nesting depth like
+    /// [`enqueue`](Self::enqueue) so polymorphic recursion through a field trips
+    /// the limit rather than looping forever.
+    fn discover_records(
+        &mut self,
+        ty: Ty<'tcx>,
+        worklist: &mut Vec<(DefId, &'tcx [Ty<'tcx>])>,
+    ) {
+        match *ty.kind() {
+            TyKind::Record { def, args, .. } => {
+                if self.records.insert((def, args)) {
+                    let depth = args.iter().map(|&t| ty_depth(t)).max().unwrap_or(0);
+                    assert!(
+                        depth <= RECURSION_LIMIT,
+                        "monomorphize: record field nesting depth {depth} exceeds the \
+                         recursion limit ({RECURSION_LIMIT}); this is almost certainly \
+                         unbounded instantiation from polymorphic recursion through a field"
+                    );
+                    worklist.push((def, args));
+                }
+                for &arg in args {
+                    self.discover_records(arg, worklist);
+                }
+            }
+            TyKind::Closure { params, ret } => {
+                for &p in params {
+                    self.discover_records(p, worklist);
+                }
+                self.discover_records(ret, worklist);
+            }
+            TyKind::Nullable(inner) => self.discover_records(inner, worklist),
+            _ => {}
+        }
+    }
+
+    /// Close [`records`](Self::records) over record fields: a record reachable
+    /// only as another record's field (never in a signature) still needs its
+    /// layout. Each instance's field types are substituted under its type
+    /// arguments — mirroring [`resolve_layout`] — and the records they mention are
+    /// added, to a fixed point.
+    fn close_records_over_fields(
+        &mut self,
+        records: &FxHashMap<DefId, Record<'tcx>>,
+        tcx: &TyCtxt<'tcx>,
+    ) {
+        let mut worklist: Vec<(DefId, &'tcx [Ty<'tcx>])> = self.records.iter().copied().collect();
+        while let Some((def, args)) = worklist.pop() {
+            let Some(record) = records.get(&def) else {
+                continue;
+            };
+            let mut subst = Subst::default();
+            for ((_, gid), &ty) in record.ty_params.iter().zip(args.iter()) {
+                subst.insert(*gid, ty);
+            }
+            let field_tys: Vec<Ty<'tcx>> = match record.fields.as_ref() {
+                Some(RecordFields::Named(fields)) => {
+                    fields.iter().map(|(_, ty, _)| *ty).collect()
+                }
+                Some(RecordFields::Unnamed(fields)) => fields.iter().map(|(ty, _)| *ty).collect(),
+                Some(RecordFields::Variants(variants)) => {
+                    variants.iter().flat_map(|v| v.fields.iter().copied()).collect()
+                }
+                None => Vec::new(),
+            };
+            for field_ty in field_tys {
+                let ground = subst_ty(tcx, field_ty, &subst);
+                self.discover_records(ground, &mut worklist);
+            }
         }
     }
 

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -229,6 +229,31 @@ impl<'tcx> RecordTable<'tcx> {
         }
     }
 
+    /// Build the table from a monomorphized program's record instances. Each
+    /// instance's nominal type is already capability-canonicalized
+    /// ([`Flexivity::Irrelevant`]), the form [`is_rr`](Rr::is_rr) looks up, so it
+    /// is used directly as the key.
+    pub fn from_records(records: &[mir::RecordInstance<'tcx>]) -> Self {
+        use crate::semi::ctxt::DefaultCap;
+        let mut table = RecordTable::new();
+        for r in records {
+            let managed = match r.default_cap {
+                DefaultCap::Value => Managed::Value,
+                DefaultCap::Shared => Managed::Shared,
+                DefaultCap::Regional => Managed::Regional,
+            };
+            let fields = match r.layout {
+                mir::RecordLayout::Compound(members) => members.iter().map(|m| m.ty).collect(),
+                mir::RecordLayout::Variant(variants) => variants
+                    .iter()
+                    .flat_map(|v| v.fields.iter().copied())
+                    .collect(),
+            };
+            table.insert(r.ty, RecordShape { managed, fields });
+        }
+        table
+    }
+
     /// Register `canonical_ty`'s shape. `canonical_ty` must carry
     /// [`Flexivity::Irrelevant`] (the form `is_rr` looks up).
     pub fn insert(&mut self, canonical_ty: Ty<'tcx>, shape: RecordShape<'tcx>) {

--- a/include/Reussir-c/Types.h
+++ b/include/Reussir-c/Types.h
@@ -142,6 +142,12 @@ void reussirRecordTypeComplete(MlirType record, intptr_t nMembers,
                                bool const *memberIsField,
                                ReussirCapability defaultCapability);
 
+// Whether an identified record type has had its body filled in. A handle
+// obtained from `reussirRecordTypeGetIncomplete` reports `false` until
+// `reussirRecordTypeComplete` runs; this lets a caller look a record up by name
+// and skip rebuilding its members when it is already complete.
+bool reussirRecordTypeIsComplete(MlirType record);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -152,3 +152,7 @@ void reussirRecordTypeComplete(MlirType record, intptr_t nMembers,
   llvm::cast<RecordType>(unwrap(record))
       .complete(memberTypes, fields, toCapability(defaultCapability));
 }
+
+bool reussirRecordTypeIsComplete(MlirType record) {
+  return llvm::cast<RecordType>(unwrap(record)).getComplete();
+}


### PR DESCRIPTION
## Summary

Threads the Perceus ownership analysis into `reussir-codegen` and lowers
heap-allocated, reference-counted (`[shared]`) records end to end — the next
codegen milestone after by-value records (#269).

- **Type lowering.** A `[shared]` record's value is an `!reussir.rc<!record>`
  pointer; a record-typed field that is itself shared lowers to an inline `rc`
  link, which falls out of lowering the field type. `[value]` records are
  unchanged.
- **Construction.** A shared record packs its payload with
  `reussir.record.compound` and boxes it with `reussir.rc.create` (the
  rc-create-fusion pass folds the two into one allocation later). The ground MIR
  has no explicit rc node, so the constructor performs the boxing itself.
- **Projection** is a type-directed walk: an inline `[value]` record is read with
  `record.extract`; a shared record is borrowed (`rc.borrow`) and navigated with
  `ref.project` / `ref.load`, crossing into nested `rc` links as needed.
- **Ownership.** `lower_program` now takes the type arena and runs
  `ownership::analyze_function` per function, emitting each anchor's
  reference-count ops around the node. An `rc` pointer is incremented/decremented
  directly (`rc.inc` / `rc.dec`); an inline record that transitively owns rc
  fields is acquired/dropped through a spilled reference (`ref.spilled` +
  `ref.acquire` / `ref.drop`). The downstream pipeline passes
  (token-instantiation, rc-decrement / acquire-drop expansion) synthesize the
  allocation tokens and destructor glue.

Per-op builders use the `dialect!`-generated ODS builders; only `reussir.rc.create`
is hand-written, because its `AttrSizedOperandSegments` attribute is left unset by
the generated builder.

### Not in scope (still explicit lowering errors)

Regional records, enums / `match`, regions, closures, and strings.

## Tests

- Unit (MLIR verify): shared-record construction + nested-field projection emits
  the expected `rc.create` / `rc.borrow` / `ref.project` / `ref.load` / `rc.inc`
  / `rc.dec`; an unused shared parameter is dropped on entry.
- E2E (JIT, runs through the runtime allocator): nested construction + projection
  round-trips a value; aliasing the same box across two parameters exercises the
  `rc.inc` / `rc.dec` balance (a wrong count would double-free or leak).
- A shared `testing::context()` helper installs the tracing subscriber for both
  the unit and integration tests (replacing the unit-test-only init).

Gate: `reussir-codegen` (5 unit + 5 e2e), `reussir-backend`, `rrc`,
`reussir-core` (165), and the lit/integration suite (237) all pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)