### PR TITLE
[tests] migrate REPL lit tests from the Haskell REPL to rrepl

### DIFF
--- a/tests/integration/repl-rs/multiline.repl
+++ b/tests/integration/repl-rs/multiline.repl
@@ -1,4 +1,5 @@
-// RUN: %reussir-repl -i %s -lerror -Onone | %FileCheck %s
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
 
 // Test multiline function definition
 :{

--- a/tests/integration/repl-rs/nat_back_and_forth.repl
+++ b/tests/integration/repl-rs/nat_back_and_forth.repl
@@ -1,4 +1,5 @@
-// RUN: %reussir-repl -i %s -lerror -Oaggressive | %FileCheck %s
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
 
 :{
 enum Nat {

--- a/tests/integration/repl-rs/pattern_bool.repl
+++ b/tests/integration/repl-rs/pattern_bool.repl
@@ -1,4 +1,5 @@
-// RUN: %reussir-repl -i %s -lerror -Oaggressive | %FileCheck %s
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
 
 // Test: pattern matching on bool constants
 

--- a/tests/integration/repl-rs/pattern_bool_nested.repl
+++ b/tests/integration/repl-rs/pattern_bool_nested.repl
@@ -1,4 +1,5 @@
-// RUN: %reussir-repl -i %s -lerror -Oaggressive | %FileCheck %s
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
 
 // Test: nested pattern matching on bool with multiple arguments
 

--- a/tests/integration/repl-rs/pattern_enum_option.repl
+++ b/tests/integration/repl-rs/pattern_enum_option.repl
@@ -1,4 +1,5 @@
-// RUN: %reussir-repl -i %s -lerror -Oaggressive | %FileCheck %s
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
 
 // Test: pattern matching on a shallow Option-like enum with nested int patterns
 

--- a/tests/integration/repl-rs/pattern_enum_result.repl
+++ b/tests/integration/repl-rs/pattern_enum_result.repl
@@ -1,4 +1,5 @@
-// RUN: %reussir-repl -i %s -lerror -Oaggressive | %FileCheck %s
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
 
 // Test: pattern matching on Result enum with mixed constructor and integer patterns
 

--- a/tests/integration/repl-rs/pattern_int.repl
+++ b/tests/integration/repl-rs/pattern_int.repl
@@ -1,4 +1,5 @@
-// RUN: %reussir-repl -i %s -lerror -Oaggressive | %FileCheck %s
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
 
 // Test: integer constant patterns, wildcard, and variable binding
 

--- a/tests/integration/repl-rs/pattern_int_guard.repl
+++ b/tests/integration/repl-rs/pattern_int_guard.repl
@@ -1,4 +1,5 @@
-// RUN: %reussir-repl -i %s -lerror -Oaggressive | %FileCheck %s
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
 
 // Test: integer pattern matching with guards
 

--- a/tests/integration/repl-rs/record.repl
+++ b/tests/integration/repl-rs/record.repl
@@ -1,13 +1,17 @@
-// RUN: %reussir-repl -i %s -lerror -Odefault | %FileCheck %s
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
 
 struct [value] Point { x : i64, y : i64 }
+// CHECK: Definition added.
 
 { let p = Point { x : 1, y : 2 } ; p.x }
 // CHECK: 1 : i64
 
 struct RcWrapper<T> { value : T }
+// CHECK: Definition added.
 
 fn wrap<T>(value : T) -> RcWrapper<T> { RcWrapper { value: value } }
+// CHECK: Definition added.
 
 wrap(Point { x : 1, y : 2 }).value.y
 // CHECK: 2 : i64


### PR DESCRIPTION
Moves nine `repl/*.repl` tests off the Haskell `%reussir-repl` driver onto the Rust REPL (`%rrepl`, suite `repl-rs/`), part of the Haskell→Rust migration (#290).

### Migrated (9, all pass)
`pattern_bool`, `pattern_bool_nested`, `pattern_int`, `pattern_int_guard`, `pattern_enum_option`, `pattern_enum_result`, `nat_back_and_forth`, `multiline`, `record`.

rrepl reproduces the Haskell REPL's output almost verbatim (`Definition added.`, `<value> : <type>`) and supports the same `:{`/`}:` multiline blocks and `:dump context|compiled|bindings` commands, so the bodies port unchanged. The only edits: the `// REQUIRES: rrepl` + `%rrepl -i %s -lerror` RUN header (dropping the Haskell `-O*` flag), and `record` gains the `Definition added.` lines rrepl emits after each definition. The `repl-rs/` suite now runs 18 tests, all green.

### Still on the Haskell REPL (tracked in #290)
- `pattern_num_of_true.repl` — an `enum [value] Node` matched in a function fails to lower: `'reussir.ref.spilled' op spilled type capability must be unspecified, spilled type capability: value`. Default-capability enums are fine; the `[value]` capability drives the bad `ref.spilled`. A real codegen bug, filed in #290.
- `polymorphic.repl` — uses `core::intrinsic::math::cos/sin` (the math-intrinsics gap). repl-rs already has its own non-math `polymorphic.repl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)