### PR TITLE
[backend][frontend] regional `[field]` link mutation + flexivity coloring fixes

### DIFF
--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -179,6 +179,29 @@ pub fn record_variant<'c>(
         .expect("valid reussir.record.variant")
 }
 
+/// `reussir.nullable.create (<value> : <type>)? : <result_type>` — wrap a
+/// non-null pointer into a nullable pointer, or build a null pointer when no
+/// value is given.
+///
+/// The op's `$ptr` operand is `Optional`, and melior's generated builder is
+/// `(context, result_type, location)` — it exposes no parameter for that operand,
+/// so it can only build the null pointer. The value-wrapping (non-null) case is
+/// built raw here, adding the single pointer operand.
+pub fn nullable_create<'c>(
+    value: Option<Value<'c, '_>>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let mut builder = OperationBuilder::new("reussir.nullable.create", location);
+    if let Some(value) = value {
+        builder = builder.add_operands(&[value]);
+    }
+    builder
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.nullable.create")
+}
+
 /// `reussir.region.run (-> <result_type>)? { <body> }` — execute a region scope.
 ///
 /// The body region's single block takes a `!reussir.region` argument (the arena

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -41,7 +41,7 @@ use smallvec::SmallVec;
 
 use crate::source::SourceMap;
 
-use super::ty::{TypeCtx, is_unit, num_class, regional_capability};
+use super::ty::{TypeCtx, field_link_element, is_unit, num_class, regional_capability};
 use super::{LoweringError, Result, err};
 
 /// The lexical environment threaded through one block scope: the SSA value bound
@@ -454,11 +454,14 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             }
             RegionRun(body) => self.region_run(block, env, body, e.ty),
             Proj(base, path) => self.proj(block, env, base, path).map(Some),
-            Assign(..) => err("assignment lowering not yet implemented"),
+            Assign(dst, field, src) => {
+                self.assign(block, env, dst, *field, src)?;
+                Ok(None)
+            }
             Match(..) => err("match lowering not yet implemented"),
             Ctor { args, .. } => self.compound(block, env, e, args).map(Some),
             Variant { variant, args, .. } => self.variant(block, env, e, *variant, args).map(Some),
-            NullableCall(_) => err("nullable lowering not yet implemented"),
+            NullableCall(inner) => self.nullable_call(block, env, e, *inner).map(Some),
             Closure(_) | ClosureCall { .. } => err("closure lowering not yet implemented"),
             GlobalStr(_) => err("string literal lowering not yet implemented"),
             Poison => err("poison expression reached lowering"),
@@ -623,6 +626,69 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         }
     }
 
+    /// Lower `dst->field := src` — store into a mutable `[field]` link.
+    ///
+    /// Mutation is only legal on a region-local `flex` regional record, so the
+    /// destination is borrowed at `flex` capability, the `[field]` slot is
+    /// projected out to a writable `field`-capability reference, and the source
+    /// (a `nullable<rc<…>>` value) is stored into it.
+    fn assign<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        dst: &Expr<'tcx>,
+        field: u32,
+        src: &Expr<'tcx>,
+    ) -> Result<()> {
+        let loc = self.loc();
+        let dst_val = self
+            .expr(block, env, dst)?
+            .ok_or_else(|| LoweringError("assignment target is unit".into()))?;
+        if regional_capability(dst.ty)? != ReussirCapability::Flex {
+            return err("assignment target is not a mutable (flex) regional record");
+        }
+        let inner = self.tys.record_inner_of(dst.ty)?;
+        let ref_ty = self.tys.ref_type_with_cap(inner, ReussirCapability::Flex);
+        let borrowed = self.append(
+            block,
+            dialect::rc_borrow(self.context, ref_ty, dst_val, loc).into(),
+        );
+        let proj = self.projected_member(dst.ty, ReussirCapability::Flex, field)?;
+        let field_ref_ty = self.tys.ref_type_with_cap(proj.elem_ty, proj.proj_cap);
+        let index = IntegerAttribute::new(Type::index(self.context), i64::from(field));
+        let field_ref = self.append(
+            block,
+            dialect::ref_project(self.context, field_ref_ty, borrowed, index, loc).into(),
+        );
+        let src_val = self
+            .expr(block, env, src)?
+            .ok_or_else(|| LoweringError("assignment source is unit".into()))?;
+        block.append_operation(dialect::ref_store(self.context, field_ref, src_val, loc).into());
+        Ok(())
+    }
+
+    /// Lower a nullable constructor (`Nullable::NonNull{e}` or `Nullable::Null`)
+    /// to `reussir.nullable.create`, wrapping the pointer value (or building the
+    /// null pointer when there is no inner expression).
+    fn nullable_call<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        e: &Expr<'tcx>,
+        inner: Option<&'tcx Expr<'tcx>>,
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let result_ty = self.tys.mlir_ty(e.ty)?;
+        let value = match inner {
+            Some(x) => Some(
+                self.expr(block, env, x)?
+                    .ok_or_else(|| LoweringError("nullable payload is unit".into()))?,
+            ),
+            None => None,
+        };
+        Ok(self.append(block, builders::nullable_create(value, result_ty, loc)))
+    }
+
     /// Project a chain of fields out of a record value.
     ///
     /// The walk is type-directed (see [`Cursor`]): an inline `[value]` record is
@@ -675,8 +741,9 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     );
                     self.project_ref(block, borrowed, ty, cap, idx)
                 } else {
-                    // An inline `[value]` record value: read the field out by value.
-                    let field_ty = self.field_at(ty, idx)?;
+                    // An inline `[value]` record value: read the field out by value
+                    // (an inline record has no `[field]` link members).
+                    let (field_ty, _) = self.field_at(ty, idx)?;
                     let field_mlir = self.tys.mlir_ty(field_ty)?;
                     let extracted = self.append(
                         block,
@@ -757,8 +824,33 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         ref_cap: ReussirCapability,
         idx: u32,
     ) -> Result<ProjectedMember<'c, 'tcx>> {
-        let field_ty = self.field_at(record_ty, idx)?;
-        if self.tys.is_shared_record(field_ty) {
+        let (field_ty, is_field) = self.field_at(record_ty, idx)?;
+        if is_field {
+            // A mutable link: `nullable<rc<inner, flex|rigid>>`. Taken out of a
+            // `flex` parent the slot is itself writable (`field` capability); out
+            // of a `rigid` (frozen) parent it is read-only. The MIR types the
+            // member `Nullable<Record>`, so name the link's element record.
+            let inner = self.tys.record_inner_of(field_link_element(field_ty))?;
+            let link_cap = if ref_cap == ReussirCapability::Flex {
+                ReussirCapability::Flex
+            } else {
+                ReussirCapability::Rigid
+            };
+            let elem_ty = self
+                .tys
+                .nullable_type(self.tys.rc_type_with_cap(inner, link_cap));
+            let proj_cap = if ref_cap == ReussirCapability::Flex {
+                ReussirCapability::Field
+            } else {
+                ref_cap
+            };
+            Ok(ProjectedMember {
+                field_ty,
+                elem_ty,
+                proj_cap,
+                is_link: true,
+            })
+        } else if self.tys.is_shared_record(field_ty) {
             let inner = self.tys.record_inner_of(field_ty)?;
             Ok(ProjectedMember {
                 field_ty,
@@ -783,9 +875,9 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         }
     }
 
-    /// The MIR type of field `idx` of a compound record. A mutable `[field]` link
-    /// is not projected yet and surfaces as an explicit error.
-    fn field_at(&self, record_ty: Ty<'tcx>, idx: u32) -> Result<Ty<'tcx>> {
+    /// The MIR type of field `idx` of a compound record, and whether it is a
+    /// mutable `[field]` link.
+    fn field_at(&self, record_ty: Ty<'tcx>, idx: u32) -> Result<(Ty<'tcx>, bool)> {
         let rec = self
             .tys
             .record_of(record_ty)
@@ -797,10 +889,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let field = members
             .get(idx as usize)
             .ok_or_else(|| LoweringError(format!("field index {idx} out of range").into()))?;
-        if field.is_field {
-            return err("projection of a regional field link not yet implemented");
-        }
-        Ok(field.ty)
+        Ok((field.ty, field.is_field))
     }
 
     /// Materialize a [`Cursor`] as a loaded SSA value, loading through a trailing

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -25,12 +25,16 @@
 //! * **regional (`[regional]`) records** — construction of region-allocated
 //!   `flex` boxes (`reussir.rc.create … region`), `region-run` scopes
 //!   (`reussir.region.run`/`region.yield`), calls into `regional` functions
-//!   (threading the implicit region handle), and projection of their scalar /
-//!   by-value / `[shared]` members (capability-aware borrow/project/load).
+//!   (threading the implicit region handle), projection of their scalar /
+//!   by-value / `[shared]` members (capability-aware borrow/project/load), and
+//!   mutation of a `[field]` link (`c->f := …` — project the `nullable<rc<…>>`
+//!   slot to a writable `field` reference and store), with the `Nullable`
+//!   constructor lowering to `reussir.nullable.create`.
 //!
-//! Regional `[field]` links (projection and assignment), a non-`[field]` member
-//! that is itself a regional record, enums/`match`, closures, and strings are not
-//! yet lowered and surface as an explicit [`LoweringError`] rather than wrong code.
+//! Reading a `[field]` link back (which needs `match`/`nullable.dispatch`), a
+//! non-`[field]` member that is itself a regional record, enums/`match`,
+//! closures, and strings are not yet lowered and surface as an explicit
+//! [`LoweringError`] rather than wrong code.
 //!
 //! Every callee/trampoline target in the MIR is already resolved to an interned
 //! [`mir::Symbol`](reussir_core::full::mir::Symbol) (mono did the mangling), so
@@ -489,6 +493,99 @@ mod tests {
         assert!(mlir.contains("reussir.ref.load"), "{mlir}");
         // The reference into the region-local record carries `flex` capability.
         assert!(mlir.contains("ref<") && mlir.contains("flex"), "{mlir}");
+    }
+
+    #[test]
+    fn lowers_regional_field_link_assignment() {
+        // Assigning through a mutable `[field]` link on a `flex` regional record:
+        // the record's `[field]` member lowers to a `nullable<rc<…>>` slot; the
+        // assignment borrows the record at `flex`, projects the slot to a writable
+        // `field`-capability reference, builds the `Nullable::NonNull{..}` value
+        // (`reussir.nullable.create`), and stores it (`reussir.ref.store`).
+        let src = r#"
+            struct [regional] Cell { v: i64, next: [field] Cell }
+            regional fn set(c: [flex] Cell, x: [flex] Cell) -> i64 {
+                c->next := Nullable::NonNull{x};
+                c.v
+            }
+        "#;
+        let mlir = lower_source(src);
+        // The `[field]` member is a nullable rc link in the record's layout.
+        assert!(mlir.contains("!reussir.nullable<"), "{mlir}");
+        // Projecting the `[field]` slot out of a `flex` parent yields a writable
+        // `field`-capability reference.
+        assert!(mlir.contains("field>"), "{mlir}");
+        assert!(mlir.contains("reussir.nullable.create"), "{mlir}");
+        assert!(mlir.contains("reussir.ref.project"), "{mlir}");
+        assert!(mlir.contains("reussir.ref.store"), "{mlir}");
+    }
+
+    #[test]
+    fn rejects_nullable_over_a_non_pointer_element() {
+        // The frontend's pointer-like check for a `Nullable` inner is
+        // conservative and passes a `[value]` record; that record lowers to an
+        // inline (non-pointer) type, which cannot sit behind a `nullable`. Lower
+        // it to an explicit error rather than a malformed `nullable<record<…>>`.
+        let src = r#"
+            struct [value] Pair { a: i64 }
+            fn wrap(p: Pair) -> Nullable<Pair> { Nullable::NonNull{ p } }
+        "#;
+        let context = crate::testing::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let err = lower_program(&context, tcx, &full, None, None)
+                .expect_err("a nullable over a non-pointer element must not lower");
+            assert!(
+                err.to_string().contains("does not lower to a pointer"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn lowers_regional_field_construction_and_self_link() {
+        // The canonical loop-back shape, now that a `[field]` slot's null is
+        // colored `flex`: construct a `flex` `Cell` whose `[field]` `next` is
+        // `Nullable::Null` (a null nullable), then link it to itself
+        // (`c->next := Nullable::NonNull{c}`) and read a scalar back. Exercises
+        // `[field]` construction (null + record-with-nullable-member layout) and
+        // assignment together, all the way through the lowering pipeline.
+        let src = r#"
+            struct [regional] Cell { v: i64, next: [field] Cell }
+            regional fn loop_back(seed: i64) -> i64 {
+                let c = Cell { v: seed, next: Nullable::Null };
+                c->next := Nullable::NonNull{c};
+                c.v
+            }
+            pub fn run(n: i64) -> i64 { regional { loop_back(n) } }
+        "#;
+        let context = reussir_backend::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let mut module =
+                lower_program(&context, tcx, &full, None, None).expect("lowering succeeds");
+            let printed = module.as_operation().to_string();
+            // The null field and the self-link both build nullable rc values.
+            assert!(printed.contains("reussir.nullable.create"), "{printed}");
+            reussir_backend::pipeline::run_lowering_pipeline(
+                &context,
+                &mut module,
+                &reussir_backend::pipeline::LoweringOptions::default(),
+            )
+            .expect("pipeline lowers the [field] module to LLVM");
+        });
     }
 
     #[test]

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -27,8 +27,8 @@ use std::cell::RefCell;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use reussir_backend::dialect::ty::{
-    ReussirAtomicKind, ReussirCapability, ReussirRecordKind, rc, record_complete_in_place,
-    record_incomplete, record_is_complete, r#ref, region,
+    ReussirAtomicKind, ReussirCapability, ReussirRecordKind, nullable, rc,
+    record_complete_in_place, record_incomplete, record_is_complete, r#ref, region,
 };
 use reussir_backend::melior::Context;
 use reussir_backend::melior::ir::Type;
@@ -105,11 +105,26 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             .is_some_and(|rec| rec.default_cap == DefaultCap::Regional)
     }
 
-    /// Lower a ground type to MLIR: records resolve through the layout table,
-    /// everything else is a scalar.
+    /// Lower a ground type to MLIR: records resolve through the layout table, a
+    /// nullable pointer wraps its (pointer-typed) element, and everything else is
+    /// a scalar.
     pub(super) fn mlir_ty(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
         match *ty.kind() {
             TyKind::Record { .. } => self.record_type(ty),
+            // A `Nullable<T>` wraps its element's MLIR pointer type (an `rc` link
+            // for the regional/shared records that can sit behind a nullable
+            // `[field]` slot) so it may additionally hold null. The dialect's
+            // `nullable` needs a non-null *pointer* element; the frontend's
+            // pointer-like check is conservative (it passes a `[value]` record),
+            // so reject a concrete non-pointer element here rather than build a
+            // malformed `nullable<record<…>>` that later passes fall over.
+            TyKind::Nullable(inner) => {
+                if !(self.is_shared_record(inner) || self.is_regional_record(inner)) {
+                    return err("`Nullable` element does not lower to a pointer: only a \
+                         managed `[shared]`/`[regional]` record can sit behind a nullable");
+                }
+                Ok(nullable(self.mlir_ty(inner)?))
+            }
             _ => scalar_ty(self.context, ty),
         }
     }
@@ -124,6 +139,16 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             TyKind::Record { .. } => self.record_inner_of(ty),
             _ => self.mlir_ty(ty),
         }
+    }
+
+    /// Lower a mutable `[field]` link member to its stored type. The member is
+    /// typed `Nullable<Record>` in the MIR, but the record stores the bare
+    /// element record type (under the `field` flag the dialect derives the
+    /// `nullable<rc<…>>` slot itself), so this strips the nullable wrapper and
+    /// names the link's element record.
+    fn field_member_ty(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
+        let element = field_link_element(ty);
+        self.record_inner_of(element)
     }
 
     /// The payload compound type for variant `idx` of an enum-typed `ty` — the
@@ -217,7 +242,14 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
                 let mut tys = Vec::with_capacity(members.len());
                 let mut is_field = Vec::with_capacity(members.len());
                 for m in members {
-                    tys.push(self.member_ty(m.ty)?);
+                    // A `[field]` link member stores the bare element record type;
+                    // the dialect derives its `nullable<rc<…>>` slot from the flag.
+                    let member_ty = if m.is_field {
+                        self.field_member_ty(m.ty)?
+                    } else {
+                        self.member_ty(m.ty)?
+                    };
+                    tys.push(member_ty);
                     is_field.push(m.is_field);
                 }
                 (tys, is_field)
@@ -291,6 +323,12 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         region(self.context)
     }
 
+    /// `!reussir.nullable<pointer>` — a nullable wrapper around a pointer type
+    /// (the `rc` link stored in a mutable `[field]` slot), which may hold null.
+    pub(super) fn nullable_type(&self, pointer: Type<'c>) -> Type<'c> {
+        nullable(pointer)
+    }
+
     /// `!reussir.ref<inner, cap>` — a borrowed reference at an explicit
     /// capability, as produced by `reussir.rc.borrow` and `reussir.ref.project`:
     /// `shared` into a shared value, or `flex`/`rigid` into a regional one
@@ -328,6 +366,16 @@ pub(super) fn regional_capability(ty: Ty<'_>) -> Result<ReussirCapability> {
             "regional record reached codegen with an unrefined flexivity coloring \
              ({other:?}); elaboration must resolve it to flex or rigid"
         )),
+    }
+}
+
+/// The element record a mutable `[field]` link points at. The link is typed
+/// `Nullable<Record>` in the MIR; this strips the nullable wrapper to name the
+/// pointee record (tolerating an already-bare record type).
+pub(super) fn field_link_element(ty: Ty<'_>) -> Ty<'_> {
+    match *ty.kind() {
+        TyKind::Nullable(inner) => inner,
+        _ => ty,
     }
 }
 

--- a/crates/reussir-compiler/tests/variant_debug_info.rs
+++ b/crates/reussir-compiler/tests/variant_debug_info.rs
@@ -62,7 +62,10 @@ fn enum_debug_info_is_a_discriminated_variant_part() {
     );
     // One variant part per enum (Shape and List), not the old `{tag, union}`.
     let parts = ir.matches("DW_TAG_variant_part").count();
-    assert!(parts >= 2, "expected a variant part per enum, found {parts}");
+    assert!(
+        parts >= 2,
+        "expected a variant part per enum, found {parts}"
+    );
     // The old union form must be gone — the fixup rewrites it in place.
     assert!(
         !ir.contains("DW_TAG_union_type"),

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -52,7 +52,7 @@ pub fn elaborate<'a, 'tcx>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::semi::ty::{Flexivity, IntTy};
+    use crate::semi::ty::{Flexivity, IntTy, TyKind};
     use crate::with_tcx;
 
     /// Parse + lower + elaborate, asserting there are no errors, then run `f`
@@ -336,6 +336,105 @@ mod tests {
                    regional fn f(c: [flex] Cell<i32>) -> i32 { let g = || c; 0 }";
         assert!(
             has_error(src, "closure cannot return a flex value"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_non_regional_function_returning_flex() {
+        // The `frozen()` shape: a plain function cannot return a flex value — the
+        // only way its body could produce one is a region-run, which freezes to
+        // `rigid` on exit, so a `[flex]` return can never be satisfied.
+        let src = "struct [regional] A { v: i32, next: [field] A }\n\
+                   fn frozen(x: i32) -> [flex] A { regional { A { v: x, next: Nullable::Null } } }";
+        assert!(
+            has_error(src, "non-regional function cannot return a flex value"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_non_regional_function_taking_flex_param() {
+        // A flex value cannot exist outside a region, so it cannot be handed to a
+        // plain function as an argument.
+        let src = "struct [regional] A { v: i32, next: [field] A }\n\
+                   fn f(a: [flex] A) -> i32 { a.v }";
+        assert!(
+            has_error(src, "non-regional function cannot take flex parameter"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn accepts_regional_function_with_flex_signature() {
+        // A `regional fn` shares its caller's region, so flex params and a flex
+        // return are legal there — the boundary check must not over-reject them.
+        let src = "struct [regional] A { v: i32, next: [field] A }\n\
+                   regional fn thread(a: [flex] A) -> [flex] A { a }";
+        assert!(!has_error(src, "cannot"), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn colors_field_link_null_flex() {
+        // `Nullable::Null` stored into a `[field]` slot of a flex record must be
+        // colored `flex` (a freshly-built region-local value), not left at the
+        // record's default `Regional` — otherwise it reaches the backend uncolored.
+        let src = "struct [regional] Cell { v: i32, next: [field] Cell }\n\
+                   regional fn clear(c: [flex] Cell) -> i32 { c->next := Nullable::Null; c.v }";
+        check(src, |elab, _| {
+            // Body is `Seq[ Assign(c, next, Nullable::Null), c.v ]`.
+            let body = function(elab, "clear").body.as_ref().unwrap();
+            let hir::ExprKind::Seq(items) = &body.kind else {
+                panic!("expected a block, got {:?}", body.kind)
+            };
+            let src_ty = items
+                .iter()
+                .find_map(|e| match &e.kind {
+                    hir::ExprKind::Assign(_, _, src) => Some(src.ty),
+                    _ => None,
+                })
+                .expect("an assignment");
+            let TyKind::Nullable(inner) = src_ty.kind() else {
+                panic!("assignment source is not Nullable: {src_ty:?}")
+            };
+            assert_eq!(
+                inner.flexivity(),
+                Some(Flexivity::Flex),
+                "a `[field]` null's element should be flex, got {:?}",
+                inner.flexivity()
+            );
+        });
+    }
+
+    #[test]
+    fn rejects_storing_a_rigid_value_into_a_field_link() {
+        // A `[field]` link on a flex record holds region-local (flex) values. A
+        // frozen (`rigid`) value — here the result of a `region { }` that escaped
+        // its region — is a flexivity mismatch against that flex slot.
+        let src = "struct [regional] Cell { v: i32, next: [field] Cell }\n\
+                   fn frozen() -> Cell { regional { Cell { v: 0, next: Nullable::Null } } }\n\
+                   regional fn t(c: [flex] Cell) -> i32 { c->next := Nullable::NonNull{ frozen() }; c.v }";
+        assert!(
+            has_error(src, "flexivity mismatch"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_returning_a_frozen_body_as_flex() {
+        // A regional function whose body is a frozen (`rigid`) value but which
+        // declares a `[flex]` return is a flexivity mismatch at the return — the
+        // residual the boundary check alone (which only guards the non-regional
+        // case) would miss.
+        let src = "struct [regional] A { v: i32, next: [field] A }\n\
+                   fn mk() -> A { regional { A { v: 0, next: Nullable::Null } } }\n\
+                   regional fn f() -> [flex] A { mk() }";
+        assert!(
+            has_error(src, "flexivity mismatch"),
             "{:#?}",
             reports_of(src)
         );

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -31,6 +31,34 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // generics; the body may add more (e.g. a generic assigned into a link).
         self.regional_generics = proto.regional_generics.clone();
 
+        // A flex value is region-local and cannot be materialized, so it cannot
+        // escape its region across a function boundary. A `regional fn` shares its
+        // caller's region (it takes the region as an implicit parameter), so flex
+        // may cross its boundary; a plain function has no such region, so a flex
+        // parameter or return is rejected. This also rejects declaring a `[flex]`
+        // return whose body can only be a frozen (`rigid`) region-run result.
+        if !proto.is_regional {
+            if self.is_flex(proto.return_ty) {
+                self.error(
+                    span,
+                    "a non-regional function cannot return a flex value: a flex \
+                     value cannot escape its region",
+                );
+            }
+            for (name, ty) in &proto.params {
+                if self.is_flex(*ty) {
+                    let name = self.sym(*name);
+                    self.error(
+                        span,
+                        format!(
+                            "a non-regional function cannot take flex parameter \
+                             `{name}`: a flex value cannot escape its region"
+                        ),
+                    );
+                }
+            }
+        }
+
         let mut params = Vec::new();
         for (name, ty) in &proto.params {
             let var = self.vars.fresh(*name, *ty, None);
@@ -83,6 +111,38 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 span,
                 format!("type mismatch: expected `{e:?}`, found `{f:?}`"),
             );
+            return;
+        }
+        // `unify` reconciles structure but not flexivity coloring, so check it
+        // here at the head (peeling `Nullable`, e.g. a `[field]` link). Two
+        // colorings are compatible when one refines to the other in the
+        // [refinement tree](crate::semi::ty::Flexivity); the incompatible cases
+        // are the siblings — `Flex` versus `Rigid`. Rejecting them is what stops a
+        // frozen `rigid` value being stored into a flex `[field]` link, or a
+        // frozen `region { }` result satisfying a `[flex]` return. An `Unknown`
+        // head (a non-record, or a not-yet-solved hole such as a `Nullable::Null`
+        // element) is the tree root and compatible with either, so it simply
+        // takes the expected coloring.
+        if let (Some(f), Some(e)) = (self.head_flexivity(found), self.head_flexivity(expected))
+            && !f.compatible(e)
+        {
+            self.error(
+                span,
+                format!(
+                    "flexivity mismatch: a `{f:?}` regional value cannot be used where \
+                     `{e:?}` is required (one does not refine to the other)"
+                ),
+            );
+        }
+    }
+
+    /// The flexivity coloring at the head of `ty`, peeling a `Nullable` wrapper
+    /// (a `[field]` link is a `Nullable<Record>`). `None` for a non-record head.
+    fn head_flexivity(&mut self, ty: Ty<'tcx>) -> Option<crate::semi::ty::Flexivity> {
+        match self.infer.shallow_resolve(ty).kind() {
+            TyKind::Record { flex, .. } => Some(*flex),
+            TyKind::Nullable(inner) => self.head_flexivity(*inner),
+            _ => None,
         }
     }
 
@@ -598,10 +658,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // A mutable field's type is already the nullable link type.
         let src = self.check_expr(src, field_ty);
         // The assigned value must be a `Nullable<R>` whose element `R` is a
-        // regional record — only a regional value belongs in a flex record's
-        // mutable link. If `R` is concrete it must be regional here; if `R` is a
-        // generic, record the requirement for the monomorphization call-boundary
-        // check (the same `regional_generics` channel as a `[flex] T` parameter).
+        // regional record — only a regional value belongs in a mutable link. Its
+        // *flexivity* (a frozen `rigid` value cannot go into a flex `[field]`
+        // link) is enforced by the checking boundary above: `check_expr` unified
+        // `src` against the link's flex slot type. If `R` is a generic, record the
+        // requirement for the monomorphization call-boundary check (the same
+        // `regional_generics` channel as a `[flex] T` parameter).
         let resolved = self.infer.shallow_resolve(src.ty);
         if let TyKind::Nullable(inner) = resolved.kind() {
             let inner = self.infer.shallow_resolve(*inner);
@@ -695,7 +757,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             }
             _ => return None,
         };
-        let field_ty = self.infer.instantiate_ty(decl_ty, &inst);
+        let field_ty = self.field_member_ty(decl_ty, mutable, &inst);
         Some((idx as u32, field_ty, mutable))
     }
 
@@ -931,14 +993,50 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match fields {
             Some(RecordFields::Named(fs)) => fs
                 .iter()
-                .map(|(n, t, _)| (Some(*n), self.infer.instantiate_ty(*t, inst)))
+                .map(|(n, t, is_field)| (Some(*n), self.field_member_ty(*t, *is_field, inst)))
                 .collect(),
             Some(RecordFields::Unnamed(fs)) => fs
                 .iter()
-                .map(|(t, _)| (None, self.infer.instantiate_ty(*t, inst)))
+                .map(|(t, is_field)| (None, self.field_member_ty(*t, *is_field, inst)))
                 .collect(),
             _ => Vec::new(),
         }
+    }
+
+    /// The *expected* type of a struct member when constructing or mutating the
+    /// struct — the target a field argument or assignment source is checked
+    /// against. A plain member is its (instantiated) declared type. A mutable
+    /// `[field]` link — always a `Nullable<Record>` — points at a region-local
+    /// value, so its slot element is `Flex`: it lives in a flex regional record
+    /// (a fresh construction is born flex; assignment requires a flex target).
+    /// This flex expectation is what colors an otherwise-unknown value stored
+    /// through it — e.g. a standalone `Nullable::Null` has an unconstrained
+    /// element, and checking it against this flex slot solves that hole to `flex`
+    /// rather than the record's default `Regional`. (A concrete `rigid` value
+    /// meeting this flex slot is a flexivity mismatch, caught by [`expect`].)
+    fn field_member_ty(
+        &mut self,
+        decl_ty: Ty<'tcx>,
+        is_field: bool,
+        inst: &Instantiation<'tcx>,
+    ) -> Ty<'tcx> {
+        let ty = self.infer.instantiate_ty(decl_ty, inst);
+        if is_field { self.flex_link_ty(ty) } else { ty }
+    }
+
+    /// Color a `[field]` link's slot element `Flex`. The link is a
+    /// `Nullable<Record>`; this refines a concrete pointee record's coloring and
+    /// leaves a generic (or any other) element untouched (a `[flex] T` requirement
+    /// is tracked through the `regional_generics` channel instead).
+    fn flex_link_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
+        use crate::semi::ty::Flexivity;
+        if let TyKind::Nullable(inner) = ty.kind()
+            && let TyKind::Record { def, args, .. } = self.infer.shallow_resolve(*inner).kind()
+        {
+            let flexed = self.tcx.mk_record(*def, args, Flexivity::Flex);
+            return self.tcx.mk_nullable(flexed);
+        }
+        ty
     }
 
     fn record_ty(

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -48,16 +48,56 @@ pub struct HoleId(pub u32);
 /// interact in exactly one place — a region-managed record needs rc only when
 /// its flexivity is `Rigid` (frozen/escaped); see `full::ownership`.
 ///
-/// These do **not** form a total order — `Flex` and `Rigid` are incomparable
-/// (different axes: mutability vs materializability) — so there is no
-/// subsumption helper. Flexivity-as-a-bound is deferred until its semantics are
-/// settled; for now this is purely the coloring stored on [`TyKind::Record`].
+/// The colorings form a **refinement tree** — each one refines (is more specific
+/// than) its parent:
+///
+/// ```text
+/// Unknown (absent — a non-regional or not-yet-resolved head; see `flexivity()`)
+/// ├─ Irrelevant   (a value/shared record: carries no regional coloring)
+/// └─ Regional     (unrefined: may still resolve to flex or rigid)
+///    ├─ Flex      (region-local, mutable)
+///    └─ Rigid     (frozen, materializable)
+/// ```
+///
+/// Two colorings are **compatible** ([`compatible`](Self::compatible)) when one
+/// refines to the other — i.e. they are comparable, a directed path connects
+/// them in the tree. The only incompatibilities are the sibling pairs: `Flex`
+/// versus `Rigid` (a mutable region-local value is not a frozen one), and
+/// `Irrelevant` versus a regional coloring. This is a compatibility *check*, not
+/// full lattice unification: it does not rewrite a `Regional` head to the more
+/// refined `Flex`/`Rigid` it meets.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Flexivity {
     Irrelevant,
     Regional,
     Flex,
     Rigid,
+}
+
+impl Flexivity {
+    /// This coloring's parent in the refinement tree, or `None` for a child of
+    /// the (absent) `Unknown` root.
+    fn parent(self) -> Option<Flexivity> {
+        match self {
+            Flexivity::Irrelevant | Flexivity::Regional => None,
+            Flexivity::Flex | Flexivity::Rigid => Some(Flexivity::Regional),
+        }
+    }
+
+    /// Whether `self` is `other` or refines from it — `self` lies on the path
+    /// from the root down to `other` (equivalently, `other` is an ancestor of
+    /// `self`, or they are equal).
+    fn refines_from(self, other: Flexivity) -> bool {
+        self == other || self.parent().is_some_and(|p| p.refines_from(other))
+    }
+
+    /// Whether two colorings are compatible: one refines to the other, so a
+    /// directed path connects them in the [refinement tree](Flexivity). `Flex`
+    /// and `Rigid` (incomparable siblings), and `Irrelevant` versus a regional
+    /// coloring, are the only incompatible pairs.
+    pub fn compatible(self, other: Flexivity) -> bool {
+        self.refines_from(other) || other.refines_from(self)
+    }
 }
 
 /// A width-tagged integer type.
@@ -237,5 +277,30 @@ impl<'tcx> TyCtxt<'tcx> {
             return &[];
         }
         self.arena.alloc_slice_copy(slice)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Flexivity::{Flex, Irrelevant, Regional, Rigid};
+
+    #[test]
+    fn flexivity_compatibility_follows_the_refinement_tree() {
+        // Reflexive, and symmetric.
+        for x in [Irrelevant, Regional, Flex, Rigid] {
+            assert!(x.compatible(x), "{x:?} should be compatible with itself");
+            for y in [Irrelevant, Regional, Flex, Rigid] {
+                assert_eq!(x.compatible(y), y.compatible(x), "symmetry {x:?}/{y:?}");
+            }
+        }
+        // Regional is the parent of Flex and Rigid, so it refines to either.
+        assert!(Regional.compatible(Flex));
+        assert!(Regional.compatible(Rigid));
+        // Siblings do not refine to each other.
+        assert!(!Flex.compatible(Rigid));
+        // Irrelevant is in a separate subtree from the regional colorings.
+        assert!(!Irrelevant.compatible(Regional));
+        assert!(!Irrelevant.compatible(Flex));
+        assert!(!Irrelevant.compatible(Rigid));
     }
 }


### PR DESCRIPTION
Final PR of the regional-record lowering stack (after #280 vtable, #281 builders, #282 construction/region-run, #283 member projection). It lowers the mutable `[field]` link subset, and fixes two elaboration flexivity-coloring bugs that block it (fixes #284).

## Frontend (`reussir-core semi`) — commit 1

Two flexivity fixes surfaced while wiring up `[field]` lowering:

1. **`[field]` link elements are now colored `Flex`.** A `[field]` member is `Nullable<Record>`; its declared element kept the record's default `Regional` coloring, so a value stored through the link — especially a payload-less `Nullable::Null` (fresh hole) — unified to `Regional` and reached the backend uncolored. A link only lives in a freshly-built (`Flex`) regional record, so `field_member_ty` colors the element `Flex` at every use (construction + mutation).
2. **A non-regional function cannot take/return a flex value** (fixes #284). Flex is region-local and can't escape its region; a `regional fn` shares the caller's region, a plain `fn` doesn't. This rejects, at the signature, a `[flex]` return whose body could only be a frozen `rigid` region-run result — instead of deferring to a backend type-mismatch.

## Backend (`reussir-codegen`, `builders`) — commit 2

- `nullable_create` builder (the generated one can't express the optional `$ptr` operand's non-null case).
- `ty.rs`: `[field]` member → bare element under the `field` flag (`field_member_ty`); `Nullable<T>` → `!reussir.nullable<…>`; `field_link_element`.
- `expr.rs`: `projected_member` maps a `[field]` slot to its `nullable<rc<…, flex|rigid>>` element at `field` capability; `assign` lowers `c->f := v` (borrow `flex` → project slot → store); `nullable_call` lowers the `Nullable` constructor.

## Tests

- Frontend: rejects non-regional flex return / flex param; accepts regional flex signature; `[field]` null colored flex.
- Codegen: `[field]` assignment, and the canonical self-linking loop-back shape through the full pipeline.

Reading a `[field]` link back (needs `match`/`nullable.dispatch`) and a non-`[field]` member that is itself a regional record remain explicit `LoweringError`s.

Closes #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)