### PR TITLE
[frontend] multi-file source cache (ariadne) + lossless textual IR locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,7 @@ dependencies = [
  "palc",
  "serde_json",
  "stacker",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/reussir-codegen/src/lower/debug.rs
+++ b/crates/reussir-codegen/src/lower/debug.rs
@@ -61,13 +61,18 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
 
     /// Set the module-level debug attributes the conversion pass reads (the
     /// source file's basename and directory). No-op unless debug info is enabled.
+    ///
+    /// These name the *compile unit's* file — the crate root
+    /// ([`crate::source::FileId::ROOT`], the primary input). Per-op line
+    /// locations carry their own per-function file names via `FileLineColLoc`.
     pub(super) fn set_module_debug_attrs(&self, module: &mut Module<'c>) {
         if !self.debug_enabled() {
             return;
         }
         let Some(source) = self.source else { return };
-        let basename = StringAttribute::new(self.context, &source.basename());
-        let directory = StringAttribute::new(self.context, &source.directory());
+        let root = crate::source::FileId::ROOT;
+        let basename = StringAttribute::new(self.context, &source.basename(root));
+        let directory = StringAttribute::new(self.context, &source.directory(root));
         let mut op = module.as_operation_mut();
         op.set_attribute("reussir.dbg.file_basename", basename.into());
         op.set_attribute("reussir.dbg.file_directory", directory.into());

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -41,7 +41,7 @@ use reussir_core::surface::{Span, Visibility};
 use reussir_syntax::kind::{Resolver, TokenKey};
 use smallvec::SmallVec;
 
-use crate::source::SourceMap;
+use crate::source::{FileId, SourceCache};
 
 use super::ty::{TypeCtx, field_link_element, is_unit, num_class, regional_capability};
 use super::{LoweringError, Result, err};
@@ -209,7 +209,7 @@ pub(super) struct Lowerer<'c, 'p, 'tcx> {
     records: RecordTable<'tcx>,
     /// Resolves MIR byte spans to file/line/column; `None` lowers to `unknown`
     /// locations.
-    pub(super) source: Option<&'p SourceMap<'p>>,
+    pub(super) source: Option<&'p SourceCache>,
     /// Resolves interned source names for debug info; `Some` (with `source`)
     /// enables DWARF variable/type emission. See [`debug`](super::debug).
     pub(super) names: Option<&'p dyn Resolver<TokenKey>>,
@@ -223,6 +223,9 @@ pub(super) struct Lowerer<'c, 'p, 'tcx> {
     /// expression's span by [`expr`](Self::expr) (saved and restored around each
     /// node), so every op a node emits shares that node's source position.
     cur_loc: RefCell<Location<'c>>,
+    /// The file the current function's spans index (functions from different
+    /// files share one module); set by [`function`](Self::function).
+    cur_file: std::cell::Cell<FileId>,
     /// Record symbols whose debug composite is currently being built — the
     /// recursion guard for [`debug`](super::debug). A type that reaches itself
     /// (directly or through a boxed field) is emitted as a memberless
@@ -235,7 +238,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         context: &'c Context,
         tcx: &'p TyCtxt<'tcx>,
         program: &'p mir::Program<'tcx>,
-        source: Option<&'p SourceMap<'p>>,
+        source: Option<&'p SourceCache>,
         names: Option<&'p dyn Resolver<TokenKey>>,
     ) -> Self {
         Lowerer {
@@ -250,6 +253,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             var_tys: RefCell::new(FxHashMap::default()),
             temp_tys: RefCell::new(FxHashMap::default()),
             cur_loc: RefCell::new(Location::unknown(context)),
+            cur_file: std::cell::Cell::new(FileId::ROOT),
             dbg_building: RefCell::new(FxHashSet::default()),
         }
     }
@@ -265,13 +269,16 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         *self.cur_loc.borrow()
     }
 
-    /// Resolve a MIR span to a `FileLineColLoc`, or `unknown` without a source
-    /// map or span.
+    /// Resolve a MIR span (an offset into the current function's file) to a
+    /// `FileLineColLoc`, or `unknown` without a source cache or span — or when
+    /// the file's content could not be obtained (a re-ingested dump whose
+    /// source is virtual or missing), since offsets then resolve to nothing.
     pub(super) fn location(&self, span: Option<Span>) -> Location<'c> {
         match (self.source, span) {
-            (Some(map), Some(span)) => {
-                let (line, col) = map.span_start(span);
-                Location::new(self.context, &map.filename(), line, col)
+            (Some(cache), Some(span)) if cache.is_available(self.cur_file.get()) => {
+                let file = self.cur_file.get();
+                let (line, col) = cache.line_col(file, span.start as usize);
+                Location::new(self.context, cache.name(file), line, col)
             }
             _ => Location::unknown(self.context),
         }
@@ -293,6 +300,9 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
 
     /// Lower one MIR function to a `func.func` operation.
     pub(super) fn function(&self, func: &mir::Function<'tcx>) -> Result<Operation<'c>> {
+        // The function's spans index its own declaration file; every
+        // `location` below resolves against it.
+        self.cur_file.set(func.file);
         // The function and its entry-level ops (block args, return) take the
         // body's source position; nested nodes refine it as they are walked.
         let loc = self.location(func.body.and_then(|b| b.span));

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -63,7 +63,7 @@ use reussir_core::full::mir;
 use reussir_core::semi::ty::TyCtxt;
 use reussir_syntax::kind::{Resolver, TokenKey};
 
-use crate::source::SourceMap;
+use crate::source::SourceCache;
 use expr::Lowerer;
 
 /// A construct the current lowering subset does not handle.
@@ -100,7 +100,7 @@ pub fn lower_program<'c, 'tcx>(
     context: &'c Context,
     tcx: &TyCtxt<'tcx>,
     program: &mir::Program<'tcx>,
-    source: Option<&SourceMap<'_>>,
+    source: Option<&SourceCache>,
     names: Option<&dyn Resolver<TokenKey>>,
 ) -> Result<Module<'c>> {
     let mut module = Module::new(Location::unknown(context));
@@ -166,8 +166,8 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let path = std::path::Path::new("add.rr");
-            let map = crate::source::SourceMap::new(path, src);
+            let mut map = crate::source::SourceCache::new();
+            map.add_file("add.rr", src);
             let module =
                 lower_program(&context, tcx, &full, Some(&map), None).expect("lowering succeeds");
             let printed = module
@@ -204,8 +204,8 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let path = std::path::Path::new("pt.rr");
-            let map = crate::source::SourceMap::new(path, src);
+            let mut map = crate::source::SourceCache::new();
+            map.add_file("pt.rr", src);
             let module = lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()))
                 .expect("lowering succeeds");
             let printed = module
@@ -252,8 +252,8 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let path = std::path::Path::new("variant.rr");
-            let map = crate::source::SourceMap::new(path, src);
+            let mut map = crate::source::SourceCache::new();
+            map.add_file("variant.rr", src);
             let module = lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()))
                 .expect("lowering succeeds");
             let printed = module

--- a/crates/reussir-codegen/src/source.rs
+++ b/crates/reussir-codegen/src/source.rs
@@ -1,74 +1,13 @@
 //! Source-position mapping for attaching MLIR locations to lowered ops.
 //!
-//! The MIR carries byte-offset [`Span`]s; a [`SourceMap`] resolves those to
-//! `(line, column)` against the original source so lowering can label each op
-//! with a `FileLineColLoc` (and, with debug info enabled, emit correct DWARF line
-//! tables). Lowering without a source map falls back to `unknown` locations.
+//! The MIR carries file-local byte-offset [`Span`](reussir_core::surface::Span)s
+//! plus a per-function [`FileId`]; the compilation's [`SourceCache`] resolves
+//! those to `(file, line, column)` so lowering can label each op with a
+//! `FileLineColLoc` (and, with debug info enabled, emit correct DWARF line
+//! tables). Lowering without a source cache falls back to `unknown` locations.
 //!
-//! TODO(multifile): this maps a *single* source file. Once `rrc` grows a
-//! crate-like multi-file structure, a [`Span`] will need to identify its file
-//! too, and this should become a file cache keyed by file id (ariadne's
-//! [`Cache`](ariadne::Cache) / [`sources`](ariadne::sources) already model this).
+//! Re-exported from `reussir_syntax` so the whole pipeline shares one
+//! authority for offsets: diagnostics (ariadne caret reports) and debug info
+//! read the same per-file line index.
 
-use std::borrow::Cow;
-use std::path::Path;
-
-use ariadne::Source;
-use reussir_core::surface::Span;
-
-/// A line index over one source file, labelling positions with its path.
-///
-/// Wraps [`ariadne::Source`] (the same line cache the parser uses for
-/// diagnostics) to resolve byte offsets to `(line, column)`.
-pub struct SourceMap<'a> {
-    path: &'a Path,
-    source: Source<&'a str>,
-}
-
-impl<'a> SourceMap<'a> {
-    /// Build the line index for `source`, labelling positions with `path`.
-    pub fn new(path: &'a Path, source: &'a str) -> Self {
-        SourceMap {
-            path,
-            source: Source::from(source),
-        }
-    }
-
-    /// The source path positions are labelled with.
-    pub fn path(&self) -> &Path {
-        self.path
-    }
-
-    /// The full path as a string, for a `FileLineColLoc` filename.
-    pub fn filename(&self) -> Cow<'_, str> {
-        self.path.to_string_lossy()
-    }
-
-    /// The file name component, for the DWARF `DIFile` basename.
-    pub fn basename(&self) -> Cow<'_, str> {
-        self.path
-            .file_name()
-            .map_or(Cow::Borrowed(""), |n| n.to_string_lossy())
-    }
-
-    /// The parent directory, for the DWARF `DIFile` directory.
-    pub fn directory(&self) -> Cow<'_, str> {
-        self.path
-            .parent()
-            .map_or(Cow::Borrowed(""), |d| d.to_string_lossy())
-    }
-
-    /// The 1-based `(line, column)` of a byte `offset` (ariadne reports both
-    /// zero-indexed).
-    pub fn line_col(&self, offset: usize) -> (usize, usize) {
-        match self.source.get_byte_line(offset) {
-            Some((_, line, col)) => (line + 1, col + 1),
-            None => (1, 1),
-        }
-    }
-
-    /// The 1-based `(line, column)` at the start of `span`.
-    pub fn span_start(&self, span: Span) -> (usize, usize) {
-        self.line_col(span.start as usize)
-    }
-}
+pub use reussir_syntax::source::{FileId, SourceCache};

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -220,8 +220,8 @@ fn lowers_variant_debug_info_through_the_pipeline() {
         );
         let (full, reports) = monomorphize(&elab.mono_input());
         assert!(reports.is_empty(), "mono reports: {reports:#?}");
-        let path = std::path::Path::new("variant.rr");
-        let map = reussir_codegen::source::SourceMap::new(path, src);
+        let mut map = reussir_codegen::source::SourceCache::new();
+        map.add_file("variant.rr", src);
         lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()))
             .expect("variant lowering with debug info succeeds")
     });

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -478,10 +478,10 @@ fn frontend<'c, 'tcx>(
         Stage::Hir => {
             let parsed =
                 hir::build::parse_program(tcx, source).map_err(|e| format!("{name}: {e}"))?;
-            // The dump's file table names the original sources; refetch them
-            // from disk so spans keep resolving (missing/virtual files degrade
-            // to plain diagnostics and unknown debug locations, with a
-            // warning). An old, table-less dump has no locations at all.
+            // The dump's file table names the original sources. Rebuild the
+            // same dense ids, but delay opening paths until diagnostics or
+            // debug locations actually need source text. An old, table-less
+            // dump has no locations at all.
             let dump_sources = refetch_sources(&parsed.files);
             if target == Stage::Hir {
                 let printer = match &dump_sources {
@@ -547,10 +547,9 @@ fn frontend<'c, 'tcx>(
 }
 
 /// Rebuild a source cache from an IR dump's file table so its spans keep
-/// resolving: real paths are re-read from disk; a virtual (`<bracketed>`) or
-/// unreadable file becomes a name-only placeholder — its spans survive in the
-/// IR but degrade to plain diagnostics and unknown debug locations — with a
-/// warning naming it. `None` for a dump printed without locations.
+/// resolving: real paths are registered for lazy loading, while virtual
+/// (`<bracketed>`) entries become name-only placeholders. `None` means the dump
+/// was printed without locations.
 fn refetch_sources(files: &[String]) -> Option<SourceCache> {
     if files.is_empty() {
         return None;
@@ -559,19 +558,8 @@ fn refetch_sources(files: &[String]) -> Option<SourceCache> {
     for name in files {
         if name.starts_with('<') {
             cache.add_unavailable(name);
-            continue;
-        }
-        match std::fs::read_to_string(name) {
-            Ok(text) => {
-                cache.add_file(name, text);
-            }
-            Err(e) => {
-                eprintln!(
-                    "warning: cannot re-read source file `{name}` referenced by the IR dump \
-                     ({e}); its diagnostics and debug locations will lack source context"
-                );
-                cache.add_unavailable(name);
-            }
+        } else {
+            cache.add_lazy_file(name);
         }
     }
     Some(cache)

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -23,7 +23,7 @@ use reussir_backend::llvm::LlvmLowering;
 use reussir_backend::melior::ir::Module;
 use reussir_backend::pipeline::{self, LoweringOptions, OptLevel};
 use reussir_codegen::lower::lower_program;
-use reussir_codegen::source::SourceMap;
+use reussir_codegen::source::{FileId, SourceCache};
 use reussir_compiler::{
     OutputKind, RelocMode, TargetMachine, TargetSpec, emit_to_file, parse_llvm_ir,
 };
@@ -155,6 +155,13 @@ struct Cli {
     #[arg(short = 'g', long = "debug")]
     debug: bool,
 
+    /// Omit source locations (the file table and `[start..end]` spans) from
+    /// `hir`/`mir` text dumps. The default dump is lossless — it round-trips
+    /// spans and file attribution — but structural readers (FileCheck tests,
+    /// quick inspection) may prefer the bare program.
+    #[arg(long = "no-source-locations")]
+    no_source_locations: bool,
+
     /// Log the lowering/backend `tracing` events (to stderr) at DEBUG level.
     /// `RUST_LOG`, if set, takes precedence over this.
     #[arg(short = 'v', long = "verbose")]
@@ -217,19 +224,23 @@ fn parse_reloc(s: &str) -> Result<RelocMode, String> {
     }
 }
 
-fn read_input(path: &PathBuf) -> Result<(String, String), String> {
+/// Read the input into a fresh source cache; the input becomes
+/// [`FileId::ROOT`].
+fn read_input(path: &PathBuf) -> Result<SourceCache, String> {
     use std::io::Read;
+    let mut cache = SourceCache::new();
     if path.as_os_str() == "-" {
         let mut buf = String::new();
         std::io::stdin()
             .read_to_string(&mut buf)
             .map_err(|e| format!("failed to read stdin: {e}"))?;
-        Ok(("<stdin>".to_owned(), buf))
+        cache.add_virtual("<stdin>", buf);
     } else {
         let text = std::fs::read_to_string(path)
             .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
-        Ok((path.display().to_string(), text))
+        cache.add_file(path, text);
     }
+    Ok(cache)
 }
 
 /// Writes a text stage to `path`, or to stdout when it is `-`.
@@ -313,7 +324,9 @@ fn run(cli: &Cli) -> Result<bool, String> {
     }
     let opt = parse_opt(&cli.opt)?;
     let reloc = parse_reloc(&cli.relocation_mode)?;
-    let (name, source) = read_input(&cli.input)?;
+    let sources = read_input(&cli.input)?;
+    let name = sources.name(FileId::ROOT).to_owned();
+    let source = sources.source(FileId::ROOT);
 
     let spec = TargetSpec {
         triple: cli.target_triple.clone(),
@@ -328,7 +341,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
             .output_kind()
             .ok_or_else(|| format!("cannot emit `{target}` from LLVM IR"))?;
         let machine = TargetMachine::new(&spec, opt, reloc)?;
-        let finalized = parse_llvm_ir(&name, &source)?;
+        let finalized = parse_llvm_ir(&name, source)?;
         emit_to_file(finalized, &machine, opt, kind, &cli.output)?;
         return Ok(true);
     }
@@ -337,26 +350,13 @@ fn run(cli: &Cli) -> Result<bool, String> {
     if cli.disable_backend_multithreading {
         context.enable_multi_threading(false);
     }
-    let source_map = SourceMap::new(&cli.input, &source);
-
     // Front leg: reach an MLIR module (or a text dump for `hir`/`mir`). A `.mlir`
     // input parses directly; source/`.hir`/`.mir` run the frontend in the arena.
     let produced = match input_stage {
-        Stage::Mlir => Module::parse(&context, &source)
+        Stage::Mlir => Module::parse(&context, source)
             .map(Produced::Module)
             .ok_or_else(|| format!("{name}: failed to parse MLIR module"))?,
-        _ => match in_arena(|tcx| {
-            frontend(
-                &context,
-                tcx,
-                input_stage,
-                target,
-                &name,
-                &source,
-                &source_map,
-                cli,
-            )
-        }) {
+        _ => match in_arena(|tcx| frontend(&context, tcx, input_stage, target, &sources, cli)) {
             Ok(produced) => produced,
             Err(msg) => {
                 if !msg.is_empty() {
@@ -421,27 +421,24 @@ fn run(cli: &Cli) -> Result<bool, String> {
 ///
 /// An empty `Err` string signals diagnostics were already printed (a compile
 /// failure, exit 1) rather than a driver error (exit 2).
-#[allow(clippy::too_many_arguments)]
 fn frontend<'c, 'tcx>(
     context: &'c reussir_backend::melior::Context,
     tcx: &TyCtxt<'tcx>,
     input: Stage,
     target: Stage,
-    name: &str,
-    source: &str,
-    source_map: &SourceMap<'_>,
+    sources: &SourceCache,
     cli: &Cli,
 ) -> Result<Produced<'c>, String> {
+    let name = sources.name(FileId::ROOT);
+    let source = sources.source(FileId::ROOT);
     match input {
         Stage::Rr => {
             let parse = reussir_syntax::parse(source);
             if !parse.ok() {
-                let map = diagnostics::SourceMap::new(source);
                 let color = std::io::stderr().is_terminal();
                 let _ = diagnostics::render_errors(
-                    name,
-                    source,
-                    &map,
+                    sources,
+                    FileId::ROOT,
                     &parse.errors,
                     color,
                     std::io::stderr().lock(),
@@ -450,19 +447,20 @@ fn frontend<'c, 'tcx>(
             }
             let prog = surface::program(&parse.root);
             let elab = elaborate(tcx, &prog, parse.resolver());
-            if render_reports(name, source, &elab.reports) {
+            if render_reports(sources, &elab.reports) {
                 return Err(String::new());
             }
             if target == Stage::Hir {
-                let text = hir::print::Printer::new(&elab.defs, elab.resolver).program(
-                    &elab.elaborated,
-                    &elab.records,
-                    &elab.trampolines,
-                );
+                let printer = if cli.no_source_locations {
+                    hir::print::Printer::new(&elab.defs, elab.resolver)
+                } else {
+                    hir::print::Printer::with_sources(&elab.defs, elab.resolver, sources)
+                };
+                let text = printer.program(&elab.elaborated, &elab.records, &elab.trampolines);
                 return Ok(Produced::Text(text));
             }
             let (full, reports) = monomorphize(&elab.mono_input());
-            if render_reports(name, source, &reports) {
+            if render_reports(sources, &reports) {
                 return Err(String::new());
             }
             finish_mir(
@@ -470,8 +468,8 @@ fn frontend<'c, 'tcx>(
                 tcx,
                 target,
                 name,
-                Some(source_map),
-                cli.debug,
+                Some(sources),
+                cli,
                 &full,
                 &elab.defs,
                 elab.resolver,
@@ -480,12 +478,19 @@ fn frontend<'c, 'tcx>(
         Stage::Hir => {
             let parsed =
                 hir::build::parse_program(tcx, source).map_err(|e| format!("{name}: {e}"))?;
+            // The dump's file table names the original sources; refetch them
+            // from disk so spans keep resolving (missing/virtual files degrade
+            // to plain diagnostics and unknown debug locations, with a
+            // warning). An old, table-less dump has no locations at all.
+            let dump_sources = refetch_sources(&parsed.files);
             if target == Stage::Hir {
-                let text = hir::print::Printer::new(&parsed.defs, &parsed.names).program(
-                    &parsed.funcs,
-                    &parsed.records,
-                    &parsed.trampolines,
-                );
+                let printer = match &dump_sources {
+                    Some(cache) if !cli.no_source_locations => {
+                        hir::print::Printer::with_sources(&parsed.defs, &parsed.names, cache)
+                    }
+                    _ => hir::print::Printer::new(&parsed.defs, &parsed.names),
+                };
+                let text = printer.program(&parsed.funcs, &parsed.records, &parsed.trampolines);
                 return Ok(Produced::Text(text));
             }
             let input = MonoInput {
@@ -497,18 +502,25 @@ fn frontend<'c, 'tcx>(
                 trampolines: &parsed.trampolines,
             };
             let (full, reports) = monomorphize(&input);
-            if render_reports(name, source, &reports) {
-                return Err(String::new());
+            match &dump_sources {
+                Some(cache) => {
+                    if render_reports(cache, &reports) {
+                        return Err(String::new());
+                    }
+                }
+                None => {
+                    if render_reports(sources, &reports) {
+                        return Err(String::new());
+                    }
+                }
             }
-            // A re-parsed IR carries no original source, so debug locations would
-            // be meaningless: lower without a source map.
             finish_mir(
                 context,
                 tcx,
                 target,
                 name,
-                None,
-                cli.debug,
+                dump_sources.as_ref(),
+                cli,
                 &full,
                 &parsed.defs,
                 &parsed.names,
@@ -517,13 +529,14 @@ fn frontend<'c, 'tcx>(
         Stage::Mir => {
             let parsed =
                 mir::build::parse_program(tcx, source).map_err(|e| format!("{name}: {e}"))?;
+            let dump_sources = refetch_sources(&parsed.files);
             finish_mir(
                 context,
                 tcx,
                 target,
                 name,
-                None,
-                cli.debug,
+                dump_sources.as_ref(),
+                cli,
                 &parsed.program,
                 &parsed.defs,
                 &parsed.names,
@@ -531,6 +544,37 @@ fn frontend<'c, 'tcx>(
         }
         _ => unreachable!("frontend only handles rr/hir/mir inputs"),
     }
+}
+
+/// Rebuild a source cache from an IR dump's file table so its spans keep
+/// resolving: real paths are re-read from disk; a virtual (`<bracketed>`) or
+/// unreadable file becomes a name-only placeholder — its spans survive in the
+/// IR but degrade to plain diagnostics and unknown debug locations — with a
+/// warning naming it. `None` for a dump printed without locations.
+fn refetch_sources(files: &[String]) -> Option<SourceCache> {
+    if files.is_empty() {
+        return None;
+    }
+    let mut cache = SourceCache::new();
+    for name in files {
+        if name.starts_with('<') {
+            cache.add_unavailable(name);
+            continue;
+        }
+        match std::fs::read_to_string(name) {
+            Ok(text) => {
+                cache.add_file(name, text);
+            }
+            Err(e) => {
+                eprintln!(
+                    "warning: cannot re-read source file `{name}` referenced by the IR dump \
+                     ({e}); its diagnostics and debug locations will lack source context"
+                );
+                cache.add_unavailable(name);
+            }
+        }
+    }
+    Some(cache)
 }
 
 /// Finish the front leg from a ground MIR program: a `mir` dump, or lowering to
@@ -541,20 +585,24 @@ fn finish_mir<'c, 'tcx>(
     tcx: &TyCtxt<'tcx>,
     target: Stage,
     name: &str,
-    source_map: Option<&SourceMap<'_>>,
-    debug: bool,
+    sources: Option<&SourceCache>,
+    cli: &Cli,
     program: &mir::Program<'tcx>,
     defs: &DefTable,
     resolver: &dyn Resolver<TokenKey>,
 ) -> Result<Produced<'c>, String> {
     if target == Stage::Mir {
-        return Ok(Produced::Text(
-            mir::print::Printer::new(defs, resolver).program(program),
-        ));
+        let printer = match sources {
+            Some(cache) if !cli.no_source_locations => {
+                mir::print::Printer::with_sources(defs, resolver, cache)
+            }
+            _ => mir::print::Printer::new(defs, resolver),
+        };
+        return Ok(Produced::Text(printer.program(program)));
     }
     // Names feed variable/function debug info; only meaningful with `-g`.
-    let names = debug.then_some(resolver);
-    let module = lower_program(context, tcx, program, source_map, names)
-        .map_err(|e| format!("{name}: {e}"))?;
+    let names = cli.debug.then_some(resolver);
+    let module =
+        lower_program(context, tcx, program, sources, names).map_err(|e| format!("{name}: {e}"))?;
     Ok(Produced::Module(module))
 }

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -17,6 +17,7 @@
 
 use lasso::{Rodeo, Spur};
 use reussir_syntax::kind::TokenKey;
+use reussir_syntax::source::FileId;
 
 use crate::literal::{FloatLit, Integer};
 use crate::semi::ctxt::DefaultCap;
@@ -77,6 +78,11 @@ pub struct Function<'tcx> {
     pub return_ty: Ty<'tcx>,
     /// `None` for a declared-but-undefined function.
     pub body: Option<&'tcx Expr<'tcx>>,
+    /// The file the function's spans index in the compilation's source cache
+    /// (drives per-function debug locations). Serialized in the textual MIR as
+    /// `in <id>` against the dump's source-file table, so the association
+    /// survives a dump/re-parse round trip.
+    pub file: FileId,
 }
 
 /// A function parameter: source name, local variable, and ground type.

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -27,6 +27,11 @@ pub struct Parsed<'tcx> {
     pub program: mir::Program<'tcx>,
     pub defs: DefTable,
     pub names: Names,
+    /// The dump's source-file table, in id order: each file's display name.
+    /// Function/expr spans are byte offsets into these files (by `FileId` =
+    /// table index); a `<bracketed>` name is virtual (content not on disk).
+    /// Empty for a dump printed without locations.
+    pub files: Vec<String>,
 }
 
 /// A minimal [`Resolver`]: a fresh `TokenKey` interner for source names and
@@ -62,6 +67,22 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
     let raw = ir::ProgramParser::new()
         .parse(lex(text))
         .map_err(|e| format!("{e:?}"))?;
+    // The file table must be dense and in-order: spans index it positionally.
+    let mut files = Vec::with_capacity(raw.files.len());
+    for (i, f) in raw.files.iter().enumerate() {
+        if f.id as usize != i {
+            return Err(format!(
+                "source-file table is not dense: entry {} declares id {}",
+                i, f.id
+            ));
+        }
+        files.push(f.name.clone());
+    }
+    for f in &raw.funcs {
+        if let Some(id) = file_ref_check(&files, f.file) {
+            return Err(id);
+        }
+    }
     let mut b = Builder {
         tcx,
         symbols: Rodeo::default(),
@@ -74,6 +95,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
         program,
         defs: b.defs,
         names: b.names,
+        files,
     })
 }
 
@@ -191,6 +213,10 @@ impl<'tcx> Builder<'_, 'tcx> {
             params,
             return_ty,
             body,
+            // `in <id>` when the dump carries locations; else the primary file.
+            file: f.file.map_or(reussir_syntax::source::FileId::ROOT, |i| {
+                reussir_syntax::source::FileId::from_index(i)
+            }),
         }
     }
 
@@ -428,7 +454,9 @@ impl<'tcx> Builder<'_, 'tcx> {
             id: self.ids.fresh(),
             kind,
             ty,
-            span: None,
+            span: e
+                .span
+                .map(|(start, end)| crate::surface::Span { start, end }),
         }
     }
 }
@@ -473,6 +501,17 @@ fn cmp(op: raw::CmpOp) -> CmpOp {
     }
 }
 
+/// Reject an `in <id>` reference past the end of the dump's file table.
+fn file_ref_check(files: &[String], file: Option<u32>) -> Option<String> {
+    match file {
+        Some(id) if id as usize >= files.len() => Some(format!(
+            "function references file {id}, but the source-file table has {} entr(y/ies)",
+            files.len()
+        )),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::parse_program;
@@ -501,6 +540,51 @@ mod tests {
                 "round-trip mismatch\n=== printed ===\n{text}\n=== reparsed ===\n{text2}"
             );
         });
+    }
+
+    /// The lossless form: print WITH the source cache (file table, per-fn
+    /// `in <file>`, node spans), parse back, re-print against a cache rebuilt
+    /// from the dump's own table, and assert text equality.
+    fn roundtrip_with_locations(source: &str) {
+        use reussir_syntax::source::SourceCache;
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+
+            let cache = SourceCache::single("<test>", source);
+            let text = Printer::with_sources(&elab.defs, elab.resolver, &cache).program(&full);
+            assert!(
+                text.contains("0 = \"<test>\";"),
+                "file table missing:\n{text}"
+            );
+            assert!(text.contains(" in 0"), "fn file reference missing:\n{text}");
+            let parsed = parse_program(tcx, &text).expect("re-parse");
+            assert_eq!(parsed.files, vec!["<test>".to_string()]);
+            let mut cache2 = SourceCache::new();
+            for name in &parsed.files {
+                cache2.add_unavailable(name);
+            }
+            let text2 = Printer::with_sources(&parsed.defs, &parsed.names, &cache2)
+                .program(&parsed.program);
+            assert_eq!(
+                text, text2,
+                "lossless round-trip mismatch\n=== printed ===\n{text}\n=== reparsed ===\n{text2}"
+            );
+        });
+    }
+
+    #[test]
+    fn locations_survive_the_textual_round_trip() {
+        roundtrip_with_locations(
+            "pub fn fib(n: u64) -> u64 { \
+             let m = n + 1; \
+             if n <= 1 { m } else { fib(n - 1) + fib(n - 2) } }",
+        );
     }
 
     #[test]

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -579,6 +579,33 @@ mod tests {
     }
 
     #[test]
+    fn source_file_table_escapes_debug_quoted_names() {
+        use reussir_syntax::source::SourceCache;
+        let source = "fn id(x: i32) -> i32 { x }";
+        let file_name = r#"<quoted"path\name>"#;
+
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+
+            let mut cache = SourceCache::new();
+            cache.add_virtual(file_name, source);
+            let text = Printer::with_sources(&elab.defs, elab.resolver, &cache).program(&full);
+            assert!(
+                text.contains(r#"0 = "<quoted\"path\\name>";"#),
+                "file table was not debug-escaped:\n{text}"
+            );
+            let parsed = parse_program(tcx, &text).expect("re-parse");
+            assert_eq!(parsed.files, vec![file_name.to_string()]);
+        });
+    }
+
+    #[test]
     fn locations_survive_the_textual_round_trip() {
         roundtrip_with_locations(
             "pub fn fib(n: u64) -> u64 { \

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -13,12 +13,21 @@ grammar<'input>;
 pub Program: raw::Program = <items:Item*> => raw::Program::from_items(items);
 
 Item: raw::Item = {
+    <f:FileDecl> => raw::Item::File(f),
     "record" "@" <s:Sym> ":" <cap:DefCap> <kind:RecordBody> ";"
         => raw::Item::Record(raw::RecordDecl { symbol: s, default_cap: cap, ty: kind.0, body: kind.1 }),
     <f:Func> => raw::Item::Func(f),
     "extern" <abi:"quoted"> "trampoline" <export:"quoted"> "=" "@" <target:Sym> ";"
         => raw::Item::Tramp(raw::Tramp { abi: abi.to_string(), export: export.to_string(), target }),
 };
+
+/// One source-file table entry: `0 = "src/lib.rr";`. Spans are byte offsets
+/// into these files; a `<bracketed>` name is a virtual file (unfetchable).
+FileDecl: raw::FileEntry = <id:"int"> "=" <name:"quoted"> ";"
+    => raw::FileEntry { id: raw::small_u32(&id), name: name.to_string() };
+
+/// A source span: `[start..end]`, byte offsets into the owning item's file.
+Span: raw::Span = "[" <s:"int"> ".." <e:"int"> "]" => (raw::small_u32(&s), raw::small_u32(&e));
 
 /// The capability a record declares by default.
 DefCap: raw::DefCap = {
@@ -50,8 +59,16 @@ Sym: String = <s:"ident"> => s.to_string();
 
 Func: raw::Func =
     <p:"pub"?> <r:"regional"?> "fn" "@" <symbol:Sym>
-    "(" <params:Comma<Param>> ")" "->" <ret:Ty> <body:Body>
-    => raw::Func { is_pub: p.is_some(), regional: r.is_some(), symbol, params, ret, body };
+    "(" <params:Comma<Param>> ")" "->" <ret:Ty> <file:("in" <"int">)?> <body:Body>
+    => raw::Func {
+        is_pub: p.is_some(),
+        regional: r.is_some(),
+        symbol,
+        params,
+        ret,
+        file: file.as_ref().map(raw::small_u32),
+        body,
+    };
 
 Body: Option<raw::Expr> = {
     "{" <b:Block> "}" => Some(b),
@@ -95,14 +112,18 @@ Cap: raw::Cap = {
 /// A block body: `;`-separated statements; a single expression is not wrapped.
 /// A multi-item block is a `Seq` typed by its last item (correct by
 /// construction, so it needs no printed annotation).
-Block: raw::Expr = <first:Expr> <rest:(";" <Expr>)*> => {
-    if rest.is_empty() {
+/// A leading `[start..end]` is the enclosing `Seq`'s own span. A single
+/// spanless expression is not wrapped (a spanless one-statement `Seq` prints
+/// indistinguishably and is normalized away — structurally, not semantically,
+/// significant).
+Block: raw::Expr = <sp:Span?> <first:Expr> <rest:(";" <Expr>)*> => {
+    if sp.is_none() && rest.is_empty() {
         first
     } else {
         let mut v = vec![first];
         v.extend(rest);
         let ty = v.last().unwrap().ty.clone();
-        raw::Expr::new(raw::Kind::Seq(v), ty)
+        raw::Expr::new(raw::Kind::Seq(v), ty).with_span(sp)
     }
 };
 
@@ -110,9 +131,10 @@ Block: raw::Expr = <first:Expr> <rest:(";" <Expr>)*> => {
 /// read back, so no type is ever invented. `let` (always `unit`) and a braced
 /// block (a `Seq`) are the two structural exceptions.
 Expr: raw::Expr = {
-    <a:Atom> ":" <t:Ty> => raw::Expr::new(a, t),
-    "let" <var:"var"> "(" <name:"ident"> ")" "=" <value:Expr>
-        => raw::Expr::new(raw::Kind::Let { var, name: name.to_string(), value }, raw::Ty::Unit),
+    <a:Atom> ":" <t:Ty> <sp:Span?> => raw::Expr::new(a, t).with_span(sp),
+    "let" <sp:Span?> <var:"var"> "(" <name:"ident"> ")" "=" <value:Expr>
+        => raw::Expr::new(raw::Kind::Let { var, name: name.to_string(), value }, raw::Ty::Unit)
+            .with_span(sp),
     "{" <b:Block> "}" => b,
 };
 
@@ -290,6 +312,8 @@ extern {
         ";" => Token::Semi,
         "," => Token::Comma,
         "." => Token::Dot,
+        ".." => Token::DotDot,
+        "in" => Token::In,
         "=" => Token::Eq,
         "=>" => Token::FatArrow,
         "_" => Token::Underscore,

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -4,8 +4,10 @@
 //! arena MIR. Covers every MIR form: functions, types, expressions, and
 //! `match` decision trees.
 
+use std::borrow::Cow;
+
 use crate::full::mir::raw as raw;
-use crate::ir_lex::{Token, LexError};
+use crate::ir_lex::{LexError, Token, unescape_debug_str};
 use crate::literal::{FloatLit, Integer};
 
 grammar<'input>;
@@ -18,13 +20,13 @@ Item: raw::Item = {
         => raw::Item::Record(raw::RecordDecl { symbol: s, default_cap: cap, ty: kind.0, body: kind.1 }),
     <f:Func> => raw::Item::Func(f),
     "extern" <abi:"quoted"> "trampoline" <export:"quoted"> "=" "@" <target:Sym> ";"
-        => raw::Item::Tramp(raw::Tramp { abi: abi.to_string(), export: export.to_string(), target }),
+        => raw::Item::Tramp(raw::Tramp { abi: abi.into(), export: export.into(), target }),
 };
 
 /// One source-file table entry: `0 = "src/lib.rr";`. Spans are byte offsets
 /// into these files; a `<bracketed>` name is a virtual file (unfetchable).
 FileDecl: raw::FileEntry = <id:"int"> "=" <name:"quoted"> ";"
-    => raw::FileEntry { id: raw::small_u32(&id), name: name.to_string() };
+    => raw::FileEntry { id: raw::small_u32(&id), name: unescape_debug_str(name).into_owned() };
 
 /// A source span: `[start..end]`, byte offsets into the owning item's file.
 Span: raw::Span = "[" <s:"int"> ".." <e:"int"> "]" => (raw::small_u32(&s), raw::small_u32(&e));
@@ -46,16 +48,16 @@ RecordBody: (raw::Ty, raw::RecordBody) = {
 /// A compound field: an optional `name:` prefix (absent for a tuple field), an
 /// optional `field` marker (a mutable `[field]` link), and its ground type.
 Member: raw::Member = <n:(<"quoted"> ":")?> <f:"field"?> <t:Ty>
-    => raw::Member { name: n.map(|s| s.to_string()), is_field: f.is_some(), ty: t };
+    => raw::Member { name: n.map(|s| s.into()), is_field: f.is_some(), ty: t };
 
 /// An enum variant: its mangled payload symbol, source name, and ordered field
 /// types.
 Variant: raw::Variant =
     "@" <symbol:Sym> <name:"ident"> "(" <fs:Comma<Ty>> ")"
-        => raw::Variant { symbol, name: name.to_string(), fields: fs };
+        => raw::Variant { symbol, name: name.into(), fields: fs };
 
 /// A symbol body (after `@`).
-Sym: String = <s:"ident"> => s.to_string();
+Sym: String = <s:"ident"> => s.into();
 
 Func: raw::Func =
     <p:"pub"?> <r:"regional"?> "fn" "@" <symbol:Sym>
@@ -77,7 +79,7 @@ Body: Option<raw::Expr> = {
 
 Param: raw::Param =
     <var:"var"> "(" <name:"ident"> ")" ":" <ty:Ty>
-    => raw::Param { var, name: name.to_string(), ty };
+    => raw::Param { var, name: name.into(), ty };
 
 // ----- types -----
 
@@ -93,7 +95,7 @@ Ty: raw::Ty = {
     "!" => raw::Ty::Bottom,
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
     <cap:Cap> <path:"ident"> <args:TyArgs?>
-        => raw::Ty::Record { cap, path: path.to_string(), args: args.unwrap_or_default() },
+        => raw::Ty::Record { cap, path: path.into(), args: args.unwrap_or_default() },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };
@@ -133,7 +135,7 @@ Block: raw::Expr = <sp:Span?> <first:Expr> <rest:(";" <Expr>)*> => {
 Expr: raw::Expr = {
     <a:Atom> ":" <t:Ty> <sp:Span?> => raw::Expr::new(a, t).with_span(sp),
     "let" <sp:Span?> <var:"var"> "(" <name:"ident"> ")" "=" <value:Expr>
-        => raw::Expr::new(raw::Kind::Let { var, name: name.to_string(), value }, raw::Ty::Unit)
+        => raw::Expr::new(raw::Kind::Let { var, name: name.into(), value }, raw::Ty::Unit)
             .with_span(sp),
     "{" <b:Block> "}" => b,
 };
@@ -260,7 +262,7 @@ extern {
         "intu" => Token::IntU(<u16>),
         "fp" => Token::Fp(<u16>),
         "ident" => Token::Ident(<&'input str>),
-        "quoted" => Token::Quoted(<&'input str>),
+        "quoted" => Token::Quoted(<Cow<'input, str>>),
         "pub" => Token::Pub,
         "regional" => Token::Regional,
         "fn" => Token::Fn,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -16,6 +16,7 @@ use std::fmt::Write;
 
 use pprint::{Doc, Printer as PpPrinter, hardline, indent, pprint};
 use reussir_syntax::kind::{Resolver, TokenKey};
+use reussir_syntax::source::SourceCache;
 
 use crate::full::mir;
 use crate::semi::ctxt::DefaultCap;
@@ -36,11 +37,33 @@ const IR_PRINTER: PpPrinter = PpPrinter {
 pub struct Printer<'a> {
     defs: &'a DefTable,
     resolver: &'a dyn Resolver<TokenKey>,
+    /// When present, the dump carries source locations: the file table
+    /// (`0 = "path";`), each function's `in <file>`, and every node's
+    /// `[start..end]` span — the lossless round-trip form (`rrc --emit mir`).
+    /// Without it the dump is the bare program (human display).
+    sources: Option<&'a SourceCache>,
 }
 
 impl<'a> Printer<'a> {
     pub fn new(defs: &'a DefTable, resolver: &'a dyn Resolver<TokenKey>) -> Self {
-        Printer { defs, resolver }
+        Printer {
+            defs,
+            resolver,
+            sources: None,
+        }
+    }
+
+    /// A printer that also serializes source locations against `sources`.
+    pub fn with_sources(
+        defs: &'a DefTable,
+        resolver: &'a dyn Resolver<TokenKey>,
+        sources: &'a SourceCache,
+    ) -> Self {
+        Printer {
+            defs,
+            resolver,
+            sources: Some(sources),
+        }
     }
 
     /// Render `program`. The program owns the symbol interner, borrowed here to
@@ -50,9 +73,15 @@ impl<'a> Printer<'a> {
             symbols: &program.symbols,
             defs: self.defs,
             resolver: self.resolver,
+            sources: self.sources,
         };
 
         let mut items: Vec<Doc<'static>> = Vec::new();
+        if let Some(cache) = self.sources {
+            for id in cache.ids() {
+                items.push(text(format!("{} = \"{}\";", id.index(), cache.name(id))));
+            }
+        }
         for rec in &program.records {
             items.push(r.record(rec));
         }
@@ -88,6 +117,7 @@ struct Render<'a> {
     symbols: &'a lasso::Rodeo,
     defs: &'a DefTable,
     resolver: &'a dyn Resolver<TokenKey>,
+    sources: Option<&'a SourceCache>,
 }
 
 impl Render<'_> {
@@ -162,7 +192,12 @@ impl Render<'_> {
                 )) + self.ty(p.ty)
             })
             .collect();
-        let sig = text(head) + comma_sep(params) + text(") -> ") + self.ty(func.return_ty);
+        let loc = if self.sources.is_some() {
+            text(format!(" in {}", func.file.index()))
+        } else {
+            Doc::Null
+        };
+        let sig = text(head) + comma_sep(params) + text(") -> ") + self.ty(func.return_ty) + loc;
 
         match func.body {
             Some(body) => {
@@ -219,7 +254,12 @@ impl Render<'_> {
         match e.kind {
             mir::ExprKind::Seq(items) => {
                 let n = items.len();
-                let mut d = Doc::Null;
+                // The leading `[span]` is the `Seq`'s own (its items carry
+                // theirs inline) — the dual of the grammar's `Block` rule.
+                let mut d = match (self.sources, e.span) {
+                    (Some(_), Some(sp)) => text(format!("[{}..{}]", sp.start, sp.end)) + hardline(),
+                    _ => Doc::Null,
+                };
                 for (i, item) in items.iter().enumerate() {
                     if i > 0 {
                         d = d + hardline();
@@ -246,20 +286,30 @@ impl Render<'_> {
                 name,
                 value,
             } => {
-                text("let ")
+                text("let")
+                    + self.span_doc(e.span)
+                    + text(" ")
                     + var(v)
                     + text(format!(" ({}) = ", self.resolver.resolve(name)))
                     + self.value(value)
             }
             mir::ExprKind::Seq(_) => text("{ ") + self.expr(e) + text(" }"),
-            mir::ExprKind::If(c, t, f) => self.typed(self.render_if(c, t, f), e.ty),
-            mir::ExprKind::Match(scrut, tree) => self.typed(self.render_match(scrut, &tree), e.ty),
-            _ => self.typed(self.atom(e), e.ty),
+            mir::ExprKind::If(c, t, f) => self.typed(self.render_if(c, t, f), e),
+            mir::ExprKind::Match(scrut, tree) => self.typed(self.render_match(scrut, &tree), e),
+            _ => self.typed(self.atom(e), e),
         }
     }
 
-    fn typed(&self, atom: Doc<'static>, ty: Ty<'_>) -> Doc<'static> {
-        atom + text(" : ") + self.ty(ty)
+    /// ` [start..end]` — a node's span suffix (locations mode only).
+    fn span_doc(&self, span: Option<crate::surface::Span>) -> Doc<'static> {
+        match (self.sources, span) {
+            (Some(_), Some(sp)) => text(format!(" [{}..{}]", sp.start, sp.end)),
+            _ => Doc::Null,
+        }
+    }
+
+    fn typed(&self, atom: Doc<'static>, e: &mir::Expr<'_>) -> Doc<'static> {
+        atom + text(" : ") + self.ty(e.ty) + self.span_doc(e.span)
     }
 
     /// `if C then { T } else { F }` — braces delimit the branches (no

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -79,7 +79,7 @@ impl<'a> Printer<'a> {
         let mut items: Vec<Doc<'static>> = Vec::new();
         if let Some(cache) = self.sources {
             for id in cache.ids() {
-                items.push(text(format!("{} = \"{}\";", id.index(), cache.name(id))));
+                items.push(text(format!("{} = {:?};", id.index(), cache.name(id))));
             }
         }
         for rec in &program.records {

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -12,10 +12,23 @@
 //! correct by construction. This makes the round trip value-sound, not merely
 //! text-faithful.
 
-/// A whole program: record instances (with their ground layout), functions,
-/// exported trampolines.
+/// A byte-offset span, file-local (the file is carried at the item level).
+pub type Span = (u32, u32);
+
+/// One source-file table entry: the dense id spans index by, and the file's
+/// display name (a `<bracketed>` name denotes a virtual file whose content
+/// cannot be re-read from disk).
+#[derive(Clone, Debug)]
+pub struct FileEntry {
+    pub id: u32,
+    pub name: String,
+}
+
+/// A whole program: the source-file table, record instances (with their
+/// ground layout), functions, exported trampolines.
 #[derive(Clone, Debug)]
 pub struct Program {
+    pub files: Vec<FileEntry>,
     pub records: Vec<RecordDecl>,
     pub funcs: Vec<Func>,
     pub trampolines: Vec<Tramp>,
@@ -24,6 +37,7 @@ pub struct Program {
 /// One top-level item, as the grammar yields them before partitioning.
 #[derive(Clone, Debug)]
 pub enum Item {
+    File(FileEntry),
     Record(RecordDecl),
     Func(Func),
     Tramp(Tramp),
@@ -82,12 +96,14 @@ impl Program {
     /// Partition a flat item list into a [`Program`].
     pub fn from_items(items: Vec<Item>) -> Program {
         let mut p = Program {
+            files: Vec::new(),
             records: Vec::new(),
             funcs: Vec::new(),
             trampolines: Vec::new(),
         };
         for item in items {
             match item {
+                Item::File(f) => p.files.push(f),
                 Item::Record(r) => p.records.push(r),
                 Item::Func(f) => p.funcs.push(f),
                 Item::Tramp(t) => p.trampolines.push(t),
@@ -104,6 +120,9 @@ pub struct Func {
     pub symbol: String,
     pub params: Vec<Param>,
     pub ret: Ty,
+    /// The file-table id the function's spans index (`in <id>`); absent in a
+    /// hand-written dump (defaults to the table's first entry / ROOT).
+    pub file: Option<u32>,
     pub body: Option<Expr>,
 }
 
@@ -197,6 +216,9 @@ pub fn float_path_segs(text: &str) -> Vec<u32> {
 pub struct Expr {
     pub kind: Box<Kind>,
     pub ty: Ty,
+    /// The node's source span (`@start..end`), byte offsets into the owning
+    /// item's file.
+    pub span: Option<Span>,
 }
 
 impl Expr {
@@ -204,7 +226,13 @@ impl Expr {
         Expr {
             kind: Box::new(kind),
             ty,
+            span: None,
         }
+    }
+
+    pub fn with_span(mut self, span: Option<Span>) -> Expr {
+        self.span = span;
+        self
     }
 }
 

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -45,6 +45,7 @@ use lasso::Rodeo;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use reussir_syntax::kind::{Resolver, TokenKey};
+use reussir_syntax::source::FileId;
 
 use crate::full::mangle::Mangler;
 use crate::full::mir;
@@ -109,6 +110,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         seen: FxHashSet::default(),
         records: FxHashSet::default(),
         reports: Vec::new(),
+        cur_file: FileId::ROOT,
         ids: mir::ExprIdGen::default(),
     };
 
@@ -128,6 +130,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             // No body/prototype recorded (e.g. an item that failed to elaborate).
             continue;
         };
+        driver.cur_file = func.file;
 
         // Bind this instance's generics, then ground the signature and lower the
         // body into the MIR.
@@ -171,6 +174,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             params,
             return_ty,
             body,
+            file: func.file,
         });
     }
 
@@ -189,6 +193,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         let Some(record) = input.records.get(&def) else {
             continue;
         };
+        driver.cur_file = record.file;
         for &gid in &record.regional_generics {
             let Some(pos) = record.ty_params.iter().position(|(_, g)| *g == gid) else {
                 continue;
@@ -393,6 +398,9 @@ struct Driver<'a, 'tcx> {
     /// Ground record instances whose layout is needed (keyed flex-independently).
     records: FxHashSet<(DefId, &'tcx [Ty<'tcx>])>,
     reports: Vec<Report>,
+    /// The declaration file of the item currently being instantiated; stamped
+    /// onto reports so multi-file diagnostics point into the right source.
+    cur_file: FileId,
     /// Source of fresh [`mir::ExprId`] anchors for every lowered node. A single
     /// counter across the whole program: one semi expr may lower into many MIR
     /// exprs (once per instantiation), so semi ids are not reused.
@@ -421,6 +429,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             severity: Severity::Error,
             message: message.into(),
             span,
+            file: self.cur_file,
         });
     }
 

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -366,6 +366,7 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
             params,
             return_ty: ret,
             body: Some(body),
+            file: reussir_syntax::source::FileId::ROOT,
         }
     }
 }

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -131,6 +131,11 @@ pub enum Token<'a> {
     Comma,
     #[token(".")]
     Dot,
+    /// The span-range separator (`@start..end`). Longest-match beats `Dot`,
+    /// and the float regex requires a digit after its dot, so `12..34` lexes
+    /// `Int(12) DotDot Int(34)`.
+    #[token("..")]
+    DotDot,
     #[token("=")]
     Eq,
     #[token("->")]

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -5,6 +5,8 @@
 //! path is coarse (a lex failure means a printer bug or corrupt input, not user
 //! source). Identifiers borrow the input; widths/values are parsed eagerly.
 
+use std::borrow::Cow;
+
 use logos::Logos;
 
 use crate::literal::Integer;
@@ -203,9 +205,82 @@ pub enum Token<'a> {
     /// Unicode XID like the surface lexer, so source identifiers round-trip.
     #[regex(r"[\p{XID_Start}_]\p{XID_Continue}*", |l| l.slice())]
     Ident(&'a str),
-    /// A double-quoted string (trampoline abi / export names).
-    #[regex(r#""[^"]*""#, |l| { let s = l.slice(); &s[1..s.len() - 1] })]
-    Quoted(&'a str),
+    /// A double-quoted string body.
+    #[regex(r#""([^"\\]|\\.)*""#, |l| quoted_body(l.slice()))]
+    Quoted(Cow<'a, str>),
+}
+
+fn quoted_body(raw: &str) -> Cow<'_, str> {
+    let body = raw
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(raw);
+    Cow::Borrowed(body)
+}
+
+pub(crate) fn unescape_debug_str(raw: Cow<'_, str>) -> Cow<'_, str> {
+    if !raw.as_ref().contains('\\') {
+        return raw;
+    }
+
+    let body = raw.as_ref();
+    let mut out = String::with_capacity(body.len());
+    let mut chars = body.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+
+        let Some(escaped) = chars.next() else {
+            out.push('\\');
+            break;
+        };
+
+        match escaped {
+            '0' => out.push('\0'),
+            'n' => out.push('\n'),
+            'r' => out.push('\r'),
+            't' => out.push('\t'),
+            '\\' => out.push('\\'),
+            '"' => out.push('"'),
+            'u' if chars.peek() == Some(&'{') => {
+                chars.next();
+                let mut digits = String::new();
+                let mut closed = false;
+
+                for h in chars.by_ref() {
+                    if h == '}' {
+                        closed = true;
+                        break;
+                    }
+                    digits.push(h);
+                }
+
+                if closed {
+                    if let Ok(code) = u32::from_str_radix(&digits, 16) {
+                        if let Some(ch) = char::from_u32(code) {
+                            out.push(ch);
+                            continue;
+                        }
+                    }
+                }
+
+                out.push_str("\\u{");
+                out.push_str(&digits);
+                if closed {
+                    out.push('}');
+                }
+            }
+            other => {
+                out.push('\\');
+                out.push(other);
+            }
+        }
+    }
+
+    Cow::Owned(out)
 }
 
 /// A lexing failure: the byte span that did not match any token.

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -25,6 +25,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let Some(proto) = self.functions.get(&def).cloned() else {
             return;
         };
+        // Attribute the body's reports to the function's declaration file (the
+        // package driver checks items from many files in one pass).
+        self.set_current_file(proto.file);
         self.enter_function(&proto.generics);
         // A `[regional]` function body runs inside an implicit region: its
         // parameters may already be flex and it may construct regional records
@@ -87,6 +90,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             is_regional: proto.is_regional,
             body,
             span,
+            file: proto.file,
         });
     }
 

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -2,6 +2,7 @@
 //! the scan/collect driver.
 
 use reussir_syntax::kind::{Resolver, TokenKey};
+use reussir_syntax::source::{FileId, SourceCache};
 use rustc_hash::FxHashMap;
 
 use crate::semi::infer::InferCtxt;
@@ -32,12 +33,15 @@ pub enum Severity {
     Warning,
 }
 
-/// A diagnostic.
+/// A diagnostic. The `span` indexes `file`'s text in the compilation's
+/// [`SourceCache`]; items never straddle files, so one file id per report is
+/// exact.
 #[derive(Clone, Debug)]
 pub struct Report {
     pub severity: Severity,
     pub message: String,
     pub span: Option<Span>,
+    pub file: FileId,
 }
 
 /// Render `reports` to stderr with source-caret context and return whether any
@@ -45,35 +49,34 @@ pub struct Report {
 /// could not trace back to a span — an internal/whole-program error — prints as
 /// a plain line. The frontend driver (`rrc`) funnels through here so parse and
 /// elaboration diagnostics render identically.
-pub fn render_reports(name: &str, source: &str, reports: &[Report]) -> bool {
+pub fn render_reports(cache: &SourceCache, reports: &[Report]) -> bool {
     use std::io::IsTerminal;
 
     let color = std::io::stderr().is_terminal();
-    render_reports_to(name, source, reports, color, std::io::stderr().lock())
+    render_reports_to(cache, reports, color, std::io::stderr().lock())
 }
 
 /// Writer-taking variant of [`render_reports`], for frontends that own their
 /// display (e.g. the REPL TUI renders into a buffer and styles the lines
 /// itself — stderr would be invisible in the alternate screen).
 pub fn render_reports_to(
-    name: &str,
-    source: &str,
+    cache: &SourceCache,
     reports: &[Report],
     color: bool,
     out: impl std::io::Write,
 ) -> bool {
-    use reussir_syntax::diagnostics::{self, Diagnostic, Severity as RenderSeverity, SourceMap};
+    use reussir_syntax::diagnostics::{self, Diagnostic, Severity as RenderSeverity};
 
     let had_error = reports
         .iter()
         .any(|r| matches!(r.severity, Severity::Error));
-    // The happy path carries no reports; skip building the byte→char map.
     if reports.is_empty() {
         return had_error;
     }
     let diags: Vec<Diagnostic> = reports
         .iter()
         .map(|r| Diagnostic {
+            file: r.file,
             span: r.span.map(|s| (s.start, s.end)),
             severity: match r.severity {
                 Severity::Error => RenderSeverity::Error,
@@ -82,8 +85,7 @@ pub fn render_reports_to(
             message: &r.message,
         })
         .collect();
-    let map = SourceMap::new(source);
-    let _ = diagnostics::render(name, source, &map, &diags, color, out);
+    let _ = diagnostics::render(cache, &diags, color, out);
     had_error
 }
 
@@ -124,6 +126,8 @@ pub struct Record<'tcx> {
     /// monomorphization call boundary, like a function's `regional_generics`.
     pub regional_generics: Vec<GenericId>,
     pub span: Option<Span>,
+    /// The file the record is declared in (spans index it).
+    pub file: FileId,
 }
 
 /// A collected function prototype (signature only).
@@ -144,6 +148,8 @@ pub struct FuncProto<'tcx> {
     pub return_ty: Ty<'tcx>,
     pub is_regional: bool,
     pub span: Option<Span>,
+    /// The file the function is declared in (spans index it).
+    pub file: FileId,
 }
 
 /// Records the generic at the head of a `[flex]`-annotated type (peeling
@@ -258,6 +264,11 @@ pub struct Elaborator<'a, 'tcx> {
     pub strings: StringUniqifier,
     pub elaborated: Vec<Function<'tcx>>,
     pub reports: Vec<Report>,
+    /// The file whose items are currently being processed; stamped onto every
+    /// report and declared item. The driver sets it per input file
+    /// ([`Elaborator::set_current_file`]); the check passes restore it per item
+    /// from the item's own declaration file.
+    pub current_file: FileId,
 
     // ----- per-function working state (reset by `enter_function`) -----
     pub infer: InferCtxt<'a, 'tcx>,
@@ -317,6 +328,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             strings: StringUniqifier::new(),
             elaborated: Vec::new(),
             reports: Vec::new(),
+            current_file: FileId::ROOT,
             infer: InferCtxt::new(tcx),
             vars: VarEnv::default(),
             generic_names: FxHashMap::default(),
@@ -330,11 +342,18 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     // ----- diagnostics -----
 
+    /// Switch the file whose items are being processed. Reports and item
+    /// declarations from here on are attributed to `file`.
+    pub fn set_current_file(&mut self, file: FileId) {
+        self.current_file = file;
+    }
+
     pub fn error(&mut self, span: Option<Span>, message: impl Into<String>) {
         self.reports.push(Report {
             severity: Severity::Error,
             message: message.into(),
             span,
+            file: self.current_file,
         });
     }
 
@@ -343,6 +362,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             severity: Severity::Warning,
             message: message.into(),
             span,
+            file: self.current_file,
         });
     }
 
@@ -705,6 +725,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             fields: None,
             regional_generics: Vec::new(),
             span,
+            file: self.current_file,
         };
         self.records.insert(def, record);
         Some(def)
@@ -755,6 +776,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return_ty,
             is_regional: func.is_regional,
             span,
+            file: self.current_file,
         };
         self.functions.insert(def, proto);
         Some(def)
@@ -783,6 +805,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let ty_params = record.ty_params.clone();
         let span = record.span;
         let default_cap = record.default_cap;
+        let file = record.file;
+        // Attribute field-resolution reports to the record's declaration file.
+        self.set_current_file(file);
         self.generic_names = ty_params.iter().map(|(n, id)| (*n, *id)).collect();
 
         // A generic at the head of a `[field]` link (`inner: [field] T`) must be

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -4,6 +4,7 @@
 //! Pattern matches are compiled to a [`DecisionTree`].
 
 use reussir_syntax::kind::TokenKey;
+use reussir_syntax::source::FileId;
 
 use crate::literal::{FloatLit, Integer};
 use crate::semi::ty::{DefId, GenericId, Ty};
@@ -218,4 +219,7 @@ pub struct Function<'tcx> {
     pub is_regional: bool,
     pub body: Option<Expr<'tcx>>,
     pub span: Option<Span>,
+    /// The file the function is declared in; its spans (and its body's) index
+    /// that file in the compilation's source cache.
+    pub file: FileId,
 }

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -12,6 +12,7 @@
 //! representation stable as multi-file resolution arrives.
 
 use reussir_syntax::kind::{InternKey, Resolver, TokenKey};
+use reussir_syntax::source::FileId;
 use rustc_hash::FxHashMap;
 
 use crate::ir_lex::lex;
@@ -37,6 +38,11 @@ pub struct Parsed<'tcx> {
     pub trampolines: Vec<TrampolineRoot<'tcx>>,
     pub defs: DefTable,
     pub names: Names,
+    /// The dump's source-file table, in id order: each file's display name.
+    /// Item/expr spans are byte offsets into these files (by [`FileId`] =
+    /// table index); a `<bracketed>` name is virtual (content not on disk).
+    /// Empty for a dump printed without locations.
+    pub files: Vec<String>,
 }
 
 /// A fresh `TokenKey` interner for source names and `#path` segments.
@@ -71,6 +77,27 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
     let raw = hir_ir::ProgramParser::new()
         .parse(lex(text))
         .map_err(|e| format!("{e:?}"))?;
+    // The file table must be dense and in-order: spans index it positionally.
+    let mut files = Vec::with_capacity(raw.files.len());
+    for (i, f) in raw.files.iter().enumerate() {
+        if f.id as usize != i {
+            return Err(format!(
+                "source-file table is not dense: entry {} declares id {}",
+                i, f.id
+            ));
+        }
+        files.push(f.name.clone());
+    }
+    for f in &raw.funcs {
+        if let Some(id) = file_ref_check(&files, f.file) {
+            return Err(id);
+        }
+    }
+    for r in &raw.records {
+        if let Some(id) = file_ref_check(&files, r.file) {
+            return Err(id);
+        }
+    }
     let mut b = Builder {
         tcx,
         names: Names::default(),
@@ -87,6 +114,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
         trampolines,
         defs: b.defs,
         names: b.names,
+        files,
     })
 }
 
@@ -189,7 +217,8 @@ impl<'tcx> Builder<'_, 'tcx> {
             default_cap,
             fields: Some(fields),
             regional_generics,
-            span: None,
+            span: span_of(r.span),
+            file: file_of(r.file),
         };
         (def, record)
     }
@@ -228,7 +257,8 @@ impl<'tcx> Builder<'_, 'tcx> {
             return_ty,
             is_regional: f.regional,
             body,
-            span: None,
+            span: span_of(f.span),
+            file: file_of(f.file),
         }
     }
 
@@ -298,12 +328,17 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::Kind::Assign(dst, field, src) => {
                 ExprKind::Assign(self.boxed(dst), *field, self.boxed(src))
             }
-            raw::Kind::Let { var, name, value } => {
+            raw::Kind::Let {
+                var,
+                name,
+                name_span,
+                value,
+            } => {
                 let name = self.names.intern(name);
                 ExprKind::Let {
                     var: VarId(*var),
                     name,
-                    span: None,
+                    span: span_of(*name_span),
                     value: self.boxed(value),
                 }
             }
@@ -386,7 +421,7 @@ impl<'tcx> Builder<'_, 'tcx> {
         Expr {
             kind,
             ty,
-            span: None,
+            span: span_of(e.span),
             id: self.fresh_expr_id(),
         }
     }
@@ -494,6 +529,28 @@ fn cmp(op: raw::CmpOp) -> CmpOp {
     }
 }
 
+/// A raw `[start..end]` span into the owning item's file.
+fn span_of(sp: Option<raw::Span>) -> Option<crate::surface::Span> {
+    sp.map(|(start, end)| crate::surface::Span { start, end })
+}
+
+/// A raw `in <id>` file reference; a dump printed without locations has none
+/// and everything indexes the primary file.
+fn file_of(f: Option<u32>) -> FileId {
+    f.map_or(FileId::ROOT, FileId::from_index)
+}
+
+/// Reject an `in <id>` reference past the end of the dump's file table.
+fn file_ref_check(files: &[String], file: Option<u32>) -> Option<String> {
+    match file {
+        Some(id) if id as usize >= files.len() => Some(format!(
+            "function references file {id}, but the source-file table has {} entr(y/ies)",
+            files.len()
+        )),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::parse_program;
@@ -527,6 +584,65 @@ mod tests {
                 "round-trip mismatch\n=== printed ===\n{text}\n=== reparsed ===\n{text2}"
             );
         });
+    }
+
+    /// The lossless form: print WITH the source cache (file table + spans),
+    /// parse back, re-print against a cache rebuilt from the dump's own file
+    /// table, and assert text equality — so files, item locations, node
+    /// spans, and `let`-name spans all survive the trip.
+    fn roundtrip_with_locations(source: &str) {
+        use reussir_syntax::source::SourceCache;
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+
+            let cache = SourceCache::single("<test>", source);
+            let text = Printer::with_sources(&elab.defs, elab.resolver, &cache).program(
+                &elab.elaborated,
+                &elab.records,
+                &elab.trampolines,
+            );
+            assert!(
+                text.contains("0 = \"<test>\";"),
+                "file table missing:\n{text}"
+            );
+            assert!(text.contains(" in 0"), "item location missing:\n{text}");
+            let parsed = parse_program(tcx, &text).expect("re-parse");
+            assert_eq!(parsed.files, vec!["<test>".to_string()]);
+            // Rebuild the render cache exactly as a driver would from the table.
+            let mut cache2 = SourceCache::new();
+            for name in &parsed.files {
+                cache2.add_unavailable(name);
+            }
+            let text2 = Printer::with_sources(&parsed.defs, &parsed.names, &cache2).program(
+                &parsed.funcs,
+                &parsed.records,
+                &parsed.trampolines,
+            );
+            assert_eq!(
+                text, text2,
+                "lossless round-trip mismatch\n=== printed ===\n{text}\n=== reparsed ===\n{text2}"
+            );
+        });
+    }
+
+    #[test]
+    fn locations_survive_the_textual_round_trip() {
+        roundtrip_with_locations(
+            "struct Pair { a: i64, b: i64 }\n\
+             pub fn f(n: i64) -> i64 { let p = Pair { a: n, b: 1 }; p.a + p.b }",
+        );
+    }
+
+    #[test]
+    fn locations_survive_for_control_flow_and_matches() {
+        roundtrip_with_locations(
+            "enum Opt { None, Some(i64) }\n\
+             pub fn g(o: Opt) -> i64 { match o { Opt::None => 0, Opt::Some(x) => { let y = x; y } } }",
+        );
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -630,6 +630,35 @@ mod tests {
     }
 
     #[test]
+    fn source_file_table_escapes_debug_quoted_names() {
+        use reussir_syntax::source::SourceCache;
+        let source = "fn id(x: i32) -> i32 { x }";
+        let file_name = r#"<quoted"path\name>"#;
+
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+
+            let mut cache = SourceCache::new();
+            cache.add_virtual(file_name, source);
+            let text = Printer::with_sources(&elab.defs, elab.resolver, &cache).program(
+                &elab.elaborated,
+                &elab.records,
+                &elab.trampolines,
+            );
+            assert!(
+                text.contains(r#"0 = "<quoted\"path\\name>";"#),
+                "file table was not debug-escaped:\n{text}"
+            );
+            let parsed = parse_program(tcx, &text).expect("re-parse");
+            assert_eq!(parsed.files, vec![file_name.to_string()]);
+        });
+    }
+
+    #[test]
     fn locations_survive_the_textual_round_trip() {
         roundtrip_with_locations(
             "struct Pair { a: i64, b: i64 }\n\

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -14,28 +14,44 @@ grammar<'input>;
 pub Program: raw::Program = <items:Item*> => raw::Program::from_items(items);
 
 Item: raw::Item = {
+    <f:FileDecl> => raw::Item::File(f),
     <r:RecordDecl> => raw::Item::Record(r),
     <t:TrampDecl> => raw::Item::Tramp(t),
     <f:Func> => raw::Item::Func(f),
 };
 
+/// One source-file table entry: `0 = "src/lib.rr";`. Spans are byte offsets
+/// into these files; a `<bracketed>` name is a virtual file (unfetchable).
+FileDecl: raw::FileEntry = <id:"int"> "=" <name:"quoted"> ";"
+    => raw::FileEntry { id: raw::small_u32(&id), name: name.to_string() };
+
+/// A source span: `[start..end]`, byte offsets into the owning item's file.
+Span: raw::Span = "[" <s:"int"> ".." <e:"int"> "]" => (raw::small_u32(&s), raw::small_u32(&e));
+
+/// An item's source location: its file-table id and its span.
+ItemLoc: (u32, Option<raw::Span>) = "in" <f:"int"> <sp:Span?> => (raw::small_u32(&f), sp);
+
 RecordDecl: raw::Record = {
-    <default_cap:DefaultCap> "struct" "#" <path:"ident"> <generics:Generics?>
+    <default_cap:DefaultCap> "struct" "#" <path:"ident"> <generics:Generics?> <loc:ItemLoc?>
     "{" <ms:Comma<Member>> "}" ";"
     => raw::Record {
         default_cap,
         kind: raw::RecordKind::Struct,
         path: path.to_string(),
         generics: generics.unwrap_or_default(),
+        file: loc.map(|l| l.0),
+        span: loc.and_then(|l| l.1),
         body: raw::RecordBody::Compound(ms),
     },
-    <default_cap:DefaultCap> "enum" "#" <path:"ident"> <generics:Generics?>
+    <default_cap:DefaultCap> "enum" "#" <path:"ident"> <generics:Generics?> <loc:ItemLoc?>
     "{" <vs:Comma<Variant>> "}" ";"
     => raw::Record {
         default_cap,
         kind: raw::RecordKind::Enum,
         path: path.to_string(),
         generics: generics.unwrap_or_default(),
+        file: loc.map(|l| l.0),
+        span: loc.and_then(|l| l.1),
         body: raw::RecordBody::Variant(vs),
     },
 };
@@ -66,7 +82,7 @@ TrampDecl: raw::Tramp =
 
 Func: raw::Func =
     <p:"pub"?> <r:"regional"?> "fn" "#" <path:"ident"> <generics:Generics?>
-    "(" <params:Comma<Param>> ")" "->" <ret:Ty> <body:Body>
+    "(" <params:Comma<Param>> ")" "->" <ret:Ty> <loc:ItemLoc?> <body:Body>
     => raw::Func {
         is_pub: p.is_some(),
         regional: r.is_some(),
@@ -74,6 +90,8 @@ Func: raw::Func =
         generics: generics.unwrap_or_default(),
         params,
         ret,
+        file: loc.map(|l| l.0),
+        span: loc.and_then(|l| l.1),
         body,
     };
 
@@ -121,23 +139,30 @@ Cap: raw::Cap = {
 
 // ----- expressions -----
 
-Block: raw::Expr = <first:Expr> <rest:(";" <Expr>)*> => {
-    if rest.is_empty() {
+/// A leading `[start..end]` is the enclosing `Seq`'s own span. A single
+/// spanless expression is not wrapped (a spanless one-statement `Seq` prints
+/// indistinguishably and is normalized away — structurally, not semantically,
+/// significant).
+Block: raw::Expr = <sp:Span?> <first:Expr> <rest:(";" <Expr>)*> => {
+    if sp.is_none() && rest.is_empty() {
         first
     } else {
         let mut v = vec![first];
         v.extend(rest);
         let ty = v.last().unwrap().ty.clone();
-        raw::Expr::new(raw::Kind::Seq(v), ty)
+        raw::Expr::new(raw::Kind::Seq(v), ty).with_span(sp)
     }
 };
 
 /// Every value expression is `Atom : Ty`; `let` (always `unit`) and a braced
 /// block (a `Seq`) are the structural exceptions whose type is not printed.
 Expr: raw::Expr = {
-    <a:Atom> ":" <t:Ty> => raw::Expr::new(a, t),
-    "let" <var:"var"> "(" <name:"ident"> ")" "=" <value:Expr>
-        => raw::Expr::new(raw::Kind::Let { var, name: name.to_string(), value }, raw::Ty::Unit),
+    <a:Atom> ":" <t:Ty> <sp:Span?> => raw::Expr::new(a, t).with_span(sp),
+    "let" <sp:Span?> <var:"var"> "(" <name:"ident"> <nsp:Span?> ")" "=" <value:Expr>
+        => raw::Expr::new(
+            raw::Kind::Let { var, name: name.to_string(), name_span: nsp, value },
+            raw::Ty::Unit,
+        ).with_span(sp),
     "{" <b:Block> "}" => b,
 };
 
@@ -312,6 +337,8 @@ extern {
         ";" => Token::Semi,
         "," => Token::Comma,
         "." => Token::Dot,
+        ".." => Token::DotDot,
+        "in" => Token::In,
         "=" => Token::Eq,
         "=>" => Token::FatArrow,
         "_" => Token::Underscore,

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -5,9 +5,11 @@
 //! Builds the owned `semi::hir::raw` AST, which
 //! `semi::hir::build` re-interns into the HIR.
 
-use crate::semi::hir::raw as raw;
-use crate::ir_lex::{Token, LexError};
+use std::borrow::Cow;
+
+use crate::ir_lex::{LexError, Token, unescape_debug_str};
 use crate::literal::{FloatLit, Integer};
+use crate::semi::hir::raw as raw;
 
 grammar<'input>;
 
@@ -23,7 +25,7 @@ Item: raw::Item = {
 /// One source-file table entry: `0 = "src/lib.rr";`. Spans are byte offsets
 /// into these files; a `<bracketed>` name is a virtual file (unfetchable).
 FileDecl: raw::FileEntry = <id:"int"> "=" <name:"quoted"> ";"
-    => raw::FileEntry { id: raw::small_u32(&id), name: name.to_string() };
+    => raw::FileEntry { id: raw::small_u32(&id), name: unescape_debug_str(name).into_owned() };
 
 /// A source span: `[start..end]`, byte offsets into the owning item's file.
 Span: raw::Span = "[" <s:"int"> ".." <e:"int"> "]" => (raw::small_u32(&s), raw::small_u32(&e));
@@ -37,7 +39,7 @@ RecordDecl: raw::Record = {
     => raw::Record {
         default_cap,
         kind: raw::RecordKind::Struct,
-        path: path.to_string(),
+        path: path.into(),
         generics: generics.unwrap_or_default(),
         file: loc.map(|l| l.0),
         span: loc.and_then(|l| l.1),
@@ -48,7 +50,7 @@ RecordDecl: raw::Record = {
     => raw::Record {
         default_cap,
         kind: raw::RecordKind::Enum,
-        path: path.to_string(),
+        path: path.into(),
         generics: generics.unwrap_or_default(),
         file: loc.map(|l| l.0),
         span: loc.and_then(|l| l.1),
@@ -65,18 +67,18 @@ DefaultCap: raw::DefaultCap = {
 /// A compound field: an optional `name:` prefix (absent for a tuple field), an
 /// optional `field` marker (a mutable `[field]` link), and its type.
 Member: raw::Member = <n:(<"quoted"> ":")?> <f:"field"?> <t:Ty>
-    => raw::Member { name: n.map(|s| s.to_string()), is_field: f.is_some(), ty: t };
+    => raw::Member { name: n.map(|s| s.into()), is_field: f.is_some(), ty: t };
 
 /// An enum variant: its source name and ordered field types.
 Variant: raw::Variant =
-    <name:"ident"> "(" <fs:Comma<Ty>> ")" => raw::Variant { name: name.to_string(), fields: fs };
+    <name:"ident"> "(" <fs:Comma<Ty>> ")" => raw::Variant { name: name.into(), fields: fs };
 
 TrampDecl: raw::Tramp =
     "extern" <abi:"quoted"> "trampoline" <name:"quoted"> "=" "#" <target:"ident"> <ta:TyArgs?> ";"
     => raw::Tramp {
-        abi: abi.to_string(),
-        name: name.to_string(),
-        target: target.to_string(),
+        abi: abi.into(),
+        name: name.into(),
+        target: target.into(),
         ty_args: ta.unwrap_or_default(),
     };
 
@@ -86,7 +88,7 @@ Func: raw::Func =
     => raw::Func {
         is_pub: p.is_some(),
         regional: r.is_some(),
-        path: path.to_string(),
+        path: path.into(),
         generics: generics.unwrap_or_default(),
         params,
         ret,
@@ -106,7 +108,7 @@ Body: Option<raw::Expr> = {
 };
 
 Param: raw::Param = <var:"var"> "(" <name:"ident"> ")" ":" <ty:Ty>
-    => raw::Param { var, name: name.to_string(), ty };
+    => raw::Param { var, name: name.into(), ty };
 
 // ----- types -----
 
@@ -123,7 +125,7 @@ Ty: raw::Ty = {
     <g:"generic"> => raw::Ty::Generic(g),
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
     <cap:Cap> "#" <path:"ident"> <args:TyArgs?>
-        => raw::Ty::Record { cap, path: path.to_string(), args: args.unwrap_or_default() },
+        => raw::Ty::Record { cap, path: path.into(), args: args.unwrap_or_default() },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };
@@ -160,7 +162,7 @@ Expr: raw::Expr = {
     <a:Atom> ":" <t:Ty> <sp:Span?> => raw::Expr::new(a, t).with_span(sp),
     "let" <sp:Span?> <var:"var"> "(" <name:"ident"> <nsp:Span?> ")" "=" <value:Expr>
         => raw::Expr::new(
-            raw::Kind::Let { var, name: name.to_string(), name_span: nsp, value },
+            raw::Kind::Let { var, name: name.into(), name_span: nsp, value },
             raw::Ty::Unit,
         ).with_span(sp),
     "{" <b:Block> "}" => b,
@@ -185,11 +187,11 @@ Atom: raw::Kind = {
     "assign" "(" <dst:Expr> "," <field:"int"> "," <src:Expr> ")"
         => raw::Kind::Assign(dst, raw::small_u32(&field), src),
     <r:"regional"?> "#" <path:"ident"> <ta:TyArgs?> "(" <args:Comma<Expr>> ")"
-        => raw::Kind::FuncCall { regional: r.is_some(), path: path.to_string(), ty_args: ta.unwrap_or_default(), args },
+        => raw::Kind::FuncCall { regional: r.is_some(), path: path.into(), ty_args: ta.unwrap_or_default(), args },
     "#" <path:"ident"> <ta:TyArgs?> "{" <args:Comma<Expr>> "}"
-        => raw::Kind::CompoundCall { path: path.to_string(), ty_args: ta.unwrap_or_default(), args },
+        => raw::Kind::CompoundCall { path: path.into(), ty_args: ta.unwrap_or_default(), args },
     "#" <path:"ident"> <ta:TyArgs?> "#" <v:"int"> "(" <args:Comma<Expr>> ")"
-        => raw::Kind::VariantCall { path: path.to_string(), ty_args: ta.unwrap_or_default(), variant: raw::small_usize(&v), args },
+        => raw::Kind::VariantCall { path: path.into(), ty_args: ta.unwrap_or_default(), variant: raw::small_usize(&v), args },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"
@@ -296,7 +298,7 @@ extern {
         "field" => Token::Field,
         "extern" => Token::Extern,
         "trampoline" => Token::Trampoline,
-        "quoted" => Token::Quoted(<&'input str>),
+        "quoted" => Token::Quoted(<Cow<'input, str>>),
         "let" => Token::Let,
         "if" => Token::If,
         "then" => Token::Then,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -76,7 +76,7 @@ impl<'a> Printer<'a> {
         let mut items: Vec<Doc<'static>> = Vec::new();
         if let Some(cache) = self.sources {
             for id in cache.ids() {
-                items.push(text(format!("{} = \"{}\";", id.index(), cache.name(id))));
+                items.push(text(format!("{} = {:?};", id.index(), cache.name(id))));
             }
         }
         let mut recs: Vec<&Record<'_>> = records.values().collect();

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -14,6 +14,7 @@
 
 use pprint::{Doc, Printer as PpPrinter, hardline, indent, pprint};
 use reussir_syntax::kind::{Resolver, TokenKey};
+use reussir_syntax::source::SourceCache;
 
 use crate::semi::ctxt::{DefaultCap, Record, RecordFields, TrampolineRoot};
 use crate::semi::hir::{
@@ -33,11 +34,34 @@ const IR_PRINTER: PpPrinter = PpPrinter {
 pub struct Printer<'a> {
     defs: &'a DefTable,
     resolver: &'a dyn Resolver<TokenKey>,
+    /// When present, the dump carries source locations: the file table
+    /// (`0 = "path";`), each item's `in <file> [span]`, and every node's
+    /// `[start..end]` span — the lossless round-trip form (`rrc --emit hir`).
+    /// Without it the dump is the bare program (human display, e.g. the
+    /// REPL's `:dump context`).
+    sources: Option<&'a SourceCache>,
 }
 
 impl<'a> Printer<'a> {
     pub fn new(defs: &'a DefTable, resolver: &'a dyn Resolver<TokenKey>) -> Self {
-        Printer { defs, resolver }
+        Printer {
+            defs,
+            resolver,
+            sources: None,
+        }
+    }
+
+    /// A printer that also serializes source locations against `sources`.
+    pub fn with_sources(
+        defs: &'a DefTable,
+        resolver: &'a dyn Resolver<TokenKey>,
+        sources: &'a SourceCache,
+    ) -> Self {
+        Printer {
+            defs,
+            resolver,
+            sources: Some(sources),
+        }
     }
 
     /// Render the resumable Semi output: record declarations, trampoline roots,
@@ -50,6 +74,11 @@ impl<'a> Printer<'a> {
         trampolines: &[TrampolineRoot<'_>],
     ) -> String {
         let mut items: Vec<Doc<'static>> = Vec::new();
+        if let Some(cache) = self.sources {
+            for id in cache.ids() {
+                items.push(text(format!("{} = \"{}\";", id.index(), cache.name(id))));
+            }
+        }
         let mut recs: Vec<&Record<'_>> = records.values().collect();
         // Sort by qualified path (phase-canonical: identical across the original
         // elaboration and a reparse, unlike the session-local `DefId`).
@@ -115,7 +144,8 @@ impl<'a> Printer<'a> {
             RecordKind::EnumKind => "enum #",
         };
         let head = text(format!("{cap}{kind}{}", self.path(r.def)))
-            + self.generics_binder(&r.ty_params, &r.regional_generics);
+            + self.generics_binder(&r.ty_params, &r.regional_generics)
+            + self.item_loc(r.file, r.span);
         head + text(" { ") + self.record_body(r) + text(" };")
     }
 
@@ -193,13 +223,38 @@ impl<'a> Printer<'a> {
                 text(format!("v{} ({}): ", var.0, self.resolver.resolve(*name))) + self.ty(*ty)
             })
             .collect();
-        sig = sig + text("(") + comma_sep(params) + text(") -> ") + self.ty(f.return_ty);
+        sig = sig
+            + text("(")
+            + comma_sep(params)
+            + text(") -> ")
+            + self.ty(f.return_ty)
+            + self.item_loc(f.file, f.span);
 
         match &f.body {
             Some(body) => {
                 sig + text(" {") + indent(hardline() + self.expr(body)) + hardline() + text("}")
             }
             None => sig + text(";"),
+        }
+    }
+
+    /// ` in <file> [span]` — an item's source location (locations mode only).
+    fn item_loc(
+        &self,
+        file: reussir_syntax::source::FileId,
+        span: Option<crate::surface::Span>,
+    ) -> Doc<'static> {
+        if self.sources.is_none() {
+            return Doc::Null;
+        }
+        text(format!(" in {}", file.index())) + self.span_doc(span)
+    }
+
+    /// ` [start..end]` — a node's span suffix (locations mode only).
+    fn span_doc(&self, span: Option<crate::surface::Span>) -> Doc<'static> {
+        match (self.sources, span) {
+            (Some(_), Some(sp)) => text(format!(" [{}..{}]", sp.start, sp.end)),
+            _ => Doc::Null,
         }
     }
 
@@ -257,7 +312,12 @@ impl<'a> Printer<'a> {
         match &e.kind {
             ExprKind::Seq(items) => {
                 let n = items.len();
-                let mut d = Doc::Null;
+                // The leading `[span]` is the `Seq`'s own (its items carry
+                // theirs inline) — the dual of the grammar's `Block` rule.
+                let mut d = match (self.sources, e.span) {
+                    (Some(_), Some(sp)) => text(format!("[{}..{}]", sp.start, sp.end)) + hardline(),
+                    _ => Doc::Null,
+                };
                 for (i, item) in items.iter().enumerate() {
                     if i > 0 {
                         d = d + hardline();
@@ -280,23 +340,27 @@ impl<'a> Printer<'a> {
             ExprKind::Let {
                 var: v,
                 name,
+                span: name_span,
                 value,
-                ..
             } => {
-                text("let ")
+                text("let")
+                    + self.span_doc(e.span)
+                    + text(" ")
                     + var(*v)
-                    + text(format!(" ({}) = ", self.resolver.resolve(*name)))
+                    + text(format!(" ({}", self.resolver.resolve(*name)))
+                    + self.span_doc(*name_span)
+                    + text(") = ")
                     + self.value(value)
             }
             ExprKind::Seq(_) => text("{ ") + self.expr(e) + text(" }"),
-            ExprKind::If(c, t, f) => self.typed(self.render_if(c, t, f), e.ty),
-            ExprKind::Match(scrut, tree) => self.typed(self.render_match(scrut, tree), e.ty),
-            _ => self.typed(self.atom(e), e.ty),
+            ExprKind::If(c, t, f) => self.typed(self.render_if(c, t, f), e),
+            ExprKind::Match(scrut, tree) => self.typed(self.render_match(scrut, tree), e),
+            _ => self.typed(self.atom(e), e),
         }
     }
 
-    fn typed(&self, atom: Doc<'static>, ty: Ty<'_>) -> Doc<'static> {
-        atom + text(" : ") + self.ty(ty)
+    fn typed(&self, atom: Doc<'static>, e: &Expr<'_>) -> Doc<'static> {
+        atom + text(" : ") + self.ty(e.ty) + self.span_doc(e.span)
     }
 
     fn render_if(&self, c: &Expr<'_>, t: &Expr<'_>, f: &Expr<'_>) -> Doc<'static> {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -7,14 +7,15 @@
 //! holes, so the textual form does not represent them.
 
 pub use crate::full::mir::raw::{
-    ArithOp, Cap, CmpOp, FloatLit, Integer, float_lit, float_path_segs, small_u32, small_u64,
-    small_usize,
+    ArithOp, Cap, CmpOp, FileEntry, FloatLit, Integer, Span, float_lit, float_path_segs, small_u32,
+    small_u64, small_usize,
 };
 
 /// The whole HIR program: enough to resume into monomorphization — the record
 /// declarations and trampoline roots mono needs, plus the elaborated functions.
 #[derive(Clone, Debug)]
 pub struct Program {
+    pub files: Vec<FileEntry>,
     pub records: Vec<Record>,
     pub trampolines: Vec<Tramp>,
     pub funcs: Vec<Func>,
@@ -23,6 +24,7 @@ pub struct Program {
 /// One top-level item, as the grammar yields them before partitioning.
 #[derive(Clone, Debug)]
 pub enum Item {
+    File(FileEntry),
     Record(Record),
     Tramp(Tramp),
     Func(Func),
@@ -31,12 +33,14 @@ pub enum Item {
 impl Program {
     pub fn from_items(items: Vec<Item>) -> Program {
         let mut p = Program {
+            files: Vec::new(),
             records: Vec::new(),
             trampolines: Vec::new(),
             funcs: Vec::new(),
         };
         for item in items {
             match item {
+                Item::File(f) => p.files.push(f),
                 Item::Record(r) => p.records.push(r),
                 Item::Tramp(t) => p.trampolines.push(t),
                 Item::Func(f) => p.funcs.push(f),
@@ -56,6 +60,9 @@ pub struct Record {
     pub kind: RecordKind,
     pub path: String,
     pub generics: Vec<Generic>,
+    /// The file-table id the record's span indexes (`in <id>`).
+    pub file: Option<u32>,
+    pub span: Option<Span>,
     pub body: RecordBody,
 }
 
@@ -114,6 +121,9 @@ pub struct Func {
     pub generics: Vec<Generic>,
     pub params: Vec<Param>,
     pub ret: Ty,
+    /// The file-table id the function's spans index (`in <id>`).
+    pub file: Option<u32>,
+    pub span: Option<Span>,
     pub body: Option<Expr>,
 }
 
@@ -166,6 +176,9 @@ pub type StrTag = [u64; 4];
 pub struct Expr {
     pub kind: Box<Kind>,
     pub ty: Ty,
+    /// The node's source span (`[start..end]`), byte offsets into the owning
+    /// function's file.
+    pub span: Option<Span>,
 }
 
 impl Expr {
@@ -173,7 +186,13 @@ impl Expr {
         Expr {
             kind: Box::new(kind),
             ty,
+            span: None,
         }
+    }
+
+    pub fn with_span(mut self, span: Option<Span>) -> Expr {
+        self.span = span;
+        self
     }
 }
 
@@ -198,6 +217,8 @@ pub enum Kind {
     Let {
         var: u32,
         name: String,
+        /// The binding name's own span (distinct from the node's).
+        name_span: Option<Span>,
         value: Expr,
     },
     Seq(Vec<Expr>),

--- a/crates/reussir-core/src/semi/repl.rs
+++ b/crates/reussir-core/src/semi/repl.rs
@@ -241,6 +241,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 return_ty: wrapper_ty,
                 is_regional: false,
                 span,
+                file: self.current_file,
             },
         );
         self.elaborated.push(Function {
@@ -254,6 +255,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             is_regional: false,
             body: Some(body),
             span,
+            file: self.current_file,
         });
         self.trampolines.push(TrampolineRoot {
             name: export.to_string(),
@@ -283,6 +285,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     return_ty: self.tcx.mk_unit(),
                     is_regional: false,
                     span,
+                    file: self.current_file,
                 },
             );
             let dec_body = Expr {
@@ -302,6 +305,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 is_regional: false,
                 body: Some(dec_body),
                 span,
+                file: self.current_file,
             });
             self.trampolines.push(TrampolineRoot {
                 name: format!("{export}_dec"),
@@ -341,6 +345,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 )])),
                 regional_generics: Vec::new(),
                 span: None,
+                file: self.current_file,
             },
         );
         Some(def)

--- a/crates/reussir-repl/src/frontend/plain.rs
+++ b/crates/reussir-repl/src/frontend/plain.rs
@@ -10,7 +10,8 @@
 use std::io::{BufRead, Write};
 
 use reussir_core::semi::render_reports;
-use reussir_syntax::diagnostics::{self, SourceMap};
+use reussir_syntax::diagnostics;
+use reussir_syntax::source::SourceCache;
 
 use crate::session::{Exit, Outcome, ReplSession};
 
@@ -29,7 +30,7 @@ pub fn drive(
             continue;
         }
         let outcome = session.eval(&input);
-        if let Some(exit) = render(&outcome, &input) {
+        if let Some(exit) = render(&outcome, session.sources()) {
             return exit;
         }
     }
@@ -86,14 +87,14 @@ fn prompt(text: &str, interactive: bool) {
 
 /// Render one outcome (stdout for results, stderr for diagnostics).
 /// `Some(exit)` when the outcome ends the drive loop.
-pub fn render(outcome: &Outcome, input: &str) -> Option<Exit> {
+pub fn render(outcome: &Outcome, sources: &SourceCache) -> Option<Exit> {
     match outcome {
         Outcome::Empty => {}
         Outcome::Quit => return Some(Exit::Quit),
         Outcome::ClearRequested => return Some(Exit::Clear),
         Outcome::Text(text) => println!("{text}"),
         Outcome::Definitions { count, warnings } => {
-            render_reports("<repl>", input, warnings);
+            render_reports(sources, warnings);
             for _ in 0..*count {
                 println!("Definition added.");
             }
@@ -103,7 +104,7 @@ pub fn render(outcome: &Outcome, input: &str) -> Option<Exit> {
             ty,
             warnings,
         } => {
-            render_reports("<repl>", input, warnings);
+            render_reports(sources, warnings);
             // Unit results print bare, matching the established contract.
             if ty == "()" {
                 println!("()");
@@ -117,16 +118,14 @@ pub fn render(outcome: &Outcome, input: &str) -> Option<Exit> {
             ty,
             warnings,
         } => {
-            render_reports("<repl>", input, warnings);
+            render_reports(sources, warnings);
             println!("{name} = {value} : {ty}");
         }
-        Outcome::ParseErrors(errors) => {
-            let map = SourceMap::new(input);
-            let _ =
-                diagnostics::render_errors("<repl>", input, &map, errors, false, std::io::stderr());
+        Outcome::ParseErrors { file, errors } => {
+            let _ = diagnostics::render_errors(sources, *file, errors, false, std::io::stderr());
         }
         Outcome::Reports(reports) => {
-            render_reports("<repl>", input, reports);
+            render_reports(sources, reports);
         }
         Outcome::Backend(message) => eprintln!("error: {message}"),
     }

--- a/crates/reussir-repl/src/frontend/tui.rs
+++ b/crates/reussir-repl/src/frontend/tui.rs
@@ -26,7 +26,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, Input, TextArea};
 
 use reussir_core::semi::{Report, Severity, render_reports_to};
-use reussir_syntax::diagnostics::{self, SourceMap};
+use reussir_syntax::diagnostics;
 
 use reussir_jit::OptLevel;
 
@@ -360,10 +360,14 @@ impl Tui {
         // rebuilds the session at the level the user chose, not the CLI's.
         self.config.opt = session.opt;
 
-        self.render_outcome(&outcome, &text)
+        self.render_outcome(&outcome, session.sources())
     }
 
-    fn render_outcome(&mut self, outcome: &Outcome, input: &str) -> Option<Exit> {
+    fn render_outcome(
+        &mut self,
+        outcome: &Outcome,
+        sources: &reussir_syntax::source::SourceCache,
+    ) -> Option<Exit> {
         match outcome {
             Outcome::Empty => {}
             Outcome::Quit => return Some(Exit::Quit),
@@ -374,7 +378,7 @@ impl Tui {
                 }
             }
             Outcome::Definitions { count, warnings } => {
-                self.render_reports(warnings, input);
+                self.render_reports(warnings, sources);
                 for _ in 0..*count {
                     self.push_line(Line::from("Definition added.".green()));
                 }
@@ -384,7 +388,7 @@ impl Tui {
                 ty,
                 warnings,
             } => {
-                self.render_reports(warnings, input);
+                self.render_reports(warnings, sources);
                 self.out_counter += 1;
                 let title = format!("Out[{}]", self.out_counter);
                 let content = if ty == "()" {
@@ -407,7 +411,7 @@ impl Tui {
                 ty,
                 warnings,
             } => {
-                self.render_reports(warnings, input);
+                self.render_reports(warnings, sources);
                 // A binding cell is titled by its name instead of `Out[n]`.
                 let content = vec![
                     Span::styled(value.clone(), Style::default().add_modifier(Modifier::BOLD)),
@@ -416,16 +420,14 @@ impl Tui {
                 ];
                 self.push_boxed(name, content);
             }
-            Outcome::ParseErrors(errors) => {
-                let map = SourceMap::new(input);
+            Outcome::ParseErrors { file, errors } => {
                 let mut rendered = Vec::new();
-                let _ =
-                    diagnostics::render_errors("<repl>", input, &map, errors, false, &mut rendered);
+                let _ = diagnostics::render_errors(sources, *file, errors, false, &mut rendered);
                 for line in String::from_utf8_lossy(&rendered).lines() {
                     self.push_line(Line::from(line.to_string().red()));
                 }
             }
-            Outcome::Reports(reports) => self.render_reports(reports, input),
+            Outcome::Reports(reports) => self.render_reports(reports, sources),
             Outcome::Backend(message) => {
                 self.push_line(Line::from(format!("error: {message}").red()));
             }
@@ -436,16 +438,14 @@ impl Tui {
     /// Render elaboration/mono reports with the shared ariadne caret
     /// renderer (the same one `rrc` and the plain frontend use), one report
     /// at a time so each block can be styled by its severity.
-    fn render_reports(&mut self, reports: &[Report], input: &str) {
+    fn render_reports(
+        &mut self,
+        reports: &[Report],
+        sources: &reussir_syntax::source::SourceCache,
+    ) {
         for report in reports {
             let mut rendered = Vec::new();
-            let _ = render_reports_to(
-                "<repl>",
-                input,
-                std::slice::from_ref(report),
-                false,
-                &mut rendered,
-            );
+            let _ = render_reports_to(sources, std::slice::from_ref(report), false, &mut rendered);
             let style = match report.severity {
                 Severity::Error => Style::default().fg(Color::Red),
                 Severity::Warning => Style::default().fg(Color::Yellow),

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -16,6 +16,7 @@ use reussir_core::semi::{Checkpoint, Elaborator, Report, Severity};
 use reussir_core::{in_arena, surface};
 use reussir_jit::{ModuleHandle, OptLevel, OrcJit};
 use reussir_syntax::diagnostics::ParseError;
+use reussir_syntax::source::{FileId, SourceCache};
 use reussir_syntax::{
     Interner, MultiThreadedTokenInterner, ReplInputKind, new_threaded_interner, parse_repl,
 };
@@ -53,8 +54,12 @@ pub enum Outcome {
         ty: String,
         warnings: Vec<Report>,
     },
-    /// Syntax errors in the input (render against the input source).
-    ParseErrors(Vec<ParseError>),
+    /// Syntax errors in the input; `file` is the input's entry in the
+    /// session's [`SourceCache`] (render against it).
+    ParseErrors {
+        file: FileId,
+        errors: Vec<ParseError>,
+    },
     /// Elaboration/monomorphization diagnostics (input was rolled back).
     Reports(Vec<Report>),
     /// A backend (lowering/JIT) failure; the input was rolled back.
@@ -141,6 +146,12 @@ pub struct ReplSession<'a, 'tcx> {
     /// sizes and alignments (cached once — they never change per engine).
     data_layout: String,
     triple: String,
+    /// Every input of the session, as `<repl>` virtual files. The persistent
+    /// elaborator can report against an *older* input's span (e.g. a generic
+    /// defined earlier failing to monomorphize now), so all inputs stay
+    /// renderable — not just the current one. Grows monotonically; failed
+    /// inputs' entries are harmless (`:clear` starts a fresh session).
+    sources: SourceCache,
 }
 
 impl<'a, 'tcx> ReplSession<'a, 'tcx> {
@@ -176,7 +187,21 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             opt: config.opt,
             data_layout: jit.data_layout(),
             triple: jit.triple(),
+            sources: SourceCache::new(),
         }
+    }
+
+    /// The session's source cache (for rendering [`Outcome`] reports).
+    pub fn sources(&self) -> &SourceCache {
+        &self.sources
+    }
+
+    /// Register one input (or `:type` snippet) as a `<repl>` virtual file and
+    /// point the elaborator's report attribution at it.
+    fn add_input(&mut self, text: &str) -> FileId {
+        let file = self.sources.add_virtual("<repl>", text);
+        self.elab.set_current_file(file);
+        file
     }
 
     /// Evaluate one complete input (a command, definitions, or an
@@ -201,9 +226,13 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         if tokens.iter().all(|t| t.kind.is_trivia()) {
             return Outcome::Empty;
         }
+        let file = self.add_input(source);
         let parsed = parse_repl(source, self.interner.clone());
         if !parsed.parse.ok() {
-            return Outcome::ParseErrors(parsed.parse.errors);
+            return Outcome::ParseErrors {
+                file,
+                errors: parsed.parse.errors,
+            };
         }
         let cp = self.elab.checkpoint();
         match parsed.kind {
@@ -261,6 +290,7 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
                             severity: Severity::Error,
                             message: "cannot bind a unit value".to_string(),
                             span: None,
+                            file,
                         }])
                     }
                     Ok((ty, warnings)) => match self.compile_new(&cp) {
@@ -415,9 +445,13 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
     /// Check an expression's type without compiling or executing it
     /// (`:type`). Elaborator state is always rolled back.
     pub(crate) fn type_of(&mut self, source: &str) -> Outcome {
+        let file = self.add_input(source);
         let parsed = parse_repl(source, self.interner.clone());
         if !parsed.parse.ok() {
-            return Outcome::ParseErrors(parsed.parse.errors);
+            return Outcome::ParseErrors {
+                file,
+                errors: parsed.parse.errors,
+            };
         }
         if parsed.kind != ReplInputKind::Expr {
             return Outcome::Text(":type takes an expression".to_string());

--- a/crates/reussir-syntax/Cargo.toml
+++ b/crates/reussir-syntax/Cargo.toml
@@ -10,6 +10,7 @@ name = "reussir_syntax"
 
 [dependencies]
 ariadne.workspace = true
+tracing.workspace = true
 palc.workspace = true
 cstree.workspace = true
 lasso.workspace = true

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -13,17 +13,17 @@
 
 use serde_json::{Number, Value, json};
 
-use crate::diagnostics::SourceMap;
 use crate::kind::{ResolvedNode, ResolvedToken, SyntaxKind, SyntaxKind::*};
+use crate::source::CharMap;
 
-pub fn prog_to_json(root: &ResolvedNode, map: &SourceMap) -> Value {
+pub fn prog_to_json(root: &ResolvedNode, map: &CharMap) -> Value {
     assert_eq!(root.kind(), SourceFile, "expected a SourceFile root");
     let e = Emitter { map };
     Value::Array(root.children().map(|stmt| e.stmt(stmt)).collect())
 }
 
 struct Emitter<'m> {
-    map: &'m SourceMap,
+    map: &'m CharMap,
 }
 
 // ===== small helpers =====

--- a/crates/reussir-syntax/src/bin/reussir-syntax.rs
+++ b/crates/reussir-syntax/src/bin/reussir-syntax.rs
@@ -11,7 +11,8 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use palc::Parser;
-use reussir_syntax::diagnostics::{SourceMap, render_errors};
+use reussir_syntax::diagnostics::render_errors;
+use reussir_syntax::source::{CharMap, FileId, SourceCache};
 
 /// Reussir surface syntax parser (JSON AST emitter).
 #[derive(Parser)]
@@ -34,20 +35,23 @@ struct Cli {
 }
 
 fn run(cli: &Cli) -> Result<bool, String> {
-    let (display_name, source) = if cli.input.as_os_str() == "-" {
+    let mut cache = SourceCache::new();
+    let file = if cli.input.as_os_str() == "-" {
         let mut buf = String::new();
         std::io::stdin()
             .read_to_string(&mut buf)
             .map_err(|e| format!("failed to read stdin: {e}"))?;
-        ("<stdin>".to_owned(), buf)
+        cache.add_virtual("<stdin>", buf)
     } else {
         let text = std::fs::read_to_string(&cli.input)
             .map_err(|e| format!("failed to read {}: {e}", cli.input.display()))?;
-        (cli.input.display().to_string(), text)
+        cache.add_file(&cli.input, text)
     };
+    debug_assert_eq!(file, FileId::ROOT);
+    let source = cache.source(file);
 
-    let parse = reussir_syntax::parse(&source);
-    let map = SourceMap::new(&source);
+    let parse = reussir_syntax::parse(source);
+    let map = CharMap::new(source);
 
     if !parse.errors.is_empty() {
         let color = match cli.color.as_str() {
@@ -56,11 +60,12 @@ fn run(cli: &Cli) -> Result<bool, String> {
             _ => std::io::stderr().is_terminal(),
         };
         let stderr = std::io::stderr().lock();
-        render_errors(&display_name, &source, &map, &parse.errors, color, stderr)
+        render_errors(&cache, file, &parse.errors, color, stderr)
             .map_err(|e| format!("failed to render diagnostics: {e}"))?;
         eprintln!(
-            "error: {} syntax error(s) in {display_name}",
-            parse.errors.len()
+            "error: {} syntax error(s) in {}",
+            parse.errors.len(),
+            cache.name(file)
         );
         return Ok(false);
     }

--- a/crates/reussir-syntax/src/diagnostics.rs
+++ b/crates/reussir-syntax/src/diagnostics.rs
@@ -1,13 +1,16 @@
 //! Parse error representation and user-facing rendering via [`ariadne`].
 //!
 //! Both the parser's own [`ParseError`]s and the middle-end's diagnostics render
-//! through one path: a caller lowers each into a [`Diagnostic`] (a byte-offset
-//! span, a [`Severity`], and a message) and hands the batch to [`render`], which
-//! draws a source-caret report. A spanless diagnostic — one the compiler could
-//! not trace back to a source location — falls back to a plain
+//! through one path: a caller lowers each into a [`Diagnostic`] (a file, a
+//! byte-offset span, a [`Severity`], and a message) and hands the batch to
+//! [`render`], which draws a source-caret report against the compilation's
+//! [`SourceCache`]. A spanless diagnostic — one the compiler could not trace
+//! back to a source location — falls back to a plain
 //! `{file_name}: severity: message` line.
 
-use ariadne::{Color, Config, Label, Report, ReportKind, Source};
+use ariadne::{Color, Config, Label, Report, ReportKind};
+
+use crate::source::{FileId, SourceCache};
 
 /// A parse (or lexical) error. Spans are byte offsets into the source.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,11 +28,12 @@ pub enum Severity {
 }
 
 /// A source-anchored diagnostic ready to render. The `span` is a byte-offset
-/// half-open range into the source, or `None` when the diagnostic cannot be
-/// pinned to a location (an internal/whole-program error) — in which case
-/// [`render`] prints it without a caret.
+/// half-open range into `file`, or `None` when the diagnostic cannot be pinned
+/// to a location (an internal/whole-program error) — in which case [`render`]
+/// prints it without a caret.
 #[derive(Debug, Clone)]
 pub struct Diagnostic<'a> {
+    pub file: FileId,
     pub span: Option<(u32, u32)>,
     pub severity: Severity,
     pub message: &'a str,
@@ -58,59 +62,32 @@ impl Severity {
     }
 }
 
-/// Maps byte offsets to character (Unicode scalar) offsets. The frontend
-/// records character offsets, so all externally visible spans go through this
-/// table.
-pub struct SourceMap {
-    /// `byte_to_char[b]` is the number of chars strictly before byte `b`.
-    byte_to_char: Vec<u32>,
-}
-
-impl SourceMap {
-    pub fn new(source: &str) -> Self {
-        let mut byte_to_char = vec![0u32; source.len() + 1];
-        let mut chars = 0u32;
-        for (idx, c) in source.char_indices() {
-            byte_to_char[idx..idx + c.len_utf8()].fill(chars);
-            chars += 1;
-        }
-        byte_to_char[source.len()] = chars;
-        Self { byte_to_char }
-    }
-
-    pub fn char_offset(&self, byte: u32) -> u32 {
-        self.byte_to_char[byte as usize]
-    }
-
-    pub fn char_span(&self, span: (u32, u32)) -> (u32, u32) {
-        (self.char_offset(span.0), self.char_offset(span.1))
-    }
-}
-
 /// Render `diagnostics` with source context to `out`.
 ///
-/// A diagnostic with a span draws an `ariadne` source-caret report; the `ariadne`
-/// cache holds the single source file and spans are converted to character
-/// offsets, which is what [`ariadne::Source`] indexes by. A spanless diagnostic
-/// is written as a plain `{file_name}: severity: message` line — the compiler
+/// A diagnostic with a span draws an `ariadne` source-caret report; `cache`
+/// serves every file of the compilation, and byte spans are converted to the
+/// character offsets [`ariadne::Source`] indexes by. A spanless diagnostic is
+/// written as a plain `{file_name}: severity: message` line — the compiler
 /// could not trace it back to source, so there is nothing to point at.
 pub fn render(
-    file_name: &str,
-    source: &str,
-    source_map: &SourceMap,
+    cache: &SourceCache,
     diagnostics: &[Diagnostic],
     color: bool,
     mut out: impl std::io::Write,
 ) -> std::io::Result<()> {
-    let cache = (file_name, Source::from(source));
     for diag in diagnostics {
         // An empty source has no line to anchor a caret on; treat every
         // span as absent rather than hand ariadne an out-of-bounds range.
-        let span = if source.is_empty() { None } else { diag.span };
+        let span = if cache.source(diag.file).is_empty() {
+            None
+        } else {
+            diag.span
+        };
         let Some(bytes) = span else {
             writeln!(
                 out,
-                "{file_name}: {}: {}",
+                "{}: {}: {}",
+                cache.name(diag.file),
                 diag.severity.label(),
                 diag.message
             )?;
@@ -121,11 +98,11 @@ pub fn render(
         // character, e.g. an unexpected-EOF parse error) pulls back onto the
         // last character — out of bounds, ariadne would render the frame
         // with no source line at all.
-        let (start, end) = source_map.char_span(bytes);
-        let len = source.chars().count() as u32;
+        let (start, end) = cache.char_span(diag.file, bytes);
+        let len = cache.char_len(diag.file);
         let start = start.min(len.saturating_sub(1));
         let end = end.clamp(start + 1, len.max(start + 1));
-        let span = (file_name, start as usize..end as usize);
+        let span = (diag.file, start as usize..end as usize);
         // The message heads the report (a greppable summary line) and annotates
         // the underlined span, so the caret line stands on its own.
         Report::build(diag.severity.report_kind(), span.clone())
@@ -137,17 +114,17 @@ pub fn render(
                     .with_color(diag.severity.color()),
             )
             .finish()
-            .write(cache.clone(), &mut out)?;
+            .write(cache, &mut out)?;
     }
     Ok(())
 }
 
-/// Render parse `errors` with source context — a thin adapter over [`render`]
-/// that tags each as a [`Severity::Error`].
+/// Render parse `errors` — which are always local to one file — against
+/// `file`: a thin adapter over [`render`] that tags each as a
+/// [`Severity::Error`].
 pub fn render_errors(
-    file_name: &str,
-    source: &str,
-    source_map: &SourceMap,
+    cache: &SourceCache,
+    file: FileId,
     errors: &[ParseError],
     color: bool,
     out: impl std::io::Write,
@@ -155,10 +132,11 @@ pub fn render_errors(
     let diagnostics: Vec<Diagnostic> = errors
         .iter()
         .map(|e| Diagnostic {
+            file,
             span: Some(e.span),
             severity: Severity::Error,
             message: &e.message,
         })
         .collect();
-    render(file_name, source, source_map, &diagnostics, color, out)
+    render(cache, &diagnostics, color, out)
 }

--- a/crates/reussir-syntax/src/diagnostics.rs
+++ b/crates/reussir-syntax/src/diagnostics.rs
@@ -76,12 +76,14 @@ pub fn render(
     mut out: impl std::io::Write,
 ) -> std::io::Result<()> {
     for diag in diagnostics {
-        // An empty source has no line to anchor a caret on; treat every
-        // span as absent rather than hand ariadne an out-of-bounds range.
-        let span = if cache.source(diag.file).is_empty() {
-            None
-        } else {
-            diag.span
+        // An unavailable or empty source has no line to anchor a caret on;
+        // treat the span as absent rather than hand ariadne an out-of-bounds
+        // range.
+        let span = match diag.span {
+            Some(span) if cache.is_available(diag.file) && cache.char_len(diag.file) > 0 => {
+                Some(span)
+            }
+            _ => None,
         };
         let Some(bytes) = span else {
             writeln!(

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -19,9 +19,11 @@ pub mod diagnostics;
 pub mod kind;
 pub mod lexer;
 pub(crate) mod parser;
+pub mod source;
 
-use diagnostics::{ParseError, SourceMap};
+use diagnostics::ParseError;
 use kind::{ResolvedNode, SyntaxKind};
+use source::CharMap;
 
 // The shared-interner types [`parse_with_interner`] / [`parse_repl`] take, so
 // downstream crates don't need a direct cstree dependency. `Interner` is the
@@ -55,7 +57,7 @@ impl Parse {
     /// call it only when [`Parse::ok`] holds. Lowering a tree
     /// that still contains error nodes panics (the recovery shape is not a
     /// valid AST).
-    pub fn to_json(&self, map: &SourceMap) -> serde_json::Value {
+    pub fn to_json(&self, map: &CharMap) -> serde_json::Value {
         assert!(
             self.ok(),
             "to_json requires an error-free parse; got {} error(s)",
@@ -139,9 +141,7 @@ fn repl_route(p: &parser::Parser) -> ReplInputKind {
         FnKw | ModKw => p.nth(1).is_ident_like() && p.nth(1) != AsKw,
         // Records may also carry a capability annotation before the name:
         // `struct [value] V { ... }`.
-        StructKw | EnumKw => {
-            (p.nth(1).is_ident_like() && p.nth(1) != AsKw) || p.nth(1) == LBracket
-        }
+        StructKw | EnumKw => (p.nth(1).is_ident_like() && p.nth(1) != AsKw) || p.nth(1) == LBracket,
         // `extern "C" trampoline ...` — a string cannot follow a variable.
         ExternKw => p.nth(1) == StringLit,
         // `pub <item>` — mirrors `stmt`'s post-visibility dispatch.
@@ -214,7 +214,7 @@ mod tests {
     }
 
     fn json_of(source: &str) -> serde_json::Value {
-        let map = SourceMap::new(source);
+        let map = CharMap::new(source);
         parse_ok(source).to_json(&map)
     }
 

--- a/crates/reussir-syntax/src/source.rs
+++ b/crates/reussir-syntax/src/source.rs
@@ -45,16 +45,49 @@ struct SourceFile {
     name: String,
     /// The on-disk path, when the file is real (feeds DWARF file attributes).
     path: Option<PathBuf>,
-    /// The text plus `ariadne`'s line index over it.
-    source: Source<String>,
-    /// `false` for a placeholder whose content could not be obtained (a
-    /// virtual or missing file referenced by a re-ingested IR dump): spans
-    /// into it are structurally valid but cannot resolve to source text, so
-    /// diagnostics degrade to plain lines and debug locations to `unknown`.
-    available: bool,
+    /// The file contents, or a delayed on-disk read for source tables
+    /// reconstructed from textual IR dumps.
+    state: SourceState,
     /// `byte_to_char[b]` = number of chars strictly before byte `b`; built on
     /// first use (only diagnostics need it — `ariadne` indexes by char).
     byte_to_char: OnceLock<Vec<u32>>,
+}
+
+enum SourceState {
+    Loaded(Source<String>),
+    LazyPath(OnceLock<Result<Source<String>, String>>),
+    Unavailable,
+}
+
+impl SourceFile {
+    fn source(&self) -> Option<&Source<String>> {
+        match &self.state {
+            SourceState::Loaded(source) => Some(source),
+            SourceState::LazyPath(source) => {
+                let path = self
+                    .path
+                    .as_deref()
+                    .expect("lazy source files always carry an on-disk path");
+                match source.get_or_init(|| match std::fs::read_to_string(path) {
+                    Ok(text) => Ok(Source::from(text)),
+                    Err(error) => {
+                        tracing::warn!(
+                            source = %self.name,
+                            path = %path.display(),
+                            %error,
+                            "cannot read source file on demand; diagnostics and debug locations \
+                             will lack source context"
+                        );
+                        Err(error.to_string())
+                    }
+                }) {
+                    Ok(source) => Some(source),
+                    Err(_) => None,
+                }
+            }
+            SourceState::Unavailable => None,
+        }
+    }
 }
 
 /// All source files of one compilation, in insertion order.
@@ -84,8 +117,22 @@ impl SourceCache {
         self.push(SourceFile {
             name,
             path: Some(path),
-            source: Source::from(source.into()),
-            available: true,
+            state: SourceState::Loaded(Source::from(source.into())),
+            byte_to_char: OnceLock::new(),
+        })
+    }
+
+    /// Register an on-disk file by path but delay reading it until source text
+    /// is needed. This is useful when re-ingesting HIR/MIR dumps: the file table
+    /// must keep its dense ids, but a structural reprint may never need to touch
+    /// the original source files.
+    pub fn add_lazy_file(&mut self, path: impl Into<PathBuf>) -> FileId {
+        let path = path.into();
+        let name = path.display().to_string();
+        self.push(SourceFile {
+            name,
+            path: Some(path),
+            state: SourceState::LazyPath(OnceLock::new()),
             byte_to_char: OnceLock::new(),
         })
     }
@@ -96,8 +143,7 @@ impl SourceCache {
         self.push(SourceFile {
             name: name.into(),
             path: None,
-            source: Source::from(source.into()),
-            available: true,
+            state: SourceState::Loaded(Source::from(source.into())),
             byte_to_char: OnceLock::new(),
         })
     }
@@ -110,8 +156,7 @@ impl SourceCache {
         self.push(SourceFile {
             name: name.into(),
             path: None,
-            source: Source::from(String::new()),
-            available: false,
+            state: SourceState::Unavailable,
             byte_to_char: OnceLock::new(),
         })
     }
@@ -119,7 +164,7 @@ impl SourceCache {
     /// Whether the file's content is present (see
     /// [`add_unavailable`](Self::add_unavailable)).
     pub fn is_available(&self, id: FileId) -> bool {
-        self.file(id).available
+        self.file(id).source().is_some()
     }
 
     fn push(&mut self, file: SourceFile) -> FileId {
@@ -134,7 +179,7 @@ impl SourceCache {
 
     /// The file's text.
     pub fn source(&self, id: FileId) -> &str {
-        self.file(id).source.text()
+        self.file(id).source().map_or("", Source::text)
     }
 
     /// The file's display name.
@@ -172,7 +217,10 @@ impl SourceCache {
     /// The 1-based `(line, column)` of byte `offset`, for `FileLineColLoc`
     /// debug locations (`ariadne` reports both zero-indexed).
     pub fn line_col(&self, id: FileId, offset: usize) -> (usize, usize) {
-        match self.file(id).source.get_byte_line(offset) {
+        let Some(source) = self.file(id).source() else {
+            return (1, 1);
+        };
+        match source.get_byte_line(offset) {
             Some((_, line, col)) => (line + 1, col + 1),
             None => (1, 1),
         }
@@ -182,7 +230,7 @@ impl SourceCache {
     fn char_map(&self, id: FileId) -> &[u32] {
         let file = self.file(id);
         file.byte_to_char.get_or_init(|| {
-            let text = file.source.text();
+            let text = file.source().map_or("", Source::text);
             let mut map = vec![0u32; text.len() + 1];
             let mut chars = 0u32;
             for (idx, c) in text.char_indices() {
@@ -259,7 +307,7 @@ impl ariadne::Cache<FileId> for &SourceCache {
     fn fetch(&mut self, id: &FileId) -> Result<&Source<String>, impl fmt::Debug> {
         self.files
             .get(id.index())
-            .map(|f| &f.source)
+            .and_then(SourceFile::source)
             .ok_or_else(|| format!("no file with id {id:?} in the source cache"))
     }
 
@@ -317,5 +365,45 @@ mod tests {
         assert_eq!(cache.char_span(f, (2, 3)), (1, 2));
         // Out-of-range clamps instead of panicking.
         assert_eq!(cache.char_span(f, (100, 200)), (3, 3));
+    }
+
+    #[test]
+    fn lazy_file_reads_only_when_text_is_needed() {
+        let dir =
+            std::env::temp_dir().join(format!("reussir-source-cache-lazy-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("lazy.rr");
+        let source = r#"a
+bc
+"#;
+
+        let mut cache = SourceCache::new();
+        let file = cache.add_lazy_file(&path);
+        std::fs::write(&path, source).unwrap();
+        assert_eq!(cache.name(file), path.display().to_string());
+        assert_eq!(cache.basename(file), "lazy.rr");
+        assert!(cache.is_available(file));
+        assert_eq!(cache.source(file), source);
+        assert_eq!(cache.line_col(file, 2), (2, 1));
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::remove_dir(&dir).unwrap();
+    }
+
+    #[test]
+    fn missing_lazy_file_is_unavailable_without_panicking() {
+        let path = std::env::temp_dir().join(format!(
+            "reussir-source-cache-missing-{}.rr",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let mut cache = SourceCache::new();
+        let file = cache.add_lazy_file(&path);
+        assert!(!cache.is_available(file));
+        assert_eq!(cache.source(file), "");
+        assert_eq!(cache.line_col(file, 123), (1, 1));
+        assert_eq!(cache.char_span(file, (100, 200)), (0, 0));
     }
 }

--- a/crates/reussir-syntax/src/source.rs
+++ b/crates/reussir-syntax/src/source.rs
@@ -1,0 +1,321 @@
+//! Multi-file source management: a [`SourceCache`] owns every source file of a
+//! compilation (or REPL session), keyed by [`FileId`].
+//!
+//! Spans stay *file-local* byte offsets (`ResolvedNode::text_range` of that
+//! file's parse); a `FileId` identifies which file a span indexes. Items never
+//! straddle files, so the compiler carries one `FileId` per item/diagnostic
+//! rather than widening every span.
+//!
+//! The cache implements [`ariadne::Cache`], so diagnostics render straight from
+//! it (per-file caret reports), and it doubles as the line index the code
+//! generator resolves `FileLineColLoc` debug locations against — one authority
+//! for "what does offset N of file F mean".
+
+use std::borrow::Cow;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use ariadne::Source;
+
+/// Identifies a file in a [`SourceCache`]. Allocated densely in insertion
+/// order; the first file added is [`FileId::ROOT`] — the crate root (or the
+/// single input of a one-file compile).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FileId(u32);
+
+impl FileId {
+    /// The first file added to a cache: the crate root / primary input.
+    pub const ROOT: FileId = FileId(0);
+
+    pub fn index(self) -> usize {
+        self.0 as usize
+    }
+
+    /// The id of the file at position `index` (files are dense, in insertion
+    /// order) — for reconstructing references from a serialized file table.
+    pub fn from_index(index: u32) -> FileId {
+        FileId(index)
+    }
+}
+
+struct SourceFile {
+    /// Display name: the path as typed for an on-disk file, or a synthetic
+    /// name like `<stdin>` / `<repl>` for a virtual one.
+    name: String,
+    /// The on-disk path, when the file is real (feeds DWARF file attributes).
+    path: Option<PathBuf>,
+    /// The text plus `ariadne`'s line index over it.
+    source: Source<String>,
+    /// `false` for a placeholder whose content could not be obtained (a
+    /// virtual or missing file referenced by a re-ingested IR dump): spans
+    /// into it are structurally valid but cannot resolve to source text, so
+    /// diagnostics degrade to plain lines and debug locations to `unknown`.
+    available: bool,
+    /// `byte_to_char[b]` = number of chars strictly before byte `b`; built on
+    /// first use (only diagnostics need it — `ariadne` indexes by char).
+    byte_to_char: OnceLock<Vec<u32>>,
+}
+
+/// All source files of one compilation, in insertion order.
+#[derive(Default)]
+pub struct SourceCache {
+    files: Vec<SourceFile>,
+}
+
+impl SourceCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A cache holding a single virtual file — for rendering diagnostics
+    /// against an ad-hoc snippet (tests, REPL parse errors).
+    pub fn single(name: impl Into<String>, source: impl Into<String>) -> Self {
+        let mut cache = Self::new();
+        cache.add_virtual(name, source);
+        cache
+    }
+
+    /// Register an on-disk file's contents. The display name is the path as
+    /// given (not canonicalized), matching how the user referred to it.
+    pub fn add_file(&mut self, path: impl Into<PathBuf>, source: impl Into<String>) -> FileId {
+        let path = path.into();
+        let name = path.display().to_string();
+        self.push(SourceFile {
+            name,
+            path: Some(path),
+            source: Source::from(source.into()),
+            available: true,
+            byte_to_char: OnceLock::new(),
+        })
+    }
+
+    /// Register in-memory content with a synthetic display name (`<stdin>`,
+    /// `<repl>`, …).
+    pub fn add_virtual(&mut self, name: impl Into<String>, source: impl Into<String>) -> FileId {
+        self.push(SourceFile {
+            name: name.into(),
+            path: None,
+            source: Source::from(source.into()),
+            available: true,
+            byte_to_char: OnceLock::new(),
+        })
+    }
+
+    /// Register a name-only placeholder for a file whose content cannot be
+    /// obtained (a virtual or since-deleted file referenced by an IR dump).
+    /// Spans into it stay attributed to the name but render without source
+    /// context and resolve to no debug location.
+    pub fn add_unavailable(&mut self, name: impl Into<String>) -> FileId {
+        self.push(SourceFile {
+            name: name.into(),
+            path: None,
+            source: Source::from(String::new()),
+            available: false,
+            byte_to_char: OnceLock::new(),
+        })
+    }
+
+    /// Whether the file's content is present (see
+    /// [`add_unavailable`](Self::add_unavailable)).
+    pub fn is_available(&self, id: FileId) -> bool {
+        self.file(id).available
+    }
+
+    fn push(&mut self, file: SourceFile) -> FileId {
+        let id = FileId(u32::try_from(self.files.len()).expect("more than u32::MAX source files"));
+        self.files.push(file);
+        id
+    }
+
+    fn file(&self, id: FileId) -> &SourceFile {
+        &self.files[id.index()]
+    }
+
+    /// The file's text.
+    pub fn source(&self, id: FileId) -> &str {
+        self.file(id).source.text()
+    }
+
+    /// The file's display name.
+    pub fn name(&self, id: FileId) -> &str {
+        &self.file(id).name
+    }
+
+    /// The on-disk path, if the file is real.
+    pub fn path(&self, id: FileId) -> Option<&Path> {
+        self.file(id).path.as_deref()
+    }
+
+    /// The file name component for the DWARF `DIFile` basename. A virtual file
+    /// uses its display name.
+    pub fn basename(&self, id: FileId) -> Cow<'_, str> {
+        match self.path(id) {
+            Some(p) => p
+                .file_name()
+                .map_or(Cow::Borrowed(""), |n| n.to_string_lossy()),
+            None => Cow::Borrowed(self.name(id)),
+        }
+    }
+
+    /// The parent directory for the DWARF `DIFile` directory (empty for a
+    /// virtual file).
+    pub fn directory(&self, id: FileId) -> Cow<'_, str> {
+        match self.path(id) {
+            Some(p) => p
+                .parent()
+                .map_or(Cow::Borrowed(""), |d| d.to_string_lossy()),
+            None => Cow::Borrowed(""),
+        }
+    }
+
+    /// The 1-based `(line, column)` of byte `offset`, for `FileLineColLoc`
+    /// debug locations (`ariadne` reports both zero-indexed).
+    pub fn line_col(&self, id: FileId, offset: usize) -> (usize, usize) {
+        match self.file(id).source.get_byte_line(offset) {
+            Some((_, line, col)) => (line + 1, col + 1),
+            None => (1, 1),
+        }
+    }
+
+    /// `byte_to_char[b]` = chars strictly before byte `b`, built on first use.
+    fn char_map(&self, id: FileId) -> &[u32] {
+        let file = self.file(id);
+        file.byte_to_char.get_or_init(|| {
+            let text = file.source.text();
+            let mut map = vec![0u32; text.len() + 1];
+            let mut chars = 0u32;
+            for (idx, c) in text.char_indices() {
+                map[idx..idx + c.len_utf8()].fill(chars);
+                chars += 1;
+            }
+            map[text.len()] = chars;
+            map
+        })
+    }
+
+    /// Convert a byte-offset span into the char-offset span `ariadne` indexes
+    /// by. Out-of-range offsets clamp to the end of the file.
+    pub fn char_span(&self, id: FileId, span: (u32, u32)) -> (u32, u32) {
+        let map = self.char_map(id);
+        let of = |byte: u32| map[(byte as usize).min(map.len() - 1)];
+        (of(span.0), of(span.1))
+    }
+
+    /// The file's length in characters (Unicode scalars).
+    pub fn char_len(&self, id: FileId) -> u32 {
+        *self.char_map(id).last().expect("map covers offset 0")
+    }
+
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// All file ids, in insertion order.
+    pub fn ids(&self) -> impl Iterator<Item = FileId> {
+        (0..self.files.len() as u32).map(FileId)
+    }
+}
+
+/// A standalone byte→char offset table over one source string, for consumers
+/// that need character offsets without a whole [`SourceCache`] (e.g. the
+/// surface-verify JSON emitter, whose wire format records char offsets).
+pub struct CharMap {
+    /// `byte_to_char[b]` is the number of chars strictly before byte `b`.
+    byte_to_char: Vec<u32>,
+}
+
+impl CharMap {
+    pub fn new(source: &str) -> Self {
+        let mut byte_to_char = vec![0u32; source.len() + 1];
+        let mut chars = 0u32;
+        for (idx, c) in source.char_indices() {
+            byte_to_char[idx..idx + c.len_utf8()].fill(chars);
+            chars += 1;
+        }
+        byte_to_char[source.len()] = chars;
+        Self { byte_to_char }
+    }
+
+    pub fn char_offset(&self, byte: u32) -> u32 {
+        self.byte_to_char[byte as usize]
+    }
+
+    pub fn char_span(&self, span: (u32, u32)) -> (u32, u32) {
+        (self.char_offset(span.0), self.char_offset(span.1))
+    }
+}
+
+/// Feed `ariadne` reports straight from the cache: `fetch` hands out the
+/// per-file line index, `display` the file's name. Implemented on the shared
+/// reference so one cache serves many reports without cloning sources.
+impl ariadne::Cache<FileId> for &SourceCache {
+    type Storage = String;
+
+    fn fetch(&mut self, id: &FileId) -> Result<&Source<String>, impl fmt::Debug> {
+        self.files
+            .get(id.index())
+            .map(|f| &f.source)
+            .ok_or_else(|| format!("no file with id {id:?} in the source cache"))
+    }
+
+    fn display<'a>(&self, id: &'a FileId) -> Option<impl fmt::Display + 'a> {
+        Some(self.files.get(id.index())?.name.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_are_dense_and_root_is_first() {
+        let mut cache = SourceCache::new();
+        let a = cache.add_file("dir/a.rr", "fn a() {}\n");
+        let b = cache.add_virtual("<repl>", "1 + 1\n");
+        assert_eq!(a, FileId::ROOT);
+        assert_eq!(b.index(), 1);
+        assert_eq!(cache.name(a), "dir/a.rr");
+        assert_eq!(cache.name(b), "<repl>");
+        assert_eq!(cache.source(b), "1 + 1\n");
+        assert_eq!(cache.ids().collect::<Vec<_>>(), vec![a, b]);
+    }
+
+    #[test]
+    fn dwarf_components_split_real_paths_and_pass_virtual_names_through() {
+        let mut cache = SourceCache::new();
+        let real = cache.add_file("pkg/src/lib.rr", "");
+        let virt = cache.add_virtual("<stdin>", "");
+        assert_eq!(cache.basename(real), "lib.rr");
+        assert_eq!(cache.directory(real), "pkg/src");
+        assert_eq!(cache.basename(virt), "<stdin>");
+        assert_eq!(cache.directory(virt), "");
+    }
+
+    #[test]
+    fn line_col_is_one_based_per_file() {
+        let mut cache = SourceCache::new();
+        let a = cache.add_virtual("a", "one\ntwo\n");
+        let b = cache.add_virtual("b", "x\n");
+        assert_eq!(cache.line_col(a, 0), (1, 1));
+        assert_eq!(cache.line_col(a, 4), (2, 1));
+        assert_eq!(cache.line_col(a, 6), (2, 3));
+        // Files are independent coordinate systems.
+        assert_eq!(cache.line_col(b, 0), (1, 1));
+    }
+
+    #[test]
+    fn char_span_counts_multibyte_chars_once() {
+        let mut cache = SourceCache::new();
+        // 'é' is two bytes; the byte span after it lands two chars in.
+        let f = cache.add_virtual("u", "é=1");
+        assert_eq!(cache.char_span(f, (0, 2)), (0, 1));
+        assert_eq!(cache.char_span(f, (2, 3)), (1, 2));
+        // Out-of-range clamps instead of panicking.
+        assert_eq!(cache.char_span(f, (100, 200)), (3, 3));
+    }
+}

--- a/tests/integration/frontend/assign.rr
+++ b/tests/integration/frontend/assign.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 struct [regional] DLLink<T> {
     val: T,

--- a/tests/integration/frontend/closure.rr
+++ b/tests/integration/frontend/closure.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
 
 // CHECK: fn #test(v0 (x): (i32) -> i32) -> i32 {
 // CHECK-NEXT: apply(v0 : (i32) -> i32, 1 : i32) : i32

--- a/tests/integration/frontend/closure_call_expr.rr
+++ b/tests/integration/frontend/closure_call_expr.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 // --- Test 1: chained call (make_adder(5)(37)) ---
 fn make_adder(n : i32) -> i32 -> i32 {

--- a/tests/integration/frontend/fibonacci-generic.rr
+++ b/tests/integration/frontend/fibonacci-generic.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s -o %t.o
 // RUN: %cc %t.o %S/fibonacci.c -o %t.exe
 // RUN: %t.exe

--- a/tests/integration/frontend/fibonacci-struct.rr
+++ b/tests/integration/frontend/fibonacci-struct.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s -o %t.o
 
 // CHECK: record @_RC6Matrix : value struct Matrix { "m00": u64, "m01": u64, "m10": u64, "m11": u64 };

--- a/tests/integration/frontend/fibonacci.rr
+++ b/tests/integration/frontend/fibonacci.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s -o %t.o
 // RUN: %cc %t.o %S/fibonacci.c -o %t.exe
 // RUN: %t.exe

--- a/tests/integration/frontend/list.rr
+++ b/tests/integration/frontend/list.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
 
 enum List<T> {
     Nil,

--- a/tests/integration/frontend/list_empty.rr
+++ b/tests/integration/frontend/list_empty.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum List<T> {

--- a/tests/integration/frontend/list_reverse.rr
+++ b/tests/integration/frontend/list_reverse.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum List<T> {

--- a/tests/integration/frontend/meaningless.rr
+++ b/tests/integration/frontend/meaningless.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 enum Foo {
     Bar(Foo),

--- a/tests/integration/frontend/nat_even.rr
+++ b/tests/integration/frontend/nat_even.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s --emit mlir -o %t.mlir
 // RUN: %FileCheck %s --check-prefix=CHECK-MLIR < %t.mlir
 enum Nat {

--- a/tests/integration/frontend/nullable.rr
+++ b/tests/integration/frontend/nullable.rr
@@ -3,7 +3,7 @@
 // base yields the frozen `Nullable<[rigid] _>` view). Dispatch on nullables
 // is covered by `nullable_match.rr`.
 
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s -o %t.o
 
 struct RcBox<T> {

--- a/tests/integration/frontend/pattern_bool_basic.rr
+++ b/tests/integration/frontend/pattern_bool_basic.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 fn negate(x : bool) -> bool {
     match x {

--- a/tests/integration/frontend/pattern_bool_guard.rr
+++ b/tests/integration/frontend/pattern_bool_guard.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 fn test(x : bool, y : i32) -> i32 {
     match x {

--- a/tests/integration/frontend/pattern_bool_nested.rr
+++ b/tests/integration/frontend/pattern_bool_nested.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 enum Pair {
     MkPair(bool, bool)

--- a/tests/integration/frontend/pattern_ctor_sugar_basic.rr
+++ b/tests/integration/frontend/pattern_ctor_sugar_basic.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 enum Option<T> {
     Some(T),

--- a/tests/integration/frontend/pattern_ctor_sugar_match.rr
+++ b/tests/integration/frontend/pattern_ctor_sugar_match.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 enum Option<T> {
     Some(T),

--- a/tests/integration/frontend/pattern_int_basic.rr
+++ b/tests/integration/frontend/pattern_int_basic.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 fn classify(x : i32) -> i32 {
     match x {

--- a/tests/integration/frontend/pattern_int_bind.rr
+++ b/tests/integration/frontend/pattern_int_bind.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 fn test(x : i32) -> i32 {
     match x {

--- a/tests/integration/frontend/pattern_int_guard.rr
+++ b/tests/integration/frontend/pattern_int_guard.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 fn test(x : i32, flag : bool) -> i32 {
     match x {

--- a/tests/integration/frontend/pattern_int_multi.rr
+++ b/tests/integration/frontend/pattern_int_multi.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 fn test(x : i32) -> i32 {
     match x {

--- a/tests/integration/frontend/pattern_int_nested.rr
+++ b/tests/integration/frontend/pattern_int_nested.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 enum Wrapper {
     Val(i32),

--- a/tests/integration/frontend/pattern_mixed_ctor_int.rr
+++ b/tests/integration/frontend/pattern_mixed_ctor_int.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 enum Result {
     Ok(i32),

--- a/tests/integration/frontend/projection.rr
+++ b/tests/integration/frontend/projection.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s -o %t.o
 
 // CHECK: record @_RIC3BoxIC3BoxmEE : value struct Box::<Box::<u32>> { "val": Box::<u32> };

--- a/tests/integration/frontend/rbtree_balance_left.rr
+++ b/tests/integration/frontend/rbtree_balance_left.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
 
 enum [value] Color {
     Red,

--- a/tests/integration/frontend/region.rr
+++ b/tests/integration/frontend/region.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s -o %t.o
 
 // CHECK: record @_RIC4CellyE : regional struct Cell::<u64> { "value": u64 };

--- a/tests/integration/frontend/regional_member_projection.rr
+++ b/tests/integration/frontend/regional_member_projection.rr
@@ -6,7 +6,7 @@
 // cross-region composition (member graph frozen in one region, parent in
 // another).
 
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=MIR
 // RUN: %rrc %s -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/regional_member_projection.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe

--- a/tests/integration/frontend/trampoline.rr
+++ b/tests/integration/frontend/trampoline.rr
@@ -1,5 +1,5 @@
-// RUN: %rrc %s --emit hir -o - | %FileCheck %s
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
 
 fn foo<T : Num>(x : T) -> i32 {
     x as i32 + 1

--- a/tests/integration/frontend/variant.rr
+++ b/tests/integration/frontend/variant.rr
@@ -1,4 +1,4 @@
-// RUN: %rrc %s --emit mir -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s -o %t.o
 
 // CHECK: record @_RIC6OptionlE : value enum Option::<i32> { @_RNvIC6OptionlE4Some Some(i32), @_RNvIC6OptionlE4None None() };


### PR DESCRIPTION
First PR of the module-system series (#290 "Module system"): make the frontend multi-file-capable before `mod`/package semantics land.

## Source cache (ariadne)

`reussir_syntax::source::SourceCache` owns every source file of a compilation (or REPL session), keyed by dense `FileId`s, and implements **`ariadne::Cache<FileId>`** — diagnostics render straight from it, and it is also the line index codegen resolves `FileLineColLoc`/DWARF locations against. One authority for "what does offset N of file F mean", covering real files, virtual ones (`<stdin>`, `<repl>`), and name-only placeholders whose content can't be obtained.

Why not `ariadne::FileCache` itself: it re-reads from disk at diagnostic time (carets could render against text that changed mid-compile), can't hold virtual files, and can't serve byte→char conversion + debug line/col from the same store. `SourceCache` is the `Cache`-trait extension point over compiler-owned text; each file's line index *is* an `ariadne::Source`.

Spans stay file-local byte offsets; since items never straddle files, `Report`, `FuncProto`/`Record`, `hir::Function`, and `mir::Function` carry a `FileId` (the Haskell frontend's `currentFile` model). The elaborator's `current_file` is restored per item in the check passes, mono stamps its reports with the instantiated item's declaration file, and the `Lowerer` resolves each function's locations against that function's own file — correct per-op line tables once functions from many files share one module. The REPL session records every input as a `<repl>` file, so a late report against an *older* input's span (e.g. a generic defined earlier failing to monomorphize now) finally renders against the right text.

## Lossless textual HIR/MIR

`--emit hir/mir` dumps now round-trip source information (previously **all** spans were dropped and `--from hir/mir` lowered with no debug info):

```
0 = "dump_demo.rr";

pub fn #add(v0 (a): i64, v1 (b): i64) -> i64 in 0 [0..54] {
    [34..54]
    let [36..49] v2 (c [40..41]) = (v0 : i64 [44..45] + v1 : i64 [48..49]) : i64 [44..49];
    v2 : i64 [51..52]
}
```

- a source-file table (`<id> = "<name>";`), per-item `in <file>` (+ the item's span in HIR), a `[start..end]` suffix on every node, the `let` binding-name span, and the enclosing `Seq`'s span as a leading block marker — all parsed back by both grammars (new `..` token; `[Int..Int]` is one-token-distinguishable from `[flex]`-style caps).
- `rrc --from hir/mir` rebuilds a `SourceCache` from the dump's table by re-reading the listed files (DWARF-style: dumps carry offsets + identity, not content), so **re-ingested dumps now emit real debug info** — `rrc demo.mir -g` produces a `DIFile` for the original `.rr`. A missing or virtual file degrades to plain diagnostics + unknown locations for that file, with a warning naming it (per review discussion).
- `--no-source-locations` opts a dump out for structure-oriented readers; the ~29 FileCheck dump tests use it (span offsets in CHECK lines would shift on every test edit), and the REPL's `:dump context` stays bare — the round-trip artifact is `rrc --emit hir/mir`'s default output.

## Verification

- New unit tests: `SourceCache` (ids, DWARF components, per-file line/col, multibyte char spans) and lossless round-trip tests for both textual IRs (print-with-locations → parse → re-print, asserting the file table, item locations, and span equality).
- All suites green: core 211, syntax 29, codegen 17+26, repl 28, lit **256 passed / 4 unsupported / 0 failed**.
- Manually verified: `.rr → .mir → -g llvm-ir` carries `DIFile`+`DILocation`s; deleting the source file degrades with the warning and no bogus locations.

Next in the series: package discovery + module-aware resolution (`mod`, `root::`/`super::`, `--package-root`/`--package-name`, reserved `core`), then multi-CGU codegen, then `core::intrinsic::math::*`, then the `module_*`/`math` test migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2