### PR TITLE
[frontend] elaboration diagnostics: render with source carets, trace patterns to source

### DIFF
--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -13,6 +13,7 @@
 //! fed back in isolation. Exit 0 on success, 1 on a compile error, 2 on a usage
 //! or I/O error.
 
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -31,8 +32,9 @@ use reussir_core::full::mono::{MonoInput, monomorphize};
 use reussir_core::semi::resolve::DefTable;
 use reussir_core::semi::hir;
 use reussir_core::semi::ty::TyCtxt;
-use reussir_core::semi::{Report, Severity, elaborate};
+use reussir_core::semi::{elaborate, render_reports};
 use reussir_core::{in_arena, surface};
+use reussir_syntax::diagnostics;
 use reussir_syntax::kind::{Resolver, TokenKey};
 
 /// A stage on the compilation chain, ordered from source to object so a target
@@ -239,23 +241,6 @@ fn write_text(path: &Path, text: &str) -> Result<(), String> {
     }
 }
 
-/// Prints `reports` to stderr, each labelled with its severity, and returns
-/// whether any was an error. Warnings alone do not fail the compile.
-fn report_diagnostics(name: &str, reports: &[Report]) -> bool {
-    let mut had_error = false;
-    for report in reports {
-        let label = match report.severity {
-            Severity::Error => {
-                had_error = true;
-                "error"
-            }
-            Severity::Warning => "warning",
-        };
-        eprintln!("{name}: {label}: {}", report.message);
-    }
-    had_error
-}
-
 /// What the front (arena-scoped) leg produces: a text dump for `hir`/`mir`, or an
 /// MLIR module for `mlir` and anything past it. The module borrows the MLIR
 /// context, not the type arena, so it outlives the [`in_arena`] scope.
@@ -418,14 +403,21 @@ fn frontend<'c, 'tcx>(
         Stage::Rr => {
             let parse = reussir_syntax::parse(source);
             if !parse.ok() {
-                for err in &parse.errors {
-                    eprintln!("{name}: error: {err:?}");
-                }
+                let map = diagnostics::SourceMap::new(source);
+                let color = std::io::stderr().is_terminal();
+                let _ = diagnostics::render_errors(
+                    name,
+                    source,
+                    &map,
+                    &parse.errors,
+                    color,
+                    std::io::stderr().lock(),
+                );
                 return Err(String::new());
             }
             let prog = surface::program(&parse.root);
             let elab = elaborate(tcx, &prog, parse.resolver());
-            if report_diagnostics(name, &elab.reports) {
+            if render_reports(name, source, &elab.reports) {
                 return Err(String::new());
             }
             if target == Stage::Hir {
@@ -437,7 +429,7 @@ fn frontend<'c, 'tcx>(
                 return Ok(Produced::Text(text));
             }
             let (full, reports) = monomorphize(&elab.mono_input());
-            if report_diagnostics(name, &reports) {
+            if render_reports(name, source, &reports) {
                 return Err(String::new());
             }
             finish_mir(
@@ -472,7 +464,7 @@ fn frontend<'c, 'tcx>(
                 trampolines: &parsed.trampolines,
             };
             let (full, reports) = monomorphize(&input);
-            if report_diagnostics(name, &reports) {
+            if render_reports(name, source, &reports) {
                 return Err(String::new());
             }
             // A re-parsed IR carries no original source, so debug locations would

--- a/crates/reussir-core/src/bin/reussir-elab.rs
+++ b/crates/reussir-core/src/bin/reussir-elab.rs
@@ -5,6 +5,7 @@
 //! Full IR to stdout. The exit code is 0 on success, 1 on a syntax or
 //! elaboration error, and 2 on a usage or I/O error.
 
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -13,8 +14,9 @@ use palc::Parser;
 use reussir_core::full::mir::print::Printer;
 use reussir_core::full::mono::monomorphize;
 use reussir_core::semi::ctxt::Severity;
-use reussir_core::semi::elaborate;
-use reussir_core::surface::{self, Span};
+use reussir_core::semi::{elaborate, render_reports};
+use reussir_core::surface;
+use reussir_syntax::diagnostics::{self, SourceMap};
 
 /// Which phase to run to.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -60,45 +62,23 @@ fn read_input(path: &PathBuf) -> Result<(String, String), String> {
     }
 }
 
-/// Render one diagnostic as `name:line:col: severity: message`, mapping the
-/// byte offset to a 1-based line and column.
-fn render_report(name: &str, source: &str, span: Option<Span>, sev: &str, message: &str) {
-    let loc = span.map(|s| line_col(source, s.start as usize));
-    match loc {
-        Some((line, col)) => eprintln!("{name}:{line}:{col}: {sev}: {message}"),
-        None => eprintln!("{name}: {sev}: {message}"),
-    }
-}
-
-/// Map a byte offset (as carried by [`Span`]) to a 1-based `(line, column)`,
-/// counting columns in characters. Iterates by `char_indices` so the byte
-/// offset is compared against byte positions — correct for non-ASCII input.
-fn line_col(source: &str, offset: usize) -> (usize, usize) {
-    let mut line = 1;
-    let mut col = 1;
-    for (i, ch) in source.char_indices() {
-        if i >= offset {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 1;
-        } else {
-            col += 1;
-        }
-    }
-    (line, col)
-}
-
 fn run(cli: &Cli) -> Result<bool, String> {
     let mode = parse_mode(&cli.mode)?;
     let (name, source) = read_input(&cli.input)?;
 
+    let map = SourceMap::new(&source);
+
     let parse = reussir_syntax::parse(&source);
     if !parse.ok() {
-        for err in &parse.errors {
-            eprintln!("{name}: error: {err:?}");
-        }
+        let color = std::io::stderr().is_terminal();
+        let _ = diagnostics::render_errors(
+            &name,
+            &source,
+            &map,
+            &parse.errors,
+            color,
+            std::io::stderr().lock(),
+        );
         eprintln!("error: {} syntax error(s) in {name}", parse.errors.len());
         return Ok(false);
     }
@@ -110,13 +90,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
     let (rendered, ok) = reussir_core::in_arena(|tcx| {
         let elab = elaborate(tcx, &prog, parse.resolver());
 
-        for report in &elab.reports {
-            let sev = match report.severity {
-                Severity::Error => "error",
-                Severity::Warning => "warning",
-            };
-            render_report(&name, &source, report.span, sev, &report.message);
-        }
+        render_reports(&name, &source, &elab.reports);
         if elab.has_errors() {
             return (String::new(), false);
         }
@@ -126,13 +100,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
                 .program(&elab.elaborated, &elab.records, &elab.trampolines),
             Mode::Full => {
                 let (full, mono_reports) = monomorphize(&elab.mono_input());
-                for report in &mono_reports {
-                    let sev = match report.severity {
-                        Severity::Error => "error",
-                        Severity::Warning => "warning",
-                    };
-                    render_report(&name, &source, report.span, sev, &report.message);
-                }
+                render_reports(&name, &source, &mono_reports);
                 if mono_reports
                     .iter()
                     .any(|r| matches!(r.severity, Severity::Error))

--- a/crates/reussir-core/src/bin/reussir-elab.rs
+++ b/crates/reussir-core/src/bin/reussir-elab.rs
@@ -66,10 +66,11 @@ fn run(cli: &Cli) -> Result<bool, String> {
     let mode = parse_mode(&cli.mode)?;
     let (name, source) = read_input(&cli.input)?;
 
-    let map = SourceMap::new(&source);
-
     let parse = reussir_syntax::parse(&source);
     if !parse.ok() {
+        // Built only on the error path; a clean parse never needs it (elaboration
+        // diagnostics build their own map inside `render_reports`, also lazily).
+        let map = SourceMap::new(&source);
         let color = std::io::stderr().is_terminal();
         let _ = diagnostics::render_errors(
             &name,

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -29,7 +29,7 @@ pub mod pattern;
 pub mod resolve;
 pub mod ty_eval;
 
-pub use ctxt::{DefaultCap, Elaborator, Report, Severity};
+pub use ctxt::{DefaultCap, Elaborator, Report, Severity, render_reports};
 
 use reussir_syntax::kind::{Resolver, TokenKey};
 

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -40,6 +40,40 @@ pub struct Report {
     pub span: Option<Span>,
 }
 
+/// Render `reports` to stderr with source-caret context and return whether any
+/// was an error (warnings alone do not fail a compile). A report the middle-end
+/// could not trace back to a span — an internal/whole-program error — prints as
+/// a plain line. Both frontend drivers (`rrc`, `reussir-elab`) funnel through
+/// here so parse and elaboration diagnostics render identically.
+pub fn render_reports(name: &str, source: &str, reports: &[Report]) -> bool {
+    use std::io::IsTerminal;
+
+    use reussir_syntax::diagnostics::{self, Diagnostic, Severity as RenderSeverity, SourceMap};
+
+    let had_error = reports
+        .iter()
+        .any(|r| matches!(r.severity, Severity::Error));
+    // The happy path carries no reports; skip building the byte→char map.
+    if reports.is_empty() {
+        return had_error;
+    }
+    let diags: Vec<Diagnostic> = reports
+        .iter()
+        .map(|r| Diagnostic {
+            span: r.span.map(|s| (s.start, s.end)),
+            severity: match r.severity {
+                Severity::Error => RenderSeverity::Error,
+                Severity::Warning => RenderSeverity::Warning,
+            },
+            message: &r.message,
+        })
+        .collect();
+    let map = SourceMap::new(source);
+    let color = std::io::stderr().is_terminal();
+    let _ = diagnostics::render(name, source, &map, &diags, color, std::io::stderr().lock());
+    had_error
+}
+
 /// Per-generic metadata: its name and the trait bounds declared on it.
 #[derive(Clone, Debug)]
 pub struct GenericInfo {

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -174,7 +174,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let mut arm_spans = Vec::with_capacity(arms.len());
         for (i, (pat, body)) in arms.iter().enumerate() {
             let mark = self.vars.mark();
-            let p = self.check_pat(&pat.kind(), scrut_ty);
+            let p = self.check_pat(&pat.kind(), Some(pat.span()), scrut_ty);
             let guard = pat.guard().map(|g| {
                 let bool_ty = self.tcx.mk_bool();
                 self.check_expr(&g, bool_ty)
@@ -236,8 +236,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     // ----- pattern type-checking -----
 
     /// Type-check a surface pattern against `ty`, allocating binders into the
-    /// current scope, and return the typed [`Pat`].
-    fn check_pat(&mut self, kind: &PatternKind, ty: Ty<'tcx>) -> Pat {
+    /// current scope, and return the typed [`Pat`]. `span` is the pattern's
+    /// source span, used to blame any error; nested sub-patterns (a constructor's
+    /// arguments) carry no span of their own, so they reuse the enclosing
+    /// pattern's — coarse, but still traced to source.
+    fn check_pat(&mut self, kind: &PatternKind, span: Option<Span>, ty: Ty<'tcx>) -> Pat {
         let ty = self.infer.shallow_resolve(ty);
         match kind {
             PatternKind::Wildcard => Pat::Wild,
@@ -245,12 +248,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 let var = self.vars.fresh(*name, ty, None);
                 Pat::Bind(var)
             }
-            PatternKind::Const(c) => self.check_const_pat(c, ty),
-            PatternKind::Ctor(ctor) => self.check_ctor_pat(ctor, ty),
+            PatternKind::Const(c) => self.check_const_pat(c, span, ty),
+            PatternKind::Ctor(ctor) => self.check_ctor_pat(ctor, span, ty),
         }
     }
 
-    fn check_const_pat(&mut self, c: &Const, ty: Ty<'tcx>) -> Pat {
+    fn check_const_pat(&mut self, c: &Const, span: Option<Span>, ty: Ty<'tcx>) -> Pat {
         let ctor = match c {
             Const::ConstInt(i) => {
                 // The literal must be *some* integer, but its width/signedness
@@ -260,7 +263,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 // the `Integral` bound on the column type, exactly as an integer
                 // literal *expression* does; the eventual int-switch lowering
                 // reads the column's real type to pick the signed/unsigned cast.
-                self.register_bound(self.builtins.integral, ty, None);
+                self.register_bound(self.builtins.integral, ty, span);
                 Ctor::Int(*i as i128)
             }
             Const::ConstBool(b) => {
@@ -274,7 +277,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 Ctor::Str(self.strings.allocate(s))
             }
             Const::ConstDouble(_) => {
-                self.error(None, "floating-point patterns are not supported");
+                self.error(span, "floating-point patterns are not supported");
                 return Pat::Wild;
             }
         };
@@ -284,10 +287,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
     }
 
-    fn check_ctor_pat(&mut self, ctor: &surface::CtorPat, ty: Ty<'tcx>) -> Pat {
+    fn check_ctor_pat(&mut self, ctor: &surface::CtorPat, span: Option<Span>, ty: Ty<'tcx>) -> Pat {
         let ty = self.infer.shallow_resolve(ty);
         let TyKind::Record { def, args, .. } = ty.kind() else {
-            self.error(None, format!("cannot match constructor against `{ty:?}`"));
+            self.error(span, format!("cannot match constructor against `{ty:?}`"));
             return Pat::Wild;
         };
         // The enum is named by the path qualifier (`Enum::Variant`), resolved to
@@ -301,22 +304,22 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 }
                 None => {
                     let hint = self.record_suggestion(seg);
-                    self.error(None, format!("unknown enum `{}`{hint}", self.sym(seg)));
+                    self.error(span, format!("unknown enum `{}`{hint}", self.sym(seg)));
                     return Pat::Wild;
                 }
             },
             None => *def,
         };
         let Some(record) = self.records.get(&enum_def).cloned() else {
-            self.error(None, "unknown enum".to_string());
+            self.error(span, "unknown enum".to_string());
             return Pat::Wild;
         };
         let Some(RecordFields::Variants(variants)) = &record.fields else {
-            self.error(None, "not an enum".to_string());
+            self.error(span, "not an enum".to_string());
             return Pat::Wild;
         };
         let Some(vidx) = variants.iter().position(|v| v.name == want) else {
-            self.error(None, format!("no variant `{}`", self.sym(want)));
+            self.error(span, format!("no variant `{}`", self.sym(want)));
             return Pat::Wild;
         };
 
@@ -325,7 +328,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             || (!ctor.has_ellipsis && ctor.args.len() != payload.len())
         {
             self.error(
-                None,
+                span,
                 format!(
                     "variant `{}` has {} field(s), but the pattern binds {}",
                     self.sym(want),
@@ -349,7 +352,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .map(|(i, decl)| {
                 let field_ty = self.infer.instantiate_ty(*decl, &inst);
                 match ctor.args.get(i) {
-                    Some(arg) => self.check_pat(&arg.kind, field_ty),
+                    Some(arg) => self.check_pat(&arg.kind, span, field_ty),
                     None => Pat::Wild,
                 }
             })

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -479,6 +479,10 @@ impl Pattern {
         Pattern { node: node.clone() }
     }
 
+    pub fn span(&self) -> Span {
+        node_span(&self.node)
+    }
+
     pub fn kind(&self) -> PatternKind {
         let k = nodes(&self.node)
             .find(|n| {

--- a/crates/reussir-syntax/src/diagnostics.rs
+++ b/crates/reussir-syntax/src/diagnostics.rs
@@ -4,8 +4,8 @@
 //! through one path: a caller lowers each into a [`Diagnostic`] (a byte-offset
 //! span, a [`Severity`], and a message) and hands the batch to [`render`], which
 //! draws a source-caret report. A spanless diagnostic — one the compiler could
-//! not trace back to a source location — falls back to a plain `severity:
-//! message` line.
+//! not trace back to a source location — falls back to a plain
+//! `{file_name}: severity: message` line.
 
 use ariadne::{Color, Config, Label, Report, ReportKind, Source};
 
@@ -92,8 +92,8 @@ impl SourceMap {
 /// A diagnostic with a span draws an `ariadne` source-caret report; the `ariadne`
 /// cache holds the single source file and spans are converted to character
 /// offsets, which is what [`ariadne::Source`] indexes by. A spanless diagnostic
-/// is written as a plain `severity: message` line — the compiler could not trace
-/// it back to source, so there is nothing to point at.
+/// is written as a plain `{file_name}: severity: message` line — the compiler
+/// could not trace it back to source, so there is nothing to point at.
 pub fn render(
     file_name: &str,
     source: &str,

--- a/crates/reussir-syntax/src/diagnostics.rs
+++ b/crates/reussir-syntax/src/diagnostics.rs
@@ -1,4 +1,11 @@
 //! Parse error representation and user-facing rendering via [`ariadne`].
+//!
+//! Both the parser's own [`ParseError`]s and the middle-end's diagnostics render
+//! through one path: a caller lowers each into a [`Diagnostic`] (a byte-offset
+//! span, a [`Severity`], and a message) and hands the batch to [`render`], which
+//! draws a source-caret report. A spanless diagnostic — one the compiler could
+//! not trace back to a source location — falls back to a plain `severity:
+//! message` line.
 
 use ariadne::{Color, Config, Label, Report, ReportKind, Source};
 
@@ -7,6 +14,48 @@ use ariadne::{Color, Config, Label, Report, ReportKind, Source};
 pub struct ParseError {
     pub span: (u32, u32),
     pub message: String,
+}
+
+/// The severity of a [`Diagnostic`]. Mirrors the middle-end's own severity so a
+/// caller can map one to the other without this crate depending on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+/// A source-anchored diagnostic ready to render. The `span` is a byte-offset
+/// half-open range into the source, or `None` when the diagnostic cannot be
+/// pinned to a location (an internal/whole-program error) — in which case
+/// [`render`] prints it without a caret.
+#[derive(Debug, Clone)]
+pub struct Diagnostic<'a> {
+    pub span: Option<(u32, u32)>,
+    pub severity: Severity,
+    pub message: &'a str,
+}
+
+impl Severity {
+    fn report_kind(self) -> ReportKind<'static> {
+        match self {
+            Severity::Error => ReportKind::Error,
+            Severity::Warning => ReportKind::Warning,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        }
+    }
+
+    fn color(self) -> Color {
+        match self {
+            Severity::Error => Color::Red,
+            Severity::Warning => Color::Yellow,
+        }
+    }
 }
 
 /// Maps byte offsets to character (Unicode scalar) offsets. The frontend
@@ -38,32 +87,68 @@ impl SourceMap {
     }
 }
 
-/// Render the diagnostics with source context to the given writer.
+/// Render `diagnostics` with source context to `out`.
 ///
-/// The `ariadne` cache holds the single source file; spans are converted to
-/// character offsets, which is what `ariadne::Source` indexes by.
+/// A diagnostic with a span draws an `ariadne` source-caret report; the `ariadne`
+/// cache holds the single source file and spans are converted to character
+/// offsets, which is what [`ariadne::Source`] indexes by. A spanless diagnostic
+/// is written as a plain `severity: message` line — the compiler could not trace
+/// it back to source, so there is nothing to point at.
+pub fn render(
+    file_name: &str,
+    source: &str,
+    source_map: &SourceMap,
+    diagnostics: &[Diagnostic],
+    color: bool,
+    mut out: impl std::io::Write,
+) -> std::io::Result<()> {
+    let cache = (file_name, Source::from(source));
+    for diag in diagnostics {
+        let Some(bytes) = diag.span else {
+            writeln!(
+                out,
+                "{file_name}: {}: {}",
+                diag.severity.label(),
+                diag.message
+            )?;
+            continue;
+        };
+        // Clamp to a non-empty range so a zero-width span still shows a caret.
+        let (start, end) = source_map.char_span(bytes);
+        let span = (file_name, start as usize..end.max(start + 1) as usize);
+        // The message heads the report (a greppable summary line) and annotates
+        // the underlined span, so the caret line stands on its own.
+        Report::build(diag.severity.report_kind(), span.clone())
+            .with_config(Config::default().with_color(color))
+            .with_message(diag.message)
+            .with_label(
+                Label::new(span)
+                    .with_message(diag.message)
+                    .with_color(diag.severity.color()),
+            )
+            .finish()
+            .write(cache.clone(), &mut out)?;
+    }
+    Ok(())
+}
+
+/// Render parse `errors` with source context — a thin adapter over [`render`]
+/// that tags each as a [`Severity::Error`].
 pub fn render_errors(
     file_name: &str,
     source: &str,
     source_map: &SourceMap,
     errors: &[ParseError],
     color: bool,
-    mut out: impl std::io::Write,
+    out: impl std::io::Write,
 ) -> std::io::Result<()> {
-    let cache = (file_name, Source::from(source));
-    for error in errors {
-        let (start, end) = source_map.char_span(error.span);
-        let span = (file_name, start as usize..end.max(start + 1) as usize);
-        Report::build(ReportKind::Error, span.clone())
-            .with_config(Config::default().with_color(color))
-            .with_message("syntax error")
-            .with_label(
-                Label::new(span)
-                    .with_message(&error.message)
-                    .with_color(Color::Red),
-            )
-            .finish()
-            .write(cache.clone(), &mut out)?;
-    }
-    Ok(())
+    let diagnostics: Vec<Diagnostic> = errors
+        .iter()
+        .map(|e| Diagnostic {
+            span: Some(e.span),
+            severity: Severity::Error,
+            message: &e.message,
+        })
+        .collect();
+    render(file_name, source, source_map, &diagnostics, color, out)
 }

--- a/tests/integration/frontend/elab_error_caret.rr
+++ b/tests/integration/frontend/elab_error_caret.rr
@@ -1,0 +1,17 @@
+// Elaboration errors are traced back to source: rendered with an ariadne caret
+// that underlines the offending span, not a bare message. This also exercises
+// the pattern-span threading — a floating-point pattern is span-less in the
+// checker until its enclosing pattern's span is threaded through.
+// RUN: %not %rrc %s --emit mir -o - 2>&1 | %FileCheck %s
+
+pub fn f(x: f64) -> i32 {
+    match x {
+        1.5 => 1,
+        _ => 0
+    }
+}
+
+// The message heads the report and annotates the underlined source line.
+// CHECK: floating-point patterns are not supported
+// CHECK: elab_error_caret.rr:9:9
+// CHECK: 1.5 => 1

--- a/tests/integration/frontend/meaningless_wrong.rr
+++ b/tests/integration/frontend/meaningless_wrong.rr
@@ -15,4 +15,6 @@ fn foo(x : Foo, flag: bool) -> Foo {
     }
 }
 
-// CHECK: Non-exhaustive pattern match
+// The diagnostic is rendered with a source caret pointing at the `match`.
+// CHECK: non-exhaustive patterns in `match`
+// CHECK: meaningless_wrong.rr:9:5


### PR DESCRIPTION
## What

Middle-end (elaboration / monomorphization) diagnostics are now rendered with **ariadne source carets**, like parse errors — and every remaining span-less pattern error is traced back to source. Addresses the *"elaboration diagnostics get no rich source report, and often no span at all"* enhancement in #290.

### Before

```
$ rrc bad.rr --emit mir -o -
bad.rr: error: `Fp(Ieee(64))` does not implement `Integral`      # span dropped entirely

$ rrc bad.rr                                                      # parse error
bad.rr: error: ParseError { span: (10, 12), message: "expected a parameter name, found `->`" }
```

### After

```
$ rrc bad.rr --emit mir -o -
Error: `Fp(Ieee(64))` does not implement `Integral`
   ╭─[ bad.rr:2:5 ]
   │
 2 │     213123 / 123.0 / 0.0
   │     ───┬──
   │        ╰──── `Fp(Ieee(64))` does not implement `Integral`
───╯
```

## Why it was only a rendering gap

The span plumbing already existed: `Report.span: Option<Span>` is threaded through inference and obligation discharge. But `rrc`'s printer never read `report.span`, `reussir-elab` printed a plain `name:line:col:` prefix, and **both** dumped parse errors via `{err:?}` Debug. An ariadne caret renderer existed in `reussir-syntax` but was used only for `ParseError`.

## Changes

- **`reussir-syntax::diagnostics`** — generalize the parse renderer into `render(&[Diagnostic])` over a neutral `{span, severity, message}` type (byte→char via the existing `SourceMap`; a span-less diagnostic falls back to a plain `severity: message` line). `render_errors` becomes a thin adapter. Warnings render too (yellow).
- **`reussir-core::semi::render_reports(name, source, &[Report]) -> bool`** — one entry point both drivers share; converts `Report`s and writes to stderr with color auto-detected via `IsTerminal` (piped/test output stays plain). Returns whether any report was an error.
- **`rrc` + `reussir-elab`** — route parse *and* elaboration/mono diagnostics through the shared path; delete their bespoke printers.
- **Pattern spans** — pattern checking passed `None` for every constructor / float / arity / unknown-enum error. Add `Pattern::span()` and thread it through `check_pat` and its callees (nested sub-patterns reuse the enclosing pattern's span — coarse, but sourced). This removes the last span-less middle-end error sites (`grep 'error(None' crates/reussir-core/src` is now empty).

After this, every middle-end diagnostic carries a caret except a genuinely span-less internal error (the intended "ICE" exception).

## Tests

- Migrate `meaningless_wrong.rr`'s stale Haskell-era CHECK (`Non-exhaustive pattern match`) to the current message + caret location.
- Add `elab_error_caret.rr`: a `%not %rrc` test asserting an elaboration error renders a caret underlining the offending pattern.
- `cargo test -p reussir-syntax -p reussir-core -p reussir-compiler` green; the 17 migrated rrc-dump tests and the `surface_errors` parser test are unaffected (only stderr rendering changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)