### PR TITLE
[frontend] reussir-repl: ratatui TUI frontend with smart-Enter multiline input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,7 +74,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
  "yansi",
 ]
 
@@ -91,6 +100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atuin-nucleo-matcher"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +117,12 @@ dependencies = [
  "memchr",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -116,6 +140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,7 +157,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -138,7 +168,16 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
 ]
 
 [[package]]
@@ -147,14 +186,26 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -186,6 +237,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
 dependencies = [
  "unicode-normalization",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -232,6 +304,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +330,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "comrak"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,8 +353,8 @@ dependencies = [
  "entities",
  "finl_unicode",
  "jetscii",
- "phf",
- "phf_codegen",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
  "rustc-hash",
  "smallvec",
  "typed-arena",
@@ -273,6 +365,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "convert_case"
@@ -302,10 +403,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -315,6 +449,16 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -341,7 +485,41 @@ checksum = "3ef4cfdc000ad5eaafb304c599ab87894258acb2a508d2a805213322b18e3be3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -359,6 +537,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +578,15 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -412,10 +633,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -428,6 +685,12 @@ name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -454,6 +717,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeef4a9366aaf0ed0bb5292b7c489d80600a7431fca0d96271e10e23ac0bc2b0"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,13 +752,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -512,12 +811,29 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -527,6 +843,28 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -566,6 +904,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,13 +935,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
 name = "lalrpop"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.8.0",
  "ena",
  "itertools 0.14.0",
  "lalrpop-util",
@@ -655,10 +1021,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llvm-sys"
@@ -711,7 +1092,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -721,6 +1102,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
  "logos-codegen",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -773,11 +1173,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aac876dfce9f514df46c6d4b7267f1fc513126ddc34dfde11909584fdfc87bd"
 dependencies = [
  "comrak",
- "convert_case",
+ "convert_case 0.11.0",
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tblgen",
  "unindent",
 ]
@@ -787,6 +1187,21 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mimalloc"
@@ -813,6 +1228,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "mlir-sys"
 version = "220.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +1253,19 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nom"
@@ -847,6 +1287,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,7 +1331,16 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -882,6 +1357,15 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -909,7 +1393,31 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -942,13 +1450,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -963,12 +1524,32 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.13.1",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand",
 ]
 
 [[package]]
@@ -979,6 +1560,19 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1012,6 +1606,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "pprint"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,7 +1638,7 @@ checksum = "6a290a85f683171b6b98234cf2cba01b333c784035405a6a554484d83f69e506"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1048,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1090,9 +1696,30 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rapidhash"
@@ -1101,6 +1728,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-textarea"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c78d5ba0f26f97baed69a4c479f268a31c7b5b89d68ab939842152e383d6e73"
+dependencies = [
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1115,7 +1856,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1135,7 +1876,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1232,7 +1973,7 @@ dependencies = [
  "atuin-nucleo-matcher",
  "blake3",
  "ena",
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "ftree",
  "lalrpop",
  "lalrpop-util",
@@ -1268,6 +2009,8 @@ version = "0.1.0"
 dependencies = [
  "melior",
  "palc",
+ "ratatui",
+ "ratatui-textarea",
  "reussir-backend",
  "reussir-codegen",
  "reussir-core",
@@ -1341,7 +2084,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1397,6 +2140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1416,7 +2160,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1430,6 +2174,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -1464,10 +2219,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1513,6 +2305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +2329,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "stumpalo"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +2357,17 @@ checksum = "71a9e0a78a61853dbfaf5c7662d91a1b4ef87aa0ac7aa576485bf67c47fc9774"
 dependencies = [
  "readme-rustdocifier",
  "rustc_version",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1560,7 +2390,7 @@ dependencies = [
  "bindgen",
  "cc",
  "paste",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1570,7 +2400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1586,6 +2416,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset 0.4.2",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf 0.11.3",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
 name = "text-size"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,11 +2499,31 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1608,7 +2534,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1619,6 +2545,27 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinyvec"
@@ -1684,7 +2631,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1748,6 +2695,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,10 +2722,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1787,6 +2757,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +2787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +2803,138 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -1819,6 +2948,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,6 +2971,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1852,6 +3003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,7 +3031,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +769,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1017,6 +1049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
  "libc",
 ]
 
@@ -1357,6 +1398,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -1860,6 +1907,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2065,7 @@ dependencies = [
 name = "reussir-repl"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "melior",
  "palc",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,9 +86,17 @@ stacker = "0.1.21"
 tracing = "0.1"
 # Log-level plumbing for the REPL binary's `-l` flag.
 tracing-subscriber = "0.3"
+# Platform data directories for the REPL's persisted history
+# (XDG_DATA_HOME/~/.local/share on Linux, %LOCALAPPDATA% on Windows,
+# ~/Library/Application Support on macOS).
+dirs = "6"
 # The REPL's interactive terminal UI: ratatui renders it, ratatui-textarea is
 # the multiline input editor (smart-Enter submission lives in the REPL).
-ratatui = "0.30"
+# `unstable-rendered-line-info` provides `Paragraph::line_count`, which the
+# REPL TUI's scrollback pinning needs to count post-wrap visual rows with the
+# paragraph's own wrapping rules (hand-computed row counts would drift from
+# ratatui's word wrapping).
+ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 ratatui-textarea = "0.9"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,10 @@ stacker = "0.1.21"
 tracing = "0.1"
 # Log-level plumbing for the REPL binary's `-l` flag.
 tracing-subscriber = "0.3"
+# The REPL's interactive terminal UI: ratatui renders it, ratatui-textarea is
+# the multiline input editor (smart-Enter submission lives in the REPL).
+ratatui = "0.30"
+ratatui-textarea = "0.9"
 
 [profile.release]
 lto = "thin"

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -30,7 +30,9 @@ pub mod repl;
 pub mod resolve;
 pub mod ty_eval;
 
-pub use ctxt::{Checkpoint, DefaultCap, Elaborator, Report, Severity, render_reports};
+pub use ctxt::{
+    Checkpoint, DefaultCap, Elaborator, Report, Severity, render_reports, render_reports_to,
+};
 
 use reussir_syntax::kind::{Resolver, TokenKey};
 

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -48,6 +48,20 @@ pub struct Report {
 pub fn render_reports(name: &str, source: &str, reports: &[Report]) -> bool {
     use std::io::IsTerminal;
 
+    let color = std::io::stderr().is_terminal();
+    render_reports_to(name, source, reports, color, std::io::stderr().lock())
+}
+
+/// Writer-taking variant of [`render_reports`], for frontends that own their
+/// display (e.g. the REPL TUI renders into a buffer and styles the lines
+/// itself — stderr would be invisible in the alternate screen).
+pub fn render_reports_to(
+    name: &str,
+    source: &str,
+    reports: &[Report],
+    color: bool,
+    out: impl std::io::Write,
+) -> bool {
     use reussir_syntax::diagnostics::{self, Diagnostic, Severity as RenderSeverity, SourceMap};
 
     let had_error = reports
@@ -69,8 +83,7 @@ pub fn render_reports(name: &str, source: &str, reports: &[Report]) -> bool {
         })
         .collect();
     let map = SourceMap::new(source);
-    let color = std::io::stderr().is_terminal();
-    let _ = diagnostics::render(name, source, &map, &diags, color, std::io::stderr().lock());
+    let _ = diagnostics::render(name, source, &map, &diags, color, out);
     had_error
 }
 

--- a/crates/reussir-repl/Cargo.toml
+++ b/crates/reussir-repl/Cargo.toml
@@ -28,6 +28,8 @@ reussir-syntax = { path = "../reussir-syntax" }
 # The persistent ORC LLJIT session (links the in-process runtime).
 reussir-jit = { path = "../reussir-jit" }
 palc.workspace = true
+ratatui.workspace = true
+ratatui-textarea.workspace = true
 rustc-hash.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/reussir-repl/Cargo.toml
+++ b/crates/reussir-repl/Cargo.toml
@@ -33,3 +33,4 @@ ratatui-textarea.workspace = true
 rustc-hash.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+dirs.workspace = true

--- a/crates/reussir-repl/src/commands.rs
+++ b/crates/reussir-repl/src/commands.rs
@@ -16,7 +16,17 @@ Available commands:
   :clear                Reset the session (definitions and compiled code)
 
 Multiline input: wrap in `:{` and `}:` lines.
-Input is parsed as definitions (fn/struct/enum/...) or as an expression.";
+Input is parsed as definitions (fn/struct/enum/...) or as an expression.
+
+TUI keys:
+  Enter                 Submit (inserts a newline while the input is incomplete)
+  Alt+Enter             Insert a newline
+  Ctrl+J                Force-submit the buffer as is
+  Ctrl+U / Ctrl+R       Undo / redo in the editor
+  Up / Down             Browse history (on the first/last line)
+  PgUp / PgDn           Scroll the output
+  Ctrl+C                Clear the buffer (twice on empty: quit)
+  Ctrl+D                Quit (on an empty buffer)";
 
 /// Dispatch `command` (the input with the leading `:` stripped).
 pub fn dispatch(session: &mut ReplSession<'_, '_>, command: &str) -> Outcome {

--- a/crates/reussir-repl/src/frontend/mod.rs
+++ b/crates/reussir-repl/src/frontend/mod.rs
@@ -7,3 +7,4 @@
 //! interactive frontend on a real terminal.
 
 pub mod plain;
+pub mod tui;

--- a/crates/reussir-repl/src/frontend/tui.rs
+++ b/crates/reussir-repl/src/frontend/tui.rs
@@ -22,10 +22,10 @@ use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, Ke
 use ratatui::layout::{Constraint, Layout};
 use ratatui::style::{Color, Modifier, Style, Stylize};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, Input, TextArea};
 
-use reussir_core::semi::{Report, Severity};
+use reussir_core::semi::{Report, Severity, render_reports_to};
 use reussir_syntax::diagnostics::{self, SourceMap};
 
 use reussir_jit::OptLevel;
@@ -282,7 +282,7 @@ impl Tui {
                 }
             }
             Outcome::Definitions { count, warnings } => {
-                self.render_reports(warnings);
+                self.render_reports(warnings, input);
                 for _ in 0..*count {
                     self.push_line(Line::from("Definition added.".green()));
                 }
@@ -292,7 +292,7 @@ impl Tui {
                 ty,
                 warnings,
             } => {
-                self.render_reports(warnings);
+                self.render_reports(warnings, input);
                 self.out_counter += 1;
                 let title = format!("Out[{}]", self.out_counter);
                 let content = if ty == "()" {
@@ -318,7 +318,7 @@ impl Tui {
                     self.push_line(Line::from(line.to_string().red()));
                 }
             }
-            Outcome::Reports(reports) => self.render_reports(reports),
+            Outcome::Reports(reports) => self.render_reports(reports, input),
             Outcome::Backend(message) => {
                 self.push_line(Line::from(format!("error: {message}").red()));
             }
@@ -326,13 +326,26 @@ impl Tui {
         None
     }
 
-    fn render_reports(&mut self, reports: &[Report]) {
+    /// Render elaboration/mono reports with the shared ariadne caret
+    /// renderer (the same one `rrc` and the plain frontend use), one report
+    /// at a time so each block can be styled by its severity.
+    fn render_reports(&mut self, reports: &[Report], input: &str) {
         for report in reports {
-            let line = match report.severity {
-                Severity::Error => Line::from(format!("error: {}", report.message).red()),
-                Severity::Warning => Line::from(format!("warning: {}", report.message).yellow()),
+            let mut rendered = Vec::new();
+            let _ = render_reports_to(
+                "<repl>",
+                input,
+                std::slice::from_ref(report),
+                false,
+                &mut rendered,
+            );
+            let style = match report.severity {
+                Severity::Error => Style::default().fg(Color::Red),
+                Severity::Warning => Style::default().fg(Color::Yellow),
             };
-            self.push_line(line);
+            for line in String::from_utf8_lossy(&rendered).lines() {
+                self.push_line(Line::from(Span::styled(line.to_string(), style)));
+            }
         }
     }
 
@@ -374,10 +387,14 @@ impl Tui {
     }
 
     fn history_path() -> Option<PathBuf> {
-        let base = std::env::var_os("XDG_DATA_HOME")
-            .map(PathBuf::from)
-            .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))?;
-        Some(base.join("reussir").join("rrepl_history"))
+        // XDG_DATA_HOME/~/.local/share on Linux, %LOCALAPPDATA% on Windows
+        // (a HOME-based fallback would silently disable history there),
+        // ~/Library/Application Support on macOS.
+        Some(
+            dirs::data_local_dir()?
+                .join("reussir")
+                .join("rrepl_history"),
+        )
     }
 
     fn load_history(&mut self) {
@@ -497,15 +514,16 @@ impl Tui {
             .areas(frame.area());
 
             // Scrollback pinned to the bottom, offset by the scroll position.
-            let total = scrollback.len() as u16;
+            // Long lines wrap, so the pinning math must count *visual* rows —
+            // `line_count` applies the paragraph's own wrapping rules.
+            let paragraph =
+                Paragraph::new(Text::from(scrollback.clone())).wrap(Wrap { trim: false });
+            let total = paragraph.line_count(output_area.width) as u16;
             let view = output_area.height;
             let max_up = total.saturating_sub(view);
             *scroll_up = (*scroll_up).min(max_up);
             let offset = max_up - *scroll_up;
-            frame.render_widget(
-                Paragraph::new(Text::from(scrollback.clone())).scroll((offset, 0)),
-                output_area,
-            );
+            frame.render_widget(paragraph.scroll((offset, 0)), output_area);
 
             frame.render_widget(textarea, input_area);
 

--- a/crates/reussir-repl/src/frontend/tui.rs
+++ b/crates/reussir-repl/src/frontend/tui.rs
@@ -1,0 +1,504 @@
+//! The interactive terminal UI: a scrollback pane over a multiline input
+//! editor (ratatui + ratatui-textarea).
+//!
+//! Input submission is *smart Enter*: Enter submits when the buffer is a
+//! command or lexically complete ([`crate::input::is_incomplete`]), and
+//! inserts a newline otherwise — so a pasted or half-typed `fn f(x: i64) {`
+//! simply continues on the next line. Alt+Enter (and Shift+Enter where the
+//! terminal reports it) always inserts a newline; Ctrl+J always submits.
+//! GHCi-style `:{` … `}:` blocks are still honored for muscle-memory and
+//! paste compatibility: a buffer whose first line is `:{` submits only when
+//! its last line is `}:`.
+//!
+//! Up/Down browse history when the cursor is on the first/last line
+//! (otherwise they move within the editor); history persists across
+//! sessions. Ctrl+C clears the buffer (quit hint on empty), Ctrl+D on an
+//! empty buffer quits, PageUp/PageDown scroll the scrollback.
+
+use std::io::Write as _;
+use std::path::PathBuf;
+
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::layout::{Constraint, Layout};
+use ratatui::style::{Color, Modifier, Style, Stylize};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_textarea::{CursorMove, Input, TextArea};
+
+use reussir_core::semi::{Report, Severity};
+use reussir_syntax::diagnostics::{self, SourceMap};
+
+use crate::session::{self, Config, Exit, Outcome, ReplSession};
+
+/// Run the TUI: owns terminal setup/teardown and the `:clear` session loop.
+pub fn run(config: Config) -> Result<(), String> {
+    // `ratatui::init` enters the alternate screen + raw mode and installs a
+    // panic hook that restores the terminal.
+    let terminal = ratatui::init();
+    let _ = ratatui::crossterm::execute!(
+        std::io::stdout(),
+        ratatui::crossterm::event::EnableBracketedPaste
+    );
+    let mut tui = Tui::new(terminal, config);
+    tui.load_history();
+
+    let result = loop {
+        let exit = match session::run(config, |session| tui.drive(session)) {
+            Ok(exit) => exit,
+            Err(message) => break Err(message),
+        };
+        match exit {
+            Exit::Quit => break Ok(()),
+            Exit::Clear => {
+                tui.push_line(Line::from("Context cleared".italic()));
+                continue;
+            }
+        }
+    };
+
+    tui.save_history();
+    let _ = ratatui::crossterm::execute!(
+        std::io::stdout(),
+        ratatui::crossterm::event::DisableBracketedPaste
+    );
+    ratatui::restore();
+    result
+}
+
+struct Tui {
+    terminal: ratatui::DefaultTerminal,
+    config: Config,
+    scrollback: Vec<Line<'static>>,
+    /// Lines scrolled up from the bottom (0 = stick to newest output).
+    scroll_up: u16,
+    textarea: TextArea<'static>,
+    history: Vec<String>,
+    /// `Some(i)` while browsing history entry `i`; `None` while editing.
+    history_pos: Option<usize>,
+    /// The in-progress input stashed while browsing history.
+    stash: Vec<String>,
+    /// Consecutive Ctrl+C presses on an empty buffer (2 quits).
+    interrupts: u8,
+    /// Evaluating flag rendered in the status line during `eval`.
+    busy: bool,
+}
+
+impl Tui {
+    fn new(terminal: ratatui::DefaultTerminal, config: Config) -> Self {
+        let mut tui = Tui {
+            terminal,
+            config,
+            scrollback: vec![
+                Line::from(format!(
+                    "Reussir REPL v{} (Rust pipeline)",
+                    env!("CARGO_PKG_VERSION")
+                )),
+                Line::from(
+                    "Type :help for commands · Enter submits · Alt+Enter newline · :q quits"
+                        .italic()
+                        .dark_gray(),
+                ),
+            ],
+            scroll_up: 0,
+            textarea: TextArea::default(),
+            history: Vec::new(),
+            history_pos: None,
+            stash: Vec::new(),
+            interrupts: 0,
+            busy: false,
+        };
+        tui.reset_textarea();
+        tui
+    }
+
+    // ----- the session drive loop -----
+
+    fn drive(&mut self, session: &mut ReplSession<'_, '_>) -> Exit {
+        loop {
+            let defs = session.definition_count();
+            if self.draw(defs).is_err() {
+                return Exit::Quit;
+            }
+            match event::read() {
+                Ok(Event::Key(key)) if key.kind != KeyEventKind::Release => {
+                    if let Some(exit) = self.handle_key(key, session) {
+                        return exit;
+                    }
+                }
+                Ok(Event::Paste(text)) => {
+                    self.textarea
+                        .insert_str(text.replace("\r\n", "\n").replace('\r', "\n"));
+                }
+                Ok(_) => {} // resize triggers redraw; ignore the rest
+                Err(_) => return Exit::Quit,
+            }
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, session: &mut ReplSession<'_, '_>) -> Option<Exit> {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+
+        if !matches!(key.code, KeyCode::Char('c')) || !ctrl {
+            self.interrupts = 0;
+        }
+
+        match key.code {
+            KeyCode::Char('c') if ctrl => {
+                if self.buffer().is_empty() {
+                    self.interrupts += 1;
+                    if self.interrupts >= 2 {
+                        return Some(Exit::Quit);
+                    }
+                    self.push_line(Line::from(
+                        "(press Ctrl+C again or Ctrl+D to quit)".dark_gray(),
+                    ));
+                } else {
+                    self.reset_textarea();
+                    self.history_pos = None;
+                }
+            }
+            KeyCode::Char('d') if ctrl => {
+                if self.buffer().is_empty() {
+                    return Some(Exit::Quit);
+                }
+            }
+            KeyCode::Char('j') if ctrl => return self.submit(session),
+            KeyCode::Enter if alt || shift => {
+                self.textarea.insert_newline();
+            }
+            KeyCode::Enter => {
+                if self.wants_submit() {
+                    return self.submit(session);
+                }
+                self.textarea.insert_newline();
+            }
+            KeyCode::Up if self.textarea.cursor().0 == 0 => self.history_prev(),
+            KeyCode::Down if self.textarea.cursor().0 + 1 == self.textarea.lines().len() => {
+                self.history_next()
+            }
+            KeyCode::PageUp => {
+                self.scroll_up = self.scroll_up.saturating_add(5);
+            }
+            KeyCode::PageDown => {
+                self.scroll_up = self.scroll_up.saturating_sub(5);
+            }
+            _ => {
+                self.textarea.input(Input::from(key));
+            }
+        }
+        None
+    }
+
+    // ----- submission -----
+
+    fn buffer(&self) -> String {
+        self.textarea.lines().join("\n")
+    }
+
+    /// Should Enter submit the current buffer (as opposed to adding a line)?
+    fn wants_submit(&self) -> bool {
+        let text = self.buffer();
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return true; // submitting a blank buffer is a no-op
+        }
+        // An explicit `:{` block submits only when closed by `}:`.
+        if let Some(first) = text.lines().next()
+            && first.trim() == ":{"
+        {
+            return text.lines().last().is_some_and(|l| l.trim() == "}:");
+        }
+        // Commands are one-liners.
+        if trimmed.starts_with(':') {
+            return true;
+        }
+        !crate::input::is_incomplete(&text)
+    }
+
+    fn submit(&mut self, session: &mut ReplSession<'_, '_>) -> Option<Exit> {
+        let mut text = self.buffer();
+        // Strip an explicit `:{` … `}:` wrapper.
+        if text.lines().next().is_some_and(|l| l.trim() == ":{")
+            && text.lines().last().is_some_and(|l| l.trim() == "}:")
+        {
+            let lines: Vec<&str> = text.lines().collect();
+            text = lines[1..lines.len() - 1].join("\n");
+        }
+
+        // Echo the input into the scrollback.
+        for (i, line) in self.buffer().lines().enumerate() {
+            let prompt = if i == 0 { "λ> " } else { ".. " };
+            self.push_line(Line::from(vec![
+                Span::styled(prompt, Style::default().fg(Color::Cyan)),
+                Span::raw(line.to_string()),
+            ]));
+        }
+
+        if !text.trim().is_empty() && self.history.last().map(String::as_str) != Some(text.as_str())
+        {
+            self.history.push(text.clone());
+        }
+        self.history_pos = None;
+        self.reset_textarea();
+        self.scroll_up = 0;
+
+        if text.trim().is_empty() {
+            return None;
+        }
+
+        // Repaint with the busy marker before a (synchronous) evaluation;
+        // commands are instant and skip the flash.
+        if !text.trim_start().starts_with(':') {
+            self.busy = true;
+            let _ = self.draw(session.definition_count());
+        }
+        let outcome = session.eval(&text);
+        self.busy = false;
+
+        self.render_outcome(&outcome, &text)
+    }
+
+    fn render_outcome(&mut self, outcome: &Outcome, input: &str) -> Option<Exit> {
+        match outcome {
+            Outcome::Empty => {}
+            Outcome::Quit => return Some(Exit::Quit),
+            Outcome::ClearRequested => return Some(Exit::Clear),
+            Outcome::Text(text) => {
+                for line in text.lines() {
+                    self.push_line(Line::from(line.to_string()));
+                }
+            }
+            Outcome::Definitions { count, warnings } => {
+                self.render_reports(warnings);
+                for _ in 0..*count {
+                    self.push_line(Line::from("Definition added.".green()));
+                }
+            }
+            Outcome::Value {
+                value,
+                ty,
+                warnings,
+            } => {
+                self.render_reports(warnings);
+                if ty == "()" {
+                    self.push_line(Line::from("()".bold()));
+                } else {
+                    self.push_line(Line::from(vec![
+                        Span::styled(value.clone(), Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(" : "),
+                        Span::styled(ty.clone(), Style::default().fg(Color::Magenta)),
+                    ]));
+                }
+            }
+            Outcome::ParseErrors(errors) => {
+                let map = SourceMap::new(input);
+                let mut rendered = Vec::new();
+                let _ =
+                    diagnostics::render_errors("<repl>", input, &map, errors, false, &mut rendered);
+                for line in String::from_utf8_lossy(&rendered).lines() {
+                    self.push_line(Line::from(line.to_string().red()));
+                }
+            }
+            Outcome::Reports(reports) => self.render_reports(reports),
+            Outcome::Backend(message) => {
+                self.push_line(Line::from(format!("error: {message}").red()));
+            }
+        }
+        None
+    }
+
+    fn render_reports(&mut self, reports: &[Report]) {
+        for report in reports {
+            let line = match report.severity {
+                Severity::Error => Line::from(format!("error: {}", report.message).red()),
+                Severity::Warning => Line::from(format!("warning: {}", report.message).yellow()),
+            };
+            self.push_line(line);
+        }
+    }
+
+    // ----- history -----
+
+    fn history_prev(&mut self) {
+        let next = match self.history_pos {
+            None if self.history.is_empty() => return,
+            None => {
+                self.stash = self.textarea.lines().to_vec();
+                self.history.len() - 1
+            }
+            Some(0) => return,
+            Some(i) => i - 1,
+        };
+        self.history_pos = Some(next);
+        self.set_buffer_text(&self.history[next].clone());
+    }
+
+    fn history_next(&mut self) {
+        match self.history_pos {
+            None => {}
+            Some(i) if i + 1 < self.history.len() => {
+                self.history_pos = Some(i + 1);
+                self.set_buffer_text(&self.history[i + 1].clone());
+            }
+            Some(_) => {
+                self.history_pos = None;
+                let stash = std::mem::take(&mut self.stash);
+                self.reset_textarea();
+                for (i, line) in stash.iter().enumerate() {
+                    if i > 0 {
+                        self.textarea.insert_newline();
+                    }
+                    self.textarea.insert_str(line);
+                }
+            }
+        }
+    }
+
+    fn history_path() -> Option<PathBuf> {
+        let base = std::env::var_os("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))?;
+        Some(base.join("reussir").join("rrepl_history"))
+    }
+
+    fn load_history(&mut self) {
+        let Some(path) = Self::history_path() else {
+            return;
+        };
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            return;
+        };
+        // One entry per line; embedded newlines escaped (see save_history).
+        self.history = content
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(unescape_entry)
+            .collect();
+    }
+
+    fn save_history(&self) {
+        let Some(path) = Self::history_path() else {
+            return;
+        };
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        const KEEP: usize = 1000;
+        let start = self.history.len().saturating_sub(KEEP);
+        let mut out = String::new();
+        for entry in &self.history[start..] {
+            out.push_str(&escape_entry(entry));
+            out.push('\n');
+        }
+        let _ = std::fs::File::create(&path).and_then(|mut f| f.write_all(out.as_bytes()));
+    }
+
+    // ----- rendering -----
+
+    fn reset_textarea(&mut self) {
+        let mut textarea = TextArea::default();
+        textarea.set_cursor_line_style(Style::default());
+        textarea.set_placeholder_text("enter an expression or definition (:help for commands)");
+        textarea.set_block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray))
+                .title(" λ "),
+        );
+        self.textarea = textarea;
+    }
+
+    fn set_buffer_text(&mut self, text: &str) {
+        self.reset_textarea();
+        for (i, line) in text.lines().enumerate() {
+            if i > 0 {
+                self.textarea.insert_newline();
+            }
+            self.textarea.insert_str(line);
+        }
+        self.textarea.move_cursor(CursorMove::Bottom);
+        self.textarea.move_cursor(CursorMove::End);
+    }
+
+    fn push_line(&mut self, line: Line<'static>) {
+        self.scrollback.push(line);
+        self.scroll_up = 0;
+    }
+
+    fn draw(&mut self, defs: usize) -> std::io::Result<()> {
+        let scrollback = &self.scrollback;
+        let scroll_up = &mut self.scroll_up;
+        let textarea = &self.textarea;
+        let opt = self.config.opt;
+        let busy = self.busy;
+
+        self.terminal.draw(|frame| {
+            let input_height = (textarea.lines().len() as u16 + 2)
+                .min(frame.area().height * 2 / 5)
+                .max(3);
+            let [output_area, input_area, status_area] = Layout::vertical([
+                Constraint::Min(1),
+                Constraint::Length(input_height),
+                Constraint::Length(1),
+            ])
+            .areas(frame.area());
+
+            // Scrollback pinned to the bottom, offset by the scroll position.
+            let total = scrollback.len() as u16;
+            let view = output_area.height;
+            let max_up = total.saturating_sub(view);
+            *scroll_up = (*scroll_up).min(max_up);
+            let offset = max_up - *scroll_up;
+            frame.render_widget(
+                Paragraph::new(Text::from(scrollback.clone())).scroll((offset, 0)),
+                output_area,
+            );
+
+            frame.render_widget(textarea, input_area);
+
+            let status = Line::from(vec![
+                Span::styled(
+                    if busy { " evaluating… " } else { " ready " },
+                    if busy {
+                        Style::default().fg(Color::Yellow)
+                    } else {
+                        Style::default().fg(Color::Green)
+                    },
+                ),
+                Span::raw(format!("│ opt: {opt:?} │ defs: {defs} ")).dark_gray(),
+                Span::raw("│ Enter submit · Alt+Enter newline · Ctrl+J force · PgUp/PgDn scroll ")
+                    .dark_gray(),
+            ]);
+            frame.render_widget(Paragraph::new(status), status_area);
+        })?;
+        Ok(())
+    }
+}
+
+// History entries are one line each; embedded newlines/backslashes escaped.
+fn escape_entry(entry: &str) -> String {
+    entry.replace('\\', "\\\\").replace('\n', "\\n")
+}
+
+fn unescape_entry(entry: &str) -> String {
+    let mut out = String::with_capacity(entry.len());
+    let mut chars = entry.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('\\') => out.push('\\'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
+}

--- a/crates/reussir-repl/src/frontend/tui.rs
+++ b/crates/reussir-repl/src/frontend/tui.rs
@@ -457,6 +457,12 @@ impl Tui {
     }
 
     fn push_line(&mut self, line: Line<'static>) {
+        // Cap the scrollback so a long session cannot grow without bound;
+        // drop in chunks to amortize the shift.
+        const CAP: usize = 10_000;
+        if self.scrollback.len() >= CAP {
+            self.scrollback.drain(..CAP / 10);
+        }
         self.scrollback.push(line);
         self.scroll_up = 0;
     }

--- a/crates/reussir-repl/src/frontend/tui.rs
+++ b/crates/reussir-repl/src/frontend/tui.rs
@@ -28,6 +28,8 @@ use ratatui_textarea::{CursorMove, Input, TextArea};
 use reussir_core::semi::{Report, Severity};
 use reussir_syntax::diagnostics::{self, SourceMap};
 
+use reussir_jit::OptLevel;
+
 use crate::session::{self, Config, Exit, Outcome, ReplSession};
 
 /// Run the TUI: owns terminal setup/teardown and the `:clear` session loop.
@@ -50,6 +52,7 @@ pub fn run(config: Config) -> Result<(), String> {
         match exit {
             Exit::Quit => break Ok(()),
             Exit::Clear => {
+                tui.out_counter = 0;
                 tui.push_line(Line::from("Context cleared".italic()));
                 continue;
             }
@@ -81,6 +84,9 @@ struct Tui {
     interrupts: u8,
     /// Evaluating flag rendered in the status line during `eval`.
     busy: bool,
+    /// Jupyter-style `Out[n]` numbering for evaluated values; resets with
+    /// the session on `:clear`.
+    out_counter: usize,
 }
 
 impl Tui {
@@ -106,6 +112,7 @@ impl Tui {
             stash: Vec::new(),
             interrupts: 0,
             busy: false,
+            out_counter: 0,
         };
         tui.reset_textarea();
         tui
@@ -116,7 +123,8 @@ impl Tui {
     fn drive(&mut self, session: &mut ReplSession<'_, '_>) -> Exit {
         loop {
             let defs = session.definition_count();
-            if self.draw(defs).is_err() {
+            let opt = session.opt;
+            if self.draw(defs, opt).is_err() {
                 return Exit::Quit;
             }
             match event::read() {
@@ -252,10 +260,13 @@ impl Tui {
         // commands are instant and skip the flash.
         if !text.trim_start().starts_with(':') {
             self.busy = true;
-            let _ = self.draw(session.definition_count());
+            let _ = self.draw(session.definition_count(), session.opt);
         }
         let outcome = session.eval(&text);
         self.busy = false;
+        // Keep the restart config in step with `:set opt`, so a `:clear`
+        // rebuilds the session at the level the user chose, not the CLI's.
+        self.config.opt = session.opt;
 
         self.render_outcome(&outcome, &text)
     }
@@ -282,15 +293,21 @@ impl Tui {
                 warnings,
             } => {
                 self.render_reports(warnings);
-                if ty == "()" {
-                    self.push_line(Line::from("()".bold()));
+                self.out_counter += 1;
+                let title = format!("Out[{}]", self.out_counter);
+                let content = if ty == "()" {
+                    vec![Span::styled(
+                        "()".to_string(),
+                        Style::default().add_modifier(Modifier::BOLD),
+                    )]
                 } else {
-                    self.push_line(Line::from(vec![
+                    vec![
                         Span::styled(value.clone(), Style::default().add_modifier(Modifier::BOLD)),
                         Span::raw(" : "),
                         Span::styled(ty.clone(), Style::default().fg(Color::Magenta)),
-                    ]));
-                }
+                    ]
+                };
+                self.push_boxed(&title, content);
             }
             Outcome::ParseErrors(errors) => {
                 let map = SourceMap::new(input);
@@ -427,11 +444,45 @@ impl Tui {
         self.scroll_up = 0;
     }
 
-    fn draw(&mut self, defs: usize) -> std::io::Result<()> {
+    /// Render a one-line result in a titled box (a Jupyter-style output
+    /// cell):
+    ///
+    /// ```text
+    /// ╭─ Out[1] ─╮
+    /// │ 42 : i64 │
+    /// ╰──────────╯
+    /// ```
+    fn push_boxed(&mut self, title: &str, content: Vec<Span<'static>>) {
+        let border = Style::default().fg(Color::DarkGray);
+        let content_w: usize = content.iter().map(|s| s.content.chars().count()).sum();
+        let head_w = title.chars().count() + 3; // "─ <title> "
+        let inner_w = (content_w + 2).max(head_w + 1);
+
+        self.push_line(Line::from(vec![
+            Span::styled("╭─ ", border),
+            Span::styled(
+                title.to_string(),
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(format!(" {}╮", "─".repeat(inner_w - head_w)), border),
+        ]));
+        let mut mid = vec![Span::styled("│ ", border)];
+        mid.extend(content);
+        mid.push(Span::styled(
+            format!("{}│", " ".repeat(inner_w - content_w - 1)),
+            border,
+        ));
+        self.push_line(Line::from(mid));
+        self.push_line(Line::from(Span::styled(
+            format!("╰{}╯", "─".repeat(inner_w)),
+            border,
+        )));
+    }
+
+    fn draw(&mut self, defs: usize, opt: OptLevel) -> std::io::Result<()> {
         let scrollback = &self.scrollback;
         let scroll_up = &mut self.scroll_up;
         let textarea = &self.textarea;
-        let opt = self.config.opt;
         let busy = self.busy;
 
         self.terminal.draw(|frame| {

--- a/crates/reussir-repl/src/input.rs
+++ b/crates/reussir-repl/src/input.rs
@@ -1,0 +1,58 @@
+//! Input-completeness detection for smart-Enter submission.
+//!
+//! The TUI submits on Enter only when the buffer looks like a complete
+//! input; otherwise Enter inserts a newline and the user keeps typing. An
+//! input is *incomplete* when its delimiters are unbalanced-open or its last
+//! lexical element is unterminated — the cheap, purely lexical part of the
+//! judgment. (A balanced-but-ill-formed input counts as complete: submitting
+//! surfaces the parse error, which beats trapping the user in multiline
+//! mode.)
+
+use reussir_syntax::kind::SyntaxKind;
+use reussir_syntax::lexer;
+
+/// Would `source` plausibly continue on the next line?
+pub fn is_incomplete(source: &str) -> bool {
+    let (tokens, errors) = lexer::tokenize(source);
+
+    let mut depth = 0i64;
+    for token in &tokens {
+        match token.kind {
+            SyntaxKind::LBrace | SyntaxKind::LParen | SyntaxKind::LBracket => depth += 1,
+            SyntaxKind::RBrace | SyntaxKind::RParen | SyntaxKind::RBracket => depth -= 1,
+            _ => {}
+        }
+    }
+    if depth > 0 {
+        return true;
+    }
+
+    // An unterminated string or block comment lexes as an error whose span
+    // reaches the end of the input.
+    let end = source.len() as u32;
+    errors.iter().any(|e| e.span.1 >= end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_incomplete;
+
+    #[test]
+    fn open_delimiters_are_incomplete() {
+        assert!(is_incomplete("fn f(x: i64) -> i64 {"));
+        assert!(is_incomplete("f(1,"));
+        assert!(is_incomplete("match x {\n  1 => 2,"));
+        assert!(is_incomplete("/* comment"));
+    }
+
+    #[test]
+    fn balanced_inputs_are_complete() {
+        assert!(!is_incomplete("1 + 1"));
+        assert!(!is_incomplete("fn f(x: i64) -> i64 { x }"));
+        assert!(!is_incomplete("let a = 1; a"));
+        // Balanced but ill-formed still submits (surfacing the error).
+        assert!(!is_incomplete("fn f() -> }{"));
+        // Over-closed submits too.
+        assert!(!is_incomplete("f(1))"));
+    }
+}

--- a/crates/reussir-repl/src/input.rs
+++ b/crates/reussir-repl/src/input.rs
@@ -2,11 +2,12 @@
 //!
 //! The TUI submits on Enter only when the buffer looks like a complete
 //! input; otherwise Enter inserts a newline and the user keeps typing. An
-//! input is *incomplete* when its delimiters are unbalanced-open or its last
-//! lexical element is unterminated — the cheap, purely lexical part of the
-//! judgment. (A balanced-but-ill-formed input counts as complete: submitting
-//! surfaces the parse error, which beats trapping the user in multiline
-//! mode.)
+//! input is *incomplete* when its delimiters are unbalanced-open, it ends in
+//! an operator or separator that can only continue, or its last lexical
+//! element is unterminated — the cheap, purely lexical part of the judgment.
+//! (A balanced-but-ill-formed input counts as complete: submitting surfaces
+//! the parse error, which beats trapping the user in multiline mode. This is
+//! a coarse guess by design; Ctrl+J force-submits past it.)
 
 use reussir_syntax::kind::SyntaxKind;
 use reussir_syntax::lexer;
@@ -27,6 +28,39 @@ pub fn is_incomplete(source: &str) -> bool {
         return true;
     }
 
+    // A trailing infix/prefix operator or separator can only continue: no
+    // valid input ends in one, so this cannot trap the user in multiline
+    // mode (and Ctrl+J force-submits regardless).
+    use SyntaxKind::*;
+    if let Some(last) = tokens.iter().rev().find(|t| !t.kind.is_trivia())
+        && matches!(
+            last.kind,
+            Plus | Minus
+                | Star
+                | Slash
+                | Percent
+                | Bang
+                | EqEq
+                | BangEq
+                | LAngle
+                | RAngle
+                | LtEq
+                | GtEq
+                | AmpAmp
+                | PipePipe
+                | Eq
+                | ColonEq
+                | Comma
+                | Dot
+                | Arrow
+                | FatArrow
+                | PathSep
+                | Colon
+        )
+    {
+        return true;
+    }
+
     // An unterminated string or block comment lexes as an error whose span
     // reaches the end of the input.
     let end = source.len() as u32;
@@ -43,6 +77,18 @@ mod tests {
         assert!(is_incomplete("f(1,"));
         assert!(is_incomplete("match x {\n  1 => 2,"));
         assert!(is_incomplete("/* comment"));
+    }
+
+    #[test]
+    fn trailing_operators_continue() {
+        assert!(is_incomplete("1 +"));
+        assert!(is_incomplete("let a ="));
+        assert!(is_incomplete("x =="));
+        assert!(is_incomplete("f(1),"));
+        assert!(is_incomplete("Foo::"));
+        assert!(is_incomplete("x."));
+        assert!(is_incomplete("fn f(x: i64) ->"));
+        assert!(is_incomplete("let x: "));
     }
 
     #[test]

--- a/crates/reussir-repl/src/input.rs
+++ b/crates/reussir-repl/src/input.rs
@@ -61,10 +61,15 @@ pub fn is_incomplete(source: &str) -> bool {
         return true;
     }
 
-    // An unterminated string or block comment lexes as an error whose span
-    // reaches the end of the input.
+    // An unterminated string or block comment can only continue. Other
+    // lexical errors reaching the end of the input (an unrecognized
+    // character, a malformed number) can never be completed by more input —
+    // treating them as incomplete would trap the user in multiline mode, so
+    // they submit and surface the error instead.
     let end = source.len() as u32;
-    errors.iter().any(|e| e.span.1 >= end)
+    errors
+        .iter()
+        .any(|e| e.span.1 >= end && e.message.starts_with("unterminated"))
 }
 
 #[cfg(test)]
@@ -89,6 +94,14 @@ mod tests {
         assert!(is_incomplete("x."));
         assert!(is_incomplete("fn f(x: i64) ->"));
         assert!(is_incomplete("let x: "));
+    }
+
+    #[test]
+    fn uncompletable_lex_errors_submit() {
+        // No amount of further input fixes these; submitting surfaces the
+        // error instead of trapping the user in multiline mode.
+        assert!(!is_incomplete("1 + $"));
+        assert!(!is_incomplete("0x"));
     }
 
     #[test]

--- a/crates/reussir-repl/src/lib.rs
+++ b/crates/reussir-repl/src/lib.rs
@@ -25,5 +25,6 @@
 pub mod commands;
 pub mod externalize;
 pub mod frontend;
+pub mod input;
 pub mod session;
 pub mod value;

--- a/crates/reussir-repl/src/main.rs
+++ b/crates/reussir-repl/src/main.rs
@@ -30,6 +30,11 @@ struct Cli {
     /// Input file for line-by-line execution (script mode).
     #[arg(short = 'i', long = "input")]
     input: Option<PathBuf>,
+
+    /// Use the plain line-based prompt even on a capable terminal
+    /// (implied by `TERM=dumb`, script mode, and piped stdin/stdout).
+    #[arg(long = "no-tui")]
+    no_tui: bool,
 }
 
 fn parse_log_level(level: &str) -> Result<tracing::Level, String> {
@@ -71,7 +76,12 @@ fn run(cli: &Cli) -> Result<(), String> {
     };
 
     // Mode selection: a script file or piped stdin drive the plain
-    // line-based frontend; a real terminal gets the TUI.
+    // line-based frontend; a real terminal gets the TUI unless opted out
+    // (`--no-tui`) or incapable (`TERM=dumb` — set by e.g. Emacs shells on
+    // every platform; an *unset* TERM stays on the TUI, since Windows
+    // terminals conventionally don't set it at all). The plain fallback on
+    // a terminal keeps its line prompts.
+    let mut interactive = false;
     let mut lines: Box<dyn BufRead> = match &cli.input {
         Some(path) => {
             let file = std::fs::File::open(path)
@@ -79,17 +89,30 @@ fn run(cli: &Cli) -> Result<(), String> {
             Box::new(BufReader::new(file))
         }
         None => {
-            if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+            let on_terminal = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+            let dumb = matches!(std::env::var("TERM").as_deref(), Ok("dumb"));
+            if on_terminal && !dumb && !cli.no_tui {
                 return tui::run(config);
             }
+            interactive = on_terminal;
             Box::new(BufReader::new(std::io::stdin()))
         }
     };
 
+    if interactive {
+        println!(
+            "Reussir REPL v{} (Rust pipeline)",
+            env!("CARGO_PKG_VERSION")
+        );
+        println!("Type :help for available commands, :q to quit");
+    }
+
     // Each `:clear` tears the whole session (arena, elaborator, JIT) down
     // and starts a fresh one; the input stream carries on where it was.
     loop {
-        let exit = session::run(config, |session| plain::drive(session, &mut lines, false))?;
+        let exit = session::run(config, |session| {
+            plain::drive(session, &mut lines, interactive)
+        })?;
         match exit {
             Exit::Quit => return Ok(()),
             Exit::Clear => {

--- a/crates/reussir-repl/src/main.rs
+++ b/crates/reussir-repl/src/main.rs
@@ -11,7 +11,7 @@ use std::process::ExitCode;
 use palc::Parser;
 
 use reussir_jit::OptLevel;
-use reussir_repl::frontend::plain;
+use reussir_repl::frontend::{plain, tui};
 use reussir_repl::session::{self, Config, Exit};
 
 /// Reussir REPL (Rust pipeline).
@@ -70,32 +70,26 @@ fn run(cli: &Cli) -> Result<(), String> {
         opt: resolve_opt(cli)?,
     };
 
-    let (mut lines, interactive): (Box<dyn BufRead>, bool) = match &cli.input {
+    // Mode selection: a script file or piped stdin drive the plain
+    // line-based frontend; a real terminal gets the TUI.
+    let mut lines: Box<dyn BufRead> = match &cli.input {
         Some(path) => {
             let file = std::fs::File::open(path)
                 .map_err(|e| format!("failed to open {}: {e}", path.display()))?;
-            (Box::new(BufReader::new(file)), false)
+            Box::new(BufReader::new(file))
         }
         None => {
-            let interactive = std::io::stdin().is_terminal();
-            (Box::new(BufReader::new(std::io::stdin())), interactive)
+            if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+                return tui::run(config);
+            }
+            Box::new(BufReader::new(std::io::stdin()))
         }
     };
-
-    if interactive {
-        println!(
-            "Reussir REPL v{} (Rust pipeline)",
-            env!("CARGO_PKG_VERSION")
-        );
-        println!("Type :help for available commands, :q to quit");
-    }
 
     // Each `:clear` tears the whole session (arena, elaborator, JIT) down
     // and starts a fresh one; the input stream carries on where it was.
     loop {
-        let exit = session::run(config, |session| {
-            plain::drive(session, &mut lines, interactive)
-        })?;
+        let exit = session::run(config, |session| plain::drive(session, &mut lines, false))?;
         match exit {
             Exit::Quit => return Ok(()),
             Exit::Clear => {

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -324,10 +324,17 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         }
     }
 
-    /// Number of accepted (elaborated) definitions, expression wrappers
-    /// included; shown in the TUI status line.
+    /// Number of accepted user definitions — functions and records, the
+    /// synthetic `__repl_expr_N` wrappers excluded; shown in the TUI status
+    /// line.
     pub fn definition_count(&self) -> usize {
-        self.elab.elaborated.len()
+        let functions = self
+            .elab
+            .elaborated
+            .iter()
+            .filter(|f| !self.elab.sym(f.name).starts_with("__repl_"))
+            .count();
+        functions + self.elab.records.len()
     }
 
     /// Render a ground Semi type for display (`i64`, `f64`, `List::<i64>`).

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -324,6 +324,12 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         }
     }
 
+    /// Number of accepted (elaborated) definitions, expression wrappers
+    /// included; shown in the TUI status line.
+    pub fn definition_count(&self) -> usize {
+        self.elab.elaborated.len()
+    }
+
     /// Render a ground Semi type for display (`i64`, `f64`, `List::<i64>`).
     pub(crate) fn render_ty(&self, ty: Ty<'tcx>) -> String {
         match *ty.kind() {

--- a/crates/reussir-syntax/src/diagnostics.rs
+++ b/crates/reussir-syntax/src/diagnostics.rs
@@ -113,9 +113,16 @@ pub fn render(
             )?;
             continue;
         };
-        // Clamp to a non-empty range so a zero-width span still shows a caret.
+        // Clamp to a non-empty, in-bounds range: a zero-width span still
+        // shows a caret, and an end-of-input span (one past the last
+        // character, e.g. an unexpected-EOF parse error) pulls back onto the
+        // last character — out of bounds, ariadne would render the frame
+        // with no source line at all.
         let (start, end) = source_map.char_span(bytes);
-        let span = (file_name, start as usize..end.max(start + 1) as usize);
+        let len = source.chars().count() as u32;
+        let start = start.min(len.saturating_sub(1));
+        let end = end.clamp(start + 1, len.max(start + 1));
+        let span = (file_name, start as usize..end as usize);
         // The message heads the report (a greppable summary line) and annotates
         // the underlined span, so the caret line stands on its own.
         Report::build(diag.severity.report_kind(), span.clone())

--- a/crates/reussir-syntax/src/diagnostics.rs
+++ b/crates/reussir-syntax/src/diagnostics.rs
@@ -104,7 +104,10 @@ pub fn render(
 ) -> std::io::Result<()> {
     let cache = (file_name, Source::from(source));
     for diag in diagnostics {
-        let Some(bytes) = diag.span else {
+        // An empty source has no line to anchor a caret on; treat every
+        // span as absent rather than hand ariadne an out-of-bounds range.
+        let span = if source.is_empty() { None } else { diag.span };
+        let Some(bytes) = span else {
             writeln!(
                 out,
                 "{file_name}: {}: {}",

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -288,6 +288,7 @@ impl SyntaxKind {
             Bang => "`!`",
             Pipe => "`|`",
             Underscore => "`_`",
+            Eof => "the end of the input",
             ErrorToken => "invalid input",
             _ => "a syntax node",
         }

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -116,10 +116,7 @@ pub struct ReplParse {
 /// prefix is an item keyword followed by `as` — `fn as i64` is a cast of a
 /// variable named `fn` — which routes to expressions, so an item literally
 /// named `as` cannot be entered at the REPL.
-pub fn parse_repl(
-    source: &str,
-    interner: std::sync::Arc<MultiThreadedTokenInterner>,
-) -> ReplParse {
+pub fn parse_repl(source: &str, interner: std::sync::Arc<MultiThreadedTokenInterner>) -> ReplParse {
     let mut kind = ReplInputKind::Expr;
     let parse = parse_impl(source, interner, |p| {
         kind = repl_route(p);


### PR DESCRIPTION
PR 3 of the Rust-REPL stack (#289 and #292 are merged; rebased onto main). `rrepl` on a real terminal now runs the ratatui interface; script/pipe modes keep the plain frontend, and `--no-tui` / `TERM=dumb` fall back to a plain interactive prompt loop.

## What

- **Layout**: styled scrollback pane over a `ratatui-textarea` editor (bordered `λ` box that grows with content up to 40% of the screen), plus a status line: ready/evaluating indicator, live opt level (tracks `:set opt`, survives `:clear`), user-definition count (functions + records; expression wrappers excluded), key hints. Long lines wrap, with bottom-pinning computed from post-wrap visual rows (`Paragraph::line_count`). Evaluated values render as Jupyter-style `Out[n]` cells; diagnostics render with the same ariadne caret frames as `rrc` (via a new `render_reports_to` writer variant in core).
- **Smart Enter** (the design goal from the planning discussion): Enter submits when the buffer is a command or *lexically complete* — the new `input::is_incomplete` checks delimiter balance, unterminated strings/block comments, and trailing operators/separators (`1 +`, `let a =`, `Foo::` continue) — and inserts a newline otherwise, so `fn f(x: i64) {` + Enter just continues on line 2. Alt+Enter (and Shift+Enter where the terminal reports it) always insert a newline; Ctrl+J force-submits. A balanced-but-ill-formed buffer submits so the parse error surfaces rather than trapping the user in multiline mode.
- **`:{ … }:` still honored** interactively (paste/muscle-memory compat): a buffer opening with `:{` submits only once closed with `}:`, markers stripped.
- **History**: Up/Down browse at the buffer's first/last line (cursor movement elsewhere), in-progress input stashed and restored; persisted to the platform data dir via `dirs` (`$XDG_DATA_HOME`/`~/.local/share` on Linux, `%LOCALAPPDATA%` on Windows, `~/Library/Application Support` on macOS; newline-escaped entries, capped at 1000).
- **Keys**: Ctrl+C clears the buffer (twice on empty quits), Ctrl+D on empty quits, PageUp/PageDown scroll the scrollback (auto-stick to bottom on new output), bracketed paste inserted as text.
- `:clear` rebuilds the whole session (arena/elaborator/JIT) while the TUI scrollback survives.

- **Also in this PR**: `reussir-syntax` unexpected-EOF parse errors now render a caret at the last character with "found the end of the input" (previously an empty ariadne frame and "found a syntax node") — benefits `rrc` equally.

## Testing

- `input::is_incomplete` unit tests (open delimiters, unterminated comment, balanced/over-closed inputs).
- Drove the TUI end-to-end through a sized PTY (`script` + `stty rows 30 cols 100`): banner, placeholder, `1+1` → echo `λ> 1+1`, busy indicator during eval, `2 : i64` result, defs counter 0→1, `:q` clean exit with terminal restored.
- `repl-rs` lit suite still 4/4; crate unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
