### PR TITLE
[backend] reussir-codegen: settle refcount of temporary projection bases

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -927,13 +927,12 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let scrut_val = self
             .expr(block, env, scrut)?
             .ok_or_else(|| LoweringError("match scrutinee is unit".into()))?;
-        // Record the scrutinee's type so the ownership pass's per-arm drop (keyed
-        // to the scrutinee id for a non-variable scrutinee) resolves it, and hold
-        // its value in `temps` for the same reason.
-        self.temp_tys.borrow_mut().insert(scrut.id, scrut.ty);
+        // Record the scrutinee's value and type so the ownership pass's per-arm
+        // drop (keyed to the scrutinee id for a non-variable scrutinee) resolves
+        // it.
         let temps_mark = env.temps.len();
         let anchors_mark = env.anchors.len();
-        env.temps.insert(scrut.id, scrut_val);
+        self.remember_temp(env, scrut, scrut_val);
         let root_idx = env.anchors.len();
         env.anchors.push((
             SmallVec::new(),
@@ -1541,6 +1540,15 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let base_val = self
             .expr(block, env, base)?
             .ok_or_else(|| LoweringError("projection base is unit".into()))?;
+        // A borrow-projection through a *temporary* rr base (`foo(x).field`, not
+        // `xs.field`) leaves the base owned by no variable; the ownership pass
+        // frees it with a `DropValue` keyed to this `Proj` node, which resolves
+        // the base's value through `env.temps`. Record it so that drop can land.
+        // A `Var` root is dropped via `env.vars`, and a nested `Proj` root is
+        // registered by its own recursive lowering, so neither needs this.
+        if !matches!(base.kind, ExprKind::Var(_) | ExprKind::Proj(..)) {
+            self.remember_temp(env, base, base_val);
+        }
         let mut cursor = Cursor::Value {
             val: base_val,
             ty: base.ty,
@@ -1819,6 +1827,20 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             }
         }
         Ok(())
+    }
+
+    /// Record a temporary's value and type under its [`ExprId`] so a value-keyed
+    /// reference-count op the ownership pass anchored to a *later* node can find
+    /// it. A deferred `DropValue`/`DupValue` (the `match` scrutinee's per-arm
+    /// drop, or a projection base freed after the field is borrowed out) fires
+    /// in [`emit_rc_after`](Self::emit_rc_after) of the node it is keyed to, not
+    /// of the temporary itself, so the value must outlive its own lowering; this
+    /// stashes it. Entries live for the rest of the (sub)scope — the ids are
+    /// unique, so a stale entry is never mislooked-up, and subscope truncation
+    /// reclaims them.
+    fn remember_temp<'b>(&self, env: &mut Env<'c, 'b, 'tcx>, e: &Expr<'tcx>, val: Value<'c, 'b>) {
+        self.temp_tys.borrow_mut().insert(e.id, e.ty);
+        env.temps.insert(e.id, val);
     }
 
     /// Increment the refcount of the temporary held in [`Env::temps`] under `id`

--- a/tests/integration/frontend/proj_temp_base_drop.rr
+++ b/tests/integration/frontend/proj_temp_base_drop.rr
@@ -1,0 +1,31 @@
+// Regression: projecting a field out of a *temporary* reference-counted base
+// (`make(x).val`, not `rc.val`) must settle the temporary's refcount. The
+// ownership pass frees the base with a `DropValue` keyed to the `Proj` node,
+// which the lowering resolves through `env.temps`; before the fix this bailed
+// with "reference-count op on an unbound temporary is not supported".
+
+// RUN: %rrc %s --emit mlir -o - | %FileCheck %s --check-prefix=CHECK-MLIR
+
+struct [shared] RcBox<T> {
+    val : T
+}
+
+fn make(x : u32) -> RcBox<u32> {
+    RcBox { val : x }
+}
+
+pub fn temp_project(x : u32) -> u32 {
+    make(x).val
+}
+
+extern "C" trampoline "temp_project_ffi" = temp_project;
+
+// The temporary `make(x)` result is borrowed, its field projected and loaded,
+// and then the temporary itself is dec'd — the field read keeps no owning ref.
+// CHECK-MLIR-LABEL: func.func @_RC12temp_project(
+// CHECK-MLIR:       %[[TMP:.+]] = call @_RC4make(
+// CHECK-MLIR:       %[[REF:.+]] = reussir.rc.borrow(%[[TMP]]
+// CHECK-MLIR:       reussir.ref.project(%[[REF]]
+// CHECK-MLIR:       reussir.ref.load
+// CHECK-MLIR:       reussir.rc.dec(%[[TMP]]
+// CHECK-MLIR:       return


### PR DESCRIPTION
## What

Fixes the **"deferred drop of a temporary RR base in `Proj`"** codegen regression tracked in #290.

Projecting a field out of a *temporary* reference-counted base — e.g. `make(x).field`, where the base is an owned call result bound to no variable — failed to lower:

```
lowering error: reference-count op on an unbound temporary is not supported
```

## Why

The ownership pass frees such a base with a `DropValue` keyed to the `Proj` node (`navigate_base`, `crates/reussir-core/src/full/ownership.rs`). The lowering resolves value-keyed rc ops through `env.temps`, but only the **match scrutinee** was ever recorded there. A projection base was neither the currently-lowered node nor the scrutinee, so `emit_dec_temp` found no entry and bailed. (A *variable* base like `xs.field` is fine — it drops via `env.vars`.)

## Fix

In `proj`, record a temporary base's value+type under its `ExprId` before walking the field path — the same trick `lower_match` already uses for the scrutinee — factored into a shared `remember_temp` helper. A `Var` base drops via `env.vars` and a nested `Proj` base registers its own root during recursive lowering, so neither needs it.

### Before / after (`make(x).val`)

Before: hard error. After:

```mlir
%0 = call @_RC4make(%arg0) : ...
%1 = reussir.rc.borrow(%0 ...)
%2 = reussir.ref.project(%1 ...) [0]
%3 = reussir.ref.load(%2 ...)
reussir.rc.dec(%0 ...)   // <-- temporary base now freed after the borrow
return %3
```

## Test

Adds `tests/integration/frontend/proj_temp_base_drop.rr`, a FileCheck regression asserting the temporary is borrowed → projected → loaded → dec'd. `cargo test -p reussir-codegen -p reussir-compiler` and the existing `match`/list lowering tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)