### PR TITLE
[backend] region-patterns: always give region-allocated objects a vtable

### DIFF
--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -507,7 +507,10 @@ def ReussirRcCreateOp : ReussirRcOp<"create", [
   let extraClassDeclaration = [{
     bool needsVTable() {
       auto recordType = llvm::dyn_cast<RecordType>(getValue().getType());
-      return getRegion() && recordType && !isTriviallyCopyable(recordType);
+      // A region-allocated object always needs a vtable: the region reclaims
+      // every object it owns and reads the vtable for its layout (and any
+      // drop/scan) to do so, even when the payload is trivially copyable.
+      return getRegion() && recordType;
     }
   }];
 }
@@ -556,7 +559,10 @@ def ReussirRcCreateCompoundOp : ReussirRcOp<"create_compound", [
 
     bool needsVTable() {
       auto recordType = getRecordType();
-      return getRegion() && recordType && !isTriviallyCopyable(recordType);
+      // A region-allocated object always needs a vtable: the region reclaims
+      // every object it owns and reads the vtable for its layout (and any
+      // drop/scan) to do so, even when the payload is trivially copyable.
+      return getRegion() && recordType;
     }
   }];
 }
@@ -597,7 +603,10 @@ def ReussirRcCreateVariantOp : ReussirRcOp<"create_variant", [
 
     bool needsVTable() {
       auto recordType = getRecordType();
-      return getRegion() && recordType && !isTriviallyCopyable(recordType);
+      // A region-allocated object always needs a vtable: the region reclaims
+      // every object it owns and reads the vtable for its layout (and any
+      // drop/scan) to do so, even when the payload is trivially copyable.
+      return getRegion() && recordType;
     }
   }];
 }

--- a/lib/Conversion/RegionPatterns/RegionPatterns.cpp
+++ b/lib/Conversion/RegionPatterns/RegionPatterns.cpp
@@ -48,8 +48,12 @@ private:
       return existingVTable;
     mlir::OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(moduleOp.getBody());
-    mlir::FlatSymbolRefAttr dropOpRef = mlir::SymbolRefAttr::get(dropOp);
-    auto vtableOp = ReussirRegionVTableOp::create(builder, 
+    // A trivially-copyable record has no destructor: the vtable is still needed
+    // (for the object's size/alignment and scan program), but its drop pointer
+    // is left null, which the runtime skips.
+    mlir::FlatSymbolRefAttr dropOpRef =
+        dropOp ? mlir::SymbolRefAttr::get(dropOp) : mlir::FlatSymbolRefAttr{};
+    auto vtableOp = ReussirRegionVTableOp::create(builder,
         moduleOp.getLoc(), vtableName, type, dropOpRef);
     return vtableOp;
   }
@@ -65,8 +69,12 @@ public:
     mlir::Type elementType = op.getRcPtr().getType().getElementType();
     RecordType recordType = llvm::dyn_cast<RecordType>(elementType);
     auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
+    // A trivially-copyable record needs no destructor, so leave the vtable's
+    // drop pointer null rather than synthesizing a no-op dtor.
     mlir::func::FuncOp dropFunc =
-        createDtorIfNotExists(moduleOp, recordType, rewriter);
+        isTriviallyCopyable(recordType)
+            ? mlir::func::FuncOp{}
+            : createDtorIfNotExists(moduleOp, recordType, rewriter);
     ReussirRegionVTableOp vtableOp =
         createVTableIfNotExists(moduleOp, recordType, dropFunc, rewriter);
     mlir::FlatSymbolRefAttr vtableRef = mlir::SymbolRefAttr::get(vtableOp);


### PR DESCRIPTION
**Stack 1/5** of the regional-record lowering work.

A region-allocated object always needs a vtable — the region reclaims every object it owns and reads the vtable for the object's **size/alignment** (to `dealloc` it) and its **scan program** (to walk children). So `needsVTable()` on `reussir.rc.create{,_compound,_variant}` no longer excludes trivially-copyable records; previously a scalar-only region object got a null vtable and the runtime faulted reclaiming it.

A trivially-copyable record has no destructor, so `AttachVTablePattern` leaves the vtable's `drop` pointer **null** (the runtime's `VTable.drop` is `Option` and `Header::drop` skips it) instead of synthesizing a no-op dtor; the scan program and size/alignment are still emitted.

Independent backend change; no codegen depends on it. Covered by the existing `region_vtable*` lit tests (incl. `region_vtable_no_drop.mlir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)