### PR TITLE
[tests] migrate the module and math tests from the Haskell driver to rrc

### DIFF
--- a/tests/integration/frontend/math.rr
+++ b/tests/integration/frontend/math.rr
@@ -1,14 +1,23 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %reussir-elab --mode full %s | %FileCheck %s
-// RUN: %reussir-compiler %s -o %t.o
+// The `core::intrinsic::math` intrinsics: the trailing constant `i32` is the
+// fast-math flag (`1` = reassoc, `127` = fast, `0` = none). The HIR dump pins
+// the checked intrinsic form and its flag; the MLIR dump pins the `math`
+// dialect op with its `fastmath` attribute.
 
-// CHECK-DAG: fn _RC3cos(x: f64) -> f64 {
-// CHECK-NEXT-DAG: intrinsic<core::intrinsic::math::cos>(v0, 1.0 : i32) : f64
-// CHECK-NEXT-DAG: }
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mlir -o - | %FileCheck %s --check-prefix=MLIR
+// RUN: %rrc %s -o %t.o
 
-// CHECK-DAG: fn _RC3sin(x: f64) -> f64 {
-// CHECK-NEXT-DAG: intrinsic<core::intrinsic::math::sin>(v0, 127.0 : i32) : f64
-// CHECK-NEXT-DAG: }
+// CHECK: fn #cos(v0 (x): f64) -> f64 {
+// CHECK-NEXT: intrinsic#math#cos#1(v0 : f64) : f64
+// CHECK-NEXT: }
+
+// CHECK: fn #sin(v0 (x): f64) -> f64 {
+// CHECK-NEXT: intrinsic#math#sin#127(v0 : f64) : f64
+// CHECK-NEXT: }
+
+// MLIR: math.cos %{{.*}} fastmath<reassoc> : f64
+// MLIR: math.sin %{{.*}} fastmath<fast> : f64
+
 fn cos(x : f64) -> f64 {
     core::intrinsic::math::cos(x, 1)
 }
@@ -16,3 +25,9 @@ fn cos(x : f64) -> f64 {
 fn sin(x : f64) -> f64 {
     core::intrinsic::math::sin(x, 127)
 }
+
+pub fn main(x : f64) -> f64 {
+    cos(x) + sin(x)
+}
+
+extern "C" trampoline "reussir_main" = main;

--- a/tests/integration/frontend/module_basic.rr
+++ b/tests/integration/frontend/module_basic.rr
@@ -1,5 +1,12 @@
-// RUN: %reussir-elab --mode semi --package-root %S/module_basic --package-name mylib
-// RUN: %reussir-elab --mode full --package-root %S/module_basic --package-name mylib
-// RUN: %reussir-compiler --package-root %S/module_basic --package-name mylib -o %t.o
-// RUN: %cc %t.o %S/module_basic/driver.c -o %t.exe
+// A two-file package: `lib.rr` declares `mod math;` and calls `math::add`
+// cross-module; the exported trampoline drives the C driver. The HIR dump
+// pins the fully-qualified item paths module resolution produced.
+
+// RUN: %rrc --package-root %S/module_basic --package-name mylib --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc --package-root %S/module_basic --package-name mylib -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/module_basic/driver.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
+
+// CHECK: pub fn #mylib::entry(v0 (n): u64) -> u64 {
+// CHECK-NEXT: #mylib::math::add(v0 : u64, 10 : u64) : u64
+// CHECK: pub fn #mylib::math::add(v0 (a): u64, v1 (b): u64) -> u64 {

--- a/tests/integration/frontend/module_cycle_duplicate.rr
+++ b/tests/integration/frontend/module_cycle_duplicate.rr
@@ -1,5 +1,7 @@
-// RUN: %reussir-elab --mode semi --package-root %S/module_cycle_duplicate --package-name mypkg
-// RUN: %reussir-elab --mode full --package-root %S/module_cycle_duplicate --package-name mypkg
-// RUN: %reussir-compiler --package-root %S/module_cycle_duplicate --package-name mypkg -o %t.o
-// RUN: %cc %t.o %S/module_cycle_duplicate/driver.c -o %t.exe
+// Discovery tolerates a duplicate `mod a;` declaration and an `a` ↔ `b`
+// declaration cycle: each file joins the package exactly once (keyed by its
+// canonical path), and cross-references still resolve.
+
+// RUN: %rrc --package-root %S/module_cycle_duplicate --package-name mypkg -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/module_cycle_duplicate/driver.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe

--- a/tests/integration/frontend/module_missing_file.rr
+++ b/tests/integration/frontend/module_missing_file.rr
@@ -1,8 +1,9 @@
-// RUN: %not %reussir-elab --mode semi --package-root %S/module_missing_file --package-name mypkg 2>&1 | %FileCheck %s --check-prefix=ERR
-// RUN: %not %reussir-elab --mode full --package-root %S/module_missing_file --package-name mypkg 2>&1 | %FileCheck %s --check-prefix=ERR
-// RUN: %not %reussir-compiler --package-root %S/module_missing_file --package-name mypkg -o %t.o 2>&1 | %FileCheck %s --check-prefix=ERR
+// A `mod missing;` declaration with no source file is a discovery error
+// naming both candidate paths (`missing.rr` and `missing/mod.rr`).
 
-// ERR: Error: module 'missing'
-// ERR: has no source file
-// ERR: missing.rr
-// ERR: missing{{[/\\]}}mod.rr
+// RUN: %not %rrc --package-root %S/module_missing_file --package-name mypkg -o %t.o 2>&1 | %FileCheck %s --check-prefix=ERR
+
+// ERR: error: module 'missing'
+// ERR-SAME: has no source file
+// ERR-SAME: missing.rr
+// ERR-SAME: missing{{[/\\]}}mod.rr

--- a/tests/integration/frontend/module_nested.rr
+++ b/tests/integration/frontend/module_nested.rr
@@ -1,5 +1,6 @@
-// RUN: %reussir-elab --mode semi --package-root %S/module_nested --package-name mypkg
-// RUN: %reussir-elab --mode full --package-root %S/module_nested --package-name mypkg
-// RUN: %reussir-compiler --package-root %S/module_nested --package-name mypkg -o %t.o
-// RUN: %cc %t.o %S/module_nested/driver.c -o %t.exe
+// A nested module tree: `lib.rr` → `utils/mod.rr` → `utils/math.rr`, with
+// calls through two module levels (`utils::math::double`, `utils::offset`).
+
+// RUN: %rrc --package-root %S/module_nested --package-name mypkg -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/module_nested/driver.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe

--- a/tests/integration/frontend/module_relative_paths.rr
+++ b/tests/integration/frontend/module_relative_paths.rr
@@ -1,5 +1,7 @@
-// RUN: %reussir-elab --mode semi --package-root %S/module_relative_paths --package-name mypkg
-// RUN: %reussir-elab --mode full --package-root %S/module_relative_paths --package-name mypkg
-// RUN: %reussir-compiler --package-root %S/module_relative_paths --package-name mypkg -o %t.o
-// RUN: %cc %t.o %S/module_relative_paths/driver.c -o %t.exe
+// Module-relative reference paths: `root::` (package-root-relative),
+// `super::` and `super::super::` (parent-relative), across a tree of four
+// modules — the discovery and resolution rules of the reference frontend.
+
+// RUN: %rrc --package-root %S/module_relative_paths --package-name mypkg -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/module_relative_paths/driver.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe

--- a/tests/integration/frontend/module_reserved_package.rr
+++ b/tests/integration/frontend/module_reserved_package.rr
@@ -1,5 +1,6 @@
-// RUN: %not %reussir-elab --mode semi --package-root %S/module_reserved_package --package-name core 2>&1 | %FileCheck %s --check-prefix=ERR
-// RUN: %not %reussir-elab --mode full --package-root %S/module_reserved_package --package-name core 2>&1 | %FileCheck %s --check-prefix=ERR
-// RUN: %not %reussir-compiler --package-root %S/module_reserved_package --package-name core -o %t.o 2>&1 | %FileCheck %s --check-prefix=ERR
+// The package name `core` is reserved for the built-in core package
+// (`core::intrinsic::math::…`), so a user package cannot claim it.
 
-// ERR: Error: package name 'core' is reserved for the built-in core package
+// RUN: %not %rrc --package-root %S/module_reserved_package --package-name core -o %t.o 2>&1 | %FileCheck %s --check-prefix=ERR
+
+// ERR: error: package name 'core' is reserved for the built-in core package

--- a/tests/integration/repl-rs/polymorphic_math.repl
+++ b/tests/integration/repl-rs/polymorphic_math.repl
@@ -1,4 +1,4 @@
-// RUN: %reussir-repl -i %s -lerror -Onone | %FileCheck %s
+// RUN: %rrepl -i %s -lerror -Onone | %FileCheck %s
 
 fn cos_squared(x: f64) -> f64 { let y = core::intrinsic::math::cos(x, 0); y * y }
 // CHECK: Definition added.


### PR DESCRIPTION
Final PR of the module-system series (#290), stacked on #317: the module/math lit corpus moves off `%reussir-elab`/`%reussir-compiler`.

- **module_basic / module_nested / module_relative_paths / module_cycle_duplicate** — compile with `%rrc --package-root … --package-name …` and execute against their existing C drivers (standard rrc exec conventions). `module_basic` also FileChecks the HIR dump's fully-qualified paths (`#mylib::math::add`), pinning module resolution.
- **module_missing_file / module_reserved_package** — `%not %rrc` with the rrc-spelled diagnostics (`error: module 'missing' … has no source file; expected one of: …`; `error: package name 'core' is reserved for the built-in core package`).
- **math.rr** — `%rrc`, checking the HIR intrinsic form (`intrinsic#cos#1(v0 : f64)`) and the emitted `math.cos … fastmath<reassoc>` / `math.sin … fastmath<fast>` MLIR, plus an object compile.
- **repl/polymorphic.repl** — the last math-gated Haskell REPL test moves to `repl-rs/polymorphic_math.repl` on `%rrepl`, content unchanged (`poly_add(127) → 1 : i64`, `poly_add(127.0) → 1.0 : f64` — cos²+sin² through the new intrinsics, on-the-fly instantiation, `:dump compiled` symbols).

Source fixtures (`module_*/…`, drivers) are untouched — only RUN/CHECK lines change. All 9 migrated tests pass; the full suite is green (261 discovered: 257 passed / 4 unsupported / 0 failed).

After the series merges, #290's "Module system" and "Math intrinsics" items can be ticked; the only `.rr` tests left on the Haskell driver are `field_shorthand`, `fn_lift`, `relocation_mode`, `target_triple`, and the sanitizer rbtree quartet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2