### PR TITLE
[backend] inc-dec-cancellation: don't cancel a retain across a consuming call

### DIFF
--- a/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
@@ -106,12 +106,26 @@ llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
         // increment.
         break;
       }
-      // If encounter any of the following, there is a chance that nested
-      // operation may demand rc management. Hence, we abort the cancellation.
-      if (llvm::isa<mlir::CallableOpInterface>(next) ||
-          llvm::isa<mlir::RegionBranchOpInterface>(next) ||
-          llvm::isa<ReussirClosureApplyOp>(next) ||
-          llvm::isa<ReussirClosureEvalOp>(next))
+      // A call *site* (`mlir::CallOpInterface`, e.g. `func.call`) is opaque: it
+      // may consume the incremented value (a closure application lowers to a
+      // `func.call` that takes ownership of its closure), so cancelling across it
+      // could drop a live reference. Guard on the call-site interface — *not*
+      // `CallableOpInterface`, which is the call *target* (`func.func`) and never
+      // appears mid-block. A control-flow op with regions is likewise opaque.
+      if (llvm::isa<mlir::CallOpInterface>(next) ||
+          llvm::isa<mlir::RegionBranchOpInterface>(next))
+        break;
+      // `closure.apply`/`closure.eval` consume/mutate only their own closure
+      // operand, so they are risky only when that operand may alias the
+      // incremented pointer; an application of an unrelated closure is harmless
+      // and does not block the cancellation.
+      if (auto applyOp = llvm::dyn_cast<ReussirClosureApplyOp>(next);
+          applyOp && aliasAnalysis.alias(op.getRcPtr(), applyOp.getClosure()) !=
+                         mlir::AliasResult::NoAlias)
+        break;
+      if (auto evalOp = llvm::dyn_cast<ReussirClosureEvalOp>(next);
+          evalOp && aliasAnalysis.alias(op.getRcPtr(), evalOp.getClosure()) !=
+                        mlir::AliasResult::NoAlias)
         break;
       next = next->getNextNode();
     }

--- a/tests/integration/conversion/inc_dec_cancellation_across_call.mlir
+++ b/tests/integration/conversion/inc_dec_cancellation_across_call.mlir
@@ -1,0 +1,34 @@
+// RUN: %reussir-opt %s --reussir-inc-dec-cancellation | %FileCheck %s
+
+// Regression (#290): `reussir-inc-dec-cancellation` must not cancel an
+// `rc.inc` against a later aliased `rc.dec` when a *call* sits between them.
+// A call site (`func.call`) is opaque and may consume the incremented
+// reference — a closure application lowers to a `func.call` that takes
+// ownership of its closure — so erasing the retain across it frees a value that
+// is still live afterward. This is the closure-in-`[shared]`-record double-free:
+// the closure was loaded twice from the same field (so the loads MustAlias) and
+// the first borrow-extract retain was cancelled across the consuming `apply1`.
+
+!clo = !reussir.closure<(i32) -> i32>
+
+module {
+  func.func private @apply1(%f: !reussir.rc<!clo>, %x: i32) -> i32
+
+  func.func @retain_across_call(%f: !reussir.rc<!clo>) -> i32 {
+    %c4 = arith.constant 4 : i32
+    // The incremented reference is handed to (and consumed by) the call, so
+    // this retain must survive: cancelling it against the decrement below would
+    // release the value while the call still owns it.
+    reussir.rc.inc (%f : !reussir.rc<!clo>)
+    %r = func.call @apply1(%f, %c4) : (!reussir.rc<!clo>, i32) -> i32
+    reussir.rc.dec (%f : !reussir.rc<!clo>)
+    return %r : i32
+  }
+}
+
+// The retain, the consuming call, and the release all survive — the call blocks
+// the cancellation (without the fix the inc/dec pair is erased across it).
+// CHECK-LABEL: func.func @retain_across_call
+// CHECK:       reussir.rc.inc
+// CHECK:       call @apply1
+// CHECK:       reussir.rc.dec


### PR DESCRIPTION
## What

`reussir-inc-dec-cancellation` was erasing a needed `rc.inc` across a consuming `func.call`, double-freeing a closure stored in a `[shared]` record. This is the root cause of the `closure_struct_materialize.rr` segfault tracked in #290 (`test_sbox_multi`).

## Root cause

The pass walks forward from each `rc.inc` to find a `MustAlias` `rc.dec` to cancel it against, aborting on ops that might touch refcounts. The abort guard checked `CallableOpInterface` — but that's the call **target** (`func.func`); a call **site** is `CallOpInterface` (`func.call`), which the guard never matched. So a consuming `func.call` between an inc and an aliased dec didn't stop the walk, and the retain was cancelled across it.

Concretely: a closure in a `[shared]` record is loaded twice from the same field, so the two `ref.load`s **MustAlias**. The first borrow-extract `rc.inc` — whose reference is consumed by the `apply1` call — got cancelled against the record-drop's `rc.dec`. The first `apply1` then saw the closure as uniquely owned, took `closure.uniqify`'s in-place path, and **freed the box's closure**; the second load was a use-after-free.

- `-Onone`: deterministic wrong result (24 instead of 42).
- `-O`: double-free → SIGSEGV.
- A `[value]` struct reaches the field with `record.extract` (no `MustAlias`), so it was unaffected — hence `[shared]`-specific.

The frontend MLIR was **correct and balanced** (an `rc.inc` before each `apply1`); only this backend transform was wrong.

## Fix

- Guard on `mlir::CallOpInterface` (call sites) and `RegionBranchOpInterface`, not `CallableOpInterface`.
- Refine the closure guard: `closure.apply`/`closure.eval` consume only their own closure operand, so they block cancellation **only when that operand may alias** the incremented pointer (an application of an unrelated closure is harmless — allows more valid cancellations).

## Tests

- Adds `tests/integration/conversion/inc_dec_cancellation_across_call.mlir`: a retain consumed by a call must survive the pass. **Verified failing before the fix** (inc/dec erased → 0 `rc.inc`) **and passing after**.
- The existing `inc_dec_cancellation.mlir` and `closure_rc_ops.mlir` still pass.
- `cargo test -p reussir-codegen -p reussir-core -p reussir-compiler` green.
- End-to-end: `closure_struct_materialize` (the crasher) now returns 42 at all opt levels, and the full closure/rbtree suite passes. That `.rr` test still uses closure-call-by-name, so it migrates to `%rrc` once #300 lands (kept out of this PR to keep it independently mergeable).

## Investigation notes for #290

The precise diagnosis (missing inc confirmed in the lowered IR, `MustAlias` explaining value-vs-shared, the `CallableOpInterface`-vs-`CallOpInterface` mixup) is recorded in #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)