### PR TITLE
[tests] migrate MLIR-check + TRMC + closure-HIR frontend tests to rrc

### DIFF
--- a/tests/integration/frontend/closure.rr
+++ b/tests/integration/frontend/closure.rr
@@ -1,34 +1,38 @@
-// RUN: %reussir-elab --mode semi %s | %FileCheck %s
+// RUN: %rrc %s --emit hir -o - | %FileCheck %s
 
-// CHECK-DAG: fn test(v0 (x): (i32) -> i32) -> i32 {
-// CHECK-NEXT-DAG:     closure_call(v0, 1.0 : i32) : i32
-// CHECK-NEXT-DAG: }
+// CHECK: fn #test(v0 (x): (i32) -> i32) -> i32 {
+// CHECK-NEXT: apply(v0 : (i32) -> i32, 1 : i32) : i32
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn #test2(v0 (x): (i32, i32) -> i32) -> i32 {
+// CHECK-NEXT: apply(v0 : (i32, i32) -> i32, 1 : i32, 2 : i32) : i32
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn #partial(v0 (x): (i32, bool) -> i32) -> (bool) -> i32 {
+// CHECK-NEXT: apply(v0 : (i32, bool) -> i32, 1 : i32) : (bool) -> i32
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK: fn #abstract() -> (bool) -> u64 {
+// CHECK-NEXT: let v0 (u) = 1 : u64;
+// CHECK-NEXT: closure[v0: u64](v1: bool) { if v1 : bool then {
+// CHECK-NEXT: 0 : u64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: v0 : u64
+// CHECK-NEXT: } : u64 } : (bool) -> u64
+// CHECK-NEXT: }
+
 fn test(x : i32 -> i32) -> i32 {
     x(1)
 }
 
-// CHECK-DAG: fn test2(v0 (x): (i32, i32) -> i32) -> i32 {
-// CHECK-NEXT-DAG:     closure_call(v0, 1.0 : i32, 2.0 : i32) : i32
-// CHECK-NEXT-DAG: }
 fn test2(x : (i32, i32) -> i32) -> i32 {
     x(1, 2)
 }
 
-// CHECK-DAG: fn partial(v0 (x): (i32, bool) -> i32) -> (bool) -> i32 {
-// CHECK-NEXT-DAG:     closure_call(v0, 1.0 : i32) : (bool) -> i32
-// CHECK-NEXT-DAG: }
 fn partial(x : (i32, bool) -> i32) -> bool -> i32 {
     x(1)
 }
 
-// CHECK-DAG: fn abstract() -> (bool) -> u64 {
-// CHECK-NEXT-DAG:     {
-// CHECK-NEXT-DAG:         let v0 (u) : u64 = 1.0 : u64;
-// CHECK-NEXT-DAG:         closure[v0 : u64](v1 : bool) {
-// CHECK-NEXT-DAG:             if v1 then 0.0 : u64 else v0
-// CHECK-NEXT-DAG:         } : (bool) -> u64
-// CHECK-NEXT-DAG:     }
-// CHECK-NEXT-DAG: }
 fn abstract() -> bool -> u64 {
     let u = 1;
     |x| if (x) { 0 } else { u }

--- a/tests/integration/frontend/list_append.rr
+++ b/tests/integration/frontend/list_append.rr
@@ -1,5 +1,4 @@
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
-// RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
+// RUN: %rrc %s --emit mlir -o - | %FileCheck %s --check-prefix=CHECK-MLIR
 enum List<T> {
     Nil,
     Cons(T, List<T>)
@@ -17,22 +16,22 @@ fn append(a : List<i32>, b : List<i32>) -> List<i32> {
 
 // --- MLIR ownership checks ---
 // append(%0=a, %1=b): consuming first list, passing through second
-// CHECK-MLIR-LABEL: func.func @"_RC6append"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// CHECK-MLIR-LABEL: func.func private @_RC6append(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0 :
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec a, yield b (ownership of b transfers to caller)
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       reussir.scf.yield %1 :
-// Cons(x, xs): load xs, inc xs, load x, dec a, build Cons{x, append(xs, b)}
+// CHECK-MLIR:       reussir.rc.dec(%arg0 :
+// CHECK-MLIR:       reussir.scf.yield %arg1 :
+// Cons(x, xs): load x, load xs, inc xs, dec a, build Cons{x, append(xs, b)}
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       func.call @"_RC6append"
+// CHECK-MLIR:       reussir.rc.inc
+// CHECK-MLIR:       reussir.rc.dec(%arg0 :
+// CHECK-MLIR:       call @_RC6append
 // CHECK-MLIR:       reussir.record.compound
 // CHECK-MLIR:       reussir.record.variant
 // CHECK-MLIR:       reussir.rc.create

--- a/tests/integration/frontend/list_empty.rr
+++ b/tests/integration/frontend/list_empty.rr
@@ -1,5 +1,5 @@
-// RUN: %reussir-elab --mode semi %s | %FileCheck %s
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum List<T> {
     Nil,
@@ -20,65 +20,55 @@ pub fn empty2(list : List<i32>) -> bool {
     }
 }
 
-// CHECK:      ;; Instantiated Generics
-// CHECK-NEXT: Generic @0 should be instantiated to:
-// CHECK-NEXT: i32
-// CHECK:      ;; Elaborated Records
-// CHECK-NEXT: enum [shared] List<T@0>{
-// CHECK-NEXT:     Nil,
-// CHECK-NEXT:     Cons
-// CHECK-NEXT: }
-// CHECK:      enum_variant [value] List::Nil<T@0>()
-// CHECK:      enum_variant [value] List::Cons<T@0>(T0, List<T0>)
-// CHECK:      ;; Elaborated Functions
-// CHECK-NEXT: pub fn empty2(v0 (list): List<i32>) -> bool {
-// CHECK-NEXT:     match v0 {
-// CHECK-NEXT:         switch (0) {
-// CHECK-NEXT:             ctor@0 => {
-// CHECK-NEXT:                 1.0 : bool
+// CHECK:      [shared] enum #List<$0> { Nil(), Cons($0, #List::<$0>) };
+// CHECK:      pub fn #empty1(v0 (list): #List::<i32>) -> bool {
+// CHECK-NEXT:     match v0 : #List::<i32> {
+// CHECK-NEXT:         switch scrut {
+// CHECK-NEXT:             #0 => {
+// CHECK-NEXT:                 => true : bool
 // CHECK-NEXT:             }
-// CHECK-NEXT:             ctor@1 => {
-// CHECK-NEXT:                 0.0 : bool
+// CHECK-NEXT:             #1 => {
+// CHECK-NEXT:                 => false : bool
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } : bool
 // CHECK-NEXT: }
-// CHECK:      pub fn empty1(v0 (list): List<i32>) -> bool {
-// CHECK-NEXT:     match v0 {
-// CHECK-NEXT:         switch (0) {
-// CHECK-NEXT:             ctor@0 => {
-// CHECK-NEXT:                 1.0 : bool
+// CHECK:      pub fn #empty2(v0 (list): #List::<i32>) -> bool {
+// CHECK-NEXT:     match v0 : #List::<i32> {
+// CHECK-NEXT:         switch scrut {
+// CHECK-NEXT:             #0 => {
+// CHECK-NEXT:                 => true : bool
 // CHECK-NEXT:             }
-// CHECK-NEXT:             ctor@1 => {
-// CHECK-NEXT:                 0.0 : bool
+// CHECK-NEXT:             #1 => {
+// CHECK-NEXT:                 => false : bool
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } : bool
 // CHECK-NEXT: }
 
 // --- MLIR ownership checks: both branches dec the list, no inc needed ---
 // empty1: match with wildcard
-// CHECK-MLIR-LABEL: func.func @"_RC6empty1"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// CHECK-MLIR-LABEL: func.func @_RC6empty1(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec scrutinee, yield true
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       arith.constant 1 : i1
+// CHECK-MLIR:       reussir.rc.dec(%arg0
+// CHECK-MLIR:       arith.constant true
 // Cons: dec scrutinee, yield false (no pattern bindings extracted)
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       arith.constant 0 : i1
+// CHECK-MLIR:       reussir.rc.dec(%arg0
+// CHECK-MLIR:       arith.constant false
 
 // empty2: match with explicit Cons(..)
-// CHECK-MLIR-LABEL: func.func @"_RC6empty2"(%0 :
+// CHECK-MLIR-LABEL: func.func @_RC6empty2(%arg0
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec, yield true
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.dec(%arg0
 // Cons: dec, yield false (no pattern bindings extracted)
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       arith.constant 0 : i1
+// CHECK-MLIR:       reussir.rc.dec(%arg0
+// CHECK-MLIR:       arith.constant false

--- a/tests/integration/frontend/list_inc1.rr
+++ b/tests/integration/frontend/list_inc1.rr
@@ -1,5 +1,5 @@
-// RUN: %reussir-compiler %s -t llvm-ir -o %t.ll --opt-level aggressive
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit llvm-ir -o %t.ll -O aggressive
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %reussir-opt %t.mlir \
 // RUN:   --reussir-rc-create-fusion \
 // RUN:   --reussir-trmc-recursion-analysis | %FileCheck %s --check-prefix=CHECK-TRMC
@@ -15,7 +15,7 @@ fn inc1(list : List<i32>) -> List<i32> {
     }
 }
 
-// CHECK-TRMC-LABEL: func.func @_RC4inc1(
+// CHECK-TRMC-LABEL: func.func private @_RC4inc1(
 // CHECK-TRMC: %[[NEW:.+]], %[[TAILHOLE:.+]] = "reussir.rc.create_variant"(%{{.+}}, %{{.+}}) <{holeFields = array<i64: 1>
 // CHECK-TRMC: func.call @_RC4inc1.trmc(%{{.+}}, %[[TAILHOLE]]) : (!reussir.rc<!reussir.record<variant
 // CHECK-TRMC: scf.yield %[[NEW]] : !reussir.rc<!reussir.record<variant

--- a/tests/integration/frontend/list_length.rr
+++ b/tests/integration/frontend/list_length.rr
@@ -1,5 +1,4 @@
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
-// RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
+// RUN: %rrc %s --emit mlir -o - | %FileCheck %s --check-prefix=CHECK-MLIR
 enum List<T> {
     Nil,
     Cons(T, List<T>)
@@ -17,12 +16,12 @@ fn length(list : List<i32>) -> i32 {
 
 // --- MLIR ownership checks ---
 // length(%0=list): consuming structural traversal
-// CHECK-MLIR-LABEL: func.func @"_RC6length"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// CHECK-MLIR-LABEL: func.func private @_RC6length(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0 :
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec list, yield 0
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.dec(%arg0 :
 // CHECK-MLIR:       arith.constant 0 : i32
 // CHECK-MLIR:       reussir.scf.yield
 // Cons(_, xs): load xs (RC), inc xs, dec list, recurse
@@ -30,5 +29,5 @@ fn length(list : List<i32>) -> i32 {
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       func.call @"_RC6length"
+// CHECK-MLIR:       reussir.rc.dec(%arg0 :
+// CHECK-MLIR:       call @_RC6length

--- a/tests/integration/frontend/list_nth.rr
+++ b/tests/integration/frontend/list_nth.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum List<T> {
     Nil,
@@ -28,26 +28,26 @@ fn nth(list : List<i32>, n : i32) -> Option<i32> {
 
 // --- MLIR ownership checks ---
 // nth(%0=list, %1=n): consuming traversal with index
-// CHECK-MLIR-LABEL: func.func @"_RC3nth"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// CHECK-MLIR-LABEL: func.func private @_RC3nth(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec list, return None
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       reussir.record.compound
 // CHECK-MLIR:       reussir.record.variant
-// Cons(x, xs): extract fields, check index
+// Cons(x, xs): extract fields (head then tail), inc tail, dec list, check index
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.inc
+// CHECK-MLIR:       reussir.rc.dec(%arg0
 // n==0 branch: dec xs, return Some(x)
 // CHECK-MLIR:       reussir.rc.dec
 // CHECK-MLIR:       reussir.record.compound
 // CHECK-MLIR:       reussir.record.variant
 // CHECK-MLIR:       reussir.rc.create
 // n!=0 branch: recurse with xs and n-1
-// CHECK-MLIR:       func.call @"_RC3nth"
+// CHECK-MLIR:       call @_RC3nth

--- a/tests/integration/frontend/list_reverse.rr
+++ b/tests/integration/frontend/list_reverse.rr
@@ -1,5 +1,5 @@
-// RUN: %reussir-elab --mode semi %s | %FileCheck %s
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum List<T> {
     Nil,
@@ -17,59 +17,47 @@ pub fn reverse(list : List<i32>) -> List<i32> {
     reverse_impl(list, List::Nil {})
 }
 
-// CHECK:      ;; Instantiated Generics
-// CHECK-NEXT: Generic @0 should be instantiated to:
-// CHECK-NEXT: i32
-// CHECK:      ;; Elaborated Records
-// CHECK-NEXT: enum [shared] List<T@0>{
-// CHECK-NEXT:     Nil,
-// CHECK-NEXT:     Cons
-// CHECK-NEXT: }
-// CHECK:      enum_variant [value] List::Nil<T@0>()
-// CHECK:      enum_variant [value] List::Cons<T@0>(T0, List<T0>)
-// CHECK:      ;; Elaborated Functions
-// CHECK-NEXT: fn reverse_impl(v0 (list): List<i32>, v1 (acc): List<i32>) -> List<i32> {
-// CHECK-NEXT:     match v0 {
-// CHECK-NEXT:         switch (0) {
-// CHECK-NEXT:             ctor@0 => {
-// CHECK-NEXT:                 v1
+// CHECK:      [shared] enum #List<$0> { Nil(), Cons($0, #List::<$0>) };
+// CHECK:      fn #reverse_impl(v0 (list): #List::<i32>, v1 (acc): #List::<i32>) -> #List::<i32> {
+// CHECK-NEXT:     match v0 : #List::<i32> {
+// CHECK-NEXT:         switch scrut {
+// CHECK-NEXT:             #0 => {
+// CHECK-NEXT:                 => v1 : #List::<i32>
 // CHECK-NEXT:             }
-// CHECK-NEXT:             ctor@1 => {
-// CHECK-NEXT:                 pattern var v2 (0, 1)
-// CHECK-NEXT:                 pattern var v3 (0, 0)
-// CHECK-NEXT:                 reverse_impl(v2, List<i32>[1](List::Cons<i32>(v3, v1) : List::Cons<i32>) : List<i32>) : List<i32>
+// CHECK-NEXT:             #1 => {
+// CHECK-NEXT:                 v2=scrut.0 v3=scrut.1 => #reverse_impl(v3 : #List::<i32>, #List::<i32>#1(v2 : i32, v1 : #List::<i32>) : #List::<i32>) : #List::<i32>
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
-// CHECK:      pub fn reverse(v0 (list): List<i32>) -> List<i32> {
-// CHECK-NEXT:     reverse_impl(v0, List<i32>[0](List::Nil<i32>() : List::Nil<i32>) : List<i32>) : List<i32>
+// CHECK:      pub fn #reverse(v0 (list): #List::<i32>) -> #List::<i32> {
+// CHECK-NEXT:     #reverse_impl(v0 : #List::<i32>, #List::<i32>#0() : #List::<i32>) : #List::<i32>
 // CHECK-NEXT: }
 
 // --- MLIR ownership checks for reverse_impl ---
 // reverse_impl(%0=list, %1=acc): match on list via borrow+dispatch
-// CHECK-MLIR-LABEL: func.func @"_RC12reverse_impl"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// CHECK-MLIR-LABEL: func.func private @_RC12reverse_impl(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil branch: dec scrutinee (list), yield acc
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       reussir.scf.yield %1 :
-// Cons branch: load tail (xs), inc xs, load head (x), dec scrutinee, build new cons, call
+// CHECK-MLIR:       reussir.rc.dec(%arg0
+// CHECK-MLIR:       reussir.scf.yield %arg1 :
+// Cons branch: load head (x) then tail (xs), inc xs, dec scrutinee, build new cons, call
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.inc
+// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       reussir.record.compound
 // CHECK-MLIR:       reussir.record.variant
 // CHECK-MLIR:       reussir.rc.create
-// CHECK-MLIR:       func.call @"_RC12reverse_impl"
+// CHECK-MLIR:       call @_RC12reverse_impl
 
 // reverse: no RC ops, just create Nil and call reverse_impl
-// CHECK-MLIR-LABEL: func.func @"_RC7reverse"
+// CHECK-MLIR-LABEL: func.func @_RC7reverse
 // CHECK-MLIR-NOT:   reussir.rc.inc
 // CHECK-MLIR-NOT:   reussir.rc.dec
-// CHECK-MLIR:       func.return
+// CHECK-MLIR:       return

--- a/tests/integration/frontend/list_sum.rr
+++ b/tests/integration/frontend/list_sum.rr
@@ -1,5 +1,4 @@
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
-// RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
+// RUN: %rrc %s --emit mlir -o - | %FileCheck %s --check-prefix=CHECK-MLIR
 enum List<T> {
     Nil,
     Cons(T, List<T>)
@@ -16,20 +15,20 @@ fn sum(list : List<i32>) -> i32 {
 
 // --- MLIR ownership checks ---
 // sum(%0=list): consuming traversal returning primitive
-// CHECK-MLIR-LABEL: func.func @"_RC3sum"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// CHECK-MLIR-LABEL: func.func private @_RC3sum(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0 :
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec list, yield 0
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.dec(%arg0 :
 // CHECK-MLIR:       arith.constant 0 : i32
 // CHECK-MLIR:       reussir.scf.yield
-// Cons: load xs (RC), inc xs, load x (i32), dec list, recurse
+// Cons: load x (i32), load xs (RC), inc xs, dec list, recurse
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       func.call @"_RC3sum"
+// CHECK-MLIR:       reussir.rc.inc
+// CHECK-MLIR:       reussir.rc.dec(%arg0 :
+// CHECK-MLIR:       call @_RC3sum

--- a/tests/integration/frontend/match_ctor_reconcile_keep_scrut_dec.rr
+++ b/tests/integration/frontend/match_ctor_reconcile_keep_scrut_dec.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -Onone -t mlir -o %t.mlir
+// RUN: %rrc %s -O none --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 
 enum Tree {
@@ -21,12 +21,12 @@ fn g(t: Tree, z: Tree) -> Tree {
 
 extern "C" trampoline "g_ffi" = g;
 
-// CHECK-MLIR-LABEL: func.func @"_RC1g"(%0 :
+// CHECK-MLIR-LABEL: func.func private @_RC1g(%arg0:
 // CHECK-MLIR: reussir.record.dispatch
 // CHECK-MLIR: [0] ->
-// CHECK-MLIR: reussir.rc.dec (%0 :
-// CHECK-MLIR: reussir.scf.yield %1 :
+// CHECK-MLIR: reussir.rc.dec(%arg0 :
+// CHECK-MLIR: reussir.scf.yield %arg1 :
 // CHECK-MLIR: [1] ->
-// CHECK-MLIR-DAG: reussir.rc.dec (%0 :
-// CHECK-MLIR-DAG: reussir.rc.dec (%1 :
+// CHECK-MLIR-DAG: reussir.rc.dec(%arg0 :
+// CHECK-MLIR-DAG: reussir.rc.dec(%arg1 :
 // CHECK-MLIR: reussir.scf.yield

--- a/tests/integration/frontend/match_scrutinee_drop_timing.rr
+++ b/tests/integration/frontend/match_scrutinee_drop_timing.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -Onone -t mlir -o %t.mlir
+// RUN: %rrc %s --emit mlir -O none -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 
 enum Term {
@@ -48,26 +48,26 @@ fn eval2(env: Env, x: Term) -> Value {
 extern "C" trampoline "eval_ffi" = eval;
 extern "C" trampoline "eval2_ffi" = eval2;
 
-// Matching on a consuming scrutinee must preserve outer variables reused in
-// the match arms by incrementing them before the scrutinee call.
-// CHECK-MLIR-LABEL: func.func @"_RC5eval2"(%0 :
-// CHECK-MLIR: ^bb{{[0-9]+}}(%{{[0-9]+}} : !reussir.ref<!_RNvC4Term3App shared normal>):
-// CHECK-MLIR: %[[T2:[0-9]+]] = reussir.ref.load
-// CHECK-MLIR: reussir.rc.inc (%[[T2]] : !reussir.rc<!_RC4Term shared normal>)
-// CHECK-MLIR: %[[U2:[0-9]+]] = reussir.ref.load
-// CHECK-MLIR: reussir.rc.inc (%[[U2]] : !reussir.rc<!_RC4Term shared normal>)
-// CHECK-MLIR: reussir.rc.dec (%1 : !reussir.rc<!_RC4Term shared normal>)
-// CHECK-MLIR: reussir.rc.inc (%0 : !reussir.rc<!_RC3Env shared normal>)
-// CHECK-MLIR: %[[MATCHED2:[0-9]+]] = func.call @"_RC5eval2"(%0, %[[T2]]) : (!reussir.rc<!_RC3Env shared normal>, !reussir.rc<!_RC4Term shared normal>) -> (!reussir.rc<!_RC5Value shared normal>)
-
 // Matching on a variable scrutinee must drop the matched root before the
 // branch-local sequence consumes projected fields from that root.
-// CHECK-MLIR-LABEL: func.func @"_RC4eval"(%0 :
-// CHECK-MLIR: ^bb{{[0-9]+}}(%{{[0-9]+}} : !reussir.ref<!_RNvC4Term3App shared normal>):
+// CHECK-MLIR-LABEL: func.func private @_RC4eval(%arg0
+// CHECK-MLIR: ^bb{{[0-9]+}}(%arg{{[0-9]+}}: !reussir.ref<{{.*}}_RNvC4Term3App
 // CHECK-MLIR: %[[T1:[0-9]+]] = reussir.ref.load
-// CHECK-MLIR: reussir.rc.inc (%[[T1]] : !reussir.rc<!_RC4Term shared normal>)
 // CHECK-MLIR: %[[U1:[0-9]+]] = reussir.ref.load
-// CHECK-MLIR: reussir.rc.inc (%[[U1]] : !reussir.rc<!_RC4Term shared normal>)
-// CHECK-MLIR: reussir.rc.dec (%1 : !reussir.rc<!_RC4Term shared normal>)
-// CHECK-MLIR: reussir.rc.inc (%0 : !reussir.rc<!_RC3Env shared normal>)
-// CHECK-MLIR: %[[MATCHED1:[0-9]+]] = func.call @"_RC4eval"(%0, %[[T1]]) : (!reussir.rc<!_RC3Env shared normal>, !reussir.rc<!_RC4Term shared normal>) -> (!reussir.rc<!_RC5Value shared normal>)
+// CHECK-MLIR: reussir.rc.inc(%[[T1]]
+// CHECK-MLIR: reussir.rc.inc(%[[U1]]
+// CHECK-MLIR: reussir.rc.dec(%arg1
+// CHECK-MLIR: reussir.rc.inc(%arg0
+// CHECK-MLIR: %[[MATCHED1:[0-9]+]] = func.call @_RC4eval(%arg0, %[[T1]])
+
+// Matching on a consuming scrutinee must preserve outer variables reused in
+// the match arms by incrementing them before the scrutinee call.
+// CHECK-MLIR-LABEL: func.func private @_RC5eval2(%arg0
+// CHECK-MLIR: ^bb{{[0-9]+}}(%arg{{[0-9]+}}: !reussir.ref<{{.*}}_RNvC4Term3App
+// CHECK-MLIR: %[[T2:[0-9]+]] = reussir.ref.load
+// CHECK-MLIR: %[[U2:[0-9]+]] = reussir.ref.load
+// CHECK-MLIR: reussir.rc.inc(%[[T2]]
+// CHECK-MLIR: reussir.rc.inc(%[[U2]]
+// CHECK-MLIR: reussir.rc.dec(%arg1
+// CHECK-MLIR: reussir.rc.inc(%arg0
+// CHECK-MLIR: %[[MATCHED2:[0-9]+]] = func.call @_RC5eval2(%arg0, %[[T2]])

--- a/tests/integration/frontend/match_whole_scrutinee_ownership.rr
+++ b/tests/integration/frontend/match_whole_scrutinee_ownership.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -Onone -t mlir -o %t.mlir
+// RUN: %rrc %s --emit mlir -O none -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 
 enum Term {
@@ -46,24 +46,24 @@ fn eval2(x: Term) -> Value {
 extern "C" trampoline "eval_ffi" = eval;
 extern "C" trampoline "eval2_ffi" = eval2;
 
-// Matching on a temporary and binding the whole scrutinee must reuse ownership
-// instead of inserting an extra rc.inc for the bound root.
-// CHECK-MLIR-LABEL: func.func @"_RC5eval2"(%0 :
-// CHECK-MLIR: %[[MATCHED2:[0-9]+]] = func.call @"_RC4eval"(%{{[0-9]+}}) : (!reussir.rc<!_RC4Term shared normal>) -> (!reussir.rc<!_RC5Value shared normal>)
-// CHECK-MLIR: %[[BORROW2:[0-9]+]] = reussir.rc.borrow (%[[MATCHED2]] : !reussir.rc<!_RC5Value shared normal>) : !reussir.ref<!_RC5Value shared normal>
-// CHECK-MLIR: %{{[0-9]+}} = reussir.record.dispatch (%[[BORROW2]] : !reussir.ref<!_RC5Value shared normal>) -> !reussir.rc<!_RC5Value shared normal> {
-// CHECK-MLIR: [0] ->{
-// CHECK-MLIR-NOT: reussir.rc.inc (%[[MATCHED2]] : !reussir.rc<!_RC5Value shared normal>)
-// CHECK-MLIR: %[[RHS2:[0-9]+]] = func.call @"_RC4eval"(%{{[0-9]+}}) : (!reussir.rc<!_RC4Term shared normal>) -> (!reussir.rc<!_RC5Value shared normal>)
-// CHECK-MLIR: %{{[0-9]+}} = reussir.record.compound (%[[MATCHED2]], %[[RHS2]] : !reussir.rc<!_RC5Value shared normal>, !reussir.rc<!_RC5Value shared normal>) : !_RNvC5Value4VApp
-
 // Matching on a variable must not eagerly dec the matched root before a catch-all
 // branch consumes that same root in the result construction.
-// CHECK-MLIR-LABEL: func.func @"_RC4eval"(%0 :
-// CHECK-MLIR: %[[MATCHED1:[0-9]+]] = func.call @"_RC4eval"(%{{[0-9]+}}) : (!reussir.rc<!_RC4Term shared normal>) -> (!reussir.rc<!_RC5Value shared normal>)
-// CHECK-MLIR: %[[BORROW1:[0-9]+]] = reussir.rc.borrow (%[[MATCHED1]] : !reussir.rc<!_RC5Value shared normal>) : !reussir.ref<!_RC5Value shared normal>
-// CHECK-MLIR: %{{[0-9]+}} = reussir.record.dispatch (%[[BORROW1]] : !reussir.ref<!_RC5Value shared normal>) -> !reussir.rc<!_RC5Value shared normal> {
-// CHECK-MLIR: [0] ->{
-// CHECK-MLIR-NOT: reussir.rc.dec (%[[MATCHED1]] : !reussir.rc<!_RC5Value shared normal>)
-// CHECK-MLIR: %[[RHS1:[0-9]+]] = func.call @"_RC4eval"(%{{[0-9]+}}) : (!reussir.rc<!_RC4Term shared normal>) -> (!reussir.rc<!_RC5Value shared normal>)
-// CHECK-MLIR: %{{[0-9]+}} = reussir.record.compound (%[[MATCHED1]], %[[RHS1]] : !reussir.rc<!_RC5Value shared normal>, !reussir.rc<!_RC5Value shared normal>) : !_RNvC5Value4VApp
+// CHECK-MLIR-LABEL: func.func private @_RC4eval(%arg0
+// CHECK-MLIR: %[[MATCHED1:[0-9]+]] = func.call @_RC4eval(%{{[0-9]+}})
+// CHECK-MLIR: %[[BORROW1:[0-9]+]] = reussir.rc.borrow(%[[MATCHED1]]
+// CHECK-MLIR: %{{[0-9]+}} = reussir.record.dispatch(%[[BORROW1]]
+// CHECK-MLIR: [0] ->
+// CHECK-MLIR-NOT: reussir.rc.dec(%[[MATCHED1]]
+// CHECK-MLIR: %[[RHS1:[0-9]+]] = func.call @_RC4eval(%{{[0-9]+}})
+// CHECK-MLIR: %{{[0-9]+}} = reussir.record.compound(%[[MATCHED1]], %[[RHS1]]
+
+// Matching on a temporary and binding the whole scrutinee must reuse ownership
+// instead of inserting an extra rc.inc for the bound root.
+// CHECK-MLIR-LABEL: func.func private @_RC5eval2(%arg0
+// CHECK-MLIR: %[[MATCHED2:[0-9]+]] = func.call @_RC4eval(%{{[0-9]+}})
+// CHECK-MLIR: %[[BORROW2:[0-9]+]] = reussir.rc.borrow(%[[MATCHED2]]
+// CHECK-MLIR: %{{[0-9]+}} = reussir.record.dispatch(%[[BORROW2]]
+// CHECK-MLIR: [0] ->
+// CHECK-MLIR-NOT: reussir.rc.inc(%[[MATCHED2]]
+// CHECK-MLIR: %[[RHS2:[0-9]+]] = func.call @_RC4eval(%{{[0-9]+}})
+// CHECK-MLIR: %{{[0-9]+}} = reussir.record.compound(%[[MATCHED2]], %[[RHS2]]

--- a/tests/integration/frontend/nat_even.rr
+++ b/tests/integration/frontend/nat_even.rr
@@ -1,5 +1,5 @@
-// RUN: %reussir-elab --mode semi %s | %FileCheck %s
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum Nat {
     Zero,
@@ -14,29 +14,20 @@ fn even(n : Nat) -> bool {
     }
 }
 
-// CHECK:      ;; Instantiated Generics
-// CHECK:      ;; Elaborated Records
-// CHECK-NEXT: enum [shared] Nat{
-// CHECK-NEXT:     Zero,
-// CHECK-NEXT:     Succ
-// CHECK-NEXT: }
-// CHECK:      enum_variant [value] Nat::Succ(Nat)
-// CHECK:      enum_variant [value] Nat::Zero()
-// CHECK:      ;; Elaborated Functions
-// CHECK-NEXT: fn even(v0 (n): Nat) -> bool {
-// CHECK-NEXT:     match v0 {
-// CHECK-NEXT:         switch (0) {
-// CHECK-NEXT:             ctor@0 => {
-// CHECK-NEXT:                 1.0 : bool
+// CHECK:      [shared] enum #Nat { Zero(), Succ(#Nat) };
+// CHECK:      fn #even(v0 (n): #Nat) -> bool {
+// CHECK-NEXT:     match v0 : #Nat {
+// CHECK-NEXT:         switch scrut {
+// CHECK-NEXT:             #0 => {
+// CHECK-NEXT:                 => true : bool
 // CHECK-NEXT:             }
-// CHECK-NEXT:             ctor@1 => {
-// CHECK-NEXT:                 switch (0, 0) {
-// CHECK-NEXT:                     ctor@0 => {
-// CHECK-NEXT:                         0.0 : bool
+// CHECK-NEXT:             #1 => {
+// CHECK-NEXT:                 switch scrut.0 {
+// CHECK-NEXT:                     #0 => {
+// CHECK-NEXT:                         => false : bool
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     ctor@1 => {
-// CHECK-NEXT:                         pattern var v1 (0, 0, 0)
-// CHECK-NEXT:                         even(v1) : bool
+// CHECK-NEXT:                     #1 => {
+// CHECK-NEXT:                         v1=scrut.0.0 => #even(v1 : #Nat) : bool
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
@@ -46,13 +37,13 @@ fn even(n : Nat) -> bool {
 
 // --- MLIR ownership checks for even (nested DT, flattened) ---
 // even(%0=n): match on n via borrow+dispatch
-// CHECK-MLIR-LABEL: func.func @"_RC4even"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// CHECK-MLIR-LABEL: func.func private @_RC4even(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0
 // CHECK-MLIR:       reussir.record.dispatch
 // Zero branch: dec scrutinee, yield true
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       arith.constant 1 : i1
+// CHECK-MLIR:       reussir.rc.dec(%arg0
+// CHECK-MLIR:       arith.constant true
 // CHECK-MLIR:       reussir.scf.yield
 // Succ branch: intermediate lookup (no inc needed), nested dispatch
 // CHECK-MLIR:       [1] ->
@@ -63,13 +54,13 @@ fn even(n : Nat) -> bool {
 // CHECK-MLIR:       reussir.record.dispatch
 // Succ(Zero): dec base scrutinee, yield false
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       arith.constant 0 : i1
+// CHECK-MLIR:       reussir.rc.dec(%arg0
+// CHECK-MLIR:       arith.constant false
 // CHECK-MLIR:       reussir.scf.yield
 // Succ(Succ(m)): load deepest binding, inc it, dec base scrutinee, call even
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       func.call @"_RC4even"
+// CHECK-MLIR:       reussir.rc.dec(%arg0
+// CHECK-MLIR:       call @_RC4even

--- a/tests/integration/frontend/quote_nonlinear.rr
+++ b/tests/integration/frontend/quote_nonlinear.rr
@@ -1,6 +1,6 @@
-// RUN: %reussir-compiler %s -t llvm-ir -o %t.ll --opt-level aggressive
-// RUN: %reussir-compiler %s -t llvm-ir -o %t.reuse.ll --opt-level aggressive --reuse-across-call
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit llvm-ir -o %t.ll -O aggressive
+// RUN: %rrc %s --emit llvm-ir -o %t.reuse.ll -O aggressive --reuse-across-call
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %reussir-opt %t.mlir \
 // RUN:   --reussir-rc-create-fusion \
 // RUN:   --reussir-trmc-recursion-analysis | %FileCheck %s --check-prefix=CHECK-TRMC
@@ -23,7 +23,7 @@ fn quote(v : Value) -> Term {
     }
 }
 
-// CHECK-TRMC-LABEL: func.func @_RC5quote(
+// CHECK-TRMC-LABEL: func.func private @_RC5quote(
 // CHECK-TRMC: %[[NEW:.+]], %[[HOLES:.+]]:2 = "reussir.rc.create_variant"(%{{.+}}, %{{.+}}) <{holeFields = array<i64: 0, 1>, operandSegmentSizes = array<i32: 0, 2, 0, 0>, tag = 1 : index}>
 // CHECK-TRMC: func.call @_RC5quote.trmc(%{{.+}}, %[[HOLES]]#0) : (!reussir.rc<!reussir.record<variant
 // CHECK-TRMC: func.call @_RC5quote.trmc(%{{.+}}, %[[HOLES]]#1) : (!reussir.rc<!reussir.record<variant

--- a/tests/integration/frontend/struct_ownership.rr
+++ b/tests/integration/frontend/struct_ownership.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 
 struct [value] ValueBox<T> {
@@ -15,17 +15,17 @@ fn consume(x : ValueBox<RcBox>) {
     let x_ = x
 }
 
-// CHECK-MLIR-LABEL: func.func @"_RC12multiplicity"
-// CHECK-MLIR: %{{[0-9]+}} = reussir.ref.spilled (%{{[0-9]+}} : !_RIC8ValueBoxC5RcBoxE) : !reussir.ref<!_RIC8ValueBoxC5RcBoxE normal>
-// CHECK-MLIR-NEXT: reussir.ref.acquire (%{{[0-9]+}} : !reussir.ref<!_RIC8ValueBoxC5RcBoxE normal>)
-// CHECK-MLIR-NEXT: func.call @"_RC7consume"
-// CHECK-MLIR-NEXT: func.return %{{[0-9]+}} : !_RIC8ValueBoxC5RcBoxE
+// CHECK-MLIR-LABEL: func.func @_RC12multiplicity
+// CHECK-MLIR: %{{[0-9]+}} = reussir.ref.spilled(%arg0 : {{.*}}) : !reussir.ref<{{.*}}>
+// CHECK-MLIR-NEXT: reussir.ref.acquire(%{{[0-9]+}} : !reussir.ref<{{.*}}>)
+// CHECK-MLIR-NEXT: call @_RC7consume
+// CHECK-MLIR-NEXT: return %arg0 : {{.*}}
 pub fn multiplicity(x : ValueBox<RcBox>) -> ValueBox<RcBox> {
     consume(x);
     x
 }
 
-// CHECK-MLIR-LABEL: func.func @"_RC7consume"
-// CHECK-MLIR: %{{[0-9]+}} = reussir.ref.spilled (%{{[0-9]+}} : !_RIC8ValueBoxC5RcBoxE) : !reussir.ref<!_RIC8ValueBoxC5RcBoxE normal>
-// CHECK-MLIR-NEXT: reussir.ref.drop (%{{[0-9]+}} : !reussir.ref<!_RIC8ValueBoxC5RcBoxE normal>)
-// CHECK-MLIR-NEXT: func.return
+// CHECK-MLIR-LABEL: func.func private @_RC7consume
+// CHECK-MLIR: %{{[0-9]+}} = reussir.ref.spilled(%arg0 : {{.*}}) : !reussir.ref<{{.*}}>
+// CHECK-MLIR-NEXT: reussir.ref.drop(%{{[0-9]+}} : !reussir.ref<{{.*}}>)
+// CHECK-MLIR-NEXT: return

--- a/tests/integration/frontend/tree_count_leaves.rr
+++ b/tests/integration/frontend/tree_count_leaves.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum Tree {
     Leaf(i32),
@@ -16,23 +16,23 @@ fn count_leaves(t : Tree) -> i32 {
 }
 
 // --- MLIR ownership checks ---
-// CHECK-MLIR-LABEL: func.func @"_RC12count_leaves"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// CHECK-MLIR-LABEL: func.func private @_RC12count_leaves(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0
 // CHECK-MLIR:       reussir.record.dispatch
 // Leaf(_): ignore value, dec scrutinee, return 1
 // CHECK-MLIR:       [0] ->
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       arith.constant 1 : i32
 // CHECK-MLIR:       reussir.scf.yield
 // Node(l, r): inc both children, dec scrutinee, recurse on both
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       func.call @"_RC12count_leaves"
-// CHECK-MLIR:       func.call @"_RC12count_leaves"
+// CHECK-MLIR:       reussir.rc.inc
+// CHECK-MLIR:       reussir.rc.dec(%arg0
+// CHECK-MLIR:       call @_RC12count_leaves
+// CHECK-MLIR:       call @_RC12count_leaves

--- a/tests/integration/frontend/tree_mirror.rr
+++ b/tests/integration/frontend/tree_mirror.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum Tree {
     Leaf(i32),
@@ -16,16 +16,16 @@ fn mirror(t : Tree) -> Tree {
 }
 
 // --- MLIR ownership checks ---
-// mirror(%0=t): consuming transformation with allocation
-// CHECK-MLIR-LABEL: func.func @"_RC6mirror"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// mirror(%arg0=t): consuming transformation with allocation
+// CHECK-MLIR-LABEL: func.func private @_RC6mirror(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0
 // CHECK-MLIR:       reussir.record.dispatch
 // Leaf(x): x is i32, dec scrutinee, build new Leaf
 // CHECK-MLIR:       [0] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       reussir.record.compound
 // CHECK-MLIR:       reussir.record.variant
 // CHECK-MLIR:       reussir.rc.create
@@ -33,14 +33,14 @@ fn mirror(t : Tree) -> Tree {
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.inc
+// CHECK-MLIR:       reussir.rc.dec(%arg0
 // Recursive calls in swapped order: mirror(r) then mirror(l)
-// CHECK-MLIR:       func.call @"_RC6mirror"
-// CHECK-MLIR:       func.call @"_RC6mirror"
+// CHECK-MLIR:       call @_RC6mirror
+// CHECK-MLIR:       call @_RC6mirror
 // Build new Node from swapped results
 // CHECK-MLIR:       reussir.record.compound
 // CHECK-MLIR:       reussir.record.variant

--- a/tests/integration/frontend/tree_sum.rr
+++ b/tests/integration/frontend/tree_sum.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -t mlir -o %t.mlir
+// RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum Tree {
     Leaf(i32),
@@ -16,25 +16,25 @@ fn tree_sum(t : Tree) -> i32 {
 }
 
 // --- MLIR ownership checks ---
-// tree_sum(%0=t): match on tree
-// CHECK-MLIR-LABEL: func.func @"_RC8tree_sum"(%0 :
-// CHECK-MLIR:       reussir.rc.borrow (%0 :
+// tree_sum(%arg0=t): match on tree
+// CHECK-MLIR-LABEL: func.func private @_RC8tree_sum(%arg0
+// CHECK-MLIR:       reussir.rc.borrow(%arg0
 // CHECK-MLIR:       reussir.record.dispatch
 // Leaf(x): x is i32, no inc needed, dec scrutinee
 // CHECK-MLIR:       [0] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
+// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       reussir.scf.yield
 // Node(l, r): both children are RC, both need inc, then dec scrutinee
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
-// CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec (%0 :
-// CHECK-MLIR:       func.call @"_RC8tree_sum"
-// CHECK-MLIR:       func.call @"_RC8tree_sum"
+// CHECK-MLIR:       reussir.rc.inc
+// CHECK-MLIR:       reussir.rc.dec(%arg0
+// CHECK-MLIR:       call @_RC8tree_sum
+// CHECK-MLIR:       call @_RC8tree_sum


### PR DESCRIPTION
Second batch of the Haskell→rrc lit migration (#290), following #304 (the e2e/MIR batch). Moves the structural ownership `CHECK-MLIR` tests, the two TRMC `reussir-opt` tests, and a closure HIR-dump test off `%reussir-compiler`/`%reussir-elab` onto `%rrc`.

### Migrated (17 tests, all pass under lit)
- **CHECK-MLIR ownership** (frontend MLIR, `--emit mlir`): `list_sum`, `list_length`, `list_append`, `list_nth`, `list_reverse`, `list_empty`, `nat_even`, `tree_sum`, `tree_mirror`, `tree_count_leaves`, `match_ctor_reconcile_keep_scrut_dec`, `match_whole_scrutinee_ownership`, `match_scrutinee_drop_timing`, `struct_ownership`.
- **TRMC** (`--emit mlir` → `reussir-opt --reussir-rc-create-fusion --reussir-trmc-recursion-analysis`, plus `--emit llvm-ir --reuse-across-call`): `list_inc1`, `quote_nonlinear`.
- **HIR dump** (`--emit hir`): `closure`. `list_empty`, `list_reverse`, `nat_even` also had `%reussir-elab --mode semi` HIR blocks re-transcribed to rrc's HIR syntax.

### How the checks were ported
The op *sequence* is what these tests assert (which `rc.inc`/`rc.dec`/`borrow`/`project`/`load` in which match arm), so that intent is preserved. Applied rrc's spelling deltas:
- `func.func @"NAME"` → `func.func @NAME` (`pub`) or `func.func private @NAME` (non-`pub`).
- block args `%0`/`%1` → `%arg0`/`%arg1`; no space before `(` on `reussir.*` ops; `func.return` → `return`; `func.call @"NAME"` → `call @NAME`; `arith.constant 1/0 : i1` → `arith.constant true/false`.
- long record types matched with `{{.*}}` / captured vars.

Two intent-preserving adjustments, noted in the commit: (1) where rrc emits a different intra-arm op order (both `ref.load`s then both `rc.inc`s vs the old interleaving) the CHECK lines were reordered — the asserted op set and every `CHECK-...-NOT` guard are unchanged; (2) function blocks were reordered to rrc's emission order where `CHECK-LABEL` requires file order to match input order (e.g. `eval` before `eval2`).

### Still on the Haskell driver (rrc gaps, tracked in #290)
`field_shorthand`, `math`, `nullable`, `fn_lift`, `module_*`, and `relocation_mode`/`target_triple` (rrc omits the `target triple =` module line and has a different CLI `--help`/no `dynamic-no-pic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)