### PR TITLE
[backend] reussir-codegen: lower closures (create/apply/eval)

### DIFF
--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -239,6 +239,93 @@ pub fn region_yield<'c>(value: Option<Value<'c, '_>>, location: Location<'c>) ->
     builder.build().expect("valid reussir.region.yield")
 }
 
+/// `reussir.closure.create -> <result_type> { body … }` — create a closure from
+/// an inlined body region.
+///
+/// The result is a shared `!reussir.rc<closure<(inputs) -> output>>`; the body
+/// region's single block takes the closure input types as arguments (captures
+/// followed by parameters) and terminates with `reussir.closure.yield`. This
+/// builds the *inlined* form — no allocation token (the token-instantiation pass
+/// supplies it) and no outlined vtable (the closure-outlining pass generates the
+/// evaluate/drop/clone functions and vtable from the body). The op has a custom
+/// assembly format and no generated builder, so it is built raw here.
+pub fn closure_create<'c>(
+    result_type: Type<'c>,
+    body: Region<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.closure.create", location)
+        .add_regions([body])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.closure.create")
+}
+
+/// `reussir.closure.yield (<value> : <type>)?` — terminate a
+/// `reussir.closure.create` body, yielding the closure's result (absent for a
+/// closure with no output). Built raw like [`region_yield`] — the generated
+/// builder exposes no parameter for the `Optional` value operand.
+pub fn closure_yield<'c>(value: Option<Value<'c, '_>>, location: Location<'c>) -> Operation<'c> {
+    let mut builder = OperationBuilder::new("reussir.closure.yield", location);
+    if let Some(value) = value {
+        builder = builder.add_operands(&[value]);
+    }
+    builder.build().expect("valid reussir.closure.yield")
+}
+
+/// `reussir.closure.apply (<arg> : <type>) to (<closure> : <type>) : <result_type>`
+/// — supply one leading argument to a closure, yielding a closure with one fewer
+/// input. Built raw here; the result type is the residual closure `rc` type.
+pub fn closure_apply<'c>(
+    arg: Value<'c, '_>,
+    closure: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.closure.apply", location)
+        .add_operands(&[arg, closure])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.closure.apply")
+}
+
+/// `reussir.closure.uniqify (<closure> : <type>) : <result_type>` — obtain a
+/// uniquely-owned copy of a closure.
+///
+/// It expands (in the SCF-lowering pass) to an `rc.is_unique` guarded `scf.if`:
+/// a uniquely-referenced closure is returned as-is, otherwise it is deep-cloned
+/// (and the shared reference dropped). It must precede any `reussir.closure.apply`
+/// on a closure that may be shared, because `apply` writes the argument into the
+/// closure box *in place* — mutating a shared closure would corrupt every other
+/// holder. The result type is the same closure `rc` type as the input.
+pub fn closure_uniqify<'c>(
+    closure: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.closure.uniqify", location)
+        .add_operands(&[closure])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.closure.uniqify")
+}
+
+/// `reussir.closure.eval (<closure> : <type>) (: <result_type>)?` — evaluate a
+/// fully-applied closure, producing its result (absent for a closure with no
+/// output). Built raw here; `result_type` is `None` for a unit-returning closure.
+pub fn closure_eval<'c>(
+    closure: Value<'c, '_>,
+    result_type: Option<Type<'c>>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let mut builder = OperationBuilder::new("reussir.closure.eval", location);
+    builder = builder.add_operands(&[closure]);
+    if let Some(result_type) = result_type {
+        builder = builder.add_results(&[result_type]);
+    }
+    builder.build().expect("valid reussir.closure.eval")
+}
+
 /// `reussir.record.extract (<record> : <type>) [<index>] : <field_type>` —
 /// project a field out of a record value.
 ///

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -462,7 +462,8 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             Ctor { args, .. } => self.compound(block, env, e, args).map(Some),
             Variant { variant, args, .. } => self.variant(block, env, e, *variant, args).map(Some),
             NullableCall(inner) => self.nullable_call(block, env, e, *inner).map(Some),
-            Closure(_) | ClosureCall { .. } => err("closure lowering not yet implemented"),
+            Closure(c) => self.closure(block, env, c).map(Some),
+            ClosureCall { target, args } => self.closure_call(block, env, target, args),
             GlobalStr(_) => err("string literal lowering not yet implemented"),
             Poison => err("poison expression reached lowering"),
         }
@@ -687,6 +688,162 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             None => None,
         };
         Ok(self.append(block, builders::nullable_create(value, result_ty, loc)))
+    }
+
+    /// Lower a closure creation.
+    ///
+    /// The runtime closure has no separate capture environment: captures and
+    /// parameters share one input list with the captures leading, so a closure
+    /// lowers to a shared `rc<closure<(captures ++ params) -> ret>>` built inline
+    /// (`reussir.closure.create` with a body region), and each captured value is
+    /// then supplied with one `reussir.closure.apply`, leaving the user-visible
+    /// `rc<closure<params -> ret>>`.
+    ///
+    /// The body region is `IsolatedFromAbove`: its block arguments *are* the
+    /// closure inputs (captures then parameters), so it is lowered in a fresh
+    /// environment that binds them to those arguments and inherits no enclosing
+    /// region — a closure cannot capture a `flex`/region-local value, so the body
+    /// never allocates into the creator's region. The reference-count ops the
+    /// ownership analysis placed for the captures (a `dup` before this node for
+    /// each still-live captured `rc`) and inside the body ride on the surrounding
+    /// [`expr`](Self::expr) walk as usual.
+    fn closure<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        c: &mir::ClosureExpr<'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let ret = c.body.ty;
+        // The closure's inputs at creation: every capture, then every parameter.
+        let inputs: Vec<(VarId, Ty<'tcx>)> =
+            c.captures.iter().chain(c.params.iter()).copied().collect();
+        let input_tys: Vec<Ty<'tcx>> = inputs.iter().map(|&(_, t)| t).collect();
+        let created_ty = self.tys.closure_type(&input_tys, ret)?;
+
+        // The body block takes one argument per closure input, in order.
+        let arg_mlir = input_tys
+            .iter()
+            .map(|&t| self.tys.mlir_ty(t))
+            .collect::<Result<Vec<_>>>()?;
+        let block_args: SmallVec<[(Type<'c>, Location<'c>); 8]> =
+            arg_mlir.iter().map(|t| (*t, loc)).collect();
+        let body_block = Block::new(&block_args);
+        let mut body_env = Env::new(None);
+        for (i, &(var, ty)) in inputs.iter().enumerate() {
+            let arg = body_block
+                .argument(i)
+                .map_err(|e| LoweringError(format!("missing closure body argument: {e}").into()))?;
+            body_env.vars.insert(var, arg.into());
+            self.bind_var_ty(var, ty);
+        }
+        let value = self.expr(&body_block, &mut body_env, c.body)?;
+        if is_unit(ret) {
+            body_block.append_operation(builders::closure_yield(None, loc));
+        } else {
+            let v = value.ok_or_else(|| LoweringError("closure body produced no value".into()))?;
+            body_block.append_operation(builders::closure_yield(Some(v), loc));
+        }
+        let body_region = Region::new();
+        body_region.append_block(body_block);
+        let mut closure = self.append(
+            block,
+            builders::closure_create(created_ty, body_region, loc),
+        );
+
+        // Supply the captured values, consuming the leading inputs in order; each
+        // apply drops one input, so after capture `i` the residual closure keeps
+        // `input_tys[i + 1..]` — a slice of the original inputs, no per-step shift.
+        for (i, &(var, _)) in c.captures.iter().enumerate() {
+            let cap_val = env.vars.get(&var).copied().ok_or_else(|| {
+                LoweringError(format!("unbound captured variable {var:?}").into())
+            })?;
+            let applied_ty = self.tys.closure_type(&input_tys[i + 1..], ret)?;
+            closure = self.append(
+                block,
+                builders::closure_apply(cap_val, closure, applied_ty, loc),
+            );
+        }
+        Ok(closure)
+    }
+
+    /// Lower a closure call `target(args)`.
+    ///
+    /// The target lowers to `rc<closure<params -> ret>>`; each argument is
+    /// supplied with a `reussir.closure.apply` that consumes the leading input.
+    /// A partial application (fewer arguments than parameters) stops at the
+    /// residual closure; a full application evaluates it with
+    /// `reussir.closure.eval` and produces the result (`None` for a unit return).
+    ///
+    /// Both `apply` (which writes into the closure box in place) and `eval` (which
+    /// hands the box's payload to the body as owned, to be consumed) are only
+    /// sound on a uniquely-owned closure. The target here is an arbitrary closure
+    /// value that may be shared (the ownership analysis hands us one owned
+    /// reference, dup'ing it when the closure is reused), so it is always first
+    /// passed through `reussir.closure.uniqify`, which deep-clones it when it is
+    /// shared and returns it as-is when unique. (The capture-application in
+    /// [`closure`](Self::closure) needs no uniqify because it feeds directly from
+    /// `closure.create`, which is already unique.)
+    fn closure_call<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b>,
+        target: &Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let loc = self.loc();
+        let (params, ret) = match target.ty.kind() {
+            TyKind::Closure { params, ret } => (*params, *ret),
+            _ => return err("closure call target is not a closure"),
+        };
+        let closure_val = self
+            .expr(block, env, target)?
+            .ok_or_else(|| LoweringError("closure call target is unit".into()))?;
+        // Make the target unique before touching it. `apply` writes its argument
+        // into the closure box in place, and `eval` hands the box's payload (the
+        // values applied by earlier, possibly-curried applications) to the body as
+        // owned — the body consumes them. A shared closure is referenced by other
+        // holders that still own that same payload, so applying to *or* evaluating
+        // it in place would corrupt or double-free their values. This is needed
+        // even for a zero-argument (eval-only) call, since the target may already
+        // carry payload. `uniqify` deep-clones a shared closure and is a no-op on
+        // a unique one.
+        let target_ty = self.tys.mlir_ty(target.ty)?;
+        let mut closure = self.append(
+            block,
+            builders::closure_uniqify(closure_val, target_ty, loc),
+        );
+        for (i, a) in args.iter().enumerate() {
+            let arg_val = self
+                .expr(block, env, a)?
+                .ok_or_else(|| LoweringError("closure call argument is unit".into()))?;
+            // Apply consumes the leading input, so after argument `i` the residual
+            // closure keeps `params[i + 1..]` — a slice of the original parameters,
+            // no per-step shift or copy.
+            let applied_ty = self.tys.closure_type(&params[i + 1..], ret)?;
+            closure = self.append(
+                block,
+                builders::closure_apply(arg_val, closure, applied_ty, loc),
+            );
+        }
+        // A partial application leaves a closure value; only a fully-applied
+        // closure (every parameter supplied) is evaluated. Comparing arities
+        // rather than inspecting the result type stays correct when `ret` is
+        // itself a closure type.
+        if args.len() < params.len() {
+            return Ok(Some(closure));
+        }
+        let result_ty = if is_unit(ret) {
+            None
+        } else {
+            Some(self.tys.mlir_ty(ret)?)
+        };
+        let op = block.append_operation(builders::closure_eval(closure, result_ty, loc));
+        if result_ty.is_some() {
+            Ok(Some(op.result(0).unwrap().into()))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Project a chain of fields out of a record value.
@@ -998,7 +1155,10 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
     /// a reference (which increments every rc pointer it reaches).
     fn emit_inc<'b>(&self, block: &'b Block<'c>, val: Value<'c, 'b>, ty: Ty<'tcx>) -> Result<()> {
         let loc = self.loc();
-        if self.tys.is_shared_record(ty) {
+        // A managed `rc` pointer — a shared record, a rigid regional record, or a
+        // closure — is bumped directly; an inline `[value]` record is acquired
+        // through a reference (which reaches the rc pointers inside it).
+        if self.tys.is_managed_rc(ty) {
             block.append_operation(dialect::rc_inc(self.context, val, loc).into());
             Ok(())
         } else if matches!(ty.kind(), TyKind::Record { .. }) {
@@ -1015,7 +1175,10 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
     /// reference (releasing every rc pointer it reaches).
     fn emit_dec<'b>(&self, block: &'b Block<'c>, val: Value<'c, 'b>, ty: Ty<'tcx>) -> Result<()> {
         let loc = self.loc();
-        if self.tys.is_shared_record(ty) {
+        // The dual of [`emit_inc`](Self::emit_inc): a managed `rc` pointer (shared
+        // record, rigid regional record, or closure) is decremented directly, an
+        // inline `[value]` record dropped through a reference.
+        if self.tys.is_managed_rc(ty) {
             block.append_operation(dialect::rc_dec(self.context, val, loc).into());
             Ok(())
         } else if matches!(ty.kind(), TyKind::Record { .. }) {

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -30,11 +30,19 @@
 //!   mutation of a `[field]` link (`c->f := …` — project the `nullable<rc<…>>`
 //!   slot to a writable `field` reference and store), with the `Nullable`
 //!   constructor lowering to `reussir.nullable.create`.
+//! * **closures** — a closure lowers to a shared `rc<closure<…>>` built inline
+//!   (`reussir.closure.create` with a body region; the closure-outlining pass
+//!   generates the evaluate/drop/clone functions), with captures supplied as the
+//!   leading inputs via `reussir.closure.apply`. A call first makes its
+//!   (possibly-shared) target unique with `reussir.closure.uniqify` — `apply`
+//!   mutates the closure box in place — then applies its arguments the same way
+//!   and, once fully applied, evaluates with `reussir.closure.eval`; partial
+//!   application stops at the residual closure.
 //!
 //! Reading a `[field]` link back (which needs `match`/`nullable.dispatch`), a
-//! non-`[field]` member that is itself a regional record, enums/`match`,
-//! closures, and strings are not yet lowered and surface as an explicit
-//! [`LoweringError`] rather than wrong code.
+//! non-`[field]` member that is itself a regional record, enums/`match`, and
+//! strings are not yet lowered and surface as an explicit [`LoweringError`]
+//! rather than wrong code.
 //!
 //! Every callee/trampoline target in the MIR is already resolved to an interned
 //! [`mir::Symbol`](reussir_core::full::mir::Symbol) (mono did the mangling), so
@@ -611,6 +619,189 @@ mod tests {
                 &reussir_backend::pipeline::LoweringOptions::default(),
             )
             .expect("pipeline lowers the scalar module to LLVM");
+        });
+    }
+
+    #[test]
+    fn uniqifies_a_zero_argument_closure_call_before_eval() {
+        // A zero-argument call evaluates the target with no `apply`. `eval` still
+        // hands the closure's payload to the body to consume, so a shared target
+        // (which may carry payload from earlier curried applications) must be made
+        // unique first — evaluating it in place would let the body consume values
+        // another holder still owns. So the target is uniqified even with no
+        // arguments to apply.
+        let src = r#"
+            pub fn thunk() -> i64 { (|| 42)() }
+        "#;
+        let mlir = lower_source(src);
+        assert!(
+            mlir.contains("reussir.closure.uniqify"),
+            "no uniqify:\n{mlir}"
+        );
+        assert!(mlir.contains("reussir.closure.eval"), "no eval:\n{mlir}");
+        assert!(
+            !mlir.contains("reussir.closure.apply"),
+            "unexpected apply:\n{mlir}"
+        );
+    }
+
+    #[test]
+    fn drops_a_frozen_regional_record_by_reference_count() {
+        // A regional record that escapes its region is frozen to a `rigid` `rc`
+        // box — a managed, reference-counted value, not an inline aggregate. When
+        // such a value is bound and then goes dead, the ownership analysis drops
+        // it, which must lower to a direct `reussir.rc.dec` on the `rc` pointer
+        // (not an inline `ref.drop`, which would mis-handle the pointer). Here `c`
+        // is read by two projections — a projection *borrows* the parent and the
+        // extracted `i64` field is not itself reference-counted, so neither use
+        // transfers ownership (no `dup`): `c` is simply dropped once after the
+        // last one.
+        let src = r#"
+            struct [regional] Cell { v: i64 }
+            regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
+            pub fn run(n: i64) -> i64 {
+                let c = regional { make(n) };
+                c.v + c.v
+            }
+        "#;
+        let context = reussir_backend::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let mut module =
+                lower_program(&context, tcx, &full, None, None).expect("lowering succeeds");
+            let printed = module.as_operation().to_string();
+            // The frozen `rigid` box is dropped with a direct reference-count
+            // decrement, not spilled and dropped as an inline record.
+            assert!(printed.contains("reussir.rc.dec"), "{printed}");
+            assert!(printed.contains("rigid"), "{printed}");
+            // Borrowing projections of a non-owned (`i64`) field transfer no
+            // ownership, so `c` is dropped exactly once with no matching `inc`.
+            assert!(!printed.contains("reussir.rc.inc"), "{printed}");
+            reussir_backend::pipeline::run_lowering_pipeline(
+                &context,
+                &mut module,
+                &reussir_backend::pipeline::LoweringOptions::default(),
+            )
+            .expect("pipeline lowers the frozen-record drop to LLVM");
+        });
+    }
+
+    #[test]
+    fn dups_a_frozen_regional_record_reused_across_calls() {
+        // The `inc` dual of the drop test: a frozen `rigid` regional record reused
+        // in two calls is not a last use at the first, so the ownership analysis
+        // `dup`s it — which must lower to a direct `reussir.rc.inc` on the `rc`
+        // pointer (the managed-rc path), then each callee consumes its own
+        // reference. Passing `c` to `take` twice forces exactly this.
+        let src = r#"
+            struct [regional] Cell { v: i64 }
+            regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
+            fn take(c: Cell) -> i64 { c.v }
+            pub fn run(n: i64) -> i64 {
+                let c = regional { make(n) };
+                take(c) + take(c)
+            }
+        "#;
+        let context = reussir_backend::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let mut module =
+                lower_program(&context, tcx, &full, None, None).expect("lowering succeeds");
+            let printed = module.as_operation().to_string();
+            // The reused frozen box is retained with a direct reference-count
+            // increment, and dropped (by the callees / at last use) with a
+            // decrement — both on the `rigid` `rc` pointer.
+            assert!(printed.contains("reussir.rc.inc"), "{printed}");
+            assert!(printed.contains("reussir.rc.dec"), "{printed}");
+            assert!(printed.contains("rigid"), "{printed}");
+            reussir_backend::pipeline::run_lowering_pipeline(
+                &context,
+                &mut module,
+                &reussir_backend::pipeline::LoweringOptions::default(),
+            )
+            .expect("pipeline lowers the frozen-record reuse to LLVM");
+        });
+    }
+
+    #[test]
+    fn lowers_a_closure_with_a_capture_to_verifiable_mlir() {
+        // A closure captures the enclosing `n` and takes one parameter `x`. It
+        // lowers to an inline `reussir.closure.create` over `(n, x) -> i64`; the
+        // captured `n` is supplied with a `reussir.closure.apply`, leaving a
+        // `(x) -> i64` closure. Calling it applies `x` and evaluates
+        // (`reussir.closure.eval`) the fully-applied closure.
+        let src = r#"
+            pub fn adder(n: i64) -> i64 { (|x: i64| x + n)(1) }
+            extern "C" trampoline "adder_ffi" = adder;
+        "#;
+        let mlir = lower_source(src);
+        assert!(mlir.contains("reussir.closure.create"), "{mlir}");
+        assert!(mlir.contains("reussir.closure.apply"), "{mlir}");
+        assert!(mlir.contains("reussir.closure.eval"), "{mlir}");
+        assert!(mlir.contains("reussir.closure.yield"), "{mlir}");
+        // The call makes the (possibly-shared) target unique before the in-place
+        // `apply`; the capture-application on the fresh `create` result does not.
+        assert!(mlir.contains("reussir.closure.uniqify"), "{mlir}");
+        // The closure value is a shared `rc` over a `closure` type.
+        assert!(mlir.contains("!reussir.closure<"), "{mlir}");
+    }
+
+    #[test]
+    fn lowers_a_partially_applied_closure() {
+        // Applying fewer arguments than parameters stops at the residual closure:
+        // the inner `(…)(1)` supplies one of two parameters, so it lowers to a
+        // `reussir.closure.apply` whose result is still a closure (no
+        // `reussir.closure.eval`); the outer `(…)(2)` fully applies and evaluates.
+        let src = r#"
+            pub fn sum(n: i64) -> i64 { ((|x: i64, y: i64| x + y + n)(1))(2) }
+            extern "C" trampoline "sum_ffi" = sum;
+        "#;
+        let mlir = lower_source(src);
+        assert!(mlir.contains("reussir.closure.create"), "{mlir}");
+        assert!(mlir.contains("reussir.closure.apply"), "{mlir}");
+        // The final application evaluates the fully-applied closure.
+        assert!(mlir.contains("reussir.closure.eval"), "{mlir}");
+    }
+
+    #[test]
+    fn lowers_a_closure_through_the_pipeline() {
+        // The whole closure path lowers to the LLVM dialect: the closure-outlining
+        // pass turns the inline `closure.create` body into an evaluate function
+        // with a vtable and drop/clone functions, and apply/eval lower to the
+        // runtime protocol.
+        let src = r#"
+            pub fn adder(n: i64) -> i64 { (|x: i64| x + n)(1) }
+            extern "C" trampoline "adder_ffi" = adder;
+        "#;
+        let context = reussir_backend::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let mut module =
+                lower_program(&context, tcx, &full, None, None).expect("lowering succeeds");
+            reussir_backend::pipeline::run_lowering_pipeline(
+                &context,
+                &mut module,
+                &reussir_backend::pipeline::LoweringOptions::default(),
+            )
+            .expect("pipeline lowers the closure module to LLVM");
         });
     }
 }

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -27,7 +27,7 @@ use std::cell::RefCell;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use reussir_backend::dialect::ty::{
-    ReussirAtomicKind, ReussirCapability, ReussirRecordKind, nullable, rc,
+    ReussirAtomicKind, ReussirCapability, ReussirRecordKind, closure, nullable, rc,
     record_complete_in_place, record_incomplete, record_is_complete, r#ref, region,
 };
 use reussir_backend::melior::Context;
@@ -105,6 +105,16 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             .is_some_and(|rec| rec.default_cap == DefaultCap::Regional)
     }
 
+    /// Whether a value of type `ty` is represented as a managed `!reussir.rc<…>`
+    /// pointer whose refcount is adjusted directly with `rc.inc`/`rc.dec`: a
+    /// `[shared]` record, a regional record (reference-counted once frozen to
+    /// `rigid` — the only regional coloring that is a resource), or a closure.
+    /// This is the complement, among reference-counted values, of an inline
+    /// `[value]` record — which is acquired/dropped through a reference instead.
+    pub(super) fn is_managed_rc(&self, ty: Ty<'tcx>) -> bool {
+        self.is_shared_record(ty) || self.is_regional_record(ty) || is_closure(ty)
+    }
+
     /// Lower a ground type to MLIR: records resolve through the layout table, a
     /// nullable pointer wraps its (pointer-typed) element, and everything else is
     /// a scalar.
@@ -125,6 +135,9 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
                 }
                 Ok(nullable(self.mlir_ty(inner)?))
             }
+            // A closure value is a shared `rc<closure<params -> ret>>`; captures
+            // have already been supplied (see [`closure_type`](Self::closure_type)).
+            TyKind::Closure { params, ret } => self.closure_type(params, ret),
             _ => scalar_ty(self.context, ty),
         }
     }
@@ -305,6 +318,25 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         Ok(payload)
     }
 
+    /// `!reussir.rc<closure<(inputs) -> ret>, shared>` — the pointer type for a
+    /// closure value over `inputs`. A closure is always a shared `rc` box; the
+    /// runtime has no separate capture environment, so `inputs` is the closure's
+    /// full argument list (captures followed by parameters at creation, or just
+    /// the remaining parameters once captures have been applied). A unit return is
+    /// a closure with no output type.
+    pub(super) fn closure_type(&self, inputs: &[Ty<'tcx>], ret: Ty<'tcx>) -> Result<Type<'c>> {
+        let input_tys = inputs
+            .iter()
+            .map(|&t| self.mlir_ty(t))
+            .collect::<Result<Vec<_>>>()?;
+        let output = if is_unit(ret) {
+            None
+        } else {
+            Some(self.mlir_ty(ret)?)
+        };
+        Ok(self.rc_type(closure(self.context, &input_tys, output)))
+    }
+
     /// `!reussir.rc<inner, shared>` — the pointer type for a heap-allocated,
     /// reference-counted value with the default (non-atomic) box layout.
     pub(super) fn rc_type(&self, inner: Type<'c>) -> Type<'c> {
@@ -394,6 +426,12 @@ pub(super) fn is_unit(ty: Ty<'_>) -> bool {
     matches!(ty.kind(), TyKind::Unit)
 }
 
+/// Whether `ty` is a closure type — a shared `rc<closure<…>>` value, which is
+/// reference-counted like a `[shared]` record.
+pub(super) fn is_closure(ty: Ty<'_>) -> bool {
+    matches!(ty.kind(), TyKind::Closure { .. })
+}
+
 /// The MLIR type for a ground scalar Reussir type. Records are handled by
 /// [`TypeCtx::record_type`], which intercepts them before this fallback; reaching
 /// the `Record` arm here is a bug.
@@ -413,7 +451,8 @@ fn scalar_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
         TyKind::Str => err("string type lowering not yet implemented"),
         TyKind::Record { .. } => err("record type reached scalar lowering without a layout"),
         TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),
-        TyKind::Closure { .. } => err("closure type lowering not yet implemented"),
+        // Intercepted by [`TypeCtx::mlir_ty`]; reaching here is a bug.
+        TyKind::Closure { .. } => err("closure type reached scalar lowering without an rc wrapper"),
         TyKind::Bottom => err("bottom type reached lowering"),
         TyKind::Generic(_) | TyKind::Hole(_) => err("non-ground type reached lowering"),
     }

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -258,6 +258,119 @@ fn lowers_variant_debug_info_through_the_pipeline() {
 }
 
 #[test]
+fn runs_a_closure_with_a_captured_value() {
+    // A closure captures the enclosing `n` and takes one parameter. It lowers to
+    // an inline `closure.create` over `(n, x) -> i64`; the capture is supplied
+    // with `closure.apply`, and the call uniqifies, applies the argument, and
+    // evaluates. If the whole create/apply/eval protocol and the closure-box
+    // layout are right, the arithmetic comes back exact.
+    let src = r#"
+        pub fn adder(n: i64) -> i64 { (|x: i64| x + n)(1) }
+        extern "C" trampoline "adder_ffi" = adder;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("adder_ffi").expect("lookup adder_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        // (|x| x + n)(1) = 1 + n
+        assert_eq!(f(41), 42);
+        assert_eq!(f(-1), 0);
+    });
+}
+
+#[test]
+fn runs_a_closure_capturing_a_shared_record() {
+    // The captured value is a heap-allocated `[shared]` record, so the closure
+    // box holds an `rc` pointer in its payload. Evaluating the closure hands the
+    // payload to the body as owned and the body consumes it, so the box is freed
+    // exactly once (the capture is a last use — moved in, not dup'd). A wrong
+    // refcount would double-free or leak the `Box`; the returned scalar pins it.
+    let src = r#"
+        struct [shared] Box { v: i64 }
+        fn mk(v: i64) -> Box { Box { v: v } }
+        pub fn run(n: i64) -> i64 {
+            let b = mk(n);
+            (|x: i64| x + b.v)(1)
+        }
+        extern "C" trampoline "run_ffi" = run;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("run_ffi").expect("lookup run_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        // (|x| x + b.v)(1) with b.v = n  ⇒  1 + n
+        assert_eq!(f(41), 42);
+        assert_eq!(f(99), 100);
+    });
+}
+
+#[test]
+fn runs_a_partially_then_fully_applied_closure() {
+    // The inner `(…)(6)` supplies one of two parameters — a partial application
+    // that uniqifies, applies, and stops at the residual `(y) -> i64` closure.
+    // The outer `(…)(7)` uniqifies that residual, applies the last argument, and
+    // evaluates. Exercises the multi-argument apply chain and both the
+    // partial-application and full-application paths in one call.
+    let src = r#"
+        pub fn run(n: i64) -> i64 { ((|x: i64, y: i64| x * y + n)(6))(7) }
+        extern "C" trampoline "run_ffi" = run;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("run_ffi").expect("lookup run_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        // 6 * 7 + n = 42 + n
+        assert_eq!(f(0), 42);
+        assert_eq!(f(8), 50);
+    });
+}
+
+#[test]
+fn runs_regional_record_construction_and_projection() {
+    // A `[regional]` record is region-allocated as a `flex` box inside a
+    // `region-run` scope; projecting a scalar field out of it leaves the region
+    // as a plain `i64`. Drives the region lifecycle — allocate into the arena,
+    // read the field, tear the region down — through the runtime.
+    let src = r#"
+        struct [regional] Cell { v: i64 }
+        regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
+        pub fn run(n: i64) -> i64 { regional { make(n).v } }
+        extern "C" trampoline "run_ffi" = run;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("run_ffi").expect("lookup run_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        assert_eq!(f(7), 7);
+        assert_eq!(f(-3), -3);
+    });
+}
+
+#[test]
+fn runs_a_reused_frozen_regional_record() {
+    // A regional record that escapes its region is frozen to a `rigid` `rc` box —
+    // a managed, reference-counted value. Reusing `c` across two `take` calls is
+    // not a last use at the first, so the ownership analysis `dup`s it (a direct
+    // `rc.inc` on the `rc` pointer), and each callee consumes and drops its
+    // reference (`rc.dec`), freeing the box exactly once. A wrong count would
+    // double-free (crash) or leak; the arithmetic result pins it down. This is
+    // the runtime check for the managed-rc inc/dec path on a frozen record.
+    let src = r#"
+        struct [regional] Cell { v: i64 }
+        regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
+        fn take(c: Cell) -> i64 { c.v }
+        pub fn run(n: i64) -> i64 {
+            let c = regional { make(n) };
+            take(c) + take(c)
+        }
+        extern "C" trampoline "run_ffi" = run;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("run_ffi").expect("lookup run_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        // take(c) + take(c) = n + n
+        assert_eq!(f(21), 42);
+        assert_eq!(f(-5), -10);
+    });
+}
+
+#[test]
 fn runs_iterative_helper_and_signed_arithmetic() {
     let src = r#"
         fn iter_impl(n: u64, a: u64, b: u64) -> u64 {


### PR DESCRIPTION
## Summary

Lowers `Closure` and `ClosureCall` from the Full MIR to MLIR — the last non-`match`/non-string gap in the expression lowering subset.

A closure value is a shared `!reussir.rc<closure<(params) -> ret>>`. Following the runtime model (no separate capture environment), **captures and parameters share one input list with the captures leading**:

- **Creation** emits an inlined `reussir.closure.create` whose body region's block arguments *are* the closure inputs (captures then params), then supplies each captured value with `reussir.closure.apply`. The in-pipeline `ClosureOutlining` pass turns the inlined body into an evaluate function and generates the vtable + drop/clone functions.
- **A call** applies its arguments the same way and, once fully applied (compared by arity, since `ret` can itself be a closure), evaluates with `reussir.closure.eval`; partial application stops at the residual closure.

## Ownership model (the crux)

`reussir.closure.apply` is a **destructive in-place write** — it stores the argument into the closure box and returns the same pointer, with no uniqueness check — and it **takes ownership** of the argument; `reussir.closure.eval` **consumes** the closure. So:

- Capture-application runs on the fresh `closure.create` result (refcount 1 ⇒ already unique) — **no uniqify**.
- A call's target may be shared, so it is first passed through `reussir.closure.uniqify` (copy-on-write: unique ⇒ passthrough, shared ⇒ clone + drop original) **before** the first `apply`.

This balances against the Perceus ownership analysis, which consumes the target and each argument (dup'ing the target on reuse): `uniqify → apply → eval` consumes exactly that one target reference plus each argument, with no extra explicit drop. A closure `rc` is inc/dec'd directly, like a shared record. This mirrors the `list_map.mlir` integration test's convention.

## Changes

- `reussir-backend/builders.rs` — `closure_create`, `closure_yield`, `closure_apply`, `closure_uniqify`, `closure_eval`.
- `reussir-codegen/lower/ty.rs` — `closure_type` → `rc<closure<inputs -> ret>>`; `mlir_ty` closure arm.
- `reussir-codegen/lower/expr.rs` — `closure` (create + capture-apply) and `closure_call` (uniqify → apply → eval); `emit_inc`/`emit_dec` extended for closures.
- `reussir-codegen/lower/mod.rs` — scope docs + tests.

## Testing

`cargo test -p reussir-codegen -p reussir-backend` — green (21 codegen + 8 backend), clean under `-D warnings`. New tests cover capture + full application, partial application, and a full pipeline-to-LLVM run that exercises closure outlining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)