### PR TITLE
[frontend] render types in surface syntax in diagnostics

### DIFF
--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -340,6 +340,59 @@ mod tests {
         });
     }
 
+    /// Diagnostics spell types the way the surface does (`i32`, `bool`,
+    /// `Nullable<Cell<u64>>`, `[rigid] …`), never the internal `Debug` form
+    /// (`Int(Signed(32))`).
+    #[test]
+    fn diagnostics_render_types_in_surface_syntax() {
+        let messages = |source: &str| {
+            with_tcx(|tcx| {
+                let parse = reussir_syntax::parse(source);
+                assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+                let prog = surface::program(&parse.root);
+                let elab = elaborate(tcx, &prog, parse.resolver());
+                assert!(elab.has_errors(), "expected an error");
+                elab.reports
+                    .iter()
+                    .map(|r| r.message.clone())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+        };
+
+        let m = messages("fn bad() -> i32 { true }");
+        assert!(
+            m.contains("expected `i32`, found `bool`"),
+            "surface spelling expected: {m}"
+        );
+
+        let m = messages(
+            r#"
+            struct [regional] Cell<T> { v: T }
+            fn f(c: Cell<u64>) -> bool { c }
+            "#,
+        );
+        assert!(
+            m.contains("expected `bool`, found `[rigid] Cell<u64>`"),
+            "record spelling expected: {m}"
+        );
+
+        let m = messages(
+            r#"
+            struct [regional] Matrix<T> { m00: [field] T }
+            fn test() -> Matrix<u64> { regional { Matrix { m00: 0 } } }
+            "#,
+        );
+        assert!(
+            m.contains("`Nullable<u64>` does not implement `Integral`"),
+            "nullable spelling expected: {m}"
+        );
+        assert!(
+            !m.contains("Int(") && !m.contains("Unsigned("),
+            "no Debug leakage: {m}"
+        );
+    }
+
     /// A non-`[field]` regional-record member holds an already-*frozen* value:
     /// the member's expected type is `Rigid`-refined (`rigid_member_ty`), so a
     /// projection reads a `Rigid` value out, and construction accepts a frozen

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -112,7 +112,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             let f = self.infer.resolve(found);
             self.error(
                 span,
-                format!("type mismatch: expected `{e:?}`, found `{f:?}`"),
+                format!(
+                    "type mismatch: expected `{}`, found `{}`",
+                    self.ty_display(e),
+                    self.ty_display(f)
+                ),
             );
             return;
         }
@@ -751,7 +755,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let mut indices = Vec::new();
         for acc in accs {
             let TyKind::Record { def, args, flex } = cur.kind() else {
-                self.error(span, format!("cannot access a field of `{cur:?}`"));
+                let shown = self.infer.resolve(cur);
+                self.error(
+                    span,
+                    format!("cannot access a field of `{}`", self.ty_display(shown)),
+                );
                 return self.poison(span);
             };
             let Some((idx, field_ty, _)) = self.resolve_field(*def, args, *flex, acc) else {

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -343,6 +343,87 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.resolver.resolve(key)
     }
 
+    /// Render `ty` the way the surface spells it, for diagnostics: `i32`,
+    /// `bool`, `Cell<u64>`, `[rigid] Node`, `Nullable<Data>`,
+    /// `(i32, i32) -> i32`. A generic prints its declared name; an unsolved
+    /// inference hole prints `_` — pass a *deeply resolved* type
+    /// (`InferCtxt::resolve`) so solved holes show their solutions. The
+    /// `Debug` form (`Int(Signed(32))`) is for compiler logs only and must
+    /// not reach user-facing reports.
+    pub fn ty_display(&self, ty: Ty<'tcx>) -> String {
+        let mut out = String::new();
+        self.push_ty_display(&mut out, ty);
+        out
+    }
+
+    fn push_ty_display(&self, out: &mut String, ty: Ty<'tcx>) {
+        use crate::semi::ty::{FpTy, IntTy};
+        use std::fmt::Write as _;
+        match *ty.kind() {
+            TyKind::Int(IntTy::Signed(w)) => {
+                let _ = write!(out, "i{w}");
+            }
+            TyKind::Int(IntTy::Unsigned(w)) => {
+                let _ = write!(out, "u{w}");
+            }
+            TyKind::Fp(FpTy::Ieee(w)) => {
+                let _ = write!(out, "f{w}");
+            }
+            TyKind::Fp(FpTy::BFloat16) => out.push_str("bfloat16"),
+            TyKind::Fp(FpTy::Float8) => out.push_str("float8"),
+            TyKind::Bool => out.push_str("bool"),
+            TyKind::Str => out.push_str("str"),
+            TyKind::Unit => out.push_str("unit"),
+            TyKind::Bottom => out.push_str("!"),
+            TyKind::Generic(g) => out.push_str(
+                self.generics
+                    .get(g.0 as usize)
+                    .map_or("_", |info| self.resolver.resolve(info.name)),
+            ),
+            TyKind::Hole(_) => out.push('_'),
+            TyKind::Nullable(inner) => {
+                out.push_str("Nullable<");
+                self.push_ty_display(out, inner);
+                out.push('>');
+            }
+            TyKind::Record { def, args, flex } => {
+                match flex {
+                    Flexivity::Flex => out.push_str("[flex] "),
+                    Flexivity::Rigid => out.push_str("[rigid] "),
+                    Flexivity::Regional => out.push_str("[regional] "),
+                    Flexivity::Irrelevant => {}
+                }
+                out.push_str(&self.defs.path(def).display(self.resolver));
+                if !args.is_empty() {
+                    out.push('<');
+                    for (i, &arg) in args.iter().enumerate() {
+                        if i > 0 {
+                            out.push_str(", ");
+                        }
+                        self.push_ty_display(out, arg);
+                    }
+                    out.push('>');
+                }
+            }
+            TyKind::Closure { params, ret } => {
+                if let [single] = params {
+                    self.push_ty_display(out, *single);
+                } else {
+                    out.push('(');
+                    for (i, &p) in params.iter().enumerate() {
+                        if i > 0 {
+                            out.push_str(", ");
+                        }
+                        self.push_ty_display(out, p);
+                    }
+                    out.push(')');
+                }
+                out.push_str(" -> ");
+                self.push_ty_display(out, ret);
+            }
+        }
+    }
+
     /// Record one successful resolution of `name`, feeding the frecency model
     /// that ranks future "did you mean" suggestions.
     pub(super) fn record_use(&mut self, name: TokenKey) {

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -248,7 +248,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     Ok(_) => Discharge::Solved,
                     Err(_) => {
                         let name = &self.traits.trait_def(tref.trait_id).name;
-                        Discharge::Failed(format!("`{self_ty:?}` does not implement `{name}`"))
+                        Discharge::Failed(format!(
+                            "`{}` does not implement `{name}`",
+                            self.ty_display(self_ty)
+                        ))
                     }
                 }
             }

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -314,7 +314,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return self.check_nullable_pat(ctor, span, ty);
         }
         let TyKind::Record { def, args, .. } = ty.kind() else {
-            self.error(span, format!("cannot match constructor against `{ty:?}`"));
+            let shown = self.infer.resolve(ty);
+            self.error(
+                span,
+                format!(
+                    "cannot match constructor against `{}`",
+                    self.ty_display(shown)
+                ),
+            );
             return Pat::Wild;
         };
         // The enum is named by the path qualifier (`Enum::Variant`), resolved to
@@ -407,9 +414,13 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 elem
             }
             _ => {
+                let shown = self.infer.resolve(ty);
                 self.error(
                     span,
-                    format!("cannot match a nullable pattern against `{ty:?}`"),
+                    format!(
+                        "cannot match a nullable pattern against `{}`",
+                        self.ty_display(shown)
+                    ),
                 );
                 return Pat::Wild;
             }

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -107,7 +107,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     if is_concretely_non_pointer(inner) {
                         self.error(
                             Some(span),
-                            format!("`Nullable` inner type `{inner:?}` is not a pointer-like type"),
+                            format!(
+                                "`Nullable` inner type `{}` is not a pointer-like type",
+                                self.ty_display(inner)
+                            ),
                         );
                     }
                     self.tcx.mk_nullable(inner)

--- a/tests/integration/frontend/invalid_record.rr
+++ b/tests/integration/frontend/invalid_record.rr
@@ -16,5 +16,5 @@ fn test() -> Matrix<u64> {
 }
 
 // The diagnostic names the mistyped link slot and points at the literal.
-// CHECK: `Nullable(Int(Unsigned(64)))` does not implement `Integral`
+// CHECK: `Nullable<u64>` does not implement `Integral`
 // CHECK: invalid_record.rr:15:29


### PR DESCRIPTION
Diagnostics leaked the compiler-internal `Debug` form of types:

```
Error: type mismatch: expected `Int(Signed(32))`, found `Bool`
Error: `Nullable(Int(Unsigned(64)))` does not implement `Integral`
```

now render as the surface spells them:

```
Error: type mismatch: expected `i32`, found `bool`
Error: `Nullable<u64>` does not implement `Integral`
Error: type mismatch: expected `bool`, found `[rigid] Cell<u64>`
```

One new method, `Elaborator::ty_display` — `i32`/`u64`/`f64`/`bfloat16`, `bool`/`str`/`unit`, `Cell<u64>` (record paths + type args, `[flex]`/`[rigid]`/`[regional]` coloring prefix), `Nullable<Data>`, `(i32, i32) -> i32` closures, generics by declared name, `_` for an unsolved hole (call sites pass deeply-resolved types so solved holes show their solutions). Every type-embedding message routes through it: `expect`'s type mismatch, field access on a non-record, constructor/nullable patterns against a non-matching scrutinee, trait-bound discharge failures, and non-pointer `Nullable` elements.

A unit test pins the spellings across scalar/record/nullable shapes and asserts no `Int(`/`Unsigned(` leakage; `invalid_record.rr`'s pinned message updates accordingly. Suites: core 207, lit 247 / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2