### PR TITLE
[frontend] reussir-repl: global `let` bindings

### DIFF
--- a/crates/reussir-core/src/semi/repl.rs
+++ b/crates/reussir-core/src/semi/repl.rs
@@ -33,6 +33,24 @@ use crate::semi::hir::{Expr, ExprKind, Function, VarId};
 use crate::semi::ty::{DefId, Flexivity, Ty, TyKind};
 use crate::surface::{self, Visibility};
 
+/// One REPL expression evaluation request (see
+/// [`Elaborator::try_repl_expr`]).
+pub struct ReplExprRequest<'a, 'tcx> {
+    /// The interned wrapper name (`__repl_expr_N`).
+    pub name: TokenKey,
+    /// The interned dec-companion name (`__repl_expr_N_dec`).
+    pub dec_name: TokenKey,
+    /// The exported C symbol (conventionally the wrapper name's text).
+    pub export: &'a str,
+    /// A `let` ascription to check the expression against, if any.
+    pub ascription: Option<&'a (surface::Type, bool)>,
+    /// The session's live global bindings (name, *value* type), in the
+    /// order the host passes their boxes on every call.
+    pub bindings: &'a [(TokenKey, Ty<'tcx>)],
+    /// The `__ReplBox` prelude record ([`Elaborator::install_repl_box`]).
+    pub repl_box: DefId,
+}
+
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Elaborate one REPL expression as the synthetic nullary function
     /// `name`, registering a C-ABI trampoline root that exports `export`
@@ -47,21 +65,60 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// by the zonk-time ambiguity check with an annotation hint.
     pub fn try_repl_expr(
         &mut self,
-        name: TokenKey,
-        dec_name: TokenKey,
-        export: &str,
+        request: &ReplExprRequest<'_, 'tcx>,
         expr: &surface::Expr,
-        repl_box: DefId,
     ) -> Result<(Ty<'tcx>, Vec<Report>), Vec<Report>> {
+        let &ReplExprRequest {
+            name,
+            dec_name,
+            export,
+            ascription,
+            bindings,
+            repl_box,
+        } = request;
         let cp = self.checkpoint();
         let span = Some(expr.span());
 
-        // Check the expression as a nullary, non-regional function body with
-        // a hole return type; inference solves the hole to the expression's
-        // type.
+        // Check the expression as a non-regional function body; the return
+        // type is the `let` ascription when the driver passes one, else a
+        // hole that inference solves to the expression's type.
         self.enter_function(&[]);
         self.regional_generics.clear();
-        let ret = self.infer.new_hole_ty();
+
+        // Pre-seed the session's global `let` bindings: each becomes a
+        // wrapper parameter `g` holding the binding's `__ReplBox<T>`,
+        // immediately shadowed (same user-visible name) by the projected
+        // payload, so the checked expression resolves the bare name to the
+        // value. The host passes every live binding's box on each call —
+        // an unused parameter is simply dropped by the ownership pass,
+        // balancing the host-side retain.
+        struct Seeded<'tcx> {
+            name: TokenKey,
+            param: VarId,
+            box_ty: Ty<'tcx>,
+            value: VarId,
+            value_ty: Ty<'tcx>,
+        }
+        let seeded: Vec<Seeded<'tcx>> = bindings
+            .iter()
+            .map(|&(bname, bty)| {
+                let box_ty = self.tcx.mk_record(repl_box, &[bty], Flexivity::Irrelevant);
+                let param = self.vars.fresh(bname, box_ty, None);
+                let value = self.vars.fresh(bname, bty, None);
+                Seeded {
+                    name: bname,
+                    param,
+                    box_ty,
+                    value,
+                    value_ty: bty,
+                }
+            })
+            .collect();
+
+        let ret = match ascription {
+            Some((ty, flex)) => self.eval_type_flex(ty, *flex),
+            None => self.infer.new_hole_ty(),
+        };
         let body = self.check_expr(expr, ret);
         self.default_numeric_holes();
         self.resolve_obligations();
@@ -107,6 +164,38 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // C ABI as one shared-box pointer. Unit has nothing to show or
         // free and skips the box.
         let boxed = !matches!(return_ty.kind(), TyKind::Unit);
+        // The binding prologue: `let x = g.value` per seeded binding, in
+        // front of the (boxed) user expression.
+        let params: Vec<(TokenKey, VarId, Ty<'tcx>)> =
+            seeded.iter().map(|b| (b.name, b.param, b.box_ty)).collect();
+        let prologue: Vec<Expr<'tcx>> = seeded
+            .iter()
+            .map(|b| {
+                let base = Expr {
+                    kind: ExprKind::Var(b.param),
+                    ty: b.box_ty,
+                    span,
+                    id: self.fresh_expr_id(),
+                };
+                let projected = Expr {
+                    kind: ExprKind::Proj(Box::new(base), vec![0]),
+                    ty: b.value_ty,
+                    span,
+                    id: self.fresh_expr_id(),
+                };
+                Expr {
+                    kind: ExprKind::Let {
+                        var: b.value,
+                        name: b.name,
+                        span,
+                        value: Box::new(projected),
+                    },
+                    ty: self.tcx.mk_unit(),
+                    span,
+                    id: self.fresh_expr_id(),
+                }
+            })
+            .collect();
         let (body, wrapper_ty) = if boxed {
             // A shared record's coloring is `Irrelevant` (only regional
             // records carry Flex/Rigid), matching `record_ty`.
@@ -127,6 +216,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         } else {
             (body, return_ty)
         };
+        let body = if prologue.is_empty() {
+            body
+        } else {
+            let ty = body.ty;
+            let mut stmts = prologue;
+            stmts.push(body);
+            Expr {
+                kind: ExprKind::Seq(stmts),
+                ty,
+                span,
+                id: self.fresh_expr_id(),
+            }
+        };
         self.functions.insert(
             def,
             FuncProto {
@@ -135,7 +237,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 visibility: Visibility::Private,
                 generics: Vec::new(),
                 regional_generics: Vec::new(),
-                params: Vec::new(),
+                params: params.iter().map(|&(n, _, t)| (n, t)).collect(),
                 return_ty: wrapper_ty,
                 is_regional: false,
                 span,
@@ -147,7 +249,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             visibility: Visibility::Private,
             generics: Vec::new(),
             regional_generics: std::mem::take(&mut self.regional_generics),
-            params: Vec::new(),
+            params,
             return_ty: wrapper_ty,
             is_regional: false,
             body: Some(body),
@@ -258,6 +360,7 @@ mod tests {
 
     use reussir_syntax::{Interner, MultiThreadedTokenInterner, new_threaded_interner};
 
+    use crate::semi::repl::ReplExprRequest;
     use crate::semi::ty::{FpTy, IntTy, Ty, TyCtxt, TyKind};
     use crate::semi::{Elaborator, Report};
     use crate::surface;
@@ -293,7 +396,17 @@ mod tests {
             let dec_key =
                 Interner::get_or_intern(&mut self.interner.clone(), &format!("{export}_dec"));
             self.elab
-                .try_repl_expr(key, dec_key, &export, &expr, self.repl_box)
+                .try_repl_expr(
+                    &ReplExprRequest {
+                        name: key,
+                        dec_name: dec_key,
+                        export: &export,
+                        ascription: None,
+                        bindings: &[],
+                        repl_box: self.repl_box,
+                    },
+                    &expr,
+                )
                 .map(|(ty, _)| ty)
         }
     }
@@ -418,6 +531,80 @@ mod tests {
             assert_eq!(t.target, f.def);
             assert_eq!(s.elab.trampolines[1].name, "__repl_expr_0_dec");
             assert_eq!(s.elab.trampolines[1].target, dec.def);
+        });
+    }
+
+    #[test]
+    fn global_bindings_become_wrapper_parameters() {
+        use crate::full::mono::monomorphize;
+
+        session(|s, tcx| {
+            // Bind `x` by evaluating an ordinary expression first (the
+            // driver stores its box), then check an expression referencing
+            // it: the wrapper takes the binding's box as a parameter and
+            // projects the value in a prologue.
+            let x_ty = s.eval("41").expect("bind rhs");
+            let x_key = Interner::get_or_intern(&mut s.interner.clone(), "x");
+
+            let p = reussir_syntax::parse_repl("x + 1", s.interner.clone());
+            assert!(p.parse.ok());
+            let expr = surface::repl_expr(&p.parse.root);
+            let key = Interner::get_or_intern(&mut s.interner.clone(), "__repl_expr_1");
+            let dec = Interner::get_or_intern(&mut s.interner.clone(), "__repl_expr_1_dec");
+            let (ty, _) = s
+                .elab
+                .try_repl_expr(
+                    &ReplExprRequest {
+                        name: key,
+                        dec_name: dec,
+                        export: "__repl_expr_1",
+                        ascription: None,
+                        bindings: &[(x_key, x_ty)],
+                        repl_box: s.repl_box,
+                    },
+                    &expr,
+                )
+                .expect("binding resolves");
+            assert_eq!(ty, tcx.mk_int(IntTy::Signed(64)));
+
+            // The wrapper's sole parameter is the binding's box.
+            let wrapper = s
+                .elab
+                .elaborated
+                .iter()
+                .find(|f| s.elab.sym(f.name) == "__repl_expr_1")
+                .expect("wrapper");
+            assert_eq!(wrapper.params.len(), 1);
+            assert!(matches!(wrapper.params[0].2.kind(), TyKind::Record { .. }));
+
+            // An unknown name still errors cleanly.
+            let p = reussir_syntax::parse_repl("y + 1", s.interner.clone());
+            let expr = surface::repl_expr(&p.parse.root);
+            let key = Interner::get_or_intern(&mut s.interner.clone(), "__repl_expr_2");
+            let dec = Interner::get_or_intern(&mut s.interner.clone(), "__repl_expr_2_dec");
+            let errs = s
+                .elab
+                .try_repl_expr(
+                    &ReplExprRequest {
+                        name: key,
+                        dec_name: dec,
+                        export: "__repl_expr_2",
+                        ascription: None,
+                        bindings: &[(x_key, x_ty)],
+                        repl_box: s.repl_box,
+                    },
+                    &expr,
+                )
+                .expect_err("unknown name");
+            assert!(
+                errs.iter().any(|r| r.message.contains("unknown")),
+                "{errs:#?}"
+            );
+
+            // The whole accumulated program (parameterized wrapper included)
+            // monomorphizes.
+            let (_, reports) = monomorphize(&s.elab.mono_input());
+            assert!(reports.is_empty(), "{reports:#?}");
         });
     }
 

--- a/crates/reussir-jit/src/orc.rs
+++ b/crates/reussir-jit/src/orc.rs
@@ -54,6 +54,7 @@ unsafe extern "C" {
         module: LLVMModuleRef,
         data_layout: *const c_char,
         triple: *const c_char,
+        strip_invariant_group_barriers: c_int,
     ) -> LLVMMemoryBufferRef;
     fn reussirHasTPDE() -> c_int;
 }
@@ -444,7 +445,12 @@ impl OrcJit {
             let data_layout = LLVMOrcLLJITGetDataLayoutStr(self.jit);
             let triple = LLVMGetDefaultTargetTriple();
             tracing::debug!("compiling module to an object with TPDE");
-            let buffer = reussirTpdeCompileToObject(module, data_layout, triple);
+            // Strip the invariant-group barrier intrinsics (which TPDE
+            // cannot compile — e.g. shared-record member projections carry
+            // them) — the JIT owns this module copy and disposes it right
+            // after, so the in-place rewrite is free here. Callers reusing
+            // a module with the LLVM backend would pass 0 instead.
+            let buffer = reussirTpdeCompileToObject(module, data_layout, triple, 1);
             LLVMDisposeMessage(triple);
             if buffer.is_null() {
                 tracing::error!("TPDE compilation failed");

--- a/crates/reussir-repl/src/commands.rs
+++ b/crates/reussir-repl/src/commands.rs
@@ -12,6 +12,7 @@ Available commands:
   :type <expr>          Show the type of an expression (no evaluation)
   :dump context         Pretty-print the accumulated definitions (HIR)
   :dump compiled        List JIT-compiled symbols
+  :dump bindings        List global `let` bindings and their current values
   :set opt <level>      Set the optimization level (none, default, aggressive, size, tpde)
   :clear                Reset the session (definitions and compiled code)
 
@@ -99,7 +100,10 @@ pub fn dispatch(session: &mut ReplSession<'_, '_>, command: &str) -> Outcome {
                 out.pop();
                 Outcome::Text(out)
             }
-            _ => Outcome::Text("usage: :dump context | :dump compiled".to_string()),
+            Some("bindings") => Outcome::Text(session.render_bindings()),
+            _ => {
+                Outcome::Text("usage: :dump context | :dump compiled | :dump bindings".to_string())
+            }
         },
         Some("set") => match (words.next(), words.next()) {
             (Some("opt"), Some(level)) => match parse_opt(level) {

--- a/crates/reussir-repl/src/frontend/plain.rs
+++ b/crates/reussir-repl/src/frontend/plain.rs
@@ -111,6 +111,15 @@ pub fn render(outcome: &Outcome, input: &str) -> Option<Exit> {
                 println!("{value} : {ty}");
             }
         }
+        Outcome::Binding {
+            name,
+            value,
+            ty,
+            warnings,
+        } => {
+            render_reports("<repl>", input, warnings);
+            println!("{name} = {value} : {ty}");
+        }
         Outcome::ParseErrors(errors) => {
             let map = SourceMap::new(input);
             let _ =

--- a/crates/reussir-repl/src/frontend/tui.rs
+++ b/crates/reussir-repl/src/frontend/tui.rs
@@ -401,6 +401,21 @@ impl Tui {
                 };
                 self.push_boxed(&title, content);
             }
+            Outcome::Binding {
+                name,
+                value,
+                ty,
+                warnings,
+            } => {
+                self.render_reports(warnings, input);
+                // A binding cell is titled by its name instead of `Out[n]`.
+                let content = vec![
+                    Span::styled(value.clone(), Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw(" : "),
+                    Span::styled(ty.clone(), Style::default().fg(Color::Magenta)),
+                ];
+                self.push_boxed(name, content);
+            }
             Outcome::ParseErrors(errors) => {
                 let map = SourceMap::new(input);
                 let mut rendered = Vec::new();

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -89,11 +89,11 @@ where
 /// inputs. The box releases itself ([`crate::value::BoundBox`]'s `Drop`) on
 /// rebinding and on session drop — while the JIT (borrowed by the session,
 /// so it strictly outlives it) still has the dec companion materialized.
-struct GlobalBinding<'tcx> {
+struct GlobalBinding<'jit, 'tcx> {
     name: reussir_syntax::kind::TokenKey,
     display: String,
     ty: Ty<'tcx>,
-    boxed: crate::value::BoundBox,
+    boxed: crate::value::BoundBox<'jit>,
 }
 
 /// A module added to the JIT whose input is not yet permanent.
@@ -132,7 +132,7 @@ pub struct ReplSession<'a, 'tcx> {
     /// place (the old box released); the whole list is released on session
     /// drop (`:clear` included) while the JIT still holds the dec
     /// companions.
-    bindings: Vec<GlobalBinding<'tcx>>,
+    bindings: Vec<GlobalBinding<'a, 'tcx>>,
     /// The `__repl_expr_N` counter (advanced only on success).
     counter: usize,
     pub(crate) opt: OptLevel,
@@ -360,7 +360,7 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         name: reussir_syntax::kind::TokenKey,
         display: String,
         ty: Ty<'tcx>,
-        boxed: crate::value::BoundBox,
+        boxed: crate::value::BoundBox<'a>,
     ) {
         let entry = GlobalBinding {
             name,

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -86,19 +86,14 @@ where
 }
 
 /// One global `let` binding: an owned `__ReplBox<T>` kept alive between
-/// inputs, plus its dec companion for release on rebinding or session drop.
+/// inputs. The box releases itself ([`crate::value::BoundBox`]'s `Drop`) on
+/// rebinding and on session drop — while the JIT (borrowed by the session,
+/// so it strictly outlives it) still has the dec companion materialized.
 struct GlobalBinding<'tcx> {
     name: reussir_syntax::kind::TokenKey,
     display: String,
     ty: Ty<'tcx>,
-    boxed: *const u8,
-    dec: extern "C" fn(*const u8),
-}
-
-impl Drop for ReplSession<'_, '_> {
-    fn drop(&mut self) {
-        self.release_bindings();
-    }
+    boxed: crate::value::BoundBox,
 }
 
 /// A module added to the JIT whose input is not yet permanent.
@@ -272,7 +267,7 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
                                 self.tcx
                                     .mk_record(self.repl_box, &[ty], Flexivity::Irrelevant);
                             let args: Vec<*const u8> =
-                                self.bindings.iter().map(|b| b.boxed).collect();
+                                self.bindings.iter().map(|b| b.boxed.as_ptr()).collect();
                             let result = if binder.is_some() {
                                 crate::value::call_and_bind(
                                     self.jit,
@@ -365,17 +360,16 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         name: reussir_syntax::kind::TokenKey,
         display: String,
         ty: Ty<'tcx>,
-        bound: crate::value::BoundBox,
+        boxed: crate::value::BoundBox,
     ) {
         let entry = GlobalBinding {
             name,
             display,
             ty,
-            boxed: bound.boxed,
-            dec: bound.dec,
+            boxed,
         };
         if let Some(existing) = self.bindings.iter_mut().find(|b| b.name == name) {
-            (existing.dec)(existing.boxed);
+            // The overwrite drops the old entry's box, releasing it.
             *existing = entry;
         } else {
             self.bindings.push(entry);
@@ -395,7 +389,7 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             // SAFETY: the session owns one reference to each binding's box;
             // it is live until `register_binding`/`Drop` release it.
             let value = unsafe {
-                crate::reflect::shared_box_payload(b.boxed, box_ty, &self.shapes).and_then(
+                crate::reflect::shared_box_payload(b.boxed.as_ptr(), box_ty, &self.shapes).and_then(
                     |payload| {
                         crate::reflect::render_value(payload, b.ty, &self.shapes, &self.printers)
                     },
@@ -559,16 +553,6 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             .filter(|r| !self.elab.sym(r.name).starts_with("__"))
             .count();
         functions + records
-    }
-
-    /// Release every global binding's box. Runs in `Drop`, while the JIT
-    /// (borrowed, so it outlives the session) still has the dec companions
-    /// materialized: the allocator is process-global, so without this a
-    /// `:clear` would leak the bindings for the process lifetime.
-    fn release_bindings(&mut self) {
-        for binding in self.bindings.drain(..) {
-            (binding.dec)(binding.boxed);
-        }
     }
 
     /// Render a ground Semi type for display (`i64`, `f64`, `List::<i64>`).

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -45,6 +45,14 @@ pub enum Outcome {
         ty: String,
         warnings: Vec<Report>,
     },
+    /// A global `let` was accepted: the value is now bound for later inputs
+    /// (rebinding the same name overwrites, releasing the old value).
+    Binding {
+        name: String,
+        value: String,
+        ty: String,
+        warnings: Vec<Report>,
+    },
     /// Syntax errors in the input (render against the input source).
     ParseErrors(Vec<ParseError>),
     /// Elaboration/monomorphization diagnostics (input was rolled back).
@@ -75,6 +83,22 @@ where
         let mut session = ReplSession::new(tcx, &interner, &context, &jit, config);
         drive(&mut session)
     }))
+}
+
+/// One global `let` binding: an owned `__ReplBox<T>` kept alive between
+/// inputs, plus its dec companion for release on rebinding or session drop.
+struct GlobalBinding<'tcx> {
+    name: reussir_syntax::kind::TokenKey,
+    display: String,
+    ty: Ty<'tcx>,
+    boxed: *const u8,
+    dec: extern "C" fn(*const u8),
+}
+
+impl Drop for ReplSession<'_, '_> {
+    fn drop(&mut self) {
+        self.release_bindings();
+    }
 }
 
 /// A module added to the JIT whose input is not yet permanent.
@@ -108,6 +132,12 @@ pub struct ReplSession<'a, 'tcx> {
     /// JIT. Later modules emit these as body-less declarations
     /// ([`crate::externalize`]); ORC resolves the calls across modules.
     pub(crate) emitted: FxHashSet<String>,
+    /// Global `let` bindings, in binding order — the order of the extra
+    /// box parameters every later wrapper takes. Rebinding overwrites in
+    /// place (the old box released); the whole list is released on session
+    /// drop (`:clear` included) while the JIT still holds the dec
+    /// companions.
+    bindings: Vec<GlobalBinding<'tcx>>,
     /// The `__repl_expr_N` counter (advanced only on success).
     counter: usize,
     pub(crate) opt: OptLevel,
@@ -138,6 +168,7 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             context,
             jit,
             emitted: FxHashSet::default(),
+            bindings: Vec::new(),
             shapes: crate::reflect::ShapeTable::default(),
             printers: crate::reflect::PrinterRegistry::default(),
             modules: Vec::new(),
@@ -190,15 +221,46 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             }
             ReplInputKind::Expr => {
                 let expr = surface::repl_expr(&parsed.parse.root);
+                // A single top-level `let` is a *global binding*: its value
+                // persists for later inputs. Multi-statement sequences keep
+                // ordinary block semantics.
+                let (rhs, binder) = match expr.kind() {
+                    surface::ExprKind::ExprSeq(mut exprs) if exprs.len() == 1 => {
+                        let only = exprs.pop().expect("length checked");
+                        match only.kind() {
+                            surface::ExprKind::Let(bname, ascription, value) => {
+                                (value, Some((bname, ascription)))
+                            }
+                            _ => (only, None),
+                        }
+                    }
+                    _ => (expr, None),
+                };
                 let export = format!("__repl_expr_{}", self.counter);
                 let name = Interner::get_or_intern(&mut self.interner.clone(), &export);
                 let dec_name =
                     Interner::get_or_intern(&mut self.interner.clone(), &format!("{export}_dec"));
-                match self
-                    .elab
-                    .try_repl_expr(name, dec_name, &export, &expr, self.repl_box)
-                {
+                let in_scope: Vec<_> = self.bindings.iter().map(|b| (b.name, b.ty)).collect();
+                match self.elab.try_repl_expr(
+                    &reussir_core::semi::repl::ReplExprRequest {
+                        name,
+                        dec_name,
+                        export: &export,
+                        ascription: binder.as_ref().and_then(|(_, a)| a.as_ref()),
+                        bindings: &in_scope,
+                        repl_box: self.repl_box,
+                    },
+                    &rhs,
+                ) {
                     Err(reports) => Outcome::Reports(reports),
+                    Ok((ty, _)) if binder.is_some() && matches!(ty.kind(), TyKind::Unit) => {
+                        self.elab.rollback(&cp);
+                        Outcome::Reports(vec![Report {
+                            severity: Severity::Error,
+                            message: "cannot bind a unit value".to_string(),
+                            span: None,
+                        }])
+                    }
                     Ok((ty, warnings)) => match self.compile_new(&cp) {
                         Err(outcome) => outcome,
                         // The input becomes permanent only after the
@@ -209,15 +271,33 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
                             let box_ty =
                                 self.tcx
                                     .mk_record(self.repl_box, &[ty], Flexivity::Irrelevant);
-                            match crate::value::call_and_render(
-                                self.jit,
-                                &export,
-                                ty,
-                                box_ty,
-                                &self.shapes,
-                                &self.printers,
-                            ) {
-                                Ok(value) => {
+                            let args: Vec<*const u8> =
+                                self.bindings.iter().map(|b| b.boxed).collect();
+                            let result = if binder.is_some() {
+                                crate::value::call_and_bind(
+                                    self.jit,
+                                    &export,
+                                    ty,
+                                    box_ty,
+                                    &self.shapes,
+                                    &self.printers,
+                                    &args,
+                                )
+                                .map(|(value, bound)| (value, Some(bound)))
+                            } else {
+                                crate::value::call_and_render(
+                                    self.jit,
+                                    &export,
+                                    ty,
+                                    box_ty,
+                                    &self.shapes,
+                                    &self.printers,
+                                    &args,
+                                )
+                                .map(|value| (value, None))
+                            };
+                            match result {
+                                Ok((value, bound)) => {
                                     self.commit(pending);
                                     self.counter += 1;
                                     // The wrapper is unspellable (an identifier
@@ -227,7 +307,10 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
                                     // monomorphizations walk only the *new*
                                     // input's call graph instead of every
                                     // historical expression's. The wrapper's
-                                    // HIR stays behind as dead code.
+                                    // HIR stays behind as dead code. (The dec
+                                    // companion's *code* stays materialized in
+                                    // the JIT — a binding's release calls it
+                                    // long after this input.)
                                     let before = self.elab.trampolines.len();
                                     self.elab
                                         .trampolines
@@ -236,10 +319,27 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
                                         self.elab.trampolines.len() < before,
                                         "the wrapper's roots must be registered"
                                     );
-                                    Outcome::Value {
-                                        value,
-                                        ty: self.render_ty(ty),
-                                        warnings,
+                                    match (binder, bound) {
+                                        (Some((bname, _)), Some(bound)) => {
+                                            let display = self.elab.sym(bname.value).to_string();
+                                            self.register_binding(
+                                                bname.value,
+                                                display.clone(),
+                                                ty,
+                                                bound,
+                                            );
+                                            Outcome::Binding {
+                                                name: display,
+                                                value,
+                                                ty: self.render_ty(ty),
+                                                warnings,
+                                            }
+                                        }
+                                        _ => Outcome::Value {
+                                            value,
+                                            ty: self.render_ty(ty),
+                                            warnings,
+                                        },
                                     }
                                 }
                                 Err(message) => {
@@ -257,6 +357,60 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         }
     }
 
+    /// Install (or overwrite) a global binding. Rebinding releases the old
+    /// box and keeps the binding's position, so the wrapper-parameter order
+    /// stays stable.
+    fn register_binding(
+        &mut self,
+        name: reussir_syntax::kind::TokenKey,
+        display: String,
+        ty: Ty<'tcx>,
+        bound: crate::value::BoundBox,
+    ) {
+        let entry = GlobalBinding {
+            name,
+            display,
+            ty,
+            boxed: bound.boxed,
+            dec: bound.dec,
+        };
+        if let Some(existing) = self.bindings.iter_mut().find(|b| b.name == name) {
+            (existing.dec)(existing.boxed);
+            *existing = entry;
+        } else {
+            self.bindings.push(entry);
+        }
+    }
+
+    /// Render the live global bindings (`:dump bindings`).
+    pub(crate) fn render_bindings(&self) -> String {
+        if self.bindings.is_empty() {
+            return "no global bindings".to_string();
+        }
+        let mut out = String::from("=== Global Bindings ===");
+        for b in &self.bindings {
+            let box_ty = self
+                .tcx
+                .mk_record(self.repl_box, &[b.ty], Flexivity::Irrelevant);
+            // SAFETY: the session owns one reference to each binding's box;
+            // it is live until `register_binding`/`Drop` release it.
+            let value = unsafe {
+                crate::reflect::shared_box_payload(b.boxed, box_ty, &self.shapes).and_then(
+                    |payload| {
+                        crate::reflect::render_value(payload, b.ty, &self.shapes, &self.printers)
+                    },
+                )
+            }
+            .unwrap_or_else(|e| format!("<{e}>"));
+            out.push_str(&format!(
+                "\n - {} : {} = {value}",
+                b.display,
+                self.render_ty(b.ty)
+            ));
+        }
+        out
+    }
+
     /// Check an expression's type without compiling or executing it
     /// (`:type`). Elaborator state is always rolled back.
     pub(crate) fn type_of(&mut self, source: &str) -> Outcome {
@@ -271,9 +425,18 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         let cp = self.elab.checkpoint();
         let name = Interner::get_or_intern(&mut self.interner.clone(), "__repl_type_probe");
         let dec_name = Interner::get_or_intern(&mut self.interner.clone(), "__repl_type_probe_dec");
-        let result =
-            self.elab
-                .try_repl_expr(name, dec_name, "__repl_type_probe", &expr, self.repl_box);
+        let in_scope: Vec<_> = self.bindings.iter().map(|b| (b.name, b.ty)).collect();
+        let result = self.elab.try_repl_expr(
+            &reussir_core::semi::repl::ReplExprRequest {
+                name,
+                dec_name,
+                export: "__repl_type_probe",
+                ascription: None,
+                bindings: &in_scope,
+                repl_box: self.repl_box,
+            },
+            &expr,
+        );
         match result {
             Ok((ty, _)) => {
                 let rendered = self.render_ty(ty);
@@ -396,6 +559,16 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             .filter(|r| !self.elab.sym(r.name).starts_with("__"))
             .count();
         functions + records
+    }
+
+    /// Release every global binding's box. Runs in `Drop`, while the JIT
+    /// (borrowed, so it outlives the session) still has the dec companions
+    /// materialized: the allocator is process-global, so without this a
+    /// `:clear` would leak the bindings for the process lifetime.
+    fn release_bindings(&mut self) {
+        for binding in self.bindings.drain(..) {
+            (binding.dec)(binding.boxed);
+        }
     }
 
     /// Render a ground Semi type for display (`i64`, `f64`, `List::<i64>`).

--- a/crates/reussir-repl/src/value.rs
+++ b/crates/reussir-repl/src/value.rs
@@ -23,20 +23,38 @@ use reussir_jit::OrcJit;
 
 use crate::reflect::{self, PrinterRegistry, ShapeTable};
 
-/// An owned `__ReplBox` kept alive past its evaluation (a global binding),
-/// with the dec companion that eventually releases it.
+/// An owned reference to an evaluated `__ReplBox` — a host-side smart
+/// pointer over the shared rc box. `Clone` retains, `Drop` releases through
+/// the dec companion; otherwise move-only, so every reference has exactly
+/// one releasing owner (a binding's box lives in the session's
+/// `GlobalBinding` and dies with it — rebinding included — with no manual
+/// bookkeeping).
 pub struct BoundBox {
-    pub boxed: *const u8,
-    pub dec: extern "C" fn(*const u8),
-}
-
-/// Calls the `_dec` companion on drop, releasing the displayed box.
-struct DecGuard {
-    dec: extern "C" fn(*const u8),
     boxed: *const u8,
+    dec: extern "C" fn(*const u8),
 }
 
-impl Drop for DecGuard {
+impl BoundBox {
+    /// The raw box pointer, for passing to wrapper calls (which retain per
+    /// reference they consume — see [`call_boxed`]) and for walking.
+    pub fn as_ptr(&self) -> *const u8 {
+        self.boxed
+    }
+}
+
+impl Clone for BoundBox {
+    fn clone(&self) -> Self {
+        // SAFETY: `self` holds a live reference; the retain mirrors the
+        // generated `rc.inc` (see `retain_box`).
+        unsafe { retain_box(self.boxed) };
+        BoundBox {
+            boxed: self.boxed,
+            dec: self.dec,
+        }
+    }
+}
+
+impl Drop for BoundBox {
     fn drop(&mut self) {
         (self.dec)(self.boxed);
     }
@@ -130,24 +148,18 @@ fn call_and_walk<'tcx>(
     if boxed.is_null() {
         return Err("the REPL wrapper returned a null box (this is a bug)".to_string());
     }
+    // Owning from here on: any early return below releases through Drop.
     let bound = BoundBox { boxed, dec };
 
     // The box payload is the `{ value: T }` compound; its sole member's
     // inline cell sits at offset 0, so the payload address *is* the inline
     // representation of `T` the walker expects.
-    // SAFETY: `boxed` is a live box of `box_ty`'s layout, owned above.
+    // SAFETY: `bound` owns a live box of `box_ty`'s layout.
     let rendered = unsafe {
-        reflect::shared_box_payload(boxed, box_ty, shapes)
-            .and_then(|payload| reflect::render_value(payload, ty, shapes, printers))
+        reflect::shared_box_payload(bound.as_ptr(), box_ty, shapes)
+            .and_then(|payload| reflect::render_value(payload, ty, shapes, printers))?
     };
-    match rendered {
-        Ok(rendered) => Ok((rendered, bound)),
-        Err(error) => {
-            // Release before surfacing the walker failure.
-            (bound.dec)(bound.boxed);
-            Err(error)
-        }
-    }
+    Ok((rendered, bound))
 }
 
 /// Look up `export` in the JIT, call it (passing the live bindings' boxes),
@@ -169,11 +181,8 @@ pub fn call_and_render<'tcx>(
         unsafe { call_unit(address, args) };
         return Ok("()".to_string());
     }
-    let (rendered, bound) = call_and_walk(jit, export, ty, box_ty, shapes, printers, args)?;
-    let _guard = DecGuard {
-        dec: bound.dec,
-        boxed: bound.boxed,
-    };
+    // The evaluated box drops (releases) here; only the rendering survives.
+    let (rendered, _bound) = call_and_walk(jit, export, ty, box_ty, shapes, printers, args)?;
     Ok(rendered)
 }
 

--- a/crates/reussir-repl/src/value.rs
+++ b/crates/reussir-repl/src/value.rs
@@ -29,12 +29,19 @@ use crate::reflect::{self, PrinterRegistry, ShapeTable};
 /// one releasing owner (a binding's box lives in the session's
 /// `GlobalBinding` and dies with it — rebinding included — with no manual
 /// bookkeeping).
-pub struct BoundBox {
+///
+/// The `'jit` borrow ties the reference to the engine whose materialized
+/// dec-companion code `Drop` calls (mirroring
+/// [`ModuleHandle`](reussir_jit::ModuleHandle)): releasing after engine
+/// disposal would be a use-after-free, and the borrow makes it a compile
+/// error instead of a discipline.
+pub struct BoundBox<'jit> {
     boxed: *const u8,
     dec: extern "C" fn(*const u8),
+    jit: std::marker::PhantomData<&'jit OrcJit>,
 }
 
-impl BoundBox {
+impl BoundBox<'_> {
     /// The raw box pointer, for passing to wrapper calls (which retain per
     /// reference they consume — see [`call_boxed`]) and for walking.
     pub fn as_ptr(&self) -> *const u8 {
@@ -42,7 +49,7 @@ impl BoundBox {
     }
 }
 
-impl Clone for BoundBox {
+impl Clone for BoundBox<'_> {
     fn clone(&self) -> Self {
         // SAFETY: `self` holds a live reference; the retain mirrors the
         // generated `rc.inc` (see `retain_box`).
@@ -50,11 +57,12 @@ impl Clone for BoundBox {
         BoundBox {
             boxed: self.boxed,
             dec: self.dec,
+            jit: std::marker::PhantomData,
         }
     }
 }
 
-impl Drop for BoundBox {
+impl Drop for BoundBox<'_> {
     fn drop(&mut self) {
         (self.dec)(self.boxed);
     }
@@ -126,15 +134,15 @@ unsafe fn call_unit(address: usize, args: &[*const u8]) {
 
 /// Call the wrapper (passing the live bindings' boxes) and return the
 /// evaluated box plus its rendering, WITHOUT releasing it — the `let` path.
-fn call_and_walk<'tcx>(
-    jit: &OrcJit,
+fn call_and_walk<'jit, 'tcx>(
+    jit: &'jit OrcJit,
     export: &str,
     ty: Ty<'tcx>,
     box_ty: Ty<'tcx>,
     shapes: &ShapeTable<'tcx>,
     printers: &PrinterRegistry,
     args: &[*const u8],
-) -> Result<(String, BoundBox), String> {
+) -> Result<(String, BoundBox<'jit>), String> {
     let address = jit.lookup(export)? as usize;
     // Resolve the dec companion *before* calling the wrapper, so a missing
     // symbol cannot strand an already-allocated box.
@@ -149,7 +157,11 @@ fn call_and_walk<'tcx>(
         return Err("the REPL wrapper returned a null box (this is a bug)".to_string());
     }
     // Owning from here on: any early return below releases through Drop.
-    let bound = BoundBox { boxed, dec };
+    let bound = BoundBox {
+        boxed,
+        dec,
+        jit: std::marker::PhantomData,
+    };
 
     // The box payload is the `{ value: T }` compound; its sole member's
     // inline cell sits at offset 0, so the payload address *is* the inline
@@ -189,15 +201,15 @@ pub fn call_and_render<'tcx>(
 /// [`call_and_render`], but keep the evaluated box alive and hand it to the
 /// caller — the global-`let` path. The caller owns the release (rebinding
 /// or session drop). Unit values are rejected upstream.
-pub fn call_and_bind<'tcx>(
-    jit: &OrcJit,
+pub fn call_and_bind<'jit, 'tcx>(
+    jit: &'jit OrcJit,
     export: &str,
     ty: Ty<'tcx>,
     box_ty: Ty<'tcx>,
     shapes: &ShapeTable<'tcx>,
     printers: &PrinterRegistry,
     args: &[*const u8],
-) -> Result<(String, BoundBox), String> {
+) -> Result<(String, BoundBox<'jit>), String> {
     call_and_walk(jit, export, ty, box_ty, shapes, printers, args)
 }
 

--- a/crates/reussir-repl/src/value.rs
+++ b/crates/reussir-repl/src/value.rs
@@ -9,11 +9,26 @@
 //! dec — held in a guard so the box is released on *every* exit path,
 //! walker failures included. Unit results skip the box (a plain `void()`
 //! export; nothing to show or free).
+//!
+//! **Global bindings** ride the same protocol in the other direction: the
+//! wrapper takes one `__ReplBox` pointer per live binding (per the
+//! trampoline C ABI: passed directly below four parameters, packed behind
+//! one struct pointer at four or more), and *consumes* each — so the host
+//! retains every passed box first, exactly what an in-language caller
+//! holding its own reference would do. A `let` input keeps the returned box
+//! alive instead of dec'ing it ([`call_and_bind`]).
 
 use reussir_core::semi::ty::{Ty, TyKind};
 use reussir_jit::OrcJit;
 
 use crate::reflect::{self, PrinterRegistry, ShapeTable};
+
+/// An owned `__ReplBox` kept alive past its evaluation (a global binding),
+/// with the dec companion that eventually releases it.
+pub struct BoundBox {
+    pub boxed: *const u8,
+    pub dec: extern "C" fn(*const u8),
+}
 
 /// Calls the `_dec` companion on drop, releasing the displayed box.
 struct DecGuard {
@@ -27,10 +42,118 @@ impl Drop for DecGuard {
     }
 }
 
-/// Look up `export` in the JIT, call it, and render the boxed result via the
-/// layout walker. `ty` is the expression's ground type (what the user sees);
-/// `box_ty` is the wrapper's actual `__ReplBox<T>` return type, used to
-/// locate the payload inside the rc box.
+/// Bump a shared rc box's refcount from the host, mirroring what generated
+/// code does before a consuming call.
+///
+/// # Safety
+///
+/// `boxed` must point at a live shared rc box (count word at offset 0).
+/// Shared counts are `AtomicKind::normal` today — a plain read-modify-write,
+/// exactly the generated `rc.inc` — and the REPL is single-threaded; if
+/// atomic rc ever lands, this must switch to an atomic add with it.
+unsafe fn retain_box(boxed: *const u8) {
+    let count = boxed.cast_mut().cast::<usize>();
+    unsafe { *count += 1 };
+}
+
+/// Invoke a wrapper export with one `__ReplBox` pointer per binding, per the
+/// trampoline C ABI: pointer parameters pass directly below four, and pack
+/// behind a single struct pointer at four or more
+/// (`CABISignatureConversion.cpp`). Retains every argument first — the
+/// callee consumes them.
+///
+/// # Safety
+///
+/// `address` must be the wrapper's materialized entry, whose Reussir
+/// signature takes exactly `args.len()` boxes and returns a box pointer.
+unsafe fn call_boxed(address: usize, args: &[*const u8]) -> *const u8 {
+    unsafe {
+        for &arg in args {
+            retain_box(arg);
+        }
+        type P = *const u8;
+        match args {
+            [] => std::mem::transmute::<usize, extern "C" fn() -> P>(address)(),
+            [a] => std::mem::transmute::<usize, extern "C" fn(P) -> P>(address)(*a),
+            [a, b] => std::mem::transmute::<usize, extern "C" fn(P, P) -> P>(address)(*a, *b),
+            [a, b, c] => {
+                std::mem::transmute::<usize, extern "C" fn(P, P, P) -> P>(address)(*a, *b, *c)
+            }
+            packed => std::mem::transmute::<usize, extern "C" fn(P) -> P>(address)(
+                packed.as_ptr().cast::<u8>(),
+            ),
+        }
+    }
+}
+
+/// [`call_boxed`] for a unit-returning wrapper (`void` return in every ABI
+/// shape).
+unsafe fn call_unit(address: usize, args: &[*const u8]) {
+    unsafe {
+        for &arg in args {
+            retain_box(arg);
+        }
+        type P = *const u8;
+        match args {
+            [] => std::mem::transmute::<usize, extern "C" fn()>(address)(),
+            [a] => std::mem::transmute::<usize, extern "C" fn(P)>(address)(*a),
+            [a, b] => std::mem::transmute::<usize, extern "C" fn(P, P)>(address)(*a, *b),
+            [a, b, c] => std::mem::transmute::<usize, extern "C" fn(P, P, P)>(address)(*a, *b, *c),
+            packed => std::mem::transmute::<usize, extern "C" fn(P)>(address)(
+                packed.as_ptr().cast::<u8>(),
+            ),
+        }
+    }
+}
+
+/// Call the wrapper (passing the live bindings' boxes) and return the
+/// evaluated box plus its rendering, WITHOUT releasing it — the `let` path.
+fn call_and_walk<'tcx>(
+    jit: &OrcJit,
+    export: &str,
+    ty: Ty<'tcx>,
+    box_ty: Ty<'tcx>,
+    shapes: &ShapeTable<'tcx>,
+    printers: &PrinterRegistry,
+    args: &[*const u8],
+) -> Result<(String, BoundBox), String> {
+    let address = jit.lookup(export)? as usize;
+    // Resolve the dec companion *before* calling the wrapper, so a missing
+    // symbol cannot strand an already-allocated box.
+    let dec: extern "C" fn(*const u8) =
+        unsafe { std::mem::transmute(jit.lookup(&format!("{export}_dec"))? as usize) };
+
+    // SAFETY: the wrapper was materialized with exactly this signature (see
+    // the module docs), and every passed box is live and retained inside
+    // `call_boxed`.
+    let boxed = unsafe { call_boxed(address, args) };
+    if boxed.is_null() {
+        return Err("the REPL wrapper returned a null box (this is a bug)".to_string());
+    }
+    let bound = BoundBox { boxed, dec };
+
+    // The box payload is the `{ value: T }` compound; its sole member's
+    // inline cell sits at offset 0, so the payload address *is* the inline
+    // representation of `T` the walker expects.
+    // SAFETY: `boxed` is a live box of `box_ty`'s layout, owned above.
+    let rendered = unsafe {
+        reflect::shared_box_payload(boxed, box_ty, shapes)
+            .and_then(|payload| reflect::render_value(payload, ty, shapes, printers))
+    };
+    match rendered {
+        Ok(rendered) => Ok((rendered, bound)),
+        Err(error) => {
+            // Release before surfacing the walker failure.
+            (bound.dec)(bound.boxed);
+            Err(error)
+        }
+    }
+}
+
+/// Look up `export` in the JIT, call it (passing the live bindings' boxes),
+/// render the boxed result via the layout walker, and release it. `ty` is
+/// the expression's ground type (what the user sees); `box_ty` the wrapper's
+/// actual `__ReplBox<T>` return type.
 pub fn call_and_render<'tcx>(
     jit: &OrcJit,
     export: &str,
@@ -38,37 +161,35 @@ pub fn call_and_render<'tcx>(
     box_ty: Ty<'tcx>,
     shapes: &ShapeTable<'tcx>,
     printers: &PrinterRegistry,
+    args: &[*const u8],
 ) -> Result<String, String> {
-    let address = jit.lookup(export)? as usize;
-    // SAFETY: the wrapper trampoline was just materialized with the C ABI
-    // shape its return type implies — `void()` for unit, pointer-returning
-    // for the shared `__ReplBox` — and the dec companion consumes exactly
-    // that pointer (see the module docs).
-    unsafe {
-        if matches!(*ty.kind(), TyKind::Unit) {
-            let f: extern "C" fn() = std::mem::transmute(address);
-            f();
-            return Ok("()".to_string());
-        }
-
-        // Resolve the dec companion *before* calling the wrapper, so a
-        // missing symbol cannot strand an already-allocated box.
-        let dec: extern "C" fn(*const u8) =
-            std::mem::transmute(jit.lookup(&format!("{export}_dec"))? as usize);
-
-        let f: extern "C" fn() -> *const u8 = std::mem::transmute(address);
-        let boxed = f();
-        if boxed.is_null() {
-            return Err("the REPL wrapper returned a null box (this is a bug)".to_string());
-        }
-        let _guard = DecGuard { dec, boxed };
-
-        // The box payload is the `{ value: T }` compound; its sole member's
-        // inline cell sits at offset 0, so the payload address *is* the
-        // inline representation of `T` the walker expects.
-        let payload = reflect::shared_box_payload(boxed, box_ty, shapes)?;
-        reflect::render_value(payload, ty, shapes, printers)
+    if matches!(*ty.kind(), TyKind::Unit) {
+        let address = jit.lookup(export)? as usize;
+        // SAFETY: unit wrappers export `void(...)` (module docs).
+        unsafe { call_unit(address, args) };
+        return Ok("()".to_string());
     }
+    let (rendered, bound) = call_and_walk(jit, export, ty, box_ty, shapes, printers, args)?;
+    let _guard = DecGuard {
+        dec: bound.dec,
+        boxed: bound.boxed,
+    };
+    Ok(rendered)
+}
+
+/// [`call_and_render`], but keep the evaluated box alive and hand it to the
+/// caller — the global-`let` path. The caller owns the release (rebinding
+/// or session drop). Unit values are rejected upstream.
+pub fn call_and_bind<'tcx>(
+    jit: &OrcJit,
+    export: &str,
+    ty: Ty<'tcx>,
+    box_ty: Ty<'tcx>,
+    shapes: &ShapeTable<'tcx>,
+    printers: &PrinterRegistry,
+    args: &[*const u8],
+) -> Result<(String, BoundBox), String> {
+    call_and_walk(jit, export, ty, box_ty, shapes, printers, args)
 }
 
 /// Match the old REPL's float rendering: always show a decimal point

--- a/include/Reussir-c/Jit.h
+++ b/include/Reussir-c/Jit.h
@@ -42,9 +42,19 @@ void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt)
 // data layout and target triple on it. Returns NULL if TPDE support was not
 // compiled in or compilation fails; otherwise the caller owns the returned
 // memory buffer (e.g. hands it to `LLVMOrcLLJITAddObjectFile`).
+//
+// `stripInvariantGroupBarriers` (nonzero = on) rewrites the module IN PLACE
+// before compiling, replacing the `llvm.launder.invariant.group` /
+// `llvm.strip.invariant.group` barrier intrinsics — which TPDE has no
+// lowering for — with their pointer operand (always conservative-correct:
+// they are pure optimizer fences). Callers that go on to reuse the module
+// with the real LLVM backend should pass 0 to keep its invariant-group
+// information, at the price of TPDE failing on modules that carry the
+// barriers (e.g. shared-record member projections).
 LLVMMemoryBufferRef reussirTpdeCompileToObject(LLVMModuleRef module,
                                                const char *dataLayout,
-                                               const char *triple);
+                                               const char *triple,
+                                               int stripInvariantGroupBarriers);
 
 #ifdef __cplusplus
 }

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -10,6 +10,7 @@
 
 #include <llvm-c/Core.h>
 
+#include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Passes/PassBuilder.h>
@@ -64,11 +65,37 @@ void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt)
   mpm.run(m, mam);
 }
 
+namespace {
+/// TPDE has no lowering for the invariant.group barrier intrinsics the
+/// frozen/shared payload loads carry (`llvm.launder.invariant.group`,
+/// `llvm.strip.invariant.group`). Both are pure optimizer fences that
+/// return their pointer operand, so replacing the call with the operand is
+/// always conservative-correct — required for e.g. a REPL wrapper that
+/// projects a global binding's value out of its shared box.
+void stripInvariantGroupBarriers(llvm::Module &m) {
+  llvm::SmallVector<llvm::IntrinsicInst *> barriers;
+  for (llvm::Function &f : m)
+    for (llvm::BasicBlock &bb : f)
+      for (llvm::Instruction &inst : bb)
+        if (auto *intrinsic = llvm::dyn_cast<llvm::IntrinsicInst>(&inst))
+          if (intrinsic->getIntrinsicID() ==
+                  llvm::Intrinsic::launder_invariant_group ||
+              intrinsic->getIntrinsicID() ==
+                  llvm::Intrinsic::strip_invariant_group)
+            barriers.push_back(intrinsic);
+  for (llvm::IntrinsicInst *barrier : barriers) {
+    barrier->replaceAllUsesWith(barrier->getArgOperand(0));
+    barrier->eraseFromParent();
+  }
+}
+} // namespace
+
 LLVMMemoryBufferRef reussirTpdeCompileToObject(LLVMModuleRef module,
                                                const char *dataLayout,
                                                const char *triple) {
 #ifdef REUSSIR_HAS_TPDE
   llvm::Module &m = *llvm::unwrap(module);
+  stripInvariantGroupBarriers(m);
 
   // TPDE compiles directly from the module, so it must carry the host data
   // layout and triple (the freshly translated module may have neither).

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -90,12 +90,16 @@ void stripInvariantGroupBarriers(llvm::Module &m) {
 }
 } // namespace
 
-LLVMMemoryBufferRef reussirTpdeCompileToObject(LLVMModuleRef module,
-                                               const char *dataLayout,
-                                               const char *triple) {
+LLVMMemoryBufferRef
+reussirTpdeCompileToObject(LLVMModuleRef module, const char *dataLayout,
+                           const char *triple,
+                           int stripInvariantGroupBarriersFlag) {
 #ifdef REUSSIR_HAS_TPDE
   llvm::Module &m = *llvm::unwrap(module);
-  stripInvariantGroupBarriers(m);
+  // Caller-guarded: the rewrite mutates the (borrowed) module, so callers
+  // that may reuse it with the real LLVM backend keep it intact.
+  if (stripInvariantGroupBarriersFlag)
+    stripInvariantGroupBarriers(m);
 
   // TPDE compiles directly from the module, so it must carry the host data
   // layout and triple (the freshly translated module may have neither).
@@ -120,6 +124,7 @@ LLVMMemoryBufferRef reussirTpdeCompileToObject(LLVMModuleRef module,
   (void)module;
   (void)dataLayout;
   (void)triple;
+  (void)stripInvariantGroupBarriersFlag;
   return nullptr;
 #endif
 }

--- a/tests/integration/repl-rs/global_lets.repl
+++ b/tests/integration/repl-rs/global_lets.repl
@@ -1,0 +1,63 @@
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror 2>&1 | %FileCheck %s
+// RUN: %rrepl -i %s -lerror -Onone 2>&1 | %FileCheck %s
+
+// Global `let` bindings: a single top-level `let` binds its (evaluated)
+// value for every later input. Multi-statement inputs keep block semantics.
+
+let x = 40
+// CHECK: x = 40 : i64
+
+x + 2
+// CHECK: 42 : i64
+
+// A binding's right-hand side sees earlier bindings.
+let y = x * 2
+// CHECK: y = 80 : i64
+
+// Rebinding overwrites (the old value is released); uses see the new value.
+let x = 100
+// CHECK: x = 100 : i64
+
+x + y
+// CHECK: 180 : i64
+
+// Managed values bind, project, and rebind with balanced refcounts.
+struct P { a: i64, b: f64 }
+// CHECK: Definition added.
+
+let p = P { a: 7, b: 0.5 }
+// CHECK: p = P { a: 7, b: 0.5 } : P
+
+p
+// CHECK: P { a: 7, b: 0.5 } : P
+
+p.a + x
+// CHECK: 107 : i64
+
+let p = P { a: 9, b: 1.5 }
+// CHECK: p = P { a: 9, b: 1.5 } : P
+
+:dump bindings
+// CHECK: === Global Bindings ===
+// CHECK: x : i64 = 100
+// CHECK: y : i64 = 80
+// CHECK: p : P = P { a: 9, b: 1.5 }
+
+// A `let` ascription is honored.
+let z: f32 = 1.5
+// CHECK: z = 1.5 : f32
+
+// Sequences are NOT bindings: block semantics, nothing registered.
+let q = 5; q + 1
+// CHECK: 6 : i64
+
+:type x + y
+// CHECK: x + y : i64
+
+// `:clear` releases the bindings with the session.
+:clear
+// CHECK: Context cleared
+
+x
+// CHECK: unknown variable `x`


### PR DESCRIPTION
Follow-up to the merged REPL stack (#289/#292/#293/#294), implementing the global-binding design from the #294 review discussion.

## What

A **single top-level `let`** input now binds its evaluated value for every later input; multi-statement sequences (`let q = 5; q + 1`) keep ordinary block semantics. Bindings **can be overwritten** — rebinding releases the old value and keeps the parameter position stable.

```
λ> let x = 40          ╭─ x ──────╮
                       │ 40 : i64 │
                       ╰──────────╯
λ> let y = x * 2       (a binding's rhs sees earlier bindings)
λ> let x = 100         (overwrites; old box released)
λ> x + y
180 : i64
```

- **Engine** (`reussir-core`): `try_repl_expr` (API regrouped into a `ReplExprRequest` struct) pre-seeds each live binding as a wrapper parameter `g: __ReplBox<T>` shadowed by a `let x = g.value` prologue — the checked expression resolves bare names naturally, and the parameters ride the existing trampoline C ABI (pointers direct below four, packed behind one struct pointer at four or more). `let x: T = …` ascriptions check the rhs against `T`.
- **Session**: ordered `GlobalBinding` list (name, type, owned box, dec companion). The host retains each passed box before the call (a plain count increment — exactly the generated `rc.inc`, sound while shared rc is `AtomicKind::normal`); the callee consumes it, so unused parameters balance via the ownership pass's drop. `let` results keep their box instead of the dec guard; every binding is released in `ReplSession::Drop` while the JIT still holds the dec companions (the allocator is process-global — `:clear` must not leak). Unit values are rejected.
- **`:dump bindings`** lists live bindings with re-walked current values; the TUI titles a binding's cell with its name instead of `Out[n]`.
- **TPDE fix found en route**: in-language projection through a shared box emits `llvm.launder.invariant.group`, which TPDE cannot compile (this was the first in-language shared-member projection to run under TPDE). `reussirTpdeCompileToObject` now strips the launder/strip invariant.group barriers — pure optimizer fences returning their operand — before compiling.

## Tests

- Core: wrapper parameterization, unknown-name diagnostics, monomorphization of parameterized wrappers (`cargo test -p reussir-core`, 208).
- `tests/integration/repl-rs/global_lets.repl` at **both** TPDE and `-Onone`: bind/use/compose/rebind, managed records with balanced refcounts (bind → reuse → project → rebind), ascription, `:dump bindings`, sequence-vs-binding routing, `:type` with bindings in scope, `:clear` release. repl-rs suite 9/9; full lit 256/260 with zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)