### PR TITLE
[frontend] core::intrinsic::math intrinsics

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -35,6 +35,7 @@ use reussir_backend::melior::ir::{
 
 use reussir_core::full::mir::{self, DecisionTree, Expr, ExprKind, SwitchCases};
 use reussir_core::full::ownership::{OwnershipTable, RcOp, RecordTable, analyze_function};
+use reussir_core::intrinsic::IntrinsicOp;
 use reussir_core::literal::{self, Integer};
 use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use reussir_core::semi::ty::{Flexivity, IntTy, Ty, TyCtxt, TyKind};
@@ -531,6 +532,40 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             Negate(x) => self.negate(block, env, x).map(Some),
             Not(x) => self.not(block, env, x).map(Some),
             Arith(l, op, r) => self.arith(block, env, l, *op, r, e.ty).map(Some),
+            // A `core::intrinsic::<family>` call: dispatch to the family's op
+            // builder over the (scalar) operands. Each family owns its own
+            // dialect ops and attributes; the backend pipeline's dialect
+            // conversions take the emitted op from there.
+            Intrinsic { op, args } => {
+                let mut operands = Vec::with_capacity(args.len());
+                for a in args.iter() {
+                    let v = self.expr(block, env, a)?.ok_or_else(|| {
+                        LoweringError("intrinsic operand produced no value".into())
+                    })?;
+                    operands.push(v);
+                }
+                let result = self.tys.mlir_ty(e.ty)?;
+                let built = match op {
+                    IntrinsicOp::Math { func, flag } => {
+                        let fastmath =
+                            reussir_core::intrinsic::FastMath(*flag)
+                                .mlir_attr()
+                                .map(|text| {
+                                    Attribute::parse(self.context, &text)
+                                        .expect("valid fastmath attribute")
+                                });
+                        super::math::math_operation(
+                            self.context,
+                            *func,
+                            &operands,
+                            result,
+                            fastmath,
+                            loc,
+                        )
+                    }
+                };
+                Ok(Some(self.append(block, built)))
+            }
             Cmp(l, op, r) => self.cmp(block, env, l, *op, r).map(Some),
             Cast(x, t) => self.cast(block, env, x, *t),
             If(c, t, f) => self.lower_if(block, env, c, t, f, e.ty),

--- a/crates/reussir-codegen/src/lower/math.rs
+++ b/crates/reussir-codegen/src/lower/math.rs
@@ -1,0 +1,119 @@
+//! Building `math.<fn>` dialect ops for the `core::intrinsic::math`
+//! intrinsics, through melior's generated ODS builders (`ods::math`).
+//!
+//! Every surfaced intrinsic is one op over scalar float operands with an
+//! optional `fastmath` attribute; the shapes differ only in operand count,
+//! operand names, and whether the result type is inferable
+//! (`SameOperandsAndResultType`) or must be given (the `bool` classification
+//! checks, and `fpowi` whose exponent operand differs).
+
+use reussir_backend::melior::Context;
+use reussir_backend::melior::dialect::ods::math;
+use reussir_backend::melior::ir::attribute::Attribute;
+use reussir_backend::melior::ir::{Location, Operation, Type, Value};
+use reussir_core::intrinsic::MathFn;
+
+/// Build the `math` op for `func` over `operands` (already checked to the
+/// intrinsic's arity), with `fastmath` when the flag is non-empty. `result`
+/// is used only by the shapes whose result is not inferable.
+pub(super) fn math_operation<'c>(
+    context: &'c Context,
+    func: MathFn,
+    operands: &[Value<'c, '_>],
+    result: Type<'c>,
+    fastmath: Option<Attribute<'c>>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    // One arm per op: the generated builders are distinct types, so the
+    // dispatch cannot be a table — the macros keep each shape to one line.
+    macro_rules! unary {
+        ($builder:ident) => {{
+            let b = math::$builder::new(context, location).operand(operands[0]);
+            match fastmath {
+                Some(fm) => b.fastmath(fm).build().into(),
+                None => b.build().into(),
+            }
+        }};
+    }
+    macro_rules! check {
+        ($builder:ident) => {{
+            let b = math::$builder::new(context, location)
+                .result(result)
+                .operand(operands[0]);
+            match fastmath {
+                Some(fm) => b.fastmath(fm).build().into(),
+                None => b.build().into(),
+            }
+        }};
+    }
+    macro_rules! binary {
+        ($builder:ident) => {{
+            let b = math::$builder::new(context, location)
+                .lhs(operands[0])
+                .rhs(operands[1]);
+            match fastmath {
+                Some(fm) => b.fastmath(fm).build().into(),
+                None => b.build().into(),
+            }
+        }};
+    }
+
+    match func {
+        MathFn::Absf => unary!(AbsFOperationBuilder),
+        MathFn::Acos => unary!(AcosOperationBuilder),
+        MathFn::Acosh => unary!(AcoshOperationBuilder),
+        MathFn::Asin => unary!(AsinOperationBuilder),
+        MathFn::Asinh => unary!(AsinhOperationBuilder),
+        MathFn::Atan => unary!(AtanOperationBuilder),
+        MathFn::Atanh => unary!(AtanhOperationBuilder),
+        MathFn::Cbrt => unary!(CbrtOperationBuilder),
+        MathFn::Ceil => unary!(CeilOperationBuilder),
+        MathFn::Cos => unary!(CosOperationBuilder),
+        MathFn::Cosh => unary!(CoshOperationBuilder),
+        MathFn::Erf => unary!(ErfOperationBuilder),
+        MathFn::Erfc => unary!(ErfcOperationBuilder),
+        MathFn::Exp => unary!(ExpOperationBuilder),
+        MathFn::Exp2 => unary!(Exp2OperationBuilder),
+        MathFn::Expm1 => unary!(ExpM1OperationBuilder),
+        MathFn::Floor => unary!(FloorOperationBuilder),
+        MathFn::Log10 => unary!(Log10OperationBuilder),
+        MathFn::Log1p => unary!(Log1pOperationBuilder),
+        MathFn::Log2 => unary!(Log2OperationBuilder),
+        MathFn::Round => unary!(RoundOperationBuilder),
+        MathFn::Roundeven => unary!(RoundEvenOperationBuilder),
+        MathFn::Rsqrt => unary!(RsqrtOperationBuilder),
+        MathFn::Sin => unary!(SinOperationBuilder),
+        MathFn::Sinh => unary!(SinhOperationBuilder),
+        MathFn::Sqrt => unary!(SqrtOperationBuilder),
+        MathFn::Tan => unary!(TanOperationBuilder),
+        MathFn::Tanh => unary!(TanhOperationBuilder),
+        MathFn::Trunc => unary!(TruncOperationBuilder),
+        MathFn::Isfinite => check!(IsFiniteOperationBuilder),
+        MathFn::Isinf => check!(IsInfOperationBuilder),
+        MathFn::Isnan => check!(IsNaNOperationBuilder),
+        MathFn::Isnormal => check!(IsNormalOperationBuilder),
+        MathFn::Atan2 => binary!(Atan2OperationBuilder),
+        MathFn::Copysign => binary!(CopySignOperationBuilder),
+        MathFn::Powf => binary!(PowFOperationBuilder),
+        MathFn::Fma => {
+            let b = math::FmaOperationBuilder::new(context, location)
+                .a(operands[0])
+                .b(operands[1])
+                .c(operands[2]);
+            match fastmath {
+                Some(fm) => b.fastmath(fm).build().into(),
+                None => b.build().into(),
+            }
+        }
+        MathFn::Fpowi => {
+            let b = math::FPowIOperationBuilder::new(context, location)
+                .result(result)
+                .lhs(operands[0])
+                .rhs(operands[1]);
+            match fastmath {
+                Some(fm) => b.fastmath(fm).build().into(),
+                None => b.build().into(),
+            }
+        }
+    }
+}

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -52,6 +52,7 @@
 
 mod debug;
 mod expr;
+mod math;
 mod ty;
 
 use std::borrow::Cow;

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -245,6 +245,11 @@ pub enum ExprKind<'tcx> {
     },
     /// `Nullable::NonNull{e}` (Some) or `Nullable::Null` (None).
     NullableCall(Option<&'tcx Expr<'tcx>>),
+    /// A `core::intrinsic::<family>::<fn>` call (see [`crate::intrinsic`]).
+    Intrinsic {
+        op: crate::intrinsic::IntrinsicOp,
+        args: &'tcx [Expr<'tcx>],
+    },
     Closure(ClosureExpr<'tcx>),
     ClosureCall {
         target: &'tcx Expr<'tcx>,

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -435,6 +435,16 @@ impl<'tcx> Builder<'_, 'tcx> {
                     args: self.expr_slice(args),
                 }
             }
+            raw::Kind::Intrinsic {
+                family,
+                name,
+                imm,
+                args,
+            } => M::Intrinsic {
+                op: crate::intrinsic::IntrinsicOp::parse(family, name, *imm)
+                    .expect("known intrinsic in machine-emitted IR"),
+                args: self.expr_slice(args),
+            },
             raw::Kind::NullableCall(inner) => {
                 M::NullableCall(inner.as_ref().map(|x| self.expr_ref(x)))
             }
@@ -634,6 +644,14 @@ mod tests {
             "pub fn fib(n: u64) -> u64 { \
              let m = n + 1; \
              if n <= 1 { m } else { fib(n - 1) + fib(n - 2) } }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_math_intrinsics() {
+        roundtrip(
+            "pub fn f(x: f64) -> f64 { \
+             core::intrinsic::math::sqrt(core::intrinsic::math::powf(x, 2.0, 127), 0) }",
         );
     }
 

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -186,6 +186,8 @@ Atom: raw::Kind = {
     "@" <symbol:Sym> "{" <args:Comma<Expr>> "}" => raw::Kind::Ctor { symbol, args },
     "@" <symbol:Sym> "::" "#" <v:"int"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::Variant { symbol, variant: raw::small_usize(&v), args },
+    "intrinsic" "#" <family:"ident"> "#" <name:"ident"> "#" <imm:"int"> "(" <args:Comma<Expr>> ")"
+        => raw::Kind::Intrinsic { family: family.to_string(), name: name.to_string(), imm: raw::small_u32(&imm), args },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"
@@ -314,6 +316,7 @@ extern {
         "flex" => Token::Flex,
         "rigid" => Token::Rigid,
         "proj" => Token::Proj,
+        "intrinsic" => Token::Intrinsic,
         "assign" => Token::Assign,
         "Nullable" => Token::Nullable,
         "NonNull" => Token::NonNull,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -391,6 +391,15 @@ impl Render<'_> {
                     + self.arg_list(args)
                     + text(")")
             }
+            Intrinsic { op, args } => {
+                text(format!(
+                    "intrinsic#{}#{}#{}(",
+                    op.family(),
+                    op.name(),
+                    op.imm()
+                )) + self.arg_list(args)
+                    + text(")")
+            }
             NullableCall(inner) => match inner {
                 Some(x) => text("NonNull(") + self.value(x) + text(")"),
                 None => text("Null"),

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -325,6 +325,13 @@ pub enum Kind {
         args: Vec<Expr>,
     },
     NullableCall(Option<Expr>),
+    /// `intrinsic#<family>#<name>#<imm>(args…)` — a `core::intrinsic` call.
+    Intrinsic {
+        family: String,
+        name: String,
+        imm: u32,
+        args: Vec<Expr>,
+    },
     ClosureCall {
         target: Expr,
         args: Vec<Expr>,

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -696,6 +696,10 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                     regional: *regional,
                 }
             }
+            ExprKind::Intrinsic { op, args } => M::Intrinsic {
+                op: *op,
+                args: self.lower_slice(args, subst),
+            },
             ExprKind::CompoundCall {
                 target,
                 ty_args,
@@ -1223,7 +1227,10 @@ mod tests {
             If(c, t, f) => vec![c, t, f],
             Let { value, .. } => vec![value],
             Seq(es) => es.iter().collect(),
-            Call { args, .. } | Ctor { args, .. } | Variant { args, .. } => args.iter().collect(),
+            Call { args, .. }
+            | Ctor { args, .. }
+            | Variant { args, .. }
+            | Intrinsic { args, .. } => args.iter().collect(),
             NullableCall(opt) => opt.into_iter().collect(),
             ClosureCall { target, args } => std::iter::once(target).chain(args.iter()).collect(),
             Closure(c) => vec![c.body],

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -469,7 +469,8 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             }
             ExprKind::Call { args, .. }
             | ExprKind::Ctor { args, .. }
-            | ExprKind::Variant { args, .. } => {
+            | ExprKind::Variant { args, .. }
+            | ExprKind::Intrinsic { args, .. } => {
                 for arg in args {
                     s.union_with(&self.free(arg));
                 }
@@ -591,7 +592,8 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             ExprKind::Seq(es) => self.place_seq(es, live_after),
             ExprKind::Call { args, .. }
             | ExprKind::Ctor { args, .. }
-            | ExprKind::Variant { args, .. } => self.place_args(args, live_after),
+            | ExprKind::Variant { args, .. }
+            | ExprKind::Intrinsic { args, .. } => self.place_args(args, live_after),
             ExprKind::NullableCall(opt) => {
                 if let Some(x) = opt {
                     self.place(x, live_after);

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -399,6 +399,7 @@ fn kind_name(kind: &ExprKind<'_>) -> &'static str {
         ExprKind::Var(_) => "Var",
         ExprKind::Negate(_) => "Negate",
         ExprKind::Not(_) => "Not",
+        ExprKind::Intrinsic { .. } => "Intrinsic",
         ExprKind::Arith(..) => "Arith",
         ExprKind::Cmp(..) => "Cmp",
         ExprKind::Cast(..) => "Cast",
@@ -727,7 +728,8 @@ fn interp<'tcx>(
         }
         ExprKind::Call { args, .. }
         | ExprKind::Ctor { args, .. }
-        | ExprKind::Variant { args, .. } => {
+        | ExprKind::Variant { args, .. }
+        | ExprKind::Intrinsic { args, .. } => {
             for a in args {
                 interp(a, ot, rr, rc);
             }
@@ -926,7 +928,9 @@ fn children<'tcx>(e: &Expr<'tcx>) -> Vec<&'tcx Expr<'tcx>> {
         If(c, t, e) => vec![c, t, e],
         Let { value, .. } => vec![value],
         Seq(es) => es.iter().collect(),
-        Call { args, .. } | Ctor { args, .. } | Variant { args, .. } => args.iter().collect(),
+        Call { args, .. } | Ctor { args, .. } | Variant { args, .. } | Intrinsic { args, .. } => {
+            args.iter().collect()
+        }
         NullableCall(opt) => opt.into_iter().collect(),
         ClosureCall { target, args } => std::iter::once(target).chain(args.iter()).collect(),
         Closure(c) => vec![c.body],

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -1,0 +1,261 @@
+//! The built-in `core` package's math intrinsics.
+//!
+//! Reussir source reaches them as `core::intrinsic::math::<name>(args…, flag)`
+//! — the package name `core` is reserved, so the path can never collide with
+//! user code. Each intrinsic maps 1:1 onto an MLIR `math` dialect op; the
+//! trailing argument is always a **constant** `i32` fast-math flag
+//! ([`FastMath`]), and the value operands share one `FloatingPoint`-bounded
+//! type (given as an optional explicit type argument, or inferred).
+//!
+//! The surfaced set matches the reference frontend: the float unary group,
+//! the `is*` classification checks (returning `bool`), the float binary
+//! group, `fma`, and `fpowi` (float base, `i32` exponent).
+
+/// The shape of a math intrinsic's value arguments (the fast-math flag is an
+/// extra trailing argument in the surface form, not counted here).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MathKind {
+    /// One float in, same float out (`sqrt`, `sin`, …).
+    Unary,
+    /// One float in, `bool` out (`isnan`, …).
+    Check,
+    /// Two floats in, same float out (`powf`, `atan2`, `copysign`).
+    Binary,
+    /// Fused multiply-add: three floats in, same float out.
+    Fma,
+    /// Float base and `i32` exponent in, float out.
+    Fpowi,
+}
+
+macro_rules! math_fns {
+    ($($variant:ident => $name:literal : $kind:ident),* $(,)?) => {
+        /// A surfaced math intrinsic; [`Self::as_str`] is both the surface
+        /// name and the MLIR `math.<name>` mnemonic.
+        #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+        pub enum MathFn {
+            $($variant),*
+        }
+
+        impl MathFn {
+            /// Parse a surface / textual-IR name.
+            pub fn parse(name: &str) -> Option<MathFn> {
+                match name {
+                    $($name => Some(MathFn::$variant),)*
+                    _ => None,
+                }
+            }
+
+            /// The surface name, also the `math.<name>` op mnemonic.
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(MathFn::$variant => $name),*
+                }
+            }
+
+            pub fn kind(self) -> MathKind {
+                match self {
+                    $(MathFn::$variant => MathKind::$kind),*
+                }
+            }
+        }
+    };
+}
+
+math_fns! {
+    Absf => "absf": Unary,
+    Acos => "acos": Unary,
+    Acosh => "acosh": Unary,
+    Asin => "asin": Unary,
+    Asinh => "asinh": Unary,
+    Atan => "atan": Unary,
+    Atanh => "atanh": Unary,
+    Cbrt => "cbrt": Unary,
+    Ceil => "ceil": Unary,
+    Cos => "cos": Unary,
+    Cosh => "cosh": Unary,
+    Erf => "erf": Unary,
+    Erfc => "erfc": Unary,
+    Exp => "exp": Unary,
+    Exp2 => "exp2": Unary,
+    Expm1 => "expm1": Unary,
+    Floor => "floor": Unary,
+    Log10 => "log10": Unary,
+    Log1p => "log1p": Unary,
+    Log2 => "log2": Unary,
+    Round => "round": Unary,
+    Roundeven => "roundeven": Unary,
+    Rsqrt => "rsqrt": Unary,
+    Sin => "sin": Unary,
+    Sinh => "sinh": Unary,
+    Sqrt => "sqrt": Unary,
+    Tan => "tan": Unary,
+    Tanh => "tanh": Unary,
+    Trunc => "trunc": Unary,
+    Isfinite => "isfinite": Check,
+    Isinf => "isinf": Check,
+    Isnan => "isnan": Check,
+    Isnormal => "isnormal": Check,
+    Atan2 => "atan2": Binary,
+    Copysign => "copysign": Binary,
+    Powf => "powf": Binary,
+    Fma => "fma": Fma,
+    Fpowi => "fpowi": Fpowi,
+}
+
+impl MathKind {
+    /// How many *value* arguments the intrinsic takes (the constant fast-math
+    /// flag is one more).
+    pub fn value_args(self) -> usize {
+        match self {
+            MathKind::Unary | MathKind::Check => 1,
+            MathKind::Binary | MathKind::Fpowi => 2,
+            MathKind::Fma => 3,
+        }
+    }
+}
+
+/// A fast-math flag set, the constant trailing `i32` argument of every math
+/// intrinsic. Bit-compatible with MLIR's `arith.fastmath` bits; `0` is none
+/// and `127` (all bits) is `fast`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct FastMath(pub u32);
+
+impl FastMath {
+    pub const MAX: u32 = 127;
+
+    const NAMES: [(u32, &'static str); 7] = [
+        (1, "reassoc"),
+        (2, "nnan"),
+        (4, "ninf"),
+        (8, "nsz"),
+        (16, "arcp"),
+        (32, "contract"),
+        (64, "afn"),
+    ];
+
+    /// The MLIR `#arith.fastmath<…>` attribute text, or `None` for an empty
+    /// flag set (MLIR's default — no attribute needed).
+    pub fn mlir_attr(self) -> Option<String> {
+        if self.0 == 0 {
+            return None;
+        }
+        if self.0 == Self::MAX {
+            return Some("#arith.fastmath<fast>".to_string());
+        }
+        let names: Vec<&str> = Self::NAMES
+            .iter()
+            .filter(|(bit, _)| self.0 & bit != 0)
+            .map(|&(_, name)| name)
+            .collect();
+        Some(format!("#arith.fastmath<{}>", names.join(",")))
+    }
+}
+
+/// A resolved intrinsic operation: which family, which op within it, and the
+/// family's compile-time immediates. One generic `Intrinsic` IR node carries
+/// this through HIR/MIR, so the node itself — and its traversal, ownership, and
+/// monomorphization — stay family-agnostic. Adding a family (`arith`, `atomic`,
+/// …) adds a variant here plus its own checking and codegen; the shared IR
+/// plumbing is untouched.
+///
+/// The textual IR spells an op as `intrinsic#<family>#<name>#<imm>(args…)`,
+/// where `<imm>` is the family's packed immediate ([`Self::imm`]); [`Self::parse`]
+/// rebuilds the typed op from that triple.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum IntrinsicOp {
+    /// `core::intrinsic::math::<func>`, with an `arith.fastmath` flag.
+    Math { func: MathFn, flag: u32 },
+}
+
+impl IntrinsicOp {
+    /// The family segment under `core::intrinsic::` (`math`, …).
+    pub fn family(self) -> &'static str {
+        match self {
+            IntrinsicOp::Math { .. } => "math",
+        }
+    }
+
+    /// The op's name within its family (also the dialect mnemonic).
+    pub fn name(self) -> &'static str {
+        match self {
+            IntrinsicOp::Math { func, .. } => func.as_str(),
+        }
+    }
+
+    /// The family's packed immediate, as printed in the textual IR.
+    pub fn imm(self) -> u32 {
+        match self {
+            IntrinsicOp::Math { flag, .. } => flag,
+        }
+    }
+
+    /// Rebuild a typed op from a textual-IR `(family, name, imm)` triple.
+    /// `None` if the family or name is unknown.
+    pub fn parse(family: &str, name: &str, imm: u32) -> Option<IntrinsicOp> {
+        match family {
+            "math" => Some(IntrinsicOp::Math {
+                func: MathFn::parse(name)?,
+                flag: imm,
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intrinsic_op_round_trips_through_textual_triple() {
+        for op in [
+            IntrinsicOp::Math {
+                func: MathFn::Sqrt,
+                flag: 0,
+            },
+            IntrinsicOp::Math {
+                func: MathFn::Fma,
+                flag: 127,
+            },
+        ] {
+            assert_eq!(
+                IntrinsicOp::parse(op.family(), op.name(), op.imm()),
+                Some(op)
+            );
+        }
+        assert_eq!(IntrinsicOp::parse("math", "nope", 0), None);
+        assert_eq!(IntrinsicOp::parse("atomic", "sqrt", 0), None);
+    }
+
+    #[test]
+    fn names_round_trip() {
+        for f in [
+            MathFn::Sqrt,
+            MathFn::Isnan,
+            MathFn::Powf,
+            MathFn::Fma,
+            MathFn::Fpowi,
+        ] {
+            assert_eq!(MathFn::parse(f.as_str()), Some(f));
+        }
+        assert_eq!(MathFn::parse("log"), None);
+        assert_eq!(MathFn::parse("sincos"), None);
+    }
+
+    #[test]
+    fn fastmath_attr_spellings() {
+        assert_eq!(FastMath(0).mlir_attr(), None);
+        assert_eq!(
+            FastMath(127).mlir_attr().as_deref(),
+            Some("#arith.fastmath<fast>")
+        );
+        assert_eq!(
+            FastMath(6).mlir_attr().as_deref(),
+            Some("#arith.fastmath<nnan,ninf>")
+        );
+        assert_eq!(
+            FastMath(1).mlir_attr().as_deref(),
+            Some("#arith.fastmath<reassoc>")
+        );
+    }
+}

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -66,6 +66,8 @@ pub enum Token<'a> {
     Rigid,
     #[token("proj")]
     Proj,
+    #[token("intrinsic")]
+    Intrinsic,
     #[token("assign")]
     Assign,
     #[token("scrut")]

--- a/crates/reussir-core/src/lib.rs
+++ b/crates/reussir-core/src/lib.rs
@@ -9,6 +9,8 @@
 //! interner and adds the ground-only invariant and v0 symbol mangling.
 
 pub mod full;
+/// The built-in `core` package's math intrinsics (`core::intrinsic::math`).
+pub mod intrinsic;
 /// The shared logos lexer for the textual IR (both the MIR and HIR grammars).
 pub mod ir_lex;
 /// Arbitrary-precision numeric literals, carried exact through HIR/MIR and

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -267,6 +267,108 @@ mod tests {
     }
 
     #[test]
+    fn math_intrinsics_type_check_per_shape() {
+        check(
+            r#"
+                fn trig(x : f64) -> f64 {
+                    core::intrinsic::math::cos(x, 1) + core::intrinsic::math::sin(x, 127)
+                }
+                fn narrow(x : f32) -> f32 {
+                    core::intrinsic::math::sqrt<f32>(x, 0)
+                }
+                fn classify(x : f64) -> bool {
+                    core::intrinsic::math::isnan(core::intrinsic::math::powf(x, 2.0, 0), 0)
+                }
+                fn ipow(x : f64) -> f64 {
+                    core::intrinsic::math::fpowi(x, 3, 0)
+                }
+                fn fused(a : f64, b : f64, c : f64) -> f64 {
+                    core::intrinsic::math::fma(a, b, c, 127)
+                }
+            "#,
+            |elab, _| {
+                use crate::intrinsic::{IntrinsicOp, MathFn};
+                use crate::semi::hir::ExprKind;
+                // The elaborated bodies carry `Intrinsic` nodes with the parsed
+                // op + flag (spot-check `trig`).
+                let trig = &elab.elaborated[0];
+                let ExprKind::Arith(l, _, r) = &trig.body.as_ref().unwrap().kind else {
+                    panic!("trig body is an addition");
+                };
+                let ExprKind::Intrinsic { op, args } = &l.kind else {
+                    panic!("lhs is an intrinsic");
+                };
+                assert_eq!(
+                    (*op, args.len()),
+                    (
+                        IntrinsicOp::Math {
+                            func: MathFn::Cos,
+                            flag: 1
+                        },
+                        1
+                    )
+                );
+                let ExprKind::Intrinsic { op, .. } = &r.kind else {
+                    panic!("rhs is an intrinsic");
+                };
+                assert_eq!(
+                    *op,
+                    IntrinsicOp::Math {
+                        func: MathFn::Sin,
+                        flag: 127
+                    }
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn math_intrinsics_reject_bad_shapes() {
+        // A non-constant fast-math flag.
+        let msg = |reports: Vec<Report>| {
+            reports
+                .iter()
+                .map(|r| r.message.clone())
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        let m = msg(reports_of(
+            "pub fn f(x : f64) -> f64 { core::intrinsic::math::cos(x, x) }",
+        ));
+        assert!(m.contains("must be a constant integer"), "{m}");
+        // A flag out of range.
+        let m = msg(reports_of(
+            "pub fn f(x : f64) -> f64 { core::intrinsic::math::cos(x, 128) }",
+        ));
+        assert!(m.contains("must be a constant integer"), "{m}");
+        // An unknown intrinsic name, and a non-math `core` path.
+        let m = msg(reports_of(
+            "pub fn f(x : f64) -> f64 { core::intrinsic::math::tanhh(x, 1) }",
+        ));
+        assert!(
+            m.contains("unknown math intrinsic `core::intrinsic::math::tanhh`"),
+            "{m}"
+        );
+        let m = msg(reports_of(
+            "pub fn f(x : f64) -> f64 { core::other::cos(x, 1) }",
+        ));
+        assert!(
+            m.contains("the built-in `core` package has no function `core::other::cos`"),
+            "{m}"
+        );
+        // A non-float operand fails the FloatingPoint bound.
+        let m = msg(reports_of(
+            "pub fn f(x : u64) -> u64 { core::intrinsic::math::cos(x, 1) }",
+        ));
+        assert!(m.contains("does not implement `FloatingPoint`"), "{m}");
+        // Wrong arity (the trailing flag is required).
+        let m = msg(reports_of(
+            "pub fn f(x : f64) -> f64 { core::intrinsic::math::cos(x) }",
+        ));
+        assert!(m.contains("expects 2 argument(s)"), "{m}");
+    }
+
+    #[test]
     fn try_extend_accumulates_and_rolls_back_atomically() {
         use std::sync::Arc;
 

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -460,6 +460,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             let callee = self.mk_expr(ExprKind::Var(id), ty, span);
             return self.closure_apply(callee, &fc.args, span);
         }
+        // The built-in `core` package: `core::intrinsic::<family>::<fn>` calls
+        // are intrinsics, and nothing else lives under `core` (the package name
+        // is reserved, so this can never shadow user code).
+        if let Some(done) = self.infer_intrinsic(fc, span) {
+            return done;
+        }
         let Some(def) = self.resolve_function_ref(&fc.name) else {
             let hint = if fc.name.segments.is_empty() {
                 self.function_suggestion(fc.name.basename)
@@ -828,6 +834,124 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// A constructor-call expression; see [`Self::infer_ctor`] for the dispatch rules.
     fn infer_ctor_call(&mut self, cc: &surface::CtorCall, span: Option<Span>) -> Expr<'tcx> {
         self.infer_ctor(&cc.name, &cc.ty_args, &cc.args, span)
+    }
+
+    /// The built-in `core` package's intrinsics, spelled
+    /// `core::intrinsic::<family>::<fn>`. Routes to the family checker;
+    /// `None` only when the call does not target `core` at all, so ordinary
+    /// resolution proceeds. Adding a family adds an arm here plus its worker.
+    fn infer_intrinsic(
+        &mut self,
+        fc: &surface::FuncCall,
+        span: Option<Span>,
+    ) -> Option<Expr<'tcx>> {
+        if fc.name.segments.first().map(|&k| self.sym(k)) != Some("core") {
+            return None;
+        }
+        let segs: Vec<&str> = fc.name.segments.iter().map(|&k| self.sym(k)).collect();
+        // Everything under `core` is an intrinsic; nothing else lives there.
+        let ["core", "intrinsic", family] = segs.as_slice() else {
+            let shown = self.path_display(&fc.name);
+            self.error(
+                span,
+                format!("the built-in `core` package has no function `{shown}`"),
+            );
+            return Some(self.poison(span));
+        };
+        match *family {
+            "math" => Some(self.infer_math_intrinsic(fc, span)),
+            other => {
+                self.error(
+                    span,
+                    format!("unknown intrinsic family `core::intrinsic::{other}`"),
+                );
+                Some(self.poison(span))
+            }
+        }
+    }
+
+    /// (MATH) `core::intrinsic::math::<fn>::<T?>(args…, flag)`: the value
+    /// operands share one `FloatingPoint`-bounded element type `T` (explicit
+    /// or inferred; `fpowi`'s exponent is `i32`), the `is*` checks return
+    /// `bool` and everything else returns `T`, and the trailing argument is a
+    /// **constant** `i32` fast-math flag (`0..=127`, `0` = none, `127` = fast).
+    fn infer_math_intrinsic(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
+        use crate::intrinsic::{FastMath, IntrinsicOp, MathFn, MathKind};
+
+        let name = self.sym(fc.name.basename);
+        let Some(func) = MathFn::parse(name) else {
+            self.error(
+                span,
+                format!("unknown math intrinsic `core::intrinsic::math::{name}`"),
+            );
+            return self.poison(span);
+        };
+
+        // The shared element type: an optional single explicit type argument,
+        // else inferred — either way bounded by `FloatingPoint`.
+        let elem = match fc.ty_args.as_slice() {
+            [] | [None] => self.infer.new_hole_ty(),
+            [Some(t)] => self.eval_type(t),
+            _ => {
+                self.error(
+                    span,
+                    format!("`{name}` takes at most one type argument (the operand type)"),
+                );
+                return self.poison(span);
+            }
+        };
+        self.register_bound(self.builtins.floating_point, elem, span);
+
+        let kind = func.kind();
+        let want = kind.value_args() + 1;
+        if fc.args.len() != want {
+            self.error(
+                span,
+                format!(
+                    "`{name}` expects {want} argument(s) (including the trailing                      fast-math flag), got {}",
+                    fc.args.len()
+                ),
+            );
+            return self.poison(span);
+        }
+        let i32_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Signed(32));
+        let (value_args, flag_arg) = fc.args.split_at(want - 1);
+        let mut args = Vec::with_capacity(value_args.len());
+        for (i, a) in value_args.iter().enumerate() {
+            // `fpowi` raises a float to an integer power; everything else is
+            // uniform over the element type.
+            let expected = if kind == MathKind::Fpowi && i == 1 {
+                i32_ty
+            } else {
+                elem
+            };
+            args.push(self.check_expr(a, expected));
+        }
+        // The flag selects `arith.fastmath` bits at compile time, so it must
+        // be a literal — not merely an `i32`-typed expression.
+        let flag_expr = self.check_expr(&flag_arg[0], i32_ty);
+        let flag = match &flag_expr.kind {
+            ExprKind::ConstInt(n) => u32::try_from(*n).ok().filter(|f| *f <= FastMath::MAX),
+            _ => None,
+        };
+        let Some(flag) = flag else {
+            self.error(
+                flag_expr.span,
+                format!(
+                    "the fast-math flag of `{name}` must be a constant integer \
+                     in 0..=127 (0 = none, 127 = fast)"
+                ),
+            );
+            return self.poison(span);
+        };
+
+        let result = if kind == MathKind::Check {
+            self.tcx.mk_bool()
+        } else {
+            elem
+        };
+        let op = IntrinsicOp::Math { func, flag };
+        self.mk_expr(ExprKind::Intrinsic { op, args }, result, span)
     }
 
     /// Dispatch a constructor path: `Nullable::…` → [`Self::infer_nullable`]; a
@@ -1358,6 +1482,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
             },
             NullableCall(e) => NullableCall(e.map(|e| zb(self, e))),
+            Intrinsic { op, args } => Intrinsic {
+                op,
+                args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
+            },
             ClosureCall { target, args } => ClosureCall {
                 target: zb(self, target),
                 args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
@@ -1417,6 +1545,11 @@ fn free_vars<'tcx>(e: &Expr<'tcx>, out: &mut Vec<VarId>) {
     };
     match &e.kind {
         Var(v) => push(out, *v),
+        Intrinsic { args, .. } => {
+            for a in args {
+                free_vars(a, out);
+            }
+        }
         Negate(e) | Not(e) | Cast(e, _) | RegionRun(e) | Proj(e, _) => free_vars(e, out),
         Arith(l, _, r) | Cmp(l, _, r) | Assign(l, _, r) => {
             free_vars(l, out);

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -140,6 +140,12 @@ pub enum ExprKind<'tcx> {
     },
     /// `Nullable::NonNull{e}` (Some) or `Nullable::Null` (None).
     NullableCall(Option<Box<Expr<'tcx>>>),
+    /// A `core::intrinsic::<family>::<fn>` call: the resolved op (family + its
+    /// immediates) and the value operands (the node's own type is the result).
+    Intrinsic {
+        op: crate::intrinsic::IntrinsicOp,
+        args: Vec<Expr<'tcx>>,
+    },
     Closure(ClosureExpr<'tcx>),
     ClosureCall {
         target: Box<Expr<'tcx>>,

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -396,6 +396,16 @@ impl<'tcx> Builder<'_, 'tcx> {
                     args: self.exprs(args),
                 }
             }
+            raw::Kind::Intrinsic {
+                family,
+                name,
+                imm,
+                args,
+            } => ExprKind::Intrinsic {
+                op: crate::intrinsic::IntrinsicOp::parse(family, name, *imm)
+                    .expect("known intrinsic in machine-emitted IR"),
+                args: self.exprs(args),
+            },
             raw::Kind::NullableCall(inner) => {
                 ExprKind::NullableCall(inner.as_ref().map(|x| self.boxed(x)))
             }
@@ -699,6 +709,17 @@ mod tests {
         roundtrip_with_locations(
             "enum Opt { None, Some(i64) }\n\
              pub fn g(o: Opt) -> i64 { match o { Opt::None => 0, Opt::Some(x) => { let y = x; y } } }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_math_intrinsics() {
+        roundtrip(
+            "fn f(x: f64) -> bool { \
+             core::intrinsic::math::isnan(core::intrinsic::math::fma(x, x, x, 127), 0) }",
+        );
+        roundtrip_with_locations(
+            "pub fn g(x: f64) -> f64 { core::intrinsic::math::fpowi(x, 3, 1) }",
         );
     }
 

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -226,6 +226,8 @@ Atom: raw::Kind = {
         => raw::Kind::CompoundCall { path: path.0, ty_args: path.1, args },
     "#" <path:PathArgs> "#" <v:"int"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::VariantCall { path: path.0, ty_args: path.1, variant: raw::small_usize(&v), args },
+    "intrinsic" "#" <family:"ident"> "#" <name:"ident"> "#" <imm:"int"> "(" <args:Comma<Expr>> ")"
+        => raw::Kind::Intrinsic { family: family.to_string(), name: name.to_string(), imm: raw::small_u32(&imm), args },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"
@@ -350,6 +352,7 @@ extern {
         "flex" => Token::Flex,
         "rigid" => Token::Rigid,
         "proj" => Token::Proj,
+        "intrinsic" => Token::Intrinsic,
         "assign" => Token::Assign,
         "Nullable" => Token::Nullable,
         "NonNull" => Token::NonNull,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -458,6 +458,15 @@ impl<'a> Printer<'a> {
                     + self.arg_list(args)
                     + text(")")
             }
+            ExprKind::Intrinsic { op, args } => {
+                text(format!(
+                    "intrinsic#{}#{}#{}(",
+                    op.family(),
+                    op.name(),
+                    op.imm()
+                )) + self.arg_list(args)
+                    + text(")")
+            }
             ExprKind::NullableCall(inner) => match inner {
                 Some(x) => text("NonNull(") + self.value(x) + text(")"),
                 None => text("Null"),

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -247,6 +247,13 @@ pub enum Kind {
         args: Vec<Expr>,
     },
     NullableCall(Option<Expr>),
+    /// `intrinsic#<family>#<name>#<imm>(args…)` — a `core::intrinsic` call.
+    Intrinsic {
+        family: String,
+        name: String,
+        imm: u32,
+        args: Vec<Expr>,
+    },
     ClosureCall {
         target: Expr,
         args: Vec<Expr>,


### PR DESCRIPTION
Fourth PR of the module-system series (#290 "Math intrinsics not accessible yet"), stacked on #316: the reference frontend's math intrinsics come back through the reserved built-in `core` package.

## Surface & checking

`core::intrinsic::math::<fn>::<T?>(args…, flag)` — since #315 reserves the package name `core`, the path can never collide with user code. The surfaced set matches the Haskell `Tyck` table exactly: the float unary group (`absf acos acosh asin asinh atan atanh cbrt ceil cos cosh erf erfc exp exp2 expm1 floor log10 log1p log2 round roundeven rsqrt sin sinh sqrt tan tanh trunc`), the `is*` classification checks (returning `bool`), `atan2`/`copysign`/`powf`, `fma`, and `fpowi` (float base, `i32` exponent).

- The value operands share one `FloatingPoint`-bounded element type — an optional explicit type argument (`sqrt<f32>(x, 0)`) or inferred.
- The trailing argument is a **constant** `i32` fast-math flag, `0..=127` (bit-compatible with `arith.fastmath`; `0` none, `127` fast) — a non-constant or out-of-range flag is a dedicated diagnostic, as are unknown intrinsic names and non-math `core` paths (`the built-in `core` package has no function …`).

## Pipeline

`MathIntrinsic { func, args, flag }` flows through HIR and MIR (ownership treats operands like any scalar call), serializes as `intrinsic#<name>#<flag>(args…)` in both textual IRs — **lossless round trip** preserved — and lowers through **melior's generated ODS builders** (`ods::math::…OperationBuilder`, per review guidance — no raw `OperationBuilder`), attaching the `fastmath` attribute when the flag is non-empty. The shared backend pipeline already registers MathToLLVM/MathToLibm, so no backend changes.

## Verification

- Unit: `MathFn`/`FastMath` table round-trips and attribute spellings; checker accepts every shape (unary/check/binary/fma/fpowi, explicit + inferred element types) and rejects non-constant flags, out-of-range flags, unknown names, non-math `core` paths, non-float operands, and wrong arity; textual HIR/MIR round-trip tests with intrinsics (including the with-locations lossless form).
- Manual e2e: the reference `math.rr` shape emits `intrinsic<…>`-style MIR and `math.cos %arg0 fastmath<reassoc>` MLIR; `sqrt(x²+y²)` and `fpowi(x,3)` compiled → linked with a C driver → correct results; the `.mir` dump re-ingests to a working object.
- All suites green: workspace tests, lit 256 / 0 failed, clippy clean.

The `math.rr` lit test migrates to `%rrc` in the final PR of the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2