### PR TITLE
[compiler] rrc: clang-style multi-stage driver with IR I/O targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "melior"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1136,8 @@ dependencies = [
  "reussir-codegen",
  "reussir-core",
  "reussir-syntax",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1560,10 +1571,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +441,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -605,6 +626,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "llvm-sys"
@@ -1011,6 +1038,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1169,7 @@ dependencies = [
  "reussir-codegen",
  "reussir-core",
  "reussir-syntax",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1231,6 +1265,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1431,6 +1478,19 @@ dependencies = [
  "cc",
  "paste",
  "thiserror",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/crates/reussir-compiler/Cargo.toml
+++ b/crates/reussir-compiler/Cargo.toml
@@ -35,3 +35,7 @@ palc.workspace = true
 # so `-v`/`RUST_LOG` surface them (to stderr, never stdout).
 tracing.workspace = true
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+
+[dev-dependencies]
+# Auto-cleaned scratch directories for the driver integration tests.
+tempfile = "3"

--- a/crates/reussir-compiler/Cargo.toml
+++ b/crates/reussir-compiler/Cargo.toml
@@ -31,3 +31,7 @@ reussir-codegen = { path = "../reussir-codegen" }
 reussir-core = { path = "../reussir-core" }
 reussir-syntax = { path = "../reussir-syntax" }
 palc.workspace = true
+# The lowering and backend pipeline emit `tracing` events; install a subscriber
+# so `-v`/`RUST_LOG` surface them (to stderr, never stdout).
+tracing.workspace = true
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/crates/reussir-compiler/src/lib.rs
+++ b/crates/reussir-compiler/src/lib.rs
@@ -15,9 +15,11 @@ use std::ffi::{CString, c_char};
 use std::path::Path;
 
 use llvm_sys::core::{
-    LLVMContextDispose, LLVMDisposeMessage, LLVMDisposeModule, LLVMPrintModuleToString,
+    LLVMContextCreate, LLVMContextDispose, LLVMCreateMemoryBufferWithMemoryRangeCopy,
+    LLVMDisposeMemoryBuffer, LLVMDisposeMessage, LLVMDisposeModule, LLVMPrintModuleToString,
     LLVMSetTarget,
 };
+use llvm_sys::ir_reader::LLVMParseIRInContext2;
 use llvm_sys::prelude::LLVMModuleRef;
 use llvm_sys::target::{
     LLVM_InitializeAllAsmParsers, LLVM_InitializeAllAsmPrinters, LLVM_InitializeAllTargetInfos,
@@ -222,6 +224,37 @@ impl TargetMachine {
 impl Drop for TargetMachine {
     fn drop(&mut self) {
         unsafe { LLVMDisposeTargetMachine(self.machine) }
+    }
+}
+
+/// Parses LLVM IR text into a fresh context, yielding a [`Finalized`] ready for
+/// [`emit_to_file`] — the entry point for a `.ll` input, which skips the whole
+/// MLIR front of the pipeline. `name` labels parse diagnostics.
+pub fn parse_llvm_ir(name: &str, source: &str) -> Result<Finalized, String> {
+    init_targets(false);
+    unsafe {
+        let context = LLVMContextCreate();
+        // `source` is borrowed, so copy it into an LLVM-owned buffer we control.
+        let name_c =
+            CString::new(name).unwrap_or_else(|_| CString::new("<input>").expect("valid cstr"));
+        let buffer = LLVMCreateMemoryBufferWithMemoryRangeCopy(
+            source.as_ptr() as *const c_char,
+            source.len(),
+            name_c.as_ptr(),
+        );
+        let mut module: LLVMModuleRef = std::ptr::null_mut();
+        let mut err: *mut c_char = std::ptr::null_mut();
+        // `LLVMParseIRInContext2` copies what it needs and does *not* take the
+        // buffer, so we free it ourselves either way.
+        let failed = LLVMParseIRInContext2(context, buffer, &mut module, &mut err) != 0;
+        LLVMDisposeMemoryBuffer(buffer);
+        if failed {
+            let msg = c_str(err);
+            LLVMDisposeMessage(err);
+            LLVMContextDispose(context);
+            return Err(format!("{name}: failed to parse LLVM IR: {msg}"));
+        }
+        Ok(Finalized { context, module })
     }
 }
 

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -37,7 +37,10 @@ use reussir_syntax::kind::{Resolver, TokenKey};
 
 /// A stage on the compilation chain, ordered from source to object so a target
 /// can be compared against the input (`>=` means "reachable going forward").
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+///
+/// Deriving [`palc::ValueEnum`] gives `--emit`/`--from` their value parsing and a
+/// kebab-case [`Display`] (`MlirLlvm` → `mlir-llvm`, `LlvmIr` → `llvm-ir`, …).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, palc::ValueEnum)]
 enum Stage {
     /// Reussir source (`.rr`).
     Rr,
@@ -58,17 +61,13 @@ enum Stage {
 }
 
 impl Stage {
-    fn name(self) -> &'static str {
-        match self {
-            Stage::Rr => "rr",
-            Stage::Hir => "hir",
-            Stage::Mir => "mir",
-            Stage::Mlir => "mlir",
-            Stage::MlirLlvm => "mlir-llvm",
-            Stage::LlvmIr => "llvm-ir",
-            Stage::Asm => "asm",
-            Stage::Obj => "obj",
-        }
+    /// Whether this stage can be *read* as an input (it has a parser). The two
+    /// derived MLIR/assembly forms and the object file are outputs only.
+    fn is_input(self) -> bool {
+        matches!(
+            self,
+            Stage::Rr | Stage::Hir | Stage::Mir | Stage::Mlir | Stage::LlvmIr
+        )
     }
 
     /// The stage a file extension denotes, if any.
@@ -113,12 +112,12 @@ struct Cli {
     /// Stage to emit: `hir`, `mir`, `mlir`, `mlir-llvm`, `llvm-ir`, `asm`, or
     /// `obj`. Defaults to the output extension (else `obj`).
     #[arg(short = 't', long = "emit")]
-    emit: Option<String>,
+    emit: Option<Stage>,
 
     /// Treat the input as this stage instead of inferring from its extension:
     /// `rr`, `hir`, `mir`, `mlir`, or `llvm-ir`.
     #[arg(short = 'x', long = "from")]
-    from: Option<String>,
+    from: Option<Stage>,
 
     /// Optimization level: `none`, `default`, `aggressive`, or `size`.
     #[arg(short = 'O', long = "opt", default_value = "default")]
@@ -153,64 +152,45 @@ struct Cli {
     /// Emit DWARF debug info (source locations, function/variable debug types).
     #[arg(short = 'g', long = "debug")]
     debug: bool,
-}
 
-fn parse_input_stage(s: &str) -> Result<Stage, String> {
-    Ok(match s {
-        "rr" => Stage::Rr,
-        "hir" => Stage::Hir,
-        "mir" => Stage::Mir,
-        "mlir" => Stage::Mlir,
-        "ll" | "llvm-ir" | "llvmir" => Stage::LlvmIr,
-        other => return Err(format!("unknown input stage `{other}`")),
-    })
-}
-
-fn parse_emit_stage(s: &str) -> Result<Stage, String> {
-    Ok(match s {
-        "hir" => Stage::Hir,
-        "mir" => Stage::Mir,
-        "mlir" => Stage::Mlir,
-        "mlir-llvm" => Stage::MlirLlvm,
-        "llvm-ir" | "llvmir" | "ll" => Stage::LlvmIr,
-        "asm" | "assembly" => Stage::Asm,
-        "obj" | "object" => Stage::Obj,
-        other => return Err(format!("unknown --emit `{other}`")),
-    })
+    /// Log the lowering/backend `tracing` events (to stderr) at DEBUG level.
+    /// `RUST_LOG`, if set, takes precedence over this.
+    #[arg(short = 'v', long = "verbose")]
+    verbose: bool,
 }
 
 /// The stage the input enters at: `--from` if given, else the extension. `-`
 /// (stdin) has no extension, so it defaults to source.
 fn resolve_input_stage(cli: &Cli) -> Result<Stage, String> {
-    if let Some(from) = &cli.from {
-        return parse_input_stage(from);
+    let stage = if let Some(from) = cli.from {
+        from
+    } else if cli.input.as_os_str() == "-" {
+        Stage::Rr
+    } else {
+        Stage::from_extension(&cli.input).ok_or_else(|| {
+            format!(
+                "cannot infer the input stage of `{}`; pass --from",
+                cli.input.display()
+            )
+        })?
+    };
+    if !stage.is_input() {
+        return Err(format!("`{stage}` is an output-only stage; it cannot be read as input"));
     }
-    if cli.input.as_os_str() == "-" {
-        return Ok(Stage::Rr);
-    }
-    match Stage::from_extension(&cli.input) {
-        Some(stage @ (Stage::Rr | Stage::Hir | Stage::Mir | Stage::Mlir | Stage::LlvmIr)) => {
-            Ok(stage)
-        }
-        Some(other) => Err(format!(
-            "`{}` is an output-only stage; cannot read a {} input",
-            other.name(),
-            other.name()
-        )),
-        None => Err(format!(
-            "cannot infer the input stage of `{}`; pass --from",
-            cli.input.display()
-        )),
-    }
+    Ok(stage)
 }
 
 /// The stage the driver stops at: `--emit` if given, else the output extension,
 /// else an object file.
 fn resolve_target(cli: &Cli) -> Result<Stage, String> {
-    if let Some(emit) = &cli.emit {
-        return parse_emit_stage(emit);
+    let stage = cli
+        .emit
+        .or_else(|| Stage::from_extension(&cli.output))
+        .unwrap_or(Stage::Obj);
+    if stage == Stage::Rr {
+        return Err("`rr` is the source input, not an emittable stage".into());
     }
-    Ok(Stage::from_extension(&cli.output).unwrap_or(Stage::Obj))
+    Ok(stage)
 }
 
 fn parse_opt(s: &str) -> Result<OptLevel, String> {
@@ -284,8 +264,22 @@ enum Produced<'c> {
     Module(Module<'c>),
 }
 
+/// Install a `tracing` subscriber writing to **stderr** (so it never corrupts a
+/// `-o -` stdout dump). `RUST_LOG` wins if set; otherwise `-v` selects DEBUG and
+/// the default is quiet (WARN).
+fn init_tracing(verbose: bool) {
+    use tracing_subscriber::EnvFilter;
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(if verbose { "debug" } else { "warn" }));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
+    init_tracing(cli.verbose);
     match run(&cli) {
         Ok(true) => ExitCode::SUCCESS,
         Ok(false) => ExitCode::FAILURE,
@@ -303,17 +297,14 @@ fn run(cli: &Cli) -> Result<bool, String> {
     let target = resolve_target(cli)?;
     if target < input_stage {
         return Err(format!(
-            "cannot emit `{}` from a `{}` input: the pipeline only runs forward",
-            target.name(),
-            input_stage.name()
+            "cannot emit `{target}` from a `{input_stage}` input: the pipeline only runs forward"
         ));
     }
     // Only the text dumps stream to stdout; `llvm-ir`/`asm`/`obj` go through the
     // file-based LLVM emitter, so `-o -` would write a file literally named `-`.
     if cli.output.as_os_str() == "-" && target.output_kind().is_some() {
         return Err(format!(
-            "cannot write `{}` to stdout; give a file path with -o",
-            target.name()
+            "cannot write `{target}` to stdout; give a file path with -o"
         ));
     }
     let opt = parse_opt(&cli.opt)?;
@@ -331,7 +322,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
     if input_stage == Stage::LlvmIr {
         let kind = target
             .output_kind()
-            .ok_or_else(|| format!("cannot emit `{}` from LLVM IR", target.name()))?;
+            .ok_or_else(|| format!("cannot emit `{target}` from LLVM IR"))?;
         let machine = TargetMachine::new(&spec, opt, reloc)?;
         let finalized = parse_llvm_ir(&name, &source)?;
         emit_to_file(finalized, &machine, opt, kind, &cli.output)?;

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -1,41 +1,124 @@
-//! `reussir-compiler`: compile a Reussir source file to native code.
+//! `rrc`: the Reussir compiler driver.
 //!
-//! Runs the whole pipeline — parse, elaborate, monomorphize, lower to MLIR, run
-//! the Reussir lowering pipeline, then emit an object file, assembly, or LLVM IR
-//! for the selected target (the native host by default, or `--target-triple`).
-//! Exit 0 on success, 1 on a frontend (syntax/elaboration) or lowering error, 2
-//! on usage or I/O error.
+//! A clang-style pipeline driver over one totally-ordered chain of stages:
+//!
+//! ```text
+//! .rr ──elaborate──▶ .hir ──monomorphize──▶ .mir ──lower──▶ .mlir ──pipeline──▶ mlir-llvm ──translate──▶ .ll ──▶ .s/.o
+//! ```
+//!
+//! The input's extension (or `--from`) picks where to enter the chain; `-o`'s
+//! extension (or `--emit`) picks where to leave it; the driver runs exactly the
+//! transforms in between. Every intermediate is both a dump target and — except
+//! the two derived MLIR forms — a re-entry point, so a stage can be inspected or
+//! fed back in isolation. Exit 0 on success, 1 on a compile error, 2 on a usage
+//! or I/O error.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use palc::Parser;
 
 use reussir_backend::llvm::LlvmLowering;
+use reussir_backend::melior::ir::Module;
 use reussir_backend::pipeline::{self, LoweringOptions, OptLevel};
 use reussir_codegen::lower::lower_program;
 use reussir_codegen::source::SourceMap;
-use reussir_compiler::{OutputKind, RelocMode, TargetMachine, TargetSpec, emit_to_file};
-use reussir_core::full::mono::monomorphize;
+use reussir_compiler::{
+    OutputKind, RelocMode, TargetMachine, TargetSpec, emit_to_file, parse_llvm_ir,
+};
+use reussir_core::full::mir;
+use reussir_core::full::mono::{MonoInput, monomorphize};
+use reussir_core::semi::resolve::DefTable;
+use reussir_core::semi::hir;
+use reussir_core::semi::ty::TyCtxt;
 use reussir_core::semi::{Report, Severity, elaborate};
 use reussir_core::{in_arena, surface};
+use reussir_syntax::kind::{Resolver, TokenKey};
 
-/// Reussir ahead-of-time compiler.
+/// A stage on the compilation chain, ordered from source to object so a target
+/// can be compared against the input (`>=` means "reachable going forward").
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Stage {
+    /// Reussir source (`.rr`).
+    Rr,
+    /// Elaborated, still-polymorphic HIR (`.hir`).
+    Hir,
+    /// Monomorphized ground MIR (`.mir`).
+    Mir,
+    /// The Reussir MLIR dialect, before the lowering pipeline (`.mlir`).
+    Mlir,
+    /// MLIR after the lowering pipeline — the LLVM dialect (`--emit mlir-llvm`).
+    MlirLlvm,
+    /// LLVM IR text (`.ll`).
+    LlvmIr,
+    /// Target assembly (`.s`).
+    Asm,
+    /// A relocatable object file (`.o`).
+    Obj,
+}
+
+impl Stage {
+    fn name(self) -> &'static str {
+        match self {
+            Stage::Rr => "rr",
+            Stage::Hir => "hir",
+            Stage::Mir => "mir",
+            Stage::Mlir => "mlir",
+            Stage::MlirLlvm => "mlir-llvm",
+            Stage::LlvmIr => "llvm-ir",
+            Stage::Asm => "asm",
+            Stage::Obj => "obj",
+        }
+    }
+
+    /// The stage a file extension denotes, if any.
+    fn from_extension(path: &Path) -> Option<Stage> {
+        Some(match path.extension().and_then(|e| e.to_str())? {
+            "rr" => Stage::Rr,
+            "hir" => Stage::Hir,
+            "mir" => Stage::Mir,
+            "mlir" => Stage::Mlir,
+            "mlir-llvm" => Stage::MlirLlvm,
+            "ll" => Stage::LlvmIr,
+            "s" => Stage::Asm,
+            "o" => Stage::Obj,
+            _ => return None,
+        })
+    }
+
+    /// The `LLVM`-emitting output kind, for the three terminal stages.
+    fn output_kind(self) -> Option<OutputKind> {
+        match self {
+            Stage::LlvmIr => Some(OutputKind::LlvmIr),
+            Stage::Asm => Some(OutputKind::Assembly),
+            Stage::Obj => Some(OutputKind::Object),
+            _ => None,
+        }
+    }
+}
+
+/// Reussir compiler driver.
 #[derive(Parser)]
-#[command(name = "reussir-compiler", version)]
+#[command(name = "rrc", version)]
 struct Cli {
-    /// Input source file (`-` reads from stdin).
+    /// Input file (`-` reads Reussir source from stdin).
     input: PathBuf,
 
-    /// Output file. The artifact kind is inferred from its extension unless
-    /// `--emit` is given.
+    /// Output file (`-` writes a text dump — `hir`/`mir`/`mlir`/`mlir-llvm` — to
+    /// stdout). The target stage is inferred from its extension unless `--emit`
+    /// is given.
     #[arg(short = 'o', long)]
     output: PathBuf,
 
-    /// Artifact to emit: `obj`, `asm`, or `llvm-ir`. Defaults to the output
-    /// extension (`.o`/`.s`/`.ll`), else `obj`.
+    /// Stage to emit: `hir`, `mir`, `mlir`, `mlir-llvm`, `llvm-ir`, `asm`, or
+    /// `obj`. Defaults to the output extension (else `obj`).
     #[arg(short = 't', long = "emit")]
     emit: Option<String>,
+
+    /// Treat the input as this stage instead of inferring from its extension:
+    /// `rr`, `hir`, `mir`, `mlir`, or `llvm-ir`.
+    #[arg(short = 'x', long = "from")]
+    from: Option<String>,
 
     /// Optimization level: `none`, `default`, `aggressive`, or `size`.
     #[arg(short = 'O', long = "opt", default_value = "default")]
@@ -72,20 +155,62 @@ struct Cli {
     debug: bool,
 }
 
-fn parse_emit(cli: &Cli) -> Result<OutputKind, String> {
-    if let Some(e) = &cli.emit {
-        return match e.as_str() {
-            "obj" | "object" => Ok(OutputKind::Object),
-            "asm" | "assembly" => Ok(OutputKind::Assembly),
-            "llvm-ir" | "llvmir" | "ll" => Ok(OutputKind::LlvmIr),
-            other => Err(format!("unknown --emit `{other}`")),
-        };
-    }
-    Ok(match cli.output.extension().and_then(|e| e.to_str()) {
-        Some("s") => OutputKind::Assembly,
-        Some("ll") => OutputKind::LlvmIr,
-        _ => OutputKind::Object,
+fn parse_input_stage(s: &str) -> Result<Stage, String> {
+    Ok(match s {
+        "rr" => Stage::Rr,
+        "hir" => Stage::Hir,
+        "mir" => Stage::Mir,
+        "mlir" => Stage::Mlir,
+        "ll" | "llvm-ir" | "llvmir" => Stage::LlvmIr,
+        other => return Err(format!("unknown input stage `{other}`")),
     })
+}
+
+fn parse_emit_stage(s: &str) -> Result<Stage, String> {
+    Ok(match s {
+        "hir" => Stage::Hir,
+        "mir" => Stage::Mir,
+        "mlir" => Stage::Mlir,
+        "mlir-llvm" => Stage::MlirLlvm,
+        "llvm-ir" | "llvmir" | "ll" => Stage::LlvmIr,
+        "asm" | "assembly" => Stage::Asm,
+        "obj" | "object" => Stage::Obj,
+        other => return Err(format!("unknown --emit `{other}`")),
+    })
+}
+
+/// The stage the input enters at: `--from` if given, else the extension. `-`
+/// (stdin) has no extension, so it defaults to source.
+fn resolve_input_stage(cli: &Cli) -> Result<Stage, String> {
+    if let Some(from) = &cli.from {
+        return parse_input_stage(from);
+    }
+    if cli.input.as_os_str() == "-" {
+        return Ok(Stage::Rr);
+    }
+    match Stage::from_extension(&cli.input) {
+        Some(stage @ (Stage::Rr | Stage::Hir | Stage::Mir | Stage::Mlir | Stage::LlvmIr)) => {
+            Ok(stage)
+        }
+        Some(other) => Err(format!(
+            "`{}` is an output-only stage; cannot read a {} input",
+            other.name(),
+            other.name()
+        )),
+        None => Err(format!(
+            "cannot infer the input stage of `{}`; pass --from",
+            cli.input.display()
+        )),
+    }
+}
+
+/// The stage the driver stops at: `--emit` if given, else the output extension,
+/// else an object file.
+fn resolve_target(cli: &Cli) -> Result<Stage, String> {
+    if let Some(emit) = &cli.emit {
+        return parse_emit_stage(emit);
+    }
+    Ok(Stage::from_extension(&cli.output).unwrap_or(Stage::Obj))
 }
 
 fn parse_opt(s: &str) -> Result<OptLevel, String> {
@@ -122,6 +247,18 @@ fn read_input(path: &PathBuf) -> Result<(String, String), String> {
     }
 }
 
+/// Writes a text stage to `path`, or to stdout when it is `-`.
+fn write_text(path: &Path, text: &str) -> Result<(), String> {
+    if path.as_os_str() == "-" {
+        use std::io::Write;
+        std::io::stdout()
+            .write_all(text.as_bytes())
+            .map_err(|e| format!("failed to write to stdout: {e}"))
+    } else {
+        std::fs::write(path, text).map_err(|e| format!("failed to write {}: {e}", path.display()))
+    }
+}
+
 /// Prints `reports` to stderr, each labelled with its severity, and returns
 /// whether any was an error. Warnings alone do not fail the compile.
 fn report_diagnostics(name: &str, reports: &[Report]) -> bool {
@@ -139,80 +276,12 @@ fn report_diagnostics(name: &str, reports: &[Report]) -> bool {
     had_error
 }
 
-fn run(cli: &Cli) -> Result<bool, String> {
-    let kind = parse_emit(cli)?;
-    let opt = parse_opt(&cli.opt)?;
-    let reloc = parse_reloc(&cli.relocation_mode)?;
-    let (name, source) = read_input(&cli.input)?;
-
-    let parse = reussir_syntax::parse(&source);
-    if !parse.ok() {
-        for err in &parse.errors {
-            eprintln!("{name}: error: {err:?}");
-        }
-        return Ok(false);
-    }
-    let prog = surface::program(&parse.root);
-
-    // The target machine is built first: its data layout feeds the polymorphic
-    // FFI gather, which must run before the lowering pipeline erases those ops.
-    let spec = TargetSpec {
-        triple: cli.target_triple.clone(),
-        cpu: cli.target_cpu.clone(),
-        features: cli.target_features.clone(),
-    };
-    let machine = TargetMachine::new(&spec, opt, reloc)?;
-
-    // Resolve the MIR's byte spans to source positions so lowered ops carry
-    // `FileLineColLoc`s (and, with debug info, DWARF line tables). With `-g`, the
-    // parser's name resolver feeds variable/function names into the debug info.
-    let source_map = SourceMap::new(&cli.input, &source);
-    let names = cli.debug.then(|| parse.resolver());
-
-    let options = LoweringOptions {
-        opt,
-        reuse_token_across_call: cli.reuse_across_call,
-        ..LoweringOptions::default()
-    };
-    let optimize_ffi = !matches!(opt, OptLevel::None);
-
-    let context = reussir_backend::context();
-    if cli.disable_backend_multithreading {
-        context.enable_multi_threading(false);
-    }
-    // Frontend + lowering inside the arena scope. Polymorphic FFI is compiled and
-    // gathered before the pipeline (which erases the polyffi ops) and linked in
-    // after translation; the finalized LLVM module borrows neither the arena nor
-    // the MLIR context, so it outlives `tcx`.
-    let finalized = in_arena(|tcx| {
-        let elab = elaborate(tcx, &prog, parse.resolver());
-        if report_diagnostics(&name, &elab.reports) {
-            return Err(String::new());
-        }
-        let (full, reports) = monomorphize(&elab.mono_input());
-        if report_diagnostics(&name, &reports) {
-            return Err(String::new());
-        }
-        let mut module = lower_program(&context, tcx, &full, Some(&source_map), names)
-            .map_err(|e| format!("{name}: {e}"))?;
-        let prepared = LlvmLowering::prepare(&module, machine.data_layout(), optimize_ffi)
-            .map_err(|e| format!("{name}: {e}"))?;
-        pipeline::run_lowering_pipeline(&context, &mut module, &options)
-            .map_err(|e| format!("lowering pipeline failed: {e:?}"))?;
-        prepared.finish(&module).map_err(|e| format!("{name}: {e}"))
-    });
-    let finalized = match finalized {
-        Ok(finalized) => finalized,
-        Err(msg) => {
-            if !msg.is_empty() {
-                eprintln!("{msg}");
-            }
-            return Ok(false);
-        }
-    };
-
-    emit_to_file(finalized, &machine, opt, kind, &cli.output)?;
-    Ok(true)
+/// What the front (arena-scoped) leg produces: a text dump for `hir`/`mir`, or an
+/// MLIR module for `mlir` and anything past it. The module borrows the MLIR
+/// context, not the type arena, so it outlives the [`in_arena`] scope.
+enum Produced<'c> {
+    Text(String),
+    Module(Module<'c>),
 }
 
 fn main() -> ExitCode {
@@ -221,8 +290,247 @@ fn main() -> ExitCode {
         Ok(true) => ExitCode::SUCCESS,
         Ok(false) => ExitCode::FAILURE,
         Err(message) => {
-            eprintln!("error: {message}");
+            if !message.is_empty() {
+                eprintln!("error: {message}");
+            }
             ExitCode::from(2)
         }
     }
+}
+
+fn run(cli: &Cli) -> Result<bool, String> {
+    let input_stage = resolve_input_stage(cli)?;
+    let target = resolve_target(cli)?;
+    if target < input_stage {
+        return Err(format!(
+            "cannot emit `{}` from a `{}` input: the pipeline only runs forward",
+            target.name(),
+            input_stage.name()
+        ));
+    }
+    // Only the text dumps stream to stdout; `llvm-ir`/`asm`/`obj` go through the
+    // file-based LLVM emitter, so `-o -` would write a file literally named `-`.
+    if cli.output.as_os_str() == "-" && target.output_kind().is_some() {
+        return Err(format!(
+            "cannot write `{}` to stdout; give a file path with -o",
+            target.name()
+        ));
+    }
+    let opt = parse_opt(&cli.opt)?;
+    let reloc = parse_reloc(&cli.relocation_mode)?;
+    let (name, source) = read_input(&cli.input)?;
+
+    let spec = TargetSpec {
+        triple: cli.target_triple.clone(),
+        cpu: cli.target_cpu.clone(),
+        features: cli.target_features.clone(),
+    };
+
+    // A `.ll` input skips the whole MLIR front: parse the IR and run the LLVM
+    // backend straight to the requested artifact.
+    if input_stage == Stage::LlvmIr {
+        let kind = target
+            .output_kind()
+            .ok_or_else(|| format!("cannot emit `{}` from LLVM IR", target.name()))?;
+        let machine = TargetMachine::new(&spec, opt, reloc)?;
+        let finalized = parse_llvm_ir(&name, &source)?;
+        emit_to_file(finalized, &machine, opt, kind, &cli.output)?;
+        return Ok(true);
+    }
+
+    let context = reussir_backend::context();
+    if cli.disable_backend_multithreading {
+        context.enable_multi_threading(false);
+    }
+    let source_map = SourceMap::new(&cli.input, &source);
+
+    // Front leg: reach an MLIR module (or a text dump for `hir`/`mir`). A `.mlir`
+    // input parses directly; source/`.hir`/`.mir` run the frontend in the arena.
+    let produced = match input_stage {
+        Stage::Mlir => Module::parse(&context, &source)
+            .map(Produced::Module)
+            .ok_or_else(|| format!("{name}: failed to parse MLIR module"))?,
+        _ => match in_arena(|tcx| {
+            frontend(&context, tcx, input_stage, target, &name, &source, &source_map, cli)
+        }) {
+            Ok(produced) => produced,
+            Err(msg) => {
+                if !msg.is_empty() {
+                    eprintln!("{msg}");
+                }
+                return Ok(false);
+            }
+        },
+    };
+
+    let mut module = match produced {
+        Produced::Text(text) => {
+            write_text(&cli.output, &text)?;
+            return Ok(true);
+        }
+        Produced::Module(module) => module,
+    };
+
+    // A `.mlir` dump is the module as it stands, before the lowering pipeline.
+    if target == Stage::Mlir {
+        write_text(&cli.output, &module.as_operation().to_string())?;
+        return Ok(true);
+    }
+
+    // MLIR → LLVM leg: the target machine's data layout feeds the polymorphic-FFI
+    // gather, which must run before the pipeline erases those ops.
+    let machine = TargetMachine::new(&spec, opt, reloc)?;
+    let options = LoweringOptions {
+        opt,
+        reuse_token_across_call: cli.reuse_across_call,
+        ..LoweringOptions::default()
+    };
+    let optimize_ffi = !matches!(opt, OptLevel::None);
+    let prepared = LlvmLowering::prepare(&module, machine.data_layout(), optimize_ffi)
+        .map_err(|e| format!("{name}: {e}"))?;
+    pipeline::run_lowering_pipeline(&context, &mut module, &options)
+        .map_err(|e| format!("lowering pipeline failed: {e:?}"))?;
+
+    // After the pipeline the module is the LLVM dialect; dump it before it is
+    // translated out of MLIR. (`prepared`'s `Drop` releases the gathered FFI.)
+    if target == Stage::MlirLlvm {
+        drop(prepared);
+        write_text(&cli.output, &module.as_operation().to_string())?;
+        return Ok(true);
+    }
+
+    let finalized = prepared.finish(&module).map_err(|e| format!("{name}: {e}"))?;
+    let kind = target
+        .output_kind()
+        .expect("llvm-ir/asm/obj target past the mlir-llvm stage");
+    emit_to_file(finalized, &machine, opt, kind, &cli.output)?;
+    Ok(true)
+}
+
+/// The arena-scoped front leg for a source/`.hir`/`.mir` input: run the frontend
+/// from the entry stage to `target`, yielding a text dump or a lowered module.
+///
+/// An empty `Err` string signals diagnostics were already printed (a compile
+/// failure, exit 1) rather than a driver error (exit 2).
+#[allow(clippy::too_many_arguments)]
+fn frontend<'c, 'tcx>(
+    context: &'c reussir_backend::melior::Context,
+    tcx: &TyCtxt<'tcx>,
+    input: Stage,
+    target: Stage,
+    name: &str,
+    source: &str,
+    source_map: &SourceMap<'_>,
+    cli: &Cli,
+) -> Result<Produced<'c>, String> {
+    match input {
+        Stage::Rr => {
+            let parse = reussir_syntax::parse(source);
+            if !parse.ok() {
+                for err in &parse.errors {
+                    eprintln!("{name}: error: {err:?}");
+                }
+                return Err(String::new());
+            }
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            if report_diagnostics(name, &elab.reports) {
+                return Err(String::new());
+            }
+            if target == Stage::Hir {
+                let text = hir::print::Printer::new(&elab.defs, elab.resolver).program(
+                    &elab.elaborated,
+                    &elab.records,
+                    &elab.trampolines,
+                );
+                return Ok(Produced::Text(text));
+            }
+            let (full, reports) = monomorphize(&elab.mono_input());
+            if report_diagnostics(name, &reports) {
+                return Err(String::new());
+            }
+            finish_mir(
+                context,
+                tcx,
+                target,
+                name,
+                Some(source_map),
+                cli.debug,
+                &full,
+                &elab.defs,
+                elab.resolver,
+            )
+        }
+        Stage::Hir => {
+            let parsed = hir::build::parse_program(tcx, source)
+                .map_err(|e| format!("{name}: {e}"))?;
+            if target == Stage::Hir {
+                let text = hir::print::Printer::new(&parsed.defs, &parsed.names).program(
+                    &parsed.funcs,
+                    &parsed.records,
+                    &parsed.trampolines,
+                );
+                return Ok(Produced::Text(text));
+            }
+            let input = MonoInput {
+                tcx,
+                defs: &parsed.defs,
+                resolver: &parsed.names,
+                elaborated: &parsed.funcs,
+                records: &parsed.records,
+                trampolines: &parsed.trampolines,
+            };
+            let (full, reports) = monomorphize(&input);
+            if report_diagnostics(name, &reports) {
+                return Err(String::new());
+            }
+            // A re-parsed IR carries no original source, so debug locations would
+            // be meaningless: lower without a source map.
+            finish_mir(
+                context, tcx, target, name, None, cli.debug, &full, &parsed.defs, &parsed.names,
+            )
+        }
+        Stage::Mir => {
+            let parsed = mir::build::parse_program(tcx, source)
+                .map_err(|e| format!("{name}: {e}"))?;
+            finish_mir(
+                context,
+                tcx,
+                target,
+                name,
+                None,
+                cli.debug,
+                &parsed.program,
+                &parsed.defs,
+                &parsed.names,
+            )
+        }
+        _ => unreachable!("frontend only handles rr/hir/mir inputs"),
+    }
+}
+
+/// Finish the front leg from a ground MIR program: a `mir` dump, or lowering to
+/// an MLIR module for `mlir` and beyond.
+#[allow(clippy::too_many_arguments)]
+fn finish_mir<'c, 'tcx>(
+    context: &'c reussir_backend::melior::Context,
+    tcx: &TyCtxt<'tcx>,
+    target: Stage,
+    name: &str,
+    source_map: Option<&SourceMap<'_>>,
+    debug: bool,
+    program: &mir::Program<'tcx>,
+    defs: &DefTable,
+    resolver: &dyn Resolver<TokenKey>,
+) -> Result<Produced<'c>, String> {
+    if target == Stage::Mir {
+        return Ok(Produced::Text(
+            mir::print::Printer::new(defs, resolver).program(program),
+        ));
+    }
+    // Names feed variable/function debug info; only meaningful with `-g`.
+    let names = debug.then_some(resolver);
+    let module = lower_program(context, tcx, program, source_map, names)
+        .map_err(|e| format!("{name}: {e}"))?;
+    Ok(Produced::Module(module))
 }

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -5,6 +5,8 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use tempfile::TempDir;
+
 const PROGRAM: &str = r#"
     enum List<T> { Nil, Cons(T, List<T>) }
     pub fn sum(list: List<i64>) -> i64 {
@@ -16,12 +18,13 @@ const PROGRAM: &str = r#"
     extern "C" trampoline "sum_ffi" = sum;
 "#;
 
-/// A throwaway directory unique to one test.
-fn scratch(tag: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!("rrc-driver-{}-{tag}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).expect("create scratch dir");
-    dir
+/// A throwaway directory unique to one test, removed when the returned handle
+/// drops.
+fn scratch(tag: &str) -> TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("rrc-driver-{tag}-"))
+        .tempdir()
+        .expect("create scratch dir")
 }
 
 fn rrc(args: &[&Path]) -> Output {
@@ -46,10 +49,11 @@ fn read(path: &Path) -> String {
     std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
 }
 
-/// Write `PROGRAM` to a `.rr` file in a fresh scratch dir and return its path.
-fn source(tag: &str) -> (PathBuf, PathBuf) {
+/// Write `PROGRAM` to a `.rr` file in a fresh scratch dir. The returned
+/// [`TempDir`] must be kept alive for the test's duration (it cleans up on drop).
+fn source(tag: &str) -> (TempDir, PathBuf) {
     let dir = scratch(tag);
-    let src = dir.join("prog.rr");
+    let src = dir.path().join("prog.rr");
     std::fs::write(&src, PROGRAM).expect("write source");
     (dir, src)
 }
@@ -58,20 +62,20 @@ fn source(tag: &str) -> (PathBuf, PathBuf) {
 fn dumps_hir_mir_and_mlir_from_source() {
     let (dir, src) = source("dumps");
 
-    let hir = dir.join("prog.hir");
+    let hir = dir.path().join("prog.hir");
     emit(&src, "hir", &hir);
     let hir_text = read(&hir);
     assert!(hir_text.contains("fn #sum"), "hir:\n{hir_text}");
     assert!(hir_text.contains("match"), "hir:\n{hir_text}");
 
-    let mir = dir.join("prog.mir");
+    let mir = dir.path().join("prog.mir");
     emit(&src, "mir", &mir);
     let mir_text = read(&mir);
     // The MIR is mangled and monomorphized.
     assert!(mir_text.contains("sum"), "mir:\n{mir_text}");
     assert!(mir_text.contains("switch") || mir_text.contains("match"), "mir:\n{mir_text}");
 
-    let mlir = dir.join("prog.mlir");
+    let mlir = dir.path().join("prog.mlir");
     emit(&src, "mlir", &mlir);
     let mlir_text = read(&mlir);
     assert!(mlir_text.contains("reussir.record.dispatch"), "mlir:\n{mlir_text}");
@@ -82,14 +86,14 @@ fn dumps_hir_mir_and_mlir_from_source() {
 fn dumps_mlir_llvm_and_llvm_ir_from_source() {
     let (dir, src) = source("llvm");
 
-    let mlir_llvm = dir.join("prog.mlir-llvm");
+    let mlir_llvm = dir.path().join("prog.mlir-llvm");
     emit(&src, "mlir-llvm", &mlir_llvm);
     let text = read(&mlir_llvm);
     // After the pipeline the module is the LLVM dialect: no reussir ops remain.
     assert!(text.contains("llvm."), "mlir-llvm:\n{text}");
     assert!(!text.contains("reussir.record.dispatch"), "mlir-llvm still high-level:\n{text}");
 
-    let ll = dir.join("prog.ll");
+    let ll = dir.path().join("prog.ll");
     emit(&src, "llvm-ir", &ll);
     let ll_text = read(&ll);
     assert!(ll_text.contains("define"), "ll:\n{ll_text}");
@@ -100,7 +104,7 @@ fn dumps_mlir_llvm_and_llvm_ir_from_source() {
 #[test]
 fn compiles_source_to_object() {
     let (dir, src) = source("obj");
-    let obj = dir.join("prog.o");
+    let obj = dir.path().join("prog.o");
     // Target inferred from the `.o` extension (no --emit).
     let output = rrc(&[&src, Path::new("-o"), &obj]);
     assert!(
@@ -117,13 +121,13 @@ fn reenters_from_mir_and_matches_source_lowering() {
     let (dir, src) = source("mir-reentry");
 
     // Dump MIR from source, then lower that MIR file to MLIR.
-    let mir = dir.join("prog.mir");
+    let mir = dir.path().join("prog.mir");
     emit(&src, "mir", &mir);
-    let via_mir = dir.join("via-mir.mlir");
+    let via_mir = dir.path().join("via-mir.mlir");
     emit(&mir, "mlir", &via_mir);
 
     // Lowering straight from source should reach the same high-level ops.
-    let via_src = dir.join("via-src.mlir");
+    let via_src = dir.path().join("via-src.mlir");
     emit(&src, "mlir", &via_src);
 
     for path in [&via_mir, &via_src] {
@@ -138,16 +142,16 @@ fn mir_and_hir_round_trip_by_reprinting() {
     let (dir, src) = source("round-trip");
 
     // print(parse(t)) == t for MIR: dumping, re-parsing, and re-dumping is stable.
-    let mir1 = dir.join("one.mir");
+    let mir1 = dir.path().join("one.mir");
     emit(&src, "mir", &mir1);
-    let mir2 = dir.join("two.mir");
+    let mir2 = dir.path().join("two.mir");
     emit(&mir1, "mir", &mir2);
     assert_eq!(read(&mir1), read(&mir2), "MIR is not print/parse stable");
 
     // Same for HIR.
-    let hir1 = dir.join("one.hir");
+    let hir1 = dir.path().join("one.hir");
     emit(&src, "hir", &hir1);
-    let hir2 = dir.join("two.hir");
+    let hir2 = dir.path().join("two.hir");
     emit(&hir1, "hir", &hir2);
     assert_eq!(read(&hir1), read(&hir2), "HIR is not print/parse stable");
 }
@@ -157,16 +161,16 @@ fn reenters_from_mlir_and_llvm_ir_to_object() {
     let (dir, src) = source("obj-reentry");
 
     // .mlir -> .o : parse the dialect, run the pipeline, emit.
-    let mlir = dir.join("prog.mlir");
+    let mlir = dir.path().join("prog.mlir");
     emit(&src, "mlir", &mlir);
-    let obj_from_mlir = dir.join("from-mlir.o");
+    let obj_from_mlir = dir.path().join("from-mlir.o");
     emit(&mlir, "obj", &obj_from_mlir);
     assert!(std::fs::metadata(&obj_from_mlir).expect("obj from mlir").len() > 0);
 
     // .ll -> .o : parse LLVM IR and run the backend.
-    let ll = dir.join("prog.ll");
+    let ll = dir.path().join("prog.ll");
     emit(&src, "llvm-ir", &ll);
-    let obj_from_ll = dir.join("from-ll.o");
+    let obj_from_ll = dir.path().join("from-ll.o");
     emit(&ll, "obj", &obj_from_ll);
     assert!(std::fs::metadata(&obj_from_ll).expect("obj from ll").len() > 0);
 }
@@ -175,7 +179,7 @@ fn reenters_from_mlir_and_llvm_ir_to_object() {
 fn infers_mlir_llvm_from_the_output_extension() {
     let (dir, src) = source("mlir-llvm-ext");
     // No --emit: the `.mlir-llvm` extension selects the post-pipeline dump.
-    let out = dir.join("prog.mlir-llvm");
+    let out = dir.path().join("prog.mlir-llvm");
     let output = rrc(&[&src, Path::new("-o"), &out]);
     assert!(
         output.status.success(),
@@ -200,9 +204,9 @@ fn rejects_stdout_for_file_artifacts() {
 fn rejects_running_the_pipeline_backward() {
     let (dir, _src) = source("backward");
     // A `.mir` input cannot produce HIR (an earlier stage).
-    let mir = dir.join("prog.mir");
+    let mir = dir.path().join("prog.mir");
     std::fs::write(&mir, "").expect("write empty mir");
-    let output = rrc(&[&mir, Path::new("-o"), &dir.join("out.hir"), Path::new("--emit"), Path::new("hir")]);
+    let output = rrc(&[&mir, Path::new("-o"), &dir.path().join("out.hir"), Path::new("--emit"), Path::new("hir")]);
     assert!(!output.status.success(), "expected backward pipeline to fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("only runs forward"), "stderr:\n{stderr}");
@@ -215,7 +219,7 @@ fn compiles_to_the_wasm_target() {
     // the pipeline) end to end; the emitted object is a real wasm module even
     // though its runtime symbols stay unresolved until link.
     let (dir, src) = source("wasm");
-    let obj = dir.join("prog.wasm.o");
+    let obj = dir.path().join("prog.wasm.o");
     let output = rrc(&[
         &src,
         Path::new("--target-triple"),

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -207,3 +207,32 @@ fn rejects_running_the_pipeline_backward() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("only runs forward"), "stderr:\n{stderr}");
 }
+
+#[test]
+fn compiles_to_the_wasm_target() {
+    // Cross-compile to WebAssembly via `--target-triple`. This exercises the
+    // cross-target path (all LLVM targets registered, wasm data layout feeding
+    // the pipeline) end to end; the emitted object is a real wasm module even
+    // though its runtime symbols stay unresolved until link.
+    let (dir, src) = source("wasm");
+    let obj = dir.join("prog.wasm.o");
+    let output = rrc(&[
+        &src,
+        Path::new("--target-triple"),
+        Path::new("wasm32-unknown-unknown"),
+        Path::new("-o"),
+        &obj,
+    ]);
+    assert!(
+        output.status.success(),
+        "wasm compile failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bytes = std::fs::read(&obj).expect("read wasm object");
+    // A WebAssembly object begins with the magic `\0asm` followed by the version.
+    assert!(
+        bytes.starts_with(b"\0asm"),
+        "not a wasm object, leading bytes: {:02x?}",
+        &bytes[..bytes.len().min(8)]
+    );
+}

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -1,0 +1,209 @@
+//! Driver end-to-end tests: run the real `rrc` binary through the stage chain,
+//! checking that each input/output pair produces the expected artifact and that
+//! the re-entry points (`.mir`/`.mlir`/`.ll` inputs) rejoin the pipeline.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const PROGRAM: &str = r#"
+    enum List<T> { Nil, Cons(T, List<T>) }
+    pub fn sum(list: List<i64>) -> i64 {
+        match list {
+            List::Nil => 0,
+            List::Cons(x, xs) => x + sum(xs)
+        }
+    }
+    extern "C" trampoline "sum_ffi" = sum;
+"#;
+
+/// A throwaway directory unique to one test.
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("rrc-driver-{}-{tag}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+fn rrc(args: &[&Path]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rrc"))
+        .args(args)
+        .output()
+        .expect("spawn rrc")
+}
+
+/// Compile `input` to `target` (`--emit target`), writing `out`; assert success.
+fn emit(input: &Path, target: &str, out: &Path) {
+    let output = rrc(&[input, Path::new("-o"), out, Path::new("--emit"), Path::new(target)]);
+    assert!(
+        output.status.success(),
+        "rrc {} -> {target} failed:\n{}",
+        input.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn read(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Write `PROGRAM` to a `.rr` file in a fresh scratch dir and return its path.
+fn source(tag: &str) -> (PathBuf, PathBuf) {
+    let dir = scratch(tag);
+    let src = dir.join("prog.rr");
+    std::fs::write(&src, PROGRAM).expect("write source");
+    (dir, src)
+}
+
+#[test]
+fn dumps_hir_mir_and_mlir_from_source() {
+    let (dir, src) = source("dumps");
+
+    let hir = dir.join("prog.hir");
+    emit(&src, "hir", &hir);
+    let hir_text = read(&hir);
+    assert!(hir_text.contains("fn #sum"), "hir:\n{hir_text}");
+    assert!(hir_text.contains("match"), "hir:\n{hir_text}");
+
+    let mir = dir.join("prog.mir");
+    emit(&src, "mir", &mir);
+    let mir_text = read(&mir);
+    // The MIR is mangled and monomorphized.
+    assert!(mir_text.contains("sum"), "mir:\n{mir_text}");
+    assert!(mir_text.contains("switch") || mir_text.contains("match"), "mir:\n{mir_text}");
+
+    let mlir = dir.join("prog.mlir");
+    emit(&src, "mlir", &mlir);
+    let mlir_text = read(&mlir);
+    assert!(mlir_text.contains("reussir.record.dispatch"), "mlir:\n{mlir_text}");
+    assert!(mlir_text.contains("func.func"), "mlir:\n{mlir_text}");
+}
+
+#[test]
+fn dumps_mlir_llvm_and_llvm_ir_from_source() {
+    let (dir, src) = source("llvm");
+
+    let mlir_llvm = dir.join("prog.mlir-llvm");
+    emit(&src, "mlir-llvm", &mlir_llvm);
+    let text = read(&mlir_llvm);
+    // After the pipeline the module is the LLVM dialect: no reussir ops remain.
+    assert!(text.contains("llvm."), "mlir-llvm:\n{text}");
+    assert!(!text.contains("reussir.record.dispatch"), "mlir-llvm still high-level:\n{text}");
+
+    let ll = dir.join("prog.ll");
+    emit(&src, "llvm-ir", &ll);
+    let ll_text = read(&ll);
+    assert!(ll_text.contains("define"), "ll:\n{ll_text}");
+    // The exported C-ABI trampoline is present.
+    assert!(ll_text.contains("sum_ffi"), "ll:\n{ll_text}");
+}
+
+#[test]
+fn compiles_source_to_object() {
+    let (dir, src) = source("obj");
+    let obj = dir.join("prog.o");
+    // Target inferred from the `.o` extension (no --emit).
+    let output = rrc(&[&src, Path::new("-o"), &obj]);
+    assert!(
+        output.status.success(),
+        "rrc -> obj failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bytes = std::fs::metadata(&obj).expect("object exists").len();
+    assert!(bytes > 0, "object file is empty");
+}
+
+#[test]
+fn reenters_from_mir_and_matches_source_lowering() {
+    let (dir, src) = source("mir-reentry");
+
+    // Dump MIR from source, then lower that MIR file to MLIR.
+    let mir = dir.join("prog.mir");
+    emit(&src, "mir", &mir);
+    let via_mir = dir.join("via-mir.mlir");
+    emit(&mir, "mlir", &via_mir);
+
+    // Lowering straight from source should reach the same high-level ops.
+    let via_src = dir.join("via-src.mlir");
+    emit(&src, "mlir", &via_src);
+
+    for path in [&via_mir, &via_src] {
+        let text = read(path);
+        assert!(text.contains("reussir.record.dispatch"), "{}: {text}", path.display());
+        assert!(text.contains("sum_ffi"), "{}: {text}", path.display());
+    }
+}
+
+#[test]
+fn mir_and_hir_round_trip_by_reprinting() {
+    let (dir, src) = source("round-trip");
+
+    // print(parse(t)) == t for MIR: dumping, re-parsing, and re-dumping is stable.
+    let mir1 = dir.join("one.mir");
+    emit(&src, "mir", &mir1);
+    let mir2 = dir.join("two.mir");
+    emit(&mir1, "mir", &mir2);
+    assert_eq!(read(&mir1), read(&mir2), "MIR is not print/parse stable");
+
+    // Same for HIR.
+    let hir1 = dir.join("one.hir");
+    emit(&src, "hir", &hir1);
+    let hir2 = dir.join("two.hir");
+    emit(&hir1, "hir", &hir2);
+    assert_eq!(read(&hir1), read(&hir2), "HIR is not print/parse stable");
+}
+
+#[test]
+fn reenters_from_mlir_and_llvm_ir_to_object() {
+    let (dir, src) = source("obj-reentry");
+
+    // .mlir -> .o : parse the dialect, run the pipeline, emit.
+    let mlir = dir.join("prog.mlir");
+    emit(&src, "mlir", &mlir);
+    let obj_from_mlir = dir.join("from-mlir.o");
+    emit(&mlir, "obj", &obj_from_mlir);
+    assert!(std::fs::metadata(&obj_from_mlir).expect("obj from mlir").len() > 0);
+
+    // .ll -> .o : parse LLVM IR and run the backend.
+    let ll = dir.join("prog.ll");
+    emit(&src, "llvm-ir", &ll);
+    let obj_from_ll = dir.join("from-ll.o");
+    emit(&ll, "obj", &obj_from_ll);
+    assert!(std::fs::metadata(&obj_from_ll).expect("obj from ll").len() > 0);
+}
+
+#[test]
+fn infers_mlir_llvm_from_the_output_extension() {
+    let (dir, src) = source("mlir-llvm-ext");
+    // No --emit: the `.mlir-llvm` extension selects the post-pipeline dump.
+    let out = dir.join("prog.mlir-llvm");
+    let output = rrc(&[&src, Path::new("-o"), &out]);
+    assert!(
+        output.status.success(),
+        "rrc -> mlir-llvm (by extension) failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = read(&out);
+    assert!(text.contains("llvm."), "mlir-llvm:\n{text}");
+    assert!(!text.contains("reussir.record.dispatch"), "still high-level:\n{text}");
+}
+
+#[test]
+fn rejects_stdout_for_file_artifacts() {
+    let (_dir, src) = source("stdout-obj");
+    let output = rrc(&[&src, Path::new("-o"), Path::new("-"), Path::new("--emit"), Path::new("obj")]);
+    assert!(!output.status.success(), "expected obj-to-stdout to be rejected");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("stdout"), "stderr:\n{stderr}");
+}
+
+#[test]
+fn rejects_running_the_pipeline_backward() {
+    let (dir, _src) = source("backward");
+    // A `.mir` input cannot produce HIR (an earlier stage).
+    let mir = dir.join("prog.mir");
+    std::fs::write(&mir, "").expect("write empty mir");
+    let output = rrc(&[&mir, Path::new("-o"), &dir.join("out.hir"), Path::new("--emit"), Path::new("hir")]);
+    assert!(!output.status.success(), "expected backward pipeline to fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("only runs forward"), "stderr:\n{stderr}");
+}


### PR DESCRIPTION
## What

Turns `rrc` from a source-only AOT compiler into a **clang-style pipeline driver** over one totally-ordered stage chain:

```
.rr ──elaborate──▶ .hir ──monomorphize──▶ .mir ──lower──▶ .mlir ──pipeline──▶ mlir-llvm ──translate──▶ .ll ──▶ .s/.o
```

The **input extension** (or `-x/--from`) picks where to enter the chain; the **`-o` extension** (or `-t/--emit`) picks where to leave it; the driver runs exactly the transforms in between. Every intermediate is a dump target and — except the two derived MLIR forms — a re-entry point, so a stage can be inspected or fed back in isolation.

- **Output targets** (`--emit`): `hir`, `mir`, `mlir` (reussir dialect, pre-pipeline), `mlir-llvm` (LLVM dialect, post-pipeline), `llvm-ir`, `asm`, `obj`.
- **Input stages** (`--from` / extension): `rr`, `hir`, `mir`, `mlir`, `llvm-ir`. Text stages write to stdout with `-o -`.
- Producing a stage **earlier** than the input is rejected ("the pipeline only runs forward").

## How

Reuses existing infrastructure — **no new parsers**:
- HIR/MIR text printers **and** parsers already exist (`semi::hir`, `full::mir`); a `.hir`/`.mir` re-entry rebuilds a `MonoInput`/`mir::Program` and rejoins mono/lowering.
- MLIR round-trips via `Module::parse` / `to_string`; a `.mlir` re-entry runs the lowering pipeline.
- New `parse_llvm_ir` (llvm-sys `LLVMParseIRInContext2`) handles the `.ll` leg, which skips straight to the LLVM backend.

`mlir` is the **pre-pipeline** (high-level reussir) form the FileCheck-MLIR tests want; `mlir-llvm` is the post-pipeline LLVM-dialect module, dumped after `run_lowering_pipeline` and before translation.

## Why

This collapses the Haskell `reussir-elab` (`--mode semi`→`hir`, `--mode full`→`mir`) and `reussir-compiler -t mlir` tool surfaces into `rrc`, and enables **stage-isolated** lit tests (`--from mir foo.mir -t mlir`, `--from mlir foo.mlir -o foo.o`). It's the groundwork for migrating the frontend test corpus off Haskell.

## Tests

`tests/driver.rs` spawns the real `rrc` binary through each entry→exit pair:
- source dumps (`hir`/`mir`/`mlir`/`mlir-llvm`/`llvm-ir`), source→object (extension-inferred);
- re-entry `mir→mlir` (matches source lowering), `mlir→obj`, `ll→obj`;
- `mir`/`hir` print→parse→print **round-trip identity**;
- backward-pipeline rejection.

All green under `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)