### PR TITLE
[frontend] nullable-pattern dispatch and nullable value refcounting

### DIFF
--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -203,6 +203,57 @@ pub fn nullable_create<'c>(
         .expect("valid reussir.nullable.create")
 }
 
+/// `reussir.nullable.check (%v : nullable<…>) : i1` — `true` iff the nullable
+/// holds a non-null pointer. Built raw so the `i1` result type can be set
+/// (melior's generated builder does not expose it).
+pub fn nullable_check<'c>(
+    context: &'c Context,
+    nullable: Value<'c, '_>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.nullable.check", location)
+        .add_operands(&[nullable])
+        .add_results(&[IntegerType::new(context, 1).into()])
+        .build()
+        .expect("valid reussir.nullable.check")
+}
+
+/// `reussir.nullable.coerce (%v : nullable<…>) : <result_type>` — unwrap a
+/// nullable known to be non-null into its pointer (an identity after LLVM
+/// conversion; the null case must have been ruled out by a check/dispatch
+/// first).
+pub fn nullable_coerce<'c>(
+    nullable: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.nullable.coerce", location)
+        .add_operands(&[nullable])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.nullable.coerce")
+}
+
+/// `reussir.nullable.dispatch (%v : nullable<…>) (-> <result_type>)?` — the
+/// two-region null dispatch: the first (non-null) region's block takes the
+/// unwrapped pointer as its argument, the second (null) region's block takes
+/// none; both terminate with `reussir.scf.yield` ([`scf_yield`]).
+pub fn nullable_dispatch<'c>(
+    nullable: Value<'c, '_>,
+    result_type: Option<Type<'c>>,
+    non_null: Region<'c>,
+    null: Region<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let mut builder = OperationBuilder::new("reussir.nullable.dispatch", location)
+        .add_operands(&[nullable])
+        .add_regions_vec(vec![non_null, null]);
+    if let Some(result_type) = result_type {
+        builder = builder.add_results(&[result_type]);
+    }
+    builder.build().expect("valid reussir.nullable.dispatch")
+}
+
 /// `reussir.region.run (-> <result_type>)? { <body> }` — execute a region scope.
 ///
 /// The body region's single block takes a `!reussir.region` argument (the arena

--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -203,41 +203,14 @@ pub fn nullable_create<'c>(
         .expect("valid reussir.nullable.create")
 }
 
-/// `reussir.nullable.check (%v : nullable<…>) : i1` — `true` iff the nullable
-/// holds a non-null pointer. Built raw so the `i1` result type can be set
-/// (melior's generated builder does not expose it).
-pub fn nullable_check<'c>(
-    context: &'c Context,
-    nullable: Value<'c, '_>,
-    location: Location<'c>,
-) -> Operation<'c> {
-    OperationBuilder::new("reussir.nullable.check", location)
-        .add_operands(&[nullable])
-        .add_results(&[IntegerType::new(context, 1).into()])
-        .build()
-        .expect("valid reussir.nullable.check")
-}
-
-/// `reussir.nullable.coerce (%v : nullable<…>) : <result_type>` — unwrap a
-/// nullable known to be non-null into its pointer (an identity after LLVM
-/// conversion; the null case must have been ruled out by a check/dispatch
-/// first).
-pub fn nullable_coerce<'c>(
-    nullable: Value<'c, '_>,
-    result_type: Type<'c>,
-    location: Location<'c>,
-) -> Operation<'c> {
-    OperationBuilder::new("reussir.nullable.coerce", location)
-        .add_operands(&[nullable])
-        .add_results(&[result_type])
-        .build()
-        .expect("valid reussir.nullable.coerce")
-}
-
 /// `reussir.nullable.dispatch (%v : nullable<…>) (-> <result_type>)?` — the
 /// two-region null dispatch: the first (non-null) region's block takes the
 /// unwrapped pointer as its argument, the second (null) region's block takes
 /// none; both terminate with `reussir.scf.yield` ([`scf_yield`]).
+///
+/// Built raw like [`region_run`]: the op's result is `Optional`, which
+/// melior's generated builder cannot express (`nullable.check`/`coerce` have
+/// required results and use their generated builders directly).
 pub fn nullable_dispatch<'c>(
     nullable: Value<'c, '_>,
     result_type: Option<Type<'c>>,

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -2060,15 +2060,16 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         inc: bool,
     ) -> Result<()> {
         let loc = self.loc();
+        let i1 = IntegerType::new(self.context, 1).into();
         let flag = self.append(
             block,
-            builders::nullable_check(self.context, val, loc),
+            dialect::nullable_check(self.context, i1, val, loc).into(),
         );
         let then_block = Block::new(&[]);
         let inner_mlir = self.tys.mlir_ty(inner)?;
         let unwrapped = self.append(
             &then_block,
-            builders::nullable_coerce(val, inner_mlir, loc),
+            dialect::nullable_coerce(self.context, inner_mlir, val, loc).into(),
         );
         if inc {
             self.emit_inc(&then_block, unwrapped, inner)?;

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -1028,8 +1028,83 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             SwitchCases::Int { cases, default } => {
                 self.int_switch(block, env, root_idx, path, cases, default, result_ty)
             }
-            SwitchCases::Nullable { .. } => err("nullable-pattern match lowering not yet implemented"),
+            SwitchCases::Nullable { non_null, null } => {
+                self.nullable_switch(block, env, root_idx, path, non_null, null, result_ty)
+            }
             SwitchCases::String { .. } => err("string-pattern match lowering not yet implemented"),
+        }
+    }
+
+    /// Lower a nullable `Switch` to `reussir.nullable.dispatch`: the non-null
+    /// region's block receives the unwrapped pointer as its argument, anchored
+    /// at the switch's *own* path (the payload occupies the scrutinee's
+    /// occurrence — see the `Family::Nullable` compilation in
+    /// `semi::pattern`); the null region receives nothing.
+    #[allow(clippy::too_many_arguments)]
+    fn nullable_switch<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        root_idx: usize,
+        path: &[u32],
+        non_null: &'tcx DecisionTree<'tcx>,
+        null: &'tcx DecisionTree<'tcx>,
+        result_ty: Ty<'tcx>,
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let loc = self.loc();
+        let (scrut_val, scrut_ty) = self.resolve_loaded(block, env, root_idx, path)?;
+        let TyKind::Nullable(inner) = *scrut_ty.kind() else {
+            return err("nullable match on a non-nullable scrutinee");
+        };
+        let unit = is_unit(result_ty);
+        let result_type = if unit {
+            None
+        } else {
+            Some(self.tys.mlir_ty(result_ty)?)
+        };
+
+        // Non-null region: the block argument is the unwrapped pointer,
+        // pushed as a fresh anchor at `path` so bindings (and any deeper
+        // projections) in the sub-tree resolve to it.
+        let inner_mlir = self.tys.mlir_ty(inner)?;
+        let non_null_block = Block::new(&[(inner_mlir, loc)]);
+        let arg: Value<'c, '_> = non_null_block
+            .argument(0)
+            .map_err(|e| LoweringError(format!("missing dispatch block argument: {e}").into()))?
+            .into();
+        let anchor_path = SmallVec::<[u32; 4]>::from_slice(path);
+        env.subscope(|scope| {
+            scope
+                .anchors
+                .push((anchor_path, Anchor::Root { val: arg, ty: inner }));
+            let value = self.lower_tree(&non_null_block, scope, root_idx, non_null, result_ty)?;
+            non_null_block.append_operation(builders::scf_yield(value, loc));
+            Ok::<_, LoweringError>(())
+        })?;
+        let non_null_region = Region::new();
+        non_null_region.append_block(non_null_block);
+
+        // Null region: no argument, no new anchor.
+        let null_block = Block::new(&[]);
+        env.subscope(|scope| {
+            let value = self.lower_tree(&null_block, scope, root_idx, null, result_ty)?;
+            null_block.append_operation(builders::scf_yield(value, loc));
+            Ok::<_, LoweringError>(())
+        })?;
+        let null_region = Region::new();
+        null_region.append_block(null_block);
+
+        let op = block.append_operation(builders::nullable_dispatch(
+            scrut_val,
+            result_type,
+            non_null_region,
+            null_region,
+            loc,
+        ));
+        if unit {
+            Ok(None)
+        } else {
+            Ok(Some(op.result(0).unwrap().into()))
         }
     }
 
@@ -1049,7 +1124,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         // Resolve the enum once: `whole` is the un-narrowed value at this path
         // (kept in each arm's `Case` anchor for a whole-value binding), and the
         // variant reference feeds the dispatch.
-        let whole = self.resolve(block, env, path)?;
+        let whole = self.resolve(block, env, root_idx, path)?;
         let (variant_ref, enum_ty, cap) = self.resolve_variant_ref(block, whole)?;
         let variants = match self.tys.record_of(enum_ty).map(|r| r.layout) {
             Some(mir::RecordLayout::Variant(variants)) => variants,
@@ -1124,7 +1199,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         result_ty: Ty<'tcx>,
     ) -> Result<Option<Value<'c, 'b>>> {
         let loc = self.loc();
-        let (cond, _) = self.resolve_loaded(block, env, path)?;
+        let (cond, _) = self.resolve_loaded(block, env, root_idx, path)?;
         let unit = is_unit(result_ty);
         let result_tys = if unit {
             Vec::new()
@@ -1167,7 +1242,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         result_ty: Ty<'tcx>,
     ) -> Result<Option<Value<'c, 'b>>> {
         let loc = self.loc();
-        let (scrut_val, scrut_ty) = self.resolve_loaded(block, env, path)?;
+        let (scrut_val, scrut_ty) = self.resolve_loaded(block, env, root_idx, path)?;
         let width = match scrut_ty.kind() {
             TyKind::Int(IntTy::Signed(w) | IntTy::Unsigned(w)) => *w,
             _ => return err("integer match on a non-integer scrutinee"),
@@ -1386,11 +1461,11 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         bindings: &'tcx [(VarId, &'tcx [u32])],
     ) -> Result<()> {
         for &(var, path) in bindings {
-            let (val, ty) = if path.is_empty() {
-                self.root_anchor(env, root_idx)?
-            } else {
-                self.resolve_loaded(block, env, path)?
-            };
+            // An empty path goes through `resolve` like everything else: a
+            // dispatch may have re-anchored the root's own path (a nullable
+            // switch on the scrutinee binds its unwrapped payload there), and
+            // the latest anchor must win over the raw root.
+            let (val, ty) = self.resolve_loaded(block, env, root_idx, path)?;
             self.bind_var_ty(var, ty);
             env.vars.insert(var, val);
         }
@@ -1414,27 +1489,16 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         }
     }
 
-    /// The root scrutinee value and type of the enclosing match (its `[]` anchor).
-    fn root_anchor<'b>(
-        &self,
-        env: &Env<'c, 'b, 'tcx>,
-        root_idx: usize,
-    ) -> Result<(Value<'c, 'b>, Ty<'tcx>)> {
-        match env.anchors.get(root_idx) {
-            Some((_, Anchor::Root { val, ty })) => Ok((*val, *ty)),
-            _ => err("match root anchor missing"),
-        }
-    }
-
     /// Resolve the scrutinee sub-value at `path` to a loaded SSA value and its MIR
     /// type, projecting from the nearest anchor (see [`resolve`](Self::resolve)).
     fn resolve_loaded<'b>(
         &self,
         block: &'b Block<'c>,
         env: &Env<'c, 'b, 'tcx>,
+        root_idx: usize,
         path: &[u32],
     ) -> Result<(Value<'c, 'b>, Ty<'tcx>)> {
-        let cursor = self.resolve(block, env, path)?;
+        let cursor = self.resolve(block, env, root_idx, path)?;
         let ty = match &cursor {
             Cursor::Value { ty, .. } | Cursor::Ref { ty, .. } => *ty,
         };
@@ -1479,10 +1543,15 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         &self,
         block: &'b Block<'c>,
         env: &Env<'c, 'b, 'tcx>,
+        root_idx: usize,
         path: &[u32],
     ) -> Result<Cursor<'c, 'b, 'tcx>> {
         let mut best: Option<(usize, usize)> = None;
-        for (i, (anchor_path, _)) in env.anchors.iter().enumerate() {
+        // Only this match's anchors are candidates: `path` is relative to the
+        // root at `root_idx`, while earlier anchors belong to *enclosing*
+        // matches whose paths live in a different coordinate space (a nested
+        // match's `[1]` must not hit an outer switch's `[1]` anchor).
+        for (i, (anchor_path, _)) in env.anchors.iter().enumerate().skip(root_idx) {
             if anchor_path.len() <= path.len() && path[..anchor_path.len()] == anchor_path[..] {
                 let take = best.is_none_or(|(_, len)| anchor_path.len() >= len);
                 if take {
@@ -1950,6 +2019,8 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             let reference = self.spill(block, val, ty)?;
             block.append_operation(dialect::ref_acquire(self.context, reference, loc).into());
             Ok(())
+        } else if let TyKind::Nullable(inner) = *ty.kind() {
+            self.emit_rc_nullable(block, val, inner, true)
         } else {
             err("reference-count increment on an unsupported type")
         }
@@ -1970,9 +2041,49 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             let reference = self.spill(block, val, ty)?;
             block.append_operation(dialect::ref_drop(self.context, reference, loc).into());
             Ok(())
+        } else if let TyKind::Nullable(inner) = *ty.kind() {
+            self.emit_rc_nullable(block, val, inner, false)
         } else {
             err("reference-count decrement on an unsupported type")
         }
+    }
+
+    /// Null-guarded refcount op on a `Nullable<inner>` value: `rc.inc`/`rc.dec`
+    /// reject a nullable operand and do not null-check, so the pointer is
+    /// checked, unwrapped (`nullable.coerce`), and counted only when non-null —
+    /// a null link is a no-op, never a deallocation (issue 213).
+    fn emit_rc_nullable<'b>(
+        &self,
+        block: &'b Block<'c>,
+        val: Value<'c, 'b>,
+        inner: Ty<'tcx>,
+        inc: bool,
+    ) -> Result<()> {
+        let loc = self.loc();
+        let flag = self.append(
+            block,
+            builders::nullable_check(self.context, val, loc),
+        );
+        let then_block = Block::new(&[]);
+        let inner_mlir = self.tys.mlir_ty(inner)?;
+        let unwrapped = self.append(
+            &then_block,
+            builders::nullable_coerce(val, inner_mlir, loc),
+        );
+        if inc {
+            self.emit_inc(&then_block, unwrapped, inner)?;
+        } else {
+            self.emit_dec(&then_block, unwrapped, inner)?;
+        }
+        then_block.append_operation(scf::r#yield(&[], loc));
+        let then_region = Region::new();
+        then_region.append_block(then_block);
+        let else_block = Block::new(&[]);
+        else_block.append_operation(scf::r#yield(&[], loc));
+        let else_region = Region::new();
+        else_region.append_block(else_block);
+        block.append_operation(scf::r#if(flag, &[], then_region, else_region, loc));
+        Ok(())
     }
 
     /// Spill a value to a fresh stack slot and return an (unspecified-capability)

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -236,6 +236,67 @@ mod tests {
         );
     }
 
+    /// A nullable match dispatches on the two built-in constructors; the
+    /// `NonNull` payload binder gets the element type, and the whole match
+    /// unifies as usual.
+    #[test]
+    fn nullable_patterns_type_and_dispatch() {
+        check(
+            r#"
+            struct RcBox<T> { value: T }
+
+            fn unwrap_or(n: Nullable<RcBox<i32>>, d: i32) -> i32 {
+                match n {
+                    Nullable::NonNull(b) => b.value,
+                    Nullable::Null => d
+                }
+            }
+            "#,
+            |elab, tcx| {
+                let body = function(elab, "unwrap_or").body.as_ref().unwrap();
+                assert_eq!(body.ty, tcx.mk_int(IntTy::Signed(32)));
+                // The match compiled to a nullable switch.
+                let hir::ExprKind::Match(_, tree) = &body.kind else {
+                    panic!("expected a match body, got {:?}", body.kind);
+                };
+                let hir::DecisionTree::Switch { cases, .. } = tree else {
+                    panic!("expected a switch, got {tree:?}");
+                };
+                assert!(
+                    matches!(cases, hir::SwitchCases::Nullable { .. }),
+                    "expected a nullable switch"
+                );
+            },
+        );
+    }
+
+    /// Omitting the `Null` arm is a non-exhaustive match, like any other
+    /// missing case of a closed family.
+    #[test]
+    fn nullable_match_missing_null_arm_is_non_exhaustive() {
+        with_tcx(|tcx| {
+            let source = r#"
+                struct RcBox<T> { value: T }
+
+                fn oops(n: Nullable<RcBox<i32>>) -> i32 {
+                    match n {
+                        Nullable::NonNull(b) => b.value
+                    }
+                }
+            "#;
+            let parse = reussir_syntax::parse(source);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(
+                elab.reports
+                    .iter()
+                    .any(|r| r.message.contains("non-exhaustive")),
+                "expected a non-exhaustive diagnostic: {:#?}",
+                elab.reports
+            );
+        });
+    }
+
     /// A `[field]` link projects at the *base's* view: `Flex` (writable)
     /// through a flex base, `Rigid` (a frozen view) through a rigid base —
     /// after the region freezes, `x.f` must not hand out a mutable coloring

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -557,6 +557,22 @@ mod tests {
     }
 
     #[test]
+    fn roundtrips_a_nullable_match() {
+        roundtrip(
+            r#"
+            struct RcBox<T> { value: T }
+
+            pub fn unwrap_or(n: Nullable<RcBox<i32>>, d: i32) -> i32 {
+                match n {
+                    Nullable::NonNull(b) => b.value,
+                    Nullable::Null => d
+                }
+            }
+            "#,
+        );
+    }
+
+    #[test]
     fn roundtrips_nested_scrutinee_paths() {
         // A nested pattern produces depth-2 scrutinee paths (`scrut.1.0`),
         // whose adjacent indices lex as one float-shaped token — the grammar

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -63,6 +63,11 @@ enum Ctor<'tcx> {
     Int(&'tcx Integer),
     Bool(bool),
     Str(StringToken),
+    /// The non-null case of a `Nullable<T>` scrutinee, with one field: the
+    /// unwrapped `T`.
+    NonNull,
+    /// The null case of a `Nullable<T>` scrutinee (no fields).
+    Null,
 }
 
 impl Ctor<'_> {
@@ -72,6 +77,7 @@ impl Ctor<'_> {
             Ctor::Int(_) => Family::Int,
             Ctor::Bool(_) => Family::Bool,
             Ctor::Str(_) => Family::Str,
+            Ctor::NonNull | Ctor::Null => Family::Nullable,
         }
     }
 }
@@ -85,6 +91,8 @@ enum Family {
     Variant,
     /// A closed two-case family (`true` / `false`).
     Bool,
+    /// A closed two-case family (`NonNull` / `Null`).
+    Nullable,
     /// Open families: there are always more values than literals, so they need a
     /// default branch.
     Int,
@@ -300,6 +308,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         ty: Ty<'tcx>,
     ) -> Pat<'tcx> {
         let ty = self.infer.shallow_resolve(ty);
+        // The built-in nullable constructors, by the same qualifier convention
+        // as [`Elaborator::infer_ctor`] on the expression side.
+        if ctor.path.segments.last().map(|k| self.sym(*k)) == Some("Nullable") {
+            return self.check_nullable_pat(ctor, span, ty);
+        }
         let TyKind::Record { def, args, .. } = ty.kind() else {
             self.error(span, format!("cannot match constructor against `{ty:?}`"));
             return Pat::Wild;
@@ -371,6 +384,70 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         Pat::Ctor {
             ctor: Ctor::Variant(vidx),
             fields,
+        }
+    }
+
+    /// `Nullable::NonNull(p)` / `Nullable::Null` patterns against a
+    /// `Nullable<T>` scrutinee. `NonNull` binds one sub-pattern at the element
+    /// type; `Null` binds nothing.
+    fn check_nullable_pat(
+        &mut self,
+        ctor: &surface::CtorPat,
+        span: Option<Span>,
+        ty: Ty<'tcx>,
+    ) -> Pat<'tcx> {
+        // The scrutinee must be (or become) a nullable; a still-unsolved hole
+        // is solved to `Nullable<α>` so the sub-pattern can constrain `α`.
+        let inner = match ty.kind() {
+            TyKind::Nullable(inner) => self.infer.shallow_resolve(*inner),
+            TyKind::Hole(_) => {
+                let elem = self.infer.new_hole_ty();
+                let want = self.tcx.mk_nullable(elem);
+                let _ = self.infer.unify(ty, want);
+                elem
+            }
+            _ => {
+                self.error(
+                    span,
+                    format!("cannot match a nullable pattern against `{ty:?}`"),
+                );
+                return Pat::Wild;
+            }
+        };
+        match self.sym(ctor.path.basename) {
+            "NonNull" => {
+                if ctor.args.len() != 1 {
+                    self.error(
+                        span,
+                        format!(
+                            "`Nullable::NonNull` binds exactly 1 value, but the \
+                             pattern binds {}",
+                            ctor.args.len()
+                        ),
+                    );
+                }
+                let field = match ctor.args.first() {
+                    Some(arg) => self.check_pat(&arg.kind, span, inner),
+                    None => Pat::Wild,
+                };
+                Pat::Ctor {
+                    ctor: Ctor::NonNull,
+                    fields: vec![field],
+                }
+            }
+            "Null" => {
+                if !ctor.args.is_empty() {
+                    self.error(span, "`Nullable::Null` binds no values");
+                }
+                Pat::Ctor {
+                    ctor: Ctor::Null,
+                    fields: Vec::new(),
+                }
+            }
+            other => {
+                self.error(span, format!("unknown nullable constructor `{other}`"));
+                Pat::Wild
+            }
         }
     }
 
@@ -462,6 +539,24 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 let if_false = Box::new(self.compile_match(f, reached, exhaustive));
                 SwitchCases::Bool { if_true, if_false }
             }
+            // Closed two-case family. The non-null case exposes one field —
+            // the unwrapped element — at the *same* occurrence as the switch
+            // itself: the textual-IR arms carry no field index and the
+            // codegen dispatch rebinds the scrutinee's path to the unwrapped
+            // pointer (unwrapping is a pointer no-op), matching the reference.
+            Family::Nullable => {
+                let inner = match self.infer.shallow_resolve(col_ty).kind() {
+                    TyKind::Nullable(inner) => self.infer.shallow_resolve(*inner),
+                    // A non-nullable column type means the pattern arm already
+                    // errored in `check_nullable_pat`; recover with Bottom.
+                    _ => self.tcx.mk(TyKind::Bottom),
+                };
+                let nn = self.specialize_nonnull(&m, j, &occ, inner);
+                let non_null = Box::new(self.compile_match(nn, reached, exhaustive));
+                let nl = self.specialize_scalar(&m, j, &Ctor::Null, &occ);
+                let null = Box::new(self.compile_match(nl, reached, exhaustive));
+                SwitchCases::Nullable { non_null, null }
+            }
             // Open: one case per literal, plus a default for everything else.
             Family::Int => {
                 let mut cases = Vec::new();
@@ -528,6 +623,56 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             };
             let mut pats = row.pats[..j].to_vec();
             pats.extend(sub);
+            pats.extend_from_slice(&row.pats[j + 1..]);
+            let mut bindings = row.bindings.clone();
+            bindings.extend(bind);
+            rows.push(Row {
+                pats,
+                bindings,
+                guard: row.guard.clone(),
+                body: row.body.clone(),
+                arm: row.arm,
+            });
+        }
+        Matrix { cols, rows }
+    }
+
+    /// `S(NonNull, P)`: keep the rows that can match the non-null case,
+    /// expanding the single unwrapped-element field into a fresh column at the
+    /// *same* occurrence `occ` (see the `Family::Nullable` arm — unwrapping a
+    /// non-null is a pointer no-op, so the payload occupies the scrutinee's
+    /// own path, unlike a variant's `occ ++ [i]` fields).
+    fn specialize_nonnull(
+        &self,
+        m: &Matrix<'tcx>,
+        j: usize,
+        occ: &PatVarRef,
+        inner: Ty<'tcx>,
+    ) -> Matrix<'tcx> {
+        let mut cols = m.cols[..j].to_vec();
+        cols.push(Column {
+            occ: occ.clone(),
+            ty: inner,
+        });
+        cols.extend_from_slice(&m.cols[j + 1..]);
+
+        let mut rows = Vec::new();
+        for row in &m.rows {
+            let (sub, bind): (Pat<'tcx>, Option<(VarId, PatVarRef)>) = match &row.pats[j] {
+                Pat::Ctor {
+                    ctor: Ctor::NonNull,
+                    fields,
+                } => (fields[0].clone(), None),
+                // A `Null` pattern cannot match this case.
+                Pat::Ctor { .. } => continue,
+                Pat::Wild => (Pat::Wild, None),
+                // Binding the whole nullable: within the non-null case the
+                // nullable and its unwrapped element are the same pointer, so
+                // the binder's occurrence stays `occ` like everything else.
+                Pat::Bind(var) => (Pat::Wild, Some((*var, occ.clone()))),
+            };
+            let mut pats = row.pats[..j].to_vec();
+            pats.push(sub);
             pats.extend_from_slice(&row.pats[j + 1..]);
             let mut bindings = row.bindings.clone();
             bindings.extend(bind);

--- a/tests/integration/frontend/invalid_record.rr
+++ b/tests/integration/frontend/invalid_record.rr
@@ -1,11 +1,18 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %not %reussir-elab --mode full %s
+// A `[field]` link's element must be a regional record; instantiating
+// `Matrix<u64>` puts a plain `u64` behind one. rrc rejects this during
+// elaboration: the link slot types as `Nullable<u64>`, which the literal
+// argument cannot satisfy. (The instantiation-level check — a non-regional
+// type argument reaching a `[field] T` — is enforced at monomorphization and
+// unit-tested as `field_link_generic_must_be_regional`.)
 
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
 
 struct [regional] Matrix<T> {
-    m00: [field] T 
+    m00: [field] T
 }
 
 fn test() -> Matrix<u64> {
     regional {Matrix{ m00 : 0 }}
 }
+
+// CHECK: does not implement `Integral`

--- a/tests/integration/frontend/invalid_record.rr
+++ b/tests/integration/frontend/invalid_record.rr
@@ -15,4 +15,6 @@ fn test() -> Matrix<u64> {
     regional {Matrix{ m00 : 0 }}
 }
 
-// CHECK: does not implement `Integral`
+// The diagnostic names the mistyped link slot and points at the literal.
+// CHECK: `Nullable(Int(Unsigned(64)))` does not implement `Integral`
+// CHECK: invalid_record.rr:15:29

--- a/tests/integration/frontend/issue_213_noop_deallocate_null.rr
+++ b/tests/integration/frontend/issue_213_noop_deallocate_null.rr
@@ -1,4 +1,4 @@
-// RUN: %reussir-compiler %s -o %t.ll -t llvm-ir
+// RUN: %rrc %s --emit llvm-ir -o %t.ll
 // RUN: %FileCheck %s --check-prefix=LLVM < %t.ll
 
 fn apply1(f : i32 -> i32, x : i32) -> i32 {
@@ -17,6 +17,9 @@ pub fn test_sbox_multi() -> i32 {
     a + b
 }
 
+// A null nullable token must never be blindly deallocated: releases go
+// through a null check (or a token-aware runtime call), not a direct
+// `__reussir_deallocate(null)`.
 // LLVM-LABEL: define {{.*}}@_RC15test_sbox_multi
 // LLVM-NOT: call void @__reussir_deallocate(ptr null
 // LLVM: ret i32

--- a/tests/integration/frontend/nullable.rr
+++ b/tests/integration/frontend/nullable.rr
@@ -1,30 +1,11 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %reussir-elab --mode full %s | %FileCheck %s
-// RUN: %reussir-compiler %s -o %t.o
+// Nullable in value position: constructed (`NonNull`/`Null`), returned from
+// functions, and read out of a `[field]` link (projection through a rigid
+// base yields the frozen `Nullable<[rigid] _>` view). Dispatch on nullables
+// is covered by `nullable_match.rr`.
 
-// CHECK-DAG: struct _RC4Data (aka Data){
-// CHECK-NEXT-DAG: value: u64
-// CHECK-NEXT-DAG: }
+// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o
 
-// CHECK-DAG: struct _RC6RegBox (aka RegBox){
-// CHECK-NEXT-DAG: value: [field] _RC4Data
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: struct _RIC5RcBoxlE (aka RcBox<i32>){
-// CHECK-NEXT-DAG: value: i32
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC3baz(reg: Rc<_RC6RegBox, Rigid>) -> Nullable<Rc<_RC4Data, Rigid>> {
-// CHECK-NEXT-DAG: v0.0 : Nullable<Rc<_RC4Data, Regional>>
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC3foo() -> Nullable<Rc<_RIC5RcBoxlE, Shared>> {
-// CHECK-NEXT-DAG: nonnull{rc_wrap(compound(1.0 : i32) : _RIC5RcBoxlE) : Rc<_RIC5RcBoxlE, Shared>} : Nullable<Rc<_RIC5RcBoxlE, Shared>>
-// CHECK-NEXT-DAG: }
-
-// CHECK-DAG: fn _RC3bar() -> Nullable<Rc<_RIC5RcBoxdE, Shared>> {
-// CHECK-NEXT-DAG: null : Nullable<Rc<_RIC5RcBoxdE, Shared>>
-// CHECK-NEXT-DAG: }
 struct RcBox<T> {
     value: T
 }
@@ -49,4 +30,20 @@ fn baz(reg : RegBox) -> Nullable<Data> {
     reg.value
 }
 
+// CHECK-DAG: record @_RC4Data : regional struct Data { "value": u64 };
+// CHECK-DAG: record @_RC6RegBox : regional struct RegBox { "value": field Nullable<[regional] Data> };
+// CHECK-DAG: record @_RIC5RcBoxlE : shared struct RcBox::<i32> { "value": i32 };
 
+// CHECK: fn @_RC3bar() -> Nullable<RcBox::<f64>> {
+// CHECK-NEXT: Null : Nullable<RcBox::<f64>>
+// CHECK-NEXT: }
+
+// An unannotated regional parameter is pinned rigid; the `[field]` link
+// projects at the base's (frozen) view.
+// CHECK: fn @_RC3baz(v0 (reg): [rigid] RegBox) -> Nullable<[rigid] Data> {
+// CHECK-NEXT: proj(v0 : [rigid] RegBox, 0) : Nullable<[rigid] Data>
+// CHECK-NEXT: }
+
+// CHECK: fn @_RC3foo() -> Nullable<RcBox::<i32>> {
+// CHECK-NEXT: NonNull(@_RIC5RcBoxlE{1 : i32} : RcBox::<i32>) : Nullable<RcBox::<i32>>
+// CHECK-NEXT: }

--- a/tests/integration/frontend/nullable_match.c
+++ b/tests/integration/frontend/nullable_match.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int32_t read_wrapped_ffi(int32_t);
+extern int32_t read_empty_ffi(void);
+extern int32_t drop_unmatched_ffi(int32_t);
+extern uint64_t second_ffi(uint64_t);
+extern uint64_t end_of_list_ffi(uint64_t);
+
+#define EXPECT(what, got, want)                                                \
+  do {                                                                         \
+    long long g = (long long)(got), w = (long long)(want);                     \
+    if (g != w) {                                                              \
+      fprintf(stderr, "FAIL %s: got %lld want %lld\n", what, g, w);            \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+int main(void) {
+  EXPECT("read_wrapped", read_wrapped_ffi(42), 42);
+  EXPECT("read_empty", read_empty_ffi(), -1);
+  EXPECT("drop_unmatched", drop_unmatched_ffi(5), 7);
+  EXPECT("second", second_ffi(41), 42);           /* tail.v = v + 1 */
+  EXPECT("end_of_list", end_of_list_ffi(7), 108); /* tail.v + 100 */
+  /* Second round: surface double-free / use-after-free in the rc paths. */
+  EXPECT("read_wrapped#2", read_wrapped_ffi(-3), -3);
+  EXPECT("second#2", second_ffi(0), 1);
+  return 0;
+}

--- a/tests/integration/frontend/nullable_match.rr
+++ b/tests/integration/frontend/nullable_match.rr
@@ -1,0 +1,83 @@
+// Nullable-pattern dispatch (#290): `match` on a `Nullable<T>` lowers to
+// `reussir.nullable.dispatch`, with the unwrapped payload bound at the
+// scrutinee's own occurrence. The harness executes dispatch over shared
+// values, over frozen regional `[field]` links (including a nested match on
+// the unwrapped payload's own link), and the null-guarded refcounting of a
+// nullable that is bound and dropped without being matched.
+
+// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/nullable_match.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+struct RcBox<T> { value: T }
+
+fn wrap(v: i32) -> Nullable<RcBox<i32>> {
+    Nullable::NonNull { RcBox { value: v } }
+}
+
+fn empty() -> Nullable<RcBox<i32>> {
+    Nullable::Null
+}
+
+pub fn read_wrapped(v: i32) -> i32 {
+    match wrap(v) {
+        Nullable::NonNull(b) => b.value,
+        Nullable::Null => -1
+    }
+}
+// MIR: fn @_RC12read_wrapped
+// MIR: switch scrut {
+// MIR-NEXT: NonNull => {
+// MIR-NEXT: v{{[0-9]+}}=scrut =>
+
+pub fn read_empty() -> i32 {
+    match empty() {
+        Nullable::NonNull(b) => b.value,
+        Nullable::Null => -1
+    }
+}
+
+// A nullable bound but never matched: dropped through a null check, never a
+// blind deallocation.
+pub fn drop_unmatched(v: i32) -> i32 {
+    let n = wrap(v);
+    let e = empty();
+    7
+}
+
+struct [regional] Cell { v: u64, next: [field] Cell }
+
+regional fn mk2(v: u64) -> [flex] Cell {
+    let tail : [flex] Cell = Cell { v: v + 1, next: Nullable::Null };
+    let head : [flex] Cell = Cell { v: v, next: Nullable::Null };
+    head->next := Nullable::NonNull { tail };
+    head
+}
+
+// Match on a frozen `[field]` link; the payload projects further.
+pub fn second(v: u64) -> u64 {
+    let c = regional { mk2(v) };
+    match c.next {
+        Nullable::NonNull(inner) => inner.v,
+        Nullable::Null => 0
+    }
+}
+
+// A nested nullable match on the unwrapped payload's own link.
+pub fn end_of_list(v: u64) -> u64 {
+    let c = regional { mk2(v) };
+    match c.next {
+        Nullable::NonNull(inner) => match inner.next {
+            Nullable::NonNull(deeper) => deeper.v,
+            Nullable::Null => inner.v + 100
+        },
+        Nullable::Null => 0
+    }
+}
+
+extern "C" trampoline "read_wrapped_ffi" = read_wrapped;
+extern "C" trampoline "read_empty_ffi" = read_empty;
+extern "C" trampoline "drop_unmatched_ffi" = drop_unmatched;
+extern "C" trampoline "second_ffi" = second;
+extern "C" trampoline "end_of_list_ffi" = end_of_list;


### PR DESCRIPTION
Closes the **"Nullable in value position + nullable-pattern dispatch"** item of #290. Frontend-only — the dialect already had everything needed (`nullable.dispatch`/`check`/`coerce`); the Rust pipeline just never used it.

## What was missing

`Nullable` expressions worked, but: matching on a nullable failed at elaboration ("cannot match constructor against `Nullable<..>`" — `hir::SwitchCases::Nullable` existed end-to-end but *nothing produced it*), codegen bailed on the switch, and a nullable **value** couldn't be refcounted (`rc.inc`/`rc.dec` reject nullable operands and don't null-guard), so even `let n = c.next;` died in lowering.

## The implementation (mirroring the Haskell reference's conventions)

- **Patterns**: `Nullable::NonNull(p)` / `Nullable::Null` route by the same `Nullable`-qualifier convention as expressions, through new `Ctor::NonNull`/`Null` heads (a closed two-case family) into `SwitchCases::Nullable`. The NonNull payload column **reuses the scrutinee's own occurrence path** — the textual-IR arms carry no field index, and unwrapping a non-null is a pointer no-op (this is the reference's `dtRefMap` rebinding convention).
- **Codegen**: `reussir.nullable.dispatch`, the exact op the reference emits — the non-null region's block argument is the unwrapped pointer, pushed as a fresh anchor at the switch's path. Three new melior builders (`nullable.check`/`coerce`/`dispatch`; only `create` existed).
- **Refcounting**: `emit_inc`/`emit_dec` gain a `Nullable` arm — `check` + `scf.if` + `coerce` + count. A null link is a no-op, **never a blind deallocation** (the issue-213 property, now asserted against rrc's own LLVM output too).

## Two pre-existing match-lowering bugs this surfaced

Both in scrutinee-path resolution, both only reachable once a dispatch re-anchors a path the way the nullable payload does:
1. `resolve` scanned **all** anchors, so a nested match's relative paths could hit an *enclosing* switch's anchor at a longer prefix (`[1]` of the inner match matching the outer's `[1]` anchor). It now considers only the current match's anchors (`root_idx` scoping).
2. `bind_pattern` special-cased empty paths straight to the raw root anchor, bypassing any anchor that re-bound the root's own path — exactly what `match x { Nullable::NonNull(b) => .. }` does. Empty paths now resolve like everything else (latest anchor wins).

## Tests (ports + new, per review discussion)

- **Ported from the Haskell driver to `%rrc`**: `nullable.rr` (value position, MIR text + object compile), `issue_213_noop_deallocate_null.rr` (LLVM `deallocate(ptr null` check), `invalid_record.rr` (rrc rejects at elaboration, earlier than Haskell's full-phase failure; the instantiation-level `[field] T` check remains unit-tested at mono).
- **New `nullable_match.rr` + C harness, executing**: dispatch over shared values and frozen `[field]` links, a *nested* nullable match on the unwrapped payload's own link, and null-guarded drops of unmatched nullables — two rounds to flush double-frees.
- **Semi unit tests**: payload typing + `SwitchCases::Nullable` production, missing-`Null`-arm non-exhaustiveness, and the HIR textual round-trip of a nullable match (printer/parser arms existed but were unreachable from real elaboration until now).

Suites: core 195, codegen 43, lit **247 passed / 4 unsupported / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2