### PR TITLE
[frontend][backend] arbitrary-precision numeric literals with single rounding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +700,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
  "logos-codegen",
+]
+
+[[package]]
+name = "malachite-base"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f44099731f17094b07825c88ccb5fbd1bfa1f82fafff7daa33e8b8652db16e"
+dependencies = [
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "libm",
+ "ryu",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a137660cdba20f136c8a223125f08088adb4e0b72fbb8466f08c43e31cc0427d"
+dependencies = [
+ "itertools 0.14.0",
+ "libm",
+ "malachite-base",
+ "wide",
 ]
 
 [[package]]
@@ -1187,6 +1217,8 @@ dependencies = [
  "lalrpop-util",
  "lasso",
  "logos",
+ "malachite-base",
+ "malachite-nz",
  "pprint",
  "rapidhash",
  "reussir-syntax",
@@ -1284,6 +1316,21 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -1722,6 +1769,16 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wide"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,11 @@ strsim = "0.11"
 lalrpop = "0.22"
 lalrpop-util = "0.22"
 pprint = "0.3"
+# Arbitrary-precision integers carrying numeric literals losslessly from the
+# surface AST through HIR/MIR; rounding to the target format happens exactly
+# once, in codegen. NOTE: LGPL-3.0-only (see the licensing note in LICENSE).
+malachite-base = "0.9"
+malachite-nz = "0.9"
 # llvm-sys provides the ORC/LLJIT and target-machine C API that mlir-sys does
 # not bind. Its version tracks LLVM major.minor (22.1 -> 221), and it discovers
 # LLVM via LLVM_SYS_221_PREFIX (set by CMake).

--- a/LICENSE
+++ b/LICENSE
@@ -249,3 +249,21 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+==============================================================================
+Third-party components under other licenses
+==============================================================================
+
+The compiler toolchain (not the Reussir runtime or programs compiled by it)
+depends on the following LGPL-licensed Rust crates:
+
+  * malachite-base, malachite-nz — LGPL-3.0-only
+    (arbitrary-precision arithmetic for numeric literals)
+
+These libraries are used unmodified, as ordinary Cargo dependencies. Their
+source is available from their upstream repository
+(https://github.com/mhogrefe/malachite). In accordance with the LGPL, the
+complete corresponding source of the compiler binaries that link them is this
+repository itself, which is sufficient to relink against a modified version
+of the libraries. The Reussir Project's own code remains available under the
+Apache-2.0 OR MIT terms above.

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -24,8 +24,8 @@ use reussir_backend::melior::Context;
 use reussir_backend::melior::dialect::arith::{self, CmpfPredicate, CmpiPredicate};
 use reussir_backend::melior::dialect::{func, scf};
 use reussir_backend::melior::ir::attribute::{
-    Attribute, DenseI64ArrayAttribute, FlatSymbolRefAttribute, FloatAttribute, IntegerAttribute,
-    StringAttribute, TypeAttribute,
+    Attribute, DenseI64ArrayAttribute, FlatSymbolRefAttribute, IntegerAttribute, StringAttribute,
+    TypeAttribute,
 };
 use reussir_backend::melior::ir::r#type::{FunctionType, IntegerType};
 use reussir_backend::melior::ir::{
@@ -34,6 +34,7 @@ use reussir_backend::melior::ir::{
 
 use reussir_core::full::mir::{self, DecisionTree, Expr, ExprKind, SwitchCases};
 use reussir_core::full::ownership::{OwnershipTable, RcOp, RecordTable, analyze_function};
+use reussir_core::literal::{self, Integer};
 use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use reussir_core::semi::ty::{IntTy, Ty, TyCtxt, TyKind};
 use reussir_core::surface::{Span, Visibility};
@@ -416,12 +417,9 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         use ExprKind::*;
         let loc = self.loc();
         match &e.kind {
-            ConstInt(n) => {
-                let attr = IntegerAttribute::new(self.tys.mlir_ty(e.ty)?, *n as i64).into();
-                Ok(Some(
-                    self.append(block, arith::constant(self.context, attr, loc)),
-                ))
-            }
+            // Emitted at full width via the textual APInt path — the value
+            // was range-checked against `e.ty` at monomorphization.
+            ConstInt(n) => Ok(Some(self.wide_int_constant(block, n, e.ty)?)),
             ConstBool(b) => {
                 let i1 = IntegerType::new(self.context, 1).into();
                 let attr = IntegerAttribute::new(i1, i64::from(*b)).into();
@@ -429,8 +427,28 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     self.append(block, arith::constant(self.context, attr, loc)),
                 ))
             }
+            // The single decimal→binary rounding in the pipeline: the exact
+            // literal is rounded into the target format host-side (no Rust
+            // float involved, so bf16/f16 work like f32/f64) and the bits are
+            // emitted through MLIR's hexadecimal form, which is exact.
             ConstFloat(f) => {
-                let attr = FloatAttribute::new(self.context, self.tys.mlir_ty(e.ty)?, *f).into();
+                let fp = match *e.ty.kind() {
+                    TyKind::Fp(fp) => fp,
+                    _ => return err("float literal with a non-float type"),
+                };
+                let (exp_bits, mant_bits) = literal::ieee_params(fp).ok_or_else(|| {
+                    LoweringError(format!("`{fp:?}` has no settled encoding").into())
+                })?;
+                let bits = f.to_ieee_bits(exp_bits, mant_bits).map_err(|_| {
+                    // Unreachable after the mono range check; keep it an error.
+                    LoweringError(format!("float literal `{f}` overflows its type").into())
+                })?;
+                let mlir_ty = self.tys.mlir_ty(e.ty)?;
+                let digits = ((1 + exp_bits + mant_bits) as usize).div_ceil(4);
+                let text = format!("0x{bits:0digits$X} : {mlir_ty}");
+                let attr = Attribute::parse(self.context, &text).ok_or_else(|| {
+                    LoweringError(format!("could not build float constant `{text}`").into())
+                })?;
                 Ok(Some(
                     self.append(block, arith::constant(self.context, attr, loc)),
                 ))
@@ -1121,8 +1139,9 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
     /// * width > 64 — an `index` cannot hold the scrutinee and the keys may exceed
     ///   `i64`, so a full-width `scf.if` compare-chain first reduces the keys to a
     ///   compact selector in `[0, cases.len()]` (case `i` → `i`, no match → the
-    ///   default), and the switch dispatches on that. (Reachable once the frontend
-    ///   types integers wider than 64 bits — it rejects `i128` today.)
+    ///   default), and the switch dispatches on that. (Keys are arbitrary
+    ///   precision end to end; this arm becomes reachable once the surface
+    ///   grows `i128`/`u128` type names.)
     #[allow(clippy::too_many_arguments)]
     fn int_switch<'b>(
         &self,
@@ -1130,7 +1149,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         env: &mut Env<'c, 'b, 'tcx>,
         root_idx: usize,
         path: &[u32],
-        cases: &'tcx [(i128, DecisionTree<'tcx>)],
+        cases: &'tcx [(&'tcx Integer, DecisionTree<'tcx>)],
         default: &'tcx DecisionTree<'tcx>,
         result_ty: Ty<'tcx>,
     ) -> Result<Option<Value<'c, 'b>>> {
@@ -1166,7 +1185,15 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 arith::index_castui(scrut_val, index_ty, loc)
             };
             let arg = self.append(block, cast);
-            (arg, cases.iter().map(|(key, _)| *key as i64).collect::<Vec<_>>())
+            // The key fits its (≤64-bit) scrutinee type, so its two's
+            // complement low word is the exact case value.
+            (
+                arg,
+                cases
+                    .iter()
+                    .map(|(key, _)| literal::low_u64(key) as i64)
+                    .collect::<Vec<_>>(),
+            )
         };
         let cases_attr = DenseI64ArrayAttribute::new(self.context, &case_values);
         let op = block.append_operation(scf::index_switch(
@@ -1194,7 +1221,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         block: &'b Block<'c>,
         scrut_val: Value<'c, 'b>,
         scrut_ty: Ty<'tcx>,
-        cases: &'tcx [(i128, DecisionTree<'tcx>)],
+        cases: &'tcx [(&'tcx Integer, DecisionTree<'tcx>)],
         idx: i64,
     ) -> Result<Value<'c, 'b>> {
         let loc = self.loc();
@@ -1203,7 +1230,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             // Every key was ruled out: select the default's slot.
             return Ok(self.index_const(block, idx));
         };
-        let key_val = self.wide_int_constant(block, *key, scrut_ty)?;
+        let key_val = self.wide_int_constant(block, key, scrut_ty)?;
         let eq = self.append(
             block,
             arith::cmpi(self.context, CmpiPredicate::Eq, scrut_val, key_val, loc),
@@ -1235,13 +1262,14 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         )
     }
 
-    /// Materialize an integer constant of `ty` holding `key`. melior's
-    /// `IntegerAttribute::new` takes only an `i64`, so a key wider than that is
-    /// built by parsing its textual attribute form (`<value> : iN`).
+    /// Materialize an integer constant of `ty` holding `key`, at any width.
+    /// melior's `IntegerAttribute::new` takes only an `i64`, so the constant is
+    /// built by parsing its textual attribute form (`<value> : iN`), which
+    /// goes through MLIR's arbitrary-precision APInt.
     fn wide_int_constant<'b>(
         &self,
         block: &'b Block<'c>,
-        key: i128,
+        key: &Integer,
         ty: Ty<'tcx>,
     ) -> Result<Value<'c, 'b>> {
         let loc = self.loc();

--- a/crates/reussir-core/Cargo.toml
+++ b/crates/reussir-core/Cargo.toml
@@ -32,6 +32,10 @@ stumpalo.workspace = true
 logos.workspace = true
 lalrpop-util.workspace = true
 pprint.workspace = true
+# Arbitrary-precision numeric literals (`literal` module): values stay exact
+# through surface/HIR/MIR; the one rounding to the target format is in codegen.
+malachite-base.workspace = true
+malachite-nz.workspace = true
 # The surface AST is a set of typed views over the parser's lossless CST.
 reussir-syntax = { path = "../reussir-syntax" }
 # Backends for utils::bitset's small-set-optimized VarId live-sets: a dense

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -18,6 +18,7 @@
 use lasso::{Rodeo, Spur};
 use reussir_syntax::kind::TokenKey;
 
+use crate::literal::{FloatLit, Integer};
 use crate::semi::ctxt::DefaultCap;
 use crate::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use crate::semi::ty::Ty;
@@ -189,8 +190,13 @@ pub struct ClosureExpr<'tcx> {
 #[derive(Clone, Copy, Debug)]
 pub enum ExprKind<'tcx> {
     GlobalStr(StringToken),
-    ConstInt(i128),
-    ConstFloat(f64),
+    /// An integer literal, arbitrary-precision (arena-allocated to keep the
+    /// node `Copy`); range-checked against its ground type at
+    /// monomorphization and emitted at full width by codegen.
+    ConstInt(&'tcx Integer),
+    /// A floating-point literal, still the *exact* decimal value: codegen
+    /// performs the single correctly-rounded conversion to the ground format.
+    ConstFloat(&'tcx FloatLit),
     ConstBool(bool),
     Var(VarId),
     Negate(&'tcx Expr<'tcx>),
@@ -268,7 +274,7 @@ pub enum DecisionTree<'tcx> {
 #[derive(Clone, Copy, Debug)]
 pub enum SwitchCases<'tcx> {
     Int {
-        cases: &'tcx [(i128, DecisionTree<'tcx>)],
+        cases: &'tcx [(&'tcx Integer, DecisionTree<'tcx>)],
         default: &'tcx DecisionTree<'tcx>,
     },
     Bool {

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -280,7 +280,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::Cases::Int { cases, default } => {
                 let mut cs = Vec::with_capacity(cases.len());
                 for (n, t) in cases {
-                    cs.push((*n, self.tree(t)));
+                    cs.push((self.tcx.alloc(n.clone()), self.tree(t)));
                 }
                 let default = self.tree_ref(default);
                 S::Int {
@@ -324,8 +324,8 @@ impl<'tcx> Builder<'_, 'tcx> {
         use mir::ExprKind as M;
         let ty = self.ty(&e.ty);
         let kind: M<'tcx> = match &*e.kind {
-            raw::Kind::ConstInt(n) => M::ConstInt(*n),
-            raw::Kind::ConstFloat(f) => M::ConstFloat(*f),
+            raw::Kind::ConstInt(n) => M::ConstInt(self.tcx.alloc(n.clone())),
+            raw::Kind::ConstFloat(f) => M::ConstFloat(self.tcx.alloc(f.clone())),
             raw::Kind::ConstBool(b) => M::ConstBool(*b),
             raw::Kind::GlobalStr(words) => M::GlobalStr(StringToken::from_words(*words)),
             raw::Kind::Var(v) => M::Var(VarId(*v)),

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -6,6 +6,7 @@
 
 use crate::full::mir::raw as raw;
 use crate::ir_lex::{Token, LexError};
+use crate::literal::{FloatLit, Integer};
 
 grammar<'input>;
 
@@ -117,7 +118,7 @@ Expr: raw::Expr = {
 
 Atom: raw::Kind = {
     <n:"int"> => raw::Kind::ConstInt(n),
-    <f:"float"> => raw::Kind::ConstFloat(f),
+    <f:"float"> => raw::Kind::ConstFloat(raw::float_lit(f)),
     "true" => raw::Kind::ConstBool(true),
     "false" => raw::Kind::ConstBool(false),
     <w:StrWords> => raw::Kind::GlobalStr(w),
@@ -130,14 +131,14 @@ Atom: raw::Kind = {
     "(" <e:Expr> "as" <t:Ty> ")" => raw::Kind::Cast(e, t),
     "region" "{" <e:Expr> "}" => raw::Kind::RegionRun(e),
     "proj" "(" <base:Expr> <idxs:("," <"int">)*> ")"
-        => raw::Kind::Proj(base, idxs.into_iter().map(|n| n as u32).collect()),
+        => raw::Kind::Proj(base, idxs.iter().map(raw::small_u32).collect()),
     "assign" "(" <dst:Expr> "," <field:"int"> "," <src:Expr> ")"
-        => raw::Kind::Assign(dst, field as u32, src),
+        => raw::Kind::Assign(dst, raw::small_u32(&field), src),
     <r:"regional"?> "@" <symbol:Sym> "(" <args:Comma<Expr>> ")"
         => raw::Kind::Call { regional: r.is_some(), symbol, args },
     "@" <symbol:Sym> "{" <args:Comma<Expr>> "}" => raw::Kind::Ctor { symbol, args },
     "@" <symbol:Sym> "::" "#" <v:"int"> "(" <args:Comma<Expr>> ")"
-        => raw::Kind::Variant { symbol, variant: v as usize, args },
+        => raw::Kind::Variant { symbol, variant: raw::small_usize(&v), args },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"
@@ -165,7 +166,7 @@ Tree: raw::Tree = {
 Arm: (raw::Label, raw::Tree) = <l:Label> "=>" "{" <t:Tree> "}" => (l, t);
 
 Label: raw::Label = {
-    "#" <n:"int"> => raw::Label::Ctor(n as usize),
+    "#" <n:"int"> => raw::Label::Ctor(raw::small_usize(&n)),
     <n:"int"> => raw::Label::Int(n),
     "_" => raw::Label::Wildcard,
     "true" => raw::Label::Bool(true),
@@ -175,8 +176,14 @@ Label: raw::Label = {
     "Null" => raw::Label::Null,
 };
 
-PatRef: raw::Path = "scrut" <idxs:("." <"int">)*>
-    => idxs.into_iter().map(|n| n as u32).collect();
+PatRef: raw::Path = "scrut" <segs:PathSeg*> => segs.into_iter().flatten().collect();
+
+// One `.`-led path step. Two adjacent numeric indices (`.0.1`) lex as a single
+// float-shaped token, split back into their segments here.
+PathSeg: Vec<u32> = {
+    "." <n:"int"> => vec![raw::small_u32(&n)],
+    "." <f:"float"> => raw::float_path_segs(f),
+};
 
 Bindings: Vec<raw::Binding> = <Binding*>;
 
@@ -184,7 +191,7 @@ Binding: raw::Binding = <v:"var"> "=" <p:PatRef> => (v, p);
 
 // A string-literal tag: all four `StringToken` words, `#`-separated.
 StrWords: raw::StrTag = "str" "#" <w0:"int"> "#" <w1:"int"> "#" <w2:"int"> "#" <w3:"int">
-    => [w0 as u64, w1 as u64, w2 as u64, w3 as u64];
+    => [raw::small_u64(&w0), raw::small_u64(&w1), raw::small_u64(&w2), raw::small_u64(&w3)];
 
 ArithOp: raw::ArithOp = {
     "+" => raw::ArithOp::Add,
@@ -224,8 +231,8 @@ extern {
     type Error = LexError;
 
     enum Token<'input> {
-        "int" => Token::Int(<i128>),
-        "float" => Token::Float(<f64>),
+        "int" => Token::Int(<Integer>),
+        "float" => Token::Float(<&'input str>),
         "var" => Token::Var(<u32>),
         "ints" => Token::IntS(<u16>),
         "intu" => Token::IntU(<u16>),

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -292,7 +292,7 @@ impl Render<'_> {
         match e.kind {
             GlobalStr(s) => text(str_lit(s.words())),
             ConstInt(n) => text(format!("{n}")),
-            ConstFloat(f) => text(float_lit(f)),
+            ConstFloat(f) => text(f.to_string()),
             ConstBool(b) => text(format!("{b}")),
             Var(v) => var(v),
             Poison => text("poison"),
@@ -515,19 +515,6 @@ fn cap_name(c: Flexivity) -> &'static str {
 /// round-trips faithfully.
 fn str_lit(w: [u64; 4]) -> String {
     format!("str#{}#{}#{}#{}", w[0], w[1], w[2], w[3])
-}
-
-/// Print a float so it re-lexes as a `Token::Float`. `f64`'s `Display` renders a
-/// finite value in plain decimal (never exponent notation), but drops the point
-/// for integral values (`1.0` -> `1`) — which would otherwise re-lex as an
-/// integer — so a missing `.`/`e` means an integral value that needs `.0`.
-fn float_lit(f: f64) -> String {
-    let s = format!("{f}");
-    if s.contains(['.', 'e', 'E']) {
-        s
-    } else {
-        format!("{s}.0")
-    }
 }
 
 fn arith_sym(op: ArithOp) -> &'static str {

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -157,6 +157,37 @@ pub enum Cap {
 /// The four raw words of an interned `StringToken`.
 pub type StrTag = [u64; 4];
 
+pub use crate::literal::{FloatLit, Integer};
+
+/// Structural indices in the textual IR (`proj` paths, variant tags, string
+/// words, field numbers) are machine-emitted and always small; the lexer hands
+/// them over as [`Integer`]s, converted coarsely here (a failure means a
+/// printer bug or corrupt input, like the rest of the raw layer).
+pub fn small_u32(n: &Integer) -> u32 {
+    u32::try_from(n).expect("index in machine-emitted IR")
+}
+
+pub fn small_u64(n: &Integer) -> u64 {
+    u64::try_from(n).expect("word in machine-emitted IR")
+}
+
+pub fn small_usize(n: &Integer) -> usize {
+    usize::try_from(n).expect("index in machine-emitted IR")
+}
+
+/// Parse a float token's text into its exact value.
+pub fn float_lit(text: &str) -> FloatLit {
+    crate::literal::parse_float(text)
+}
+
+/// A float-shaped token inside a scrutinee path: `scrut.0.1` lexes `0.1` as
+/// one token, which is really two adjacent path indices — split it back.
+pub fn float_path_segs(text: &str) -> Vec<u32> {
+    text.split('.')
+        .map(|seg| seg.parse().expect("path segment in machine-emitted IR"))
+        .collect()
+}
+
 /// A typed expression node: every node carries its [`Ty`], so the re-intern pass
 /// never invents a type — the printed `kind : ty` annotation is read back
 /// verbatim, making the text round trip a soundness proof. The two exceptions
@@ -179,8 +210,8 @@ impl Expr {
 
 #[derive(Clone, Debug)]
 pub enum Kind {
-    ConstInt(i128),
-    ConstFloat(f64),
+    ConstInt(Integer),
+    ConstFloat(FloatLit),
     ConstBool(bool),
     /// An interned string literal, as its four raw `StringToken` words.
     GlobalStr([u64; 4]),
@@ -278,7 +309,7 @@ pub enum Tree {
 #[derive(Clone, Debug)]
 pub enum Cases {
     Int {
-        cases: Vec<(i128, Tree)>,
+        cases: Vec<(Integer, Tree)>,
         default: Box<Tree>,
     },
     Bool {
@@ -299,9 +330,9 @@ pub enum Cases {
 /// A switch-arm label, as the grammar reads it before partitioning into a typed
 /// [`Cases`]. The printer emits homogeneous labels per switch (all `#i`, all int,
 /// …), with a `_` wildcard standing for the default arm.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum Label {
-    Int(i128),
+    Int(Integer),
     Ctor(usize),
     Str([u64; 4]),
     Bool(bool),
@@ -316,7 +347,7 @@ pub enum Label {
 pub fn build_switch(scrutinee: Path, arms: Vec<(Label, Tree)>) -> Tree {
     let kind = arms
         .iter()
-        .map(|(l, _)| *l)
+        .map(|(l, _)| l)
         .find(|l| !matches!(l, Label::Wildcard));
     let cases = match kind {
         Some(Label::Bool(_)) => {

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -621,10 +621,16 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             ExprKind::Poison => M::Poison,
             // Negation of a literal folds into the constant, so `-128 : i8`
             // (and `-9223372036854775808 : i64`) is a single in-range value
-            // by the time the range check above sees it.
+            // by the time the range check above sees it. The exception is
+            // `-0.0`: an exact decimal has no negative zero (IEEE signed zero
+            // is a binary-format artifact), so it stays a runtime negation —
+            // folding it would turn `-0.0` into `+0.0` and flip, e.g., the
+            // sign of `1.0 / -0.0`.
             ExprKind::Negate(e) => match &e.kind {
                 ExprKind::ConstInt(n) => M::ConstInt(self.tcx.alloc(-(*n).clone())),
-                ExprKind::ConstFloat(f) => M::ConstFloat(self.tcx.alloc(f.neg())),
+                ExprKind::ConstFloat(f) if *f.mantissa() != 0 => {
+                    M::ConstFloat(self.tcx.alloc(f.neg()))
+                }
                 _ => M::Negate(self.lower_ref(e, subst)),
             },
             ExprKind::Not(e) => M::Not(self.lower_ref(e, subst)),
@@ -921,6 +927,35 @@ mod tests {
              pub fn bin() -> u8 { 0b1111_1111 }",
             |_| (),
         );
+    }
+
+    /// `-0.0` must stay a *runtime* negation: `FloatLit` is an exact decimal
+    /// with no signed zero, so folding it would produce `+0.0` and flip, e.g.,
+    /// the sign of `1.0 / -0.0`. Non-zero literals do fold.
+    #[test]
+    fn negative_zero_is_not_folded() {
+        use crate::full::mir::print::Printer as MirPrinter;
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(
+                "pub fn nz() -> f64 { -0.0 } \
+                 pub fn nn() -> f64 { -1.5 }",
+            );
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "{:#?}", elab.reports);
+            let (mir, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "{reports:#?}");
+            let text = MirPrinter::new(&elab.defs, elab.resolver).program(&mir);
+            assert!(
+                text.contains("-(0.0 : f64)"),
+                "-0.0 must stay a runtime negation:\n{text}"
+            );
+            assert!(
+                text.contains("-1.5 : f64") && !text.contains("-(1.5"),
+                "non-zero literals must fold:\n{text}"
+            );
+        });
     }
 
     #[test]

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -49,12 +49,14 @@ use reussir_syntax::kind::{Resolver, TokenKey};
 use crate::full::mangle::Mangler;
 use crate::full::mir;
 use crate::full::subst::{Subst, subst_ty};
+use crate::literal;
 use crate::semi::ctxt::{
     DefaultCap, Elaborator, Record, RecordFields, Report, Severity, TrampolineRoot,
 };
 use crate::semi::hir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{DefId, Flexivity, Ty, TyCtxt, TyKind};
+use crate::semi::ty::{FpTy, IntTy};
 use crate::surface::Span;
 
 /// Exactly the part of an [`Elaborator`] that monomorphization reads. Taking
@@ -352,6 +354,23 @@ fn ty_depth(ty: Ty<'_>) -> usize {
     }
 }
 
+/// The surface spelling of an integer type, for diagnostics.
+fn int_ty_name(ty: IntTy) -> String {
+    match ty {
+        IntTy::Signed(w) => format!("i{w}"),
+        IntTy::Unsigned(w) => format!("u{w}"),
+    }
+}
+
+/// The surface spelling of a float type, for diagnostics.
+fn fp_ty_name(ty: FpTy) -> String {
+    match ty {
+        FpTy::Ieee(w) => format!("f{w}"),
+        FpTy::BFloat16 => "bfloat16".to_string(),
+        FpTy::Float8 => "float8".to_string(),
+    }
+}
+
 /// Whether a ground type argument is a regional record. Only regional records
 /// carry a `Regional`/`Flex`/`Rigid` capability; value/shared records are
 /// `Irrelevant` and scalars carry none.
@@ -539,6 +558,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         let ty = subst_ty(self.tcx, e.ty, subst);
         self.note_records(ty);
         let kind = self.lower_kind(&e.kind, subst);
+        self.check_literal_range(&kind, ty, e.span);
         mir::Expr {
             id: self.ids.fresh(),
             kind,
@@ -547,16 +567,66 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         }
     }
 
+    /// A numeric literal is arbitrary-precision until here; now that its type
+    /// is ground, reject values the type cannot hold. Integers must be in
+    /// range; a float that would round to infinity is an error (there is no
+    /// literal syntax for `inf`, so it can only be a mistake). Checked on the
+    /// *lowered* kind so folded negations (`-128 : i8`) see the signed value.
+    fn check_literal_range(
+        &mut self,
+        kind: &mir::ExprKind<'tcx>,
+        ty: Ty<'tcx>,
+        span: Option<Span>,
+    ) {
+        match *kind {
+            mir::ExprKind::ConstInt(n) => {
+                if let TyKind::Int(int_ty) = *ty.kind()
+                    && !literal::int_fits(n, int_ty)
+                {
+                    self.error(
+                        span,
+                        format!(
+                            "integer literal `{n}` is out of range for `{}`",
+                            int_ty_name(int_ty)
+                        ),
+                    );
+                }
+            }
+            mir::ExprKind::ConstFloat(f) => {
+                if let TyKind::Fp(fp) = *ty.kind()
+                    && let Some((exp_bits, mant_bits)) = literal::ieee_params(fp)
+                    && f.to_ieee_bits(exp_bits, mant_bits).is_err()
+                {
+                    self.error(
+                        span,
+                        format!(
+                            "float literal `{f}` is out of range for `{}` (it would round to infinity)",
+                            fp_ty_name(fp)
+                        ),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn lower_kind(&mut self, kind: &ExprKind<'tcx>, subst: &Subst<'tcx>) -> mir::ExprKind<'tcx> {
         use mir::ExprKind as M;
         match kind {
             ExprKind::GlobalStr(s) => M::GlobalStr(*s),
-            ExprKind::ConstInt(n) => M::ConstInt(*n),
-            ExprKind::ConstFloat(f) => M::ConstFloat(*f),
+            ExprKind::ConstInt(n) => M::ConstInt(n),
+            ExprKind::ConstFloat(f) => M::ConstFloat(f),
             ExprKind::ConstBool(b) => M::ConstBool(*b),
             ExprKind::Var(v) => M::Var(*v),
             ExprKind::Poison => M::Poison,
-            ExprKind::Negate(e) => M::Negate(self.lower_ref(e, subst)),
+            // Negation of a literal folds into the constant, so `-128 : i8`
+            // (and `-9223372036854775808 : i64`) is a single in-range value
+            // by the time the range check above sees it.
+            ExprKind::Negate(e) => match &e.kind {
+                ExprKind::ConstInt(n) => M::ConstInt(self.tcx.alloc(-(*n).clone())),
+                ExprKind::ConstFloat(f) => M::ConstFloat(self.tcx.alloc(f.neg())),
+                _ => M::Negate(self.lower_ref(e, subst)),
+            },
             ExprKind::Not(e) => M::Not(self.lower_ref(e, subst)),
             ExprKind::Arith(l, op, r) => {
                 M::Arith(self.lower_ref(l, subst), *op, self.lower_ref(r, subst))
@@ -818,6 +888,71 @@ mod tests {
             .iter()
             .map(|f| full.symbol(f.symbol).to_string())
             .collect()
+    }
+
+    /// Elaborate (asserting success) and monomorphize, returning the mono
+    /// diagnostics' messages.
+    fn mono_reports(source: &str) -> Vec<String> {
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(
+                !elab.has_errors(),
+                "elaboration errors: {:#?}",
+                elab.reports
+            );
+            let (_, reports) = monomorphize(&elab.mono_input());
+            reports.into_iter().map(|r| r.message).collect()
+        })
+    }
+
+    /// Literals are arbitrary-precision end to end: extremes that the old
+    /// `i64`-pinned parse panicked on (a full-range `u64`, `i64::MIN`) now
+    /// survive, and folded negation makes `-128 : i8` a single in-range value.
+    #[test]
+    fn extreme_literals_fit_their_types() {
+        with_full(
+            "pub fn big() -> u64 { 18446744073709551615 } \
+             pub fn min() -> i64 { -9223372036854775808 } \
+             pub fn neg() -> i8 { -128 } \
+             pub fn hex() -> u32 { 0xFFFF_FFFF } \
+             pub fn bin() -> u8 { 0b1111_1111 }",
+            |_| (),
+        );
+    }
+
+    #[test]
+    fn out_of_range_literals_are_diagnosed_not_panics() {
+        let r = mono_reports("pub fn f() -> i8 { 128 }");
+        assert!(
+            r.iter().any(|m| m.contains("out of range for `i8`")),
+            "{r:?}"
+        );
+        let r = mono_reports("pub fn f() -> u8 { -1 }");
+        assert!(
+            r.iter().any(|m| m.contains("out of range for `u8`")),
+            "{r:?}"
+        );
+        let r = mono_reports("pub fn f() -> u64 { 18446744073709551616 }");
+        assert!(
+            r.iter().any(|m| m.contains("out of range for `u64`")),
+            "{r:?}"
+        );
+        let r = mono_reports("pub fn f() -> f64 { 1e400 }");
+        assert!(
+            r.iter()
+                .any(|m| m.contains("out of range for `f64`") && m.contains("infinity")),
+            "{r:?}"
+        );
+        let r = mono_reports("pub fn f() -> f16 { 65520.0 }");
+        assert!(
+            r.iter().any(|m| m.contains("out of range for `f16`")),
+            "{r:?}"
+        );
+        // Well inside the range: no diagnostics.
+        assert!(mono_reports("pub fn f() -> f16 { 65504.0 }").is_empty());
     }
 
     /// **Resumability**: serialize the elaborated HIR, parse it back into a

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -155,6 +155,7 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
 
     fn const_int(&mut self, n: i128) -> Expr<'tcx> {
         let ty = self.i64();
+        let n = self.tcx.alloc(crate::literal::Integer::from(n));
         self.mk(ExprKind::ConstInt(n), ty)
     }
 

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -7,6 +7,8 @@
 
 use logos::Logos;
 
+use crate::literal::Integer;
+
 /// A lexed token. `'a` is the input lifetime ([`Token::Ident`] borrows it).
 #[derive(Logos, Clone, Debug, PartialEq)]
 #[logos(skip r"[ \t\r\n]+")]
@@ -178,12 +180,20 @@ pub enum Token<'a> {
     /// `?<id>` — an unsolved inference hole (HIR only).
     #[regex(r"\?[0-9]+", |l| l.slice()[1..].parse().ok())]
     Hole(u32),
-    /// A non-negative integer literal.
-    #[regex(r"[0-9]+", |l| l.slice().parse().ok())]
-    Int(i128),
-    /// A floating-point literal.
-    #[regex(r"[0-9]+\.[0-9]+", |l| l.slice().parse().ok())]
-    Float(f64),
+    /// An integer literal, arbitrary precision (constants print at full
+    /// width). A leading `-` is part of the token when directly adjacent —
+    /// negative constants exist in MIR via literal-negation folding, and the
+    /// printer always spaces binary operators (`a - 1`), so adjacency is
+    /// unambiguous in machine-emitted text.
+    #[regex(r"-?[0-9]+", |l| l.slice().parse().ok())]
+    Int(Integer),
+    /// A floating-point literal, kept as its raw text: the grammar parses it
+    /// into an exact [`crate::literal::FloatLit`] where a float value is
+    /// expected, and *splits* it where it is really two adjacent scrutinee
+    /// path indices (`scrut.0.1` lexes `0.1` as one float-shaped token).
+    #[regex(r"-?[0-9]+\.[0-9]+([eE][+-]?[0-9]+)?", |l| l.slice())]
+    #[regex(r"-?[0-9]+[eE][+-]?[0-9]+", |l| l.slice())]
+    Float(&'a str),
     /// A bare identifier (symbol bodies after `@`, source names, paths). Matches
     /// Unicode XID like the surface lexer, so source identifiers round-trip.
     #[regex(r"[\p{XID_Start}_]\p{XID_Continue}*", |l| l.slice())]

--- a/crates/reussir-core/src/lib.rs
+++ b/crates/reussir-core/src/lib.rs
@@ -11,6 +11,9 @@
 pub mod full;
 /// The shared logos lexer for the textual IR (both the MIR and HIR grammars).
 pub mod ir_lex;
+/// Arbitrary-precision numeric literals, carried exact through HIR/MIR and
+/// rounded to the target format exactly once.
+pub mod literal;
 pub mod semi;
 pub mod surface;
 pub mod utils;

--- a/crates/reussir-core/src/literal.rs
+++ b/crates/reussir-core/src/literal.rs
@@ -1,0 +1,583 @@
+//! Arbitrary-precision numeric literals.
+//!
+//! A numeric literal is *exact* at the source level: an integer literal is an
+//! integer, and a float literal `m.f e±x` is exactly the rational
+//! `mantissa × 10^exp10` (a decimal literal is always a finite decimal). Both
+//! are carried unrounded — [`Integer`] and [`FloatLit`] — from the surface AST
+//! through HIR and MIR. The single lossy step, correctly-rounded conversion
+//! into the ground IEEE format, happens once the type is known
+//! ([`FloatLit::to_ieee_bits`], used by codegen and by the range diagnostics
+//! at monomorphization). This avoids the classic double rounding
+//! (decimal → `f64` → `f16` can differ from decimal → `f16` by an ULP) and
+//! keeps values outside `i64`/`f64` representable until we know whether they
+//! fit their target.
+//!
+//! Printing is lossless by construction: HIR/MIR never hold a binary float,
+//! only the exact decimal, so the textual IR round-trips numerics through
+//! plain decimal forms ([`FloatLit`]'s `Display` is canonical and its
+//! `FromStr` inverts it exactly).
+
+use std::fmt;
+use std::str::FromStr;
+
+use malachite_base::num::arithmetic::traits::{DivMod, DivRound, Pow};
+use malachite_base::num::basic::traits::One;
+use malachite_base::num::conversion::traits::FromStringBase;
+use malachite_base::num::logic::traits::SignificantBits;
+use malachite_base::rounding_modes::RoundingMode;
+pub use malachite_nz::integer::Integer;
+pub use malachite_nz::natural::Natural;
+
+use crate::semi::ty::{FpTy, IntTy};
+
+/// Parse an integer literal's token text into its exact value. Accepts the
+/// surface forms: decimal digit runs, `0x`/`0o`/`0b` radix prefixes, and `_`
+/// digit separators. The lexer has validated the shape, so this is total.
+pub fn parse_int(text: &str) -> Integer {
+    let text: String = text.chars().filter(|&c| c != '_').collect();
+    let natural = if let Some(hex) = text.strip_prefix("0x").or_else(|| text.strip_prefix("0X")) {
+        Natural::from_string_base(16, &hex.to_ascii_lowercase())
+    } else if let Some(oct) = text.strip_prefix("0o").or_else(|| text.strip_prefix("0O")) {
+        Natural::from_string_base(8, oct)
+    } else if let Some(bin) = text.strip_prefix("0b").or_else(|| text.strip_prefix("0B")) {
+        Natural::from_string_base(2, bin)
+    } else {
+        Natural::from_str(&text).ok()
+    };
+    Integer::from(natural.expect("integer literal validated by the lexer"))
+}
+
+/// Parse a float literal's token text (`1.5`, `1e3`, `2.5e-7`, with optional
+/// `_` separators) into its exact decimal value. Total for lexer-validated
+/// input.
+pub fn parse_float(text: &str) -> FloatLit {
+    let text: String = text.chars().filter(|&c| c != '_').collect();
+    text.parse().expect("float literal validated by the lexer")
+}
+
+/// An exact decimal floating-point literal: the value `mantissa × 10^exp10`.
+///
+/// Canonical form (maintained by the constructor): the mantissa of a non-zero
+/// value is not divisible by 10, and zero is `(0, 0)`. Derived equality is
+/// therefore semantic equality, and `Display`/`FromStr` round-trip exactly.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct FloatLit {
+    mantissa: Integer,
+    exp10: i64,
+}
+
+/// The literal does not fit its target format: rounding it would produce an
+/// infinity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FpOverflow;
+
+impl FloatLit {
+    /// Build from a (possibly non-canonical) decimal pair, normalizing.
+    pub fn new(mut mantissa: Integer, mut exp10: i64) -> FloatLit {
+        if mantissa == 0 {
+            return FloatLit { mantissa, exp10: 0 };
+        }
+        let ten = Integer::from(10);
+        loop {
+            let (q, r) = (&mantissa).div_mod(&ten);
+            if r != 0 {
+                break;
+            }
+            mantissa = q;
+            exp10 += 1;
+        }
+        FloatLit { mantissa, exp10 }
+    }
+
+    pub fn mantissa(&self) -> &Integer {
+        &self.mantissa
+    }
+
+    /// The negated value (used when folding `Negate(lit)` into a constant).
+    pub fn neg(&self) -> FloatLit {
+        FloatLit {
+            mantissa: -self.mantissa.clone(),
+            exp10: self.exp10,
+        }
+    }
+
+    pub fn exp10(&self) -> i64 {
+        self.exp10
+    }
+
+    /// Round to the nearest (ties-to-even) value of the IEEE binary format
+    /// with `exp_bits` exponent bits and `mant_bits` explicit mantissa bits
+    /// (an implicit leading bit is assumed; total width `1 + exp_bits +
+    /// mant_bits` must be at most 128). Returns the format's raw bit pattern.
+    ///
+    /// This is the *only* decimal→binary conversion in the pipeline, and it
+    /// never goes through a host float, so formats without a Rust encoding
+    /// (`bf16`, `f16`, `f128`) round exactly once like everything else.
+    /// Overflow to infinity is an error (a literal can never mean `inf`);
+    /// underflow rounds to a subnormal or zero, as IEEE prescribes.
+    pub fn to_ieee_bits(&self, exp_bits: u32, mant_bits: u32) -> Result<u128, FpOverflow> {
+        assert!(
+            (1..=30).contains(&exp_bits) && 1 + exp_bits + mant_bits <= 128,
+            "unsupported format ({exp_bits}, {mant_bits})"
+        );
+        let sign_bit = if self.mantissa < 0 {
+            1u128 << (exp_bits + mant_bits)
+        } else {
+            0
+        };
+        if self.mantissa == 0 {
+            return Ok(0);
+        }
+        let a: &Natural = self.mantissa.unsigned_abs_ref();
+        let bias = (1i64 << (exp_bits - 1)) - 1;
+        let emax = bias;
+        let emin = 1 - bias;
+        let p = i64::from(mant_bits) + 1;
+
+        // Cheap decimal-magnitude guards so absurd exponents (`1e999999999`)
+        // resolve without materializing 10^e. log10(a) lies within
+        // [(bits-1)·log10(2), bits·log10(2) + 1); ±6000 clears every format up
+        // to binary128 (max ≈ 1.19e4932, min subnormal ≈ 6.5e-4966).
+        let bits = a.significant_bits() as i64;
+        let mag_hi = (bits * 302) / 1000 + 1 + self.exp10;
+        let mag_lo = ((bits - 1) * 301) / 1000 + self.exp10;
+        if mag_lo > 6000 {
+            return Err(FpOverflow);
+        }
+        if mag_hi < -6000 {
+            return Ok(sign_bit); // underflows to (signed) zero
+        }
+
+        // The exact value as n/d with d a power of ten.
+        let (n, d) = if self.exp10 >= 0 {
+            (
+                a * Natural::from(10u32).pow(self.exp10 as u64),
+                Natural::ONE,
+            )
+        } else {
+            (
+                a.clone(),
+                Natural::from(10u32).pow(self.exp10.unsigned_abs()),
+            )
+        };
+
+        // e2 = floor(log2(n/d)): estimate from bit lengths, then correct so
+        // that d·2^e2 <= n < d·2^(e2+1).
+        let mut e2 = n.significant_bits() as i64 - d.significant_bits() as i64;
+        if shifted_gt(&d, e2, &n) {
+            e2 -= 1;
+        } else if !shifted_gt(&d, e2 + 1, &n) {
+            e2 += 1;
+        }
+        debug_assert!(!shifted_gt(&d, e2, &n) && shifted_gt(&d, e2 + 1, &n));
+
+        // Round the significand: q = round((n/d) · 2^(p-1-target_exp)),
+        // ties to even. Clamping the exponent at emin makes the same formula
+        // produce subnormals.
+        let mut target_exp = e2.max(emin);
+        let s = p - 1 - target_exp;
+        let mut q = if s >= 0 {
+            (n << s).div_round(&d, RoundingMode::Nearest).0
+        } else {
+            n.div_round(&(d << (-s) as u64), RoundingMode::Nearest).0
+        };
+        // Rounding can carry into the next power of two (q = 2^p exactly).
+        if q.significant_bits() as i64 > p {
+            q >>= 1u32;
+            target_exp += 1;
+        }
+
+        let low = if q.significant_bits() as i64 == p {
+            // Normal: strip the implicit leading bit, store the biased exponent.
+            if target_exp > emax {
+                return Err(FpOverflow);
+            }
+            let frac = q - (Natural::ONE << (p - 1) as u64);
+            (((target_exp + bias) as u128) << mant_bits) | natural_to_u128(&frac)
+        } else {
+            // Subnormal (or zero after underflow rounding): biased exponent 0.
+            debug_assert!(target_exp == emin);
+            natural_to_u128(&q)
+        };
+        Ok(sign_bit | low)
+    }
+}
+
+/// `d · 2^k > n`, with `k` possibly negative.
+fn shifted_gt(d: &Natural, k: i64, n: &Natural) -> bool {
+    if k >= 0 {
+        (d << k as u64) > *n
+    } else {
+        *d > (n << (-k) as u64)
+    }
+}
+
+fn natural_to_u128(n: &Natural) -> u128 {
+    u128::try_from(n).expect("value bounded by the format width")
+}
+
+impl fmt::Display for FloatLit {
+    /// Canonical, lossless, and lexable: always contains `.` or `e`, plain
+    /// decimal for short values (`1.1`, `0.00123`, `250.0`) and scientific
+    /// otherwise (`2.5e300`, `5e-7`). `FromStr` inverts it exactly.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.mantissa == 0 {
+            return write!(f, "0.0");
+        }
+        if self.mantissa < 0 {
+            write!(f, "-")?;
+        }
+        let digits = self.mantissa.unsigned_abs_ref().to_string();
+        let n = digits.len() as i64;
+        // The scientific exponent: value = d.ddd × 10^sci.
+        let sci = self.exp10 + n - 1;
+        if self.exp10 >= 0 && sci <= 16 {
+            // A short integral value: digits, trailing zeros, `.0`.
+            write!(f, "{digits}")?;
+            for _ in 0..self.exp10 {
+                write!(f, "0")?;
+            }
+            write!(f, ".0")
+        } else if self.exp10 < 0 && sci >= -5 {
+            if sci >= 0 {
+                // Point inside the digits.
+                let split = (sci + 1) as usize;
+                write!(f, "{}.{}", &digits[..split], &digits[split..])
+            } else {
+                // 0.00ddd
+                write!(f, "0.")?;
+                for _ in 0..(-sci - 1) {
+                    write!(f, "0")?;
+                }
+                write!(f, "{digits}")
+            }
+        } else if n == 1 {
+            write!(f, "{digits}e{sci}")
+        } else {
+            write!(f, "{}.{}e{}", &digits[..1], &digits[1..], sci)
+        }
+    }
+}
+
+/// Parse the decimal forms `digits`, `digits.digits`, with an optional
+/// `e`/`E` exponent and optional leading `-`. (The bare-integer form is
+/// accepted for robustness even though the printers never emit it.)
+impl FromStr for FloatLit {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<FloatLit, ()> {
+        let (sign, s) = match s.strip_prefix('-') {
+            Some(rest) => (true, rest),
+            None => (false, s),
+        };
+        let (base, exp) = match s.find(['e', 'E']) {
+            Some(i) => {
+                let exp_text = &s[i + 1..];
+                let exp_digits = exp_text.strip_prefix(['+', '-']).unwrap_or(exp_text);
+                if exp_digits.is_empty() || exp_digits.contains(|c: char| !c.is_ascii_digit()) {
+                    return Err(());
+                }
+                // Saturate exponents beyond i64: the magnitude guards in
+                // `to_ieee_bits` turn them into overflow/zero as appropriate.
+                let exp = exp_text.parse::<i64>().unwrap_or_else(|_| {
+                    if exp_text.starts_with('-') {
+                        i64::MIN / 2
+                    } else {
+                        i64::MAX / 2
+                    }
+                });
+                (&s[..i], exp)
+            }
+            None => (s, 0),
+        };
+        let (int_part, frac_part) = match base.find('.') {
+            Some(i) => (&base[..i], &base[i + 1..]),
+            None => (base, ""),
+        };
+        if int_part.is_empty() && frac_part.is_empty() {
+            return Err(());
+        }
+        if int_part.contains(|c: char| !c.is_ascii_digit())
+            || frac_part.contains(|c: char| !c.is_ascii_digit())
+        {
+            return Err(());
+        }
+        let mut digits = String::with_capacity(int_part.len() + frac_part.len());
+        digits.push_str(int_part);
+        digits.push_str(frac_part);
+        let mantissa = Natural::from_str(&digits).map_err(|_| ())?;
+        let mantissa = if sign {
+            -Integer::from(mantissa)
+        } else {
+            Integer::from(mantissa)
+        };
+        Ok(FloatLit::new(
+            mantissa,
+            exp.saturating_sub(frac_part.len() as i64),
+        ))
+    }
+}
+
+/// The `(exponent bits, explicit mantissa bits)` of a semi float type, or
+/// `None` for formats without a settled encoding (`float8` today).
+pub fn ieee_params(fp: FpTy) -> Option<(u32, u32)> {
+    match fp {
+        FpTy::Ieee(16) => Some((5, 10)),
+        FpTy::Ieee(32) => Some((8, 23)),
+        FpTy::Ieee(64) => Some((11, 52)),
+        FpTy::Ieee(128) => Some((15, 112)),
+        FpTy::BFloat16 => Some((8, 7)),
+        FpTy::Ieee(_) | FpTy::Float8 => None,
+    }
+}
+
+/// Whether `n` is representable in the integer type `ty`.
+pub fn int_fits(n: &Integer, ty: IntTy) -> bool {
+    match ty {
+        IntTy::Unsigned(w) => *n >= 0 && n.unsigned_abs_ref().significant_bits() <= u64::from(w),
+        IntTy::Signed(w) => {
+            if w == 0 {
+                return false;
+            }
+            let bound = Natural::ONE << u64::from(w - 1);
+            if *n >= 0 {
+                *n.unsigned_abs_ref() < bound
+            } else {
+                *n.unsigned_abs_ref() <= bound
+            }
+        }
+    }
+}
+
+/// The low 64 bits of `n`, two's complement — the value MLIR's
+/// `DenseI64ArrayAttribute` and friends want for a key that fits its type.
+pub fn low_u64(n: &Integer) -> u64 {
+    use malachite_base::num::conversion::traits::WrappingFrom;
+    u64::wrapping_from(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lit(s: &str) -> FloatLit {
+        parse_float(s)
+    }
+
+    #[test]
+    fn integer_parsing_covers_radixes_and_separators() {
+        assert_eq!(parse_int("0"), Integer::from(0));
+        assert_eq!(parse_int("1_000_000"), Integer::from(1_000_000));
+        assert_eq!(parse_int("0xFF"), Integer::from(255));
+        assert_eq!(parse_int("0xff_ff"), Integer::from(0xFFFF));
+        assert_eq!(parse_int("0o777"), Integer::from(511));
+        assert_eq!(parse_int("0b1010_1010"), Integer::from(0xAA));
+        // Beyond i64/u64/i128: exact.
+        assert_eq!(
+            parse_int("340282366920938463463374607431768211456").to_string(),
+            "340282366920938463463374607431768211456" // 2^128
+        );
+        assert_eq!(
+            parse_int("0x1_0000_0000_0000_0000").to_string(),
+            "18446744073709551616" // 2^64
+        );
+    }
+
+    #[test]
+    fn float_parsing_is_exact_and_normalized() {
+        assert_eq!(lit("1.1"), FloatLit::new(Integer::from(11), -1));
+        assert_eq!(lit("2.50"), FloatLit::new(Integer::from(25), -1));
+        assert_eq!(lit("1e3"), FloatLit::new(Integer::from(1), 3));
+        assert_eq!(lit("2.5e-7"), FloatLit::new(Integer::from(25), -8));
+        assert_eq!(lit("0.0"), FloatLit::new(Integer::from(0), 0));
+        assert_eq!(lit("1_000.5"), FloatLit::new(Integer::from(10_005), -1));
+    }
+
+    #[test]
+    fn display_round_trips_and_always_lexes_as_a_float() {
+        for s in [
+            "0.0",
+            "1.0",
+            "1.1",
+            "0.00123",
+            "250.0",
+            "2.5e300",
+            "5e-7",
+            "1e17",
+            "123.456",
+            "9.999999999e100",
+            "1e-4966",
+        ] {
+            let v = lit(s);
+            let printed = v.to_string();
+            assert!(
+                printed.contains(['.', 'e']),
+                "`{printed}` must re-lex as a float"
+            );
+            assert_eq!(printed.parse::<FloatLit>().unwrap(), v, "via `{printed}`");
+        }
+        // Canonical spellings.
+        assert_eq!(lit("1.1").to_string(), "1.1");
+        assert_eq!(lit("1e3").to_string(), "1000.0");
+        assert_eq!(lit("2.5e300").to_string(), "2.5e300");
+        assert_eq!(lit("0.0000005").to_string(), "5e-7");
+    }
+
+    /// Differential check against Rust's own correctly-rounded parser.
+    #[test]
+    fn ieee_rounding_matches_rust_for_f32_and_f64() {
+        let cases = [
+            "0.0",
+            "1.0",
+            "0.1",
+            "1.1",
+            "2.5",
+            "3.14159265358979323846",
+            "1e-40",
+            "1.17549435e-38",
+            "3.4028235e38",
+            "1.7976931348623157e308",
+            "4.9e-324",
+            "2.2250738585072014e-308",
+            "1e-45",
+            "7e-46",
+            "0.500000000000000166533453693773481063544750213623046875",
+            "123456789.123456789",
+            "9007199254740993.0",
+            "1e-5000",
+        ];
+        for s in cases {
+            let v = lit(s);
+            let f64_bits = v.to_ieee_bits(11, 52).unwrap() as u64;
+            assert_eq!(f64_bits, s.parse::<f64>().unwrap().to_bits(), "f64 `{s}`");
+            // Rust rounds overflow to inf where we hard-error; compare only
+            // finite results.
+            let rust_f32: f32 = s.parse().unwrap();
+            match v.to_ieee_bits(8, 23) {
+                Ok(bits) => assert_eq!(bits as u32, rust_f32.to_bits(), "f32 `{s}`"),
+                Err(FpOverflow) => assert!(rust_f32.is_infinite(), "f32 `{s}`"),
+            }
+        }
+    }
+
+    /// Randomized differential check against Rust's correctly-rounded parser:
+    /// random digit strings across the whole f32/f64 exponent range (normals,
+    /// subnormals, underflow, overflow).
+    #[test]
+    fn ieee_rounding_differential_fuzz() {
+        let mut state = 0x9E37_79B9_7F4A_7C15u64;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        for _ in 0..20_000 {
+            let digits = (next() % 25 + 1) as usize;
+            let mut text = String::with_capacity(digits + 6);
+            for _ in 0..digits {
+                text.push(char::from(b'0' + (next() % 10) as u8));
+            }
+            let exp = (next() % 700) as i64 - 350;
+            text.push('e');
+            text.push_str(&exp.to_string());
+            let v = lit(&text);
+            let rust_f64: f64 = text.parse().unwrap();
+            match v.to_ieee_bits(11, 52) {
+                Ok(bits) => assert_eq!(bits as u64, rust_f64.to_bits(), "f64 `{text}`"),
+                Err(FpOverflow) => assert!(rust_f64.is_infinite(), "f64 `{text}`"),
+            }
+            let rust_f32: f32 = text.parse().unwrap();
+            match v.to_ieee_bits(8, 23) {
+                Ok(bits) => assert_eq!(bits as u32, rust_f32.to_bits(), "f32 `{text}`"),
+                Err(FpOverflow) => assert!(rust_f32.is_infinite(), "f32 `{text}`"),
+            }
+        }
+    }
+
+    /// The reason this module exists: rounding decimal → f64 → f16 differs
+    /// from decimal → f16 on halfway-straddling values.
+    #[test]
+    fn single_rounding_beats_double_rounding_for_f16() {
+        // 1 + 2^-11 = 1.00048828125 is exactly halfway between the f16 values
+        // 1.0 (0x3C00) and 1 + 2^-10 (0x3C01). Nudge it up by 1e-30 — far
+        // below f64's resolution here — and the true value is above the tie,
+        // so f16 must round UP. But f64 first rounds the nudge away, landing
+        // exactly on the tie, and the second rounding then goes to even: DOWN.
+        let s = "1.000488281250000000000000000001";
+        let direct = lit(s).to_ieee_bits(5, 10).unwrap() as u16;
+        let via_f64 = half_from_f64(s.parse::<f64>().unwrap());
+        assert_eq!(direct, 0x3C01, "single rounding goes up");
+        assert_eq!(
+            via_f64, 0x3C00,
+            "double rounding collapses to the tie, then even"
+        );
+    }
+
+    /// f64 → f16 narrowing with round-to-nearest-even, for the test above.
+    fn half_from_f64(x: f64) -> u16 {
+        // Round via the exact decimal of the f64 value: f64 is exact binary,
+        // so FloatLit::new over its exact decimal expansion is exact.
+        let bits = x.to_bits();
+        let exp = ((bits >> 52) & 0x7FF) as i64 - 1023 - 52;
+        let mant = (bits & ((1 << 52) - 1)) | (1 << 52);
+        // value = mant * 2^exp; 2^exp = 5^-exp * 10^exp for exp < 0.
+        assert!(exp < 0);
+        let m = Integer::from(mant) * Integer::from(5).pow((-exp) as u64);
+        FloatLit::new(m, exp).to_ieee_bits(5, 10).unwrap() as u16
+    }
+
+    #[test]
+    fn bf16_and_f128_round_without_a_host_type() {
+        // 1.0 in formats with no Rust encoding.
+        assert_eq!(lit("1.0").to_ieee_bits(8, 7).unwrap(), 0x3F80); // bf16
+        assert_eq!(lit("1.0").to_ieee_bits(15, 112).unwrap(), 0x3FFFu128 << 112);
+        // bf16 0.1 — correctly rounded: 0x3DCD (mantissa 0b1001101).
+        assert_eq!(lit("0.1").to_ieee_bits(8, 7).unwrap(), 0x3DCD);
+        // f128 max finite is ~1.19e4932; just below fits, above overflows.
+        assert!(lit("1.18e4932").to_ieee_bits(15, 112).is_ok());
+        assert_eq!(lit("1.2e4932").to_ieee_bits(15, 112), Err(FpOverflow));
+    }
+
+    #[test]
+    fn overflow_is_an_error_and_underflow_rounds_to_zero_or_subnormal() {
+        assert_eq!(lit("1e400").to_ieee_bits(11, 52), Err(FpOverflow));
+        assert_eq!(lit("65520.0").to_ieee_bits(5, 10), Err(FpOverflow)); // rounds to inf in f16
+        assert!(lit("65504.0").to_ieee_bits(5, 10).is_ok()); // f16 max finite
+        assert_eq!(lit("1e-1000").to_ieee_bits(11, 52).unwrap(), 0); // underflow → +0
+        assert_eq!(lit("1e-9999").to_ieee_bits(15, 112).unwrap(), 0);
+        // Smallest f64 subnormal neighborhood: 4.9e-324 rounds to bit pattern 1.
+        assert_eq!(lit("4.9e-324").to_ieee_bits(11, 52).unwrap(), 1);
+    }
+
+    #[test]
+    fn int_fits_matches_the_type_ranges() {
+        use IntTy::*;
+        let n = |s: &str| parse_int(s);
+        assert!(int_fits(&n("255"), Unsigned(8)));
+        assert!(!int_fits(&n("256"), Unsigned(8)));
+        assert!(int_fits(&n("127"), Signed(8)));
+        assert!(!int_fits(&n("128"), Signed(8)));
+        assert!(int_fits(&-n("128"), Signed(8)));
+        assert!(!int_fits(&-n("129"), Signed(8)));
+        assert!(int_fits(&n("18446744073709551615"), Unsigned(64)));
+        assert!(!int_fits(&n("18446744073709551615"), Signed(64)));
+        assert!(!int_fits(&n("18446744073709551616"), Unsigned(64)));
+        assert!(!int_fits(&-n("1"), Unsigned(64)));
+        assert!(int_fits(
+            &n("170141183460469231731687303715884105727"),
+            Signed(128)
+        ));
+        assert!(!int_fits(
+            &n("170141183460469231731687303715884105728"),
+            Signed(128)
+        ));
+    }
+
+    #[test]
+    fn low_u64_is_twos_complement() {
+        assert_eq!(low_u64(&parse_int("18446744073709551615")), u64::MAX);
+        assert_eq!(low_u64(&-parse_int("1")), u64::MAX);
+        assert_eq!(low_u64(&parse_int("42")), 42);
+    }
+}

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -193,12 +193,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             Const::ConstInt(i) => {
                 let hole = self.infer.new_hole_ty();
                 self.register_bound(self.builtins.integral, hole, span);
-                self.mk_expr(ExprKind::ConstInt(*i as i128), hole, span)
+                self.mk_expr(ExprKind::ConstInt(self.tcx.alloc(i.clone())), hole, span)
             }
-            Const::ConstDouble(f) => {
+            Const::ConstFloat(f) => {
                 let hole = self.infer.new_hole_ty();
                 self.register_bound(self.builtins.floating_point, hole, span);
-                self.mk_expr(ExprKind::ConstFloat(*f), hole, span)
+                self.mk_expr(ExprKind::ConstFloat(self.tcx.alloc(f.clone())), hole, span)
             }
             Const::ConstString(s) => {
                 let token = self.strings.allocate(s);

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -5,6 +5,7 @@
 
 use reussir_syntax::kind::TokenKey;
 
+use crate::literal::{FloatLit, Integer};
 use crate::semi::ty::{DefId, GenericId, Ty};
 use crate::surface::Span;
 use crate::utils::string::StringToken;
@@ -86,9 +87,12 @@ pub enum ExprKind<'tcx> {
     /// An interned string literal.
     GlobalStr(StringToken),
     /// An integer literal (its type is a `Num`-bounded hole until solved).
-    ConstInt(i128),
-    /// A floating-point literal.
-    ConstFloat(f64),
+    /// Arbitrary-precision: range-checked against its ground type at
+    /// monomorphization, never truncated before.
+    ConstInt(&'tcx Integer),
+    /// A floating-point literal, exact ([`crate::literal::FloatLit`]): rounded
+    /// to its ground format only in codegen.
+    ConstFloat(&'tcx FloatLit),
     ConstBool(bool),
     Negate(Box<Expr<'tcx>>),
     Not(Box<Expr<'tcx>>),
@@ -177,7 +181,7 @@ pub enum DecisionTree<'tcx> {
 #[derive(Clone, Debug)]
 pub enum SwitchCases<'tcx> {
     Int {
-        cases: Vec<(i128, DecisionTree<'tcx>)>,
+        cases: Vec<(&'tcx Integer, DecisionTree<'tcx>)>,
         default: Box<DecisionTree<'tcx>>,
     },
     Bool {

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -278,8 +278,8 @@ impl<'tcx> Builder<'_, 'tcx> {
     fn expr(&mut self, e: &raw::Expr) -> Expr<'tcx> {
         let ty = self.ty(&e.ty);
         let kind: ExprKind<'tcx> = match &*e.kind {
-            raw::Kind::ConstInt(n) => ExprKind::ConstInt(*n),
-            raw::Kind::ConstFloat(f) => ExprKind::ConstFloat(*f),
+            raw::Kind::ConstInt(n) => ExprKind::ConstInt(self.tcx.alloc(n.clone())),
+            raw::Kind::ConstFloat(f) => ExprKind::ConstFloat(self.tcx.alloc(f.clone())),
             raw::Kind::ConstBool(b) => ExprKind::ConstBool(*b),
             raw::Kind::GlobalStr(words) => ExprKind::GlobalStr(StringToken::from_words(*words)),
             raw::Kind::Var(v) => ExprKind::Var(VarId(*v)),
@@ -428,7 +428,10 @@ impl<'tcx> Builder<'_, 'tcx> {
     fn cases(&mut self, c: &raw::Cases) -> SwitchCases<'tcx> {
         match c {
             raw::Cases::Int { cases, default } => {
-                let cases = cases.iter().map(|(n, t)| (*n, self.tree(t))).collect();
+                let cases = cases
+                    .iter()
+                    .map(|(n, t)| (self.tcx.alloc(n.clone()), self.tree(t)))
+                    .collect();
                 SwitchCases::Int {
                     cases,
                     default: Box::new(self.tree(default)),
@@ -550,6 +553,31 @@ mod tests {
         roundtrip(
             "enum Opt { None, Some(i32) } \
              pub fn unwrap(o: Opt) -> i32 { match o { Opt::None => 0, Opt::Some(x) => x } }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_nested_scrutinee_paths() {
+        // A nested pattern produces depth-2 scrutinee paths (`scrut.1.0`),
+        // whose adjacent indices lex as one float-shaped token — the grammar
+        // must split it back (regression: this used to fail to re-parse).
+        roundtrip(
+            "enum L { C(i32, L), N } \
+             pub fn two(l: L) -> i32 { \
+             match l { L::C(x, L::C(y, N)) => x + y, L::C(x, t) => x, L::N => 0 } }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_extreme_and_radix_literals() {
+        // Arbitrary-precision literals survive the text round trip at full
+        // width; radix forms normalize to decimal; floats stay exact decimals.
+        roundtrip(
+            "pub fn big() -> u64 { 18446744073709551615 } \
+             pub fn hex() -> u32 { 0xDEAD_BEEF } \
+             pub fn neg() -> i64 { -9223372036854775808 } \
+             pub fn tenth() -> f64 { 0.1 } \
+             pub fn tiny() -> f64 { 2.5e-300 }",
         );
     }
 

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -7,6 +7,7 @@
 
 use crate::semi::hir::raw as raw;
 use crate::ir_lex::{Token, LexError};
+use crate::literal::{FloatLit, Integer};
 
 grammar<'input>;
 
@@ -142,7 +143,7 @@ Expr: raw::Expr = {
 
 Atom: raw::Kind = {
     <n:"int"> => raw::Kind::ConstInt(n),
-    <f:"float"> => raw::Kind::ConstFloat(f),
+    <f:"float"> => raw::Kind::ConstFloat(raw::float_lit(f)),
     "true" => raw::Kind::ConstBool(true),
     "false" => raw::Kind::ConstBool(false),
     <w:StrWords> => raw::Kind::GlobalStr(w),
@@ -155,15 +156,15 @@ Atom: raw::Kind = {
     "(" <e:Expr> "as" <t:Ty> ")" => raw::Kind::Cast(e, t),
     "region" "{" <e:Expr> "}" => raw::Kind::RegionRun(e),
     "proj" "(" <base:Expr> <idxs:("," <"int">)*> ")"
-        => raw::Kind::Proj(base, idxs.into_iter().map(|n| n as u32).collect()),
+        => raw::Kind::Proj(base, idxs.iter().map(raw::small_u32).collect()),
     "assign" "(" <dst:Expr> "," <field:"int"> "," <src:Expr> ")"
-        => raw::Kind::Assign(dst, field as u32, src),
+        => raw::Kind::Assign(dst, raw::small_u32(&field), src),
     <r:"regional"?> "#" <path:"ident"> <ta:TyArgs?> "(" <args:Comma<Expr>> ")"
         => raw::Kind::FuncCall { regional: r.is_some(), path: path.to_string(), ty_args: ta.unwrap_or_default(), args },
     "#" <path:"ident"> <ta:TyArgs?> "{" <args:Comma<Expr>> "}"
         => raw::Kind::CompoundCall { path: path.to_string(), ty_args: ta.unwrap_or_default(), args },
     "#" <path:"ident"> <ta:TyArgs?> "#" <v:"int"> "(" <args:Comma<Expr>> ")"
-        => raw::Kind::VariantCall { path: path.to_string(), ty_args: ta.unwrap_or_default(), variant: v as usize, args },
+        => raw::Kind::VariantCall { path: path.to_string(), ty_args: ta.unwrap_or_default(), variant: raw::small_usize(&v), args },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"
@@ -191,7 +192,7 @@ Tree: raw::Tree = {
 Arm: (raw::Label, raw::Tree) = <l:Label> "=>" "{" <t:Tree> "}" => (l, t);
 
 Label: raw::Label = {
-    "#" <n:"int"> => raw::Label::Ctor(n as usize),
+    "#" <n:"int"> => raw::Label::Ctor(raw::small_usize(&n)),
     <n:"int"> => raw::Label::Int(n),
     "_" => raw::Label::Wildcard,
     "true" => raw::Label::Bool(true),
@@ -201,8 +202,14 @@ Label: raw::Label = {
     "Null" => raw::Label::Null,
 };
 
-PatRef: raw::Path = "scrut" <idxs:("." <"int">)*>
-    => idxs.into_iter().map(|n| n as u32).collect();
+PatRef: raw::Path = "scrut" <segs:PathSeg*> => segs.into_iter().flatten().collect();
+
+// One `.`-led path step. Two adjacent numeric indices (`.0.1`) lex as a single
+// float-shaped token, split back into their segments here.
+PathSeg: Vec<u32> = {
+    "." <n:"int"> => vec![raw::small_u32(&n)],
+    "." <f:"float"> => raw::float_path_segs(f),
+};
 
 Bindings: Vec<raw::Binding> = <Binding*>;
 
@@ -210,7 +217,7 @@ Binding: raw::Binding = <v:"var"> "=" <p:PatRef> => (v, p);
 
 // A string-literal tag: all four `StringToken` words, `#`-separated.
 StrWords: raw::StrTag = "str" "#" <w0:"int"> "#" <w1:"int"> "#" <w2:"int"> "#" <w3:"int">
-    => [w0 as u64, w1 as u64, w2 as u64, w3 as u64];
+    => [raw::small_u64(&w0), raw::small_u64(&w1), raw::small_u64(&w2), raw::small_u64(&w3)];
 
 ArithOp: raw::ArithOp = {
     "+" => raw::ArithOp::Add,
@@ -246,8 +253,8 @@ extern {
     type Error = LexError;
 
     enum Token<'input> {
-        "int" => Token::Int(<i128>),
-        "float" => Token::Float(<f64>),
+        "int" => Token::Int(<Integer>),
+        "float" => Token::Float(<&'input str>),
         "var" => Token::Var(<u32>),
         "generic" => Token::Generic(<u32>),
         "ints" => Token::IntS(<u16>),

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -325,7 +325,7 @@ impl<'a> Printer<'a> {
         match &e.kind {
             ExprKind::GlobalStr(s) => text(str_lit(s.words())),
             ExprKind::ConstInt(n) => text(format!("{n}")),
-            ExprKind::ConstFloat(f) => text(float_lit(*f)),
+            ExprKind::ConstFloat(f) => text(f.to_string()),
             ExprKind::ConstBool(b) => text(format!("{b}")),
             ExprKind::Var(v) => var(*v),
             ExprKind::Poison => text("poison"),
@@ -563,19 +563,6 @@ fn cap_name(c: Flexivity) -> &'static str {
 /// round-trips faithfully.
 fn str_lit(w: [u64; 4]) -> String {
     format!("str#{}#{}#{}#{}", w[0], w[1], w[2], w[3])
-}
-
-/// Print a float so it re-lexes as a `Token::Float`. `f64`'s `Display` renders a
-/// finite value in plain decimal (never exponent notation), but drops the point
-/// for integral values (`1.0` -> `1`) — which would otherwise re-lex as an
-/// integer — so a missing `.`/`e` means an integral value that needs `.0`.
-fn float_lit(f: f64) -> String {
-    let s = format!("{f}");
-    if s.contains(['.', 'e', 'E']) {
-        s
-    } else {
-        format!("{s}.0")
-    }
 }
 
 fn arith_sym(op: ArithOp) -> &'static str {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -6,7 +6,10 @@
 //! may mention generics (`$n`). A fully elaborated HIR has no inference
 //! holes, so the textual form does not represent them.
 
-pub use crate::full::mir::raw::{ArithOp, Cap, CmpOp};
+pub use crate::full::mir::raw::{
+    ArithOp, Cap, CmpOp, FloatLit, Integer, float_lit, float_path_segs, small_u32, small_u64,
+    small_usize,
+};
 
 /// The whole HIR program: enough to resume into monomorphization — the record
 /// declarations and trampoline roots mono needs, plus the elaborated functions.
@@ -176,8 +179,8 @@ impl Expr {
 
 #[derive(Clone, Debug)]
 pub enum Kind {
-    ConstInt(i128),
-    ConstFloat(f64),
+    ConstInt(Integer),
+    ConstFloat(FloatLit),
     ConstBool(bool),
     /// An interned string literal, as its four raw `StringToken` words.
     GlobalStr([u64; 4]),
@@ -257,7 +260,7 @@ pub enum Tree {
 #[derive(Clone, Debug)]
 pub enum Cases {
     Int {
-        cases: Vec<(i128, Tree)>,
+        cases: Vec<(Integer, Tree)>,
         default: Box<Tree>,
     },
     Bool {
@@ -276,9 +279,9 @@ pub enum Cases {
 }
 
 /// A switch-arm label (see [`crate::full::mir::raw::Label`]).
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum Label {
-    Int(i128),
+    Int(Integer),
     Ctor(usize),
     Str([u64; 4]),
     Bool(bool),
@@ -292,7 +295,7 @@ pub enum Label {
 pub fn build_switch(scrutinee: Path, arms: Vec<(Label, Tree)>) -> Tree {
     let kind = arms
         .iter()
-        .map(|(l, _)| *l)
+        .map(|(l, _)| l)
         .find(|l| !matches!(l, Label::Wildcard));
     let cases = match kind {
         Some(Label::Bool(_)) => {

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -44,6 +44,7 @@
 //! `bindings` therefore tell code generation where in the scrutinee to read each
 //! bound variable.
 
+use crate::literal::Integer;
 use crate::semi::infer::Instantiation;
 use crate::semi::ty::{Ty, TyKind};
 use crate::surface::{self, Const, PatternKind, Span};
@@ -54,15 +55,17 @@ use super::hir::{DecisionTree, Expr, ExprKind, PatVarRef, SwitchCases, VarId};
 
 /// A head constructor: what a (refutable) pattern tests for at an occurrence.
 #[derive(Clone, PartialEq, Eq, Debug)]
-enum Ctor {
+enum Ctor<'tcx> {
     /// An enum variant, by index into the enum's variant list.
     Variant(usize),
-    Int(i128),
+    /// An integer key, arbitrary-precision (the scrutinee type bounds its
+    /// range, checked like any literal at monomorphization).
+    Int(&'tcx Integer),
     Bool(bool),
     Str(StringToken),
 }
 
-impl Ctor {
+impl Ctor<'_> {
     fn family(&self) -> Family {
         match self {
             Ctor::Variant(_) => Family::Variant,
@@ -91,16 +94,19 @@ enum Family {
 /// A type-checked pattern. Variable bindings carry the [`VarId`] allocated for
 /// them during checking; their occurrence is filled in while compiling.
 #[derive(Clone, Debug)]
-enum Pat {
+enum Pat<'tcx> {
     /// Matches anything, binds nothing (`_`).
     Wild,
     /// Matches anything, binds the value at this occurrence to `VarId`.
     Bind(VarId),
     /// Matches `ctor` and recurses into its fields.
-    Ctor { ctor: Ctor, fields: Vec<Pat> },
+    Ctor {
+        ctor: Ctor<'tcx>,
+        fields: Vec<Pat<'tcx>>,
+    },
 }
 
-impl Pat {
+impl Pat<'_> {
     fn is_ctor(&self) -> bool {
         matches!(self, Pat::Ctor { .. })
     }
@@ -118,7 +124,7 @@ struct Column<'tcx> {
 #[derive(Clone)]
 struct Row<'tcx> {
     /// One pattern per column, in column order.
-    pats: Vec<Pat>,
+    pats: Vec<Pat<'tcx>>,
     /// Bindings discovered in columns already consumed by specialization.
     bindings: Vec<(VarId, PatVarRef)>,
     guard: Option<Expr<'tcx>>,
@@ -240,7 +246,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// source span, used to blame any error; nested sub-patterns (a constructor's
     /// arguments) carry no span of their own, so they reuse the enclosing
     /// pattern's — coarse, but still traced to source.
-    fn check_pat(&mut self, kind: &PatternKind, span: Option<Span>, ty: Ty<'tcx>) -> Pat {
+    fn check_pat(&mut self, kind: &PatternKind, span: Option<Span>, ty: Ty<'tcx>) -> Pat<'tcx> {
         let ty = self.infer.shallow_resolve(ty);
         match kind {
             PatternKind::Wildcard => Pat::Wild,
@@ -253,7 +259,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
     }
 
-    fn check_const_pat(&mut self, c: &Const, span: Option<Span>, ty: Ty<'tcx>) -> Pat {
+    fn check_const_pat(&mut self, c: &Const, span: Option<Span>, ty: Ty<'tcx>) -> Pat<'tcx> {
         let ctor = match c {
             Const::ConstInt(i) => {
                 // The literal must be *some* integer, but its width/signedness
@@ -264,7 +270,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 // literal *expression* does; the eventual int-switch lowering
                 // reads the column's real type to pick the signed/unsigned cast.
                 self.register_bound(self.builtins.integral, ty, span);
-                Ctor::Int(*i as i128)
+                Ctor::Int(self.tcx.alloc(i.clone()))
             }
             Const::ConstBool(b) => {
                 let want = self.tcx.mk_bool();
@@ -276,7 +282,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 let _ = self.infer.unify(ty, want);
                 Ctor::Str(self.strings.allocate(s))
             }
-            Const::ConstDouble(_) => {
+            Const::ConstFloat(_) => {
                 self.error(span, "floating-point patterns are not supported");
                 return Pat::Wild;
             }
@@ -287,7 +293,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
     }
 
-    fn check_ctor_pat(&mut self, ctor: &surface::CtorPat, span: Option<Span>, ty: Ty<'tcx>) -> Pat {
+    fn check_ctor_pat(
+        &mut self,
+        ctor: &surface::CtorPat,
+        span: Option<Span>,
+        ty: Ty<'tcx>,
+    ) -> Pat<'tcx> {
         let ty = self.infer.shallow_resolve(ty);
         let TyKind::Record { def, args, .. } = ty.kind() else {
             self.error(span, format!("cannot match constructor against `{ty:?}`"));
@@ -505,7 +516,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         for row in &m.rows {
             // What the field columns become, and whether this row's column-`j`
             // pattern bound the whole value.
-            let (sub, bind): (Vec<Pat>, Option<(VarId, PatVarRef)>) = match &row.pats[j] {
+            let (sub, bind): (Vec<Pat<'tcx>>, Option<(VarId, PatVarRef)>) = match &row.pats[j] {
                 Pat::Ctor {
                     ctor: Ctor::Variant(w),
                     fields,
@@ -537,7 +548,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         &self,
         m: &Matrix<'tcx>,
         j: usize,
-        c: &Ctor,
+        c: &Ctor<'tcx>,
         occ: &PatVarRef,
     ) -> Matrix<'tcx> {
         let cols = cols_without(&m.cols, j);
@@ -569,7 +580,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     }
 
     /// The distinct integer literals tested in column `j`, in first-seen order.
-    fn column_ints(&self, m: &Matrix<'tcx>, j: usize) -> Vec<i128> {
+    fn column_ints(&self, m: &Matrix<'tcx>, j: usize) -> Vec<&'tcx Integer> {
         let mut seen = Vec::new();
         for row in &m.rows {
             if let Pat::Ctor {

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -21,6 +21,8 @@
 use reussir_syntax::ast::unescape_string;
 use reussir_syntax::kind::{ResolvedNode, ResolvedToken, SyntaxKind, TokenKey};
 use smallvec::{SmallVec, smallvec};
+
+use crate::literal::{self, FloatLit, Integer};
 // Bare names resolve to `SyntaxKind` variants (used pervasively in matches).
 // A handful of variant names collide with surface AST *types* defined in this
 // module; for those the local type wins for the bare name (a glob import has
@@ -125,11 +127,13 @@ pub enum FpType {
 }
 
 /// A literal constant. String literals are *decoded* (escapes resolved), so they
-/// are owned rather than an interned token key.
+/// are owned rather than an interned token key. Numeric literals are *exact*
+/// ([`crate::literal`]): carried arbitrary-precision and rounded to their
+/// ground type only at the end of the pipeline.
 #[derive(Clone, Debug)]
 pub enum Const {
-    ConstInt(i64),
-    ConstDouble(f64),
+    ConstInt(Integer),
+    ConstFloat(FloatLit),
     ConstString(String),
     ConstBool(bool),
 }
@@ -302,13 +306,8 @@ fn access_segs_of(node: &ResolvedNode) -> SmallVec<[Access; 2]> {
 
 fn constant(token: &ResolvedToken) -> Const {
     match token.kind() {
-        IntLit => Const::ConstInt(int_value(token.text())),
-        FloatLit => Const::ConstDouble(
-            token
-                .text()
-                .parse()
-                .expect("float literal validated by lexer"),
-        ),
+        IntLit => Const::ConstInt(literal::parse_int(token.text())),
+        FloatLit => Const::ConstFloat(literal::parse_float(token.text())),
         StringLit => Const::ConstString(unescape_string(token.text())),
         TrueKw => Const::ConstBool(true),
         FalseKw => Const::ConstBool(false),
@@ -316,9 +315,10 @@ fn constant(token: &ResolvedToken) -> Const {
     }
 }
 
+/// A tuple-access index. An index beyond `i64` can never name a field, so
+/// saturate rather than panic and let field resolution report it.
 fn int_value(text: &str) -> i64 {
-    text.parse()
-        .expect("integer literal validated by the lexer")
+    i64::try_from(&literal::parse_int(text)).unwrap_or(i64::MAX)
 }
 
 fn binary_op(kind: SyntaxKind) -> Option<BinOp> {

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -674,9 +674,14 @@ impl Emitter<'_> {
     fn constant(&self, token: &ResolvedToken) -> Value {
         match token.kind() {
             IntLit => tagged("ConstInt", int_value(token.text())),
+            // "ConstDouble" is the wire tag the Haskell differential verifier
+            // (`reussir-surface-verify`) decodes; keep it stable.
             FloatLit => tagged(
                 "ConstDouble",
-                Value::Number(Number::from_string_unchecked(token.text().to_owned())),
+                // Underscore separators are not valid JSON; strip them. The
+                // digits themselves are carried verbatim (arbitrary
+                // precision — serde_json's `arbitrary_precision` feature).
+                Value::Number(Number::from_string_unchecked(token.text().replace('_', ""))),
             ),
             StringLit => tagged("ConstString", Value::String(unescape_string(token.text()))),
             TrueKw => tagged("ConstBool", Value::Bool(true)),
@@ -686,11 +691,15 @@ impl Emitter<'_> {
     }
 }
 
+/// An integer literal as a JSON value: plain decimals are numbers (arbitrary
+/// precision); radix forms keep their spelling as a string, losslessly.
 fn int_value(text: &str) -> Value {
-    let n: i64 = text
-        .parse()
-        .expect("integer literal validated by the lexer");
-    Value::Number(n.into())
+    let plain = text.replace('_', "");
+    if plain.bytes().all(|b| b.is_ascii_digit()) {
+        Value::Number(Number::from_string_unchecked(plain))
+    } else {
+        Value::String(plain)
+    }
 }
 
 fn binary_op_name(kind: SyntaxKind) -> Option<&'static str> {

--- a/crates/reussir-syntax/src/lexer.rs
+++ b/crates/reussir-syntax/src/lexer.rs
@@ -4,8 +4,9 @@
 //!
 //! * identifiers follow Unicode XID rules (`XID_Start` then `XID_Continue*`),
 //! * `//` line comments and (non-nesting) `/* ... */` block comments,
-//! * integers are plain digit runs; floats are digit runs with a fraction
-//!   and/or exponent (`1.5`, `1e3`, `2.5e-7`),
+//! * integers are digit runs — decimal, or `0x`/`0o`/`0b` radix literals —
+//!   with `_` separators (`1_000`, `0xFF_FF`); floats are decimal digit runs
+//!   with a fraction and/or exponent (`1.5`, `1e3`, `2.5e-7`, `1_0.5`),
 //! * strings are double-quoted with backslash escapes (validated here,
 //!   decoded in [`crate::ast`]).
 //!
@@ -38,12 +39,19 @@ pub enum RawToken {
     #[regex(r"\p{XID_Start}\p{XID_Continue}*", classify_ident)]
     Ident(IdentClass),
 
-    #[regex(r"[0-9]+")]
+    // Decimal, hex, octal, and binary integers, with `_` digit separators
+    // (which cannot lead: a radix run needs at least one real digit, so `0x_`
+    // falls back to `0` + ident rather than lexing as an empty literal).
+    #[regex(r"[0-9][0-9_]*")]
+    #[regex(r"0[xX]_*[0-9a-fA-F][0-9a-fA-F_]*")]
+    #[regex(r"0[oO]_*[0-7][0-7_]*")]
+    #[regex(r"0[bB]_*[01][01_]*")]
     Int,
     // A float needs a fractional part, an exponent, or both; a bare digit
-    // run is an integer.
-    #[regex(r"[0-9]+\.[0-9]+([eE][+-]?[0-9]+)?")]
-    #[regex(r"[0-9]+[eE][+-]?[0-9]+")]
+    // run is an integer. Fraction and exponent digits also take `_`
+    // separators (never leading).
+    #[regex(r"[0-9][0-9_]*\.[0-9][0-9_]*([eE][+-]?[0-9][0-9_]*)?")]
+    #[regex(r"[0-9][0-9_]*[eE][+-]?[0-9][0-9_]*")]
     Float,
 
     #[token("\"", lex_string)]
@@ -294,6 +302,9 @@ pub fn tokenize(source: &str) -> (Vec<Token>, Vec<LexError>) {
                     "unterminated string literal"
                 } else if slice.starts_with("/*") {
                     "unterminated block comment"
+                } else if slice.starts_with(|c: char| c.is_ascii_digit()) {
+                    // e.g. a radix prefix with no digits (`0x`, `0b_`).
+                    "invalid numeric literal"
                 } else {
                     "unrecognized character"
                 };
@@ -348,6 +359,31 @@ mod tests {
         assert_eq!(kinds("1e3 2.5e-7"), vec![K::FloatLit, K::FloatLit]);
         // A dot after an integer is an access, not a float.
         assert_eq!(kinds("1.foo"), vec![K::IntLit, K::Dot, K::Ident]);
+    }
+
+    #[test]
+    fn radix_literals_and_separators() {
+        assert_eq!(kinds("0xFF 0o777 0b1010"), vec![K::IntLit; 3]);
+        assert_eq!(kinds("0Xff_ff 0O7_7 0B1_0"), vec![K::IntLit; 3]);
+        assert_eq!(kinds("1_000_000 1_"), vec![K::IntLit, K::IntLit]);
+        assert_eq!(kinds("1_000.5 1_0e1_0"), vec![K::FloatLit, K::FloatLit]);
+        // A separator cannot lead a literal.
+        assert_eq!(kinds("_1"), vec![K::Underscore, K::IntLit]);
+        // A radix prefix with no digits is a lex error (logos does not
+        // backtrack to the shorter `0` match), reported as such.
+        for src in ["0x", "0x_", "0b2"] {
+            let (tokens, errors) = tokenize(src);
+            assert_eq!(errors.len(), 1, "`{src}`: {errors:?}");
+            assert_eq!(errors[0].message, "invalid numeric literal", "`{src}`");
+            assert_eq!(tokens[0].kind, K::ErrorToken, "`{src}`");
+        }
+        // A digit outside the radix ends the literal (`0b12` is `0b1`, `2`).
+        assert_eq!(kinds("0b12"), vec![K::IntLit, K::IntLit]);
+        // `1._5` is not a float: a fraction cannot start with a separator.
+        assert_eq!(
+            kinds("1._5"),
+            vec![K::IntLit, K::Dot, K::Underscore, K::IntLit]
+        );
     }
 
     #[test]

--- a/crates/reussir-syntax/src/lexer.rs
+++ b/crates/reussir-syntax/src/lexer.rs
@@ -40,8 +40,10 @@ pub enum RawToken {
     Ident(IdentClass),
 
     // Decimal, hex, octal, and binary integers, with `_` digit separators
-    // (which cannot lead: a radix run needs at least one real digit, so `0x_`
-    // falls back to `0` + ident rather than lexing as an empty literal).
+    // (which cannot lead: a radix run needs at least one real digit). A
+    // digit-less prefix like `0x`/`0x_` is a lex error — logos does not
+    // backtrack to the shorter `0` match — reported as "invalid numeric
+    // literal" (see `tokenize`'s error classification).
     #[regex(r"[0-9][0-9_]*")]
     #[regex(r"0[xX]_*[0-9a-fA-F][0-9a-fA-F_]*")]
     #[regex(r"0[oO]_*[0-7][0-7_]*")]

--- a/tests/integration/frontend/ap_literals.rr
+++ b/tests/integration/frontend/ap_literals.rr
@@ -1,0 +1,60 @@
+// Arbitrary-precision numeric literals (#290): values are carried exact
+// through HIR/MIR (lossless decimal text) and rounded/range-checked only at
+// the end. The llvm-ir checks are bit-exact: they prove one *correct* decimal
+// -> target-format rounding, including for types Rust cannot even represent
+// (f16, bfloat16). LLVM spells integer constants signed, so a full-range u64
+// shows up as `ret i64 -1` -- i.e. all 64 bits really arrived. (Output is
+// sorted by symbol, hence the DAG checks.)
+
+// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %rrc %s --emit llvm-ir -o %t.ll
+// RUN: %FileCheck %s --check-prefix=LL < %t.ll
+
+// The MIR text also re-parses losslessly (the pipeline can resume from it).
+// RUN: %rrc %s --emit mir -o %t.mir
+// RUN: %rrc %t.mir --emit llvm-ir -o %t2.ll
+// RUN: %FileCheck %s --check-prefix=LL < %t2.ll
+
+// A full-range u64 literal used to panic rrc at parse (`int_value`'s i64
+// `.expect`); i64::MIN used to be unrepresentable (the magnitude overflows
+// before negation). Both are now carried exactly and emitted at full width.
+pub fn umax() -> u64 { 18446744073709551615 }
+// MIR-DAG: 18446744073709551615 : u64
+// LL-DAG: ret i64 -1
+
+pub fn imin() -> i64 { -9223372036854775808 }
+// MIR-DAG: -9223372036854775808 : i64
+// LL-DAG: ret i64 -9223372036854775808
+
+// Radix literals and digit separators normalize to the same exact value.
+pub fn hex() -> u32 { 0xDEAD_BEEF }
+// MIR-DAG: 3735928559 : u32
+// LL-DAG: ret i32 -559038737
+
+pub fn bin() -> u8 { 0b1111_1111 }
+// MIR-DAG: 255 : u8
+// LL-DAG: ret i8 -1
+
+// Floats stay exact decimals in MIR; the one correctly-rounded conversion
+// happens in codegen. 0.1 in f16 is 0xH2E66 and in bfloat16 0xR3DCD --
+// bit patterns Rust has no native type for.
+pub fn tenth16() -> f16 { 0.1 }
+// MIR-DAG: 0.1 : f16
+// LL-DAG: ret half 0xH2E66
+
+pub fn tenthb() -> bfloat16 { 0.1 }
+// MIR-DAG: 0.1 : bf16
+// LL-DAG: ret bfloat 0xR3DCD
+
+// f16's largest finite value fits (anything that would round to infinity is
+// a mono-time diagnostic instead).
+pub fn f16max() -> f16 { 65504.0 }
+// LL-DAG: ret half 0xH7BFF
+
+// Single rounding, not double: this decimal sits just above the f32 tie at
+// 1 + 2^-24, but *below* f64 resolution. Rounding through f64 first would
+// collapse onto the tie and then round to even (1.0); rounding the exact
+// decimal directly must go up to 1 + 2^-23 (spelled by LLVM as the f64-form
+// hex float 0x3FF0000020000000).
+pub fn tie32() -> f32 { 1.0000000596046447753906251 }
+// LL-DAG: ret float 0x3FF0000020000000

--- a/tests/integration/frontend/ap_literals.rr
+++ b/tests/integration/frontend/ap_literals.rr
@@ -51,6 +51,13 @@ pub fn tenthb() -> bfloat16 { 0.1 }
 pub fn f16max() -> f16 { 65504.0 }
 // LL-DAG: ret half 0xH7BFF
 
+// IEEE signed zero: an exact decimal has no negative zero, so `-0.0` is NOT
+// folded into a constant — it stays a runtime negation, and the sign survives
+// to the emitted code (folding in the decimal domain would yield +0.0 and
+// flip the sign of `1.0 / -0.0`).
+pub fn negzero() -> f64 { -0.0 }
+// LL-DAG: ret double -0.000000e+00
+
 // Single rounding, not double: this decimal sits just above the f32 tie at
 // 1 + 2^-24, but *below* f64 resolution. Rounding through f64 first would
 // collapse onto the tie and then round to even (1.0); rounding the exact

--- a/tests/integration/frontend/ap_literals_out_of_range.rr
+++ b/tests/integration/frontend/ap_literals_out_of_range.rr
@@ -1,0 +1,21 @@
+// Out-of-range literals are diagnostics at monomorphization (once every
+// literal's type is ground), never panics or silent wraps (#290). A float
+// literal that would round to infinity is a hard error: there is no `inf`
+// literal syntax, so it can only be a mistake.
+
+// RUN: %not %rrc %s --emit mir -o - 2>&1 | %FileCheck %s
+
+pub fn a() -> i8 { 128 }
+// CHECK-DAG: integer literal `128` is out of range for `i8`
+
+pub fn b() -> u8 { -1 }
+// CHECK-DAG: integer literal `-1` is out of range for `u8`
+
+pub fn c() -> u64 { 18446744073709551616 }
+// CHECK-DAG: integer literal `18446744073709551616` is out of range for `u64`
+
+pub fn d() -> f64 { 1e400 }
+// CHECK-DAG: float literal `1e400` is out of range for `f64` (it would round to infinity)
+
+pub fn e() -> f16 { 65520.0 }
+// CHECK-DAG: float literal `65520.0` is out of range for `f16`

--- a/tests/integration/frontend/meaningless_wrong.rr
+++ b/tests/integration/frontend/meaningless_wrong.rr
@@ -1,4 +1,4 @@
-// RUN: %not %reussir-elab --mode semi %s 2>&1 | %FileCheck %s
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
 enum Foo {
     Bar(Foo),
     Baz,


### PR DESCRIPTION
Addresses the **"Numeric literals are pinned to `i64`/`f64` at parse"** item of #290, plus the radix-literal lexer gap, with the design goal that everything extends unchanged to `i128`/`u128`/`f128` and formats without a Rust encoding (`bfloat16`, `f16`).

## What was broken

- `int_value` did `text.parse::<i64>().expect(...)` — a full-range `u64` literal (`18446744073709551615`) **panicked rrc**; `i64::MIN` was unwritable (the magnitude overflows before negation applies).
- Codegen truncated the (already-clamped) value again: `IntegerAttribute::new(ty, *n as i64)`.
- Float literals were rounded to `f64` at parse. Narrower targets were then rounded a second time — **double rounding**, which differs from a correct single rounding on tie-straddling decimals — and `1e400` collapsed to `inf` before its type was known.

## Design

A decimal literal is an exact value: `mantissa × 10^exp10`. The new `reussir_core::literal` module (backed by **malachite**) carries that pair — `Integer` for ints, `FloatLit` for floats — unrounded from the surface AST through HIR and MIR. The one lossy step happens after monomorphization makes the type ground:

- **Integers**: range-checked at mono (`integer literal `128` is out of range for `i8``), then emitted at full width through the textual APInt attribute path.
- **Floats**: `FloatLit::to_ieee_bits(exp_bits, mant_bits)` performs a single bigint round-to-nearest-even directly into the target format (subnormals included, overflow-to-infinity is a hard error) and codegen emits the bits via MLIR's exact hexadecimal float form. No host float is ever involved, so `bfloat16`/`f16` (and later `f128`) round exactly like `f32`/`f64`.
- Mono folds `Negate(literal)` into the constant, so `-128 : i8` and `-9223372036854775808 : i64` are single in-range values (and `let x: u8 = -1` is now a diagnostic instead of a silent runtime wrap).

Decision-tree integer keys widen from `i128` to `Integer` as agreed, removing the last i128 ceiling before `i128`/`u128` surface types.

## Lossless textual IR

HIR/MIR never hold a binary float, so the printers stay in exact decimal (`FloatLit`'s canonical `Display`/`FromStr` invert each other; MIR text re-parses to the same program — covered by round-trip tests and a `mir -> text -> llvm-ir` lit RUN). Two pre-existing round-trip holes fixed along the way: negative constants now lex, and depth-2 scrutinee paths (`scrut.0.1`, whose adjacent indices lex as one float-shaped token) re-parse correctly.

## Also

- Lexer: `0x`/`0o`/`0b` radix literals + `_` digit separators (`0xFF_FF`, `1_000.5`); a digit-less radix prefix is a proper "invalid numeric literal" error.
- LICENSE: third-party note for the LGPL-3.0 malachite crates (per discussion).
- `reussir-surface-verify` JSON stays wire-compatible (`ConstDouble` tag kept).

## Correctness evidence

- `to_ieee_bits` differentially fuzzed against Rust's correctly-rounded `from_str` (20k random decimals across the full f32/f64 exponent range, normals/subnormals/overflow/underflow), plus a crafted case where double rounding provably differs (`1 + 2^-11 + 1e-30` in f16) and bit-exact bf16/f128 vectors.
- New lit tests check **bit patterns in emitted LLVM IR**: `0.1 : f16` is `0xH2E66`, `0.1 : bfloat16` is `0xR3DCD`, and an f32 tie-straddler rounds up where the old pipeline would have collapsed to the tie.
- Full suites green: reussir-core 188, reussir-syntax 21, codegen 26+17, jit 9, rrc unit 11, and `lit`: **240 passed / 4 unsupported / 0 failed** (includes the Haskell differential-verifier and repl suites).

Closes nothing on its own — it checks off the AP-literal and diagnostics-adjacent boxes of #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2