### PR TITLE
[frontend] elaborate a bare-name call of a closure binding as a closure application

### DIFF
--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -423,10 +423,27 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// function, instantiate its generics to a substitution θ, check `argᵢ ⇐
     /// ⌈paramᵢ⌉θ`, and return `R = ⌈return_ty⌉θ`. A regional callee outside a region,
     /// an unknown name, or an arity mismatch is a diagnostic (unknown name ⇒ poison).
-    /// Note: this resolves *functions* only — a closure-valued variable is not callable
-    /// here (see `infer_closure_call`).
+    /// A bare `name` that binds a local closure value is redirected to a closure
+    /// application (`closure_apply`) — the parser cannot tell the two apart.
     fn infer_func_call(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
         let fname = self.sym(fc.name.basename);
+        // The parser emits a `FuncCall` for every bare-name application `f(x)` —
+        // it cannot tell a `fn` from a closure-valued local. A name that binds a
+        // local value is a closure application (a local binding shadows a
+        // same-named function, matching `infer_var`'s var-first precedence).
+        if fc.name.segments.is_empty()
+            && let Some((id, ty)) = self.vars.lookup(fc.name.basename)
+        {
+            self.record_use(fc.name.basename);
+            if !fc.ty_args.is_empty() {
+                self.error(
+                    span,
+                    format!("`{fname}` is a local value and cannot take type arguments"),
+                );
+            }
+            let callee = self.mk_expr(ExprKind::Var(id), ty, span);
+            return self.closure_apply(callee, &fc.args, span);
+        }
         let Some(def) = self.defs.resolve_function(fc.name.basename) else {
             let hint = self.function_suggestion(fc.name.basename);
             self.error(span, format!("unknown function `{fname}`{hint}"));
@@ -479,6 +496,20 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         span: Option<Span>,
     ) -> Expr<'tcx> {
         let callee = self.infer_expr(callee);
+        self.closure_apply(callee, args, span)
+    }
+
+    /// Apply an already-synthesized `callee` (a closure value) to `args`, shared
+    /// by [`infer_closure_call`](Self::infer_closure_call) — where the callee is
+    /// a first-class expression — and [`infer_func_call`](Self::infer_func_call),
+    /// where a bare name turned out to be a local closure binding rather than a
+    /// function. See `infer_closure_call` for the partial/full-application rules.
+    fn closure_apply(
+        &mut self,
+        callee: Expr<'tcx>,
+        args: &[surface::Expr],
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
         let (params, ret) = match callee.ty.kind() {
             TyKind::Closure { params, ret } => (params.to_vec(), *ret),
             _ => {

--- a/tests/integration/frontend/closure_call_by_name.rr
+++ b/tests/integration/frontend/closure_call_by_name.rr
@@ -1,0 +1,26 @@
+// A bare-name call `f(x)` where `f` is a closure-valued binding (a parameter or
+// a `let`) must elaborate as a closure application, not fail with "unknown
+// function `f`". The parser emits a `FuncCall` for every bare-name application,
+// so the checker disambiguates: a name that binds a local value is a closure
+// application (a local binding shadows a same-named function).
+// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+
+// Closure passed as a parameter, then applied by name.
+fn run_it(g : i32 -> i32, x : i32) -> i32 {
+    g(x)
+}
+
+// Closure bound by `let`, then applied by name.
+pub fn use_local(x : i32) -> i32 {
+    let h = |y : i32| y * 2;
+    h(x)
+}
+
+extern "C" trampoline "use_local_ffi" = use_local;
+
+// Each call lowers to a closure application (HIR `apply`), not a function call.
+// CHECK-LABEL: fn #run_it(
+// CHECK:       apply(v0
+// CHECK-LABEL: fn #use_local(
+// CHECK:       closure[]
+// CHECK:       apply(v2

--- a/tests/integration/frontend/closure_e2e.rr
+++ b/tests/integration/frontend/closure_e2e.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic
+// RUN: %rrc %s -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/closure_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 

--- a/tests/integration/frontend/closure_multiplicity.rr
+++ b/tests/integration/frontend/closure_multiplicity.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic
+// RUN: %rrc %s -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/closure_multiplicity.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 

--- a/tests/integration/frontend/closure_nested_capture.rr
+++ b/tests/integration/frontend/closure_nested_capture.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic
+// RUN: %rrc %s -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/closure_nested_capture.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 

--- a/tests/integration/frontend/rbtree2.rr
+++ b/tests/integration/frontend/rbtree2.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %rrc %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
 // RUN: %cc %t.o %S/rbtree2.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 


### PR DESCRIPTION
## What

`f(x)` where `f` is a closure-valued local (a parameter or a `let` binding) failed to elaborate:

```
error: unknown function `f`
```

This blocked the whole closure-call-by-name family. With the fix, **closure_e2e, closure_multiplicity, closure_nested_capture, and rbtree2 all pass end-to-end** under `rrc`.

## Why

The parser emits a `FuncCall` for *every* bare-name application `f(x)` — it can't tell a `fn` from a closure-valued binding. `infer_func_call` then resolved `f` as a function name and failed.

## Fix

Disambiguate in the checker (`infer_func_call`): an unqualified name that binds a **local value** is a closure application, redirected to a shared `closure_apply` helper factored out of `infer_closure_call`.

- A local binding **shadows** a same-named function — matching `infer_var`'s var-first precedence (consistent lexical scoping).
- A non-closure local now reports `called value is not a closure` instead of the misleading `unknown function`.
- Explicit type arguments on such a call are rejected (`f<i32>(x)` where `f` is a local).
- Genuinely unknown names still report `unknown function` with the suggestion hint.

```
fn run_it(g : i32 -> i32, x : i32) -> i32 { g(x) }   // g(x) => apply(v0, v1)
pub fn use_local(x : i32) -> i32 {
    let h = |y : i32| y * 2;
    h(x)                                             // h(x) => apply(v2, v0)
}
```

## Tests

- Migrate the four newly-passing e2e tests off the legacy `%reussir-compiler` to `%rrc` (`closure_e2e`, `closure_multiplicity`, `closure_nested_capture`, `rbtree2` — the last preserving `-Oaggressive --reuse-across-call`). All compile, link, and run correctly.
- Add `closure_call_by_name.rr`, a fast focused HIR regression asserting both a parameter and a `let`-bound closure elaborate to `apply` rather than a function call.
- `cargo test -p reussir-core` green (189); no elaboration-dump regressions.

## Out of scope (distinct follow-ups)

- **Function-to-closure lifting** (`fn_lift.rr`): using a `fn` *name* as a first-class value (`apply_i32(double, 21)`) and partial-applying a *named* function (`let add5 = add(5)`). Different mechanism (function item -> closure value), touches codegen.
- **Closure-in-struct materialization segfault** (`closure_struct_materialize.rr`): now elaborates and lowers, but segfaults at runtime — a separate codegen/ownership bug in materializing a closure stored in a struct field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)