### PR TITLE
[backend] reussir-codegen: source locations + DWARF debug info for the lowered subset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
 name = "reussir-codegen"
 version = "0.1.0"
 dependencies = [
+ "ariadne",
  "reussir-backend",
  "reussir-core",
  "reussir-jit",

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -114,6 +114,7 @@ unsafe extern "C" {
     pub fn reussirCreateCompilePolymorphicFFIPass(optimized: bool) -> MlirPass;
     pub fn reussirCreateInvariantGroupAnalysisPass() -> MlirPass;
     pub fn reussirCreateBasicOpsLoweringPass() -> MlirPass;
+    pub fn reussirCreateDebugInfoConversionPass() -> MlirPass;
     pub fn reussirCreateAcquireDropExpansionPass(
         expand_decrement: bool,
         outline_record: bool,
@@ -231,4 +232,65 @@ unsafe extern "C" {
         default_capability: ReussirCapability,
     );
     pub fn reussirRecordTypeIsComplete(record: MlirType) -> bool;
+
+    //==-- Reussir debug-info attribute constructors --==//
+    //
+    // The debug-info attributes describe a value's debug type/variable for the
+    // debug-info conversion pass; their custom storage cannot be built through
+    // the generic MLIR C API, so each constructor wraps the attribute's C++
+    // `get` builder.
+
+    pub fn reussirDBGIntTypeAttrGet(
+        context: MlirContext,
+        inner_type: MlirType,
+        is_signed: bool,
+        dbg_name: MlirAttribute,
+    ) -> MlirAttribute;
+    pub fn reussirDBGFPTypeAttrGet(
+        context: MlirContext,
+        inner_type: MlirType,
+        dbg_name: MlirAttribute,
+    ) -> MlirAttribute;
+    pub fn reussirDBGRecordMemberAttrGet(
+        context: MlirContext,
+        name: MlirAttribute,
+        type_attr: MlirAttribute,
+    ) -> MlirAttribute;
+    pub fn reussirDBGRecordTypeAttrGet(
+        context: MlirContext,
+        n_members: isize,
+        members: *const MlirAttribute,
+        is_variant: bool,
+        underlying_type: MlirType,
+        dbg_name: MlirAttribute,
+    ) -> MlirAttribute;
+    pub fn reussirDBGSubprogramAttrGet(
+        context: MlirContext,
+        raw_name: MlirAttribute,
+        n_type_params: isize,
+        type_params: *const MlirAttribute,
+    ) -> MlirAttribute;
+    pub fn reussirDBGBoxedTypeAttrGet(
+        context: MlirContext,
+        dbg_type: MlirAttribute,
+    ) -> MlirAttribute;
+    pub fn reussirDBGLocalVarAttrGet(
+        context: MlirContext,
+        dbg_type: MlirAttribute,
+        var_name: MlirAttribute,
+    ) -> MlirAttribute;
+    pub fn reussirDBGFuncArgAttrGet(
+        context: MlirContext,
+        dbg_type: MlirAttribute,
+        arg_name: MlirAttribute,
+        arg_index: core::ffi::c_uint,
+    ) -> MlirAttribute;
+
+    /// Set an operation's location (`mlir-sys` does not bind
+    /// `mlirOperationSetLocation`). Used to attach a fused debug location to a
+    /// local variable's defining op.
+    pub fn reussirOperationSetLocation(
+        op: mlir_sys::MlirOperation,
+        location: mlir_sys::MlirLocation,
+    );
 }

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -273,6 +273,7 @@ unsafe extern "C" {
     pub fn reussirDBGBoxedTypeAttrGet(
         context: MlirContext,
         dbg_type: MlirAttribute,
+        regional: bool,
     ) -> MlirAttribute;
     pub fn reussirDBGLocalVarAttrGet(
         context: MlirContext,

--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -11,7 +11,7 @@ use melior::Context;
 use melior::ir::attribute::{
     DenseI32ArrayAttribute, FlatSymbolRefAttribute, IntegerAttribute, StringAttribute,
 };
-use melior::ir::operation::{OperationBuilder, OperationLike, OperationRef};
+use melior::ir::operation::{OperationBuilder, OperationRef};
 use melior::ir::r#type::IntegerType;
 use melior::ir::{Identifier, Location, Operation, Type, Value};
 

--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -11,9 +11,22 @@ use melior::Context;
 use melior::ir::attribute::{
     DenseI32ArrayAttribute, FlatSymbolRefAttribute, IntegerAttribute, StringAttribute,
 };
-use melior::ir::operation::OperationBuilder;
+use melior::ir::operation::{OperationBuilder, OperationLike, OperationRef};
 use melior::ir::r#type::IntegerType;
 use melior::ir::{Identifier, Location, Operation, Type, Value};
+
+use reussir_backend_sys as sys;
+
+/// Set `operation`'s location after it has been built.
+///
+/// Used to attach a fused debug-info location (carrying a `DBGLocalVar`) to the
+/// op that defines a local variable; `mlir-sys` does not bind
+/// `mlirOperationSetLocation`, so this goes through the Reussir C API.
+pub fn set_location(operation: OperationRef<'_, '_>, location: Location<'_>) {
+    unsafe {
+        sys::reussirOperationSetLocation(operation.to_raw(), location.to_raw());
+    }
+}
 
 /// `arith.truncf %value : <from> to <result_type>`.
 ///

--- a/crates/reussir-backend/src/dialect/dbg.rs
+++ b/crates/reussir-backend/src/dialect/dbg.rs
@@ -1,0 +1,178 @@
+//! Constructors for the Reussir dialect's debug-info attributes.
+//!
+//! These attributes describe a value's debug type or a source variable; codegen
+//! attaches them as `FusedLoc` metadata and the debug-info conversion pass
+//! translates them to LLVM DI. Like the dialect's types, their custom storage
+//! cannot be built through the generic MLIR APIs, so these wrap the Reussir C API
+//! constructors.
+
+use melior::Context;
+use melior::ir::attribute::{AttributeLike, StringAttribute};
+use melior::ir::r#type::TypeLike;
+use melior::ir::{Attribute, Type};
+
+use reussir_backend_sys as sys;
+
+fn raw_attrs(attrs: &[Attribute]) -> Vec<sys::mlir_sys::MlirAttribute> {
+    attrs.iter().map(AttributeLike::to_raw).collect()
+}
+
+/// A `#reussir.dbg_inttype` debug type for an integer `inner` named `name`.
+pub fn int_type<'c>(
+    context: &'c Context,
+    inner: Type<'c>,
+    is_signed: bool,
+    name: StringAttribute<'c>,
+) -> Attribute<'c> {
+    unsafe {
+        Attribute::from_raw(sys::reussirDBGIntTypeAttrGet(
+            context.to_raw(),
+            inner.to_raw(),
+            is_signed,
+            name.to_raw(),
+        ))
+    }
+}
+
+/// A `#reussir.dbg_fptype` debug type for a floating-point `inner` named `name`.
+pub fn fp_type<'c>(
+    context: &'c Context,
+    inner: Type<'c>,
+    name: StringAttribute<'c>,
+) -> Attribute<'c> {
+    unsafe {
+        Attribute::from_raw(sys::reussirDBGFPTypeAttrGet(
+            context.to_raw(),
+            inner.to_raw(),
+            name.to_raw(),
+        ))
+    }
+}
+
+/// A `#reussir.dbg_record_member`: a field `name` with debug type `type_attr`.
+pub fn record_member<'c>(
+    context: &'c Context,
+    name: StringAttribute<'c>,
+    type_attr: Attribute<'c>,
+) -> Attribute<'c> {
+    unsafe {
+        Attribute::from_raw(sys::reussirDBGRecordMemberAttrGet(
+            context.to_raw(),
+            name.to_raw(),
+            type_attr.to_raw(),
+        ))
+    }
+}
+
+/// A `#reussir.dbg_recordtype` over `members` (each a [`record_member`]).
+/// `underlying` is the lowered MLIR record used for size/offset computation.
+pub fn record_type<'c>(
+    context: &'c Context,
+    members: &[Attribute<'c>],
+    is_variant: bool,
+    underlying: Type<'c>,
+    name: StringAttribute<'c>,
+) -> Attribute<'c> {
+    let raw = raw_attrs(members);
+    unsafe {
+        Attribute::from_raw(sys::reussirDBGRecordTypeAttrGet(
+            context.to_raw(),
+            raw.len() as isize,
+            raw.as_ptr(),
+            is_variant,
+            underlying.to_raw(),
+            name.to_raw(),
+        ))
+    }
+}
+
+/// A `#reussir.dbg_subprogram` for a function named `raw_name` with parameter
+/// debug types `type_params`.
+pub fn subprogram<'c>(
+    context: &'c Context,
+    raw_name: StringAttribute<'c>,
+    type_params: &[Attribute<'c>],
+) -> Attribute<'c> {
+    let raw = raw_attrs(type_params);
+    unsafe {
+        Attribute::from_raw(sys::reussirDBGSubprogramAttrGet(
+            context.to_raw(),
+            raw_name.to_raw(),
+            raw.len() as isize,
+            raw.as_ptr(),
+        ))
+    }
+}
+
+/// A `#reussir.dbg_boxedtype` for a reference-counted value, wrapping the
+/// payload's debug type `inner`.
+pub fn boxed_type<'c>(context: &'c Context, inner: Attribute<'c>) -> Attribute<'c> {
+    unsafe {
+        Attribute::from_raw(sys::reussirDBGBoxedTypeAttrGet(
+            context.to_raw(),
+            inner.to_raw(),
+        ))
+    }
+}
+
+/// A `#reussir.dbg_localvar` of debug type `dbg_type` and source `name`.
+pub fn local_var<'c>(
+    context: &'c Context,
+    dbg_type: Attribute<'c>,
+    name: StringAttribute<'c>,
+) -> Attribute<'c> {
+    unsafe {
+        Attribute::from_raw(sys::reussirDBGLocalVarAttrGet(
+            context.to_raw(),
+            dbg_type.to_raw(),
+            name.to_raw(),
+        ))
+    }
+}
+
+/// A `#reussir.dbg_func_arg` of debug type `dbg_type`, source `name`, and 1-based
+/// `index`.
+pub fn func_arg<'c>(
+    context: &'c Context,
+    dbg_type: Attribute<'c>,
+    name: StringAttribute<'c>,
+    index: u32,
+) -> Attribute<'c> {
+    unsafe {
+        Attribute::from_raw(sys::reussirDBGFuncArgAttrGet(
+            context.to_raw(),
+            dbg_type.to_raw(),
+            name.to_raw(),
+            index,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use melior::ir::r#type::IntegerType;
+
+    #[test]
+    fn debug_attrs_construct_and_print() {
+        let context = crate::context();
+        let i64 = IntegerType::new(&context, 64).into();
+        let name = |s| StringAttribute::new(&context, s);
+
+        let int = int_type(&context, i64, true, name("i64"));
+        assert!(int.to_string().contains("dbg_inttype"), "{int}");
+
+        let member = record_member(&context, name("x"), int);
+        let record = record_type(&context, &[member], false, i64, name("Point"));
+        assert!(record.to_string().contains("dbg_recordtype"), "{record}");
+
+        let local = local_var(&context, int, name("v"));
+        assert!(local.to_string().contains("dbg_localvar"), "{local}");
+
+        let arg = func_arg(&context, int, name("a"), 1);
+        assert!(arg.to_string().contains("dbg_func_arg"), "{arg}");
+
+        let sp = subprogram(&context, name("add"), &[int, int]);
+        assert!(sp.to_string().contains("dbg_subprogram"), "{sp}");
+    }
+}

--- a/crates/reussir-backend/src/dialect/dbg.rs
+++ b/crates/reussir-backend/src/dialect/dbg.rs
@@ -105,12 +105,19 @@ pub fn subprogram<'c>(
 }
 
 /// A `#reussir.dbg_boxedtype` for a reference-counted value, wrapping the
-/// payload's debug type `inner`.
-pub fn boxed_type<'c>(context: &'c Context, inner: Attribute<'c>) -> Attribute<'c> {
+/// payload's debug type `inner`. `regional` selects the box header the debug-info
+/// pass skips past: a shared box has a single ref-count word, a regional box a
+/// three-word `{ status, next, vtable }` header.
+pub fn boxed_type<'c>(
+    context: &'c Context,
+    inner: Attribute<'c>,
+    regional: bool,
+) -> Attribute<'c> {
     unsafe {
         Attribute::from_raw(sys::reussirDBGBoxedTypeAttrGet(
             context.to_raw(),
             inner.to_raw(),
+            regional,
         ))
     }
 }
@@ -174,5 +181,13 @@ mod tests {
 
         let sp = subprogram(&context, name("add"), &[int, int]);
         assert!(sp.to_string().contains("dbg_subprogram"), "{sp}");
+
+        let shared = boxed_type(&context, record, false);
+        assert!(shared.to_string().contains("regional : false"), "{shared}");
+        let regional = boxed_type(&context, record, true);
+        assert!(
+            regional.to_string().contains("regional : true"),
+            "{regional}"
+        );
     }
 }

--- a/crates/reussir-backend/src/dialect/mod.rs
+++ b/crates/reussir-backend/src/dialect/mod.rs
@@ -16,6 +16,7 @@
 //! `REUSSIR_INCLUDE_DIR` environment variable, which the crate's build script
 //! sets (see `build.rs`).
 
+pub mod dbg;
 pub mod ty;
 
 // melior's `dialect!` macro emits a `pub mod reussir { ... }` containing the

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -172,6 +172,10 @@ pub fn run_lowering_pipeline(
         module: sys::reussirCreateBasicOpsLoweringPass();
         module: sys::reussirCreateConvertToLLVMPass();
         module: sys::reussirCreateReconcileUnrealizedCastsPass();
+        // Convert fused Reussir debug-info attributes to LLVM DI now that
+        // functions are `llvm.func`; a function's DI only survives translation
+        // once its `llvm.func` carries a `DISubprogram`.
+        module: sys::reussirCreateDebugInfoConversionPass();
         module: sys::reussirCreateCSEPass();
         module: sys::reussirCreateCanonicalizerPass();
     );

--- a/crates/reussir-codegen/Cargo.toml
+++ b/crates/reussir-codegen/Cargo.toml
@@ -17,10 +17,12 @@ reussir-backend = { path = "../reussir-backend" }
 rustc-hash.workspace = true
 tracing.workspace = true
 smallvec.workspace = true
+# Source line/column cache for resolving MIR byte spans to MLIR locations.
+ariadne.workspace = true
+# Resolves interned source names (`TokenKey`) for debug-info variable names.
+reussir-syntax = { path = "../reussir-syntax" }
 
 [dev-dependencies]
-# End-to-end tests: source → elaborate → monomorphize → lower → run.
-reussir-syntax = { path = "../reussir-syntax" }
 # JIT-execute the lowered module to check the compiled program's meaning.
 reussir-jit = { path = "../reussir-jit" }
 tracing-subscriber = "0.3.23"

--- a/crates/reussir-codegen/src/lib.rs
+++ b/crates/reussir-codegen/src/lib.rs
@@ -8,6 +8,7 @@
 //! of any MLIR dependency.
 
 pub mod lower;
+pub mod source;
 
 // Test-only helpers, shared with the integration tests (which include the same
 // file directly via `#[path]`). Not part of the crate's API.

--- a/crates/reussir-codegen/src/lower/debug.rs
+++ b/crates/reussir-codegen/src/lower/debug.rs
@@ -152,13 +152,18 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 mlir,
                 StringAttribute::new(self.context, "bf16"),
             )),
-            // A `[shared]` record is an `rc` box: describe the payload composite
+            // A managed record is an `rc` box: describe the payload composite
             // (built over the inline record type) wrapped as a boxed type, so the
-            // pass can reach it by dereferencing past the box header.
-            TyKind::Record { .. } if self.tys.is_shared_record(ty) => {
+            // pass can reach it by dereferencing past the box header. `regional`
+            // selects which header size to skip — shared boxes have a one-word
+            // ref-count, regional boxes a three-word header.
+            TyKind::Record { .. }
+                if self.tys.is_shared_record(ty) || self.tys.is_regional_record(ty) =>
+            {
                 let payload_mlir = self.tys.record_inner_of(ty).ok()?;
                 let payload = self.dbg_record(ty, payload_mlir)?;
-                Some(dbg::boxed_type(self.context, payload))
+                let regional = self.tys.is_regional_record(ty);
+                Some(dbg::boxed_type(self.context, payload, regional))
             }
             // A by-value record: a composite of its (precisely-typed) fields. If
             // a field has no debug type the whole record is skipped.

--- a/crates/reussir-codegen/src/lower/debug.rs
+++ b/crates/reussir-codegen/src/lower/debug.rs
@@ -1,0 +1,202 @@
+//! Debug-info emission: building the Reussir `DBG*` attributes from the MIR and
+//! attaching them so the backend's debug-info conversion pass can emit DWARF.
+//!
+//! The attributes ride on locations: a function's `func.func` is given a
+//! `FusedLoc` whose metadata is a [`dbg::subprogram`] attribute, and its
+//! parameters are described by a `reussir.dbg_func_args` array attribute the pass
+//! reads. A variable's *type* is built precisely from its ground MIR type
+//! ([`dbg_type`](Lowerer::dbg_type)).
+//!
+//! Only what the conversion pass already handles is emitted: scalars and
+//! by-value records. Reference-counted (`[shared]`) records are boxed and need a
+//! pointer type plus a `DIExpression`; they are skipped here until that lands.
+//! Local (`let`) variables are likewise not emitted yet — they require attaching
+//! the attribute to a specific defining op.
+
+use reussir_backend::builders;
+use reussir_backend::dialect::dbg;
+use reussir_backend::melior::ir::attribute::{ArrayAttribute, StringAttribute};
+use reussir_backend::melior::ir::operation::{OperationMutLike, OperationResult};
+use reussir_backend::melior::ir::{Attribute, Identifier, Location, Module, Type, Value};
+
+use reussir_core::full::mir;
+use reussir_core::semi::ty::{FpTy, IntTy, Ty, TyKind};
+use reussir_syntax::kind::TokenKey;
+
+use super::expr::Lowerer;
+
+impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
+    /// Resolve an interned source name, if a resolver is available.
+    fn source_name(&self, token: TokenKey) -> Option<&'p str> {
+        self.names.map(|r| r.resolve(token))
+    }
+
+    /// Attach a local-variable debug attribute to the op that defines a `let`
+    /// binding (a fused location carrying a `DBGLocalVar`). The conversion pass
+    /// then describes the variable from that op's lowered storage.
+    ///
+    /// A binding whose value merely aliases a parameter or another local is a
+    /// block argument with no defining op, and is skipped — as is a value with no
+    /// representable debug type.
+    pub(super) fn tag_local<'b>(&self, value: Value<'c, 'b>, name: TokenKey, ty: Ty<'tcx>) {
+        if !self.debug_enabled() {
+            return;
+        }
+        let (Some(dbg_type), Some(var_name)) = (self.dbg_type(ty), self.source_name(name)) else {
+            return;
+        };
+        let Ok(result) = OperationResult::try_from(value) else {
+            return;
+        };
+        let attr = dbg::local_var(
+            self.context,
+            dbg_type,
+            StringAttribute::new(self.context, var_name),
+        );
+        let location = Location::fused(self.context, &[self.loc()], attr);
+        builders::set_location(result.owner(), location);
+    }
+
+    /// Set the module-level debug attributes the conversion pass reads (the
+    /// source file's basename and directory). No-op unless debug info is enabled.
+    pub(super) fn set_module_debug_attrs(&self, module: &mut Module<'c>) {
+        if !self.debug_enabled() {
+            return;
+        }
+        let Some(source) = self.source else { return };
+        let basename = StringAttribute::new(self.context, &source.basename());
+        let directory = StringAttribute::new(self.context, &source.directory());
+        let mut op = module.as_operation_mut();
+        op.set_attribute("reussir.dbg.file_basename", basename.into());
+        op.set_attribute("reussir.dbg.file_directory", directory.into());
+    }
+
+    /// The location for a function's `func.func`: its source position fused with a
+    /// debug subprogram attribute, or just the position when debug info is off.
+    pub(super) fn subprogram_location(&self, func: &mir::Function<'tcx>) -> Location<'c> {
+        let base = self.location(func.body.and_then(|b| b.span));
+        if !self.debug_enabled() {
+            return base;
+        }
+        let raw_name = StringAttribute::new(self.context, self.program.symbol(func.symbol));
+        let param_types: Vec<Attribute<'c>> = func
+            .params
+            .iter()
+            .filter_map(|p| self.dbg_type(p.ty))
+            .collect();
+        let subprogram = dbg::subprogram(self.context, raw_name, &param_types);
+        Location::fused(self.context, &[base], subprogram)
+    }
+
+    /// The `reussir.dbg_func_args` attribute describing a function's parameters
+    /// (name, debug type, 1-based index), or `None` when debug info is off or no
+    /// parameter has a representable debug type.
+    pub(super) fn dbg_func_args_attr(
+        &self,
+        func: &mir::Function<'tcx>,
+    ) -> Option<(Identifier<'c>, Attribute<'c>)> {
+        if !self.debug_enabled() {
+            return None;
+        }
+        let args: Vec<Attribute<'c>> = func
+            .params
+            .iter()
+            .enumerate()
+            .filter_map(|(i, p)| {
+                let dbg_type = self.dbg_type(p.ty)?;
+                let name = StringAttribute::new(self.context, self.source_name(p.name)?);
+                Some(dbg::func_arg(self.context, dbg_type, name, i as u32 + 1))
+            })
+            .collect();
+        if args.is_empty() {
+            return None;
+        }
+        let array = ArrayAttribute::new(self.context, &args);
+        Some((
+            Identifier::new(self.context, "reussir.dbg_func_args"),
+            array.into(),
+        ))
+    }
+
+    /// Build the debug type attribute for a ground MIR type, or `None` if it has
+    /// no representation the conversion pass handles yet (boxed records,
+    /// closures, strings, ...).
+    pub(super) fn dbg_type(&self, ty: Ty<'tcx>) -> Option<Attribute<'c>> {
+        let mlir = self.tys.mlir_ty(ty).ok()?;
+        match *ty.kind() {
+            TyKind::Int(IntTy::Signed(w)) => Some(dbg::int_type(
+                self.context,
+                mlir,
+                true,
+                StringAttribute::new(self.context, &format!("i{w}")),
+            )),
+            TyKind::Int(IntTy::Unsigned(w)) => Some(dbg::int_type(
+                self.context,
+                mlir,
+                false,
+                StringAttribute::new(self.context, &format!("u{w}")),
+            )),
+            TyKind::Bool => Some(dbg::int_type(
+                self.context,
+                mlir,
+                false,
+                StringAttribute::new(self.context, "bool"),
+            )),
+            TyKind::Fp(FpTy::Ieee(w)) => Some(dbg::fp_type(
+                self.context,
+                mlir,
+                StringAttribute::new(self.context, &format!("f{w}")),
+            )),
+            TyKind::Fp(FpTy::BFloat16) => Some(dbg::fp_type(
+                self.context,
+                mlir,
+                StringAttribute::new(self.context, "bf16"),
+            )),
+            // A `[shared]` record is an `rc` box: describe the payload composite
+            // (built over the inline record type) wrapped as a boxed type, so the
+            // pass can reach it by dereferencing past the box header.
+            TyKind::Record { .. } if self.tys.is_shared_record(ty) => {
+                let payload_mlir = self.tys.record_inner_of(ty).ok()?;
+                let payload = self.dbg_record(ty, payload_mlir)?;
+                Some(dbg::boxed_type(self.context, payload))
+            }
+            // A by-value record: a composite of its (precisely-typed) fields. If
+            // a field has no debug type the whole record is skipped.
+            TyKind::Record { .. } => self.dbg_record(ty, mlir),
+            _ => None,
+        }
+    }
+
+    /// Build a `dbg_recordtype` for a by-value record, or `None` if any field
+    /// lacks a debug type.
+    fn dbg_record(&self, ty: Ty<'tcx>, underlying: Type<'c>) -> Option<Attribute<'c>> {
+        let rec = self.tys.record_of(ty)?;
+        let members = match rec.layout {
+            mir::RecordLayout::Compound(members) => members,
+            mir::RecordLayout::Variant(_) => return None,
+        };
+        let member_attrs: Option<Vec<Attribute<'c>>> = members
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                let field_type = self.dbg_type(m.ty)?;
+                // The source field name, falling back to the positional index for
+                // a tuple field (or layout rebuilt from textual MIR).
+                let field_name = m
+                    .name
+                    .map(|s| self.program.symbol(s).to_string())
+                    .unwrap_or_else(|| i.to_string());
+                let name = StringAttribute::new(self.context, &field_name);
+                Some(dbg::record_member(self.context, name, field_type))
+            })
+            .collect();
+        let name = StringAttribute::new(self.context, self.program.symbol(rec.symbol));
+        Some(dbg::record_type(
+            self.context,
+            &member_attrs?,
+            false,
+            underlying,
+            name,
+        ))
+    }
+}

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -31,8 +31,11 @@ use reussir_core::full::mir::{self, Expr, ExprKind};
 use reussir_core::full::ownership::{OwnershipTable, RcOp, RecordTable, analyze_function};
 use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use reussir_core::semi::ty::{IntTy, Ty, TyCtxt, TyKind};
-use reussir_core::surface::Visibility;
+use reussir_core::surface::{Span, Visibility};
+use reussir_syntax::kind::{Resolver, TokenKey};
 use smallvec::SmallVec;
+
+use crate::source::SourceMap;
 
 use super::ty::{TypeCtx, is_unit, num_class};
 use super::{LoweringError, Result, err};
@@ -63,13 +66,23 @@ enum Cursor<'c, 'b, 'tcx> {
 /// `drop` keyed by a variable knows whether to emit an `rc` op or to recurse
 /// through an inline record).
 pub(super) struct Lowerer<'c, 'p, 'tcx> {
-    context: &'c Context,
-    tcx: &'p TyCtxt<'tcx>,
-    program: &'p mir::Program<'tcx>,
-    tys: TypeCtx<'c, 'p, 'tcx>,
+    pub(super) context: &'c Context,
+    pub(super) tcx: &'p TyCtxt<'tcx>,
+    pub(super) program: &'p mir::Program<'tcx>,
+    pub(super) tys: TypeCtx<'c, 'p, 'tcx>,
     records: RecordTable<'tcx>,
+    /// Resolves MIR byte spans to file/line/column; `None` lowers to `unknown`
+    /// locations.
+    pub(super) source: Option<&'p SourceMap<'p>>,
+    /// Resolves interned source names for debug info; `Some` (with `source`)
+    /// enables DWARF variable/type emission. See [`debug`](super::debug).
+    pub(super) names: Option<&'p dyn Resolver<TokenKey>>,
     ownership: RefCell<OwnershipTable>,
     var_tys: RefCell<FxHashMap<VarId, Ty<'tcx>>>,
+    /// The location attached to ops as they are built. Set to the current
+    /// expression's span by [`expr`](Self::expr) (saved and restored around each
+    /// node), so every op a node emits shares that node's source position.
+    cur_loc: RefCell<Location<'c>>,
 }
 
 impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
@@ -77,6 +90,8 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         context: &'c Context,
         tcx: &'p TyCtxt<'tcx>,
         program: &'p mir::Program<'tcx>,
+        source: Option<&'p SourceMap<'p>>,
+        names: Option<&'p dyn Resolver<TokenKey>>,
     ) -> Self {
         Lowerer {
             context,
@@ -84,13 +99,35 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             program,
             tys: TypeCtx::new(context, program),
             records: RecordTable::from_records(&program.records),
+            source,
+            names,
             ownership: RefCell::new(OwnershipTable::default()),
             var_tys: RefCell::new(FxHashMap::default()),
+            cur_loc: RefCell::new(Location::unknown(context)),
         }
     }
 
-    fn loc(&self) -> Location<'c> {
-        Location::unknown(self.context)
+    /// Whether debug info should be emitted (both a source map and a name
+    /// resolver were supplied).
+    pub(super) fn debug_enabled(&self) -> bool {
+        self.source.is_some() && self.names.is_some()
+    }
+
+    /// The location currently attached to emitted ops (see [`cur_loc`](Self::cur_loc)).
+    pub(super) fn loc(&self) -> Location<'c> {
+        *self.cur_loc.borrow()
+    }
+
+    /// Resolve a MIR span to a `FileLineColLoc`, or `unknown` without a source
+    /// map or span.
+    pub(super) fn location(&self, span: Option<Span>) -> Location<'c> {
+        match (self.source, span) {
+            (Some(map), Some(span)) => {
+                let (line, col) = map.span_start(span);
+                Location::new(self.context, &map.filename(), line, col)
+            }
+            _ => Location::unknown(self.context),
+        }
     }
 
     /// Record the ground type of a local, so reference-count ops keyed by it can
@@ -105,7 +142,10 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
 
     /// Lower one MIR function to a `func.func` operation.
     pub(super) fn function(&self, func: &mir::Function<'tcx>) -> Result<Operation<'c>> {
-        let loc = self.loc();
+        // The function and its entry-level ops (block args, return) take the
+        // body's source position; nested nodes refine it as they are walked.
+        let loc = self.location(func.body.and_then(|b| b.span));
+        self.cur_loc.replace(loc);
         let param_tys = func
             .params
             .iter()
@@ -150,14 +190,20 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
 
         // A `private` function carries an explicit `sym_visibility` attribute;
         // the printer renders it as the `private` keyword.
-        let attributes = if func.visibility == Visibility::Private {
-            vec![(
+        let mut attributes = Vec::new();
+        if func.visibility == Visibility::Private {
+            attributes.push((
                 Identifier::new(self.context, "sym_visibility"),
                 StringAttribute::new(self.context, "private").into(),
-            )]
-        } else {
-            Vec::new()
-        };
+            ));
+        }
+        // Debug info (when enabled): the parameters' names/types as an attribute
+        // the conversion pass reads, and the function's own location fused with a
+        // subprogram attribute.
+        if let Some(args) = self.dbg_func_args_attr(func) {
+            attributes.push(args);
+        }
+        let func_loc = self.subprogram_location(func);
 
         Ok(func::func(
             self.context,
@@ -165,7 +211,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             TypeAttribute::new(fn_ty.into()),
             region,
             &attributes,
-            loc,
+            func_loc,
         ))
     }
 
@@ -182,10 +228,17 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         env: &mut Env<'c, 'b>,
         e: &Expr<'tcx>,
     ) -> Result<Option<Value<'c, 'b>>> {
-        self.emit_rc_before(block, env, e.id)?;
-        let value = self.expr_inner(block, env, e)?;
-        self.emit_rc_after(block, env, e.id, e.ty, value)?;
-        Ok(value)
+        // Attach this node's source position to every op it emits, restoring the
+        // enclosing node's position afterwards.
+        let prev = self.cur_loc.replace(self.location(e.span));
+        let result = (|| {
+            self.emit_rc_before(block, env, e.id)?;
+            let value = self.expr_inner(block, env, e)?;
+            self.emit_rc_after(block, env, e.id, e.ty, value)?;
+            Ok(value)
+        })();
+        self.cur_loc.replace(prev);
+        result
     }
 
     /// Lower the node itself, without its surrounding reference-count ops.
@@ -243,9 +296,10 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 }
                 Ok(last)
             }
-            Let { var, value, .. } => {
+            Let { var, name, value } => {
                 self.bind_var_ty(*var, value.ty);
                 if let Some(v) = self.expr(block, env, value)? {
+                    self.tag_local(v, *name, value.ty);
                     env.insert(*var, v);
                 }
                 Ok(None)

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -31,6 +31,7 @@
 //! lowering only looks names up in the program's symbol table — it needs no
 //! `DefTable`/resolver/`Mangler`.
 
+mod debug;
 mod expr;
 mod ty;
 
@@ -42,7 +43,9 @@ use reussir_backend::melior::ir::{BlockLike, Location, Module};
 
 use reussir_core::full::mir;
 use reussir_core::semi::ty::TyCtxt;
+use reussir_syntax::kind::{Resolver, TokenKey};
 
+use crate::source::SourceMap;
 use expr::Lowerer;
 
 /// A construct the current lowering subset does not handle.
@@ -67,14 +70,25 @@ fn err<T>(msg: impl Into<Cow<'static, str>>) -> Result<T> {
 ///
 /// `tcx` is the type arena the program was monomorphized in; the ownership
 /// analysis that places reference-count ops is run per function against it.
+/// `source`, when given, labels each lowered op with a `FileLineColLoc` resolved
+/// from the MIR's byte spans (and carries the file name into the module's debug
+/// attributes); without it, ops get `unknown` locations.
+///
+/// `names`, when given *together with* `source`, additionally emits DWARF debug
+/// info: it resolves the interned source names of functions, parameters, and
+/// locals so the debug-info conversion pass can describe each variable and its
+/// (precise) type. Without `names`, only line locations are emitted.
 pub fn lower_program<'c, 'tcx>(
     context: &'c Context,
     tcx: &TyCtxt<'tcx>,
     program: &mir::Program<'tcx>,
+    source: Option<&SourceMap<'_>>,
+    names: Option<&dyn Resolver<TokenKey>>,
 ) -> Result<Module<'c>> {
-    let module = Module::new(Location::unknown(context));
+    let mut module = Module::new(Location::unknown(context));
+    let lowerer = Lowerer::new(context, tcx, program, source, names);
+    lowerer.set_module_debug_attrs(&mut module);
     let body = module.body();
-    let lowerer = Lowerer::new(context, tcx, program);
     for func in &program.functions {
         body.append_operation(lowerer.function(func)?);
     }
@@ -110,7 +124,8 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let module = lower_program(&context, tcx, &full).expect("lowering succeeds");
+            let module =
+                lower_program(&context, tcx, &full, None, None).expect("lowering succeeds");
             assert!(
                 module.as_operation().verify(),
                 "module verifies:\n{}",
@@ -118,6 +133,81 @@ mod tests {
             );
             module.as_operation().to_string()
         })
+    }
+
+    #[test]
+    fn attaches_source_locations() {
+        use reussir_backend::melior::ir::operation::OperationPrintingFlags;
+        let src = "pub fn add(a: i64, b: i64) -> i64 { a + b }\n";
+        let context = crate::testing::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let path = std::path::Path::new("add.rr");
+            let map = crate::source::SourceMap::new(path, src);
+            let module =
+                lower_program(&context, tcx, &full, Some(&map), None).expect("lowering succeeds");
+            let printed = module
+                .as_operation()
+                .to_string_with_flags(OperationPrintingFlags::new().enable_debug_info(true, false))
+                .expect("print with locations");
+            assert!(printed.contains("loc(\"add.rr\":1:"), "{printed}");
+        });
+    }
+
+    #[test]
+    fn emits_debug_info_for_a_function() {
+        use reussir_backend::melior::ir::operation::OperationPrintingFlags;
+        // Exercises every kind of debug type emitted: scalars, a `[value]` record
+        // (with named members), a `[shared]` record (boxed), and a `let` local.
+        let src = r#"
+            struct [value] Point { x: i64, y: f64 }
+            struct [shared] Boxed { n: i64 }
+            fn proj(p: Point) -> i64 { let q = p.x; q }
+            fn unbox(b: Boxed) -> i64 { b.n }
+            pub fn entry(a: i64, b: f64) -> i64 {
+                let p = Point { x: a, y: b };
+                let bx = Boxed { n: a };
+                proj(p) + unbox(bx)
+            }
+            extern "C" trampoline "entry" = entry;
+        "#;
+        let context = crate::testing::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let path = std::path::Path::new("pt.rr");
+            let map = crate::source::SourceMap::new(path, src);
+            let module = lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()))
+                .expect("lowering succeeds");
+            let printed = module
+                .as_operation()
+                .to_string_with_flags(OperationPrintingFlags::new().enable_debug_info(true, false))
+                .expect("print with debug info");
+            // Module file attributes, the subprogram + parameter array, and every
+            // debug-type form including precise member names and the boxed type.
+            assert!(printed.contains("reussir.dbg.file_basename"), "{printed}");
+            assert!(printed.contains("dbg_subprogram"), "{printed}");
+            assert!(printed.contains("dbg_func_args"), "{printed}");
+            assert!(printed.contains("dbg_recordtype"), "{printed}");
+            assert!(printed.contains("dbg_inttype"), "{printed}");
+            assert!(printed.contains("dbg_fptype"), "{printed}");
+            assert!(printed.contains("dbg_boxedtype"), "{printed}");
+            assert!(printed.contains("dbg_localvar"), "{printed}");
+            // Field names are preserved (not positional).
+            assert!(printed.contains("name : \"x\""), "{printed}");
+            assert!(printed.contains("name : \"y\""), "{printed}");
+        });
     }
 
     #[test]
@@ -246,7 +336,8 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let mut module = lower_program(&context, tcx, &full).expect("lowering succeeds");
+            let mut module =
+                lower_program(&context, tcx, &full, None, None).expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -191,7 +191,11 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
     /// `!reussir.ref<inner>` with unspecified capability — the form a spilled
     /// stack reference takes, used to acquire/drop an inline value in place.
     pub(super) fn unspecified_ref_type(&self, inner: Type<'c>) -> Type<'c> {
-        r#ref(inner, ReussirCapability::Unspecified, ReussirAtomicKind::Normal)
+        r#ref(
+            inner,
+            ReussirCapability::Unspecified,
+            ReussirAtomicKind::Normal,
+        )
     }
 }
 

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -90,6 +90,15 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             .is_some_and(|rec| rec.default_cap == DefaultCap::Shared)
     }
 
+    /// Whether `ty` is a `[regional]` record. Like a `[shared]` record its value
+    /// is a boxed `rc` pointer, but the box carries a larger three-word header, so
+    /// debug info reaches the payload at a different offset. (Regional records are
+    /// not lowered yet; this lets debug-info emission stay correct once they are.)
+    pub(super) fn is_regional_record(&self, ty: Ty<'tcx>) -> bool {
+        self.record_of(ty)
+            .is_some_and(|rec| rec.default_cap == DefaultCap::Regional)
+    }
+
     /// Lower a ground type to MLIR: records resolve through the layout table,
     /// everything else is a scalar.
     pub(super) fn mlir_ty(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {

--- a/crates/reussir-codegen/src/source.rs
+++ b/crates/reussir-codegen/src/source.rs
@@ -1,0 +1,74 @@
+//! Source-position mapping for attaching MLIR locations to lowered ops.
+//!
+//! The MIR carries byte-offset [`Span`]s; a [`SourceMap`] resolves those to
+//! `(line, column)` against the original source so lowering can label each op
+//! with a `FileLineColLoc` (and, with debug info enabled, emit correct DWARF line
+//! tables). Lowering without a source map falls back to `unknown` locations.
+//!
+//! TODO(multifile): this maps a *single* source file. Once `rrc` grows a
+//! crate-like multi-file structure, a [`Span`] will need to identify its file
+//! too, and this should become a file cache keyed by file id (ariadne's
+//! [`Cache`](ariadne::Cache) / [`sources`](ariadne::sources) already model this).
+
+use std::borrow::Cow;
+use std::path::Path;
+
+use ariadne::Source;
+use reussir_core::surface::Span;
+
+/// A line index over one source file, labelling positions with its path.
+///
+/// Wraps [`ariadne::Source`] (the same line cache the parser uses for
+/// diagnostics) to resolve byte offsets to `(line, column)`.
+pub struct SourceMap<'a> {
+    path: &'a Path,
+    source: Source<&'a str>,
+}
+
+impl<'a> SourceMap<'a> {
+    /// Build the line index for `source`, labelling positions with `path`.
+    pub fn new(path: &'a Path, source: &'a str) -> Self {
+        SourceMap {
+            path,
+            source: Source::from(source),
+        }
+    }
+
+    /// The source path positions are labelled with.
+    pub fn path(&self) -> &Path {
+        self.path
+    }
+
+    /// The full path as a string, for a `FileLineColLoc` filename.
+    pub fn filename(&self) -> Cow<'_, str> {
+        self.path.to_string_lossy()
+    }
+
+    /// The file name component, for the DWARF `DIFile` basename.
+    pub fn basename(&self) -> Cow<'_, str> {
+        self.path
+            .file_name()
+            .map_or(Cow::Borrowed(""), |n| n.to_string_lossy())
+    }
+
+    /// The parent directory, for the DWARF `DIFile` directory.
+    pub fn directory(&self) -> Cow<'_, str> {
+        self.path
+            .parent()
+            .map_or(Cow::Borrowed(""), |d| d.to_string_lossy())
+    }
+
+    /// The 1-based `(line, column)` of a byte `offset` (ariadne reports both
+    /// zero-indexed).
+    pub fn line_col(&self, offset: usize) -> (usize, usize) {
+        match self.source.get_byte_line(offset) {
+            Some((_, line, col)) => (line + 1, col + 1),
+            None => (1, 1),
+        }
+    }
+
+    /// The 1-based `(line, column)` at the start of `span`.
+    pub fn span_start(&self, span: Span) -> (usize, usize) {
+        self.line_col(span.start as usize)
+    }
+}

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -33,7 +33,7 @@ fn jit_run<R>(source: &str, run: impl FnOnce(&OrcJit) -> R) -> R {
         );
         let (full, reports) = monomorphize(&elab.mono_input());
         assert!(reports.is_empty(), "mono reports: {reports:#?}");
-        lower_program(&context, tcx, &full).expect("scalar lowering succeeds")
+        lower_program(&context, tcx, &full, None, None).expect("scalar lowering succeeds")
     });
 
     run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
@@ -108,7 +108,9 @@ fn runs_shared_record_construction_and_projection() {
         extern "C" trampoline "build_and_read_ffi" = build_and_read;
     "#;
     jit_run(src, |jit| {
-        let a = jit.lookup("build_and_read_ffi").expect("lookup build_and_read_ffi");
+        let a = jit
+            .lookup("build_and_read_ffi")
+            .expect("lookup build_and_read_ffi");
         let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
         assert_eq!(f(5), 5);
         assert_eq!(f(42), 42);

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -14,6 +14,7 @@ use palc::Parser;
 use reussir_backend::llvm::LlvmLowering;
 use reussir_backend::pipeline::{self, LoweringOptions, OptLevel};
 use reussir_codegen::lower::lower_program;
+use reussir_codegen::source::SourceMap;
 use reussir_compiler::{OutputKind, RelocMode, TargetMachine, TargetSpec, emit_to_file};
 use reussir_core::full::mono::monomorphize;
 use reussir_core::semi::{Report, Severity, elaborate};
@@ -65,6 +66,10 @@ struct Cli {
     /// backend's worker threads (e.g. some sanitizers/debuggers).
     #[arg(long = "disable-backend-multithreading")]
     disable_backend_multithreading: bool,
+
+    /// Emit DWARF debug info (source locations, function/variable debug types).
+    #[arg(short = 'g', long = "debug")]
+    debug: bool,
 }
 
 fn parse_emit(cli: &Cli) -> Result<OutputKind, String> {
@@ -158,6 +163,12 @@ fn run(cli: &Cli) -> Result<bool, String> {
     };
     let machine = TargetMachine::new(&spec, opt, reloc)?;
 
+    // Resolve the MIR's byte spans to source positions so lowered ops carry
+    // `FileLineColLoc`s (and, with debug info, DWARF line tables). With `-g`, the
+    // parser's name resolver feeds variable/function names into the debug info.
+    let source_map = SourceMap::new(&cli.input, &source);
+    let names = cli.debug.then(|| parse.resolver());
+
     let options = LoweringOptions {
         opt,
         reuse_token_across_call: cli.reuse_across_call,
@@ -182,7 +193,8 @@ fn run(cli: &Cli) -> Result<bool, String> {
         if report_diagnostics(&name, &reports) {
             return Err(String::new());
         }
-        let mut module = lower_program(&context, tcx, &full).map_err(|e| format!("{name}: {e}"))?;
+        let mut module = lower_program(&context, tcx, &full, Some(&source_map), names)
+            .map_err(|e| format!("{name}: {e}"))?;
         let prepared = LlvmLowering::prepare(&module, machine.data_layout(), optimize_ffi)
             .map_err(|e| format!("{name}: {e}"))?;
         pipeline::run_lowering_pipeline(&context, &mut module, &options)

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -116,6 +116,10 @@ pub enum RecordLayout<'tcx> {
 pub struct Member<'tcx> {
     pub ty: Ty<'tcx>,
     pub is_field: bool,
+    /// The source field name (interned), for debug info. `None` for a tuple
+    /// (unnamed) field, or when the layout was rebuilt from textual MIR (which
+    /// does not carry field names). Not part of the textual round-trip.
+    pub name: Option<Symbol>,
 }
 
 /// One enum variant: its source name (interned in the program's symbol table)

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -112,6 +112,7 @@ impl<'tcx> Builder<'_, 'tcx> {
                     .map(|m| mir::Member {
                         ty: self.ty(&m.ty),
                         is_field: m.is_field,
+                        name: m.name.as_deref().map(|s| self.sym(s)),
                     })
                     .collect();
                 mir::RecordLayout::Compound(self.tcx.alloc_slice(&ms))

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -33,9 +33,10 @@ RecordBody: (raw::Ty, raw::RecordBody) = {
     "enum" <t:Ty> "{" <vs:Comma<Variant>> "}" => (t, raw::RecordBody::Variant(vs)),
 };
 
-/// A compound field: an optional `field` marker (a mutable `[field]` link) and
-/// its ground type.
-Member: raw::Member = <f:"field"?> <t:Ty> => raw::Member { is_field: f.is_some(), ty: t };
+/// A compound field: an optional `name:` prefix (absent for a tuple field), an
+/// optional `field` marker (a mutable `[field]` link), and its ground type.
+Member: raw::Member = <n:(<"quoted"> ":")?> <f:"field"?> <t:Ty>
+    => raw::Member { name: n.map(|s| s.to_string()), is_field: f.is_some(), ty: t };
 
 /// An enum variant: its source name and ordered field types.
 Variant: raw::Variant =

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -111,12 +111,16 @@ impl Render<'_> {
                 let parts: Vec<Doc<'static>> = members
                     .iter()
                     .map(|m| {
+                        let name = match m.name {
+                            Some(s) => text(format!("\"{}\": ", self.sym(s))),
+                            None => Doc::Null,
+                        };
                         let marker = if m.is_field {
                             text("field ")
                         } else {
                             Doc::Null
                         };
-                        marker + self.ty(m.ty)
+                        name + marker + self.ty(m.ty)
                     })
                     .collect();
                 text("struct ") + self.ty(rec.ty) + text(" { ") + comma_sep(parts) + text(" }")

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -50,10 +50,12 @@ pub enum RecordBody {
     Variant(Vec<Variant>),
 }
 
-/// One compound field: its ground type, and whether it is a mutable `[field]`
-/// link (only regional records carry these).
+/// One compound field: its ground type, whether it is a mutable `[field]` link
+/// (only regional records carry these), and its source name (`None` for a tuple
+/// field).
 #[derive(Clone, Debug)]
 pub struct Member {
+    pub name: Option<String>,
     pub is_field: bool,
     pub ty: Ty,
 }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -267,9 +267,10 @@ fn resolve_layout<'tcx>(
         Some(RecordFields::Named(fields)) => {
             let members: Vec<mir::Member<'tcx>> = fields
                 .iter()
-                .map(|(_, ty, is_mut)| mir::Member {
+                .map(|(name, ty, is_mut)| mir::Member {
                     ty: subst_ty(tcx, *ty, &subst),
                     is_field: *is_mut,
+                    name: Some(mir::Symbol(symbols.get_or_intern(resolver.resolve(*name)))),
                 })
                 .collect();
             mir::RecordLayout::Compound(tcx.alloc_slice(&members))
@@ -280,6 +281,7 @@ fn resolve_layout<'tcx>(
                 .map(|(ty, is_mut)| mir::Member {
                     ty: subst_ty(tcx, *ty, &subst),
                     is_field: *is_mut,
+                    name: None,
                 })
                 .collect();
             mir::RecordLayout::Compound(tcx.alloc_slice(&members))
@@ -437,11 +439,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
     /// Used to close the record set over fields; bounds nesting depth like
     /// [`enqueue`](Self::enqueue) so polymorphic recursion through a field trips
     /// the limit rather than looping forever.
-    fn discover_records(
-        &mut self,
-        ty: Ty<'tcx>,
-        worklist: &mut Vec<(DefId, &'tcx [Ty<'tcx>])>,
-    ) {
+    fn discover_records(&mut self, ty: Ty<'tcx>, worklist: &mut Vec<(DefId, &'tcx [Ty<'tcx>])>) {
         match *ty.kind() {
             TyKind::Record { def, args, .. } => {
                 if self.records.insert((def, args)) {
@@ -489,13 +487,12 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 subst.insert(*gid, ty);
             }
             let field_tys: Vec<Ty<'tcx>> = match record.fields.as_ref() {
-                Some(RecordFields::Named(fields)) => {
-                    fields.iter().map(|(_, ty, _)| *ty).collect()
-                }
+                Some(RecordFields::Named(fields)) => fields.iter().map(|(_, ty, _)| *ty).collect(),
                 Some(RecordFields::Unnamed(fields)) => fields.iter().map(|(ty, _)| *ty).collect(),
-                Some(RecordFields::Variants(variants)) => {
-                    variants.iter().flat_map(|v| v.fields.iter().copied()).collect()
-                }
+                Some(RecordFields::Variants(variants)) => variants
+                    .iter()
+                    .flat_map(|v| v.fields.iter().copied())
+                    .collect(),
                 None => Vec::new(),
             };
             for field_ty in field_tys {

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -137,8 +137,8 @@ impl<'tcx> Builder<'_, 'tcx> {
     }
 
     /// Rebuild the `Record` metadata mono reads, including the ground field
-    /// layout. Struct field names are not serialized (mono ignores them), so a
-    /// struct's fields rebuild as [`RecordFields::Unnamed`] — layout-equivalent.
+    /// layout. A struct rebuilds as [`RecordFields::Named`] when its fields carry
+    /// names (debug info reads them) and [`RecordFields::Unnamed`] for a tuple.
     fn record(&mut self, r: &raw::Record) -> (DefId, Record<'tcx>) {
         let def = self.record_def(&r.path);
         let name = self.names.intern(&r.path);
@@ -153,6 +153,18 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::DefaultCap::Regional => DefaultCap::Regional,
         };
         let fields = match &r.body {
+            // Named when the fields carry names (a struct), unnamed for a tuple.
+            raw::RecordBody::Compound(members) if members.iter().any(|m| m.name.is_some()) => {
+                RecordFields::Named(
+                    members
+                        .iter()
+                        .map(|m| {
+                            let name = self.names.intern(m.name.as_deref().unwrap_or(""));
+                            (name, self.ty(&m.ty), m.is_field)
+                        })
+                        .collect(),
+                )
+            }
             raw::RecordBody::Compound(members) => RecordFields::Unnamed(
                 members
                     .iter()

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -45,9 +45,10 @@ DefaultCap: raw::DefaultCap = {
     "[" "regional" "]" => raw::DefaultCap::Regional,
 };
 
-/// A compound field: an optional `field` marker (a mutable `[field]` link) and
-/// its type.
-Member: raw::Member = <f:"field"?> <t:Ty> => raw::Member { is_field: f.is_some(), ty: t };
+/// A compound field: an optional `name:` prefix (absent for a tuple field), an
+/// optional `field` marker (a mutable `[field]` link), and its type.
+Member: raw::Member = <n:(<"quoted"> ":")?> <f:"field"?> <t:Ty>
+    => raw::Member { name: n.map(|s| s.to_string()), is_field: f.is_some(), ty: t };
 
 /// An enum variant: its source name and ordered field types.
 Variant: raw::Variant =

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -119,23 +119,22 @@ impl<'a> Printer<'a> {
         head + text(" { ") + self.record_body(r) + text(" };")
     }
 
-    /// The field layout of a record: `field?`-marked member types for a struct,
-    /// `Name(types)` variants for an enum. Struct field names are not emitted —
-    /// mono does not read them, so leaving them out keeps the form minimal and
-    /// the round-trip exact.
+    /// The field layout of a record: `name:`-prefixed (for a struct) `field?`-
+    /// marked member types, or `Name(types)` variants for an enum. Field names
+    /// are emitted so the round-trip preserves them (a tuple field has none).
     fn record_body(&self, r: &Record<'_>) -> Doc<'static> {
         match r.fields.as_ref() {
             Some(RecordFields::Named(fields)) => {
                 let parts = fields
                     .iter()
-                    .map(|(_, ty, is_mut)| self.member(*ty, *is_mut))
+                    .map(|(name, ty, is_mut)| self.member(Some(*name), *ty, *is_mut))
                     .collect();
                 comma_sep(parts)
             }
             Some(RecordFields::Unnamed(fields)) => {
                 let parts = fields
                     .iter()
-                    .map(|(ty, is_mut)| self.member(*ty, *is_mut))
+                    .map(|(ty, is_mut)| self.member(None, *ty, *is_mut))
                     .collect();
                 comma_sep(parts)
             }
@@ -156,9 +155,13 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn member(&self, ty: Ty<'_>, is_mut: bool) -> Doc<'static> {
+    fn member(&self, name: Option<TokenKey>, ty: Ty<'_>, is_mut: bool) -> Doc<'static> {
+        let name = match name {
+            Some(n) => text(format!("\"{}\": ", self.resolver.resolve(n))),
+            None => Doc::Null,
+        };
         let marker = if is_mut { text("field ") } else { Doc::Null };
-        marker + self.ty(ty)
+        name + marker + self.ty(ty)
     }
 
     fn trampoline(&self, t: &TrampolineRoot<'_>) -> Doc<'static> {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -65,9 +65,11 @@ pub enum RecordBody {
     Variant(Vec<Variant>),
 }
 
-/// One compound field: a `[field]`-mutability marker and its type.
+/// One compound field: an optional source name (absent for a tuple field), a
+/// `[field]`-mutability marker, and its type.
 #[derive(Clone, Debug)]
 pub struct Member {
+    pub name: Option<String>,
     pub is_field: bool,
     pub ty: Ty,
 }

--- a/include/Reussir-c/Attrs.h
+++ b/include/Reussir-c/Attrs.h
@@ -1,0 +1,89 @@
+//===-- Attrs.h - Reussir dialect attribute C API --------------*- C -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// C API constructors for the Reussir debug-info attributes. These attributes
+// describe a value's debug type / variable so the debug-info conversion pass can
+// emit LLVM DI; they use custom storage that the generic MLIR C API cannot
+// build, so the code generator constructs them through these entry points.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef REUSSIR_C_ATTRS_H
+#define REUSSIR_C_ATTRS_H
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//===----------------------------------------------------------------------===//
+// Debug-info attributes
+//===----------------------------------------------------------------------===//
+
+// A debug integer type: `innerType` is the lowered MLIR integer, `dbgName` a
+// `StringAttr` naming it in DWARF.
+MlirAttribute reussirDBGIntTypeAttrGet(MlirContext context, MlirType innerType,
+                                       bool isSigned, MlirAttribute dbgName);
+
+// A debug floating-point type.
+MlirAttribute reussirDBGFPTypeAttrGet(MlirContext context, MlirType innerType,
+                                      MlirAttribute dbgName);
+
+// One member of a debug record type: a field `name` (`StringAttr`) and its debug
+// type attribute (a `DBG*Type` attribute).
+MlirAttribute reussirDBGRecordMemberAttrGet(MlirContext context,
+                                            MlirAttribute name,
+                                            MlirAttribute typeAttr);
+
+// A debug record (struct / variant) type. `members` is an array of
+// `reussirDBGRecordMemberAttrGet` results; `underlyingType` is the lowered MLIR
+// record used for size/offset computation.
+MlirAttribute reussirDBGRecordTypeAttrGet(MlirContext context, intptr_t nMembers,
+                                          MlirAttribute const *members,
+                                          bool isVariant,
+                                          MlirType underlyingType,
+                                          MlirAttribute dbgName);
+
+// A debug subprogram (function) attribute: `rawName` is the source function name
+// (`StringAttr`); `typeParams` an array of parameter debug-type attributes.
+MlirAttribute reussirDBGSubprogramAttrGet(MlirContext context,
+                                          MlirAttribute rawName,
+                                          intptr_t nTypeParams,
+                                          MlirAttribute const *typeParams);
+
+// A debug type for a reference-counted (boxed) value, wrapping the payload's
+// debug type.
+MlirAttribute reussirDBGBoxedTypeAttrGet(MlirContext context,
+                                         MlirAttribute dbgType);
+
+// A debug local-variable attribute: its debug type and source name.
+MlirAttribute reussirDBGLocalVarAttrGet(MlirContext context,
+                                        MlirAttribute dbgType,
+                                        MlirAttribute varName);
+
+// A debug function-argument attribute: its debug type, source name, and 1-based
+// argument index.
+MlirAttribute reussirDBGFuncArgAttrGet(MlirContext context,
+                                       MlirAttribute dbgType,
+                                       MlirAttribute argName, unsigned argIndex);
+
+// Set an operation's location. Used by the code generator to attach a fused
+// debug-info location (carrying a `DBGLocalVar`) to the op that defines a local
+// variable; `mlir-sys` does not bind `mlirOperationSetLocation`.
+void reussirOperationSetLocation(MlirOperation op, MlirLocation location);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // REUSSIR_C_ATTRS_H

--- a/include/Reussir-c/Attrs.h
+++ b/include/Reussir-c/Attrs.h
@@ -62,9 +62,10 @@ MlirAttribute reussirDBGSubprogramAttrGet(MlirContext context,
                                           MlirAttribute const *typeParams);
 
 // A debug type for a reference-counted (boxed) value, wrapping the payload's
-// debug type.
+// debug type. `regional` selects the box header to skip past: a shared box has a
+// single ref-count word, a regional box a three-word header.
 MlirAttribute reussirDBGBoxedTypeAttrGet(MlirContext context,
-                                         MlirAttribute dbgType);
+                                         MlirAttribute dbgType, bool regional);
 
 // A debug local-variable attribute: its debug type and source name.
 MlirAttribute reussirDBGLocalVarAttrGet(MlirContext context,

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -44,6 +44,7 @@ MlirPass reussirCreateTRMCRecursionAnalysisPass(void);
 MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized);
 MlirPass reussirCreateInvariantGroupAnalysisPass(void);
 MlirPass reussirCreateBasicOpsLoweringPass(void);
+MlirPass reussirCreateDebugInfoConversionPass(void);
 
 // Acquire/drop expansion has two phases controlled by these options; the
 // pipeline runs it once with both disabled and once with both enabled.

--- a/include/Reussir/Conversion/BasicOpsLowering.h
+++ b/include/Reussir/Conversion/BasicOpsLowering.h
@@ -25,6 +25,7 @@
 namespace reussir {
 
 #define GEN_PASS_DECL_REUSSIRBASICOPSLOWERINGPASS
+#define GEN_PASS_DECL_REUSSIRDEBUGINFOCONVERSIONPASS
 #include "Reussir/Conversion/Passes.h.inc"
 
 void populateBasicOpsLoweringToLLVMConversionPatterns(

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -41,6 +41,24 @@ def ReussirBasicOpsLoweringPass
 }
 
 //===----------------------------------------------------------------------===//
+// DebugInfoConversion
+//===----------------------------------------------------------------------===//
+def ReussirDebugInfoConversionPass
+    : ReussirLoweringPass<"debug-info", "::mlir::ModuleOp"> {
+  let summary = "lower Reussir fused debug-info attributes to LLVM DI";
+  let description = [{
+    `reussir-lowering-debug-info` translates the Reussir `DBG*` attributes that
+    ride on fused locations (subprograms, local variables, function arguments)
+    into LLVM debug-info attributes, and materializes `llvm.dbg.value` ops. It
+    must run *after* `convert-to-llvm`: the conversion preserves the fused
+    locations and the `reussir.dbg_func_args` attribute onto the `llvm.func`,
+    and a function's debug info only survives translation once its `llvm.func`
+    carries a `DISubprogram`.
+  }];
+  let dependentDialects = ["::mlir::LLVM::LLVMDialect"];
+}
+
+//===----------------------------------------------------------------------===//
 // SCFOpsLowering
 //===----------------------------------------------------------------------===//
 def ReussirSCFOpsLoweringPass

--- a/include/Reussir/IR/ReussirAttrs.td
+++ b/include/Reussir/IR/ReussirAttrs.td
@@ -165,6 +165,16 @@ def Reussir_DBGLocalVar : ReussirAttr<"DBGLocalVar", "dbg_localvar"> {
     `>`
   }];
 }
+// A reference-counted (`[shared]`) value: the variable is an `rc` pointer to a
+// box `{ header, payload }`. `dbgType` describes the payload; the debug-info
+// pass presents the variable as the payload, reached by dereferencing the
+// pointer and skipping the box header (a `DW_OP_deref, DW_OP_plus_uconst`
+// expression on the `dbg.declare`).
+def Reussir_DBGBoxedType : ReussirAttr<"DBGBoxedType", "dbg_boxedtype"> {
+  let description = "Debug type for a reference-counted (boxed) value";
+  let parameters = (ins "::mlir::Attribute":$dbgType);
+  let assemblyFormat = [{ `<` $dbgType `>` }];
+}
 def Reussir_DBGFuncArg : ReussirAttr<"DBGFuncArg", "dbg_func_arg"> {
   let description = "Debug function argument attribute";
   let parameters = (ins

--- a/include/Reussir/IR/ReussirAttrs.td
+++ b/include/Reussir/IR/ReussirAttrs.td
@@ -165,15 +165,22 @@ def Reussir_DBGLocalVar : ReussirAttr<"DBGLocalVar", "dbg_localvar"> {
     `>`
   }];
 }
-// A reference-counted (`[shared]`) value: the variable is an `rc` pointer to a
-// box `{ header, payload }`. `dbgType` describes the payload; the debug-info
-// pass presents the variable as the payload, reached by dereferencing the
-// pointer and skipping the box header (a `DW_OP_deref, DW_OP_plus_uconst`
-// expression on the `dbg.declare`).
+// A reference-counted (`[shared]`/`[regional]`) value: the variable is an `rc`
+// pointer to a box `{ header, payload }`. `dbgType` describes the payload; the
+// debug-info pass presents the variable as the payload, reached by
+// dereferencing the pointer and skipping the box header (a `DW_OP_deref,
+// DW_OP_plus_uconst` expression on the `dbg.declare`). The two box flavours have
+// different header sizes — a shared box has a single ref-count word, a regional
+// box a three-word `{ status, next, vtable }` header — so `regional` selects
+// which to skip past. Once the `rc` is lowered to an opaque pointer the box type
+// is unrecoverable, hence the flag is carried here.
 def Reussir_DBGBoxedType : ReussirAttr<"DBGBoxedType", "dbg_boxedtype"> {
   let description = "Debug type for a reference-counted (boxed) value";
-  let parameters = (ins "::mlir::Attribute":$dbgType);
-  let assemblyFormat = [{ `<` $dbgType `>` }];
+  let parameters = (ins
+    "::mlir::Attribute":$dbgType,
+    "bool":$regional
+  );
+  let assemblyFormat = [{ `<` $dbgType `,` `regional` `:` $regional `>` }];
 }
 def Reussir_DBGFuncArg : ReussirAttr<"DBGFuncArg", "dbg_func_arg"> {
   let description = "Debug function argument attribute";

--- a/lib/CAPI/Attrs.cpp
+++ b/lib/CAPI/Attrs.cpp
@@ -74,8 +74,9 @@ MlirAttribute reussirDBGSubprogramAttrGet(MlirContext context,
 }
 
 MlirAttribute reussirDBGBoxedTypeAttrGet(MlirContext context,
-                                         MlirAttribute dbgType) {
-  return wrap(DBGBoxedTypeAttr::get(unwrap(context), unwrap(dbgType)));
+                                         MlirAttribute dbgType, bool regional) {
+  return wrap(
+      DBGBoxedTypeAttr::get(unwrap(context), unwrap(dbgType), regional));
 }
 
 MlirAttribute reussirDBGLocalVarAttrGet(MlirContext context,

--- a/lib/CAPI/Attrs.cpp
+++ b/lib/CAPI/Attrs.cpp
@@ -1,0 +1,98 @@
+//===-- Attrs.cpp - Reussir dialect attribute C API -----------*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir-c/Attrs.h"
+
+#include <mlir/CAPI/IR.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/Operation.h>
+
+#include "Reussir/IR/ReussirAttrs.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+using namespace reussir;
+
+namespace {
+// Collects an MlirAttribute array into a vector of unwrapped MLIR attributes.
+llvm::SmallVector<mlir::Attribute> unwrapAttrs(intptr_t n,
+                                               MlirAttribute const *attrs) {
+  llvm::SmallVector<mlir::Attribute> result;
+  result.reserve(n);
+  for (intptr_t i = 0; i < n; ++i)
+    result.push_back(unwrap(attrs[i]));
+  return result;
+}
+
+mlir::StringAttr str(MlirAttribute attr) {
+  return llvm::cast<mlir::StringAttr>(unwrap(attr));
+}
+} // namespace
+
+MlirAttribute reussirDBGIntTypeAttrGet(MlirContext context, MlirType innerType,
+                                       bool isSigned, MlirAttribute dbgName) {
+  return wrap(DBGIntTypeAttr::get(unwrap(context), unwrap(innerType), isSigned,
+                                  str(dbgName)));
+}
+
+MlirAttribute reussirDBGFPTypeAttrGet(MlirContext context, MlirType innerType,
+                                      MlirAttribute dbgName) {
+  return wrap(
+      DBGFPTypeAttr::get(unwrap(context), unwrap(innerType), str(dbgName)));
+}
+
+MlirAttribute reussirDBGRecordMemberAttrGet(MlirContext context,
+                                            MlirAttribute name,
+                                            MlirAttribute typeAttr) {
+  return wrap(
+      DBGRecordMemberAttr::get(unwrap(context), str(name), unwrap(typeAttr)));
+}
+
+MlirAttribute reussirDBGRecordTypeAttrGet(MlirContext context, intptr_t nMembers,
+                                          MlirAttribute const *members,
+                                          bool isVariant,
+                                          MlirType underlyingType,
+                                          MlirAttribute dbgName) {
+  auto memberArray =
+      mlir::ArrayAttr::get(unwrap(context), unwrapAttrs(nMembers, members));
+  return wrap(DBGRecordTypeAttr::get(unwrap(context), memberArray, isVariant,
+                                     unwrap(underlyingType), str(dbgName)));
+}
+
+MlirAttribute reussirDBGSubprogramAttrGet(MlirContext context,
+                                          MlirAttribute rawName,
+                                          intptr_t nTypeParams,
+                                          MlirAttribute const *typeParams) {
+  auto params = mlir::ArrayAttr::get(unwrap(context),
+                                     unwrapAttrs(nTypeParams, typeParams));
+  return wrap(DBGSubprogramAttr::get(unwrap(context), str(rawName), params));
+}
+
+MlirAttribute reussirDBGBoxedTypeAttrGet(MlirContext context,
+                                         MlirAttribute dbgType) {
+  return wrap(DBGBoxedTypeAttr::get(unwrap(context), unwrap(dbgType)));
+}
+
+MlirAttribute reussirDBGLocalVarAttrGet(MlirContext context,
+                                        MlirAttribute dbgType,
+                                        MlirAttribute varName) {
+  return wrap(
+      DBGLocalVarAttr::get(unwrap(context), unwrap(dbgType), str(varName)));
+}
+
+MlirAttribute reussirDBGFuncArgAttrGet(MlirContext context,
+                                       MlirAttribute dbgType,
+                                       MlirAttribute argName,
+                                       unsigned argIndex) {
+  return wrap(DBGFuncArgAttr::get(unwrap(context), unwrap(dbgType),
+                                  str(argName), argIndex));
+}
+
+void reussirOperationSetLocation(MlirOperation op, MlirLocation location) {
+  unwrap(op)->setLoc(unwrap(location));
+}

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -7,7 +7,7 @@
 # MLIR/LLVM that mlir-sys pulls in. Requires the distro's static MLIR/LLVM
 # development packages (including libpolly-<ver>-dev for the static Polly
 # archives llvm-config references).
-add_library(ReussirCAPI STATIC Dialects.cpp Passes.cpp Types.cpp Jit.cpp)
+add_library(ReussirCAPI STATIC Dialects.cpp Passes.cpp Types.cpp Attrs.cpp Jit.cpp)
 
 # Jit.cpp runs the custom Reussir LLVM passes and (when available) TPDE. Linking
 # these as usage requirements gives ReussirCAPI their headers/defines and orders

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -92,6 +92,9 @@ MlirPass reussirCreateInvariantGroupAnalysisPass(void) {
 MlirPass reussirCreateBasicOpsLoweringPass(void) {
   return wrapOwned(reussir::createReussirBasicOpsLoweringPass());
 }
+MlirPass reussirCreateDebugInfoConversionPass(void) {
+  return wrapOwned(reussir::createReussirDebugInfoConversionPass());
+}
 MlirPass reussirCreateAcquireDropExpansionPass(bool expandDecrement,
                                                bool outlineRecord) {
   reussir::ReussirAcquireDropExpansionPassOptions options;

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -2748,7 +2748,10 @@ struct BasicOpsLoweringPass
     mlir::LLVMTypeConverter converter(moduleOp.getContext(),
                                       getReussirToLLVMOptions(moduleOp));
     ensureRuntimeFunctions(moduleOp, converter);
-    lowerFusedDBGAttributeInLocations(moduleOp);
+    // Fused debug-info attributes are converted to LLVM DI by the separate
+    // `reussir-lowering-debug-info` pass, which runs after `convert-to-llvm`
+    // so the functions are already `llvm.func` (a function's DI only survives
+    // translation once its `llvm.func` carries a `DISubprogram`).
   }
 };
 } // namespace

--- a/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
+++ b/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
@@ -25,6 +25,9 @@
 
 namespace reussir {
 
+#define GEN_PASS_DEF_REUSSIRDEBUGINFOCONVERSIONPASS
+#include "Reussir/Conversion/Passes.h.inc"
+
 namespace {
 
 // Helper function to extract line and column from MLIR locations.
@@ -52,6 +55,9 @@ mlir::Type getUnderlyingTypeFromDbgAttr(mlir::Attribute dbgAttr) {
           [](DBGFPTypeAttr fptAttr) { return fptAttr.getInnerType(); })
       .template Case<DBGIntTypeAttr>(
           [](DBGIntTypeAttr intAttr) { return intAttr.getInnerType(); })
+      .template Case<DBGBoxedTypeAttr>([](DBGBoxedTypeAttr boxed) {
+        return getUnderlyingTypeFromDbgAttr(boxed.getDbgType());
+      })
       .template Case<DBGRecordTypeAttr>(
           [](DBGRecordTypeAttr recAttr) { return recAttr.getUnderlyingType(); })
       .Default([](auto attr) { return mlir::Type{}; });
@@ -137,6 +143,15 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                 nullptr);
 #endif
           })
+          // A boxed value is presented as its payload composite; the pointer is
+          // dereferenced (and the header skipped) by the `dbg.declare`'s
+          // `DIExpression`, built where the variable is declared.
+          .template Case<DBGBoxedTypeAttr>(
+              [&](DBGBoxedTypeAttr boxed) -> mlir::Attribute {
+                return translateDBGAttrToLLVM<mlir::LLVM::DITypeAttr>(
+                    moduleOp, boxed.getDbgType(), diFile, diCU, funcOp,
+                    funcScope, loc);
+              })
           .template Case<DBGSubprogramAttr>(
               [&](DBGSubprogramAttr spAttr) -> mlir::Attribute {
                 auto linkageName = funcOp.getSymNameAttr();
@@ -152,8 +167,11 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                 // TODO: function type is not emitted now
                 auto emptyRoutine = mlir::LLVM::DISubroutineTypeAttr::get(
                     moduleOp.getContext(), {});
-                // Extract line/column from the function's location
+                // Extract the line from the function's location. The fifth and
+                // sixth arguments are `line` and `scopeLine` (both lines) — not
+                // line/column.
                 auto [line, col] = extractLineCol(loc);
+                (void)col;
                 auto res = mlir::LLVM::DISubprogramAttr::get(
                     moduleOp.getContext(),
                     mlir::DistinctAttr::create(
@@ -162,8 +180,9 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                     mlir::DistinctAttr::create(
                         mlir::UnitAttr::get(moduleOp.getContext())),
                     diCU, diFile, spAttr.getRawName(), linkageName, diFile,
-                    line, col, mlir::LLVM::DISubprogramFlags::Definition,
-                    emptyRoutine, {}, {});
+                    line, /*scopeLine=*/line,
+                    mlir::LLVM::DISubprogramFlags::Definition, emptyRoutine, {},
+                    {});
 
                 return res;
               })
@@ -211,6 +230,51 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                     varType, mlir::LLVM::DIFlags::Zero);
               })
           .Default([](auto attr) { return attr; }));
+}
+
+// Spill `value` to a fresh stack slot at the builder's insertion point and
+// describe the slot with `dbg.declare`. A stack slot is a stable location: a
+// `dbg.value` on an SSA value goes stale once its registers are reused, so the
+// debugger would read garbage. `expr` transforms the slot address into the
+// variable's location (empty for a plain variable; a deref + offset for a boxed
+// one, where the slot holds an `rc` pointer to the payload).
+void spillAndDeclare(mlir::OpBuilder &builder, mlir::Location loc,
+                     mlir::MLIRContext *context, mlir::Value value,
+                     mlir::LLVM::DILocalVariableAttr varInfo,
+                     mlir::LLVM::DIExpressionAttr expr = {}) {
+  auto one = mlir::LLVM::ConstantOp::create(builder, loc, builder.getI32Type(),
+                                            builder.getI32IntegerAttr(1));
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(context);
+  auto slot = mlir::LLVM::AllocaOp::create(builder, loc, ptrType,
+                                           value.getType(), one);
+  mlir::LLVM::StoreOp::create(builder, loc, value, slot);
+  mlir::LLVM::DbgDeclareOp::create(builder, loc, slot, varInfo, expr);
+}
+
+// If `dbgType` describes a boxed (`[shared]`) value, return the `DIExpression`
+// that reaches the payload from the slot holding the `rc` pointer: dereference
+// the pointer, then skip the box header. Otherwise an empty expression.
+mlir::LLVM::DIExpressionAttr boxedExpr(mlir::ModuleOp moduleOp,
+                                       mlir::Attribute dbgType) {
+  auto boxed = llvm::dyn_cast_if_present<DBGBoxedTypeAttr>(dbgType);
+  if (!boxed)
+    return {};
+  auto payloadTy = getUnderlyingTypeFromDbgAttr(boxed.getDbgType());
+  if (!payloadTy)
+    return {};
+  auto *context = moduleOp.getContext();
+  mlir::DataLayout dataLayout{moduleOp};
+  // A shared rc box is `{ i64 refcount, payload }`; the payload begins after the
+  // 8-byte header, aligned up to its own alignment.
+  uint64_t offset =
+      llvm::alignTo(8, dataLayout.getTypeABIAlignment(payloadTy));
+  llvm::SmallVector<mlir::LLVM::DIExpressionElemAttr, 2> elems = {
+      mlir::LLVM::DIExpressionElemAttr::get(context, llvm::dwarf::DW_OP_deref,
+                                            {}),
+      mlir::LLVM::DIExpressionElemAttr::get(
+          context, llvm::dwarf::DW_OP_plus_uconst, {offset}),
+  };
+  return mlir::LLVM::DIExpressionAttr::get(context, elems);
 }
 } // namespace
 
@@ -261,38 +325,102 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
               auto argValue = funcOp.getArgument(idx);
               auto &entryBlock = funcOp.getBody().front();
               builder.setInsertionPointToStart(&entryBlock);
-              mlir::LLVM::DbgValueOp::create(builder, updatedFuncLoc, argValue,
-                                                     translated);
+              // Spill the argument to a stack slot and describe *that* with
+              // `dbg.declare`. A `dbg.value` on the SSA argument goes stale once
+              // its registers are reused (right after the prologue spills it),
+              // so a debugger reads garbage; a stack slot is a stable location.
+              //
+              // The spill is emitted at a line-0 (prologue) location so it is
+              // covered by the function prologue: a debugger setting a breakpoint
+              // on the function skips to the first body statement, by which point
+              // the argument has been stored and is inspectable.
+              mlir::Location prologueLoc =
+                  mlir::FileLineColLoc::get(context, fileBasename.getValue(),
+                                            /*line=*/0, /*column=*/0);
+              spillAndDeclare(builder, prologueLoc, context, argValue,
+                              translated,
+                              boxedExpr(moduleOp, funcArgAttr.getDbgType()));
             }
           }
         }
         // Remove the attribute after processing
         funcOp->removeAttr("reussir.dbg_func_args");
       }
+      // Local variables: codegen tags the op defining a `let` binding with a
+      // `DBGLocalVar` on its fused location. Conversion copies that location onto
+      // every op it expands the definition into, so to describe the variable just
+      // once we pick the op whose result *escapes* the tagged group — i.e. is
+      // used by an op that does not carry the same metadata; that is the value
+      // the rest of the program sees. We spill it and `dbg.declare` it (declaring
+      // each variable once), then strip the Reussir metadata off every tagged op
+      // so they translate cleanly.
+      //
+      // Declaration is deferred to after the walk so the escape check sees the
+      // original, un-stripped locations.
+      llvm::SmallVector<std::tuple<mlir::Operation *, mlir::Location,
+                                   mlir::LLVM::DILocalVariableAttr,
+                                   mlir::LLVM::DIExpressionAttr>>
+          toDeclare;
+      llvm::SmallVector<std::pair<mlir::Operation *, mlir::Location>> toStrip;
+      llvm::DenseSet<mlir::Attribute> declared;
       funcOp->walk([&](mlir::Operation *op) {
-        mlir::LocationAttr opLoc = op->getLoc();
-        if (auto innerFused =
-                llvm::dyn_cast_if_present<mlir::FusedLoc>(opLoc)) {
-          auto translated = translateDBGAttrToLLVM(
-              moduleOp, innerFused.getMetadata(), llvmDIFileAttr,
-              dbgCompileUnitAttr, funcOp, subprogram, opLoc);
-          if (translated) {
-            if (auto localVar = mlir::dyn_cast<mlir::LLVM::DILocalVariableAttr>(
-                    translated)) {
-              if (op->getNumResults() == 1) {
-                auto value = op->getResult(0);
-                builder.setInsertionPointAfterValue(value);
-                mlir::LLVM::DbgValueOp::create(builder, op->getLoc(), value,
-                                                       localVar);
-              }
-            }
-            auto updatedInnerLoc =
-                mlir::FusedLoc::get(context, fused.getLocations(), translated);
-            op->setLoc(updatedInnerLoc);
+        auto innerFused =
+            llvm::dyn_cast_if_present<mlir::FusedLoc>(op->getLoc());
+        if (!innerFused)
+          return;
+        mlir::Attribute meta = innerFused.getMetadata();
+        auto localVar = translateDBGAttrToLLVM<mlir::LLVM::DILocalVariableAttr>(
+            moduleOp, meta, llvmDIFileAttr, dbgCompileUnitAttr, funcOp,
+            subprogram, op->getLoc());
+        if (!localVar)
+          return;
+        mlir::Location varLoc = innerFused.getLocations().empty()
+                                    ? mlir::Location(innerFused)
+                                    : innerFused.getLocations().front();
+        toStrip.push_back({op, varLoc});
+        if (op->getNumResults() != 1 || !declared.insert(localVar).second)
+          return;
+        bool escapes = false;
+        for (mlir::Operation *user : op->getResult(0).getUsers()) {
+          auto userFused =
+              llvm::dyn_cast_if_present<mlir::FusedLoc>(user->getLoc());
+          if (!userFused || userFused.getMetadata() != meta) {
+            escapes = true;
+            break;
           }
         }
+        if (escapes) {
+          auto localVarAttr = llvm::dyn_cast<DBGLocalVarAttr>(meta);
+          auto expr = localVarAttr ? boxedExpr(moduleOp, localVarAttr.getDbgType())
+                                   : mlir::LLVM::DIExpressionAttr{};
+          toDeclare.push_back({op, varLoc, localVar, expr});
+        } else {
+          declared.erase(localVar);
+        }
       });
+      for (auto &[op, varLoc, localVar, expr] : toDeclare) {
+        builder.setInsertionPointAfter(op);
+        spillAndDeclare(builder, varLoc, context, op->getResult(0), localVar,
+                        expr);
+      }
+      for (auto &[op, varLoc] : toStrip)
+        op->setLoc(varLoc);
     }
   });
 }
+
+namespace {
+// Runs the fused-debug-info → LLVM DI conversion as a standalone pass. It must be
+// scheduled after `convert-to-llvm`, when functions are `llvm.func` (carrying the
+// fused subprogram location and `reussir.dbg_func_args` the conversion preserves):
+// a function's debug info only survives LLVM-IR translation once its `llvm.func`
+// has a `DISubprogram`.
+struct DebugInfoConversionPass
+    : public impl::ReussirDebugInfoConversionPassBase<DebugInfoConversionPass> {
+  using Base::Base;
+  void runOnOperation() override {
+    lowerFusedDBGAttributeInLocations(getOperation());
+  }
+};
+} // namespace
 } // namespace reussir

--- a/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
+++ b/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
@@ -264,10 +264,14 @@ mlir::LLVM::DIExpressionAttr boxedExpr(mlir::ModuleOp moduleOp,
     return {};
   auto *context = moduleOp.getContext();
   mlir::DataLayout dataLayout{moduleOp};
-  // A shared rc box is `{ i64 refcount, payload }`; the payload begins after the
-  // 8-byte header, aligned up to its own alignment.
-  uint64_t offset =
-      llvm::alignTo(8, dataLayout.getTypeABIAlignment(payloadTy));
+  // The box header is a run of pointer-sized words: one ref-count word for a
+  // shared box `{ count, payload }`, or three (`{ status, next, vtable }`) for a
+  // regional box. The payload follows, aligned up to its own alignment.
+  uint64_t headerWords = boxed.getRegional() ? 3 : 1;
+  uint64_t indexSize =
+      dataLayout.getTypeSize(mlir::IndexType::get(context));
+  uint64_t offset = llvm::alignTo(headerWords * indexSize,
+                                  dataLayout.getTypeABIAlignment(payloadTy));
   llvm::SmallVector<mlir::LLVM::DIExpressionElemAttr, 2> elems = {
       mlir::LLVM::DIExpressionElemAttr::get(context, llvm::dwarf::DW_OP_deref,
                                             {}),


### PR DESCRIPTION
## Summary

Threads source positions and debug info through code generation so `rrc -g`
produces debuggable native code. In lldb you get source-line breakpoints and can
inspect every function argument and `let` local with its **precise type and
correct value** — for all currently-lowered types (scalars, `[value]` records,
`[shared]` records).

## What's in it

- **Locations.** `lower_program` takes an optional `SourceMap` (wraps
  `ariadne::Source`, the parser's line cache); every op gets a `FileLineColLoc`
  from the MIR's byte spans via a single `loc()` seam. `rrc` gains `-g`.
- **Debug attributes.** A new `Reussir-c/Attrs` C API exposes the dialect's
  `DBG*` attributes (the `dialect!` macro only generates *op* builders). Codegen
  emits a `DBGSubprogram` per function, a `reussir.dbg_func_args` array for
  params, and a `DBGLocalVar` per `let`. Variable **types** are precise:
  `DBGIntType`/`DBGFPType`, `DBGRecordType` with real field names, and a new
  `DBGBoxedType` for `[shared]` records.
- **Conversion pass fix.** `lowerFusedDBGAttributeInLocations` matches
  `llvm.func` but ran inside `BasicOpsLowering`, *before* `convert-to-llvm` — a
  no-op, so no DI ever survived. It now runs as a dedicated
  `reussir-lowering-debug-info` pass after conversion.
- **Stable variable locations.** Variables are described with `dbg.declare` over
  a spilled stack slot (a `dbg.value` on an SSA value goes stale when registers
  are reused). Parameter spills sit at a line-0 prologue location so a function
  breakpoint lands *after* the argument is stored. A local definition may lower
  to several ops sharing the attribute, so the pass declares the one whose result
  *escapes* the group.
- **Boxed `[shared]` records.** An `rc` pointer to `{ header, payload }` is shown
  as the payload via a `DW_OP_deref, DW_OP_plus_uconst <header>` `DIExpression`.
- **Field names** round-trip faithfully through both HIR and MIR textual forms
  (quoted `"name":`), so `mir::Member` carries the source name.
- `DISubprogram` `scopeLine` fix (was the column).

## Testing

- Codegen unit test asserts every debug-type form (named members, boxed, local).
- Verified end-to-end with **lldb-22** on `rrc -g` output: source breakpoints, and
  arguments/locals of scalar, value-record, and shared-record type showing correct
  values (e.g. a `[shared] Box` param prints as `(v = 10, w = 20)`).
- Gate green: rust tests, clippy, lit 237/237, C++ ctest 17/17.

## Follow-ups (noted, not in scope)

- Fine-grained `DILexicalBlock` scoping for nested-block/shadowed locals (current
  variables are subprogram-scoped, which is valid and works).
- An `lldb`-in-`lit` harness to automate the end-to-end checks.
- Enum/variant debug info (gated behind variant lowering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)