### PR TITLE
[backend] reussir-codegen: lower a closure record member as a capability member

### DIFF
--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -142,14 +142,18 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         }
     }
 
-    /// Lower a type as it appears *as a record member*. A record-typed member is
-    /// named by its bare element type, never an `rc` pointer: the dialect boxes a
-    /// member whose element capability is `shared`/`regional` to a pointer on its
-    /// own (a `!reussir.rc<…>` member is rejected — "use capability instead"). A
-    /// scalar or `[value]` record member is the same as [`mlir_ty`](Self::mlir_ty).
+    /// Lower a type as it appears *as a record member*. A managed member is named
+    /// by its bare element type, never an `rc` pointer: the dialect boxes a member
+    /// whose element capability is `shared`/`regional` to a pointer on its own (a
+    /// `!reussir.rc<…>` member is rejected — "use capability instead"). This holds
+    /// for a `shared`/`regional` record member (its inner record type) and for a
+    /// closure member (its bare `closure` type — a closure is a shared `rc` value
+    /// just like a shared record). A scalar or `[value]` record member is the same
+    /// as [`mlir_ty`](Self::mlir_ty).
     fn member_ty(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
         match *ty.kind() {
             TyKind::Record { .. } => self.record_inner_of(ty),
+            TyKind::Closure { params, ret } => self.closure_inner(params, ret),
             _ => self.mlir_ty(ty),
         }
     }
@@ -325,6 +329,16 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
     /// the remaining parameters once captures have been applied). A unit return is
     /// a closure with no output type.
     pub(super) fn closure_type(&self, inputs: &[Ty<'tcx>], ret: Ty<'tcx>) -> Result<Type<'c>> {
+        Ok(self.rc_type(self.closure_inner(inputs, ret)?))
+    }
+
+    /// `!reussir.closure<(inputs) -> ret>` — the *bare* closure type, without the
+    /// `rc` box. A closure is a shared `rc` value, so as a standalone value it is
+    /// wrapped by [`closure_type`](Self::closure_type); as a record member it
+    /// appears bare (a shared capability member the dialect boxes), the same way
+    /// a `shared` record member is named by its inner type — see
+    /// [`member_ty`](Self::member_ty).
+    fn closure_inner(&self, inputs: &[Ty<'tcx>], ret: Ty<'tcx>) -> Result<Type<'c>> {
         let input_tys = inputs
             .iter()
             .map(|&t| self.mlir_ty(t))
@@ -334,7 +348,7 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         } else {
             Some(self.mlir_ty(ret)?)
         };
-        Ok(self.rc_type(closure(self.context, &input_tys, output)))
+        Ok(closure(self.context, &input_tys, output))
     }
 
     /// `!reussir.rc<inner, shared>` — the pointer type for a heap-allocated,

--- a/tests/integration/frontend/closure_struct_member_type.rr
+++ b/tests/integration/frontend/closure_struct_member_type.rr
@@ -16,5 +16,5 @@ pub fn go(x : i32) -> i32 {
 extern "C" trampoline "go_ffi" = go;
 
 // The member is a bare closure (a shared capability member), never `rc<closure>`.
-// CHECK-MLIR:     reussir.record<compound "_RC5Boxed" {!reussir.closure<(i32) -> i32>}>
+// CHECK-MLIR: !reussir.record<compound "_RC5Boxed" {!reussir.closure<(i32) -> i32>}>
 // CHECK-MLIR-NOT: compound "_RC5Boxed" {!reussir.rc<!reussir.closure

--- a/tests/integration/frontend/closure_struct_member_type.rr
+++ b/tests/integration/frontend/closure_struct_member_type.rr
@@ -1,0 +1,20 @@
+// A closure stored in a record must lower to a *capability* member — a bare
+// `!reussir.closure<…>` the dialect boxes — not an explicit `!reussir.rc<…>`
+// member (the record verifier rejects Rc/Ref members: "use capability
+// instead"). Regression for the codegen emitting `rc<closure>` record members.
+// RUN: %rrc %s --emit mlir -o - | %FileCheck %s --check-prefix=CHECK-MLIR
+
+struct [shared] Boxed {
+    f : i32 -> i32
+}
+
+pub fn go(x : i32) -> i32 {
+    let b = Boxed { f: |y : i32| y + 1 };
+    (b.f)(x)
+}
+
+extern "C" trampoline "go_ffi" = go;
+
+// The member is a bare closure (a shared capability member), never `rc<closure>`.
+// CHECK-MLIR:     reussir.record<compound "_RC5Boxed" {!reussir.closure<(i32) -> i32>}>
+// CHECK-MLIR-NOT: compound "_RC5Boxed" {!reussir.rc<!reussir.closure


### PR DESCRIPTION
## What

A closure stored in a record was lowered to an explicit `!reussir.rc<!reussir.closure<…>>` member — invalid IR that the record dialect rejects: *"Members must not be Rc or Ref types, use capability instead."*

```
Rust (before):  record<compound "SBox" {!reussir.rc<!reussir.closure<(i32) -> i32>>}>   ← rejected by verifier
Rust (after) /
Haskell:        record<compound "SBox" {!reussir.closure<(i32) -> i32>}>                ← bare capability member
```

## Why

[`member_ty`](crates/reussir-codegen/src/lower/ty.rs) demotes a `shared`/`regional` **record** member to its bare inner type (a capability member the dialect boxes), but a **closure** member fell through to `mlir_ty`, which wraps it in the `rc` box. A closure is a shared `rc` value just like a shared record, so as a member it must appear bare too.

rrc emitted this invalid type undetected because the "no Rc members" constraint is a record-**type** verifier that only runs on textual parse (`reussir-opt`), not on in-memory construction — so rrc's `module.verify()` (op verifier) passed and the invalid type flowed into the pipeline.

## Fix

Handle `TyKind::Closure` in `member_ty`, lowering it to the bare `!reussir.closure<…>` type (factored out of `closure_type` as `closure_inner`). Covers both compound and variant-payload members (both go through `member_ty`).

## Impact

This is a **canonicalization/validity** fix, not a behaviour change: the old `rc<closure>` member and the bare capability member lower to the same rc-closure pointer. Confirmed a struct-held closure returns the right value at every opt level (`-Onone`/`default`/`aggressive`), and the emitted MLIR now round-trips through the `reussir-opt` verifier.

## Context

This is the frontend-layout divergence found while investigating the `closure_struct_materialize` double-free (#302): the Rust codegen's `rc<closure>` member vs Haskell's `[shared]` capability member. It was **not** the cause of that double-free (that was the `IncDecCancellation` pass, fixed in #302 — a box drop feeding a latent pass bug; the layout is equivalent), but it *is* real invalid IR worth fixing on its own. See #290.

## Tests

- Adds `closure_struct_member_type.rr`: asserts the member is a bare `!reussir.closure<…>` and never `rc<closure>`.
- `cargo test -p reussir-codegen -p reussir-compiler` green; records-with-closures and the record/rbtree e2e suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)