### PR TITLE
[frontend] module system: package discovery, module-aware resolution, rrc package mode

### DIFF
--- a/crates/reussir-compiler/src/lib.rs
+++ b/crates/reussir-compiler/src/lib.rs
@@ -11,6 +11,8 @@
 //! the polymorphic-FFI gather), run the lowering pipeline, finalize, then hand
 //! the [`Finalized`] module to [`emit_to_file`].
 
+pub mod package;
+
 use std::ffi::{CString, c_char};
 use std::path::Path;
 

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -24,6 +24,7 @@ use reussir_backend::melior::ir::Module;
 use reussir_backend::pipeline::{self, LoweringOptions, OptLevel};
 use reussir_codegen::lower::lower_program;
 use reussir_codegen::source::{FileId, SourceCache};
+use reussir_compiler::package;
 use reussir_compiler::{
     OutputKind, RelocMode, TargetMachine, TargetSpec, emit_to_file, parse_llvm_ir,
 };
@@ -102,8 +103,21 @@ impl Stage {
 #[derive(Parser)]
 #[command(name = "rrc", version)]
 struct Cli {
-    /// Input file (`-` reads Reussir source from stdin).
-    input: PathBuf,
+    /// Input file (`-` reads Reussir source from stdin). Omitted in package
+    /// mode (`--package-root`/`--package-name`).
+    input: Option<PathBuf>,
+
+    /// Compile a whole package rooted at this directory: `lib.rr` is the
+    /// crate root and `mod` declarations discover the other files. Requires
+    /// `--package-name`; replaces the input file.
+    #[arg(long = "package-root")]
+    package_root: Option<PathBuf>,
+
+    /// The package's name — the first segment of every item's module path
+    /// (and of its mangled symbols). `core` is reserved for the built-in core
+    /// package.
+    #[arg(long = "package-name")]
+    package_name: Option<String>,
 
     /// Output file (`-` writes a text dump — `hir`/`mir`/`mlir`/`mlir-llvm` — to
     /// stdout). The target stage is inferred from its extension unless `--emit`
@@ -170,16 +184,16 @@ struct Cli {
 
 /// The stage the input enters at: `--from` if given, else the extension. `-`
 /// (stdin) has no extension, so it defaults to source.
-fn resolve_input_stage(cli: &Cli) -> Result<Stage, String> {
+fn resolve_input_stage(cli: &Cli, input: &Path) -> Result<Stage, String> {
     let stage = if let Some(from) = cli.from {
         from
-    } else if cli.input.as_os_str() == "-" {
+    } else if input.as_os_str() == "-" {
         Stage::Rr
     } else {
-        Stage::from_extension(&cli.input).ok_or_else(|| {
+        Stage::from_extension(input).ok_or_else(|| {
             format!(
                 "cannot infer the input stage of `{}`; pass --from",
-                cli.input.display()
+                input.display()
             )
         })?
     };
@@ -308,13 +322,12 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: &Cli) -> Result<bool, String> {
-    let input_stage = resolve_input_stage(cli)?;
+    let package = match (&cli.package_root, &cli.package_name) {
+        (Some(root), Some(name)) => Some((root.clone(), name.clone())),
+        (None, None) => None,
+        _ => return Err("--package-root and --package-name must be given together".into()),
+    };
     let target = resolve_target(cli)?;
-    if target < input_stage {
-        return Err(format!(
-            "cannot emit `{target}` from a `{input_stage}` input: the pipeline only runs forward"
-        ));
-    }
     // Only the text dumps stream to stdout; `llvm-ir`/`asm`/`obj` go through the
     // file-based LLVM emitter, so `-o -` would write a file literally named `-`.
     if cli.output.as_os_str() == "-" && target.output_kind().is_some() {
@@ -324,15 +337,73 @@ fn run(cli: &Cli) -> Result<bool, String> {
     }
     let opt = parse_opt(&cli.opt)?;
     let reloc = parse_reloc(&cli.relocation_mode)?;
-    let sources = read_input(&cli.input)?;
-    let name = sources.name(FileId::ROOT).to_owned();
-    let source = sources.source(FileId::ROOT);
-
     let spec = TargetSpec {
         triple: cli.target_triple.clone(),
         cpu: cli.target_cpu.clone(),
         features: cli.target_features.clone(),
     };
+
+    // Package mode: discover the files from `lib.rr`'s `mod` declarations and
+    // elaborate the whole package as one translation unit.
+    if let Some((root, pkg_name)) = package {
+        if cli.input.is_some() {
+            return Err(
+                "give either an input file or --package-root/--package-name, not both".into(),
+            );
+        }
+        if cli.from.is_some_and(|f| f != Stage::Rr) {
+            return Err("a package is always Reussir source; --from does not apply".into());
+        }
+        let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+        let pkg = match package::load_package(&root, &pkg_name, &interner) {
+            Ok(pkg) => pkg,
+            Err(package::PackageError::Message(msg)) => return Err(msg),
+            Err(package::PackageError::ParseErrors {
+                cache,
+                file,
+                errors,
+            }) => {
+                let color = std::io::stderr().is_terminal();
+                let _ = diagnostics::render_errors(
+                    &cache,
+                    file,
+                    &errors,
+                    color,
+                    std::io::stderr().lock(),
+                );
+                return Ok(false);
+            }
+        };
+        let name = pkg.cache.name(FileId::ROOT).to_owned();
+        let context = reussir_backend::context();
+        if cli.disable_backend_multithreading {
+            context.enable_multi_threading(false);
+        }
+        let produced =
+            match in_arena(|tcx| frontend_package(&context, tcx, target, &pkg, &interner, cli)) {
+                Ok(produced) => produced,
+                Err(msg) => {
+                    if !msg.is_empty() {
+                        eprintln!("{msg}");
+                    }
+                    return Ok(false);
+                }
+            };
+        return backend(cli, &context, produced, target, opt, reloc, &spec, &name);
+    }
+
+    let Some(input) = &cli.input else {
+        return Err("no input file (or --package-root/--package-name) given".into());
+    };
+    let input_stage = resolve_input_stage(cli, input)?;
+    if target < input_stage {
+        return Err(format!(
+            "cannot emit `{target}` from a `{input_stage}` input: the pipeline only runs forward"
+        ));
+    }
+    let sources = read_input(input)?;
+    let name = sources.name(FileId::ROOT).to_owned();
+    let source = sources.source(FileId::ROOT);
 
     // A `.ll` input skips the whole MLIR front: parse the IR and run the LLVM
     // backend straight to the requested artifact.
@@ -366,7 +437,22 @@ fn run(cli: &Cli) -> Result<bool, String> {
             }
         },
     };
+    backend(cli, &context, produced, target, opt, reloc, &spec, &name)
+}
 
+/// The shared back leg from a produced text/module: write a text dump, or run
+/// the MLIR lowering pipeline and emit the requested artifact.
+#[allow(clippy::too_many_arguments)]
+fn backend(
+    cli: &Cli,
+    context: &reussir_backend::melior::Context,
+    produced: Produced<'_>,
+    target: Stage,
+    opt: OptLevel,
+    reloc: RelocMode,
+    spec: &TargetSpec,
+    name: &str,
+) -> Result<bool, String> {
     let mut module = match produced {
         Produced::Text(text) => {
             write_text(&cli.output, &text)?;
@@ -385,7 +471,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
     // gather, which must run before the pipeline erases those ops, and is
     // stamped on the module so the pipeline's MLIR `DataLayout` queries compute
     // real target sizes and alignments.
-    let machine = TargetMachine::new(&spec, opt, reloc)?;
+    let machine = TargetMachine::new(spec, opt, reloc)?;
     pipeline::attach_target_spec(&module, machine.data_layout(), machine.triple())?;
     let options = LoweringOptions {
         opt,
@@ -395,7 +481,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
     let optimize_ffi = !matches!(opt, OptLevel::None);
     let prepared = LlvmLowering::prepare(&module, machine.data_layout(), optimize_ffi)
         .map_err(|e| format!("{name}: {e}"))?;
-    pipeline::run_lowering_pipeline(&context, &mut module, &options)
+    pipeline::run_lowering_pipeline(context, &mut module, &options)
         .map_err(|e| format!("lowering pipeline failed: {e:?}"))?;
 
     // After the pipeline the module is the LLVM dialect; dump it before it is
@@ -414,6 +500,73 @@ fn run(cli: &Cli) -> Result<bool, String> {
         .expect("llvm-ir/asm/obj target past the mlir-llvm stage");
     emit_to_file(finalized, &machine, opt, kind, &cli.output)?;
     Ok(true)
+}
+
+/// The arena-scoped front leg for package mode: elaborate every discovered
+/// file as one translation unit, then continue exactly as the single-file
+/// source path does.
+///
+/// An empty `Err` string signals diagnostics were already printed (a compile
+/// failure, exit 1) rather than a driver error (exit 2).
+fn frontend_package<'c, 'tcx>(
+    context: &'c reussir_backend::melior::Context,
+    tcx: &TyCtxt<'tcx>,
+    target: Stage,
+    pkg: &package::PackageSource,
+    interner: &std::sync::Arc<reussir_syntax::MultiThreadedTokenInterner>,
+    cli: &Cli,
+) -> Result<Produced<'c>, String> {
+    use reussir_core::semi::{PackageFile, elaborate_package};
+
+    let name = pkg.cache.name(FileId::ROOT);
+    let programs: Vec<surface::Program> = pkg
+        .files
+        .iter()
+        .map(|f| surface::program(&f.parse.root))
+        .collect();
+    let mut keys = interner.clone();
+    let files: Vec<PackageFile> = pkg
+        .files
+        .iter()
+        .zip(&programs)
+        .map(|(f, program)| PackageFile {
+            file: f.file,
+            module: f
+                .module
+                .iter()
+                .map(|seg| reussir_syntax::Interner::get_or_intern(&mut keys, seg))
+                .collect(),
+            program,
+        })
+        .collect();
+    let elab = elaborate_package(tcx, &files, interner);
+    if render_reports(&pkg.cache, &elab.reports) {
+        return Err(String::new());
+    }
+    if target == Stage::Hir {
+        let printer = if cli.no_source_locations {
+            hir::print::Printer::new(&elab.defs, elab.resolver)
+        } else {
+            hir::print::Printer::with_sources(&elab.defs, elab.resolver, &pkg.cache)
+        };
+        let text = printer.program(&elab.elaborated, &elab.records, &elab.trampolines);
+        return Ok(Produced::Text(text));
+    }
+    let (full, reports) = monomorphize(&elab.mono_input());
+    if render_reports(&pkg.cache, &reports) {
+        return Err(String::new());
+    }
+    finish_mir(
+        context,
+        tcx,
+        target,
+        name,
+        Some(&pkg.cache),
+        cli,
+        &full,
+        &elab.defs,
+        elab.resolver,
+    )
 }
 
 /// The arena-scoped front leg for a source/`.hir`/`.mir` input: run the frontend

--- a/crates/reussir-compiler/src/package.rs
+++ b/crates/reussir-compiler/src/package.rs
@@ -1,0 +1,258 @@
+//! Package discovery: map a package root directory to its source files and
+//! module paths by following `mod` declarations from `lib.rr`.
+//!
+//! The layout follows the reference frontend (Rust-flavoured):
+//!
+//! * `lib.rr` is the crate root, module path `[package]`.
+//! * A file's **location** determines its module path — `foo.rr` and
+//!   `foo/mod.rr` are `[package, foo]`, `foo/bar.rr` is `[package, foo, bar]`
+//!   — while `mod name;` declarations only drive *discovery*: a declaration
+//!   in file `F` looks for `dir(F)/name.rr`, then `dir(F)/name/mod.rr`.
+//! * Duplicate declarations and cycles are tolerated (each file is loaded
+//!   once, keyed by its canonical path); a declaration with no source file is
+//!   an error naming both candidates.
+//! * The package name `core` is reserved for the built-in core package.
+//!
+//! Files are read into the compilation's [`SourceCache`] and parsed with one
+//! **shared interner** (cross-file resolution compares interned keys); the
+//! parses are handed back so elaboration never re-parses.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use reussir_syntax::source::{FileId, SourceCache};
+use reussir_syntax::{MultiThreadedTokenInterner, Parse, parse_with_interner};
+
+/// One discovered source file: its id in the cache, its module path (package
+/// name first), and its parse.
+pub struct PackageSourceFile {
+    pub file: FileId,
+    pub module: Vec<String>,
+    pub parse: Parse,
+}
+
+/// A fully loaded package: every reachable file, read and parsed. The first
+/// entry is `lib.rr` ([`FileId::ROOT`]).
+pub struct PackageSource {
+    pub cache: SourceCache,
+    pub files: Vec<PackageSourceFile>,
+}
+
+/// A discovery failure. `Diagnostics` means parse errors were found in `file`
+/// — the caller renders them against the returned cache.
+pub enum PackageError {
+    /// A driver-level error (bad name, missing file, unreadable file).
+    Message(String),
+    /// Syntax errors in one of the package's files.
+    ParseErrors {
+        cache: SourceCache,
+        file: FileId,
+        errors: Vec<reussir_syntax::diagnostics::ParseError>,
+    },
+}
+
+/// Load the package rooted at `root` under `name`: read `lib.rr`, follow
+/// `mod` declarations transitively, and parse every file with `interner`.
+pub fn load_package(
+    root: &Path,
+    name: &str,
+    interner: &Arc<MultiThreadedTokenInterner>,
+) -> Result<PackageSource, PackageError> {
+    if name == "core" {
+        return Err(PackageError::Message(
+            "package name 'core' is reserved for the built-in core package".into(),
+        ));
+    }
+    let root = root.canonicalize().map_err(|e| {
+        PackageError::Message(format!("cannot open package root {}: {e}", root.display()))
+    })?;
+    let lib = root.join("lib.rr");
+    if !lib.is_file() {
+        return Err(PackageError::Message(format!(
+            "package root {} has no lib.rr",
+            root.display()
+        )));
+    }
+
+    let mut cache = SourceCache::new();
+    let mut files = Vec::new();
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    // Depth-first from the crate root, matching declaration order.
+    let mut work: Vec<PathBuf> = vec![lib];
+
+    while let Some(path) = work.pop() {
+        let canonical = path
+            .canonicalize()
+            .map_err(|e| PackageError::Message(format!("cannot open {}: {e}", path.display())))?;
+        // A duplicate `mod` declaration or a declaration cycle re-reaches a
+        // loaded file; each file joins the package once.
+        if !visited.insert(canonical.clone()) {
+            continue;
+        }
+        let source = std::fs::read_to_string(&canonical).map_err(|e| {
+            PackageError::Message(format!("failed to read {}: {e}", path.display()))
+        })?;
+        let file = cache.add_file(&canonical, source);
+        let parse = parse_with_interner(cache.source(file), interner.clone());
+        if !parse.ok() {
+            let errors = parse.errors.clone();
+            return Err(PackageError::ParseErrors {
+                cache,
+                file,
+                errors,
+            });
+        }
+
+        // Follow this file's `mod` declarations before parsing siblings
+        // (depth-first, so `work` is a stack pushed in reverse order).
+        let dir = canonical.parent().expect("a source file has a directory");
+        let mut children = Vec::new();
+        for decl in mod_decls(&parse) {
+            let flat = dir.join(format!("{decl}.rr"));
+            let nested = dir.join(&decl).join("mod.rr");
+            let child = if flat.is_file() {
+                flat
+            } else if nested.is_file() {
+                nested
+            } else {
+                return Err(PackageError::Message(format!(
+                    "module '{decl}' declared in {} has no source file; expected one of: {}, {}",
+                    canonical.display(),
+                    flat.display(),
+                    nested.display()
+                )));
+            };
+            children.push(child);
+        }
+        children.reverse();
+        work.extend(children);
+
+        let module = module_path(&root, &canonical, name);
+        files.push(PackageSourceFile {
+            file,
+            module,
+            parse,
+        });
+    }
+
+    Ok(PackageSource { cache, files })
+}
+
+/// The `mod` declarations of a parsed file, in source order.
+fn mod_decls(parse: &Parse) -> Vec<String> {
+    let program = reussir_core::surface::program(&parse.root);
+    program
+        .iter()
+        .filter_map(|stmt| match stmt.kind() {
+            reussir_core::surface::StmtKind::Mod(_, name) => {
+                Some(parse.resolver().resolve(name).to_owned())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// A file's module path from its location under the package root:
+/// `lib.rr` → `[pkg]`, `foo.rr` and `foo/mod.rr` → `[pkg, foo]`,
+/// `foo/bar.rr` → `[pkg, foo, bar]`.
+fn module_path(root: &Path, file: &Path, pkg: &str) -> Vec<String> {
+    let rel = file.strip_prefix(root).unwrap_or(file);
+    let mut segs: Vec<String> = rel
+        .with_extension("")
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    if segs.last().is_some_and(|s| s == "mod") {
+        segs.pop();
+    }
+    if segs.as_slice() == ["lib"] {
+        segs.clear();
+    }
+    let mut path = vec![pkg.to_owned()];
+    path.extend(segs);
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, rel: &str, content: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn interner() -> Arc<MultiThreadedTokenInterner> {
+        Arc::new(reussir_syntax::new_threaded_interner())
+    }
+
+    #[test]
+    fn discovers_nested_modules_with_location_derived_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "lib.rr", "mod utils;\npub fn e() -> u64 { 0 }");
+        write(
+            dir.path(),
+            "utils/mod.rr",
+            "mod math;\npub fn o() -> u64 { 1 }",
+        );
+        write(dir.path(), "utils/math.rr", "pub fn d(x: u64) -> u64 { x }");
+        let pkg = load_package(dir.path(), "mypkg", &interner()).unwrap_or_else(|_| panic!());
+        let modules: Vec<Vec<String>> = pkg.files.iter().map(|f| f.module.clone()).collect();
+        assert_eq!(
+            modules,
+            vec![
+                vec!["mypkg".to_owned()],
+                vec!["mypkg".to_owned(), "utils".to_owned()],
+                vec!["mypkg".to_owned(), "utils".to_owned(), "math".to_owned()],
+            ]
+        );
+        assert_eq!(pkg.files[0].file, FileId::ROOT);
+    }
+
+    #[test]
+    fn tolerates_duplicate_declarations_and_cycles() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "lib.rr",
+            "mod a;\nmod a;\npub fn e() -> u64 { 0 }",
+        );
+        write(dir.path(), "a.rr", "mod b;\npub fn f() -> u64 { 1 }");
+        write(dir.path(), "b.rr", "mod a;\npub fn g() -> u64 { 2 }");
+        let pkg = load_package(dir.path(), "p", &interner()).unwrap_or_else(|_| panic!());
+        // lib, a, b — each once despite the duplicate and the a↔b cycle.
+        assert_eq!(pkg.files.len(), 3);
+    }
+
+    #[test]
+    fn reports_a_missing_module_file_with_both_candidates() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "lib.rr",
+            "mod missing;\npub fn e() -> u64 { 0 }",
+        );
+        let Err(PackageError::Message(msg)) = load_package(dir.path(), "p", &interner()) else {
+            panic!("expected a missing-module error");
+        };
+        assert!(msg.contains("module 'missing'"), "{msg}");
+        assert!(msg.contains("has no source file"), "{msg}");
+        assert!(msg.contains("missing.rr"), "{msg}");
+        assert!(msg.contains("mod.rr"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_the_reserved_core_package_name() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "lib.rr", "pub fn e() -> u64 { 0 }");
+        let Err(PackageError::Message(msg)) = load_package(dir.path(), "core", &interner()) else {
+            panic!("expected the reserved-name error");
+        };
+        assert!(
+            msg.contains("'core' is reserved for the built-in core package"),
+            "{msg}"
+        );
+    }
+}

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -116,12 +116,16 @@ impl<'tcx> Builder<'_, 'tcx> {
     }
 
     /// The `DefId` for a record path, declaring it on first sight.
+    /// Multi-segment paths (`pkg::m::Cell`) split back into module + item
+    /// name, so re-prints display the same qualified path.
     fn record_def(&mut self, path: &str) -> crate::semi::ty::DefId {
-        let key = self.names.intern(path);
-        match self.defs.resolve_record(key) {
-            Some(d) => d,
-            None => self.defs.declare_record(key).expect("fresh record decl"),
+        let segs: Vec<_> = path.split("::").map(|s| self.names.intern(s)).collect();
+        if let Some(id) = self.defs.lookup_record(&segs) {
+            return id;
         }
+        let (name, module) = segs.split_last().expect("paths are never empty");
+        self.defs.set_module(module.to_vec());
+        self.defs.declare_record(*name).expect("fresh record decl")
     }
 
     /// Rebuild a record instance (symbol, nominal type, default capability, and

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -94,13 +94,29 @@ Ty: raw::Ty = {
     "(" ")" => raw::Ty::Unit,
     "!" => raw::Ty::Bottom,
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
-    <cap:Cap> <path:"ident"> <args:TyArgs?>
-        => raw::Ty::Record { cap, path: path.into(), args: args.unwrap_or_default() },
+    <cap:Cap> <path:TyPathArgs>
+        => raw::Ty::Record { cap, path: path.0, args: path.1 },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };
 
-TyArgs: Vec<raw::Ty> = "::" "<" <CommaPlus<Ty>> ">";
+/// A qualified record-type path with an optional turbofish
+/// (`pkg::m::Cell::<u64>`), factored into one recursive production so the
+/// grammar stays LR(1): after each `::` the next token — an identifier vs
+/// `<` — decides between another path segment and the type-argument list.
+TyPathArgs: (String, Vec<raw::Ty>) = <first:"ident"> <tail:TyPathArgsTail> => {
+    let (rest, args) = tail;
+    (format!("{first}{rest}"), args)
+};
+
+TyPathArgsTail: (String, Vec<raw::Ty>) = {
+    => (String::new(), Vec::new()),
+    "::" <seg:"ident"> <tail:TyPathArgsTail> => {
+        let (rest, args) = tail;
+        (format!("::{seg}{rest}"), args)
+    },
+    "::" "<" <tys:CommaPlus<Ty>> ">" => (String::new(), tys),
+};
 
 Cap: raw::Cap = {
     => raw::Cap::None,

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -31,7 +31,8 @@ pub mod resolve;
 pub mod ty_eval;
 
 pub use ctxt::{
-    Checkpoint, DefaultCap, Elaborator, Report, Severity, render_reports, render_reports_to,
+    Checkpoint, DefaultCap, Elaborator, PackageFile, Report, Severity, render_reports,
+    render_reports_to,
 };
 
 use reussir_syntax::kind::{Resolver, TokenKey};
@@ -49,6 +50,21 @@ pub fn elaborate<'a, 'tcx>(
 ) -> Elaborator<'a, 'tcx> {
     let mut elab = Elaborator::new(tcx, resolver);
     elab.run(program);
+    elab
+}
+
+/// Elaborate a whole package — one translation unit spanning many files, each
+/// under its own module path. All items are declared before any is resolved,
+/// so cross-file references work in any order. Every file must have been
+/// parsed with **one shared interner** (`resolver` resolves its keys):
+/// cross-file resolution compares interned keys.
+pub fn elaborate_package<'a, 'tcx>(
+    tcx: &'a TyCtxt<'tcx>,
+    files: &[PackageFile<'_>],
+    resolver: &'a dyn Resolver<TokenKey>,
+) -> Elaborator<'a, 'tcx> {
+    let mut elab = Elaborator::new(tcx, resolver);
+    elab.run_package(files);
     elab
 }
 
@@ -73,6 +89,181 @@ mod tests {
             );
             f(&elab, tcx);
         });
+    }
+
+    /// Parse a set of `(module path, source)` files with one shared interner
+    /// and elaborate them as a package rooted at `pkg`.
+    fn check_package(
+        pkg: &str,
+        files: &[(&[&str], &str)],
+        f: impl for<'a, 'tcx> FnOnce(&Elaborator<'a, 'tcx>, &TyCtxt<'tcx>),
+    ) {
+        use std::sync::Arc;
+
+        use reussir_syntax::Interner;
+        use reussir_syntax::source::FileId;
+
+        with_tcx(|tcx| {
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let mut keys = interner.clone();
+            let pkg_key = Interner::get_or_intern(&mut keys, pkg);
+            let parses: Vec<_> = files
+                .iter()
+                .map(|(_, src)| {
+                    let p = reussir_syntax::parse_with_interner(src, interner.clone());
+                    assert!(p.ok(), "parse errors for {src:?}: {:#?}", p.errors);
+                    p
+                })
+                .collect();
+            let programs: Vec<surface::Program> =
+                parses.iter().map(|p| surface::program(&p.root)).collect();
+            let pkg_files: Vec<PackageFile> = files
+                .iter()
+                .zip(&programs)
+                .enumerate()
+                .map(|(i, ((module, _), program))| {
+                    let mut path = vec![pkg_key];
+                    path.extend(
+                        module
+                            .iter()
+                            .map(|seg| Interner::get_or_intern(&mut keys, seg)),
+                    );
+                    PackageFile {
+                        file: FileId::from_index(i as u32),
+                        module: path,
+                        program,
+                    }
+                })
+                .collect();
+            let elab = elaborate_package(tcx, &pkg_files, &interner);
+            f(&elab, tcx);
+        });
+    }
+
+    #[test]
+    fn package_elaboration_resolves_across_modules() {
+        // The reference `module_basic` shape: `lib.rr` calls `math::add`.
+        check_package(
+            "mylib",
+            &[
+                (
+                    &[],
+                    r#"
+                        mod math;
+                        pub fn entry(n: u64) -> u64 { math::add(n, 10) }
+                        extern "C" trampoline "entry_ffi" = entry;
+                    "#,
+                ),
+                (&["math"], r#"pub fn add(a: u64, b: u64) -> u64 { a + b }"#),
+            ],
+            |elab, _| {
+                assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+                // Module paths drive the v0 mangling: nested `Nv` wrappers.
+                let (full, reports) = crate::full::mono::monomorphize(&elab.mono_input());
+                assert!(reports.is_empty(), "mono reports: {reports:#?}");
+                let symbols: Vec<&str> = full
+                    .functions
+                    .iter()
+                    .map(|f| full.symbol(f.symbol))
+                    .collect();
+                assert!(symbols.contains(&"_RNvC5mylib5entry"), "{symbols:?}");
+                assert!(symbols.contains(&"_RNvNvC5mylib4math3add"), "{symbols:?}");
+            },
+        );
+    }
+
+    #[test]
+    fn package_relative_paths_resolve_root_and_super() {
+        // The reference `module_relative_paths` shape, exercising `super::`,
+        // `super::super::`, `root::`, and cross-module record types.
+        check_package(
+            "mypkg",
+            &[
+                (
+                    &[],
+                    r#"
+                        mod models;
+                        mod utils;
+                        pub fn entry(n: u64) -> u64 {
+                            root::utils::nested::compute(n) + root::models::seed()
+                        }
+                    "#,
+                ),
+                (
+                    &["models"],
+                    r#"
+                        pub fn seed() -> u64 { 3 }
+                        pub fn scale(x: u64, k: u64) -> u64 { x * k }
+                        pub struct Wrap { v: u64 }
+                    "#,
+                ),
+                (
+                    &["utils"],
+                    r#"
+                        mod math;
+                        mod nested;
+                        pub fn offset() -> u64 { 4 }
+                    "#,
+                ),
+                (
+                    &["utils", "math"],
+                    r#"
+                        pub fn scaled_offset(x: u64) -> u64 {
+                            root::models::scale(super::offset(), x)
+                        }
+                    "#,
+                ),
+                (
+                    &["utils", "nested"],
+                    r#"
+                        pub fn compute(x: u64) -> u64 {
+                            let w = super::super::models::Wrap { v: x };
+                            super::math::scaled_offset(w.v) + super::super::models::seed()
+                        }
+                    "#,
+                ),
+            ],
+            |elab, _| {
+                assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+            },
+        );
+    }
+
+    #[test]
+    fn same_item_name_in_two_modules_stays_distinct() {
+        check_package(
+            "p",
+            &[
+                (&[], "mod a; mod b;\npub fn go() -> u64 { a::f() + b::f() }"),
+                (&["a"], "pub fn f() -> u64 { 1 }\npub struct S { v: u64 }"),
+                (&["b"], "pub fn f() -> u64 { 2 }\npub struct S { v: bool }"),
+            ],
+            |elab, _| {
+                assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+                let (full, reports) = crate::full::mono::monomorphize(&elab.mono_input());
+                assert!(reports.is_empty(), "mono reports: {reports:#?}");
+                let symbols: Vec<&str> = full
+                    .functions
+                    .iter()
+                    .map(|f| full.symbol(f.symbol))
+                    .collect();
+                assert!(symbols.contains(&"_RNvNvC1p1a1f"), "{symbols:?}");
+                assert!(symbols.contains(&"_RNvNvC1p1b1f"), "{symbols:?}");
+            },
+        );
+    }
+
+    #[test]
+    fn unresolved_cross_module_reference_reports_the_full_path() {
+        check_package(
+            "p",
+            &[(&[], "pub fn go() -> u64 { missing::f() }")],
+            |elab, _| {
+                assert!(elab.has_errors());
+                let msg = &elab.reports[0].message;
+                assert!(msg.contains("unknown function `missing::f`"), "{msg}");
+            },
+        );
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -25,9 +25,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let Some(proto) = self.functions.get(&def).cloned() else {
             return;
         };
-        // Attribute the body's reports to the function's declaration file (the
-        // package driver checks items from many files in one pass).
-        self.set_current_file(proto.file);
+        // The body's references resolve (and its reports attribute) in the
+        // function's own declaration scope — the package driver checks items
+        // from many files/modules in one pass.
+        self.enter_item_scope(def, proto.file);
         self.enter_function(&proto.generics);
         // A `[regional]` function body runs inside an implicit region: its
         // parameters may already be flex and it may construct regional records
@@ -455,9 +456,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             let callee = self.mk_expr(ExprKind::Var(id), ty, span);
             return self.closure_apply(callee, &fc.args, span);
         }
-        let Some(def) = self.defs.resolve_function(fc.name.basename) else {
-            let hint = self.function_suggestion(fc.name.basename);
-            self.error(span, format!("unknown function `{fname}`{hint}"));
+        let Some(def) = self.resolve_function_ref(&fc.name) else {
+            let hint = if fc.name.segments.is_empty() {
+                self.function_suggestion(fc.name.basename)
+            } else {
+                String::new()
+            };
+            let shown = self.path_display(&fc.name);
+            self.error(span, format!("unknown function `{shown}`{hint}"));
             return self.poison(span);
         };
         self.record_use(fc.name.basename);
@@ -820,9 +826,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.infer_ctor(&cc.name, &cc.ty_args, &cc.args, span)
     }
 
-    /// Dispatch a constructor path: `Nullable::…` → [`Self::infer_nullable`], a
-    /// qualified `Enum::Variant` → [`Self::infer_variant`], otherwise a struct name →
-    /// [`Self::infer_struct`].
+    /// Dispatch a constructor path: `Nullable::…` → [`Self::infer_nullable`]; a
+    /// qualified path whose qualifier resolves to an enum (`Enum::Variant`,
+    /// `m::Enum::Variant`) → [`Self::infer_variant`]; otherwise a struct —
+    /// bare (`Foo`) or module-qualified (`m::Foo`) — → [`Self::infer_struct_def`].
     fn infer_ctor(
         &mut self,
         path: &surface::Path,
@@ -835,11 +842,26 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         if qualifier.map(|k| self.sym(k)) == Some("Nullable") {
             return self.infer_nullable(self.sym(path.basename), args, span);
         }
-        // An enum variant: `Enum::Variant`.
         if let Some(enum_key) = qualifier {
-            return self.infer_variant(enum_key, path.basename, ty_args, args, span);
+            // The qualifier resolving to an enum wins (`Enum::Variant`); a
+            // qualifier that is a module path instead falls through to a
+            // module-qualified struct constructor (`m::Foo{…}`).
+            if let Some(def) = self.resolve_ctor_qualifier(path)
+                && matches!(self.records[&def].fields, Some(RecordFields::Variants(_)))
+            {
+                self.record_use(enum_key);
+                return self.infer_variant(def, enum_key, path.basename, ty_args, args, span);
+            }
+            let Some(def) = self.resolve_record_ref(path) else {
+                let hint = self.record_suggestion(enum_key);
+                let shown = self.path_display(path);
+                self.error(span, format!("unknown constructor `{shown}`{hint}"));
+                return self.poison(span);
+            };
+            self.record_use(path.basename);
+            return self.infer_struct_def(def, path.basename, ty_args, args, span);
         }
-        // A struct constructor.
+        // A bare struct constructor.
         self.infer_struct(path.basename, ty_args, args, span)
     }
 
@@ -893,6 +915,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return self.poison(span);
         };
         self.record_use(name);
+        self.infer_struct_def(def, name, ty_args, args, span)
+    }
+
+    /// The resolved-def core of [`Self::infer_struct`] (shared with the
+    /// module-qualified constructor path).
+    fn infer_struct_def(
+        &mut self,
+        def: DefId,
+        name: TokenKey,
+        ty_args: &[Option<surface::Type>],
+        args: &[(Option<TokenKey>, surface::Expr)],
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
         let record = self.records[&def].clone();
         if matches!(record.fields, Some(RecordFields::Variants(_))) {
             self.error(
@@ -934,21 +969,13 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// regional enum outside a region is a diagnostic.
     fn infer_variant(
         &mut self,
+        def: DefId,
         enum_name: TokenKey,
         variant: TokenKey,
         ty_args: &[Option<surface::Type>],
         args: &[(Option<TokenKey>, surface::Expr)],
         span: Option<Span>,
     ) -> Expr<'tcx> {
-        let Some(def) = self.defs.resolve_record(enum_name) else {
-            let hint = self.record_suggestion(enum_name);
-            self.error(
-                span,
-                format!("unknown enum `{}`{hint}", self.sym(enum_name)),
-            );
-            return self.poison(span);
-        };
-        self.record_use(enum_name);
         let record = self.records[&def].clone();
         let Some(RecordFields::Variants(variants)) = &record.fields else {
             self.error(span, format!("`{}` is not an enum", self.sym(enum_name)));

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -89,6 +89,16 @@ pub fn render_reports_to(
     had_error
 }
 
+/// One file of a package, ready to elaborate: its id in the compilation's
+/// source cache, its module path (`[pkg]` for `lib.rr`, `[pkg, sub, …]` for
+/// submodules), and its parsed program. All files of a package must share one
+/// token interner — cross-file resolution compares interned keys.
+pub struct PackageFile<'p> {
+    pub file: FileId,
+    pub module: Vec<TokenKey>,
+    pub program: &'p surface::Program,
+}
+
 /// Per-generic metadata: its name and the trait bounds declared on it.
 #[derive(Clone, Debug)]
 pub struct GenericInfo {
@@ -463,6 +473,82 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.frecency.record(name);
     }
 
+    // ----- module-aware reference resolution -----
+
+    /// Classify a reference path's qualifier segments: the `root`/`super`
+    /// module keywords (by their interned text) or ordinary names.
+    pub(super) fn classify_segs(&self, path: &surface::Path) -> Vec<crate::semi::resolve::PathSeg> {
+        use crate::semi::resolve::PathSeg;
+        path.segments
+            .iter()
+            .map(|&k| match self.sym(k) {
+                "root" => PathSeg::Root,
+                "super" => PathSeg::Super,
+                _ => PathSeg::Name(k),
+            })
+            .collect()
+    }
+
+    /// Render a reference path as the user wrote it (`a::b::name`).
+    pub(super) fn path_display(&self, path: &surface::Path) -> String {
+        let mut out = String::new();
+        for &seg in &path.segments {
+            out.push_str(self.sym(seg));
+            out.push_str("::");
+        }
+        out.push_str(self.sym(path.basename));
+        out
+    }
+
+    /// Resolve a type reference: bare names in the current module (falling
+    /// back to the crate root), qualified paths per the module-relative rules
+    /// (see [`DefTable::resolve_record_path`]).
+    pub(super) fn resolve_record_ref(&self, path: &surface::Path) -> Option<DefId> {
+        if path.segments.is_empty() {
+            self.defs.resolve_record(path.basename)
+        } else {
+            self.defs
+                .resolve_record_path(&self.classify_segs(path), path.basename)
+        }
+    }
+
+    /// Resolve a value (function) reference; see [`Self::resolve_record_ref`].
+    pub(super) fn resolve_function_ref(&self, path: &surface::Path) -> Option<DefId> {
+        if path.segments.is_empty() {
+            self.defs.resolve_function(path.basename)
+        } else {
+            self.defs
+                .resolve_function_path(&self.classify_segs(path), path.basename)
+        }
+    }
+
+    /// Resolve a constructor path's *qualifier* as a record: for
+    /// `m::Enum::Variant` the qualifier is `m::Enum` (the basename names the
+    /// variant). `None` when the path has no qualifier.
+    pub(super) fn resolve_ctor_qualifier(&self, path: &surface::Path) -> Option<DefId> {
+        let (&enum_name, mods) = path.segments.split_last()?;
+        if mods.is_empty() {
+            self.defs.resolve_record(enum_name)
+        } else {
+            let mods_path = surface::Path {
+                basename: enum_name,
+                segments: mods.iter().copied().collect(),
+            };
+            self.defs
+                .resolve_record_path(&self.classify_segs(&mods_path), enum_name)
+        }
+    }
+
+    /// Enter `def`'s declaration scope: reports attribute to `file`, and
+    /// bare/relative references resolve against the item's own module (its
+    /// qualified path minus the item name).
+    pub(super) fn enter_item_scope(&mut self, def: DefId, file: FileId) {
+        self.set_current_file(file);
+        let path = &self.defs.path(def).0;
+        let module = path[..path.len() - 1].to_vec();
+        self.defs.set_module(module);
+    }
+
     // ----- "did you mean" suggestions -----
     //
     // Each helper fuzzy-searches the relevant namespace for the closest spelling
@@ -643,24 +729,57 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
     }
 
-    /// Run the three collection passes over a program: scan record stubs and
-    /// function prototypes, populate record fields, then check function bodies.
+    /// Run the collection passes over one program in the current module (the
+    /// single-file / REPL entry): scan record stubs and function prototypes,
+    /// populate record fields, then check function bodies.
     pub fn run(&mut self, program: &surface::Program) {
+        let file = self.current_file;
+        let module = self.defs.module().to_vec();
+        self.run_files(&[(file, module, program)]);
+    }
+
+    /// Run the collection passes over a whole package — one translation unit
+    /// spanning many files, each with its own module path.
+    pub fn run_package(&mut self, files: &[PackageFile<'_>]) {
+        let files: Vec<(FileId, Vec<TokenKey>, &surface::Program)> = files
+            .iter()
+            .map(|f| (f.file, f.module.clone(), f.program))
+            .collect();
+        self.run_files(&files);
+    }
+
+    /// The shared driver: scan **all** files' record stubs and function
+    /// prototypes first (cross-file forward references and mutual recursion),
+    /// then populate record fields, check function bodies (each pass restores
+    /// the owning item's file/module scope), and collect trampoline roots per
+    /// file.
+    fn run_files(&mut self, files: &[(FileId, Vec<TokenKey>, &surface::Program)]) {
         // Project each item once — `kind()` re-walks the node and is not
-        // memoized — then run the passes over the typed collections. Record
-        // stubs and function prototypes must all exist before field types and
-        // bodies are resolved (mutual recursion / forward references).
+        // memoized — then run the passes over the typed collections, each item
+        // tagged with its file/module scope.
+        struct Scope<'p> {
+            file: FileId,
+            module: &'p [TokenKey],
+        }
         let mut records = Vec::new();
         let mut functions = Vec::new();
         let mut trampolines = Vec::new();
-        for stmt in program {
-            let span = span_of(stmt);
-            match stmt.kind() {
-                surface::StmtKind::Record(rec) => records.push((rec, span)),
-                surface::StmtKind::Function(func) => functions.push((func, span)),
-                surface::StmtKind::ExternTrampoline(t) => trampolines.push((t, span)),
-                // `mod` is a no-op while every program is one flat module.
-                surface::StmtKind::Mod(..) => {}
+        for (file, module, program) in files {
+            for stmt in *program {
+                let scope = Scope {
+                    file: *file,
+                    module,
+                };
+                let span = span_of(stmt);
+                match stmt.kind() {
+                    surface::StmtKind::Record(rec) => records.push((rec, span, scope)),
+                    surface::StmtKind::Function(func) => functions.push((func, span, scope)),
+                    surface::StmtKind::ExternTrampoline(t) => trampolines.push((t, span, scope)),
+                    // `mod` declarations drive package *discovery* (the driver
+                    // maps them to files before elaboration); here they carry
+                    // no items.
+                    surface::StmtKind::Mod(..) => {}
+                }
             }
         }
         // The later passes are keyed by the DefId each scan returned — never by
@@ -669,27 +788,37 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // item's fields or checking a body against the wrong prototype.
         let record_defs: Vec<Option<DefId>> = records
             .iter()
-            .map(|(rec, span)| self.scan_record(rec, *span))
+            .map(|(rec, span, scope)| {
+                self.set_current_file(scope.file);
+                self.defs.set_module(scope.module.to_vec());
+                self.scan_record(rec, *span)
+            })
             .collect();
         let function_defs: Vec<Option<DefId>> = functions
             .iter()
-            .map(|(func, span)| self.scan_function(func, *span))
+            .map(|(func, span, scope)| {
+                self.set_current_file(scope.file);
+                self.defs.set_module(scope.module.to_vec());
+                self.scan_function(func, *span)
+            })
             .collect();
         records
             .iter()
             .zip(record_defs)
-            .filter_map(|((rec, _), def)| Some((rec, def?)))
+            .filter_map(|((rec, _, _), def)| Some((rec, def?)))
             .for_each(|(rec, def)| {
                 self.populate_record(rec, def);
             });
         functions
             .iter()
             .zip(function_defs)
-            .filter_map(|((func, span), def)| Some((func, *span, def?)))
+            .filter_map(|((func, span, _), def)| Some((func, *span, def?)))
             .for_each(|(func, span, def)| {
                 self.check_function(func, def, span);
             });
-        trampolines.iter().for_each(|(tramp, span)| {
+        trampolines.iter().for_each(|(tramp, span, scope)| {
+            self.set_current_file(scope.file);
+            self.defs.set_module(scope.module.to_vec());
             self.collect_trampoline(tramp, *span);
         });
     }
@@ -806,8 +935,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let span = record.span;
         let default_cap = record.default_cap;
         let file = record.file;
-        // Attribute field-resolution reports to the record's declaration file.
-        self.set_current_file(file);
+        // Field types resolve (and reports attribute) in the record's own
+        // declaration scope.
+        self.enter_item_scope(def, file);
         self.generic_names = ty_params.iter().map(|(n, id)| (*n, *id)).collect();
 
         // A generic at the head of a `[field]` link (`inner: [field] T`) must be
@@ -882,13 +1012,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // The target's type arguments are concrete here (no generics in scope).
         let ty_args: Vec<Ty<'tcx>> = tramp.ty_args.iter().map(|t| self.eval_type(t)).collect();
 
-        let Some(target) = self.defs.resolve_function(tramp.func.basename) else {
-            let hint = self.function_suggestion(tramp.func.basename);
+        let Some(target) = self.resolve_function_ref(&tramp.func) else {
+            let hint = if tramp.func.segments.is_empty() {
+                self.function_suggestion(tramp.func.basename)
+            } else {
+                String::new()
+            };
             self.error(
                 span,
                 format!(
                     "trampoline target function `{}` not found{hint}",
-                    self.sym(tramp.func.basename)
+                    self.path_display(&tramp.func)
                 ),
             );
             return;

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -134,19 +134,27 @@ impl<'tcx> Builder<'_, 'tcx> {
     }
 
     /// Resolve-or-declare a function path to a stable `DefId` (shared by the
-    /// definition and its call sites, in any order).
+    /// definition and its call sites, in any order). Multi-segment paths
+    /// (`pkg::m::f`) split back into module + item name, so mangling sees the
+    /// same segments the original elaboration produced.
     fn function_def(&mut self, path: &str) -> DefId {
-        let key = self.names.intern(path);
-        self.defs
-            .resolve_function(key)
-            .unwrap_or_else(|| self.defs.declare_function(key).expect("fresh fn decl"))
+        let segs: Vec<_> = path.split("::").map(|s| self.names.intern(s)).collect();
+        if let Some(id) = self.defs.lookup_function(&segs) {
+            return id;
+        }
+        let (name, module) = segs.split_last().expect("paths are never empty");
+        self.defs.set_module(module.to_vec());
+        self.defs.declare_function(*name).expect("fresh fn decl")
     }
 
     fn record_def(&mut self, path: &str) -> DefId {
-        let key = self.names.intern(path);
-        self.defs
-            .resolve_record(key)
-            .unwrap_or_else(|| self.defs.declare_record(key).expect("fresh record decl"))
+        let segs: Vec<_> = path.split("::").map(|s| self.names.intern(s)).collect();
+        if let Some(id) = self.defs.lookup_record(&segs) {
+            return id;
+        }
+        let (name, module) = segs.split_last().expect("paths are never empty");
+        self.defs.set_module(module.to_vec());
+        self.defs.declare_record(*name).expect("fresh record decl")
     }
 
     /// Rebuild a generic binder list (`ty_params`) and its regional subset from

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -34,23 +34,23 @@ Span: raw::Span = "[" <s:"int"> ".." <e:"int"> "]" => (raw::small_u32(&s), raw::
 ItemLoc: (u32, Option<raw::Span>) = "in" <f:"int"> <sp:Span?> => (raw::small_u32(&f), sp);
 
 RecordDecl: raw::Record = {
-    <default_cap:DefaultCap> "struct" "#" <path:"ident"> <generics:Generics?> <loc:ItemLoc?>
+    <default_cap:DefaultCap> "struct" "#" <path:QPath> <generics:Generics?> <loc:ItemLoc?>
     "{" <ms:Comma<Member>> "}" ";"
     => raw::Record {
         default_cap,
         kind: raw::RecordKind::Struct,
-        path: path.into(),
+        path,
         generics: generics.unwrap_or_default(),
         file: loc.map(|l| l.0),
         span: loc.and_then(|l| l.1),
         body: raw::RecordBody::Compound(ms),
     },
-    <default_cap:DefaultCap> "enum" "#" <path:"ident"> <generics:Generics?> <loc:ItemLoc?>
+    <default_cap:DefaultCap> "enum" "#" <path:QPath> <generics:Generics?> <loc:ItemLoc?>
     "{" <vs:Comma<Variant>> "}" ";"
     => raw::Record {
         default_cap,
         kind: raw::RecordKind::Enum,
-        path: path.into(),
+        path,
         generics: generics.unwrap_or_default(),
         file: loc.map(|l| l.0),
         span: loc.and_then(|l| l.1),
@@ -74,21 +74,21 @@ Variant: raw::Variant =
     <name:"ident"> "(" <fs:Comma<Ty>> ")" => raw::Variant { name: name.into(), fields: fs };
 
 TrampDecl: raw::Tramp =
-    "extern" <abi:"quoted"> "trampoline" <name:"quoted"> "=" "#" <target:"ident"> <ta:TyArgs?> ";"
+    "extern" <abi:"quoted"> "trampoline" <name:"quoted"> "=" "#" <target:PathArgs> ";"
     => raw::Tramp {
         abi: abi.into(),
         name: name.into(),
-        target: target.into(),
-        ty_args: ta.unwrap_or_default(),
+        target: target.0,
+        ty_args: target.1,
     };
 
 Func: raw::Func =
-    <p:"pub"?> <r:"regional"?> "fn" "#" <path:"ident"> <generics:Generics?>
+    <p:"pub"?> <r:"regional"?> "fn" "#" <path:QPath> <generics:Generics?>
     "(" <params:Comma<Param>> ")" "->" <ret:Ty> <loc:ItemLoc?> <body:Body>
     => raw::Func {
         is_pub: p.is_some(),
         regional: r.is_some(),
-        path: path.into(),
+        path,
         generics: generics.unwrap_or_default(),
         params,
         ret,
@@ -98,6 +98,35 @@ Func: raw::Func =
     };
 
 Generics: Vec<raw::Generic> = "<" <CommaPlus<Generic>> ">";
+
+/// A fully-qualified item path: `a::b::Name`. Serialized with its segments
+/// joined; the rebuild pass splits them back into module + item name.
+QPath: String = <first:"ident"> <rest:("::" <"ident">)*> => {
+    let mut s = first.to_string();
+    for seg in rest {
+        s.push_str("::");
+        s.push_str(seg);
+    }
+    s
+};
+
+/// A qualified path with an optional turbofish (`a::b::f::<T, U>`), factored
+/// into one recursive production: after each `::` the next token — an
+/// identifier vs `<` — decides between another path segment and the
+/// type-argument list, which keeps the grammar LR(1).
+PathArgs: (String, Vec<raw::Ty>) = <first:"ident"> <tail:PathArgsTail> => {
+    let (rest, args) = tail;
+    (format!("{first}{rest}"), args)
+};
+
+PathArgsTail: (String, Vec<raw::Ty>) = {
+    => (String::new(), Vec::new()),
+    "::" <seg:"ident"> <tail:PathArgsTail> => {
+        let (rest, args) = tail;
+        (format!("::{seg}{rest}"), args)
+    },
+    "::" "<" <tys:CommaPlus<Ty>> ">" => (String::new(), tys),
+};
 
 Generic: raw::Generic = <r:"regional"?> <g:"generic">
     => raw::Generic { id: g, regional: r.is_some() };
@@ -124,13 +153,11 @@ Ty: raw::Ty = {
     "!" => raw::Ty::Bottom,
     <g:"generic"> => raw::Ty::Generic(g),
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
-    <cap:Cap> "#" <path:"ident"> <args:TyArgs?>
-        => raw::Ty::Record { cap, path: path.into(), args: args.unwrap_or_default() },
+    <cap:Cap> "#" <path:PathArgs>
+        => raw::Ty::Record { cap, path: path.0, args: path.1 },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };
-
-TyArgs: Vec<raw::Ty> = "::" "<" <CommaPlus<Ty>> ">";
 
 Cap: raw::Cap = {
     => raw::Cap::None,
@@ -186,12 +213,12 @@ Atom: raw::Kind = {
         => raw::Kind::Proj(base, idxs.iter().map(raw::small_u32).collect()),
     "assign" "(" <dst:Expr> "," <field:"int"> "," <src:Expr> ")"
         => raw::Kind::Assign(dst, raw::small_u32(&field), src),
-    <r:"regional"?> "#" <path:"ident"> <ta:TyArgs?> "(" <args:Comma<Expr>> ")"
-        => raw::Kind::FuncCall { regional: r.is_some(), path: path.into(), ty_args: ta.unwrap_or_default(), args },
-    "#" <path:"ident"> <ta:TyArgs?> "{" <args:Comma<Expr>> "}"
-        => raw::Kind::CompoundCall { path: path.into(), ty_args: ta.unwrap_or_default(), args },
-    "#" <path:"ident"> <ta:TyArgs?> "#" <v:"int"> "(" <args:Comma<Expr>> ")"
-        => raw::Kind::VariantCall { path: path.into(), ty_args: ta.unwrap_or_default(), variant: raw::small_usize(&v), args },
+    <r:"regional"?> "#" <path:PathArgs> "(" <args:Comma<Expr>> ")"
+        => raw::Kind::FuncCall { regional: r.is_some(), path: path.0, ty_args: path.1, args },
+    "#" <path:PathArgs> "{" <args:Comma<Expr>> "}"
+        => raw::Kind::CompoundCall { path: path.0, ty_args: path.1, args },
+    "#" <path:PathArgs> "#" <v:"int"> "(" <args:Comma<Expr>> ")"
+        => raw::Kind::VariantCall { path: path.0, ty_args: path.1, variant: raw::small_usize(&v), args },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -324,11 +324,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
             return Pat::Wild;
         };
-        // The enum is named by the path qualifier (`Enum::Variant`), resolved to
-        // its def; bare `Variant` falls back to the scrutinee's own record def.
+        // The enum is named by the path qualifier (`Enum::Variant`, possibly
+        // module-qualified: `m::Enum::Variant`), resolved to its def; bare
+        // `Variant` falls back to the scrutinee's own record def.
         let want = ctor.path.basename;
         let enum_def = match ctor.path.segments.last() {
-            Some(&seg) => match self.defs.resolve_record(seg) {
+            Some(&seg) => match self.resolve_ctor_qualifier(&ctor.path) {
                 Some(d) => {
                     self.record_use(seg);
                     d

--- a/crates/reussir-core/src/semi/resolve.rs
+++ b/crates/reussir-core/src/semi/resolve.rs
@@ -1,9 +1,8 @@
 //! Name resolution: globally-unique item identities ([`DefId`]) with
-//! fully-qualified paths, and a scope that maps references to them.
+//! fully-qualified paths, and module-aware scopes that map references to them.
 //!
-//! Surface code names items by bare or type-qualified token paths (`Foo`,
-//! `Enum::Variant`); within a module those names are not unique across the whole
-//! program once modules enter the picture. Resolution assigns every top-level
+//! Surface code names items by bare or qualified token paths (`Foo`,
+//! `Enum::Variant`, `utils::math::double`). Resolution assigns every top-level
 //! item a [`DefId`] and records its **fully-qualified path** (the enclosing
 //! module segments followed by the item name), so two same-named records in
 //! different modules are genuinely distinct — `TyKind::Record` carries the
@@ -13,9 +12,12 @@
 //! resolved separately, mirroring the surface, but share one dense `DefId`
 //! space so a single id keys the type/HIR layers.
 //!
-//! Today every program is one flat module, so a path is just `[name]` and the
-//! scope is one map; the representation already carries module prefixes so
-//! nested modules and cross-unit resolution slot in without reshaping callers.
+//! The scopes are keyed by **full path**: a bare reference resolves in the
+//! current module first and falls back to the crate root; a qualified
+//! reference is tried absolute, then relative to the current module, then
+//! relative to the package root (the reference-frontend rules). The `root::` /
+//! `super::` keywords are classified by the *caller* (the elaborator owns the
+//! text of interned segments) into [`PathSeg`]s before resolution.
 
 use reussir_syntax::kind::{Resolver, TokenKey};
 use rustc_hash::FxHashMap;
@@ -50,22 +52,38 @@ impl QualifiedPath {
     }
 }
 
+/// One classified segment of a reference path: the `root`/`super` module
+/// keywords, or an ordinary name. Classification is textual (the segments are
+/// interned tokens), so the elaborator performs it and resolution stays
+/// key-only.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PathSeg {
+    /// `root::` — the package root (the first segment of the current module).
+    Root,
+    /// `super::` — the parent module (a leading run may pop several levels).
+    Super,
+    /// An ordinary module/item name.
+    Name(TokenKey),
+}
+
 #[derive(Clone, Debug)]
 pub struct DefInfo {
     pub path: QualifiedPath,
     pub kind: DefKind,
 }
 
-/// The resolution registry: every item's [`DefInfo`] (indexed by [`DefId`]) plus
-/// the current module's name→def scopes.
+/// The resolution registry: every item's [`DefInfo`] (indexed by [`DefId`])
+/// plus the full-path-keyed namespaces and the current module.
 #[derive(Default)]
 pub struct DefTable {
     defs: Vec<DefInfo>,
-    /// The enclosing module path (empty = crate root) that items qualify under.
+    /// The module path items currently declare under and bare references
+    /// resolve against (empty = crate root; `[pkg, sub]` inside a package).
     module: Vec<TokenKey>,
-    /// Type-namespace scope (records) and value-namespace scope (functions).
-    types: FxHashMap<TokenKey, DefId>,
-    values: FxHashMap<TokenKey, DefId>,
+    /// Type-namespace scope (records) and value-namespace scope (functions),
+    /// keyed by the item's full qualified path.
+    types: FxHashMap<Box<[TokenKey]>, DefId>,
+    values: FxHashMap<Box<[TokenKey]>, DefId>,
 }
 
 impl DefTable {
@@ -73,23 +91,34 @@ impl DefTable {
         Self::default()
     }
 
+    /// Switch the module items declare under and references resolve against.
+    pub fn set_module(&mut self, module: Vec<TokenKey>) {
+        self.module = module;
+    }
+
+    /// The current module path (empty = crate root).
+    pub fn module(&self) -> &[TokenKey] {
+        &self.module
+    }
+
     fn declare(
         &mut self,
-        scope: impl Fn(&mut Self) -> &mut FxHashMap<TokenKey, DefId>,
+        scope: impl Fn(&mut Self) -> &mut FxHashMap<Box<[TokenKey]>, DefId>,
         name: TokenKey,
         kind: DefKind,
     ) -> Option<DefId> {
-        if scope(self).contains_key(&name) {
-            return None; // name clash in this scope
-        }
-        let id = DefId(self.defs.len() as u32);
         let mut path = self.module.clone();
         path.push(name);
+        let key: Box<[TokenKey]> = path.clone().into_boxed_slice();
+        if scope(self).contains_key(&key) {
+            return None; // name clash in this module's namespace
+        }
+        let id = DefId(self.defs.len() as u32);
         self.defs.push(DefInfo {
             path: QualifiedPath(path),
             kind,
         });
-        scope(self).insert(name, id);
+        scope(self).insert(key, id);
         Some(id)
     }
 
@@ -104,26 +133,133 @@ impl DefTable {
         self.declare(|s| &mut s.values, name, DefKind::Function)
     }
 
-    /// Resolve a type reference (a record name) in scope.
+    /// Look up an exact fully-qualified path in the type namespace.
+    pub fn lookup_record(&self, path: &[TokenKey]) -> Option<DefId> {
+        self.types.get(path).copied()
+    }
+
+    /// Look up an exact fully-qualified path in the value namespace.
+    pub fn lookup_function(&self, path: &[TokenKey]) -> Option<DefId> {
+        self.values.get(path).copied()
+    }
+
+    /// Resolve a *bare* type reference: the current module first, then the
+    /// crate root.
     pub fn resolve_record(&self, name: TokenKey) -> Option<DefId> {
-        self.types.get(&name).copied()
+        self.resolve_bare(&self.types, name)
     }
 
-    /// Resolve a value reference (a function name) in scope.
+    /// Resolve a *bare* value reference: the current module first, then the
+    /// crate root.
     pub fn resolve_function(&self, name: TokenKey) -> Option<DefId> {
-        self.values.get(&name).copied()
+        self.resolve_bare(&self.values, name)
     }
 
-    /// Every record name currently in the type-namespace scope. Order is
-    /// unspecified; used to build "did you mean" suggestions on a failed lookup.
+    fn resolve_bare(
+        &self,
+        scope: &FxHashMap<Box<[TokenKey]>, DefId>,
+        name: TokenKey,
+    ) -> Option<DefId> {
+        let mut path = self.module.clone();
+        path.push(name);
+        if let Some(&id) = scope.get(path.as_slice()) {
+            return Some(id);
+        }
+        scope.get([name].as_slice()).copied()
+    }
+
+    /// Resolve a *qualified* type reference (see [`Self::resolve_qualified`]).
+    pub fn resolve_record_path(&self, segs: &[PathSeg], name: TokenKey) -> Option<DefId> {
+        self.resolve_qualified(&self.types, segs, name)
+    }
+
+    /// Resolve a *qualified* value reference (see [`Self::resolve_qualified`]).
+    pub fn resolve_function_path(&self, segs: &[PathSeg], name: TokenKey) -> Option<DefId> {
+        self.resolve_qualified(&self.values, segs, name)
+    }
+
+    /// Resolve `segs::name` against the current module:
+    ///
+    /// * A path led by `root::` resolves against the package root (the first
+    ///   segment of the current module); one led by `super::`s pops that many
+    ///   trailing segments off the current module. The keyword run must be a
+    ///   prefix; popping past the root fails.
+    /// * Any other path is tried **absolute**, then **relative to the current
+    ///   module**, then **relative to the package root** — first hit wins.
+    fn resolve_qualified(
+        &self,
+        scope: &FxHashMap<Box<[TokenKey]>, DefId>,
+        segs: &[PathSeg],
+        name: TokenKey,
+    ) -> Option<DefId> {
+        let plain = |segs: &[PathSeg]| -> Option<Vec<TokenKey>> {
+            segs.iter()
+                .map(|s| match s {
+                    PathSeg::Name(k) => Some(*k),
+                    // `root`/`super` past the leading position do not nest.
+                    PathSeg::Root | PathSeg::Super => None,
+                })
+                .collect()
+        };
+        match segs {
+            [PathSeg::Root, rest @ ..] => {
+                let rest = plain(rest)?;
+                let mut path: Vec<TokenKey> = self.module.first().copied().into_iter().collect();
+                path.extend(rest);
+                path.push(name);
+                scope.get(path.as_slice()).copied()
+            }
+            [PathSeg::Super, ..] => {
+                let supers = segs.iter().take_while(|s| **s == PathSeg::Super).count();
+                let rest = plain(&segs[supers..])?;
+                // Each `super` pops one level; popping past the package root
+                // is unresolvable.
+                if supers > self.module.len() {
+                    return None;
+                }
+                let mut path = self.module[..self.module.len() - supers].to_vec();
+                path.extend(rest);
+                path.push(name);
+                scope.get(path.as_slice()).copied()
+            }
+            _ => {
+                let segs = plain(segs)?;
+                let mut absolute = segs.clone();
+                absolute.push(name);
+                if let Some(&id) = scope.get(absolute.as_slice()) {
+                    return Some(id);
+                }
+                let mut in_module = self.module.clone();
+                in_module.extend_from_slice(&segs);
+                in_module.push(name);
+                if let Some(&id) = scope.get(in_module.as_slice()) {
+                    return Some(id);
+                }
+                let root = self.module.first().copied()?;
+                let mut in_root = vec![root];
+                in_root.extend_from_slice(&segs);
+                in_root.push(name);
+                scope.get(in_root.as_slice()).copied()
+            }
+        }
+    }
+
+    /// Every record name (the item's own, unqualified name) in the type
+    /// namespace. Order is unspecified; used to build "did you mean"
+    /// suggestions on a failed lookup.
     pub fn record_names(&self) -> impl Iterator<Item = TokenKey> + '_ {
-        self.types.keys().copied()
+        self.types
+            .keys()
+            .map(|p| *p.last().expect("paths are never empty"))
     }
 
-    /// Every function name currently in the value-namespace scope. Order is
-    /// unspecified; used to build "did you mean" suggestions on a failed lookup.
+    /// Every function name (the item's own, unqualified name) in the value
+    /// namespace. Order is unspecified; used to build "did you mean"
+    /// suggestions on a failed lookup.
     pub fn function_names(&self) -> impl Iterator<Item = TokenKey> + '_ {
-        self.values.keys().copied()
+        self.values
+            .keys()
+            .map(|p| *p.last().expect("paths are never empty"))
     }
 
     /// The number of declared defs — a checkpoint for [`DefTable::truncate`].
@@ -135,10 +271,10 @@ impl DefTable {
         self.defs.is_empty()
     }
 
-    /// Retract every def declared at index `>= len`, removing its name from the
-    /// owning namespace scope. The REPL uses this to roll an elaboration
+    /// Retract every def declared at index `>= len`, removing its path from
+    /// the owning namespace scope. The REPL uses this to roll an elaboration
     /// attempt back atomically; it relies on `declare` rejecting clashes, so a
-    /// name in a scope always maps to the def that introduced it.
+    /// path in a scope always maps to the def that introduced it.
     pub fn truncate(&mut self, len: usize) {
         while self.defs.len() > len {
             let id = DefId((self.defs.len() - 1) as u32);
@@ -147,7 +283,7 @@ impl DefTable {
                 DefKind::Record => &mut self.types,
                 DefKind::Function => &mut self.values,
             };
-            let removed = scope.remove(&info.path.name());
+            let removed = scope.remove(info.path.0.as_slice());
             debug_assert_eq!(removed, Some(id), "scope must point at the popped def");
         }
     }
@@ -170,6 +306,10 @@ mod tests {
     /// A distinct interned key for a name in tests (no parser).
     fn k(n: u32) -> TokenKey {
         TokenKey::try_from_u32(n).expect("nonzero key")
+    }
+
+    fn name(n: u32) -> PathSeg {
+        PathSeg::Name(k(n))
     }
 
     #[test]
@@ -196,6 +336,87 @@ mod tests {
         let mut t = DefTable::new();
         assert!(t.declare_record(k(1)).is_some());
         assert!(t.declare_record(k(1)).is_none());
+    }
+
+    #[test]
+    fn same_name_in_two_modules_is_distinct() {
+        let mut t = DefTable::new();
+        t.set_module(vec![k(10), k(11)]); // pkg::a
+        let in_a = t.declare_function(k(1)).expect("fresh");
+        t.set_module(vec![k(10), k(12)]); // pkg::b
+        let in_b = t.declare_function(k(1)).expect("fresh");
+        assert_ne!(in_a, in_b);
+        // A bare reference resolves in the *current* module.
+        assert_eq!(t.resolve_function(k(1)), Some(in_b));
+        t.set_module(vec![k(10), k(11)]);
+        assert_eq!(t.resolve_function(k(1)), Some(in_a));
+    }
+
+    #[test]
+    fn qualified_paths_resolve_absolute_module_relative_and_root_relative() {
+        let mut t = DefTable::new();
+        // pkg::utils::math::double
+        t.set_module(vec![k(10), k(20), k(21)]);
+        let double = t.declare_function(k(1)).expect("fresh");
+        // From pkg::lib (module [pkg]): `utils::math::double` resolves
+        // root-relatively (and module-relatively — [pkg]+segs — identically).
+        t.set_module(vec![k(10)]);
+        assert_eq!(
+            t.resolve_function_path(&[name(20), name(21)], k(1)),
+            Some(double)
+        );
+        // Absolute (full path spelled out).
+        assert_eq!(
+            t.resolve_function_path(&[name(10), name(20), name(21)], k(1)),
+            Some(double)
+        );
+        // From a sibling module, root-relative still lands.
+        t.set_module(vec![k(10), k(30)]);
+        assert_eq!(
+            t.resolve_function_path(&[name(20), name(21)], k(1)),
+            Some(double)
+        );
+        assert_eq!(t.resolve_function_path(&[name(99)], k(1)), None);
+    }
+
+    #[test]
+    fn root_and_super_resolve_against_the_current_module() {
+        let mut t = DefTable::new();
+        // pkg::models::seed
+        t.set_module(vec![k(10), k(40)]);
+        let seed = t.declare_function(k(2)).expect("fresh");
+        // pkg::utils::offset
+        t.set_module(vec![k(10), k(20)]);
+        let offset = t.declare_function(k(3)).expect("fresh");
+
+        // From pkg::utils::math: `super::offset`, `super::super::models::seed`,
+        // `root::models::seed`.
+        t.set_module(vec![k(10), k(20), k(21)]);
+        assert_eq!(
+            t.resolve_function_path(&[PathSeg::Super], k(3)),
+            Some(offset)
+        );
+        assert_eq!(
+            t.resolve_function_path(&[PathSeg::Super, PathSeg::Super, name(40)], k(2)),
+            Some(seed)
+        );
+        assert_eq!(
+            t.resolve_function_path(&[PathSeg::Root, name(40)], k(2)),
+            Some(seed)
+        );
+        // Popping past the package root fails.
+        assert_eq!(
+            t.resolve_function_path(
+                &[
+                    PathSeg::Super,
+                    PathSeg::Super,
+                    PathSeg::Super,
+                    PathSeg::Super
+                ],
+                k(2)
+            ),
+            None
+        );
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -92,8 +92,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return self.tcx.mk_generic(generic);
         }
 
-        // The built-in nullable type.
-        if self.sym(key) == "Nullable" {
+        // The built-in nullable type (a root builtin: never module-qualified).
+        if path.segments.is_empty() && self.sym(key) == "Nullable" {
             return match args {
                 [inner] => {
                     let inner = self.eval_type(inner);
@@ -122,13 +122,16 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             };
         }
 
-        // A user record, resolved to its def.
-        let Some(def) = self.defs.resolve_record(key) else {
-            let hint = self.record_suggestion(key);
-            self.error(
-                Some(span),
-                format!("unknown type `{}`{hint}", self.sym(key)),
-            );
+        // A user record, resolved to its def — bare in the current module, or
+        // module-qualified (`utils::math::Cell`, `root::…`, `super::…`).
+        let Some(def) = self.resolve_record_ref(path) else {
+            let hint = if path.segments.is_empty() {
+                self.record_suggestion(key)
+            } else {
+                String::new()
+            };
+            let shown = self.path_display(path);
+            self.error(Some(span), format!("unknown type `{shown}`{hint}"));
             return self.tcx.mk(TyKind::Bottom);
         };
         self.record_use(key);

--- a/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
+++ b/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
@@ -20,6 +20,7 @@
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/BinaryFormat/Dwarf.h>
 #include <llvm/Support/MathExtras.h>
+#include <llvm/Support/Path.h>
 #include <llvm/Support/TypeSize.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
@@ -459,9 +460,26 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
     if (auto fused =
             llvm::dyn_cast_if_present<mlir::FusedLocWith<DBGSubprogramAttr>>(
                 funcLoc)) {
+      // The subprogram's own file: a multi-file translation unit stamps each
+      // function's `FileLineColLoc` with its declaration file, which may not
+      // be the compile unit's (the module attribute names the crate root).
+      // Deriving the `DIFile` from the location keeps `decl_file` correct;
+      // the module-level file remains the fallback for a function whose
+      // location carries no file (e.g. re-ingested IR with missing sources).
+      mlir::LLVM::DIFileAttr funcFileAttr = llvmDIFileAttr;
+      for (mlir::Location loc : fused.getLocations()) {
+        if (auto flc = llvm::dyn_cast<mlir::FileLineColLoc>(loc)) {
+          llvm::StringRef file = flc.getFilename().getValue();
+          if (!file.empty())
+            funcFileAttr = mlir::LLVM::DIFileAttr::get(
+                context, llvm::sys::path::filename(file),
+                llvm::sys::path::parent_path(file));
+          break;
+        }
+      }
 
       auto subprogram = translateDBGAttrToLLVM<mlir::LLVM::DISubprogramAttr>(
-          moduleOp, fused.getMetadata(), llvmDIFileAttr, dbgCompileUnitAttr,
+          moduleOp, fused.getMetadata(), funcFileAttr, dbgCompileUnitAttr,
           funcOp, nullptr, funcLoc);
       if (subprogram) {
         auto updated =
@@ -479,7 +497,7 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
           if (auto funcArgAttr = mlir::dyn_cast<DBGFuncArgAttr>(argAttr)) {
             auto translated =
                 translateDBGAttrToLLVM<mlir::LLVM::DILocalVariableAttr>(
-                    moduleOp, funcArgAttr, llvmDIFileAttr, dbgCompileUnitAttr,
+                    moduleOp, funcArgAttr, funcFileAttr, dbgCompileUnitAttr,
                     funcOp, subprogram, updatedFuncLoc);
             if (translated && idx < funcOp.getNumArguments()) {
               auto argValue = funcOp.getArgument(idx);
@@ -494,9 +512,9 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
               // covered by the function prologue: a debugger setting a breakpoint
               // on the function skips to the first body statement, by which point
               // the argument has been stored and is inspectable.
-              mlir::Location prologueLoc =
-                  mlir::FileLineColLoc::get(context, fileBasename.getValue(),
-                                            /*line=*/0, /*column=*/0);
+              mlir::Location prologueLoc = mlir::FileLineColLoc::get(
+                  context, funcFileAttr.getName().getValue(),
+                  /*line=*/0, /*column=*/0);
               spillAndDeclare(builder, prologueLoc, context, argValue,
                               translated,
                               boxedExpr(moduleOp, funcArgAttr.getDbgType()));
@@ -530,7 +548,7 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
           return;
         mlir::Attribute meta = innerFused.getMetadata();
         auto localVar = translateDBGAttrToLLVM<mlir::LLVM::DILocalVariableAttr>(
-            moduleOp, meta, llvmDIFileAttr, dbgCompileUnitAttr, funcOp,
+            moduleOp, meta, funcFileAttr, dbgCompileUnitAttr, funcOp,
             subprogram, op->getLoc());
         if (!localVar)
           return;


### PR DESCRIPTION
Second PR of the module-system series (#290 "Module system"), stacked on #314. A package is **one translation unit** spanning many files, with the reference frontend's semantics.

## Discovery — `rrc --package-root DIR --package-name NAME`

`lib.rr` is the crate root; `mod name;` declarations resolve to `dir/name.rr` then `dir/name/mod.rr`, transitively. Duplicate declarations and cycles are tolerated (each file loads once, keyed by canonical path); a declaration with no source file errors naming both candidates; **`core` is reserved** for the built-in core package. A file's *location* determines its module path (`lib.rr` → `[pkg]`, `foo.rr` / `foo/mod.rr` → `[pkg, foo]`, `foo/bar.rr` → `[pkg, foo, bar]`) — `mod` only drives discovery, matching the Haskell `computeModulePath`/`resolveOneModule` behavior. All files are read into the #314 `SourceCache` and parsed once with one shared interner (cross-file resolution compares interned keys).

## Resolution

`DefTable`'s type/value namespaces are now keyed by **full qualified path** with a current-module scope:

- bare references: current module, then crate root;
- qualified references: absolute, then module-relative, then package-root-relative (first hit wins);
- `root::` resolves against the package root; a leading `super::` run pops module levels (past the root fails) — classified textually by the elaborator into `PathSeg`s.

Types, function calls, constructors (`m::Enum::Variant` vs `m::Foo{…}` disambiguated by whether the qualifier resolves to an enum), patterns, and trampoline targets all route through it. Each item's field types and body resolve in its **own declaration scope** (`enter_item_scope`, restored per item), so one pass checks items from many modules. Same-named items in different modules are distinct defs and mangle distinctly — the v0 mangler already encoded path segments, so `utils/math.rr`'s `double` is `_RNvNvNvC5mypkg5utils4math6double` with no mangler change.

`elaborate_package` scans **every** file's record stubs and prototypes before any field or body resolves, so cross-file forward references and mutual recursion work in any order (the Haskell shared-`SemiContext` model).

## Textual IR

Both grammars accept multi-segment qualified paths; the `path ::<tyargs>` ambiguity is kept LR(1) by factoring path-segment-or-turbofish into one recursive production. The rebuild pass splits serialized paths back into module + item segments, so a package's lossless dump (#314) **round-trips byte-identically** and re-ingests to the same symbols.

## Backend (isolated commit, flagged for review)

`DbgInfoConversion` hung every `DISubprogram` off the single module-level `DIFile` — wrong for a multi-file TU (every function claimed the crate root as `decl_file`). Since the frontend now stamps each function's `FileLineColLoc` with its own file, the conversion derives the subprogram's `DIFile` from that location, keeping the module-level file as the compile unit's and as the fallback. This is the minimal change for the goal's "correct debuginfo"; single-file output is unchanged (derived file ≡ module file). Verified: a 3-file package with `-g` emits three `DIFile`s, each subprogram attributed to its own source.

## Verification

- Unit: module-scoped `DefTable` (distinct same-name items, absolute/module/root-relative, `root::`/`super::`, over-popping), package elaboration (the `module_basic`/`module_relative_paths` shapes as in-process tests, mangled-symbol assertions, full-path error messages), discovery (nested `mod.rr` layouts, duplicate+cycle tolerance, missing-file message, reserved `core`).
- Manual e2e: 3-file nested package → object → linked with a C driver → correct result; `--emit hir|mir` dumps re-parse byte-identically and the re-ingested `.mir` compiles and runs; `-g` shows per-file `DIFile`s.
- All suites green: workspace unit tests, lit 256 passed / 4 unsupported / 0 failed, clippy clean.

The existing `module_*` lit tests stay on the Haskell driver until the final PR of the series migrates them (per plan); PR 3 (multi-CGU) and PR 4 (`core::intrinsic::math`) come next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2