### PR TITLE
[tests] migrate e2e + MIR-dump frontend tests from the Haskell driver to rrc

### DIFF
--- a/tests/integration/frontend/closure_struct_materialize.rr
+++ b/tests/integration/frontend/closure_struct_materialize.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic
+// RUN: %rrc %s -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/closure_struct_materialize.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 

--- a/tests/integration/frontend/fibonacci-generic.rr
+++ b/tests/integration/frontend/fibonacci-generic.rr
@@ -1,39 +1,37 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %reussir-elab --mode full %s | %FileCheck %s
-// RUN: %reussir-compiler %s -o %t.o
+// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o
 // RUN: %cc %t.o %S/fibonacci.c -o %t.exe
 // RUN: %t.exe
 
-// CHECK-DAG: struct _RIC6MatrixyE (aka Matrix<u64>){
-// CHECK-NEXT-DAG: m00: u64,
-// CHECK-NEXT-DAG: m01: u64,
-// CHECK-NEXT-DAG: m10: u64,
-// CHECK-NEXT-DAG: m11: u64
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RIC9fibonacciyE<u64>(n: u64) -> u64 {
-// CHECK-NEXT-DAG: let v1 (x) : _RIC6MatrixyE = compound(0.0 : u64, 1.0 : u64, 1.0 : u64, 1.0 : u64) : _RIC6MatrixyE in
-// CHECK-NEXT-DAG: let v2 (eye) : _RIC6MatrixyE = compound(1.0 : u64, 0.0 : u64, 0.0 : u64, 1.0 : u64) : _RIC6MatrixyE in
-// CHECK-NEXT-DAG: _RIC26fibonacci_logarithmic_implyE(v0, v2, v1) : u64
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RIC26fibonacci_logarithmic_implyE<u64>(n: u64, a: _RIC6MatrixyE, b: _RIC6MatrixyE) -> u64 {
-// CHECK-NEXT-DAG: if (v0 == 0.0 : u64) : bool then
-// CHECK-NEXT-DAG: v1.1 : u64
-// CHECK-NEXT-DAG: else
-// CHECK-NEXT-DAG: if ((v0 % 2.0 : u64) : u64 == 1.0 : u64) : bool then
-// CHECK-NEXT-DAG: _RIC26fibonacci_logarithmic_implyE((v0 / 2.0 : u64) : u64, _RIC6matmulyE(v1, v2) : _RIC6MatrixyE, _RIC6matmulyE(v2, v2) : _RIC6MatrixyE) : u64
-// CHECK-NEXT-DAG: else
-// CHECK-NEXT-DAG: _RIC26fibonacci_logarithmic_implyE((v0 / 2.0 : u64) : u64, v1, _RIC6matmulyE(v2, v2) : _RIC6MatrixyE) : u64
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RIC6matmulyE<u64>(a: _RIC6MatrixyE, b: _RIC6MatrixyE) -> _RIC6MatrixyE {
-// CHECK-NEXT-DAG: let v2 (m00) : u64 = ((v0.0 : u64 * v1.0 : u64) : u64 + (v0.1 : u64 * v1.2 : u64) : u64) : u64 in
-// CHECK-NEXT-DAG: let v3 (m01) : u64 = ((v0.0 : u64 * v1.1 : u64) : u64 + (v0.1 : u64 * v1.3 : u64) : u64) : u64 in
-// CHECK-NEXT-DAG: let v4 (m10) : u64 = ((v0.2 : u64 * v1.0 : u64) : u64 + (v0.3 : u64 * v1.2 : u64) : u64) : u64 in
-// CHECK-NEXT-DAG: let v5 (m11) : u64 = ((v0.2 : u64 * v1.1 : u64) : u64 + (v0.3 : u64 * v1.3 : u64) : u64) : u64 in
-// CHECK-NEXT-DAG: compound(v2, v3, v4, v5) : _RIC6MatrixyE
-// CHECK-NEXT-DAG: }
+// CHECK: record @_RIC6MatrixyE : value struct Matrix::<u64> { "m00": u64, "m01": u64, "m10": u64, "m11": u64 };
+// CHECK-EMPTY:
+// CHECK: fn @_RIC26fibonacci_logarithmic_implyE(v0 (n): u64, v1 (a): Matrix::<u64>, v2 (b): Matrix::<u64>) -> u64 {
+// CHECK-NEXT: if (v0 : u64 == 0 : u64) : bool then {
+// CHECK-NEXT: proj(v1 : Matrix::<u64>, 1) : u64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: if ((v0 : u64 % 2 : u64) : u64 == 1 : u64) : bool then {
+// CHECK-NEXT: @_RIC26fibonacci_logarithmic_implyE((v0 : u64 / 2 : u64) : u64, @_RIC6matmulyE(v1 : Matrix::<u64>, v2 : Matrix::<u64>) : Matrix::<u64>, @_RIC6matmulyE(v2 : Matrix::<u64>, v2 : Matrix::<u64>) : Matrix::<u64>) : u64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: @_RIC26fibonacci_logarithmic_implyE((v0 : u64 / 2 : u64) : u64, v1 : Matrix::<u64>, @_RIC6matmulyE(v2 : Matrix::<u64>, v2 : Matrix::<u64>) : Matrix::<u64>) : u64
+// CHECK-NEXT: } : u64
+// CHECK-NEXT: } : u64
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn @_RIC6matmulyE(v0 (a): Matrix::<u64>, v1 (b): Matrix::<u64>) -> Matrix::<u64> {
+// CHECK-NEXT: let v2 (m00) = ((proj(v0 : Matrix::<u64>, 0) : u64 * proj(v1 : Matrix::<u64>, 0) : u64) : u64 + (proj(v0 : Matrix::<u64>, 1) : u64 * proj(v1 : Matrix::<u64>, 2) : u64) : u64) : u64;
+// CHECK-NEXT: let v3 (m01) = ((proj(v0 : Matrix::<u64>, 0) : u64 * proj(v1 : Matrix::<u64>, 1) : u64) : u64 + (proj(v0 : Matrix::<u64>, 1) : u64 * proj(v1 : Matrix::<u64>, 3) : u64) : u64) : u64;
+// CHECK-NEXT: let v4 (m10) = ((proj(v0 : Matrix::<u64>, 2) : u64 * proj(v1 : Matrix::<u64>, 0) : u64) : u64 + (proj(v0 : Matrix::<u64>, 3) : u64 * proj(v1 : Matrix::<u64>, 2) : u64) : u64) : u64;
+// CHECK-NEXT: let v5 (m11) = ((proj(v0 : Matrix::<u64>, 2) : u64 * proj(v1 : Matrix::<u64>, 1) : u64) : u64 + (proj(v0 : Matrix::<u64>, 3) : u64 * proj(v1 : Matrix::<u64>, 3) : u64) : u64) : u64;
+// CHECK-NEXT: @_RIC6MatrixyE{v2 : u64, v3 : u64, v4 : u64, v5 : u64} : Matrix::<u64>
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn @_RIC9fibonacciyE(v0 (n): u64) -> u64 {
+// CHECK-NEXT: let v1 (x) = @_RIC6MatrixyE{0 : u64, 1 : u64, 1 : u64, 1 : u64} : Matrix::<u64>;
+// CHECK-NEXT: let v2 (eye) = @_RIC6MatrixyE{1 : u64, 0 : u64, 0 : u64, 1 : u64} : Matrix::<u64>;
+// CHECK-NEXT: @_RIC26fibonacci_logarithmic_implyE(v0 : u64, v2 : Matrix::<u64>, v1 : Matrix::<u64>) : u64
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: extern "C" trampoline "fibonacci_ffi" = @_RIC9fibonacciyE;
 struct [value] Matrix<T : Num> {
     m00: T, 
     m01: T,

--- a/tests/integration/frontend/fibonacci-shared.rr
+++ b/tests/integration/frontend/fibonacci-shared.rr
@@ -1,6 +1,6 @@
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
-// RUN: %reussir-compiler %s -o %t.o
+// RUN: %rrc %s -o %t.o
 // RUN: %cc %t.o %S/fibonacci.c -o %t.exe \
 // RUN:    -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
@@ -53,42 +53,43 @@ fn fibonacci<T : Integral>(n : T) -> T {
 extern "C" trampoline "fibonacci_ffi" = fibonacci<u64>;
 
 // --- MLIR ownership checks ---
-
-// matmul: both RC matrix params are dec'd before creating the result
-// CHECK-MLIR-LABEL: func.func @"_RIC6matmulyE"(%0 :
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR-NEXT:  reussir.rc.dec (%1 :
-// CHECK-MLIR:       reussir.record.compound
-// CHECK-MLIR:       reussir.rc.create
-// CHECK-MLIR:       func.return
-
-// fibonacci<u64>: no RC ops, just create matrices and call impl
-// CHECK-MLIR-LABEL: func.func @"_RIC9fibonacciyE"
-// CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR-NOT:   reussir.rc.dec
-// CHECK-MLIR:       func.return
+// rrc emits the monomorphized functions in the order: impl, matmul, fibonacci.
 
 // fibonacci_logarithmic_impl: n==0 branch decs both a and b; else branches inc b
-// CHECK-MLIR-LABEL: func.func @"_RIC26fibonacci_logarithmic_implyE"(%0 : i64, %1 :
-// n==0 true branch: borrow a, load field, dec both b and a
+// CHECK-MLIR-LABEL: func.func private @_RIC26fibonacci_logarithmic_implyE(%arg0: i64, %arg1:
+// n==0 true branch: dec b, borrow a, load field, dec a
 // CHECK-MLIR:       scf.if
-// CHECK-MLIR:       reussir.rc.dec (%2 :
-// CHECK-MLIR:       reussir.rc.borrow (%1 :
+// CHECK-MLIR:       reussir.rc.dec(%arg2 :
+// CHECK-MLIR:       reussir.rc.borrow(%arg1 :
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR-NEXT:  reussir.rc.dec (%1 :
+// CHECK-MLIR-NEXT:  reussir.rc.dec(%arg1 :
 // CHECK-MLIR:       scf.yield
 // n%2==1 branch: inc b before first matmul, inc b before second matmul
 // CHECK-MLIR:       } else {
 // CHECK-MLIR:       scf.if
-// CHECK-MLIR:       reussir.rc.inc (%2 :
-// CHECK-MLIR:       func.call @"_RIC6matmulyE"(%1, %2)
-// CHECK-MLIR:       reussir.rc.inc (%2 :
-// CHECK-MLIR:       func.call @"_RIC6matmulyE"(%2, %2)
-// CHECK-MLIR:       func.call @"_RIC26fibonacci_logarithmic_implyE"
+// CHECK-MLIR:       reussir.rc.inc(%arg2 :
+// CHECK-MLIR:       func.call @_RIC6matmulyE(%arg1, %arg2)
+// CHECK-MLIR:       reussir.rc.inc(%arg2 :
+// CHECK-MLIR:       func.call @_RIC6matmulyE(%arg2, %arg2)
+// CHECK-MLIR:       func.call @_RIC26fibonacci_logarithmic_implyE
 // CHECK-MLIR:       scf.yield
 // n%2==0 branch: inc b, matmul(b,b), pass a directly to recursive call
 // CHECK-MLIR:       } else {
-// CHECK-MLIR:       reussir.rc.inc (%2 :
-// CHECK-MLIR:       func.call @"_RIC6matmulyE"(%2, %2)
-// CHECK-MLIR:       func.call @"_RIC26fibonacci_logarithmic_implyE"({{%[0-9]+}}, %1, {{%[0-9]+}})
+// CHECK-MLIR:       reussir.rc.inc(%arg2 :
+// CHECK-MLIR:       func.call @_RIC6matmulyE(%arg2, %arg2)
+// CHECK-MLIR:       func.call @_RIC26fibonacci_logarithmic_implyE({{%[0-9]+}}, %arg1, {{%[0-9]+}})
+
+// matmul: both RC matrix params are dec'd before creating the result
+// CHECK-MLIR-LABEL: func.func private @_RIC6matmulyE(%arg0:
+// CHECK-MLIR:       reussir.rc.dec(%arg0 :
+// CHECK-MLIR:       reussir.rc.dec(%arg1 :
+// CHECK-MLIR:       reussir.record.compound
+// CHECK-MLIR:       reussir.rc.create
+// CHECK-MLIR:       return
+
+// fibonacci<u64>: no RC ops, just create matrices and call impl
+// CHECK-MLIR-LABEL: func.func private @_RIC9fibonacciyE
+// CHECK-MLIR-NOT:   reussir.rc.inc
+// CHECK-MLIR-NOT:   reussir.rc.dec
+// CHECK-MLIR:       return

--- a/tests/integration/frontend/fibonacci-struct.rr
+++ b/tests/integration/frontend/fibonacci-struct.rr
@@ -1,31 +1,28 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %reussir-elab --mode full %s | %FileCheck %s
-// RUN: %reussir-compiler %s -o %t.o
+// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o
 
-// CHECK-DAG: struct _RC6Matrix (aka Matrix){
-// CHECK-NEXT-DAG: m00: u64,
-// CHECK-NEXT-DAG: m01: u64,
-// CHECK-NEXT-DAG: m10: u64,
-// CHECK-NEXT-DAG: m11: u64
-// CHECK-NEXT-DAG: }
+// CHECK: record @_RC6Matrix : value struct Matrix { "m00": u64, "m01": u64, "m10": u64, "m11": u64 };
+// CHECK-EMPTY:
+// CHECK: fn @_RC26fibonacci_logarithmic_impl(v0 (n): u64, v1 (a): Matrix, v2 (b): Matrix) -> u64 {
+// CHECK-NEXT: if (v0 : u64 == 0 : u64) : bool then {
+// CHECK-NEXT: proj(v1 : Matrix, 1) : u64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: if ((v0 : u64 % 2 : u64) : u64 == 1 : u64) : bool then {
+// CHECK-NEXT: @_RC26fibonacci_logarithmic_impl((v0 : u64 / 2 : u64) : u64, @_RC6matmul(v1 : Matrix, v2 : Matrix) : Matrix, @_RC6matmul(v2 : Matrix, v2 : Matrix) : Matrix) : u64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: @_RC26fibonacci_logarithmic_impl((v0 : u64 / 2 : u64) : u64, v1 : Matrix, @_RC6matmul(v2 : Matrix, v2 : Matrix) : Matrix) : u64
+// CHECK-NEXT: } : u64
+// CHECK-NEXT: } : u64
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn @_RC6matmul(v0 (a): Matrix, v1 (b): Matrix) -> Matrix {
+// CHECK-NEXT: let v2 (m00) = ((proj(v0 : Matrix, 0) : u64 * proj(v1 : Matrix, 0) : u64) : u64 + (proj(v0 : Matrix, 1) : u64 * proj(v1 : Matrix, 2) : u64) : u64) : u64;
+// CHECK-NEXT: let v3 (m01) = ((proj(v0 : Matrix, 0) : u64 * proj(v1 : Matrix, 1) : u64) : u64 + (proj(v0 : Matrix, 1) : u64 * proj(v1 : Matrix, 3) : u64) : u64) : u64;
+// CHECK-NEXT: let v4 (m10) = ((proj(v0 : Matrix, 2) : u64 * proj(v1 : Matrix, 0) : u64) : u64 + (proj(v0 : Matrix, 3) : u64 * proj(v1 : Matrix, 2) : u64) : u64) : u64;
+// CHECK-NEXT: let v5 (m11) = ((proj(v0 : Matrix, 2) : u64 * proj(v1 : Matrix, 1) : u64) : u64 + (proj(v0 : Matrix, 3) : u64 * proj(v1 : Matrix, 3) : u64) : u64) : u64;
+// CHECK-NEXT: @_RC6Matrix{v2 : u64, v3 : u64, v4 : u64, v5 : u64} : Matrix
+// CHECK-NEXT: }
 
-// CHECK-DAG: fn _RC26fibonacci_logarithmic_impl(n: u64, a: _RC6Matrix, b: _RC6Matrix) -> u64 {
-// CHECK-NEXT-DAG: if (v0 == 0.0 : u64) : bool then
-// CHECK-NEXT-DAG: v1.1 : u64
-// CHECK-NEXT-DAG: else
-// CHECK-NEXT-DAG: if ((v0 % 2.0 : u64) : u64 == 1.0 : u64) : bool then
-// CHECK-NEXT-DAG: _RC26fibonacci_logarithmic_impl((v0 / 2.0 : u64) : u64, _RC6matmul(v1, v2) : _RC6Matrix, _RC6matmul(v2, v2) : _RC6Matrix) : u64
-// CHECK-NEXT-DAG: else
-// CHECK-NEXT-DAG: _RC26fibonacci_logarithmic_impl((v0 / 2.0 : u64) : u64, v1, _RC6matmul(v2, v2) : _RC6Matrix) : u64
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC6matmul(a: _RC6Matrix, b: _RC6Matrix) -> _RC6Matrix {
-// CHECK-NEXT-DAG: let v2 (m00) : u64 = ((v0.0 : u64 * v1.0 : u64) : u64 + (v0.1 : u64 * v1.2 : u64) : u64) : u64 in
-// CHECK-NEXT-DAG: let v3 (m01) : u64 = ((v0.0 : u64 * v1.1 : u64) : u64 + (v0.1 : u64 * v1.3 : u64) : u64) : u64 in
-// CHECK-NEXT-DAG: let v4 (m10) : u64 = ((v0.2 : u64 * v1.0 : u64) : u64 + (v0.3 : u64 * v1.2 : u64) : u64) : u64 in
-// CHECK-NEXT-DAG: let v5 (m11) : u64 = ((v0.2 : u64 * v1.1 : u64) : u64 + (v0.3 : u64 * v1.3 : u64) : u64) : u64 in
-// CHECK-NEXT-DAG: compound(v2, v3, v4, v5) : _RC6Matrix
-// CHECK-NEXT-DAG: }
 struct [value] Matrix {
     m00: u64, 
     m01: u64,

--- a/tests/integration/frontend/fibonacci.rr
+++ b/tests/integration/frontend/fibonacci.rr
@@ -1,40 +1,45 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %reussir-elab --mode full %s | %FileCheck %s
-// RUN: %reussir-compiler %s -o %t.o
+// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o
 // RUN: %cc %t.o %S/fibonacci.c -o %t.exe
 // RUN: %t.exe
 
-// CHECK-DAG: pub fn _RC14fibonacci_iter(n: u64) -> u64 {
-// CHECK-NEXT-DAG: _RC19fibonacci_iter_impl(v0, 0.0 : u64, 1.0 : u64) : u64
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC26fibonacci_logarithmic_impl(n: u64, a00: u64, a01: u64, a10: u64, a11: u64, b00: u64, b01: u64, b10: u64, b11: u64) -> u64 {
-// CHECK-NEXT-DAG: if (v0 == 0.0 : u64) : bool then
-// CHECK-NEXT-DAG: v2
-// CHECK-NEXT-DAG: else
-// CHECK-NEXT-DAG: if ((v0 % 2.0 : u64) : u64 == 1.0 : u64) : bool then
-// CHECK-NEXT-DAG: let v9 (na00) : u64 = ((v1 * v5) : u64 + (v2 * v7) : u64) : u64 in
-// CHECK-NEXT-DAG: let v10 (na01) : u64 = ((v1 * v6) : u64 + (v2 * v8) : u64) : u64 in
-// CHECK-NEXT-DAG: let v11 (na10) : u64 = ((v3 * v5) : u64 + (v4 * v7) : u64) : u64 in
-// CHECK-NEXT-DAG: let v12 (na11) : u64 = ((v3 * v6) : u64 + (v4 * v8) : u64) : u64 in
-// CHECK-NEXT-DAG: _RC26fibonacci_logarithmic_impl((v0 / 2.0 : u64) : u64, v9, v10, v11, v12, ((v5 * v5) : u64 + (v6 * v7) : u64) : u64, ((v5 * v6) : u64 + (v6 * v8) : u64) : u64, ((v7 * v5) : u64 + (v8 * v7) : u64) : u64, ((v7 * v6) : u64 + (v8 * v8) : u64) : u64) : u64
-// CHECK-NEXT-DAG: else
-// CHECK-NEXT-DAG: _RC26fibonacci_logarithmic_impl((v0 / 2.0 : u64) : u64, v1, v2, v3, v4, ((v5 * v5) : u64 + (v6 * v7) : u64) : u64, ((v5 * v6) : u64 + (v6 * v8) : u64) : u64, ((v7 * v5) : u64 + (v8 * v7) : u64) : u64, ((v7 * v6) : u64 + (v8 * v8) : u64) : u64) : u64
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: pub fn _RC9fibonacci(n: u64) -> u64 {
-// CHECK-NEXT-DAG: if (v0 <= 1.0 : u64) : bool then
-// CHECK-NEXT-DAG: v0
-// CHECK-NEXT-DAG: else
-// CHECK-NEXT-DAG: (_RC9fibonacci((v0 - 1.0 : u64) : u64) : u64 + _RC9fibonacci((v0 - 2.0 : u64) : u64) : u64) : u64
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC19fibonacci_iter_impl(n: u64, acc0: u64, acc1: u64) -> u64 {
-// CHECK-NEXT-DAG: if (v0 == 0.0 : u64) : bool then
-// CHECK-NEXT-DAG: v1
-// CHECK-NEXT-DAG: else
-// CHECK-NEXT-DAG: _RC19fibonacci_iter_impl((v0 - 1.0 : u64) : u64, v2, (v1 + v2) : u64) : u64
-// CHECK-NEXT-DAG: }
+// CHECK: pub fn @_RC14fibonacci_iter(v0 (n): u64) -> u64 {
+// CHECK-NEXT: @_RC19fibonacci_iter_impl(v0 : u64, 0 : u64, 1 : u64) : u64
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn @_RC19fibonacci_iter_impl(v0 (n): u64, v1 (acc0): u64, v2 (acc1): u64) -> u64 {
+// CHECK-NEXT: if (v0 : u64 == 0 : u64) : bool then {
+// CHECK-NEXT: v1 : u64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: @_RC19fibonacci_iter_impl((v0 : u64 - 1 : u64) : u64, v2 : u64, (v1 : u64 + v2 : u64) : u64) : u64
+// CHECK-NEXT: } : u64
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn @_RC26fibonacci_logarithmic_impl(v0 (n): u64, v1 (a00): u64, v2 (a01): u64, v3 (a10): u64, v4 (a11): u64, v5 (b00): u64, v6 (b01): u64, v7 (b10): u64, v8 (b11): u64) -> u64 {
+// CHECK-NEXT: if (v0 : u64 == 0 : u64) : bool then {
+// CHECK-NEXT: v2 : u64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: if ((v0 : u64 % 2 : u64) : u64 == 1 : u64) : bool then {
+// CHECK-NEXT: let v9 (na00) = ((v1 : u64 * v5 : u64) : u64 + (v2 : u64 * v7 : u64) : u64) : u64;
+// CHECK-NEXT: let v10 (na01) = ((v1 : u64 * v6 : u64) : u64 + (v2 : u64 * v8 : u64) : u64) : u64;
+// CHECK-NEXT: let v11 (na10) = ((v3 : u64 * v5 : u64) : u64 + (v4 : u64 * v7 : u64) : u64) : u64;
+// CHECK-NEXT: let v12 (na11) = ((v3 : u64 * v6 : u64) : u64 + (v4 : u64 * v8 : u64) : u64) : u64;
+// CHECK-NEXT: @_RC26fibonacci_logarithmic_impl((v0 : u64 / 2 : u64) : u64, v9 : u64, v10 : u64, v11 : u64, v12 : u64, ((v5 : u64 * v5 : u64) : u64 + (v6 : u64 * v7 : u64) : u64) : u64, ((v5 : u64 * v6 : u64) : u64 + (v6 : u64 * v8 : u64) : u64) : u64, ((v7 : u64 * v5 : u64) : u64 + (v8 : u64 * v7 : u64) : u64) : u64, ((v7 : u64 * v6 : u64) : u64 + (v8 : u64 * v8 : u64) : u64) : u64) : u64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: @_RC26fibonacci_logarithmic_impl((v0 : u64 / 2 : u64) : u64, v1 : u64, v2 : u64, v3 : u64, v4 : u64, ((v5 : u64 * v5 : u64) : u64 + (v6 : u64 * v7 : u64) : u64) : u64, ((v5 : u64 * v6 : u64) : u64 + (v6 : u64 * v8 : u64) : u64) : u64, ((v7 : u64 * v5 : u64) : u64 + (v8 : u64 * v7 : u64) : u64) : u64, ((v7 : u64 * v6 : u64) : u64 + (v8 : u64 * v8 : u64) : u64) : u64) : u64
+// CHECK-NEXT: } : u64
+// CHECK-NEXT: } : u64
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: pub fn @_RC9fibonacci(v0 (n): u64) -> u64 {
+// CHECK-NEXT: if (v0 : u64 <= 1 : u64) : bool then {
+// CHECK-NEXT: v0 : u64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: (@_RC9fibonacci((v0 : u64 - 1 : u64) : u64) : u64 + @_RC9fibonacci((v0 : u64 - 2 : u64) : u64) : u64) : u64
+// CHECK-NEXT: } : u64
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: extern "C" trampoline "fibonacci_ffi" = @_RC9fibonacci;
 pub fn fibonacci(n: u64) -> u64 {
     if n <= 1 {
         n

--- a/tests/integration/frontend/huge_value_struct_call_and_return.rr
+++ b/tests/integration/frontend/huge_value_struct_call_and_return.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o
+// RUN: %rrc %s -o %t.o
 // RUN: %cc %t.o %S/huge_value_struct_call_and_return.c -o %t.exe
 // RUN: %t.exe
 

--- a/tests/integration/frontend/nbe-hoas.rr
+++ b/tests/integration/frontend/nbe-hoas.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %rrc %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
 // RUN: %cc %t.o %S/nbe.rr.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 enum Term {

--- a/tests/integration/frontend/nbe.rr
+++ b/tests/integration/frontend/nbe.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %rrc %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
 // RUN: %cc %t.o %S/nbe.rr.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 

--- a/tests/integration/frontend/projection.rr
+++ b/tests/integration/frontend/projection.rr
@@ -1,63 +1,40 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %reussir-elab --mode full %s | %FileCheck %s
-// RUN: %reussir-compiler %s -o %t.o
+// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o
 
-// CHECK-DAG: struct _RIC3BoxIC3BoxmEE (aka Box<Box<u32>>){
-// CHECK-NEXT-DAG: val: _RIC3BoxmE
-// CHECK-NEXT-DAG: }
+// CHECK: record @_RIC3BoxIC3BoxmEE : value struct Box::<Box::<u32>> { "val": Box::<u32> };
+// CHECK-EMPTY:
+// CHECK: record @_RIC3BoxIC5RcBoxIC5RcBoxIC5RcBoxIC3BoxIC3BoxmEEEEEE : value struct Box::<RcBox::<RcBox::<RcBox::<Box::<Box::<u32>>>>>> { "val": RcBox::<RcBox::<RcBox::<Box::<Box::<u32>>>>> };
+// CHECK-EMPTY:
+// CHECK: record @_RIC3BoxmE : value struct Box::<u32> { "val": u32 };
+// CHECK-EMPTY:
+// CHECK: record @_RIC5RcBoxIC3BoxIC3BoxmEEE : shared struct RcBox::<Box::<Box::<u32>>> { "val": Box::<Box::<u32>> };
+// CHECK-EMPTY:
+// CHECK: record @_RIC5RcBoxIC5RcBoxIC3BoxIC3BoxmEEEE : shared struct RcBox::<RcBox::<Box::<Box::<u32>>>> { "val": RcBox::<Box::<Box::<u32>>> };
+// CHECK-EMPTY:
+// CHECK: record @_RIC5RcBoxIC5RcBoxIC5RcBoxIC3BoxIC3BoxmEEEEE : shared struct RcBox::<RcBox::<RcBox::<Box::<Box::<u32>>>>> { "val": RcBox::<RcBox::<Box::<Box::<u32>>>> };
+// CHECK-EMPTY:
+// CHECK: record @_RIC5RcBoxIC5RcBoxIC5RcBoxmEEE : shared struct RcBox::<RcBox::<RcBox::<u32>>> { "val": RcBox::<RcBox::<u32>> };
+// CHECK-EMPTY:
+// CHECK: record @_RIC5RcBoxIC5RcBoxmEE : shared struct RcBox::<RcBox::<u32>> { "val": RcBox::<u32> };
+// CHECK-EMPTY:
+// CHECK: record @_RIC5RcBoxmE : shared struct RcBox::<u32> { "val": u32 };
+// CHECK-EMPTY:
+// CHECK: pub fn @_RC10rc_project(v0 (rc): RcBox::<u32>) -> u32 {
+// CHECK-NEXT: proj(v0 : RcBox::<u32>, 0) : u32
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: pub fn @_RC11mixed_chain(v0 (rc): Box::<RcBox::<RcBox::<RcBox::<Box::<Box::<u32>>>>>>) -> u32 {
+// CHECK-NEXT: proj(v0 : Box::<RcBox::<RcBox::<RcBox::<Box::<Box::<u32>>>>>>, 0, 0, 0, 0, 0, 0) : u32
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: pub fn @_RC18rc_project_chained(v0 (rc): RcBox::<RcBox::<u32>>) -> u32 {
+// CHECK-NEXT: proj(v0 : RcBox::<RcBox::<u32>>, 0, 0) : u32
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: pub fn @_RC20rc_project_chained_2(v0 (rc): RcBox::<RcBox::<RcBox::<u32>>>) -> u32 {
+// CHECK-NEXT: proj(v0 : RcBox::<RcBox::<RcBox::<u32>>>, 0, 0, 0) : u32
+// CHECK-NEXT: }
 
-// CHECK-DAG: struct _RIC5RcBoxmE (aka RcBox<u32>){
-// CHECK-NEXT-DAG: val: u32
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: struct _RC5Point (aka Point){
-// CHECK-NEXT-DAG: x: u64,
-// CHECK-NEXT-DAG: y: u64
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: struct _RIC3BoxIC5RcBoxIC5RcBoxIC5RcBoxIC3BoxIC3BoxmEEEEEE (aka Box<RcBox<RcBox<RcBox<Box<Box<u32>>>>>>){
-// CHECK-NEXT-DAG: val: _RIC5RcBoxIC5RcBoxIC5RcBoxIC3BoxIC3BoxmEEEEE
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: struct _RIC3BoxmE (aka Box<u32>){
-// CHECK-NEXT-DAG: val: u32
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: struct _RIC5RcBoxIC5RcBoxIC5RcBoxIC3BoxIC3BoxmEEEEE (aka RcBox<RcBox<RcBox<Box<Box<u32>>>>>){
-// CHECK-NEXT-DAG: val: _RIC5RcBoxIC5RcBoxIC3BoxIC3BoxmEEEE
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: struct _RIC5RcBoxIC5RcBoxIC3BoxIC3BoxmEEEE (aka RcBox<RcBox<Box<Box<u32>>>>){
-// CHECK-NEXT-DAG: val: _RIC5RcBoxIC3BoxIC3BoxmEEE
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: struct _RIC5RcBoxIC3BoxIC3BoxmEEE (aka RcBox<Box<Box<u32>>>){
-// CHECK-NEXT-DAG: val: _RIC3BoxIC3BoxmEE
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: struct _RIC5RcBoxIC5RcBoxIC5RcBoxmEEE (aka RcBox<RcBox<RcBox<u32>>>){
-// CHECK-NEXT-DAG: val: _RIC5RcBoxIC5RcBoxmEE
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: struct _RIC5RcBoxIC5RcBoxmEE (aka RcBox<RcBox<u32>>){
-// CHECK-NEXT-DAG: val: _RIC5RcBoxmE
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: pub fn _RC18rc_project_chained(rc: Rc<_RIC5RcBoxIC5RcBoxmEE, Shared>) -> u32 {
-// CHECK-NEXT-DAG: v0.0.0 : u32
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: pub fn _RC20rc_project_chained_2(rc: Rc<_RIC5RcBoxIC5RcBoxIC5RcBoxmEEE, Shared>) -> u32 {
-// CHECK-NEXT-DAG: v0.0.0.0 : u32
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: pub fn _RC11mixed_chain(rc: _RIC3BoxIC5RcBoxIC5RcBoxIC5RcBoxIC3BoxIC3BoxmEEEEEE) -> u32 {
-// CHECK-NEXT-DAG: v0.0.0.0.0.0.0 : u32
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: pub fn _RC10rc_project(rc: Rc<_RIC5RcBoxmE, Shared>) -> u32 {
-// CHECK-NEXT-DAG: v0.0 : u32
-// CHECK-NEXT-DAG: }
 struct [value] Point {
     x : u64,
     y : u64

--- a/tests/integration/frontend/rbtree-zipper.rr
+++ b/tests/integration/frontend/rbtree-zipper.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %rrc %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
 // RUN: %cc %t.o %S/rbtree2.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 

--- a/tests/integration/frontend/region.rr
+++ b/tests/integration/frontend/region.rr
@@ -1,27 +1,25 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %reussir-elab --mode full %s | %FileCheck %s
-// RUN: %reussir-compiler %s -o %t.o
+// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o
 
-// CHECK-DAG: struct _RIC4CellyE (aka Cell<u64>){
-// CHECK-NEXT-DAG: value: u64
-// CHECK-NEXT-DAG: }
+// CHECK: record @_RIC4CellyE : regional struct Cell::<u64> { "value": u64 };
+// CHECK-EMPTY:
+// CHECK: fn @_RC11freeze_cell() -> [rigid] Cell::<u64> {
+// CHECK-NEXT: region { @_RIC4CellyE{1 : u64} : [flex] Cell::<u64> } : [rigid] Cell::<u64>
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: regional fn @_RC17regional_function(v0 (x): u64) -> [flex] Cell::<u64> {
+// CHECK-NEXT: @_RIC4CellyE{v0 : u64} : [flex] Cell::<u64>
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn @_RC25freeze_cell_with_let_expr() -> [rigid] Cell::<u64> {
+// CHECK-NEXT: region { { let v0 (x) = regional @_RC17regional_function(42 : u64) : [flex] Cell::<u64>;
+// CHECK-NEXT: v0 : [flex] Cell::<u64> } } : [rigid] Cell::<u64>
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn @_RC7trivial() -> u64 {
+// CHECK-NEXT: region { 1 : u64 } : u64
+// CHECK-NEXT: }
 
-// CHECK-DAG: regional fn _RC17regional_function(x: u64) -> Rc<_RIC4CellyE, Flex> {
-// CHECK-NEXT-DAG: rc_wrap(compound(v0) : _RIC4CellyE) : Rc<_RIC4CellyE, Flex>
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC25freeze_cell_with_let_expr() -> Rc<_RIC4CellyE, Rigid> {
-// CHECK-NEXT-DAG: run_region{let v0 (x) : Rc<_RIC4CellyE, Flex> = _RC17regional_function[regional](42.0 : u64) : Rc<_RIC4CellyE, Flex> in
-// CHECK-NEXT-DAG: v0} : Rc<_RIC4CellyE, Rigid>
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC7trivial() -> u64 {
-// CHECK-NEXT-DAG: run_region{1.0 : u64} : u64
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC11freeze_cell() -> Rc<_RIC4CellyE, Rigid> {
-// CHECK-NEXT-DAG: run_region{rc_wrap(compound(1.0 : u64) : _RIC4CellyE) : Rc<_RIC4CellyE, Flex>} : Rc<_RIC4CellyE, Rigid>
-// CHECK-NEXT-DAG: }
 fn trivial() -> u64 {
     regional {
         1

--- a/tests/integration/frontend/vapp.rr
+++ b/tests/integration/frontend/vapp.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %rrc %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
 // RUN: %cc %t.o %S/vapp.rr.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 

--- a/tests/integration/frontend/variant.rr
+++ b/tests/integration/frontend/variant.rr
@@ -1,42 +1,22 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %reussir-elab --mode full %s | %FileCheck %s
-// RUN: %reussir-compiler %s -o %t.o
+// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o
 
-// CHECK-DAG: enum _RIC6OptionlE (aka Option<i32>){
-// CHECK-NEXT-DAG: _RINvC6Option4SomelE,
-// CHECK-NEXT-DAG: _RINvC6Option4NonelE
-// CHECK-NEXT-DAG: }
+// CHECK: record @_RIC6OptionlE : value enum Option::<i32> { @_RNvIC6OptionlE4Some Some(i32), @_RNvIC6OptionlE4None None() };
+// CHECK-EMPTY:
+// CHECK: record @_RIC8RcOptionlE : shared enum RcOption::<i32> { @_RNvIC8RcOptionlE4Some Some(i32), @_RNvIC8RcOptionlE4None None() };
+// CHECK-EMPTY:
+// CHECK: fn @_RC3bar() -> RcOption::<i32> {
+// CHECK-NEXT: @_RIC8RcOptionlE::#1() : RcOption::<i32>
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn @_RC3baz() -> RcOption::<i32> {
+// CHECK-NEXT: @_RIC8RcOptionlE::#0(1 : i32) : RcOption::<i32>
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn @_RC3foo() -> Option::<i32> {
+// CHECK-NEXT: @_RIC6OptionlE::#1() : Option::<i32>
+// CHECK-NEXT: }
 
-// CHECK-DAG: enum_variant _RINvC6Option4SomelE (aka Option::Some<i32>){
-// CHECK-NEXT-DAG: [0]: i32
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: enum _RIC8RcOptionlE (aka RcOption<i32>){
-// CHECK-NEXT-DAG: _RINvC8RcOption4SomelE,
-// CHECK-NEXT-DAG: _RINvC8RcOption4NonelE
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: enum_variant _RINvC6Option4NonelE (aka Option::None<i32>){
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: enum_variant _RINvC8RcOption4SomelE (aka RcOption::Some<i32>){
-// CHECK-NEXT-DAG: [0]: i32
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: enum_variant _RINvC8RcOption4NonelE (aka RcOption::None<i32>){
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC3baz() -> Rc<_RIC8RcOptionlE, Shared> {
-// CHECK-NEXT-DAG: rc_wrap(variant[0](compound(1.0 : i32) : _RINvC8RcOption4SomelE) : _RIC8RcOptionlE) : Rc<_RIC8RcOptionlE, Shared>
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC3foo() -> _RIC6OptionlE {
-// CHECK-NEXT-DAG: variant[1](compound() : _RINvC6Option4NonelE) : _RIC6OptionlE
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC3bar() -> Rc<_RIC8RcOptionlE, Shared> {
-// CHECK-NEXT-DAG: rc_wrap(variant[1](compound() : _RINvC8RcOption4NonelE) : _RIC8RcOptionlE) : Rc<_RIC8RcOptionlE, Shared>
-// CHECK-NEXT-DAG: }
 enum [value] Option<T> {
     Some(T),
     None


### PR DESCRIPTION
Moves the frontend lit tests that `rrc` can now fully handle off the legacy `%reussir-compiler`/`%reussir-elab` binaries onto `%rrc`. Part of the ongoing Haskell→Rust frontend migration (#290).

### Pure e2e (compile → link `.c` harness → run) — mechanical driver swap
`huge_value_struct_call_and_return`, `rbtree-zipper`, `nbe`, `nbe-hoas`, `vapp`, `closure_struct_materialize`.

`closure_struct_materialize` is the one that was blocked on the closure-call-by-name (#300) and inc-dec-cancellation (#302) fixes — it now runs correctly (returns 42) at every opt level.

### MIR-dump checks + compile/e2e
`fibonacci`, `fibonacci-generic`, `fibonacci-struct`, `variant`, `projection`, `region`.

The old `%reussir-elab --mode full | FileCheck` blocks are re-transcribed to rrc's `--emit mir` spelling (`@`-prefixed monomorphized symbols, `vN (name)` params, `proj(..)` projections, arbitrary-precision integer literals — no `.0` on `u64` literals). The redundant `--mode semi` smoke line is dropped (the `-o %t.o` compile already exercises elaboration).

`fibonacci-shared` additionally ports its structural `CHECK-MLIR` ownership block (dec-before-create, inc-before-each-matmul, borrow/project/load) to rrc's op spelling and emission order (impl → matmul → fibonacci).

### Not migrated
The `module_*` tests stay on the Haskell driver — `rrc` takes a single `<INPUT>` file and has no `--package-root`/`--package-name` yet (tracked in #290).

### Verification
All 13 migrated tests pass under lit against the freshly-built `rrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)