### PR TITLE
[frontend] incremental REPL engine APIs: shared interner, atomic elaborator extension, tracked JIT modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +342,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -592,6 +612,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb"
 dependencies = [
+ "dashmap",
  "hashbrown 0.14.5",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,10 @@ smallvec = "1.15"
 # keep the v0 Punycode encoder's per-occurrence "code points placed to the left"
 # query sub-linear, so Bootstring encoding is O(n log n) rather than O(n²).
 ftree = "1.3.0"
-cstree = { version = "0.14", features = ["derive", "lasso_compat"] }
+# `multi_threaded_interning` provides the shared (Arc-able) token interner a
+# REPL session uses to keep TokenKeys stable across many `parse` calls (see
+# `reussir_syntax::parse_with_interner`).
+cstree = { version = "0.14", features = ["derive", "lasso_compat", "multi_threaded_interning"] }
 # rustc's extracted union-find: keyed unification with value merging and
 # snapshot/rollback (the logged path-compression makes speculation correct).
 ena = "0.14"

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -136,6 +136,30 @@ mod tests {
     }
 
     #[test]
+    fn residual_holes_are_ambiguity_errors_in_batch_mode() {
+        with_tcx(|tcx| {
+            // Nothing constrains the element type of a bare `Nullable::Null`
+            // (no obligation is registered, so there is no bound to fail
+            // either): a legitimate inference outcome, not an ICE. Zonking
+            // must report it instead of handing monomorphization a type
+            // `subst_ty` would panic on.
+            let source = "fn f() -> i64 { let x = Nullable::Null; 42 }";
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            let ambiguous: Vec<_> = elab
+                .reports
+                .iter()
+                .filter(|r| r.message.contains("cannot infer"))
+                .collect();
+            // Exactly one report, at the offending expression — not one per
+            // enclosing node that shares the hole.
+            assert_eq!(ambiguous.len(), 1, "reports: {:#?}", elab.reports);
+        });
+    }
+
+    #[test]
     fn duplicate_definitions_are_rejected_without_clobbering() {
         with_tcx(|tcx| {
             let source = "struct P { x: i32, y: i32 }\n\

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -26,10 +26,11 @@ pub mod ctxt;
 pub mod fulfill;
 pub mod hir;
 pub mod pattern;
+pub mod repl;
 pub mod resolve;
 pub mod ty_eval;
 
-pub use ctxt::{DefaultCap, Elaborator, Report, Severity, render_reports};
+pub use ctxt::{Checkpoint, DefaultCap, Elaborator, Report, Severity, render_reports};
 
 use reussir_syntax::kind::{Resolver, TokenKey};
 
@@ -69,6 +70,113 @@ mod tests {
                 elab.reports
             );
             f(&elab, tcx);
+        });
+    }
+
+    #[test]
+    fn try_extend_accumulates_and_rolls_back_atomically() {
+        use std::sync::Arc;
+
+        with_tcx(|tcx| {
+            // The REPL flow: many small parses sharing one interner, one
+            // persistent elaborator.
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = |src: &str| {
+                let p = reussir_syntax::parse_with_interner(src, interner.clone());
+                assert!(p.ok(), "parse errors for {src:?}: {:#?}", p.errors);
+                p
+            };
+            let mut elab = Elaborator::new(tcx, &interner);
+
+            // Input 1: a definition is accepted.
+            let p1 = parse("fn double(x: i32) -> i32 { x + x }");
+            elab.try_extend(&surface::program(&p1.root))
+                .expect("first definition");
+            assert_eq!(elab.elaborated.len(), 1);
+
+            // Input 2: a batch containing a duplicate is rejected wholesale —
+            // including its error-free items.
+            let p2 = parse(
+                "fn triple(x: i32) -> i32 { 3 * x }\n\
+                 fn double(x: i32) -> i32 { x }",
+            );
+            let errs = elab
+                .try_extend(&surface::program(&p2.root))
+                .expect_err("duplicate must be rejected");
+            assert!(
+                errs.iter()
+                    .any(|r| r.message.contains("defined more than once")),
+                "{errs:#?}"
+            );
+            assert_eq!(elab.elaborated.len(), 1, "batch rolled back");
+            assert!(!elab.has_errors(), "rejected reports don't persist");
+
+            // Input 3: `triple` was rolled back, so its name is free again,
+            // and cross-input references (`double`) resolve.
+            let p3 = parse("fn triple(x: i32) -> i32 { double(x) + x }");
+            elab.try_extend(&surface::program(&p3.root))
+                .expect("retracted name is reusable");
+            assert_eq!(elab.elaborated.len(), 2);
+
+            // Input 4: a type error rolls back the whole batch too.
+            let p4 = parse("fn bad() -> i32 { true }");
+            elab.try_extend(&surface::program(&p4.root))
+                .expect_err("type mismatch");
+            assert_eq!(elab.elaborated.len(), 2);
+
+            // A record checkpointed away frees its fields and name as well.
+            let p5 = parse("struct P { x: i32 }\nstruct P { y: i32 }");
+            elab.try_extend(&surface::program(&p5.root))
+                .expect_err("duplicate record in one batch");
+            assert!(elab.records.values().all(|r| elab.sym(r.name) != "P"));
+            let p6 = parse("struct P { x: i32, y: i32 }");
+            elab.try_extend(&surface::program(&p6.root))
+                .expect("name free after rollback");
+        });
+    }
+
+    #[test]
+    fn duplicate_definitions_are_rejected_without_clobbering() {
+        with_tcx(|tcx| {
+            let source = "struct P { x: i32, y: i32 }\n\
+                          struct P { z: f64 }\n\
+                          fn f(a: i32) -> i32 { a }\n\
+                          fn f(b: f64, c: f64) -> f64 { b }";
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+
+            let duplicates = elab
+                .reports
+                .iter()
+                .filter(|r| r.message.contains("defined more than once"))
+                .count();
+            assert_eq!(duplicates, 2, "reports: {:#?}", elab.reports);
+
+            // The first `P` keeps its own fields — the duplicate declaration
+            // must not repopulate the surviving record.
+            let p = elab
+                .records
+                .values()
+                .find(|r| elab.sym(r.name) == "P")
+                .expect("record P");
+            let crate::semi::ctxt::RecordFields::Named(fields) =
+                p.fields.as_ref().expect("populated")
+            else {
+                panic!("named fields");
+            };
+            assert_eq!(fields.len(), 2);
+
+            // Only the first `f` was checked; the duplicate's body was not
+            // elaborated against the surviving prototype.
+            let fs: Vec<_> = elab
+                .elaborated
+                .iter()
+                .filter(|f| elab.sym(f.name) == "f")
+                .collect();
+            assert_eq!(fs.len(), 1);
+            assert_eq!(fs[0].params.len(), 1);
         });
     }
 

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -8,6 +8,7 @@ use crate::semi::ty::{DefId, Flexivity, GenericId, Ty, TyKind};
 use crate::surface::{self, BinOp, Const, Span, UnaryOp};
 
 use super::ctxt::{Elaborator, RecordFields};
+use super::fulfill::{collect_holes, ty_has_hole};
 use super::hir::{ArithOp, ClosureExpr, CmpOp, Expr, ExprKind, Function, VarId};
 
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
@@ -1195,14 +1196,47 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     // ----- zonking -----
 
-    /// Resolve every type in an expression tree against the solved holes.
+    /// Resolve every type in an expression tree against the solved holes,
+    /// reporting any residual hole as an ambiguity error.
+    ///
+    /// Zonking is the inference boundary: bidirectional checking legitimately
+    /// leaves a hole unsolved when nothing constrains it (e.g. the element
+    /// type of a bare `Nullable::Null`), so a survivor here is a *user* error
+    /// asking for an annotation — never something later passes should see.
+    /// Downstream of zonking, HIR types are hole-free or errors were
+    /// reported; monomorphization's `subst_ty` panic on a hole is a genuine
+    /// ICE, not a reachable diagnostic.
     pub(super) fn zonk_expr(&mut self, mut e: Expr<'tcx>) -> Expr<'tcx> {
-        e.ty = self.infer.resolve(e.ty);
-        e.kind = self.zonk_kind(e.kind);
+        // Children first: a hole shared along a spine (`if c { Nullable::Null }
+        // else { x }`) is reported at the innermost expression that exhibits
+        // it — where the annotation belongs — and suppressed on the ancestors.
+        e.kind = self.zonk_kind(e.kind, e.span);
+        e.ty = self.zonk_ty(e.ty, e.span);
         e
     }
 
-    fn zonk_kind(&mut self, kind: ExprKind<'tcx>) -> ExprKind<'tcx> {
+    /// Resolve one type; report its not-yet-reported holes against `span`
+    /// (the expression the type belongs to). See [`Elaborator::zonk_expr`].
+    fn zonk_ty(&mut self, ty: Ty<'tcx>, span: Option<Span>) -> Ty<'tcx> {
+        let ty = self.infer.resolve(ty);
+        if ty_has_hole(ty) {
+            let mut holes = Vec::new();
+            collect_holes(ty, &mut holes);
+            let mut fresh = false;
+            for hole in holes {
+                fresh |= self.reported_holes.insert(hole);
+            }
+            if fresh {
+                self.error(
+                    span,
+                    "cannot infer the type of this expression; add a type annotation",
+                );
+            }
+        }
+        ty
+    }
+
+    fn zonk_kind(&mut self, kind: ExprKind<'tcx>, span: Option<Span>) -> ExprKind<'tcx> {
         use ExprKind::*;
         let zb = |s: &mut Self, e: Box<Expr<'tcx>>| Box::new(s.zonk_expr(*e));
         match kind {
@@ -1211,7 +1245,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             Arith(l, op, r) => Arith(zb(self, l), op, zb(self, r)),
             Cmp(l, op, r) => Cmp(zb(self, l), op, zb(self, r)),
             Cast(e, t) => {
-                let t = self.infer.resolve(t);
+                let t = self.zonk_ty(t, span);
                 Cast(zb(self, e), t)
             }
             If(c, t, f) => If(zb(self, c), zb(self, t), zb(self, f)),
@@ -1237,7 +1271,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 regional,
             } => FuncCall {
                 target,
-                ty_args: ty_args.into_iter().map(|t| self.infer.resolve(t)).collect(),
+                ty_args: ty_args.into_iter().map(|t| self.zonk_ty(t, span)).collect(),
                 args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
                 regional,
             },
@@ -1247,7 +1281,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 args,
             } => CompoundCall {
                 target,
-                ty_args: ty_args.into_iter().map(|t| self.infer.resolve(t)).collect(),
+                ty_args: ty_args.into_iter().map(|t| self.zonk_ty(t, span)).collect(),
                 args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
             },
             VariantCall {
@@ -1257,7 +1291,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 args,
             } => VariantCall {
                 target,
-                ty_args: ty_args.into_iter().map(|t| self.infer.resolve(t)).collect(),
+                ty_args: ty_args.into_iter().map(|t| self.zonk_ty(t, span)).collect(),
                 variant,
                 args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
             },
@@ -1270,12 +1304,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 captures: c
                     .captures
                     .into_iter()
-                    .map(|(v, t)| (v, self.infer.resolve(t)))
+                    .map(|(v, t)| (v, self.zonk_ty(t, span)))
                     .collect(),
                 params: c
                     .params
                     .into_iter()
-                    .map(|(v, t)| (v, self.infer.resolve(t)))
+                    .map(|(v, t)| (v, self.zonk_ty(t, span)))
                     .collect(),
                 body: zb(self, c.body),
             }),

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -15,10 +15,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// against the declared return type (`Γ ⊢ body ⇐ return_ty`), discharge the
     /// collected trait obligations, then zonk. Drives the checking judgment over a
     /// whole function body.
-    pub(super) fn check_function(&mut self, func: &surface::Function, span: Option<Span>) {
-        let Some(def) = self.defs.resolve_function(func.name) else {
-            return;
-        };
+    pub(super) fn check_function(
+        &mut self,
+        func: &surface::Function,
+        def: DefId,
+        span: Option<Span>,
+    ) {
         let Some(proto) = self.functions.get(&def).cloned() else {
             return;
         };
@@ -574,7 +576,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     /// Whether `ty`'s head (peeling `Nullable`) is a flex regional record — a
     /// value that cannot be materialized, hence cannot escape its region.
-    fn is_flex(&mut self, ty: Ty<'tcx>) -> bool {
+    pub(super) fn is_flex(&mut self, ty: Ty<'tcx>) -> bool {
         match self.infer.shallow_resolve(ty).kind() {
             TyKind::Record {
                 flex: crate::semi::ty::Flexivity::Flex,

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -8,7 +8,7 @@ use crate::semi::infer::InferCtxt;
 use crate::semi::resolve::DefTable;
 use crate::semi::traits::builtins::Builtins;
 use crate::semi::traits::{TraitDb, TraitId};
-use crate::semi::ty::{DefId, Flexivity, GenericId, Ty, TyCtxt, TyKind};
+use crate::semi::ty::{DefId, Flexivity, GenericId, HoleId, Ty, TyCtxt, TyKind};
 use crate::surface::{self, Span};
 use crate::utils::frecency::Frecency;
 use crate::utils::fuzzy::FuzzyIndex;
@@ -257,6 +257,10 @@ pub struct Elaborator<'a, 'tcx> {
     /// [`Function`]. See [`FuncProto::regional_generics`].
     pub regional_generics: Vec<GenericId>,
     pub fulfill: FulfillCtxt<'tcx>,
+    /// Holes already reported as ambiguous for the current function, so each
+    /// yields exactly one diagnostic — from `resolve_obligations` when a bound
+    /// on it can't be resolved, else from zonking (see `zonk_ty`).
+    pub(super) reported_holes: rustc_hash::FxHashSet<HoleId>,
     expr_counter: u32,
 }
 
@@ -306,6 +310,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             inside_region: false,
             regional_generics: Vec::new(),
             fulfill: FulfillCtxt::default(),
+            reported_holes: rustc_hash::FxHashSet::default(),
             expr_counter: 0,
         }
     }
@@ -454,6 +459,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.generic_names.clear();
         self.inside_region = false;
         self.fulfill = FulfillCtxt::default();
+        self.reported_holes.clear();
         for (name, id) in generics {
             self.generic_names.insert(*name, *id);
         }
@@ -468,6 +474,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// monotonic (`strings`, `frecency`, `expr_counter`, the type arena) is
     /// deliberately left to grow — stale entries are unreachable once the
     /// defs that referenced them are retracted.
+    ///
+    /// Any *future* accumulated state must be added here: notably, once
+    /// user-defined traits/impls land, `traits` stops being fixed at
+    /// construction and a rejected batch's impls must roll back too.
     pub fn checkpoint(&self) -> Checkpoint {
         Checkpoint {
             defs: self.defs.len(),
@@ -551,19 +561,23 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .iter()
             .map(|(func, span)| self.scan_function(func, *span))
             .collect();
-        for ((rec, _), def) in records.iter().zip(&record_defs) {
-            if let Some(def) = def {
-                self.populate_record(rec, *def);
-            }
-        }
-        for ((func, span), def) in functions.iter().zip(&function_defs) {
-            if let Some(def) = def {
-                self.check_function(func, *def, *span);
-            }
-        }
-        for (tramp, span) in &trampolines {
+        records
+            .iter()
+            .zip(record_defs)
+            .filter_map(|((rec, _), def)| Some((rec, def?)))
+            .for_each(|(rec, def)| {
+                self.populate_record(rec, def);
+            });
+        functions
+            .iter()
+            .zip(function_defs)
+            .filter_map(|((func, span), def)| Some((func, *span, def?)))
+            .for_each(|(func, span, def)| {
+                self.check_function(func, def, span);
+            });
+        trampolines.iter().for_each(|(tramp, span)| {
             self.collect_trampoline(tramp, *span);
-        }
+        });
     }
 
     fn scan_record(&mut self, rec: &surface::Record, span: Option<Span>) -> Option<DefId> {

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -260,6 +260,17 @@ pub struct Elaborator<'a, 'tcx> {
     expr_counter: u32,
 }
 
+/// A checkpoint of the elaborator's accumulated state; see
+/// [`Elaborator::checkpoint`].
+#[derive(Clone, Copy, Debug)]
+pub struct Checkpoint {
+    pub(super) defs: usize,
+    pub(super) generics: usize,
+    pub(super) trampolines: usize,
+    pub(super) elaborated: usize,
+    pub(super) reports: usize,
+}
+
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     pub fn new(tcx: &'a TyCtxt<'tcx>, resolver: &'a dyn Resolver<TokenKey>) -> Self {
         let mut traits = TraitDb::new();
@@ -450,6 +461,64 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     // ----- driver -----
 
+    /// A snapshot of the elaborator's accumulated (append-only) state, taken
+    /// with [`Elaborator::checkpoint`] and restored with
+    /// [`Elaborator::rollback`]. Everything a [`run`](Elaborator::run) call
+    /// appends is covered; state that is content-addressed or purely
+    /// monotonic (`strings`, `frecency`, `expr_counter`, the type arena) is
+    /// deliberately left to grow — stale entries are unreachable once the
+    /// defs that referenced them are retracted.
+    pub fn checkpoint(&self) -> Checkpoint {
+        Checkpoint {
+            defs: self.defs.len(),
+            generics: self.generics.len(),
+            trampolines: self.trampolines.len(),
+            elaborated: self.elaborated.len(),
+            reports: self.reports.len(),
+        }
+    }
+
+    /// Restore the accumulated state to `cp`. Per-function working state is
+    /// reset by `enter_function` on the next check, so it needs no restoring.
+    pub fn rollback(&mut self, cp: &Checkpoint) {
+        self.defs.truncate(cp.defs);
+        // `records`/`functions` are keyed by the dense DefId space, and the
+        // passes only ever insert under DefIds declared in the same run, so
+        // retracting every id past the checkpoint restores both maps.
+        let live = cp.defs as u32;
+        self.records.retain(|def, _| def.0 < live);
+        self.functions.retain(|def, _| def.0 < live);
+        self.generics.truncate(cp.generics);
+        self.trampolines.truncate(cp.trampolines);
+        self.elaborated.truncate(cp.elaborated);
+        self.reports.truncate(cp.reports);
+    }
+
+    /// Incrementally elaborate one batch of items against the accumulated
+    /// program, atomically: on any error the elaborator is rolled back to its
+    /// state before the call and the batch's reports are returned as `Err`;
+    /// on success the batch's warnings (if any) are returned as `Ok` and the
+    /// items stay. Duplicate definitions are rejected (the existing "defined
+    /// more than once" path), never replaced — a REPL session's items are
+    /// immutable once accepted.
+    ///
+    /// Forward references *within* the batch work exactly as in batch mode;
+    /// references to previously accepted items resolve through the persistent
+    /// [`DefTable`].
+    pub fn try_extend(&mut self, program: &surface::Program) -> Result<Vec<Report>, Vec<Report>> {
+        let cp = self.checkpoint();
+        self.run(program);
+        // Split the batch's reports off first: the caller renders them either
+        // way, and `has_errors` should keep reflecting only accepted state.
+        let new = self.reports.split_off(cp.reports);
+        if new.iter().any(|r| r.severity == Severity::Error) {
+            self.rollback(&cp);
+            Err(new)
+        } else {
+            Ok(new)
+        }
+    }
+
     /// Run the three collection passes over a program: scan record stubs and
     /// function prototypes, populate record fields, then check function bodies.
     pub fn run(&mut self, program: &surface::Program) {
@@ -470,24 +539,34 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 surface::StmtKind::Mod(..) => {}
             }
         }
-        for (rec, span) in &records {
-            self.scan_record(rec, *span);
+        // The later passes are keyed by the DefId each scan returned — never by
+        // re-resolving the name — so an item whose declaration failed (e.g. a
+        // duplicate) is skipped instead of clobbering the previously declared
+        // item's fields or checking a body against the wrong prototype.
+        let record_defs: Vec<Option<DefId>> = records
+            .iter()
+            .map(|(rec, span)| self.scan_record(rec, *span))
+            .collect();
+        let function_defs: Vec<Option<DefId>> = functions
+            .iter()
+            .map(|(func, span)| self.scan_function(func, *span))
+            .collect();
+        for ((rec, _), def) in records.iter().zip(&record_defs) {
+            if let Some(def) = def {
+                self.populate_record(rec, *def);
+            }
         }
-        for (func, span) in &functions {
-            self.scan_function(func, *span);
-        }
-        for (rec, _) in &records {
-            self.populate_record(rec);
-        }
-        for (func, span) in &functions {
-            self.check_function(func, *span);
+        for ((func, span), def) in functions.iter().zip(&function_defs) {
+            if let Some(def) = def {
+                self.check_function(func, *def, *span);
+            }
         }
         for (tramp, span) in &trampolines {
             self.collect_trampoline(tramp, *span);
         }
     }
 
-    fn scan_record(&mut self, rec: &surface::Record, span: Option<Span>) {
+    fn scan_record(&mut self, rec: &surface::Record, span: Option<Span>) -> Option<DefId> {
         let ty_params = self.collect_generics(&rec.ty_params, span);
         let default_cap = match rec.default_cap {
             surface::Capability::Value => DefaultCap::Value,
@@ -507,7 +586,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 span,
                 format!("record `{}` is defined more than once", self.sym(name)),
             );
-            return;
+            return None;
         };
         let record = Record {
             def,
@@ -520,9 +599,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             span,
         };
         self.records.insert(def, record);
+        Some(def)
     }
 
-    fn scan_function(&mut self, func: &surface::Function, span: Option<Span>) {
+    fn scan_function(&mut self, func: &surface::Function, span: Option<Span>) -> Option<DefId> {
         let generics = self.collect_generics(&func.generics, span);
         self.generic_names = generics.iter().map(|(n, id)| (*n, *id)).collect();
 
@@ -555,7 +635,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 span,
                 format!("function `{}` is defined more than once", self.sym(name)),
             );
-            return;
+            return None;
         };
         let proto = FuncProto {
             def,
@@ -569,6 +649,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             span,
         };
         self.functions.insert(def, proto);
+        Some(def)
     }
 
     /// Allocate generics for a list of `(name, bounds)` declarations.
@@ -587,10 +668,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .collect()
     }
 
-    fn populate_record(&mut self, rec: &surface::Record) {
-        let Some(def) = self.defs.resolve_record(rec.name) else {
-            return;
-        };
+    fn populate_record(&mut self, rec: &surface::Record, def: DefId) {
         let Some(record) = self.records.get(&def) else {
             return;
         };

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -16,8 +16,9 @@
 //! each obligation against the (now solved) self type — via impl search for
 //! concrete types and super-trait subsumption for in-scope generics.
 
+use crate::semi::hir;
 use crate::semi::traits::{Obligation, TraitRef};
-use crate::semi::ty::TyKind;
+use crate::semi::ty::{FpTy, IntTy, TyKind};
 use crate::surface::Span;
 
 use super::ctxt::Elaborator;
@@ -112,6 +113,50 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
         for p in pending {
             self.error(p.span, "type annotations needed: cannot resolve a bound");
+        }
+    }
+
+    /// REPL defaulting: solve numeric holes that only literal/arithmetic
+    /// bounds constrain. A hole pending a `FloatingPoint` obligation defaults
+    /// to `f64`; a hole pending `Integral` or `Num` defaults to `i64` (the
+    /// generalization of GHCi-style defaulting the old REPL applied to the
+    /// root type only). Obligations stay registered — the subsequent
+    /// [`resolve_obligations`](Elaborator::resolve_obligations) discharges
+    /// them against the now-solved types, and still errors on genuinely
+    /// conflicting bounds.
+    ///
+    /// Order matters: a hole can carry both `Num` (from arithmetic) and
+    /// `FloatingPoint` (from a float literal), e.g. `1.5 * 2`; the float
+    /// default must win, so `FloatingPoint` holes are solved first.
+    pub(super) fn default_numeric_holes(&mut self) {
+        let f64_ty = self.tcx.mk_fp(FpTy::Ieee(64));
+        let i64_ty = self.tcx.mk_int(IntTy::Signed(64));
+        let passes = [
+            (self.builtins.floating_point, f64_ty),
+            (self.builtins.integral, i64_ty),
+            (self.builtins.num, i64_ty),
+        ];
+        for (want, default) in passes {
+            let candidates: Vec<_> = self
+                .fulfill
+                .pending
+                .iter()
+                .filter(|p| {
+                    let Obligation::Trait(tref) = &p.obligation;
+                    tref.trait_id == want
+                })
+                .map(|p| {
+                    let Obligation::Trait(tref) = &p.obligation;
+                    tref.self_ty()
+                })
+                .collect();
+            for ty in candidates {
+                let ty = self.infer.shallow_resolve(ty);
+                if matches!(ty.kind(), TyKind::Hole(_)) {
+                    // Unifying a hole with a ground type cannot fail.
+                    let _ = self.infer.unify(ty, default);
+                }
+            }
         }
     }
 
@@ -213,7 +258,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 /// Does `ty` contain an unsolved inference hole anywhere in its structure?
 /// `ty` is expected to be deeply resolved (`InferCtxt::resolve`), so a remaining
 /// `Hole` is an unsolved variable, not an indirection.
-fn ty_has_hole(ty: crate::semi::ty::Ty<'_>) -> bool {
+pub(super) fn ty_has_hole(ty: crate::semi::ty::Ty<'_>) -> bool {
     match ty.kind() {
         TyKind::Hole(_) => true,
         TyKind::Record { args, .. } => args.iter().any(|a| ty_has_hole(*a)),
@@ -222,6 +267,74 @@ fn ty_has_hole(ty: crate::semi::ty::Ty<'_>) -> bool {
         }
         TyKind::Nullable(inner) => ty_has_hole(*inner),
         _ => false,
+    }
+}
+
+/// Does any type anywhere in a zonked expression tree still hold an inference
+/// hole? Monomorphization panics on a residual hole (`subst_ty`), so a REPL
+/// input must be rejected up front when one survives zonking — e.g. a bare
+/// `Nullable::Null`, whose element hole carries no obligation for
+/// [`Elaborator::default_numeric_holes`] to solve. Mirrors the `zonk_expr`
+/// traversal: node types, cast targets, call type arguments, closure
+/// capture/parameter types, and decision-tree bodies/guards.
+pub(super) fn expr_has_hole(e: &hir::Expr<'_>) -> bool {
+    use hir::ExprKind::*;
+    if ty_has_hole(e.ty) {
+        return true;
+    }
+    match &e.kind {
+        GlobalStr(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_) | Poison => false,
+        Negate(e) | Not(e) | RegionRun(e) | Proj(e, _) => expr_has_hole(e),
+        Cast(e, t) => ty_has_hole(*t) || expr_has_hole(e),
+        Arith(l, _, r) | Cmp(l, _, r) => expr_has_hole(l) || expr_has_hole(r),
+        If(c, t, f) => expr_has_hole(c) || expr_has_hole(t) || expr_has_hole(f),
+        Assign(dst, _, src) => expr_has_hole(dst) || expr_has_hole(src),
+        Let { value, .. } => expr_has_hole(value),
+        Seq(es) => es.iter().any(expr_has_hole),
+        FuncCall { ty_args, args, .. }
+        | CompoundCall { ty_args, args, .. }
+        | VariantCall { ty_args, args, .. } => {
+            ty_args.iter().any(|t| ty_has_hole(*t)) || args.iter().any(expr_has_hole)
+        }
+        NullableCall(e) => e.as_deref().is_some_and(expr_has_hole),
+        Closure(c) => {
+            c.captures
+                .iter()
+                .chain(&c.params)
+                .any(|(_, t)| ty_has_hole(*t))
+                || expr_has_hole(&c.body)
+        }
+        ClosureCall { target, args } => expr_has_hole(target) || args.iter().any(expr_has_hole),
+        Match(scrutinee, tree) => expr_has_hole(scrutinee) || tree_has_hole(tree),
+    }
+}
+
+fn tree_has_hole(tree: &hir::DecisionTree<'_>) -> bool {
+    use hir::{DecisionTree::*, SwitchCases};
+    match tree {
+        Uncovered | Unreachable => false,
+        Leaf { body, .. } => expr_has_hole(body),
+        Guard {
+            guard,
+            success,
+            failure,
+            ..
+        } => expr_has_hole(guard) || tree_has_hole(success) || tree_has_hole(failure),
+        Switch { cases, .. } => match cases {
+            SwitchCases::Int { cases, default } => {
+                cases.iter().any(|(_, t)| tree_has_hole(t)) || tree_has_hole(default)
+            }
+            SwitchCases::Bool { if_true, if_false } => {
+                tree_has_hole(if_true) || tree_has_hole(if_false)
+            }
+            SwitchCases::Ctor(trees) => trees.iter().any(tree_has_hole),
+            SwitchCases::String { cases, default } => {
+                cases.iter().any(|(_, t)| tree_has_hole(t)) || tree_has_hole(default)
+            }
+            SwitchCases::Nullable { non_null, null } => {
+                tree_has_hole(non_null) || tree_has_hole(null)
+            }
+        },
     }
 }
 

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -16,9 +16,8 @@
 //! each obligation against the (now solved) self type — via impl search for
 //! concrete types and super-trait subsumption for in-scope generics.
 
-use crate::semi::hir;
 use crate::semi::traits::{Obligation, TraitRef};
-use crate::semi::ty::{FpTy, IntTy, TyKind};
+use crate::semi::ty::{FpTy, HoleId, IntTy, TyKind};
 use crate::surface::Span;
 
 use super::ctxt::Elaborator;
@@ -113,6 +112,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
         for p in pending {
             self.error(p.span, "type annotations needed: cannot resolve a bound");
+            // The unresolved bound is the root cause; suppress the zonk-time
+            // "cannot infer" report for the holes it is stuck on, so each
+            // hole yields exactly one diagnostic.
+            let Obligation::Trait(tref) = &p.obligation;
+            let self_ty = self.infer.resolve(tref.self_ty());
+            let mut holes = Vec::new();
+            collect_holes(self_ty, &mut holes);
+            self.reported_holes.extend(holes);
         }
     }
 
@@ -137,26 +144,20 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             (self.builtins.num, i64_ty),
         ];
         for (want, default) in passes {
-            let candidates: Vec<_> = self
-                .fulfill
+            self.fulfill
                 .pending
                 .iter()
-                .filter(|p| {
+                .filter_map(|p| {
                     let Obligation::Trait(tref) = &p.obligation;
-                    tref.trait_id == want
+                    (tref.trait_id == want).then(|| tref.self_ty())
                 })
-                .map(|p| {
-                    let Obligation::Trait(tref) = &p.obligation;
-                    tref.self_ty()
-                })
-                .collect();
-            for ty in candidates {
-                let ty = self.infer.shallow_resolve(ty);
-                if matches!(ty.kind(), TyKind::Hole(_)) {
-                    // Unifying a hole with a ground type cannot fail.
-                    let _ = self.infer.unify(ty, default);
-                }
-            }
+                .for_each(|ty| {
+                    let ty = self.infer.shallow_resolve(ty);
+                    if matches!(ty.kind(), TyKind::Hole(_)) {
+                        // Unifying a hole with a ground type cannot fail.
+                        let _ = self.infer.unify(ty, default);
+                    }
+                });
         }
     }
 
@@ -270,71 +271,20 @@ pub(super) fn ty_has_hole(ty: crate::semi::ty::Ty<'_>) -> bool {
     }
 }
 
-/// Does any type anywhere in a zonked expression tree still hold an inference
-/// hole? Monomorphization panics on a residual hole (`subst_ty`), so a REPL
-/// input must be rejected up front when one survives zonking — e.g. a bare
-/// `Nullable::Null`, whose element hole carries no obligation for
-/// [`Elaborator::default_numeric_holes`] to solve. Mirrors the `zonk_expr`
-/// traversal: node types, cast targets, call type arguments, closure
-/// capture/parameter types, and decision-tree bodies/guards.
-pub(super) fn expr_has_hole(e: &hir::Expr<'_>) -> bool {
-    use hir::ExprKind::*;
-    if ty_has_hole(e.ty) {
-        return true;
-    }
-    match &e.kind {
-        GlobalStr(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_) | Poison => false,
-        Negate(e) | Not(e) | RegionRun(e) | Proj(e, _) => expr_has_hole(e),
-        Cast(e, t) => ty_has_hole(*t) || expr_has_hole(e),
-        Arith(l, _, r) | Cmp(l, _, r) => expr_has_hole(l) || expr_has_hole(r),
-        If(c, t, f) => expr_has_hole(c) || expr_has_hole(t) || expr_has_hole(f),
-        Assign(dst, _, src) => expr_has_hole(dst) || expr_has_hole(src),
-        Let { value, .. } => expr_has_hole(value),
-        Seq(es) => es.iter().any(expr_has_hole),
-        FuncCall { ty_args, args, .. }
-        | CompoundCall { ty_args, args, .. }
-        | VariantCall { ty_args, args, .. } => {
-            ty_args.iter().any(|t| ty_has_hole(*t)) || args.iter().any(expr_has_hole)
+/// Collect every hole in a deeply-resolved type, in structural order.
+/// Companion to [`ty_has_hole`]; used to report each hole once (see
+/// `Elaborator::zonk_ty` and the unresolved-bound path of
+/// [`Elaborator::resolve_obligations`]).
+pub(super) fn collect_holes(ty: crate::semi::ty::Ty<'_>, out: &mut Vec<HoleId>) {
+    match ty.kind() {
+        TyKind::Hole(h) => out.push(*h),
+        TyKind::Record { args, .. } => args.iter().for_each(|a| collect_holes(*a, out)),
+        TyKind::Closure { params, ret } => {
+            params.iter().for_each(|p| collect_holes(*p, out));
+            collect_holes(*ret, out);
         }
-        NullableCall(e) => e.as_deref().is_some_and(expr_has_hole),
-        Closure(c) => {
-            c.captures
-                .iter()
-                .chain(&c.params)
-                .any(|(_, t)| ty_has_hole(*t))
-                || expr_has_hole(&c.body)
-        }
-        ClosureCall { target, args } => expr_has_hole(target) || args.iter().any(expr_has_hole),
-        Match(scrutinee, tree) => expr_has_hole(scrutinee) || tree_has_hole(tree),
-    }
-}
-
-fn tree_has_hole(tree: &hir::DecisionTree<'_>) -> bool {
-    use hir::{DecisionTree::*, SwitchCases};
-    match tree {
-        Uncovered | Unreachable => false,
-        Leaf { body, .. } => expr_has_hole(body),
-        Guard {
-            guard,
-            success,
-            failure,
-            ..
-        } => expr_has_hole(guard) || tree_has_hole(success) || tree_has_hole(failure),
-        Switch { cases, .. } => match cases {
-            SwitchCases::Int { cases, default } => {
-                cases.iter().any(|(_, t)| tree_has_hole(t)) || tree_has_hole(default)
-            }
-            SwitchCases::Bool { if_true, if_false } => {
-                tree_has_hole(if_true) || tree_has_hole(if_false)
-            }
-            SwitchCases::Ctor(trees) => trees.iter().any(tree_has_hole),
-            SwitchCases::String { cases, default } => {
-                cases.iter().any(|(_, t)| tree_has_hole(t)) || tree_has_hole(default)
-            }
-            SwitchCases::Nullable { non_null, null } => {
-                tree_has_hole(non_null) || tree_has_hole(null)
-            }
-        },
+        TyKind::Nullable(inner) => collect_holes(*inner, out),
+        _ => {}
     }
 }
 

--- a/crates/reussir-core/src/semi/repl.rs
+++ b/crates/reussir-core/src/semi/repl.rs
@@ -1,0 +1,289 @@
+//! REPL-specific elaboration: one expression checked as a synthetic nullary
+//! function, exposed to the JIT through a C-ABI trampoline root.
+//!
+//! A REPL driver keeps one persistent [`Elaborator`] for the whole session
+//! (see [`Elaborator::try_extend`]) and calls [`Elaborator::try_repl_expr`]
+//! for every expression input. On success the accumulated program gains a
+//! private `fn __repl_expr_N() -> T { <expr> }` plus a
+//! [`TrampolineRoot`](super::ctxt::TrampolineRoot) exporting the same name,
+//! so monomorphization roots the wrapper and codegen emits a host-callable
+//! `extern "C"` entry for it. On any error the elaborator rolls back
+//! atomically, exactly like `try_extend`.
+
+use reussir_syntax::kind::TokenKey;
+
+use crate::semi::ctxt::{Checkpoint, Elaborator, FuncProto, Report, Severity, TrampolineRoot};
+use crate::semi::fulfill::{expr_has_hole, ty_has_hole};
+use crate::semi::hir::Function;
+use crate::semi::ty::Ty;
+use crate::surface::{self, Visibility};
+
+impl<'a, 'tcx> Elaborator<'a, 'tcx> {
+    /// Elaborate one REPL expression as the synthetic nullary function
+    /// `name`, registering a C-ABI trampoline root that exports `export`
+    /// (conventionally the same text, `__repl_expr_N`; the driver interns it
+    /// into the shared session interner).
+    ///
+    /// Atomic: `Err` carries the input's reports with all state rolled back;
+    /// `Ok` carries the expression's resolved (ground) type plus any
+    /// warnings. Numeric inference holes are defaulted REPL-style
+    /// ([`default_numeric_holes`](Elaborator::default_numeric_holes)); a hole
+    /// that survives defaulting — e.g. a bare `Nullable::Null` — is rejected
+    /// with an annotation hint rather than left to panic in
+    /// monomorphization.
+    pub fn try_repl_expr(
+        &mut self,
+        name: TokenKey,
+        export: &str,
+        expr: &surface::Expr,
+    ) -> Result<(Ty<'tcx>, Vec<Report>), Vec<Report>> {
+        let cp = self.checkpoint();
+        let span = Some(expr.span());
+
+        let def = match self.defs.declare_function(name) {
+            Some(def) => def,
+            None => {
+                // Defensive: the driver allocates a fresh `__repl_expr_N` per
+                // input, so a clash means a driver bug, not user error.
+                self.error(span, format!("`{}` is already defined", self.sym(name)));
+                return Err(self.take_reports_and_rollback(&cp));
+            }
+        };
+
+        // Check the expression as a nullary, non-regional function body with
+        // a hole return type; inference solves the hole to the expression's
+        // type.
+        self.enter_function(&[]);
+        self.regional_generics = Vec::new();
+        let ret = self.infer.new_hole_ty();
+        let body = self.check_expr(expr, ret);
+        self.default_numeric_holes();
+        self.resolve_obligations();
+        let body = self.zonk_expr(body);
+        let return_ty = self.infer.resolve(ret);
+
+        // A residual hole would panic in monomorphization (`subst_ty`);
+        // reject it here with an actionable message instead.
+        if ty_has_hole(return_ty) || expr_has_hole(&body) {
+            self.error(
+                span,
+                "cannot infer the type of this expression; add a type annotation",
+            );
+        }
+        // The wrapper is an ordinary (non-regional) function, so its result
+        // must not be region-local (mirrors the check_function boundary rule).
+        if self.is_flex(return_ty) {
+            self.error(
+                span,
+                "a REPL expression cannot produce a flex value: a flex value \
+                 cannot escape its region",
+            );
+        }
+
+        let new = self.reports.split_off(cp.reports);
+        if new.iter().any(|r| r.severity == Severity::Error) {
+            self.rollback(&cp);
+            return Err(new);
+        }
+
+        // Accept: register the prototype (later inputs may call the wrapper),
+        // the elaborated body, and the trampoline root that seeds
+        // monomorphization and names the exported C entry.
+        self.functions.insert(
+            def,
+            FuncProto {
+                def,
+                name,
+                visibility: Visibility::Private,
+                generics: Vec::new(),
+                regional_generics: Vec::new(),
+                params: Vec::new(),
+                return_ty,
+                is_regional: false,
+                span,
+            },
+        );
+        self.elaborated.push(Function {
+            def,
+            name,
+            visibility: Visibility::Private,
+            generics: Vec::new(),
+            regional_generics: std::mem::take(&mut self.regional_generics),
+            params: Vec::new(),
+            return_ty,
+            is_regional: false,
+            body: Some(body),
+            span,
+        });
+        self.trampolines.push(TrampolineRoot {
+            name: export.to_string(),
+            abi: "C".to_string(),
+            target: def,
+            ty_args: Vec::new(),
+        });
+        Ok((return_ty, new))
+    }
+
+    /// Split off the reports added since `cp`, then roll back.
+    fn take_reports_and_rollback(&mut self, cp: &Checkpoint) -> Vec<Report> {
+        let new = self.reports.split_off(cp.reports);
+        self.rollback(cp);
+        new
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use reussir_syntax::{Interner, MultiThreadedTokenInterner, new_threaded_interner};
+
+    use crate::semi::ty::{FpTy, IntTy, Ty, TyCtxt, TyKind};
+    use crate::semi::{Elaborator, Report};
+    use crate::surface;
+    use crate::with_tcx;
+
+    /// A REPL-session harness: one shared interner, one elaborator, a
+    /// counter for `__repl_expr_N` names.
+    struct Session<'a, 'tcx> {
+        interner: Arc<MultiThreadedTokenInterner>,
+        elab: Elaborator<'a, 'tcx>,
+        counter: usize,
+    }
+
+    impl<'a, 'tcx> Session<'a, 'tcx> {
+        fn define(&mut self, source: &str) {
+            let p = reussir_syntax::parse_repl(source, self.interner.clone());
+            assert_eq!(p.kind, reussir_syntax::ReplInputKind::Items, "{source}");
+            assert!(p.parse.ok(), "{source}: {:#?}", p.parse.errors);
+            self.elab
+                .try_extend(&surface::program(&p.parse.root))
+                .unwrap_or_else(|e| panic!("{source}: {e:#?}"));
+        }
+
+        fn eval(&mut self, source: &str) -> Result<Ty<'tcx>, Vec<Report>> {
+            let p = reussir_syntax::parse_repl(source, self.interner.clone());
+            assert_eq!(p.kind, reussir_syntax::ReplInputKind::Expr, "{source}");
+            assert!(p.parse.ok(), "{source}: {:#?}", p.parse.errors);
+            let expr = surface::repl_expr(&p.parse.root);
+            let export = format!("__repl_expr_{}", self.counter);
+            self.counter += 1;
+            let key = Interner::get_or_intern(&mut self.interner.clone(), &export);
+            self.elab
+                .try_repl_expr(key, &export, &expr)
+                .map(|(ty, _)| ty)
+        }
+    }
+
+    fn session<R>(f: impl for<'a, 'tcx> FnOnce(&mut Session<'a, 'tcx>, &TyCtxt<'tcx>) -> R) -> R {
+        with_tcx(|tcx| {
+            let interner = Arc::new(new_threaded_interner());
+            // The elaborator borrows the session interner as its resolver —
+            // the same shape a real REPL driver uses.
+            let resolver: &dyn reussir_syntax::kind::Resolver<reussir_syntax::kind::TokenKey> =
+                &interner;
+            let mut s = Session {
+                interner: interner.clone(),
+                elab: Elaborator::new(tcx, resolver),
+                counter: 0,
+            };
+            f(&mut s, tcx)
+        })
+    }
+
+    #[test]
+    fn defaults_numeric_literals() {
+        session(|s, tcx| {
+            // An unconstrained integer literal defaults to i64...
+            assert_eq!(s.eval("1 + 1").unwrap(), tcx.mk_int(IntTy::Signed(64)));
+            // ...a float literal to f64, including mixed Num+FloatingPoint
+            // obligations on one hole.
+            assert_eq!(s.eval("1.5").unwrap(), tcx.mk_fp(FpTy::Ieee(64)));
+            assert_eq!(s.eval("1.5 * 2.0").unwrap(), tcx.mk_fp(FpTy::Ieee(64)));
+            // Ground types are untouched.
+            assert!(matches!(s.eval("true").unwrap().kind(), TyKind::Bool));
+            assert!(matches!(s.eval("1 == 2").unwrap().kind(), TyKind::Bool));
+        });
+    }
+
+    #[test]
+    fn defaulting_reaches_generic_instantiations() {
+        session(|s, tcx| {
+            s.define("fn id<T>(x: T) -> T { x }");
+            // The literal's hole flows into `id`'s instantiation; defaulting
+            // must solve it there, not just at the root type.
+            assert_eq!(s.eval("id(1)").unwrap(), tcx.mk_int(IntTy::Signed(64)));
+        });
+    }
+
+    #[test]
+    fn expression_sequences_get_block_semantics() {
+        session(|s, tcx| {
+            assert_eq!(
+                s.eval("let a = 10; let b = 20; a + b").unwrap(),
+                tcx.mk_int(IntTy::Signed(64))
+            );
+        });
+    }
+
+    #[test]
+    fn residual_holes_are_rejected_cleanly() {
+        session(|s, _| {
+            // `Nullable::Null`'s element hole carries no numeric obligation,
+            // so defaulting cannot solve it; the guard must reject it instead
+            // of letting monomorphization panic.
+            let errs = s.eval("Nullable::Null").expect_err("unconstrained hole");
+            assert!(
+                errs.iter().any(|r| r.message.contains("cannot infer")),
+                "{errs:#?}"
+            );
+            // The failed input rolled back: the next one reuses the def space
+            // without a clash and the session stays usable.
+            assert_eq!(s.elab.elaborated.len(), 0);
+            s.counter = 0;
+            s.eval("42").expect("session still usable");
+        });
+    }
+
+    #[test]
+    fn registers_the_wrapper_and_trampoline() {
+        session(|s, _| {
+            s.eval("40 + 2").unwrap();
+            assert_eq!(s.elab.elaborated.len(), 1);
+            let f = &s.elab.elaborated[0];
+            assert_eq!(s.elab.sym(f.name), "__repl_expr_0");
+            assert!(f.generics.is_empty() && f.params.is_empty());
+            assert_eq!(s.elab.trampolines.len(), 1);
+            let t = &s.elab.trampolines[0];
+            assert_eq!(t.name, "__repl_expr_0");
+            assert_eq!(t.abi, "C");
+            assert_eq!(t.target, f.def);
+        });
+    }
+
+    #[test]
+    fn monomorphizes_on_the_fly_instantiations() {
+        use crate::full::mono::monomorphize;
+
+        session(|s, _| {
+            s.define("fn poly_add<T : Num>(x: T) -> T { x + x }");
+            s.eval("poly_add(21)").unwrap();
+            s.eval("poly_add(1.5)").unwrap();
+
+            // The maintained HIR monomorphizes with both on-the-fly
+            // instantiations of `poly_add` and both expression trampolines.
+            let (program, reports) = monomorphize(&s.elab.mono_input());
+            assert!(reports.is_empty(), "{reports:#?}");
+            assert_eq!(program.trampolines.len(), 2);
+            let names: Vec<&str> = program
+                .functions
+                .iter()
+                .map(|f| program.symbol(f.symbol))
+                .collect();
+            assert!(
+                names.iter().filter(|n| n.contains("poly_add")).count() >= 2,
+                "{names:?}"
+            );
+        });
+    }
+}

--- a/crates/reussir-core/src/semi/repl.rs
+++ b/crates/reussir-core/src/semi/repl.rs
@@ -13,7 +13,6 @@
 use reussir_syntax::kind::TokenKey;
 
 use crate::semi::ctxt::{Checkpoint, Elaborator, FuncProto, Report, Severity, TrampolineRoot};
-use crate::semi::fulfill::{expr_has_hole, ty_has_hole};
 use crate::semi::hir::Function;
 use crate::semi::ty::Ty;
 use crate::surface::{self, Visibility};
@@ -29,8 +28,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// warnings. Numeric inference holes are defaulted REPL-style
     /// ([`default_numeric_holes`](Elaborator::default_numeric_holes)); a hole
     /// that survives defaulting — e.g. a bare `Nullable::Null` — is rejected
-    /// with an annotation hint rather than left to panic in
-    /// monomorphization.
+    /// by the zonk-time ambiguity check with an annotation hint.
     pub fn try_repl_expr(
         &mut self,
         name: TokenKey,
@@ -40,21 +38,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let cp = self.checkpoint();
         let span = Some(expr.span());
 
-        let def = match self.defs.declare_function(name) {
-            Some(def) => def,
-            None => {
-                // Defensive: the driver allocates a fresh `__repl_expr_N` per
-                // input, so a clash means a driver bug, not user error.
-                self.error(span, format!("`{}` is already defined", self.sym(name)));
-                return Err(self.take_reports_and_rollback(&cp));
-            }
-        };
-
         // Check the expression as a nullary, non-regional function body with
         // a hole return type; inference solves the hole to the expression's
         // type.
         self.enter_function(&[]);
-        self.regional_generics = Vec::new();
+        self.regional_generics.clear();
         let ret = self.infer.new_hole_ty();
         let body = self.check_expr(expr, ret);
         self.default_numeric_holes();
@@ -62,14 +50,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let body = self.zonk_expr(body);
         let return_ty = self.infer.resolve(ret);
 
-        // A residual hole would panic in monomorphization (`subst_ty`);
-        // reject it here with an actionable message instead.
-        if ty_has_hole(return_ty) || expr_has_hole(&body) {
-            self.error(
-                span,
-                "cannot infer the type of this expression; add a type annotation",
-            );
-        }
         // The wrapper is an ordinary (non-regional) function, so its result
         // must not be region-local (mirrors the check_function boundary rule).
         if self.is_flex(return_ty) {
@@ -86,9 +66,24 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return Err(new);
         }
 
-        // Accept: register the prototype (later inputs may call the wrapper),
-        // the elaborated body, and the trampoline root that seeds
-        // monomorphization and names the exported C entry.
+        // Accept: declare the wrapper and register its prototype (later
+        // inputs may call it), the elaborated body, and the trampoline root
+        // that seeds monomorphization and names the exported C entry.
+        //
+        // Declaring only now — after the body checked — keeps the "every
+        // resolvable def has a prototype" invariant the call paths index by
+        // (`self.functions[&def]`). Today no surface input can name the
+        // wrapper anyway (a leading `_` cannot start an identifier), but the
+        // invariant should hold structurally, not by lexical accident.
+        let def = match self.defs.declare_function(name) {
+            Some(def) => def,
+            None => {
+                // Defensive: the driver allocates a fresh `__repl_expr_N` per
+                // input, so a clash means a driver bug, not user error.
+                self.error(span, format!("`{}` is already defined", self.sym(name)));
+                return Err(self.take_reports_and_rollback(&cp));
+            }
+        };
         self.functions.insert(
             def,
             FuncProto {
@@ -242,6 +237,24 @@ mod tests {
             assert_eq!(s.elab.elaborated.len(), 0);
             s.counter = 0;
             s.eval("42").expect("session still usable");
+        });
+    }
+
+    #[test]
+    fn clashing_wrapper_names_are_a_clean_error() {
+        session(|s, _| {
+            s.eval("1").expect("first use of the name");
+            // A driver bug reusing an export name must surface as a report
+            // (and roll back), not corrupt the session.
+            s.counter = 0;
+            let errs = s.eval("2").expect_err("name already taken");
+            assert!(
+                errs.iter().any(|r| r.message.contains("already defined")),
+                "{errs:#?}"
+            );
+            assert_eq!(s.elab.elaborated.len(), 1, "clashing input rolled back");
+            s.counter = 1;
+            s.eval("2").expect("session still usable");
         });
     }
 

--- a/crates/reussir-core/src/semi/resolve.rs
+++ b/crates/reussir-core/src/semi/resolve.rs
@@ -126,6 +126,32 @@ impl DefTable {
         self.values.keys().copied()
     }
 
+    /// The number of declared defs — a checkpoint for [`DefTable::truncate`].
+    pub fn len(&self) -> usize {
+        self.defs.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.defs.is_empty()
+    }
+
+    /// Retract every def declared at index `>= len`, removing its name from the
+    /// owning namespace scope. The REPL uses this to roll an elaboration
+    /// attempt back atomically; it relies on `declare` rejecting clashes, so a
+    /// name in a scope always maps to the def that introduced it.
+    pub fn truncate(&mut self, len: usize) {
+        while self.defs.len() > len {
+            let id = DefId((self.defs.len() - 1) as u32);
+            let info = self.defs.pop().expect("len checked above");
+            let scope = match info.kind {
+                DefKind::Record => &mut self.types,
+                DefKind::Function => &mut self.values,
+            };
+            let removed = scope.remove(&info.path.name());
+            debug_assert_eq!(removed, Some(id), "scope must point at the popped def");
+        }
+    }
+
     pub fn info(&self, def: DefId) -> &DefInfo {
         &self.defs[def.0 as usize]
     }
@@ -170,5 +196,23 @@ mod tests {
         let mut t = DefTable::new();
         assert!(t.declare_record(k(1)).is_some());
         assert!(t.declare_record(k(1)).is_none());
+    }
+
+    #[test]
+    fn truncate_retracts_later_defs() {
+        let mut t = DefTable::new();
+        let a = t.declare_record(k(1)).expect("fresh");
+        let cp = t.len();
+        t.declare_record(k(2)).expect("fresh");
+        t.declare_function(k(3)).expect("fresh");
+        t.truncate(cp);
+        // Defs before the checkpoint survive; later ones are gone from both
+        // the registry and their namespace scopes.
+        assert_eq!(t.resolve_record(k(1)), Some(a));
+        assert_eq!(t.resolve_record(k(2)), None);
+        assert_eq!(t.resolve_function(k(3)), None);
+        assert_eq!(t.len(), cp);
+        // A retracted name can be declared again.
+        assert!(t.declare_record(k(2)).is_some());
     }
 }

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -1049,6 +1049,16 @@ pub fn program(root: &ResolvedNode) -> Program {
     root.children().map(Stmt::new).collect()
 }
 
+/// View the root of a REPL expression parse
+/// ([`reussir_syntax::parse_repl`] with [`reussir_syntax::ReplInputKind::Expr`])
+/// as a typed expression. The root is a brace-less `BlockExpr`, so its
+/// [`Expr::kind`] is an [`ExprKind::ExprSeq`] and `let x = 1; x + 1` inputs
+/// get block semantics.
+pub fn repl_expr(root: &ResolvedNode) -> Expr {
+    assert_eq!(root.kind(), BlockExpr, "expected a REPL expression root");
+    Expr::new(root)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/reussir-jit/src/lib.rs
+++ b/crates/reussir-jit/src/lib.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 
 pub mod orc;
 
-pub use orc::{OptLevel, OrcJit};
+pub use orc::{ModuleHandle, OptLevel, OrcJit};
 
 /// Locates the Reussir runtime shared library.
 ///

--- a/crates/reussir-jit/src/orc.rs
+++ b/crates/reussir-jit/src/orc.rs
@@ -112,17 +112,23 @@ pub struct OrcJit {
 /// needs when a module was added but materialization then failed. Dropping
 /// the handle instead releases only the tracker: the module stays in the
 /// session permanently (its resources fold into the dylib default).
+///
+/// The `'jit` lifetime borrows the owning [`OrcJit`]: the tracker points
+/// into that engine's `ExecutionSession`, so a handle released (dropped or
+/// removed) after the engine's disposal would be a use-after-free. The
+/// borrow makes that ordering a compile error.
 #[derive(Debug)]
-pub struct ModuleHandle {
+pub struct ModuleHandle<'jit> {
     tracker: LLVMOrcResourceTrackerRef,
+    jit: std::marker::PhantomData<&'jit OrcJit>,
 }
 
 // Resource trackers are part of the execution session, which is internally
 // synchronized (same rationale as `OrcJit` itself).
-unsafe impl Send for ModuleHandle {}
-unsafe impl Sync for ModuleHandle {}
+unsafe impl Send for ModuleHandle<'_> {}
+unsafe impl Sync for ModuleHandle<'_> {}
 
-impl Drop for ModuleHandle {
+impl Drop for ModuleHandle<'_> {
     fn drop(&mut self) {
         unsafe { LLVMOrcReleaseResourceTracker(self.tracker) }
     }
@@ -273,7 +279,7 @@ impl OrcJit {
     /// Like [`OrcJit::add_ir_module`], but scopes the module's resources to a
     /// returned [`ModuleHandle`] so it can later be removed with
     /// [`OrcJit::remove_module`].
-    pub fn add_ir_module_tracked(&self, name: &str, ir: &str) -> Result<ModuleHandle, String> {
+    pub fn add_ir_module_tracked(&self, name: &str, ir: &str) -> Result<ModuleHandle<'_>, String> {
         self.tracked(|tracker| self.add_ir_module_at(name, ir, tracker))
     }
 
@@ -339,7 +345,7 @@ impl OrcJit {
         &self,
         module: &Module,
         opt: OptLevel,
-    ) -> Result<ModuleHandle, String> {
+    ) -> Result<ModuleHandle<'_>, String> {
         self.tracked(|tracker| self.add_module_at(module, opt, tracker))
     }
 
@@ -387,13 +393,16 @@ impl OrcJit {
     fn tracked(
         &self,
         add: impl FnOnce(LLVMOrcResourceTrackerRef) -> Result<(), String>,
-    ) -> Result<ModuleHandle, String> {
+    ) -> Result<ModuleHandle<'_>, String> {
         let tracker = unsafe {
             let dylib = LLVMOrcLLJITGetMainJITDylib(self.jit);
             LLVMOrcJITDylibCreateResourceTracker(dylib)
         };
         match add(tracker) {
-            Ok(()) => Ok(ModuleHandle { tracker }),
+            Ok(()) => Ok(ModuleHandle {
+                tracker,
+                jit: std::marker::PhantomData,
+            }),
             Err(message) => {
                 unsafe { LLVMOrcReleaseResourceTracker(tracker) };
                 Err(message)
@@ -406,7 +415,7 @@ impl OrcJit {
     /// modules that called into the removed module keeps its (now dangling)
     /// resolutions, so this is intended for modules whose symbols were never
     /// successfully materialized (the REPL failure-recovery path).
-    pub fn remove_module(&self, handle: ModuleHandle) -> Result<(), String> {
+    pub fn remove_module(&self, handle: ModuleHandle<'_>) -> Result<(), String> {
         // The handle's Drop releases the tracker reference after removal.
         check_error(unsafe { LLVMOrcResourceTrackerRemove(handle.tracker) })
     }

--- a/crates/reussir-jit/src/orc.rs
+++ b/crates/reussir-jit/src/orc.rs
@@ -23,8 +23,9 @@ use llvm_sys::error::{LLVMDisposeErrorMessage, LLVMErrorRef, LLVMGetErrorMessage
 use llvm_sys::ir_reader::LLVMParseIRInContext;
 use llvm_sys::orc2::lljit::{
     LLVMOrcCreateLLJIT, LLVMOrcDisposeLLJIT, LLVMOrcLLJITAddLLVMIRModule,
-    LLVMOrcLLJITAddObjectFile, LLVMOrcLLJITGetDataLayoutStr, LLVMOrcLLJITGetGlobalPrefix,
-    LLVMOrcLLJITGetMainJITDylib, LLVMOrcLLJITLookup, LLVMOrcLLJITMangleAndIntern, LLVMOrcLLJITRef,
+    LLVMOrcLLJITAddLLVMIRModuleWithRT, LLVMOrcLLJITAddObjectFile, LLVMOrcLLJITAddObjectFileWithRT,
+    LLVMOrcLLJITGetDataLayoutStr, LLVMOrcLLJITGetGlobalPrefix, LLVMOrcLLJITGetMainJITDylib,
+    LLVMOrcLLJITLookup, LLVMOrcLLJITMangleAndIntern, LLVMOrcLLJITRef,
 };
 use llvm_sys::orc2::{
     LLVMJITEvaluatedSymbol, LLVMJITSymbolFlags, LLVMJITSymbolGenericFlags, LLVMOrcAbsoluteSymbols,
@@ -32,7 +33,8 @@ use llvm_sys::orc2::{
     LLVMOrcCreateDynamicLibrarySearchGeneratorForProcess,
     LLVMOrcCreateNewThreadSafeContextFromLLVMContext, LLVMOrcCreateNewThreadSafeModule,
     LLVMOrcDefinitionGeneratorRef, LLVMOrcDisposeThreadSafeContext, LLVMOrcExecutorAddress,
-    LLVMOrcJITDylibAddGenerator, LLVMOrcJITDylibDefine,
+    LLVMOrcJITDylibAddGenerator, LLVMOrcJITDylibCreateResourceTracker, LLVMOrcJITDylibDefine,
+    LLVMOrcReleaseResourceTracker, LLVMOrcResourceTrackerRef, LLVMOrcResourceTrackerRemove,
 };
 use llvm_sys::prelude::{LLVMContextRef, LLVMMemoryBufferRef, LLVMModuleRef};
 use llvm_sys::target::{LLVM_InitializeNativeAsmPrinter, LLVM_InitializeNativeTarget};
@@ -99,6 +101,31 @@ fn check_error(error: LLVMErrorRef) -> Result<(), String> {
 /// A persistent ORC `LLJIT` engine for Reussir.
 pub struct OrcJit {
     jit: LLVMOrcLLJITRef,
+}
+
+/// A handle to one tracked module added with [`OrcJit::add_module_tracked`]
+/// or [`OrcJit::add_ir_module_tracked`]: a `ResourceTracker` scoped to that
+/// module's resources in the main `JITDylib`.
+///
+/// Passing the handle to [`OrcJit::remove_module`] removes the module's
+/// symbols and memory from the session — the failure-recovery path a REPL
+/// needs when a module was added but materialization then failed. Dropping
+/// the handle instead releases only the tracker: the module stays in the
+/// session permanently (its resources fold into the dylib default).
+#[derive(Debug)]
+pub struct ModuleHandle {
+    tracker: LLVMOrcResourceTrackerRef,
+}
+
+// Resource trackers are part of the execution session, which is internally
+// synchronized (same rationale as `OrcJit` itself).
+unsafe impl Send for ModuleHandle {}
+unsafe impl Sync for ModuleHandle {}
+
+impl Drop for ModuleHandle {
+    fn drop(&mut self) {
+        unsafe { LLVMOrcReleaseResourceTracker(self.tracker) }
+    }
 }
 
 // The LLJIT session is internally synchronized and may be used across threads.
@@ -240,6 +267,22 @@ impl OrcJit {
     /// Parses LLVM IR text and adds it to the main `JITDylib`. `name` only labels
     /// the buffer for diagnostics.
     pub fn add_ir_module(&self, name: &str, ir: &str) -> Result<(), String> {
+        self.add_ir_module_at(name, ir, std::ptr::null_mut())
+    }
+
+    /// Like [`OrcJit::add_ir_module`], but scopes the module's resources to a
+    /// returned [`ModuleHandle`] so it can later be removed with
+    /// [`OrcJit::remove_module`].
+    pub fn add_ir_module_tracked(&self, name: &str, ir: &str) -> Result<ModuleHandle, String> {
+        self.tracked(|tracker| self.add_ir_module_at(name, ir, tracker))
+    }
+
+    fn add_ir_module_at(
+        &self,
+        name: &str,
+        ir: &str,
+        tracker: LLVMOrcResourceTrackerRef,
+    ) -> Result<(), String> {
         unsafe {
             let context = LLVMContextCreate();
 
@@ -263,7 +306,7 @@ impl OrcJit {
                 return Err(format!("failed to parse LLVM IR: {message}"));
             }
 
-            self.add_owned_module(context, module)
+            self.add_owned_module(context, module, tracker)
         }
     }
 
@@ -285,6 +328,27 @@ impl OrcJit {
     /// [`reussir_backend::llvm::Finalized`] here. Until then a module containing
     /// `reussir.polyffi` fails loudly at `run_lowering_pipeline`, not silently.
     pub fn add_module(&self, module: &Module, opt: OptLevel) -> Result<(), String> {
+        self.add_module_at(module, opt, std::ptr::null_mut())
+    }
+
+    /// Like [`OrcJit::add_module`], but scopes the module's resources to a
+    /// returned [`ModuleHandle`] so it can later be removed with
+    /// [`OrcJit::remove_module`] — e.g. a REPL evicting an input whose
+    /// materialization failed after the module was added.
+    pub fn add_module_tracked(
+        &self,
+        module: &Module,
+        opt: OptLevel,
+    ) -> Result<ModuleHandle, String> {
+        self.tracked(|tracker| self.add_module_at(module, opt, tracker))
+    }
+
+    fn add_module_at(
+        &self,
+        module: &Module,
+        opt: OptLevel,
+        tracker: LLVMOrcResourceTrackerRef,
+    ) -> Result<(), String> {
         let _span = tracing::debug_span!("orcjit_add_module", opt = ?opt).entered();
         unsafe {
             // The translated module is created in (and owned alongside) `context`.
@@ -302,7 +366,7 @@ impl OrcJit {
             if opt == OptLevel::Tpde {
                 // TPDE compiles the IR to an object directly; the IR module and
                 // its context are not handed to the JIT, so we free them here.
-                let result = self.add_tpde_object(llvm_module);
+                let result = self.add_tpde_object(llvm_module, tracker);
                 LLVMDisposeModule(llvm_module);
                 LLVMContextDispose(context);
                 return result;
@@ -311,15 +375,50 @@ impl OrcJit {
             // Run the Reussir LLVM passes in place, then add the IR module.
             tracing::trace!("running backend LLVM pass pipeline");
             run_backend_llvm_pipeline(llvm_module, opt);
-            self.add_owned_module(context, llvm_module)?;
+            self.add_owned_module(context, llvm_module, tracker)?;
             tracing::debug!("added LLVM-IR module to the JIT");
             Ok(())
         }
     }
 
+    // Runs `add` against a fresh per-module resource tracker, wrapping it in a
+    // [`ModuleHandle`] on success. On failure nothing was added under the
+    // tracker, so only the tracker reference itself is released.
+    fn tracked(
+        &self,
+        add: impl FnOnce(LLVMOrcResourceTrackerRef) -> Result<(), String>,
+    ) -> Result<ModuleHandle, String> {
+        let tracker = unsafe {
+            let dylib = LLVMOrcLLJITGetMainJITDylib(self.jit);
+            LLVMOrcJITDylibCreateResourceTracker(dylib)
+        };
+        match add(tracker) {
+            Ok(()) => Ok(ModuleHandle { tracker }),
+            Err(message) => {
+                unsafe { LLVMOrcReleaseResourceTracker(tracker) };
+                Err(message)
+            }
+        }
+    }
+
+    /// Removes a tracked module's resources — its symbols and any compiled
+    /// memory — from the session. Already-materialized code in *other*
+    /// modules that called into the removed module keeps its (now dangling)
+    /// resolutions, so this is intended for modules whose symbols were never
+    /// successfully materialized (the REPL failure-recovery path).
+    pub fn remove_module(&self, handle: ModuleHandle) -> Result<(), String> {
+        // The handle's Drop releases the tracker reference after removal.
+        check_error(unsafe { LLVMOrcResourceTrackerRemove(handle.tracker) })
+    }
+
     // Compiles a module to an object with TPDE and adds the object to the main
-    // JITDylib. Does not take ownership of `module`.
-    fn add_tpde_object(&self, module: LLVMModuleRef) -> Result<(), String> {
+    // JITDylib (or to `tracker`, when non-null). Does not take ownership of
+    // `module`.
+    fn add_tpde_object(
+        &self,
+        module: LLVMModuleRef,
+        tracker: LLVMOrcResourceTrackerRef,
+    ) -> Result<(), String> {
         if !has_tpde() {
             return Err("TPDE support is not compiled into the backend".into());
         }
@@ -335,20 +434,27 @@ impl OrcJit {
                 tracing::error!("TPDE compilation failed");
                 return Err("TPDE compilation failed".into());
             }
-            let dylib = LLVMOrcLLJITGetMainJITDylib(self.jit);
-            // Consumes `buffer`.
-            check_error(LLVMOrcLLJITAddObjectFile(self.jit, dylib, buffer))?;
+            // Both variants consume `buffer`.
+            let result = if tracker.is_null() {
+                let dylib = LLVMOrcLLJITGetMainJITDylib(self.jit);
+                LLVMOrcLLJITAddObjectFile(self.jit, dylib, buffer)
+            } else {
+                LLVMOrcLLJITAddObjectFileWithRT(self.jit, tracker, buffer)
+            };
+            check_error(result)?;
             tracing::debug!("added TPDE object to the JIT");
             Ok(())
         }
     }
 
-    // Wraps an owned (context, module) pair in a thread-safe module and adds it to
-    // the main JITDylib. Consumes ownership of both.
+    // Wraps an owned (context, module) pair in a thread-safe module and adds it
+    // to the main JITDylib (or to `tracker`, when non-null). Consumes ownership
+    // of both.
     unsafe fn add_owned_module(
         &self,
         context: LLVMContextRef,
         module: LLVMModuleRef,
+        tracker: LLVMOrcResourceTrackerRef,
     ) -> Result<(), String> {
         unsafe {
             // The thread-safe context takes ownership of `context`; the
@@ -358,8 +464,14 @@ impl OrcJit {
             let ts_module = LLVMOrcCreateNewThreadSafeModule(module, ts_context);
             LLVMOrcDisposeThreadSafeContext(ts_context);
 
-            let dylib = LLVMOrcLLJITGetMainJITDylib(self.jit);
-            check_error(LLVMOrcLLJITAddLLVMIRModule(self.jit, dylib, ts_module))
+            if tracker.is_null() {
+                let dylib = LLVMOrcLLJITGetMainJITDylib(self.jit);
+                check_error(LLVMOrcLLJITAddLLVMIRModule(self.jit, dylib, ts_module))
+            } else {
+                check_error(LLVMOrcLLJITAddLLVMIRModuleWithRT(
+                    self.jit, tracker, ts_module,
+                ))
+            }
         }
     }
 
@@ -461,6 +573,86 @@ mod tests {
             return;
         }
         assert_eq!(jit_add(OptLevel::Tpde), 42);
+    }
+
+    #[test]
+    fn a_failed_add_leaves_the_session_usable() {
+        let jit = OrcJit::new().expect("create LLJIT");
+        // Unparsable IR fails the add without defining anything.
+        assert!(jit.add_ir_module_tracked("bad", "this is not IR").is_err());
+        // The session is intact: the same engine accepts and runs new code.
+        jit.add_ir_module("good", "define i32 @fine() { ret i32 7 }")
+            .expect("add after failure");
+        let address = jit.lookup("fine").expect("lookup fine");
+        let fine: extern "C" fn() -> i32 = unsafe { std::mem::transmute(address as usize) };
+        assert_eq!(fine(), 7);
+    }
+
+    #[test]
+    fn a_removed_module_frees_its_symbols_for_redefinition() {
+        let jit = OrcJit::new().expect("create LLJIT");
+        // Add a tracked module but do NOT materialize it (no lookup), then
+        // remove it — the REPL failure-recovery path.
+        let handle = jit
+            .add_ir_module_tracked("first", "define i32 @answer() { ret i32 1 }")
+            .expect("tracked add");
+        jit.remove_module(handle).expect("remove");
+
+        // The name is free again; a fresh definition materializes fine.
+        jit.add_ir_module("second", "define i32 @answer() { ret i32 42 }")
+            .expect("redefine after removal");
+        let address = jit.lookup("answer").expect("lookup answer");
+        let answer: extern "C" fn() -> i32 = unsafe { std::mem::transmute(address as usize) };
+        assert_eq!(answer(), 42);
+    }
+
+    #[test]
+    fn a_dropped_handle_keeps_the_module_alive() {
+        let jit = OrcJit::new().expect("create LLJIT");
+        let handle = jit
+            .add_ir_module_tracked("kept", "define i32 @kept() { ret i32 9 }")
+            .expect("tracked add");
+        drop(handle);
+        let address = jit.lookup("kept").expect("lookup kept");
+        let kept: extern "C" fn() -> i32 = unsafe { std::mem::transmute(address as usize) };
+        assert_eq!(kept(), 9);
+    }
+
+    #[test]
+    fn tracked_mlir_modules_run_and_duplicates_are_rejected() {
+        let context = reussir_backend::context();
+        let source = r#"
+            module {
+              func.func @tracked_add(%a: i32, %b: i32) -> i32 {
+                %0 = arith.addi %a, %b : i32
+                func.return %0 : i32
+              }
+            }
+        "#;
+        let mut module = Module::parse(&context, source).expect("module should parse");
+        reussir_backend::pipeline::run_lowering_pipeline(
+            &context,
+            &mut module,
+            &reussir_backend::pipeline::LoweringOptions::default(),
+        )
+        .expect("lowering should succeed");
+
+        let jit = OrcJit::new().expect("create LLJIT");
+        let _handle = jit
+            .add_module_tracked(&module, OptLevel::Default)
+            .expect("tracked add");
+        let address = jit.lookup("tracked_add").expect("lookup");
+        let add: extern "C" fn(i32, i32) -> i32 = unsafe { std::mem::transmute(address as usize) };
+        assert_eq!(add(20, 22), 42);
+
+        // A second module defining the same materialized symbol is rejected,
+        // and the rejection reports the duplicate.
+        let err = jit
+            .add_ir_module_tracked("dup", "define i32 @tracked_add() { ret i32 0 }")
+            .expect_err("duplicate symbol");
+        assert!(err.contains("uplicate"), "{err}");
+        // The engine is still usable afterwards.
+        assert_eq!(add(1, 2), 3);
     }
 
     // A host function defined as an absolute symbol and called from JIT'd code.

--- a/crates/reussir-jit/src/orc.rs
+++ b/crates/reussir-jit/src/orc.rs
@@ -415,8 +415,13 @@ impl OrcJit {
     /// modules that called into the removed module keeps its (now dangling)
     /// resolutions, so this is intended for modules whose symbols were never
     /// successfully materialized (the REPL failure-recovery path).
-    pub fn remove_module(&self, handle: ModuleHandle<'_>) -> Result<(), String> {
-        // The handle's Drop releases the tracker reference after removal.
+    ///
+    /// Borrows rather than consumes the handle so a failed removal leaves it
+    /// intact (dropping it then would fold the module into the session
+    /// permanently). Dropping the handle after a successful removal — or
+    /// removing twice, which reports an error — is fine: the drop releases
+    /// only this reference to the (now defunct) tracker.
+    pub fn remove_module(&self, handle: &ModuleHandle<'_>) -> Result<(), String> {
         check_error(unsafe { LLVMOrcResourceTrackerRemove(handle.tracker) })
     }
 
@@ -605,7 +610,7 @@ mod tests {
         let handle = jit
             .add_ir_module_tracked("first", "define i32 @answer() { ret i32 1 }")
             .expect("tracked add");
-        jit.remove_module(handle).expect("remove");
+        jit.remove_module(&handle).expect("remove");
 
         // The name is free again; a fresh definition materializes fine.
         jit.add_ir_module("second", "define i32 @answer() { ret i32 42 }")

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -105,35 +105,58 @@ pub struct ReplParse {
 
 /// Parse one REPL input as either top-level items or an expression sequence.
 ///
-/// The route is decided by the first significant token — `fn`, `struct`,
-/// `enum`, `mod`, `extern`, and `pub` start items, and `regional` does iff
-/// the next token is `fn` (otherwise it is a `regional { ... }` expression);
-/// everything else is an expression. No backtracking: errors are reported
-/// against the chosen route. The routing is exact — every item-starting
-/// token is a hard keyword (the lexer never classifies `fn`, `struct`, etc.
-/// as identifiers), so no expression can begin with one.
+/// The route is decided by the first tokens, no backtracking: errors are
+/// reported against the chosen route. Items are recognized by an item prefix
+/// — `fn`/`struct`/`enum`/`mod` followed by the item's name, `extern`
+/// followed by its ABI string, `pub` followed by an item form, `regional`
+/// followed by `fn` — and everything else is an expression. One token of
+/// lookahead past the head keyword is needed because keyword tokens are
+/// contextual in identifier positions ([`SyntaxKind::is_ident_like`]): a
+/// variable named `fn` may head an expression (`fn + 1`). The one ambiguous
+/// prefix is an item keyword followed by `as` — `fn as i64` is a cast of a
+/// variable named `fn` — which routes to expressions, so an item literally
+/// named `as` cannot be entered at the REPL.
 pub fn parse_repl(
     source: &str,
     interner: std::sync::Arc<cstree::interning::MultiThreadedTokenInterner>,
 ) -> ReplParse {
     let mut kind = ReplInputKind::Expr;
     let parse = parse_impl(source, interner, |p| {
-        kind = match p.current() {
-            SyntaxKind::FnKw
-            | SyntaxKind::StructKw
-            | SyntaxKind::EnumKw
-            | SyntaxKind::ModKw
-            | SyntaxKind::ExternKw
-            | SyntaxKind::PubKw => ReplInputKind::Items,
-            SyntaxKind::RegionalKw if p.nth(1) == SyntaxKind::FnKw => ReplInputKind::Items,
-            _ => ReplInputKind::Expr,
-        };
+        kind = repl_route(p);
         match kind {
             ReplInputKind::Items => p.source_file(),
             ReplInputKind::Expr => p.repl_expr_seq(),
         }
     });
     ReplParse { parse, kind }
+}
+
+/// The [`parse_repl`] routing decision; see its docs for the rationale.
+fn repl_route(p: &parser::Parser) -> ReplInputKind {
+    use SyntaxKind::*;
+    let starts_item = match p.current() {
+        // `fn f`, `struct P`, ... — the keyword is an item head iff its
+        // name follows; a keyword-named variable is followed by an operator
+        // (`fn + 1`) or nothing. `as` is the exception: `fn as i64` is a
+        // cast of a variable named `fn`.
+        FnKw | StructKw | EnumKw | ModKw => p.nth(1).is_ident_like() && p.nth(1) != AsKw,
+        // `extern "C" trampoline ...` — a string cannot follow a variable.
+        ExternKw => p.nth(1) == StringLit,
+        // `pub <item>` — mirrors `stmt`'s post-visibility dispatch.
+        PubKw => matches!(
+            p.nth(1),
+            RegionalKw | FnKw | StructKw | EnumKw | ModKw | ExternKw
+        ),
+        // `regional fn` is an item; any other `regional ...` is a region
+        // expression.
+        RegionalKw => p.nth(1) == FnKw,
+        _ => false,
+    };
+    if starts_item {
+        ReplInputKind::Items
+    } else {
+        ReplInputKind::Expr
+    }
 }
 
 /// The shared parse pipeline: lex, run `entry` on the parser, then build the
@@ -252,6 +275,18 @@ mod tests {
             "|x: i32| x + 1",
             // `regional` NOT followed by `fn` is a regional expression.
             "regional { Cell { value: 1 } }",
+            // Keyword tokens are contextual in identifier positions, so a
+            // keyword-named variable may head an expression; the name
+            // lookahead keeps these off the items route.
+            "fn + 1",
+            "struct(2)",
+            "mod.field",
+            "pub * 2",
+            "extern == 3",
+            // The documented `as` ambiguity resolves toward the cast.
+            "fn as i64",
+            // A bare keyword-named variable (nothing follows).
+            "enum",
         ];
         for source in exprs {
             let rp = parse_repl(source, interner.clone());

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -109,16 +109,16 @@ pub struct ReplParse {
 /// `enum`, `mod`, `extern`, and `pub` start items, and `regional` does iff
 /// the next token is `fn` (otherwise it is a `regional { ... }` expression);
 /// everything else is an expression. No backtracking: errors are reported
-/// against the chosen route. Since the language has no reserved identifiers,
-/// an expression *headed* by a variable literally named like an item keyword
-/// misroutes to items; accepted as a documented limitation.
+/// against the chosen route. The routing is exact — every item-starting
+/// token is a hard keyword (the lexer never classifies `fn`, `struct`, etc.
+/// as identifiers), so no expression can begin with one.
 pub fn parse_repl(
     source: &str,
     interner: std::sync::Arc<cstree::interning::MultiThreadedTokenInterner>,
 ) -> ReplParse {
-    let kind_cell = std::cell::Cell::new(ReplInputKind::Expr);
+    let mut kind = ReplInputKind::Expr;
     let parse = parse_impl(source, interner, |p| {
-        let kind = match p.current() {
+        kind = match p.current() {
             SyntaxKind::FnKw
             | SyntaxKind::StructKw
             | SyntaxKind::EnumKw
@@ -128,21 +128,17 @@ pub fn parse_repl(
             SyntaxKind::RegionalKw if p.nth(1) == SyntaxKind::FnKw => ReplInputKind::Items,
             _ => ReplInputKind::Expr,
         };
-        kind_cell.set(kind);
         match kind {
             ReplInputKind::Items => p.source_file(),
             ReplInputKind::Expr => p.repl_expr_seq(),
         }
     });
-    ReplParse {
-        parse,
-        kind: kind_cell.get(),
-    }
+    ReplParse { parse, kind }
 }
 
 /// The shared parse pipeline: lex, run `entry` on the parser, then build the
 /// lossless tree with `interner` (which becomes the tree's resolver).
-fn parse_impl<I>(source: &str, interner: I, entry: impl FnOnce(&mut parser::Parser)) -> Parse
+fn parse_impl<I>(source: &str, mut interner: I, entry: impl FnOnce(&mut parser::Parser)) -> Parse
 where
     I: cstree::interning::Interner<kind::TokenKey> + kind::Resolver<kind::TokenKey> + 'static,
 {
@@ -170,7 +166,6 @@ where
     // the first message is the most informative one.
     errors.dedup_by_key(|e| e.span.0);
 
-    let mut interner = interner;
     let green = parser::sink::Sink::new(source, &all_tokens, events, &mut interner).finish();
     let root = kind::SyntaxNode::new_root_with_resolver(green, interner);
     Parse { root, errors }

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -82,7 +82,7 @@ pub fn parse(source: &str) -> Parse {
 /// as the long-lived [`kind::Resolver`]; each parse's tree holds another.
 pub fn parse_with_interner(
     source: &str,
-    interner: std::sync::Arc<cstree::interning::MultiThreadedTokenInterner>,
+    interner: std::sync::Arc<MultiThreadedTokenInterner>,
 ) -> Parse {
     parse_impl(source, interner, |p| p.source_file())
 }
@@ -118,7 +118,7 @@ pub struct ReplParse {
 /// named `as` cannot be entered at the REPL.
 pub fn parse_repl(
     source: &str,
-    interner: std::sync::Arc<cstree::interning::MultiThreadedTokenInterner>,
+    interner: std::sync::Arc<MultiThreadedTokenInterner>,
 ) -> ReplParse {
     let mut kind = ReplInputKind::Expr;
     let parse = parse_impl(source, interner, |p| {
@@ -305,6 +305,27 @@ mod tests {
         assert!(!rp.parse.ok());
         // Lossless even under recovery.
         assert_eq!(rp.parse.root.text(), "1 + 2 3");
+    }
+
+    #[test]
+    fn repl_expr_seq_recovers_at_semicolons() {
+        let interner = std::sync::Arc::new(new_threaded_interner());
+        // An error inside one expression resynchronizes at the `;`: the
+        // expression's own diagnostic is the only one (no misleading
+        // "expected `;`"), and the rest of the sequence still parses.
+        let rp = parse_repl("1 + ; 2 + 3", interner);
+        assert_eq!(rp.kind, ReplInputKind::Expr);
+        assert_eq!(rp.parse.errors.len(), 1, "{:#?}", rp.parse.errors);
+        assert_eq!(rp.parse.root.text(), "1 + ; 2 + 3");
+        // The recovered tail is a real expression node, not error debris.
+        let tail = rp
+            .parse
+            .root
+            .children()
+            .filter(|c| c.kind() != SyntaxKind::ErrorNode)
+            .last()
+            .expect("expression after the error");
+        assert_eq!(tail.text(), "2 + 3");
     }
 
     #[test]

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -23,6 +23,12 @@ pub(crate) mod parser;
 use diagnostics::{ParseError, SourceMap};
 use kind::{ResolvedNode, SyntaxKind};
 
+// The shared-interner types [`parse_with_interner`] / [`parse_repl`] take, so
+// downstream crates don't need a direct cstree dependency. `Interner` is the
+// trait carrying `get_or_intern` (e.g. for a REPL driver interning synthetic
+// names); its `Resolver` counterpart is re-exported from [`kind`].
+pub use cstree::interning::{Interner, MultiThreadedTokenInterner, new_threaded_interner};
+
 /// The result of parsing: a lossless syntax tree (always produced, even in
 /// the presence of errors) plus collected diagnostics.
 pub struct Parse {
@@ -61,6 +67,85 @@ impl Parse {
 
 /// Parse a whole source file.
 pub fn parse(source: &str) -> Parse {
+    parse_impl(source, lasso::Rodeo::<kind::TokenKey>::new(), |p| {
+        p.source_file()
+    })
+}
+
+/// Parse a whole source file, interning token text into a caller-supplied
+/// shared interner.
+///
+/// [`TokenKey`](kind::TokenKey)s are stable across every parse that shares the
+/// interner, so typed-AST keys from one parse resolve correctly against
+/// another's — the property a REPL session needs to elaborate many small
+/// inputs against one accumulated program. The session keeps one `Arc` clone
+/// as the long-lived [`kind::Resolver`]; each parse's tree holds another.
+pub fn parse_with_interner(
+    source: &str,
+    interner: std::sync::Arc<cstree::interning::MultiThreadedTokenInterner>,
+) -> Parse {
+    parse_impl(source, interner, |p| p.source_file())
+}
+
+/// How [`parse_repl`] routed an input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReplInputKind {
+    /// Top-level items; the tree root is a `SourceFile`.
+    Items,
+    /// An expression sequence (`e1; e2; ...`); the tree root is a
+    /// `BlockExpr`.
+    Expr,
+}
+
+/// The result of parsing one REPL input.
+pub struct ReplParse {
+    pub parse: Parse,
+    pub kind: ReplInputKind,
+}
+
+/// Parse one REPL input as either top-level items or an expression sequence.
+///
+/// The route is decided by the first significant token — `fn`, `struct`,
+/// `enum`, `mod`, `extern`, and `pub` start items, and `regional` does iff
+/// the next token is `fn` (otherwise it is a `regional { ... }` expression);
+/// everything else is an expression. No backtracking: errors are reported
+/// against the chosen route. Since the language has no reserved identifiers,
+/// an expression *headed* by a variable literally named like an item keyword
+/// misroutes to items; accepted as a documented limitation.
+pub fn parse_repl(
+    source: &str,
+    interner: std::sync::Arc<cstree::interning::MultiThreadedTokenInterner>,
+) -> ReplParse {
+    let kind_cell = std::cell::Cell::new(ReplInputKind::Expr);
+    let parse = parse_impl(source, interner, |p| {
+        let kind = match p.current() {
+            SyntaxKind::FnKw
+            | SyntaxKind::StructKw
+            | SyntaxKind::EnumKw
+            | SyntaxKind::ModKw
+            | SyntaxKind::ExternKw
+            | SyntaxKind::PubKw => ReplInputKind::Items,
+            SyntaxKind::RegionalKw if p.nth(1) == SyntaxKind::FnKw => ReplInputKind::Items,
+            _ => ReplInputKind::Expr,
+        };
+        kind_cell.set(kind);
+        match kind {
+            ReplInputKind::Items => p.source_file(),
+            ReplInputKind::Expr => p.repl_expr_seq(),
+        }
+    });
+    ReplParse {
+        parse,
+        kind: kind_cell.get(),
+    }
+}
+
+/// The shared parse pipeline: lex, run `entry` on the parser, then build the
+/// lossless tree with `interner` (which becomes the tree's resolver).
+fn parse_impl<I>(source: &str, interner: I, entry: impl FnOnce(&mut parser::Parser)) -> Parse
+where
+    I: cstree::interning::Interner<kind::TokenKey> + kind::Resolver<kind::TokenKey> + 'static,
+{
     let (all_tokens, lex_errors) = lexer::tokenize(source);
     let significant: Vec<lexer::Token> = all_tokens
         .iter()
@@ -69,7 +154,7 @@ pub fn parse(source: &str) -> Parse {
         .collect();
 
     let mut p = parser::Parser::new(source, significant);
-    p.source_file();
+    entry(&mut p);
     let (events, parse_errors) = p.finish();
 
     let mut errors: Vec<ParseError> = lex_errors
@@ -85,7 +170,7 @@ pub fn parse(source: &str) -> Parse {
     // the first message is the most informative one.
     errors.dedup_by_key(|e| e.span.0);
 
-    let mut interner: lasso::Rodeo = lasso::Rodeo::new();
+    let mut interner = interner;
     let green = parser::sink::Sink::new(source, &all_tokens, events, &mut interner).finish();
     let root = kind::SyntaxNode::new_root_with_resolver(green, interner);
     Parse { root, errors }
@@ -111,6 +196,85 @@ mod tests {
     fn json_of(source: &str) -> serde_json::Value {
         let map = SourceMap::new(source);
         parse_ok(source).to_json(&map)
+    }
+
+    #[test]
+    fn shared_interner_keeps_token_keys_stable_across_parses() {
+        use cstree::interning::Resolver;
+
+        let interner = std::sync::Arc::new(new_threaded_interner());
+        let a = parse_with_interner("fn foo() -> i32 { 1 }", interner.clone());
+        let b = parse_with_interner("fn bar() -> i32 { foo() }", interner.clone());
+        assert!(a.ok() && b.ok());
+
+        // The `foo` token in parse B resolves through parse A's resolver (and
+        // the session interner) to the same text, i.e. the keys share one
+        // key space.
+        let key_in_a = token_key_of(&a, "foo").expect("foo in a");
+        let key_in_b = token_key_of(&b, "foo").expect("foo in b");
+        assert_eq!(key_in_a, key_in_b);
+        assert_eq!(interner.try_resolve(key_in_b), Some("foo"));
+    }
+
+    /// The key of the first token with the given text.
+    fn token_key_of(parse: &Parse, text: &str) -> Option<kind::TokenKey> {
+        parse
+            .root
+            .descendants_with_tokens()
+            .filter_map(|el| el.into_token())
+            .find(|t| t.text() == text)
+            .and_then(|t| t.text_key())
+    }
+
+    #[test]
+    fn repl_routes_items_and_expressions() {
+        let interner = std::sync::Arc::new(new_threaded_interner());
+        let items = [
+            "fn f() -> i32 { 1 }",
+            "struct P { x: i32 }",
+            "enum E { A, B }",
+            "pub fn g() -> i32 { 2 }",
+            "mod m;",
+            "extern \"C\" trampoline \"f_ffi\" = f;",
+            "regional fn h(c: [flex] L<i32>) { c->v := 1 }",
+            // Several items in one input.
+            "fn a() -> i32 { 1 }\nfn b() -> i32 { 2 }",
+        ];
+        for source in items {
+            let rp = parse_repl(source, interner.clone());
+            assert_eq!(rp.kind, ReplInputKind::Items, "{source}");
+            assert!(rp.parse.ok(), "{source}: {:#?}", rp.parse.errors);
+            assert_eq!(rp.parse.root.kind(), SyntaxKind::SourceFile);
+        }
+
+        let exprs = [
+            "42",
+            "1 + 2",
+            "f(1, 2)",
+            "let a = 10; let b = 20; a + b",
+            "if true { 1 } else { 0 }",
+            "{ let x = 1; x }",
+            "|x: i32| x + 1",
+            // `regional` NOT followed by `fn` is a regional expression.
+            "regional { Cell { value: 1 } }",
+        ];
+        for source in exprs {
+            let rp = parse_repl(source, interner.clone());
+            assert_eq!(rp.kind, ReplInputKind::Expr, "{source}");
+            assert!(rp.parse.ok(), "{source}: {:#?}", rp.parse.errors);
+            assert_eq!(rp.parse.root.kind(), SyntaxKind::BlockExpr);
+            assert_eq!(rp.parse.root.text(), source);
+        }
+    }
+
+    #[test]
+    fn repl_expr_seq_reports_trailing_garbage() {
+        let interner = std::sync::Arc::new(new_threaded_interner());
+        let rp = parse_repl("1 + 2 3", interner);
+        assert_eq!(rp.kind, ReplInputKind::Expr);
+        assert!(!rp.parse.ok());
+        // Lossless even under recovery.
+        assert_eq!(rp.parse.root.text(), "1 + 2 3");
     }
 
     #[test]

--- a/crates/reussir-syntax/src/parser/expr.rs
+++ b/crates/reussir-syntax/src/parser/expr.rs
@@ -424,8 +424,16 @@ impl Parser<'_> {
         while !self.at_eof() {
             let before = self.snapshot();
             self.expr();
-            if self.errored_since(&before) {
-                break;
+            if self.errored_since(&before) && !self.at(Semicolon) && !self.at_eof() {
+                // The expression errored mid-input: resynchronize at the next
+                // `;` so the following expressions still parse, collecting the
+                // skipped tokens into an error node to stay lossless. The
+                // expression's own diagnostic suffices — no extra error here.
+                let e = self.start();
+                while !self.at_eof() && !self.at(Semicolon) {
+                    self.bump();
+                }
+                e.complete(self, ErrorNode);
             }
             if self.at(Semicolon) {
                 self.bump();
@@ -434,9 +442,9 @@ impl Parser<'_> {
             }
         }
         if !self.at_eof() {
-            // Anything left over is not part of an expression sequence;
-            // collect it into an error node (mirroring source_file recovery)
-            // so the tree stays lossless.
+            // A well-formed expression followed by something other than `;`
+            // (e.g. `1 + 2 3`): collect the leftovers into an error node
+            // (mirroring source_file recovery) so the tree stays lossless.
             let e = self.start();
             self.error(format!(
                 "expected `;` or the end of the input, found {}",

--- a/crates/reussir-syntax/src/parser/expr.rs
+++ b/crates/reussir-syntax/src/parser/expr.rs
@@ -414,6 +414,42 @@ impl Parser<'_> {
         m.complete(self, BlockExpr)
     }
 
+    /// A REPL expression input: `e1; e2; ...` — semicolon-separated with no
+    /// surrounding braces, spanning the whole input. Completes as a
+    /// [`BlockExpr`] so the surface layer's existing block projection
+    /// (`BlockExpr` → `ExprSeq`) applies unchanged and `let x = 1; x + 1`
+    /// gets block semantics.
+    pub(crate) fn repl_expr_seq(&mut self) {
+        let m = self.start();
+        while !self.at_eof() {
+            let before = self.snapshot();
+            self.expr();
+            if self.errored_since(&before) {
+                break;
+            }
+            if self.at(Semicolon) {
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        if !self.at_eof() {
+            // Anything left over is not part of an expression sequence;
+            // collect it into an error node (mirroring source_file recovery)
+            // so the tree stays lossless.
+            let e = self.start();
+            self.error(format!(
+                "expected `;` or the end of the input, found {}",
+                self.current().describe()
+            ));
+            while !self.at_eof() {
+                self.bump();
+            }
+            e.complete(self, ErrorNode);
+        }
+        m.complete(self, BlockExpr);
+    }
+
     /// `|x, y: T| (-> T)? body`. A `||` token is an empty parameter list
     /// (the lexer fuses the two pipes).
     fn lambda_expr(&mut self) {


### PR DESCRIPTION
PR 1 of 3 toward the Rust `reussir-repl` (ratatui-based, replacing the Haskell driver; see follow-ups). This lands the engine-side APIs only — no new binary.

## What

- **reussir-syntax**: `parse_with_interner` / `parse_repl` intern into a shared `Arc<MultiThreadedTokenInterner>` (cstree `multi_threaded_interning` feature), so `TokenKey`s stay stable across the many small parses of a REPL session. `parse_repl` routes items vs. expressions by the first significant token (`regional` disambiguated by the following `fn`) and parses brace-less `e1; e2; ...` sequences into a `BlockExpr` root so the existing surface block projection applies unchanged.
- **reussir-core**:
  - `Elaborator::run`'s populate/check passes are now keyed by the `DefId` returned from the scan passes instead of re-resolving by name. Previously a duplicate `struct` overwrote the *surviving* record's fields and a duplicate `fn` type-checked its body against the surviving prototype.
  - `Elaborator::{checkpoint, rollback}` + `DefTable::{len, truncate}` + `try_extend`: atomic incremental elaboration. Duplicate definitions are rejected (REPL items are immutable once accepted); a failed batch rolls back wholesale, leaving the session usable.
  - `Elaborator::try_repl_expr`: elaborates one expression as a synthetic nullary private `__repl_expr_N` with a C-ABI `TrampolineRoot` (so monomorphization roots it and codegen emits a host-callable entry), with GHCi-style numeric defaulting (`FloatingPoint` holes → `f64` before `Integral`/`Num` → `i64`, so `1.5 * 2` defaults correctly) and a zonk-time ambiguity check: a residual inference hole (e.g. bare `Nullable::Null`) is reported once, at the innermost expression exhibiting it, instead of panicking later in monomorphization's `subst_ty` — this also fixes the same latent ICE for batch-mode files.
- **reussir-jit**: `add_module_tracked` / `add_ir_module_tracked` return a `ModuleHandle<'jit>` backed by an ORC `ResourceTracker` (lifetime-tied to the engine so a handle cannot outlive the session it points into); `remove_module` evicts that module's symbols — the failure-recovery path for a REPL input whose module was added but failed to materialize.

## Tests

- `cargo test -p reussir-syntax -p reussir-core`: 208 tests (23 syntax incl. TokenKey stability + routing; 185 core incl. batch-mode ambiguity reporting, rollback atomicity, clobber regression, defaulting, on-the-fly `poly_add` monomorphization at `i64` and `f64` from one maintained HIR).
- `ninja -C build reussir-jit-test`: 13 tests (tracked add/remove, failed-add recovery, duplicate rejection, dropped-handle permanence; TPDE exercised).
- Downstream unaffected: `reussir-codegen-test` (27) and `rrc-test` (18) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
