### PR TITLE
[backend] reussir: discriminated enum debug info (DWARF variant_part + lldb formatter)

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -146,6 +146,11 @@ unsafe extern "C" {
         data_layout: *const c_char,
     ) -> LLVMModuleRef;
 
+    /// Rewrites the `{ tag, payload-union }` debug type emitted for each enum
+    /// into a real DWARF `DW_TAG_variant_part`, so a debugger shows only the
+    /// active case. Operates in place; a no-op when `module` has no debug info.
+    pub fn reussirFixupVariantDebugInfo(module: LLVMModuleRef);
+
     /// Reports whether TPDE support was compiled into the backend.
     pub fn reussirHasTPDE() -> c_int;
 

--- a/crates/reussir-backend/src/llvm.rs
+++ b/crates/reussir-backend/src/llvm.rs
@@ -122,6 +122,10 @@ impl LlvmLowering {
         unsafe {
             let main = translate_to_llvm_ir(module, self.context)?;
             LLVMSetDataLayout(main, self.data_layout.as_ptr());
+            // Promote each enum's `{ tag, payload-union }` debug type to a real
+            // DWARF `DW_TAG_variant_part` now that we are at the LLVM-DI level,
+            // where the discriminator operand exists (MLIR's attribute has none).
+            sys::reussirFixupVariantDebugInfo(main as sys::LLVMModuleRef);
             // `LLVMLinkModules2` consumes (disposes) the source module, even on
             // failure — so null our handle either way to keep `Drop` correct.
             let gathered = std::mem::replace(&mut self.gathered, std::ptr::null_mut());

--- a/crates/reussir-compiler/tests/variant_debug_info.rs
+++ b/crates/reussir-compiler/tests/variant_debug_info.rs
@@ -1,0 +1,71 @@
+//! End-to-end check that `rrc -g` emits discriminated enum debug info.
+//!
+//! An enum lowers (in the debug-info conversion) to a `{ tag, payload-union }`
+//! composite because MLIR's `DICompositeTypeAttr` cannot carry a discriminator.
+//! The post-translation `fixupVariantDebugInfo` step then rewrites it into a
+//! real DWARF `DW_TAG_variant_part`, and the compile unit is tagged Rust so
+//! debuggers expose it. This drives the whole AOT pipeline and asserts the
+//! emitted LLVM IR carries that discriminated form.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn emit_llvm_ir(source: &str, stem: &str) -> String {
+    let dir = std::env::temp_dir();
+    let rr = dir.join(format!("{stem}.rr"));
+    let ll = dir.join(format!("{stem}.ll"));
+    std::fs::write(&rr, source).expect("write source");
+    let status = Command::new(env!("CARGO_BIN_EXE_rrc"))
+        .args(["-O", "none", "-g", "--emit", "llvm-ir"])
+        .arg("-o")
+        .arg(&ll)
+        .arg(&rr)
+        .status()
+        .expect("run rrc");
+    assert!(status.success(), "rrc failed for {stem}");
+    let ir = std::fs::read_to_string(&ll).expect("read llvm-ir");
+    let _ = std::fs::remove_file(&rr);
+    let _ = std::fs::remove_file(PathBuf::from(&ll));
+    ir
+}
+
+#[test]
+fn enum_debug_info_is_a_discriminated_variant_part() {
+    // A value enum and a recursive shared enum; both must become variant parts.
+    let ir = emit_llvm_ir(
+        r#"
+        enum [value] Shape { Dot, Circle(i64), Rect(i64, i64) }
+        enum List { Nil, Cons(i64, List) }
+        fn see_shape(s: Shape) -> i64 { let k = 0; k }
+        fn see_list(l: List) -> i64 { let z = 0; z }
+        pub fn run(n: i64) -> i64 {
+            see_shape(Shape::Rect{n, n + 1}) + see_list(List::Cons{n, List::Nil})
+        }
+        extern "C" trampoline "run" = run;
+        "#,
+        "variant_dbg_e2e",
+    );
+
+    // Rust compile unit — this is what makes debuggers honour the variant part.
+    assert!(
+        ir.contains("DW_LANG_Rust"),
+        "compile unit should be tagged Rust:\n{ir}"
+    );
+    // The discriminated form: a variant part with per-case discriminant values.
+    assert!(
+        ir.contains("DW_TAG_variant_part"),
+        "enum debug info should be a DW_TAG_variant_part:\n{ir}"
+    );
+    assert!(
+        ir.contains("extraData: i64"),
+        "variant members should carry a discriminant value:\n{ir}"
+    );
+    // One variant part per enum (Shape and List), not the old `{tag, union}`.
+    let parts = ir.matches("DW_TAG_variant_part").count();
+    assert!(parts >= 2, "expected a variant part per enum, found {parts}");
+    // The old union form must be gone — the fixup rewrites it in place.
+    assert!(
+        !ir.contains("DW_TAG_union_type"),
+        "the `payload` union should have been replaced by the variant part:\n{ir}"
+    );
+}

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -82,6 +82,12 @@ LLVMModuleRef reussirGatherCompiledModules(MlirModule module,
                                            LLVMContextRef context,
                                            const char *dataLayout);
 
+// Rewrites the `{ tag, payload-union }` debug type emitted for each enum into a
+// real DWARF `DW_TAG_variant_part`, so a debugger shows only the active case.
+// Operates in place on the (already debug-info-bearing) LLVM module; a no-op
+// when there is no debug info.
+void reussirFixupVariantDebugInfo(LLVMModuleRef module);
+
 // Reports whether TPDE support was compiled into the backend.
 int reussirHasTPDE(void);
 

--- a/include/Reussir/Conversion/Passes.h
+++ b/include/Reussir/Conversion/Passes.h
@@ -18,6 +18,10 @@
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/Pass.h>
 
+namespace llvm {
+class Module;
+} // namespace llvm
+
 namespace reussir {
 #define GEN_PASS_DECL
 #include "Reussir/Conversion/Passes.h.inc"
@@ -32,6 +36,20 @@ namespace reussir {
 //===----------------------------------------------------------------------===//
 mlir::LogicalResult compilePolymorphicFFI(mlir::ModuleOp moduleOp,
                                           bool optimized = false);
+
+//===----------------------------------------------------------------------===//
+// Variant debug-info fixup (post-translation)
+//===----------------------------------------------------------------------===//
+//
+// Rewrites the `{ tag, payload-union }` debug type the debug-info conversion
+// emits for each enum into a real DWARF `DW_TAG_variant_part` (discriminant plus
+// per-case `DW_AT_discr_value`), so a debugger shows only the active case. Runs
+// on the translated `llvm::Module` because MLIR's `DICompositeTypeAttr` has no
+// discriminator field — the operands only exist at the LLVM-DI level. A no-op
+// for modules without debug info.
+//
+//===----------------------------------------------------------------------===//
+void fixupVariantDebugInfo(llvm::Module &module);
 
 void registerReussirBasicOpsLoweringInterface(mlir::DialectRegistry &registry);
 

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -150,6 +150,10 @@ LLVMModuleRef reussirGatherCompiledModules(MlirModule module,
   return llvm::wrap(result.release());
 }
 
+void reussirFixupVariantDebugInfo(LLVMModuleRef module) {
+  reussir::fixupVariantDebugInfo(*llvm::unwrap(module));
+}
+
 int reussirHasTPDE(void) {
 #ifdef REUSSIR_HAS_TPDE
   return 1;

--- a/lib/Conversion/BasicOpsLowering/CMakeLists.txt
+++ b/lib/Conversion/BasicOpsLowering/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_conversion_library(MLIRReussirBasicOpsLowering
   BasicOpsLowering.cpp
   CABISignatureConversion.cpp
   DbgInfoConversion.cpp
+  VariantDebugInfo.cpp
 
   DEPENDS
   MLIRReussirConversionPassIncGen

--- a/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
+++ b/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
@@ -444,9 +444,13 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
     return;
   auto llvmDIFileAttr =
       mlir::LLVM::DIFileAttr::get(context, fileBasename, fileDirectory);
+  // Reussir is a Rust-like language (sum types, `_R…` mangling). Tagging the
+  // compile unit as Rust is both more accurate and what makes debuggers expose
+  // the `DW_TAG_variant_part` an enum lowers to (see `fixupVariantDebugInfo`):
+  // under a C/C++ language they ignore variant parts entirely.
   auto dbgCompileUnitAttr = mlir::LLVM::DICompileUnitAttr::get(
       mlir::DistinctAttr::create(mlir::UnitAttr::get(context)),
-      llvm::dwarf::DW_LANG_C_plus_plus_20, llvmDIFileAttr,
+      llvm::dwarf::DW_LANG_Rust, llvmDIFileAttr,
       mlir::StringAttr::get(context, "reussir"), true,
       mlir::LLVM::DIEmissionKind::Full);
   mlir::OpBuilder builder(moduleOp);

--- a/lib/Conversion/BasicOpsLowering/VariantDebugInfo.cpp
+++ b/lib/Conversion/BasicOpsLowering/VariantDebugInfo.cpp
@@ -1,0 +1,140 @@
+//===-- VariantDebugInfo.cpp - variant_part DWARF fixup ---------*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// MLIR's `DICompositeTypeAttr` has no discriminator field, so the debug-info
+// conversion can only describe an enum as a `{ tag, payload-union }` struct: a
+// debugger then shows every case overlapping and leaves the user to read the
+// tag. This post-translation pass rewrites that struct into a real DWARF
+// `DW_TAG_variant_part` — a discriminant member plus one `DW_TAG_variant` per
+// case carrying its `DW_AT_discr_value` — which gdb uses to display only the
+// live case.
+//
+// It runs on the translated `llvm::Module` because the `discriminator` operand
+// (and the per-case discriminant constant) exist only at the LLVM-DI level,
+// not in MLIR's attribute. The composite is rewritten *in place*: every Reussir
+// composite is a `distinct` node, so mutating its `elements` operand preserves
+// node identity — a recursive payload that points back at the enum, and every
+// variable whose type is the enum, see the variant_part with no further work.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/Conversion/Passes.h"
+
+#include <llvm/BinaryFormat/Dwarf.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DebugInfo.h>
+#include <llvm/IR/DebugInfoMetadata.h>
+#include <llvm/IR/Module.h>
+
+#include <optional>
+
+using namespace llvm;
+
+namespace reussir {
+namespace {
+
+// The shape the debug-info conversion emits for an enum: a struct whose two
+// members are `tag` (the discriminant) and `payload` (a union of the per-case
+// payload structs).
+struct VariantShape {
+  DIDerivedType *tag;
+  DIDerivedType *payload;
+  DICompositeType *cases; // the union; its elements are the per-case members
+};
+
+std::optional<VariantShape> matchVariant(DICompositeType *composite) {
+  if (composite->getTag() != dwarf::DW_TAG_structure_type)
+    return std::nullopt;
+  // `distinct` is required to mutate the `elements` operand below; every
+  // composite the conversion emits is distinct, but guard regardless.
+  if (!composite->isDistinct())
+    return std::nullopt;
+  DINodeArray elements = composite->getElements();
+  if (elements.size() != 2)
+    return std::nullopt;
+  auto *tag = dyn_cast_or_null<DIDerivedType>(elements[0]);
+  auto *payload = dyn_cast_or_null<DIDerivedType>(elements[1]);
+  if (!tag || !payload || tag->getName() != "tag" ||
+      payload->getName() != "payload")
+    return std::nullopt;
+  auto *cases = dyn_cast_or_null<DICompositeType>(payload->getBaseType());
+  if (!cases || cases->getTag() != dwarf::DW_TAG_union_type)
+    return std::nullopt;
+  return VariantShape{tag, payload, cases};
+}
+
+// Rewrite `composite`'s body into a `DW_TAG_variant_part` in place.
+void rewriteVariant(LLVMContext &ctx, DICompositeType *composite,
+                    const VariantShape &v) {
+  DIFile *file = composite->getFile();
+  uint64_t payloadOffset = v.payload->getOffsetInBits();
+
+  // The discriminant is the tag member, marked artificial (compiler-synthesised,
+  // not a source field). Scoped to the enum itself, matching what rustc emits.
+  auto *discriminator = DIDerivedType::get(
+      ctx, dwarf::DW_TAG_member, /*Name=*/StringRef(), file, /*Line=*/0,
+      /*Scope=*/composite, /*BaseType=*/v.tag->getBaseType(),
+      v.tag->getSizeInBits(), v.tag->getAlignInBits(), /*OffsetInBits=*/0,
+      /*DWARFAddressSpace=*/std::nullopt, /*PtrAuthData=*/std::nullopt,
+      DINode::FlagArtificial);
+
+  // One `DW_TAG_member` per case, tagged with its discriminant value in
+  // `extraData` (the case index, which is the tag the constructor stores). Each
+  // case payload sits at the offset the union occupied.
+  auto *i64Ty = Type::getInt64Ty(ctx);
+  SmallVector<Metadata *> variants;
+  unsigned index = 0;
+  for (DINode *element : v.cases->getElements()) {
+    auto *caseMember = dyn_cast<DIDerivedType>(element);
+    if (!caseMember) {
+      ++index;
+      continue;
+    }
+    auto *discrValue = ConstantAsMetadata::get(ConstantInt::get(i64Ty, index));
+    variants.push_back(DIDerivedType::get(
+        ctx, dwarf::DW_TAG_member, caseMember->getName(), file, /*Line=*/0,
+        /*Scope=*/composite, caseMember->getBaseType(),
+        caseMember->getSizeInBits(), caseMember->getAlignInBits(),
+        payloadOffset, /*DWARFAddressSpace=*/std::nullopt,
+        /*PtrAuthData=*/std::nullopt, DINode::FlagZero, /*ExtraData=*/discrValue));
+    ++index;
+  }
+
+  auto *variantPart = DICompositeType::get(
+      ctx, dwarf::DW_TAG_variant_part, /*Name=*/StringRef(), file, /*Line=*/0,
+      /*Scope=*/composite, /*BaseType=*/nullptr, composite->getSizeInBits(),
+      composite->getAlignInBits(), /*OffsetInBits=*/0, DINode::FlagZero,
+      /*Elements=*/DINodeArray(MDTuple::get(ctx, variants)), /*RuntimeLang=*/0,
+      /*EnumKind=*/std::nullopt, /*VTableHolder=*/nullptr,
+      /*TemplateParams=*/nullptr, /*Identifier=*/StringRef(),
+      /*Discriminator=*/discriminator);
+
+  // Mutating the distinct node's `elements` keeps its identity, so all existing
+  // references (recursive payloads, variable types) now resolve to the
+  // variant_part.
+  composite->replaceElements(DINodeArray(MDTuple::get(ctx, {variantPart})));
+}
+
+} // namespace
+
+void fixupVariantDebugInfo(llvm::Module &module) {
+  DebugInfoFinder finder;
+  finder.processModule(module);
+
+  // Collect matches first; `rewriteVariant` mutates the nodes the finder holds.
+  SmallVector<std::pair<DICompositeType *, VariantShape>> work;
+  for (DIType *type : finder.types())
+    if (auto *composite = dyn_cast<DICompositeType>(type))
+      if (auto shape = matchVariant(composite))
+        work.emplace_back(composite, *shape);
+
+  for (auto &[composite, shape] : work)
+    rewriteVariant(module.getContext(), composite, shape);
+}
+
+} // namespace reussir

--- a/tool/lldb/README.md
+++ b/tool/lldb/README.md
@@ -1,0 +1,23 @@
+# Reussir debugger formatters
+
+Reussir enums lower to a DWARF `DW_TAG_variant_part` and the compile unit is
+tagged Rust, so **gdb shows the active case automatically** — no setup needed:
+
+```
+$ gdb ./a.out
+(gdb) print my_enum
+$1 = Cons{f0: 5, f1: 0x...}
+```
+
+**lldb** (without a language plugin) instead lists every case under a synthetic
+`$variants$` node. Load `reussir_formatters.py` to collapse that to the active
+case, matching gdb:
+
+```
+(lldb) command script import /path/to/tool/lldb/reussir_formatters.py
+(lldb) frame variable my_enum
+(_RC4List) my_enum = Cons {f0: 5, f1: 0x...} { f0 = 5, f1 = 0x... }
+```
+
+Add the `command script import` line to your `~/.lldbinit` to load it always.
+Non-enum Reussir records (structs) are passed through unchanged.

--- a/tool/lldb/reussir_formatters.py
+++ b/tool/lldb/reussir_formatters.py
@@ -1,0 +1,78 @@
+"""lldb data formatters for Reussir types.
+
+Reussir enums lower to a DWARF `DW_TAG_variant_part`. gdb collapses that to the
+active case on its own; lldb (without a language plugin) instead shows every
+case under a synthetic `$variants$` node. These formatters read the discriminant
+and present only the live case — the same active-arm view gdb gives.
+
+Load with:  command script import /path/to/reussir_formatters.py
+"""
+
+import lldb
+
+
+def _active(valobj):
+    """Return (case_value, discr) for a variant_part value, or (None, None)."""
+    variants = valobj.GetChildMemberWithName("$variants$")
+    if not variants.IsValid() or variants.GetNumChildren() == 0:
+        return None, None
+    first = variants.GetChildAtIndex(0)
+    discr_node = first.GetChildMemberWithName("$discr$")
+    if not discr_node.IsValid():
+        return None, None
+    discr = discr_node.GetValueAsUnsigned()
+    n = variants.GetNumChildren()
+    idx = discr if discr < n else n - 1
+    case = variants.GetChildAtIndex(idx)
+    return case.GetChildMemberWithName("value"), discr
+
+
+class VariantProvider:
+    """Synthetic children: the active case's fields (passthrough otherwise)."""
+
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+        self.target = valobj
+
+    def update(self):
+        case, _ = _active(self.valobj)
+        # A non-variant Reussir record: show its own fields unchanged.
+        self.target = case if (case and case.IsValid()) else self.valobj
+        return False
+
+    def num_children(self):
+        return self.target.GetNumChildren()
+
+    def get_child_at_index(self, index):
+        return self.target.GetChildAtIndex(index)
+
+    def get_child_index(self, name):
+        return self.target.GetIndexOfChildWithName(name)
+
+    def has_children(self):
+        return self.target.GetNumChildren() > 0
+
+
+def variant_summary(valobj, internal_dict):
+    case, _ = _active(valobj)
+    if case is None or not case.IsValid():
+        return ""  # not a variant → fall back to the default rendering
+    name = case.GetTypeName() or ""
+    fields = []
+    for i in range(case.GetNumChildren()):
+        child = case.GetChildAtIndex(i)
+        text = child.GetValue() or child.GetSummary() or "..."
+        fields.append("%s: %s" % (child.GetName(), text))
+    return "%s {%s}" % (name, ", ".join(fields)) if fields else name
+
+
+def __lldb_init_module(debugger, internal_dict):
+    mod = __name__
+    cat = "reussir"
+    # Reussir record/enum types are mangled `_R…`; scalars are not, so this only
+    # touches our composites. Non-variant records pass through unchanged.
+    debugger.HandleCommand(
+        'type synthetic add -x "^_R" --python-class %s.VariantProvider -w %s' % (mod, cat))
+    debugger.HandleCommand(
+        'type summary add -x "^_R" -e -F %s.variant_summary -w %s' % (mod, cat))
+    debugger.HandleCommand("type category enable " + cat)


### PR DESCRIPTION
Stacked on #277 (`pm/11-variant-lowering`). Makes the enum **discriminator** work so a debugger shows only the *active* case, instead of the `{ tag, payload-union }` overlay that #277 emits.

## Why it can't be done in MLIR
MLIR's `DICompositeTypeAttr` has no `discriminator` field (and `DIDerivedType`'s `extraData` can't hold a discriminant constant), so the debug-info conversion cannot express a `DW_TAG_variant_part`. The needed operands exist only in LLVM's debug metadata — so the rewrite runs **after** MLIR→LLVM translation, on the `llvm::Module`.

## What it does
- **`fixupVariantDebugInfo`** (new, `lib/Conversion/BasicOpsLowering/VariantDebugInfo.cpp`): recognises the `{ tag, payload-union }` composite and rewrites it into a real `DW_TAG_variant_part` — a discriminant member plus one `DW_TAG_variant` per case carrying its `DW_AT_discr_value`. The composite is `distinct`, so its `elements` operand is mutated **in place**: node identity is preserved, so a recursive payload that points back at the enum and every variable typed as the enum pick up the variant part for free — *no reference rewriting, no recursion special-casing*. Runs in `LlvmLowering::finish` via a new `reussirFixupVariantDebugInfo` CAPI.
- **`DW_LANG_Rust`** compile unit: Reussir is Rust-like (sum types, `_R…` mangling). This is more accurate and *required* — under a C/C++ language, debuggers ignore variant parts entirely.

## Result (verified end-to-end via `rrc -g`, value + recursive enums)
- **gdb** — auto-selects the active case, no setup:
  ```
  (gdb) print l
  $1 = Cons{f0: 5, f1: 0x...}
  ```
- **lldb** — no language plugin, so it lists every case under a synthetic `$variants$`. `tool/lldb/reussir_formatters.py` collapses it to the active case (structs pass through unchanged):
  ```
  (lldb) command script import .../tool/lldb/reussir_formatters.py
  (lldb) frame variable l
  (_RC4List) l = Cons {f0: 5, f1: 0x...} { f0 = 5, f1 = 0x... }
  ```
- Recursive descent (from #277) still works in both.

## Tests
`crates/reussir-compiler/tests/variant_debug_info.rs` drives the whole AOT pipeline and asserts the emitted IR is a `DW_TAG_variant_part` with discriminant values (and that the `{tag,union}` form is gone), plus `DW_LANG_Rust`.

Full gate green: cargo (core + codegen + the new compiler test), clippy/fmt, ctest, lit 237/241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)