### PR TITLE
backend: mangle string globals with blake3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,7 @@ version = "0.1.0"
 dependencies = [
  "ariadne",
  "indexmap",
+ "rapidhash",
  "reussir-backend",
  "reussir-core",
  "reussir-jit",

--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -9,8 +9,8 @@
 
 use melior::Context;
 use melior::ir::attribute::{
-    ArrayAttribute, DenseI32ArrayAttribute, DenseI64ArrayAttribute, FlatSymbolRefAttribute,
-    IntegerAttribute, StringAttribute,
+    ArrayAttribute, Attribute, DenseI32ArrayAttribute, DenseI64ArrayAttribute,
+    FlatSymbolRefAttribute, IntegerAttribute, StringAttribute,
 };
 use melior::ir::operation::{OperationBuilder, OperationRef};
 use melior::ir::r#type::IntegerType;
@@ -80,6 +80,80 @@ pub fn trampoline_export<'c>(
         ])
         .build()
         .expect("valid reussir.trampoline")
+}
+
+/// `reussir.str.global @<sym_name> = "payload"`.
+pub fn str_global<'c>(
+    context: &'c Context,
+    sym_name: &str,
+    payload: &str,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.str.global", location)
+        .add_attributes(&[
+            (
+                Identifier::new(context, "sym_name"),
+                StringAttribute::new(context, sym_name).into(),
+            ),
+            (
+                Identifier::new(context, "payload"),
+                StringAttribute::new(context, payload).into(),
+            ),
+        ])
+        .build()
+        .expect("valid reussir.str.global")
+}
+
+/// `reussir.str.literal @<sym_name> : <result_type>`.
+pub fn str_literal<'c>(
+    context: &'c Context,
+    sym_name: &str,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.str.literal", location)
+        .add_attributes(&[(
+            Identifier::new(context, "sym_name"),
+            FlatSymbolRefAttribute::new(context, sym_name).into(),
+        )])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.str.literal")
+}
+
+/// `reussir.str.cast (<global>) : <result_type>`.
+pub fn str_cast<'c>(
+    value: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.str.cast", location)
+        .add_operands(&[value])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.str.cast")
+}
+
+/// `reussir.str.select (<str>) ["..."] : (...) -> (index, i1)`.
+pub fn str_select<'c>(
+    context: &'c Context,
+    value: Value<'c, '_>,
+    patterns: &[&str],
+    location: Location<'c>,
+) -> Operation<'c> {
+    let attrs: Vec<Attribute<'c>> = patterns
+        .iter()
+        .map(|p| StringAttribute::new(context, p).into())
+        .collect();
+    OperationBuilder::new("reussir.str.select", location)
+        .add_operands(&[value])
+        .add_attributes(&[(
+            Identifier::new(context, "patterns"),
+            ArrayAttribute::new(context, &attrs).into(),
+        )])
+        .add_results(&[Type::index(context), IntegerType::new(context, 1).into()])
+        .build()
+        .expect("valid reussir.str.select")
 }
 
 /// `reussir.record.compound (<fields> : <types>) : <result_type>` — construct a

--- a/crates/reussir-codegen/Cargo.toml
+++ b/crates/reussir-codegen/Cargo.toml
@@ -15,6 +15,8 @@ reussir-core = { path = "../reussir-core" }
 reussir-backend = { path = "../reussir-backend" }
 # The fast hasher for compiler-internal maps.
 rustc-hash.workspace = true
+# Hash-keyed lookup of string-literal payloads by their 256-bit token.
+rapidhash.workspace = true
 # Insertion-ordered map backing the per-function SSA environment, so a nested
 # scope recovers by truncating back to a saved length.
 indexmap.workspace = true

--- a/crates/reussir-codegen/src/lower/debug.rs
+++ b/crates/reussir-codegen/src/lower/debug.rs
@@ -149,6 +149,12 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 false,
                 StringAttribute::new(self.context, "bool"),
             )),
+            TyKind::Char => Some(dbg::int_type(
+                self.context,
+                mlir,
+                false,
+                StringAttribute::new(self.context, "char"),
+            )),
             TyKind::Fp(FpTy::Ieee(w)) => Some(dbg::fp_type(
                 self.context,
                 mlir,

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -15,11 +15,12 @@
 use std::cell::RefCell;
 
 use indexmap::IndexMap;
+use rapidhash::RapidHashMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use reussir_backend::builders;
 use reussir_backend::dialect;
-use reussir_backend::dialect::ty::ReussirCapability;
+use reussir_backend::dialect::ty::{ReussirCapability, ReussirLifeScope};
 use reussir_backend::melior::Context;
 use reussir_backend::melior::dialect::arith::{self, CmpfPredicate, CmpiPredicate};
 use reussir_backend::melior::dialect::{func, scf};
@@ -38,6 +39,7 @@ use reussir_core::literal::{self, Integer};
 use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use reussir_core::semi::ty::{Flexivity, IntTy, Ty, TyCtxt, TyKind};
 use reussir_core::surface::{Span, Visibility};
+use reussir_core::utils::string::StringToken;
 use reussir_syntax::kind::{Resolver, TokenKey};
 use smallvec::SmallVec;
 
@@ -231,6 +233,8 @@ pub(super) struct Lowerer<'c, 'p, 'tcx> {
     /// (directly or through a boxed field) is emitted as a memberless
     /// forward-declared composite instead of expanding forever.
     pub(super) dbg_building: RefCell<FxHashSet<mir::Symbol>>,
+    /// String-literal payloads by token, for `str.select` pattern emission.
+    string_payloads: RapidHashMap<StringToken, &'p str>,
 }
 
 impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
@@ -255,6 +259,11 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             cur_loc: RefCell::new(Location::unknown(context)),
             cur_file: std::cell::Cell::new(FileId::ROOT),
             dbg_building: RefCell::new(FxHashSet::default()),
+            string_payloads: program
+                .string_literals
+                .iter()
+                .map(|(token, payload)| (*token, payload.as_str()))
+                .collect(),
         }
     }
 
@@ -445,6 +454,13 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     self.append(block, arith::constant(self.context, attr, loc)),
                 ))
             }
+            ConstChar(c) => {
+                let i32_ty = IntegerType::new(self.context, 32).into();
+                let attr = IntegerAttribute::new(i32_ty, i64::from(*c)).into();
+                Ok(Some(
+                    self.append(block, arith::constant(self.context, attr, loc)),
+                ))
+            }
             // The single decimal→binary rounding in the pipeline: the exact
             // literal is rounded into the target format host-side (no Rust
             // float involved, so bf16/f16 work like f32/f64) and the bits are
@@ -557,9 +573,34 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             NullableCall(inner) => self.nullable_call(block, env, e, *inner).map(Some),
             Closure(c) => self.closure(block, env, c).map(Some),
             ClosureCall { target, args } => self.closure_call(block, env, target, args),
-            GlobalStr(_) => err("string literal lowering not yet implemented"),
+            GlobalStr(token) => self.global_str(block, e, *token).map(Some),
             Poison => err("poison expression reached lowering"),
         }
+    }
+
+    fn global_str<'b>(
+        &self,
+        block: &'b Block<'c>,
+        e: &Expr<'tcx>,
+        token: StringToken,
+    ) -> Result<Value<'c, 'b>> {
+        let ty = self.tys.mlir_ty(e.ty)?;
+        Ok(self.append(
+            block,
+            builders::str_literal(self.context, &token.mangle(), ty, self.loc()),
+        ))
+    }
+
+    fn string_payload(&self, token: StringToken) -> Result<&'p str> {
+        self.string_payloads.get(&token).copied().ok_or_else(|| {
+            LoweringError(
+                format!(
+                    "string literal payload missing for token {:?}",
+                    token.words()
+                )
+                .into(),
+            )
+        })
     }
 
     /// Construct a record from its (declaration-ordered) field args.
@@ -1038,10 +1079,15 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             SwitchCases::Int { cases, default } => {
                 self.int_switch(block, env, root_idx, path, cases, default, result_ty)
             }
+            SwitchCases::Char { cases, default } => {
+                self.char_switch(block, env, root_idx, path, cases, default, result_ty)
+            }
             SwitchCases::Nullable { non_null, null } => {
                 self.nullable_switch(block, env, root_idx, path, non_null, null, result_ty)
             }
-            SwitchCases::String { .. } => err("string-pattern match lowering not yet implemented"),
+            SwitchCases::String { cases, default } => {
+                self.string_switch(block, env, root_idx, path, cases, default, result_ty)
+            }
         }
     }
 
@@ -1231,6 +1277,129 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         }
     }
 
+    /// Lower a character `Switch` like a ≤64-bit unsigned integer switch: the
+    /// scrutinee (a 32-bit code point) casts to `index` and each code point is
+    /// its own case value.
+    #[allow(clippy::too_many_arguments)]
+    fn char_switch<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        root_idx: usize,
+        path: &[u32],
+        cases: &'tcx [(u32, DecisionTree<'tcx>)],
+        default: &'tcx DecisionTree<'tcx>,
+        result_ty: Ty<'tcx>,
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let loc = self.loc();
+        let (scrut_val, scrut_ty) = self.resolve_loaded(block, env, root_idx, path)?;
+        if !matches!(scrut_ty.kind(), TyKind::Char) {
+            return err("character match on a non-character scrutinee");
+        }
+        let index_ty = Type::index(self.context);
+        let selector = self.append(block, arith::index_castui(scrut_val, index_ty, loc));
+        let case_values: Vec<i64> = cases.iter().map(|(c, _)| i64::from(*c)).collect();
+        self.index_switch_dispatch(
+            block,
+            env,
+            root_idx,
+            selector,
+            &case_values,
+            cases.iter().map(|(_, t)| t),
+            default,
+            result_ty,
+        )
+    }
+
+    /// Lower a string `Switch`: `reussir.str.select` reduces the scrutinee to
+    /// the index of the first matching pattern plus a found bit, an
+    /// `arith.select` maps a miss to the slot one past the last case, and a
+    /// single `scf.index_switch` dispatches — the default tree is lowered
+    /// exactly once, as the switch's own (reachable) default region.
+    #[allow(clippy::too_many_arguments)]
+    fn string_switch<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        root_idx: usize,
+        path: &[u32],
+        cases: &'tcx [(StringToken, DecisionTree<'tcx>)],
+        default: &'tcx DecisionTree<'tcx>,
+        result_ty: Ty<'tcx>,
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let loc = self.loc();
+        let (scrut_val, scrut_ty) = self.resolve_loaded(block, env, root_idx, path)?;
+        if !matches!(scrut_ty.kind(), TyKind::Str) {
+            return err("string match on a non-string scrutinee");
+        }
+        let local_ty = dialect::ty::str(self.context, ReussirLifeScope::Local);
+        let local = self.append(block, builders::str_cast(scrut_val, local_ty, loc));
+        let patterns: Vec<&str> = cases
+            .iter()
+            .map(|(token, _)| self.string_payload(*token))
+            .collect::<Result<_>>()?;
+        let select =
+            block.append_operation(builders::str_select(self.context, local, &patterns, loc));
+        let selected: Value<'c, '_> = select.result(0).unwrap().into();
+        let found: Value<'c, '_> = select.result(1).unwrap().into();
+        let default_slot = self.index_const(block, cases.len() as i64);
+        let selector = self.append(block, arith::select(found, selected, default_slot, loc));
+        let case_values: Vec<i64> = (0..cases.len() as i64).collect();
+        self.index_switch_dispatch(
+            block,
+            env,
+            root_idx,
+            selector,
+            &case_values,
+            cases.iter().map(|(_, t)| t),
+            default,
+            result_ty,
+        )
+    }
+
+    /// Dispatch a decision-tree switch through one `scf.index_switch`: a
+    /// region per case (in `subtrees` order, keyed by `case_values`) and the
+    /// `default` tree as the switch's own default region, every region
+    /// terminated by `scf.yield`. Shared tail of the int/char/string switches.
+    #[allow(clippy::too_many_arguments)]
+    fn index_switch_dispatch<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        root_idx: usize,
+        selector: Value<'c, 'b>,
+        case_values: &[i64],
+        subtrees: impl Iterator<Item = &'tcx DecisionTree<'tcx>>,
+        default: &'tcx DecisionTree<'tcx>,
+        result_ty: Ty<'tcx>,
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let unit = is_unit(result_ty);
+        let result_tys = if unit {
+            Vec::new()
+        } else {
+            vec![self.tys.mlir_ty(result_ty)?]
+        };
+        let mut regions = Vec::with_capacity(case_values.len() + 1);
+        regions.push(self.tree_branch_region(env, root_idx, default, result_ty)?);
+        for subtree in subtrees {
+            regions.push(self.tree_branch_region(env, root_idx, subtree, result_ty)?);
+        }
+        let cases_attr = DenseI64ArrayAttribute::new(self.context, case_values);
+        let op = block.append_operation(scf::index_switch(
+            self.context,
+            selector,
+            &result_tys,
+            cases_attr,
+            regions,
+            self.loc(),
+        ));
+        if unit {
+            Ok(None)
+        } else {
+            Ok(Some(op.result(0).unwrap().into()))
+        }
+    }
+
     /// Lower an integer `Switch` to `scf.index_switch`. The case bodies always run
     /// through the switch (one region per key, `default` as its default region —
     /// the open family's fall-through), each terminated by `scf.yield`; only the
@@ -1262,20 +1431,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             TyKind::Int(IntTy::Signed(w) | IntTy::Unsigned(w)) => *w,
             _ => return err("integer match on a non-integer scrutinee"),
         };
-        let unit = is_unit(result_ty);
-        let result_tys = if unit {
-            Vec::new()
-        } else {
-            vec![self.tys.mlir_ty(result_ty)?]
-        };
-        // The case bodies (which run once) and the default, in `scf.index_switch`
-        // region order: default first, then one region per key.
-        let mut regions = Vec::with_capacity(cases.len() + 1);
-        regions.push(self.tree_branch_region(env, root_idx, default, result_ty)?);
-        for (_, subtree) in cases {
-            regions.push(self.tree_branch_region(env, root_idx, subtree, result_ty)?);
-        }
-        let (arg, case_values) = if width > 64 {
+        let (selector, case_values) = if width > 64 {
             // Reduce the wide keys to a dense selector, then switch on that.
             let selector = self.wide_int_selector(block, scrut_val, scrut_ty, cases, 0)?;
             (selector, (0..cases.len() as i64).collect::<Vec<_>>())
@@ -1298,20 +1454,16 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     .collect::<Vec<_>>(),
             )
         };
-        let cases_attr = DenseI64ArrayAttribute::new(self.context, &case_values);
-        let op = block.append_operation(scf::index_switch(
-            self.context,
-            arg,
-            &result_tys,
-            cases_attr,
-            regions,
-            loc,
-        ));
-        if unit {
-            Ok(None)
-        } else {
-            Ok(Some(op.result(0).unwrap().into()))
-        }
+        self.index_switch_dispatch(
+            block,
+            env,
+            root_idx,
+            selector,
+            &case_values,
+            cases.iter().map(|(_, t)| t),
+            default,
+            result_ty,
+        )
     }
 
     /// Reduce a wide-integer switch to a dense `index` selector: a right-nested

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -30,6 +30,8 @@
 //!   mutation of a `[field]` link (`c->f := …` — project the `nullable<rc<…>>`
 //!   slot to a writable `field` reference and store), with the `Nullable`
 //!   constructor lowering to `reussir.nullable.create`.
+//! * **strings** — global string literals and string-pattern dispatch through
+//!   the Reussir string dialect;
 //! * **closures** — a closure lowers to a shared `rc<closure<…>>` built inline
 //!   (`reussir.closure.create` with a body region; the closure-outlining pass
 //!   generates the evaluate/drop/clone functions), with captures supplied as the
@@ -39,9 +41,8 @@
 //!   and, once fully applied, evaluates with `reussir.closure.eval`; partial
 //!   application stops at the residual closure.
 //!
-//! Reading a `[field]` link back (which needs `match`/`nullable.dispatch`), a
-//! non-`[field]` member that is itself a regional record, enums/`match`, and
-//! strings are not yet lowered and surface as an explicit [`LoweringError`]
+//! Reading a `[field]` link back, a non-`[field]` member that is itself a
+//! regional record, and some enum paths are not yet lowered and surface as an explicit [`LoweringError`]
 //! rather than wrong code.
 //!
 //! Every callee/trampoline target in the MIR is already resolved to an interned
@@ -107,6 +108,14 @@ pub fn lower_program<'c, 'tcx>(
     let lowerer = Lowerer::new(context, tcx, program, source, names);
     lowerer.set_module_debug_attrs(&mut module);
     let body = module.body();
+    for (token, payload) in &program.string_literals {
+        body.append_operation(builders::str_global(
+            context,
+            &token.mangle(),
+            payload,
+            Location::unknown(context),
+        ));
+    }
     for func in &program.functions {
         body.append_operation(lowerer.function(func)?);
     }

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -27,8 +27,9 @@ use std::cell::RefCell;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use reussir_backend::dialect::ty::{
-    ReussirAtomicKind, ReussirCapability, ReussirRecordKind, closure, nullable, rc,
-    record_complete_in_place, record_incomplete, record_is_complete, r#ref, region,
+    ReussirAtomicKind, ReussirCapability, ReussirLifeScope, ReussirRecordKind, closure, nullable,
+    rc, record_complete_in_place, record_incomplete, record_is_complete, r#ref, region,
+    str as str_type,
 };
 use reussir_backend::melior::Context;
 use reussir_backend::melior::ir::Type;
@@ -461,8 +462,9 @@ fn scalar_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
         TyKind::Fp(FpTy::BFloat16) => Ok(Type::bfloat16(context)),
         TyKind::Fp(FpTy::Float8) => err("float8 has no standard MLIR builtin type"),
         TyKind::Bool => Ok(IntegerType::new(context, 1).into()),
+        TyKind::Char => Ok(IntegerType::new(context, 32).into()),
         TyKind::Unit => err("unit has no MLIR value type"),
-        TyKind::Str => err("string type lowering not yet implemented"),
+        TyKind::Str => Ok(str_type(context, ReussirLifeScope::Global)),
         TyKind::Record { .. } => err("record type reached scalar lowering without a layout"),
         TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),
         // Intercepted by [`TypeCtx::mlir_ty`]; reaching here is a bug.

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -511,3 +511,66 @@ fn runs_an_integer_match() {
         assert_eq!(run(-7), 999);
     });
 }
+
+#[test]
+fn runs_a_char_match() {
+    // Character-literal patterns lower like unsigned-integer switches: the
+    // 32-bit code point casts to `index` with one case region per literal.
+    let src = r#"
+        pub fn pick(c: char) -> i32 {
+            match c {
+                'x' => 1,
+                '\n' => 2,
+                '\u{1F600}' => 3,
+                _ => 0
+            }
+        }
+        extern "C" trampoline "pick" = pick;
+    "#;
+    jit_run(src, |jit| {
+        let addr = jit.lookup("pick").expect("lookup pick");
+        let pick: extern "C" fn(u32) -> i32 = unsafe { std::mem::transmute(addr as usize) };
+        assert_eq!(pick('x' as u32), 1);
+        assert_eq!(pick('\n' as u32), 2);
+        assert_eq!(pick('😀' as u32), 3);
+        assert_eq!(pick('y' as u32), 0);
+        assert_eq!(pick(0), 0);
+    });
+}
+
+#[test]
+fn runs_a_string_match() {
+    // String literals and string-pattern dispatch, with the strings kept
+    // internal to the compiled code (the public ABI stays i32 → i32): `tag`
+    // returns one of four interned globals, `classify` dispatches on it via
+    // `reussir.str.select` + `scf.index_switch`. "one" vs "onefold" checks a
+    // shared prefix with different lengths; "mystery" reaches no pattern, so
+    // the select's found bit steers into the default region.
+    let src = r#"
+        fn tag(k: i32) -> str {
+            match k {
+                0 => "zero",
+                1 => "one",
+                2 => "onefold",
+                _ => "mystery"
+            }
+        }
+        pub fn classify(k: i32) -> i32 {
+            match tag(k) {
+                "zero" => 10,
+                "one" => 11,
+                "onefold" => 12,
+                _ => 99
+            }
+        }
+        extern "C" trampoline "classify" = classify;
+    "#;
+    jit_run(src, |jit| {
+        let addr = jit.lookup("classify").expect("lookup classify");
+        let classify: extern "C" fn(i32) -> i32 = unsafe { std::mem::transmute(addr as usize) };
+        assert_eq!(classify(0), 10);
+        assert_eq!(classify(1), 11); // "one" does not collide with "onefold"
+        assert_eq!(classify(2), 12);
+        assert_eq!(classify(7), 99); // "mystery" misses every pattern
+    });
+}

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -456,7 +456,9 @@ fn frontend<'c, 'tcx>(
                 } else {
                     hir::print::Printer::with_sources(&elab.defs, elab.resolver, sources)
                 };
-                let text = printer.program(&elab.elaborated, &elab.records, &elab.trampolines);
+                let strings = elab.strings.entries();
+                let text =
+                    printer.program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
                 return Ok(Produced::Text(text));
             }
             let (full, reports) = monomorphize(&elab.mono_input());
@@ -490,7 +492,12 @@ fn frontend<'c, 'tcx>(
                     }
                     _ => hir::print::Printer::new(&parsed.defs, &parsed.names),
                 };
-                let text = printer.program(&parsed.funcs, &parsed.records, &parsed.trampolines);
+                let text = printer.program(
+                    &parsed.funcs,
+                    &parsed.strings,
+                    &parsed.records,
+                    &parsed.trampolines,
+                );
                 return Ok(Produced::Text(text));
             }
             let input = MonoInput {
@@ -500,6 +507,7 @@ fn frontend<'c, 'tcx>(
                 elaborated: &parsed.funcs,
                 records: &parsed.records,
                 trampolines: &parsed.trampolines,
+                strings: parsed.strings.clone(),
             };
             let (full, reports) = monomorphize(&input);
             match &dump_sources {

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -135,6 +135,7 @@ impl<'a> Mangler<'a> {
         match *ty.kind() {
             TyKind::Bool => out.push('b'),
             TyKind::Str => out.push('e'),
+            TyKind::Char => out.push('c'),
             TyKind::Unit => out.push('u'),
             TyKind::Bottom => out.push('z'),
             TyKind::Int(int) => out.push_str(int_code(int)),
@@ -306,6 +307,7 @@ mod tests {
             let m = Mangler::new(&defs, &resolver);
             assert_eq!(m.mangle_ty(tcx.mk_bool()), "_Rb");
             assert_eq!(m.mangle_ty(tcx.mk_str()), "_Re");
+            assert_eq!(m.mangle_ty(tcx.mk_char()), "_Rc");
             assert_eq!(m.mangle_ty(tcx.mk_unit()), "_Ru");
             assert_eq!(m.mangle_ty(tcx.mk_int(IntTy::Signed(32))), "_Rl");
             assert_eq!(m.mangle_ty(tcx.mk_int(IntTy::Unsigned(64))), "_Ry");

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -57,6 +57,7 @@ pub struct Program<'tcx> {
     pub functions: Vec<Function<'tcx>>,
     pub records: Vec<RecordInstance<'tcx>>,
     pub trampolines: Vec<Trampoline>,
+    pub string_literals: Vec<(StringToken, String)>,
     /// Interner backing every [`Symbol`] in this program.
     pub symbols: Rodeo,
 }
@@ -196,6 +197,8 @@ pub struct ClosureExpr<'tcx> {
 #[derive(Clone, Copy, Debug)]
 pub enum ExprKind<'tcx> {
     GlobalStr(StringToken),
+    /// A Unicode scalar value, stored as its 32-bit code point.
+    ConstChar(u32),
     /// An integer literal, arbitrary-precision (arena-allocated to keep the
     /// node `Copy`); range-checked against its ground type at
     /// monomorphization and emitted at full width by codegen.
@@ -286,6 +289,10 @@ pub enum SwitchCases<'tcx> {
     Bool {
         if_true: &'tcx DecisionTree<'tcx>,
         if_false: &'tcx DecisionTree<'tcx>,
+    },
+    Char {
+        cases: &'tcx [(u32, DecisionTree<'tcx>)],
+        default: &'tcx DecisionTree<'tcx>,
     },
     Ctor(&'tcx [DecisionTree<'tcx>]),
     String {

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -83,6 +83,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
             return Err(id);
         }
     }
+    let string_literals = raw::string_entries(&raw.strings)?;
     let mut b = Builder {
         tcx,
         symbols: Rodeo::default(),
@@ -90,7 +91,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
         defs: DefTable::new(),
         ids: mir::ExprIdGen::default(),
     };
-    let program = b.program(raw);
+    let program = b.program(raw, string_literals);
     Ok(Parsed {
         program,
         defs: b.defs,
@@ -162,7 +163,11 @@ impl<'tcx> Builder<'_, 'tcx> {
         }
     }
 
-    fn program(&mut self, raw: raw::Program) -> mir::Program<'tcx> {
+    fn program(
+        &mut self,
+        raw: raw::Program,
+        string_literals: Vec<(StringToken, String)>,
+    ) -> mir::Program<'tcx> {
         let records: Vec<mir::RecordInstance<'tcx>> =
             raw.records.iter().map(|r| self.record(r)).collect();
         let trampolines: Vec<mir::Trampoline> = raw
@@ -182,6 +187,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             functions,
             records,
             trampolines,
+            string_literals,
             symbols,
         }
     }
@@ -229,6 +235,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::Ty::Float8 => self.tcx.mk_fp(FpTy::Float8),
             raw::Ty::Bool => self.tcx.mk_bool(),
             raw::Ty::Str => self.tcx.mk_str(),
+            raw::Ty::Char => self.tcx.mk_char(),
             raw::Ty::Unit => self.tcx.mk_unit(),
             raw::Ty::Bottom => self.tcx.mk(TyKind::Bottom),
             raw::Ty::Nullable(inner) => {
@@ -318,6 +325,16 @@ impl<'tcx> Builder<'_, 'tcx> {
                 if_true: self.tree_ref(if_true),
                 if_false: self.tree_ref(if_false),
             },
+            raw::Cases::Char { cases, default } => {
+                let mut cs = Vec::with_capacity(cases.len());
+                for (c, t) in cases {
+                    cs.push((*c, self.tree(t)));
+                }
+                S::Char {
+                    cases: self.tcx.alloc_slice(&cs),
+                    default: self.tree_ref(default),
+                }
+            }
             raw::Cases::Ctor(arms) => {
                 let mut v = Vec::with_capacity(arms.len());
                 for t in arms {
@@ -353,6 +370,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::Kind::ConstInt(n) => M::ConstInt(self.tcx.alloc(n.clone())),
             raw::Kind::ConstFloat(f) => M::ConstFloat(self.tcx.alloc(f.clone())),
             raw::Kind::ConstBool(b) => M::ConstBool(*b),
+            raw::Kind::ConstChar(c) => M::ConstChar(*c),
             raw::Kind::GlobalStr(words) => M::GlobalStr(StringToken::from_words(*words)),
             raw::Kind::Var(v) => M::Var(VarId(*v)),
             raw::Kind::Poison => M::Poison,
@@ -516,6 +534,7 @@ fn file_ref_check(files: &[String], file: Option<u32>) -> Option<String> {
 mod tests {
     use super::parse_program;
     use crate::full::mir::print::Printer;
+    use crate::full::mir::raw;
     use crate::full::mono::monomorphize;
     use crate::semi::elaborate;
     use crate::{surface, with_tcx};
@@ -673,6 +692,14 @@ mod tests {
     }
 
     #[test]
+    fn roundtrips_char_and_string_patterns() {
+        roundtrip(
+            r#"pub fn char_pick(c: char) -> i32 { match c { 'x' => 1, '\n' => 2, _ => 0 } }
+               pub fn str_pick(s: str) -> i32 { match s { "hi" => 1, "bye" => 2, _ => 0 } }"#,
+        );
+    }
+
+    #[test]
     fn roundtrips_an_int_match() {
         // Exercises an int `switch` with a `_` default arm.
         roundtrip(
@@ -709,5 +736,23 @@ mod tests {
         // A parameterless closure has type `() -> ret`; the closure-type grammar
         // must accept zero parameters.
         roundtrip("pub fn f(n: i32) -> i32 { (|| n)() }");
+    }
+
+    #[test]
+    #[should_panic(expected = "Unicode scalar value")]
+    fn rejects_surrogate_char_atoms() {
+        // `char#<n>` in machine-emitted IR must be a valid Unicode scalar
+        // value; U+D800 is a surrogate.
+        raw::char_scalar(&crate::literal::Integer::from(0xD800u32));
+    }
+
+    #[test]
+    fn rejects_string_table_token_mismatch() {
+        let entry = raw::StringEntry {
+            token: [0; 4],
+            payload: "hi".into(),
+        };
+        let err = raw::string_entries(&[entry]).unwrap_err();
+        assert!(err.contains("does not match payload"), "{err}");
     }
 }

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -16,6 +16,7 @@ pub Program: raw::Program = <items:Item*> => raw::Program::from_items(items);
 
 Item: raw::Item = {
     <f:FileDecl> => raw::Item::File(f),
+    <s:StringDecl> => raw::Item::String(s),
     "record" "@" <s:Sym> ":" <cap:DefCap> <kind:RecordBody> ";"
         => raw::Item::Record(raw::RecordDecl { symbol: s, default_cap: cap, ty: kind.0, body: kind.1 }),
     <f:Func> => raw::Item::Func(f),
@@ -27,6 +28,10 @@ Item: raw::Item = {
 /// into these files; a `<bracketed>` name is a virtual file (unfetchable).
 FileDecl: raw::FileEntry = <id:"int"> "=" <name:"quoted"> ";"
     => raw::FileEntry { id: raw::small_u32(&id), name: unescape_debug_str(name).into_owned() };
+
+/// One string literal table entry: `str#w0#w1#w2#w3 = "payload";`.
+StringDecl: raw::StringEntry = <token:StrWords> "=" <payload:"quoted"> ";"
+    => raw::StringEntry { token, payload: unescape_debug_str(payload).into_owned() };
 
 /// A source span: `[start..end]`, byte offsets into the owning item's file.
 Span: raw::Span = "[" <s:"int"> ".." <e:"int"> "]" => (raw::small_u32(&s), raw::small_u32(&e));
@@ -91,6 +96,7 @@ Ty: raw::Ty = {
     "f8" => raw::Ty::Float8,
     "bool" => raw::Ty::Bool,
     "str" => raw::Ty::Str,
+    "char" => raw::Ty::Char,
     "(" ")" => raw::Ty::Unit,
     "!" => raw::Ty::Bottom,
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
@@ -145,6 +151,7 @@ Atom: raw::Kind = {
     <f:"float"> => raw::Kind::ConstFloat(raw::float_lit(f)),
     "true" => raw::Kind::ConstBool(true),
     "false" => raw::Kind::ConstBool(false),
+    "char" "#" <c:"int"> => raw::Kind::ConstChar(raw::char_scalar(&c)),
     <w:StrWords> => raw::Kind::GlobalStr(w),
     <v:"var"> => raw::Kind::Var(v),
     "poison" => raw::Kind::Poison,
@@ -195,6 +202,7 @@ Label: raw::Label = {
     "_" => raw::Label::Wildcard,
     "true" => raw::Label::Bool(true),
     "false" => raw::Label::Bool(false),
+    "char" "#" <c:"int"> => raw::Label::Char(raw::char_scalar(&c)),
     <w:StrWords> => raw::Label::Str(w),
     "NonNull" => raw::Label::NonNull,
     "Null" => raw::Label::Null,
@@ -299,6 +307,7 @@ extern {
         "false" => Token::False,
         "bool" => Token::Bool,
         "str" => Token::Str,
+        "char" => Token::Char,
         "bf16" => Token::BF16,
         "f8" => Token::F8,
         "(" => Token::LParen,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -82,6 +82,9 @@ impl<'a> Printer<'a> {
                 items.push(text(format!("{} = {:?};", id.index(), cache.name(id))));
             }
         }
+        for (token, payload) in &program.string_literals {
+            items.push(string_decl(*token, payload));
+        }
         for rec in &program.records {
             items.push(r.record(rec));
         }
@@ -218,6 +221,7 @@ impl Render<'_> {
             TyKind::Fp(FpTy::Float8) => text("f8"),
             TyKind::Bool => text("bool"),
             TyKind::Str => text("str"),
+            TyKind::Char => text("char"),
             TyKind::Unit => text("()"),
             TyKind::Bottom => text("!"),
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
@@ -344,6 +348,7 @@ impl Render<'_> {
             ConstInt(n) => text(format!("{n}")),
             ConstFloat(f) => text(f.to_string()),
             ConstBool(b) => text(format!("{b}")),
+            ConstChar(c) => text(format!("char#{c}")),
             Var(v) => var(v),
             Poison => text("poison"),
             Negate(x) => text("-(") + self.value(x) + text(")"),
@@ -481,6 +486,14 @@ impl Render<'_> {
                 self.arm(text("true"), if_true),
                 self.arm(text("false"), if_false),
             ],
+            mir::SwitchCases::Char { cases, default } => {
+                let mut v: Vec<Doc<'static>> = cases
+                    .iter()
+                    .map(|(c, t)| self.arm(text(format!("char#{c}")), t))
+                    .collect();
+                v.push(self.arm(text("_"), default));
+                v
+            }
             mir::SwitchCases::Ctor(arms) => arms
                 .iter()
                 .enumerate()
@@ -565,6 +578,10 @@ fn cap_name(c: Flexivity) -> &'static str {
 /// round-trips faithfully.
 fn str_lit(w: [u64; 4]) -> String {
     format!("str#{}#{}#{}#{}", w[0], w[1], w[2], w[3])
+}
+
+fn string_decl(token: crate::utils::string::StringToken, payload: &str) -> Doc<'static> {
+    text(format!("{} = {:?};", str_lit(token.words()), payload))
 }
 
 fn arith_sym(op: ArithOp) -> &'static str {

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -24,11 +24,47 @@ pub struct FileEntry {
     pub name: String,
 }
 
+/// One string literal table entry: the stable token and the decoded UTF-8 payload.
+#[derive(Clone, Debug)]
+pub struct StringEntry {
+    pub token: StrTag,
+    pub payload: String,
+}
+
+/// Validate and canonicalize a parsed string-literal table: every entry's
+/// token must re-hash from its payload (they diverge only through corrupt or
+/// hand-edited IR), duplicates collapse, and the result sorts by token so the
+/// table is identical across print/parse round trips. Shared by the HIR and
+/// MIR re-intern passes.
+pub fn string_entries(
+    raw: &[StringEntry],
+) -> Result<Vec<(crate::utils::string::StringToken, String)>, String> {
+    use crate::utils::string::StringToken;
+    let mut entries: Vec<(StringToken, String)> = Vec::with_capacity(raw.len());
+    for entry in raw {
+        let token = StringToken::from_words(entry.token);
+        let expected = StringToken::from_text(&entry.payload);
+        if token != expected {
+            return Err(format!(
+                "string literal token {:?} does not match payload {:?}",
+                token.words(),
+                entry.payload
+            ));
+        }
+        if !entries.iter().any(|(seen, _)| *seen == token) {
+            entries.push((token, entry.payload.clone()));
+        }
+    }
+    entries.sort_by_key(|(token, _)| token.words());
+    Ok(entries)
+}
+
 /// A whole program: the source-file table, record instances (with their
 /// ground layout), functions, exported trampolines.
 #[derive(Clone, Debug)]
 pub struct Program {
     pub files: Vec<FileEntry>,
+    pub strings: Vec<StringEntry>,
     pub records: Vec<RecordDecl>,
     pub funcs: Vec<Func>,
     pub trampolines: Vec<Tramp>,
@@ -38,6 +74,7 @@ pub struct Program {
 #[derive(Clone, Debug)]
 pub enum Item {
     File(FileEntry),
+    String(StringEntry),
     Record(RecordDecl),
     Func(Func),
     Tramp(Tramp),
@@ -97,6 +134,7 @@ impl Program {
     pub fn from_items(items: Vec<Item>) -> Program {
         let mut p = Program {
             files: Vec::new(),
+            strings: Vec::new(),
             records: Vec::new(),
             funcs: Vec::new(),
             trampolines: Vec::new(),
@@ -104,6 +142,7 @@ impl Program {
         for item in items {
             match item {
                 Item::File(f) => p.files.push(f),
+                Item::String(s) => p.strings.push(s),
                 Item::Record(r) => p.records.push(r),
                 Item::Func(f) => p.funcs.push(f),
                 Item::Tramp(t) => p.trampolines.push(t),
@@ -149,6 +188,7 @@ pub enum Ty {
     Float8,
     Bool,
     Str,
+    Char,
     Unit,
     Bottom,
     Nullable(Box<Ty>),
@@ -192,6 +232,14 @@ pub fn small_u64(n: &Integer) -> u64 {
 
 pub fn small_usize(n: &Integer) -> usize {
     usize::try_from(n).expect("index in machine-emitted IR")
+}
+
+/// A character atom's code point (`char#<n>`): the `u32` must be a valid
+/// Unicode scalar value (no surrogates, ≤ U+10FFFF).
+pub fn char_scalar(n: &Integer) -> u32 {
+    let code = small_u32(n);
+    char::from_u32(code).expect("Unicode scalar value in machine-emitted IR");
+    code
 }
 
 /// Parse a float token's text into its exact value.
@@ -241,6 +289,8 @@ pub enum Kind {
     ConstInt(Integer),
     ConstFloat(FloatLit),
     ConstBool(bool),
+    /// A Unicode scalar value, stored as its 32-bit code point.
+    ConstChar(u32),
     /// An interned string literal, as its four raw `StringToken` words.
     GlobalStr([u64; 4]),
     Var(u32),
@@ -344,6 +394,10 @@ pub enum Cases {
         if_true: Box<Tree>,
         if_false: Box<Tree>,
     },
+    Char {
+        cases: Vec<(u32, Tree)>,
+        default: Box<Tree>,
+    },
     Ctor(Vec<Tree>),
     Str {
         cases: Vec<([u64; 4], Tree)>,
@@ -364,6 +418,7 @@ pub enum Label {
     Ctor(usize),
     Str([u64; 4]),
     Bool(bool),
+    Char(u32),
     NonNull,
     Null,
     Wildcard,
@@ -390,6 +445,20 @@ pub fn build_switch(scrutinee: Path, arms: Vec<(Label, Tree)>) -> Tree {
             Cases::Bool {
                 if_true: if_true.unwrap(),
                 if_false: if_false.unwrap(),
+            }
+        }
+        Some(Label::Char(_)) => {
+            let (mut cases, mut default) = (Vec::new(), None);
+            for (l, t) in arms {
+                match l {
+                    Label::Char(c) => cases.push((c, t)),
+                    Label::Wildcard => default = Some(Box::new(t)),
+                    _ => {}
+                }
+            }
+            Cases::Char {
+                cases,
+                default: default.unwrap(),
             }
         }
         Some(Label::Ctor(_)) => {

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -59,6 +59,7 @@ use crate::semi::resolve::DefTable;
 use crate::semi::ty::{DefId, Flexivity, Ty, TyCtxt, TyKind};
 use crate::semi::ty::{FpTy, IntTy};
 use crate::surface::Span;
+use crate::utils::string::StringToken;
 
 /// Exactly the part of an [`Elaborator`] that monomorphization reads. Taking
 /// this rather than the whole elaborator lets a program **reconstructed from the
@@ -71,6 +72,7 @@ pub struct MonoInput<'a, 'tcx> {
     pub elaborated: &'a [Function<'tcx>],
     pub records: &'a FxHashMap<DefId, Record<'tcx>>,
     pub trampolines: &'a [TrampolineRoot<'tcx>],
+    pub strings: Vec<(StringToken, String)>,
 }
 
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
@@ -83,6 +85,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             elaborated: &self.elaborated,
             records: &self.records,
             trampolines: &self.trampolines,
+            strings: self.strings.entries(),
         }
     }
 }
@@ -256,6 +259,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             functions,
             records,
             trampolines,
+            string_literals: input.strings.clone(),
             symbols,
         },
         reports,
@@ -352,6 +356,7 @@ fn ty_depth(ty: Ty<'_>) -> usize {
         | TyKind::Fp(_)
         | TyKind::Bool
         | TyKind::Str
+        | TyKind::Char
         | TyKind::Unit
         | TyKind::Bottom
         | TyKind::Generic(_)
@@ -623,6 +628,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         use mir::ExprKind as M;
         match kind {
             ExprKind::GlobalStr(s) => M::GlobalStr(*s),
+            ExprKind::ConstChar(c) => M::ConstChar(*c),
             ExprKind::ConstInt(n) => M::ConstInt(n),
             ExprKind::ConstFloat(f) => M::ConstFloat(f),
             ExprKind::ConstBool(b) => M::ConstBool(*b),
@@ -853,6 +859,13 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 if_true: self.lower_tree_ref(if_true, subst),
                 if_false: self.lower_tree_ref(if_false, subst),
             },
+            SwitchCases::Char { cases, default } => {
+                let lowered = self.lower_keyed(cases, subst);
+                M::Char {
+                    cases: self.tcx.alloc_slice(&lowered),
+                    default: self.lower_tree_ref(default, subst),
+                }
+            }
             SwitchCases::Ctor(arms) => {
                 let lowered: Vec<mir::DecisionTree<'tcx>> =
                     arms.iter().map(|t| self.lower_tree(t, subst)).collect();
@@ -1026,8 +1039,10 @@ mod tests {
             let text0 = MirPrinter::new(&elab.defs, elab.resolver).program(&mir0);
 
             // Serialize the HIR, parse it back, and monomorphize *that*.
+            let strings = elab.strings.entries();
             let hir_text = HirPrinter::new(&elab.defs, elab.resolver).program(
                 &elab.elaborated,
+                &strings,
                 &elab.records,
                 &elab.trampolines,
             );
@@ -1039,6 +1054,7 @@ mod tests {
                 elaborated: &parsed.funcs,
                 records: &parsed.records,
                 trampolines: &parsed.trampolines,
+                strings: parsed.strings.clone(),
             };
             let (mir1, r1) = monomorphize(&input);
             assert!(r1.is_empty(), "{r1:#?}");
@@ -1118,14 +1134,17 @@ mod tests {
             );
 
             // ----- print HIR + round-trip it through the parser -----
+            let strings = elab.strings.entries();
             let hir_text = HirPrinter::new(&elab.defs, elab.resolver).program(
                 &elab.elaborated,
+                &strings,
                 &elab.records,
                 &elab.trampolines,
             );
             let hir = parse_hir(tcx, &hir_text).expect("re-parse HIR");
             let hir_text2 = HirPrinter::new(&hir.defs, &hir.names).program(
                 &hir.funcs,
+                &hir.strings,
                 &hir.records,
                 &hir.trampolines,
             );
@@ -1142,6 +1161,7 @@ mod tests {
                 elaborated: &hir.funcs,
                 records: &hir.records,
                 trampolines: &hir.trampolines,
+                strings: hir.strings.clone(),
             };
             let (mir_resumed, r_resumed) = monomorphize(&resumed_input);
             assert!(r_resumed.is_empty(), "resumed mono reports: {r_resumed:#?}");
@@ -1196,7 +1216,8 @@ mod tests {
     fn children<'tcx>(e: &mir::Expr<'tcx>) -> Vec<&'tcx mir::Expr<'tcx>> {
         use mir::ExprKind::*;
         match e.kind {
-            GlobalStr(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_) | Poison => vec![],
+            GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
+            | Poison => vec![],
             Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],
             Arith(l, _, r) | Cmp(l, _, r) | Assign(l, _, r) => vec![l, r],
             If(c, t, f) => vec![c, t, f],

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -334,6 +334,7 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
             | TyKind::Fp(_)
             | TyKind::Bool
             | TyKind::Str
+            | TyKind::Char
             | TyKind::Unit
             | TyKind::Generic(_)
             | TyKind::Hole(_)
@@ -448,6 +449,7 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 }
             }
             ExprKind::GlobalStr(_)
+            | ExprKind::ConstChar(_)
             | ExprKind::ConstInt(_)
             | ExprKind::ConstFloat(_)
             | ExprKind::ConstBool(_)
@@ -561,6 +563,7 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 }
             }
             ExprKind::GlobalStr(_)
+            | ExprKind::ConstChar(_)
             | ExprKind::ConstInt(_)
             | ExprKind::ConstFloat(_)
             | ExprKind::ConstBool(_)
@@ -989,6 +992,12 @@ fn subtrees<'tcx>(cases: &SwitchCases<'tcx>) -> SmallVec<[&'tcx DecisionTree<'tc
         SwitchCases::Bool { if_true, if_false } => {
             v.push(if_true);
             v.push(if_false);
+        }
+        SwitchCases::Char { cases, default } => {
+            for (_, t) in cases {
+                v.push(t);
+            }
+            v.push(default);
         }
         SwitchCases::Ctor(arms) => {
             for t in arms {

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -394,6 +394,7 @@ fn kind_name(kind: &ExprKind<'_>) -> &'static str {
         ExprKind::GlobalStr(_) => "GlobalStr",
         ExprKind::ConstInt(_) => "ConstInt",
         ExprKind::ConstFloat(_) => "ConstFloat",
+        ExprKind::ConstChar(_) => "ConstChar",
         ExprKind::ConstBool(_) => "ConstBool",
         ExprKind::Var(_) => "Var",
         ExprKind::Negate(_) => "Negate",
@@ -518,6 +519,7 @@ impl Renderer<'_> {
         match e.kind {
             ExprKind::Var(x) => self.leaf(e.id, text(format!("var v{}", x.0))),
             ExprKind::ConstInt(n) => self.leaf(e.id, text(format!("const {n}"))),
+            ExprKind::ConstChar(c) => self.leaf(e.id, text(format!("const char#{c}"))),
             ExprKind::ConstBool(b) => self.leaf(e.id, text(format!("const {b}"))),
             ExprKind::NullableCall(None) => self.leaf(e.id, text("null")),
             ExprKind::Let { var, value, .. } => self.block(
@@ -803,6 +805,7 @@ fn interp<'tcx>(
             }
         }
         ExprKind::GlobalStr(_)
+        | ExprKind::ConstChar(_)
         | ExprKind::ConstInt(_)
         | ExprKind::ConstFloat(_)
         | ExprKind::ConstBool(_)
@@ -916,7 +919,8 @@ fn uses_var(e: &Expr<'_>, y: VarId) -> bool {
 fn children<'tcx>(e: &Expr<'tcx>) -> Vec<&'tcx Expr<'tcx>> {
     use ExprKind::*;
     match e.kind {
-        GlobalStr(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_) | Poison => vec![],
+        GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
+        | Poison => vec![],
         Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],
         Arith(l, _, r) | Cmp(l, _, r) | Assign(l, _, r) => vec![l, r],
         If(c, t, e) => vec![c, t, e],

--- a/crates/reussir-core/src/full/subst.rs
+++ b/crates/reussir-core/src/full/subst.rs
@@ -39,6 +39,7 @@ pub fn subst_ty<'tcx>(tcx: &TyCtxt<'tcx>, ty: Ty<'tcx>, subst: &Subst<'tcx>) -> 
         | TyKind::Fp(_)
         | TyKind::Bool
         | TyKind::Str
+        | TyKind::Char
         | TyKind::Unit
         | TyKind::Bottom => ty,
         TyKind::Hole(_) => panic!("subst: an inference hole survived zonking"),

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -92,6 +92,8 @@ pub enum Token<'a> {
     Bool,
     #[token("str")]
     Str,
+    #[token("char")]
+    Char,
     #[token("bf16")]
     BF16,
     #[token("f8")]

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -216,6 +216,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 let ty = self.tcx.mk_str();
                 self.mk_expr(ExprKind::GlobalStr(token), ty, span)
             }
+            Const::ConstChar(c) => {
+                let ty = self.tcx.mk_char();
+                self.mk_expr(ExprKind::ConstChar(*c), ty, span)
+            }
             Const::ConstBool(b) => {
                 let ty = self.tcx.mk_bool();
                 self.mk_expr(ExprKind::ConstBool(*b), ty, span)
@@ -1396,7 +1400,7 @@ fn free_vars<'tcx>(e: &Expr<'tcx>, out: &mut Vec<VarId>) {
         }
         Closure(c) => free_vars(&c.body, out),
         Match(scrut, _) => free_vars(scrut, out),
-        GlobalStr(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Poison => {}
+        GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Poison => {}
     }
 }
 

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -406,6 +406,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             TyKind::Fp(FpTy::Float8) => out.push_str("float8"),
             TyKind::Bool => out.push_str("bool"),
             TyKind::Str => out.push_str("str"),
+            TyKind::Char => out.push_str("char"),
             TyKind::Unit => out.push_str("unit"),
             TyKind::Bottom => out.push('!'),
             TyKind::Generic(g) => out.push_str(

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -87,6 +87,8 @@ pub struct ClosureExpr<'tcx> {
 pub enum ExprKind<'tcx> {
     /// An interned string literal.
     GlobalStr(StringToken),
+    /// A Unicode scalar value, stored as its 32-bit code point.
+    ConstChar(u32),
     /// An integer literal (its type is a `Num`-bounded hole until solved).
     /// Arbitrary-precision: range-checked against its ground type at
     /// monomorphization, never truncated before.
@@ -188,6 +190,10 @@ pub enum SwitchCases<'tcx> {
     Bool {
         if_true: Box<DecisionTree<'tcx>>,
         if_false: Box<DecisionTree<'tcx>>,
+    },
+    Char {
+        cases: Vec<(u32, DecisionTree<'tcx>)>,
+        default: Box<DecisionTree<'tcx>>,
     },
     /// One sub-tree per variant index of the scrutinee's enum.
     Ctor(Vec<DecisionTree<'tcx>>),

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -34,6 +34,7 @@ use crate::utils::string::StringToken;
 /// [`crate::full::mono::monomorphize`] via a `MonoInput`.
 pub struct Parsed<'tcx> {
     pub funcs: Vec<Function<'tcx>>,
+    pub strings: Vec<(StringToken, String)>,
     pub records: FxHashMap<DefId, Record<'tcx>>,
     pub trampolines: Vec<TrampolineRoot<'tcx>>,
     pub defs: DefTable,
@@ -98,6 +99,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
             return Err(id);
         }
     }
+    let strings = raw::string_entries(&raw.strings)?;
     let mut b = Builder {
         tcx,
         names: Names::default(),
@@ -110,6 +112,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
     let trampolines = raw.trampolines.iter().map(|t| b.trampoline(t)).collect();
     Ok(Parsed {
         funcs,
+        strings,
         records,
         trampolines,
         defs: b.defs,
@@ -271,6 +274,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::Ty::Float8 => self.tcx.mk_fp(FpTy::Float8),
             raw::Ty::Bool => self.tcx.mk_bool(),
             raw::Ty::Str => self.tcx.mk_str(),
+            raw::Ty::Char => self.tcx.mk_char(),
             raw::Ty::Unit => self.tcx.mk_unit(),
             raw::Ty::Bottom => self.tcx.mk(TyKind::Bottom),
             raw::Ty::Generic(g) => self.tcx.mk_generic(GenericId(*g)),
@@ -311,6 +315,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::Kind::ConstInt(n) => ExprKind::ConstInt(self.tcx.alloc(n.clone())),
             raw::Kind::ConstFloat(f) => ExprKind::ConstFloat(self.tcx.alloc(f.clone())),
             raw::Kind::ConstBool(b) => ExprKind::ConstBool(*b),
+            raw::Kind::ConstChar(c) => ExprKind::ConstChar(*c),
             raw::Kind::GlobalStr(words) => ExprKind::GlobalStr(StringToken::from_words(*words)),
             raw::Kind::Var(v) => ExprKind::Var(VarId(*v)),
             raw::Kind::Poison => ExprKind::Poison,
@@ -476,6 +481,13 @@ impl<'tcx> Builder<'_, 'tcx> {
                 if_true: Box::new(self.tree(if_true)),
                 if_false: Box::new(self.tree(if_false)),
             },
+            raw::Cases::Char { cases, default } => {
+                let cases = cases.iter().map(|(c, t)| (*c, self.tree(t))).collect();
+                SwitchCases::Char {
+                    cases,
+                    default: Box::new(self.tree(default)),
+                }
+            }
             raw::Cases::Ctor(arms) => {
                 SwitchCases::Ctor(arms.iter().map(|t| self.tree(t)).collect())
             }
@@ -568,14 +580,17 @@ mod tests {
             let elab = elaborate(tcx, &prog, parse.resolver());
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
+            let strings = elab.strings.entries();
             let text = Printer::new(&elab.defs, elab.resolver).program(
                 &elab.elaborated,
+                &strings,
                 &elab.records,
                 &elab.trampolines,
             );
             let parsed = parse_program(tcx, &text).expect("re-parse");
             let text2 = Printer::new(&parsed.defs, &parsed.names).program(
                 &parsed.funcs,
+                &parsed.strings,
                 &parsed.records,
                 &parsed.trampolines,
             );
@@ -600,8 +615,10 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
             let cache = SourceCache::single("<test>", source);
+            let strings = elab.strings.entries();
             let text = Printer::with_sources(&elab.defs, elab.resolver, &cache).program(
                 &elab.elaborated,
+                &strings,
                 &elab.records,
                 &elab.trampolines,
             );
@@ -619,6 +636,7 @@ mod tests {
             }
             let text2 = Printer::with_sources(&parsed.defs, &parsed.names, &cache2).program(
                 &parsed.funcs,
+                &parsed.strings,
                 &parsed.records,
                 &parsed.trampolines,
             );
@@ -644,8 +662,10 @@ mod tests {
 
             let mut cache = SourceCache::new();
             cache.add_virtual(file_name, source);
+            let strings = elab.strings.entries();
             let text = Printer::with_sources(&elab.defs, elab.resolver, &cache).program(
                 &elab.elaborated,
+                &strings,
                 &elab.records,
                 &elab.trampolines,
             );
@@ -691,6 +711,14 @@ mod tests {
     #[test]
     fn roundtrips_a_string_literal() {
         roundtrip("pub fn greet() -> str { \"hi\" }");
+    }
+
+    #[test]
+    fn roundtrips_char_and_string_patterns() {
+        roundtrip(
+            r#"pub fn char_pick(c: char) -> i32 { match c { 'x' => 1, '\n' => 2, _ => 0 } }
+               pub fn str_pick(s: str) -> i32 { match s { "hi" => 1, "bye" => 2, _ => 0 } }"#,
+        );
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -17,6 +17,7 @@ pub Program: raw::Program = <items:Item*> => raw::Program::from_items(items);
 
 Item: raw::Item = {
     <f:FileDecl> => raw::Item::File(f),
+    <s:StringDecl> => raw::Item::String(s),
     <r:RecordDecl> => raw::Item::Record(r),
     <t:TrampDecl> => raw::Item::Tramp(t),
     <f:Func> => raw::Item::Func(f),
@@ -26,6 +27,10 @@ Item: raw::Item = {
 /// into these files; a `<bracketed>` name is a virtual file (unfetchable).
 FileDecl: raw::FileEntry = <id:"int"> "=" <name:"quoted"> ";"
     => raw::FileEntry { id: raw::small_u32(&id), name: unescape_debug_str(name).into_owned() };
+
+/// One string literal table entry: `str#w0#w1#w2#w3 = "payload";`.
+StringDecl: raw::StringEntry = <token:StrWords> "=" <payload:"quoted"> ";"
+    => raw::StringEntry { token, payload: unescape_debug_str(payload).into_owned() };
 
 /// A source span: `[start..end]`, byte offsets into the owning item's file.
 Span: raw::Span = "[" <s:"int"> ".." <e:"int"> "]" => (raw::small_u32(&s), raw::small_u32(&e));
@@ -120,6 +125,7 @@ Ty: raw::Ty = {
     "f8" => raw::Ty::Float8,
     "bool" => raw::Ty::Bool,
     "str" => raw::Ty::Str,
+    "char" => raw::Ty::Char,
     "(" ")" => raw::Ty::Unit,
     "!" => raw::Ty::Bottom,
     <g:"generic"> => raw::Ty::Generic(g),
@@ -173,6 +179,7 @@ Atom: raw::Kind = {
     <f:"float"> => raw::Kind::ConstFloat(raw::float_lit(f)),
     "true" => raw::Kind::ConstBool(true),
     "false" => raw::Kind::ConstBool(false),
+    "char" "#" <c:"int"> => raw::Kind::ConstChar(raw::char_scalar(&c)),
     <w:StrWords> => raw::Kind::GlobalStr(w),
     <v:"var"> => raw::Kind::Var(v),
     "poison" => raw::Kind::Poison,
@@ -224,6 +231,7 @@ Label: raw::Label = {
     "_" => raw::Label::Wildcard,
     "true" => raw::Label::Bool(true),
     "false" => raw::Label::Bool(false),
+    "char" "#" <c:"int"> => raw::Label::Char(raw::char_scalar(&c)),
     <w:StrWords> => raw::Label::Str(w),
     "NonNull" => raw::Label::NonNull,
     "Null" => raw::Label::Null,
@@ -324,6 +332,7 @@ extern {
         "false" => Token::False,
         "bool" => Token::Bool,
         "str" => Token::Str,
+        "char" => Token::Char,
         "bf16" => Token::BF16,
         "f8" => Token::F8,
         "(" => Token::LParen,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -23,6 +23,7 @@ use crate::semi::hir::{
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{DefId, Flexivity, FpTy, GenericId, IntTy, Ty, TyKind};
 use crate::surface::{RecordKind, Visibility};
+use crate::utils::string::StringToken;
 
 const IR_PRINTER: PpPrinter = PpPrinter {
     max_width: 100,
@@ -70,6 +71,7 @@ impl<'a> Printer<'a> {
     pub fn program(
         &self,
         funcs: &[Function<'_>],
+        strings: &[(StringToken, String)],
         records: &rustc_hash::FxHashMap<DefId, Record<'_>>,
         trampolines: &[TrampolineRoot<'_>],
     ) -> String {
@@ -78,6 +80,9 @@ impl<'a> Printer<'a> {
             for id in cache.ids() {
                 items.push(text(format!("{} = {:?};", id.index(), cache.name(id))));
             }
+        }
+        for (token, payload) in strings {
+            items.push(string_decl(*token, payload));
         }
         let mut recs: Vec<&Record<'_>> = records.values().collect();
         // Sort by qualified path (phase-canonical: identical across the original
@@ -269,6 +274,7 @@ impl<'a> Printer<'a> {
             TyKind::Fp(FpTy::Float8) => text("f8"),
             TyKind::Bool => text("bool"),
             TyKind::Str => text("str"),
+            TyKind::Char => text("char"),
             TyKind::Unit => text("()"),
             TyKind::Bottom => text("!"),
             TyKind::Generic(g) => text(format!("${}", g.0)),
@@ -391,6 +397,7 @@ impl<'a> Printer<'a> {
             ExprKind::ConstInt(n) => text(format!("{n}")),
             ExprKind::ConstFloat(f) => text(f.to_string()),
             ExprKind::ConstBool(b) => text(format!("{b}")),
+            ExprKind::ConstChar(c) => text(format!("char#{c}")),
             ExprKind::Var(v) => var(*v),
             ExprKind::Poison => text("poison"),
             ExprKind::Negate(x) => text("-(") + self.value(x) + text(")"),
@@ -546,6 +553,14 @@ impl<'a> Printer<'a> {
                 self.arm(text("true"), if_true),
                 self.arm(text("false"), if_false),
             ],
+            SwitchCases::Char { cases, default } => {
+                let mut v: Vec<Doc<'static>> = cases
+                    .iter()
+                    .map(|(c, t)| self.arm(text(format!("char#{c}")), t))
+                    .collect();
+                v.push(self.arm(text("_"), default));
+                v
+            }
             SwitchCases::Ctor(arms) => arms
                 .iter()
                 .enumerate()
@@ -627,6 +642,10 @@ fn cap_name(c: Flexivity) -> &'static str {
 /// round-trips faithfully.
 fn str_lit(w: [u64; 4]) -> String {
     format!("str#{}#{}#{}#{}", w[0], w[1], w[2], w[3])
+}
+
+fn string_decl(token: StringToken, payload: &str) -> Doc<'static> {
+    text(format!("{} = {:?};", str_lit(token.words()), payload))
 }
 
 fn arith_sym(op: ArithOp) -> &'static str {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -7,8 +7,8 @@
 //! holes, so the textual form does not represent them.
 
 pub use crate::full::mir::raw::{
-    ArithOp, Cap, CmpOp, FileEntry, FloatLit, Integer, Span, float_lit, float_path_segs, small_u32,
-    small_u64, small_usize,
+    ArithOp, Cap, CmpOp, FileEntry, FloatLit, Integer, Span, StringEntry, char_scalar, float_lit,
+    float_path_segs, small_u32, small_u64, small_usize, string_entries,
 };
 
 /// The whole HIR program: enough to resume into monomorphization — the record
@@ -16,6 +16,7 @@ pub use crate::full::mir::raw::{
 #[derive(Clone, Debug)]
 pub struct Program {
     pub files: Vec<FileEntry>,
+    pub strings: Vec<StringEntry>,
     pub records: Vec<Record>,
     pub trampolines: Vec<Tramp>,
     pub funcs: Vec<Func>,
@@ -25,6 +26,7 @@ pub struct Program {
 #[derive(Clone, Debug)]
 pub enum Item {
     File(FileEntry),
+    String(StringEntry),
     Record(Record),
     Tramp(Tramp),
     Func(Func),
@@ -34,6 +36,7 @@ impl Program {
     pub fn from_items(items: Vec<Item>) -> Program {
         let mut p = Program {
             files: Vec::new(),
+            strings: Vec::new(),
             records: Vec::new(),
             trampolines: Vec::new(),
             funcs: Vec::new(),
@@ -41,6 +44,7 @@ impl Program {
         for item in items {
             match item {
                 Item::File(f) => p.files.push(f),
+                Item::String(s) => p.strings.push(s),
                 Item::Record(r) => p.records.push(r),
                 Item::Tramp(t) => p.trampolines.push(t),
                 Item::Func(f) => p.funcs.push(f),
@@ -151,6 +155,7 @@ pub enum Ty {
     Float8,
     Bool,
     Str,
+    Char,
     Unit,
     Bottom,
     Generic(u32),
@@ -201,6 +206,8 @@ pub enum Kind {
     ConstInt(Integer),
     ConstFloat(FloatLit),
     ConstBool(bool),
+    /// A Unicode scalar value, stored as its 32-bit code point.
+    ConstChar(u32),
     /// An interned string literal, as its four raw `StringToken` words.
     GlobalStr([u64; 4]),
     Var(u32),
@@ -288,6 +295,10 @@ pub enum Cases {
         if_true: Box<Tree>,
         if_false: Box<Tree>,
     },
+    Char {
+        cases: Vec<(u32, Tree)>,
+        default: Box<Tree>,
+    },
     Ctor(Vec<Tree>),
     Str {
         cases: Vec<([u64; 4], Tree)>,
@@ -306,6 +317,7 @@ pub enum Label {
     Ctor(usize),
     Str([u64; 4]),
     Bool(bool),
+    Char(u32),
     NonNull,
     Null,
     Wildcard,
@@ -331,6 +343,20 @@ pub fn build_switch(scrutinee: Path, arms: Vec<(Label, Tree)>) -> Tree {
             Cases::Bool {
                 if_true: if_true.unwrap(),
                 if_false: if_false.unwrap(),
+            }
+        }
+        Some(Label::Char(_)) => {
+            let (mut cases, mut default) = (Vec::new(), None);
+            for (l, t) in arms {
+                match l {
+                    Label::Char(c) => cases.push((c, t)),
+                    Label::Wildcard => default = Some(Box::new(t)),
+                    _ => {}
+                }
+            }
+            Cases::Char {
+                cases,
+                default: default.unwrap(),
             }
         }
         Some(Label::Ctor(_)) => {

--- a/crates/reussir-core/src/semi/infer.rs
+++ b/crates/reussir-core/src/semi/infer.rs
@@ -300,6 +300,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             (TyKind::Fp(x), TyKind::Fp(y)) if x == y => Ok(()),
             (TyKind::Bool, TyKind::Bool)
             | (TyKind::Str, TyKind::Str)
+            | (TyKind::Char, TyKind::Char)
             | (TyKind::Unit, TyKind::Unit) => Ok(()),
             (TyKind::Generic(x), TyKind::Generic(y)) if x == y => Ok(()),
 
@@ -497,6 +498,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             (TyKind::Fp(x), TyKind::Fp(y)) if x == y => Ok(()),
             (TyKind::Bool, TyKind::Bool)
             | (TyKind::Str, TyKind::Str)
+            | (TyKind::Char, TyKind::Char)
             | (TyKind::Unit, TyKind::Unit) => Ok(()),
             (TyKind::Generic(x), TyKind::Generic(y)) if x == y => Ok(()),
 

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -61,6 +61,7 @@ enum Ctor<'tcx> {
     /// An integer key, arbitrary-precision (the scrutinee type bounds its
     /// range, checked like any literal at monomorphization).
     Int(&'tcx Integer),
+    Char(u32),
     Bool(bool),
     Str(StringToken),
     /// The non-null case of a `Nullable<T>` scrutinee, with one field: the
@@ -75,6 +76,7 @@ impl Ctor<'_> {
         match self {
             Ctor::Variant(_) => Family::Variant,
             Ctor::Int(_) => Family::Int,
+            Ctor::Char(_) => Family::Char,
             Ctor::Bool(_) => Family::Bool,
             Ctor::Str(_) => Family::Str,
             Ctor::NonNull | Ctor::Null => Family::Nullable,
@@ -96,6 +98,7 @@ enum Family {
     /// Open families: there are always more values than literals, so they need a
     /// default branch.
     Int,
+    Char,
     Str,
 }
 
@@ -284,6 +287,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 let want = self.tcx.mk_bool();
                 let _ = self.infer.unify(ty, want);
                 Ctor::Bool(*b)
+            }
+            Const::ConstChar(c) => {
+                let want = self.tcx.mk_char();
+                let _ = self.infer.unify(ty, want);
+                Ctor::Char(*c)
             }
             Const::ConstString(s) => {
                 let want = self.tcx.mk_str();
@@ -579,6 +587,16 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 let default = Box::new(self.compile_match(def, reached, exhaustive));
                 SwitchCases::Int { cases, default }
             }
+            Family::Char => {
+                let mut cases = Vec::new();
+                for c in self.column_chars(&m, j) {
+                    let sub = self.specialize_scalar(&m, j, &Ctor::Char(c), &occ);
+                    cases.push((c, self.compile_match(sub, reached, exhaustive)));
+                }
+                let def = self.default_matrix(&m, j, &occ);
+                let default = Box::new(self.compile_match(def, reached, exhaustive));
+                SwitchCases::Char { cases, default }
+            }
             Family::Str => {
                 let mut cases = Vec::new();
                 for s in self.column_strs(&m, j) {
@@ -750,6 +768,22 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         seen
     }
 
+    /// The distinct character literals tested in column `j`, in first-seen order.
+    fn column_chars(&self, m: &Matrix<'tcx>, j: usize) -> Vec<u32> {
+        let mut seen = Vec::new();
+        for row in &m.rows {
+            if let Pat::Ctor {
+                ctor: Ctor::Char(c),
+                ..
+            } = &row.pats[j]
+                && !seen.contains(c)
+            {
+                seen.push(*c);
+            }
+        }
+        seen
+    }
+
     /// The distinct string literals tested in column `j`, in first-seen order.
     fn column_strs(&self, m: &Matrix<'tcx>, j: usize) -> Vec<StringToken> {
         let mut seen = Vec::new();
@@ -845,6 +879,13 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             SwitchCases::Bool { if_true, if_false } => SwitchCases::Bool {
                 if_true: Box::new(self.zonk_tree(*if_true)),
                 if_false: Box::new(self.zonk_tree(*if_false)),
+            },
+            SwitchCases::Char { cases, default } => SwitchCases::Char {
+                cases: cases
+                    .into_iter()
+                    .map(|(k, t)| (k, self.zonk_tree(t)))
+                    .collect(),
+                default: Box::new(self.zonk_tree(*default)),
             },
             SwitchCases::Ctor(ts) => {
                 SwitchCases::Ctor(ts.into_iter().map(|t| self.zonk_tree(t)).collect())

--- a/crates/reussir-core/src/semi/traits/builtins.rs
+++ b/crates/reussir-core/src/semi/traits/builtins.rs
@@ -110,11 +110,12 @@ impl Builtins {
             implement(floating_point, ty, db);
         }
         // Primitive scalars are the `Send`/`Sync` leaves.
-        let scalars =
-            ints.iter()
-                .chain(&fps)
-                .copied()
-                .chain([tcx.mk_bool(), tcx.mk_str(), tcx.mk_unit()]);
+        let scalars = ints.iter().chain(&fps).copied().chain([
+            tcx.mk_bool(),
+            tcx.mk_str(),
+            tcx.mk_char(),
+            tcx.mk_unit(),
+        ]);
         for ty in scalars {
             implement(send, ty, db);
             implement(sync, ty, db);

--- a/crates/reussir-core/src/semi/traits/db.rs
+++ b/crates/reussir-core/src/semi/traits/db.rs
@@ -186,7 +186,12 @@ mod tests {
         with_tcx(|tcx: &TyCtxt| {
             let mut db = TraitDb::new();
             let b = Builtins::register(&mut db, tcx);
-            for ty in [tcx.mk_int(IntTy::Unsigned(64)), tcx.mk_bool(), tcx.mk_str()] {
+            for ty in [
+                tcx.mk_int(IntTy::Unsigned(64)),
+                tcx.mk_bool(),
+                tcx.mk_str(),
+                tcx.mk_char(),
+            ] {
                 assert!(db.select(&needs(b.send, ty)).is_ok());
                 assert!(db.select(&needs(b.sync, ty)).is_ok());
             }

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -133,6 +133,7 @@ pub enum TyKind<'tcx> {
     Fp(FpTy),
     Bool,
     Str,
+    Char,
     Unit,
     Closure {
         params: &'tcx [Ty<'tcx>],
@@ -236,6 +237,10 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn mk_str(&self) -> Ty<'tcx> {
         self.mk(TyKind::Str)
+    }
+
+    pub fn mk_char(&self) -> Ty<'tcx> {
+        self.mk(TyKind::Char)
     }
 
     pub fn mk_unit(&self) -> Ty<'tcx> {

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -61,6 +61,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             }),
             TypeKind::TypeBool => self.tcx.mk_bool(),
             TypeKind::TypeStr => self.tcx.mk_str(),
+            TypeKind::TypeChar => self.tcx.mk_char(),
             TypeKind::TypeUnit => self.tcx.mk_unit(),
             TypeKind::TypeArrow(args, ret) => {
                 let args: Vec<Ty> = args.iter().map(|a| self.eval_type(a)).collect();
@@ -217,6 +218,7 @@ fn is_concretely_non_pointer(t: Ty<'_>) -> bool {
             | TyKind::Fp(_)
             | TyKind::Bool
             | TyKind::Str
+            | TyKind::Char
             | TyKind::Unit
             | TyKind::Nullable(_)
     )

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -19,7 +19,7 @@
 //! concern handled elsewhere.
 
 use reussir_syntax::kind::{ResolvedNode, ResolvedToken, SyntaxKind, TokenKey};
-use reussir_syntax::literal::unescape_string;
+use reussir_syntax::literal::{unescape_char, unescape_string};
 use smallvec::{SmallVec, smallvec};
 
 use crate::literal::{self, FloatLit, Integer};
@@ -135,6 +135,7 @@ pub enum Const {
     ConstInt(Integer),
     ConstFloat(FloatLit),
     ConstString(String),
+    ConstChar(u32),
     ConstBool(bool),
 }
 
@@ -309,6 +310,7 @@ fn constant(token: &ResolvedToken) -> Const {
         IntLit => Const::ConstInt(literal::parse_int(token.text())),
         FloatLit => Const::ConstFloat(literal::parse_float(token.text())),
         StringLit => Const::ConstString(unescape_string(token.text())),
+        CharLit => Const::ConstChar(unescape_char(token.text()) as u32),
         TrueKw => Const::ConstBool(true),
         FalseKw => Const::ConstBool(false),
         k => unreachable!("unexpected constant token {k:?}"),
@@ -360,6 +362,7 @@ fn prim_type(text: &str) -> TypeKind {
         "float8" => fp(FpType::Float8),
         "bool" => TypeKind::TypeBool,
         "str" => TypeKind::TypeStr,
+        "char" => TypeKind::TypeChar,
         "unit" => TypeKind::TypeUnit,
         other => unreachable!("unexpected primitive type {other}"),
     }
@@ -373,6 +376,7 @@ pub enum TypeKind {
     TypeFp(FpType),
     TypeBool,
     TypeStr,
+    TypeChar,
     TypeUnit,
     /// A named type applied to arguments.
     TypeExpr(Path, SmallVec<[Type; 2]>),

--- a/crates/reussir-core/src/utils/string.rs
+++ b/crates/reussir-core/src/utils/string.rs
@@ -100,6 +100,17 @@ impl StringUniqifier {
         self.storage.iter().map(|(s, &token)| (s.as_str(), token))
     }
 
+    /// Return deterministic `(token, payload)` entries for textual IR and codegen.
+    pub fn entries(&self) -> Vec<(StringToken, String)> {
+        let mut entries: Vec<_> = self
+            .storage
+            .iter()
+            .map(|(s, &token)| (token, s.clone()))
+            .collect();
+        entries.sort_by_key(|(token, _)| token.words());
+        entries
+    }
+
     /// The number of distinct strings interned so far.
     pub fn len(&self) -> usize {
         self.storage.len()

--- a/crates/reussir-repl/src/commands.rs
+++ b/crates/reussir-repl/src/commands.rs
@@ -63,8 +63,10 @@ pub fn dispatch(session: &mut ReplSession<'_, '_>, command: &str) -> Outcome {
                     .filter(|(_, r)| !elab.sym(r.name).starts_with("__"))
                     .map(|(k, v)| (*k, v.clone()))
                     .collect();
+                let strings = elab.strings.entries();
                 let text = Printer::new(&elab.defs, elab.resolver).program(
                     &funcs,
+                    &strings,
                     &records,
                     &elab.trampolines,
                 );

--- a/crates/reussir-repl/src/reflect.rs
+++ b/crates/reussir-repl/src/reflect.rs
@@ -161,6 +161,7 @@ pub fn inline_size_align<'tcx>(
     };
     match *ty.kind() {
         TyKind::Bool => scalar(1),
+        TyKind::Char => scalar(4),
         TyKind::Int(int) => {
             let (prefix, width) = match int {
                 IntTy::Signed(w) => ("i", w),
@@ -366,6 +367,14 @@ impl<'tcx> Walker<'_, 'tcx> {
                 } else {
                     "false"
                 }),
+                TyKind::Char => {
+                    let value = addr.cast::<u32>().read_unaligned();
+                    let c = char::from_u32(value)
+                        .ok_or_else(|| format!("invalid stored char code point {value}"))?;
+                    out.push('\'');
+                    out.extend(c.escape_debug());
+                    out.push('\'');
+                }
                 TyKind::Int(IntTy::Signed(w)) => {
                     let v: i64 = match w {
                         8 => addr.cast::<i8>().read_unaligned() as i64,

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -616,6 +616,7 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             TyKind::Fp(reussir_core::semi::ty::FpTy::Float8) => "f8".to_string(),
             TyKind::Bool => "bool".to_string(),
             TyKind::Str => "str".to_string(),
+            TyKind::Char => "char".to_string(),
             TyKind::Unit => "()".to_string(),
             TyKind::Bottom => "!".to_string(),
             TyKind::Nullable(inner) => {

--- a/include/Reussir/Conversion/Blake3Symbol.h
+++ b/include/Reussir/Conversion/Blake3Symbol.h
@@ -1,0 +1,87 @@
+//===-- Blake3Symbol.h - BLAKE3-hashed symbol mangling ---------*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// Content-addressed symbol names for lowering-generated globals (panic
+// messages, string prefixes, string dispatchers): a Rust-v0-style identifier
+// `_RNvC<len(ns)><ns><len(digits)>[_]<digits>` whose digits are the base-62
+// encoding of the payload's 256-bit BLAKE3 digest.
+//
+// The digest-to-number convention matches the Rust frontend's `StringToken`
+// (`reussir-core`'s `utils::string` + `utils::b62`): each 8-byte chunk of the
+// digest is combined little-endian into a word, word 0 is the most
+// significant, and the alphabet is `0-9a-zA-Z`. Both sides therefore derive
+// identical digits from the same payload, on any host.
+//
+//===----------------------------------------------------------------------===//
+#ifndef REUSSIR_CONVERSION_BLAKE3SYMBOL_H
+#define REUSSIR_CONVERSION_BLAKE3SYMBOL_H
+
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/BLAKE3.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <string>
+
+namespace reussir {
+
+/// Folds a hasher's finalized 32-byte digest into four 64-bit words, word 0
+/// most significant, bytes combined little-endian within each word.
+inline std::array<uint64_t, 4> blake3Words(llvm::BLAKE3 &hasher) {
+  std::array<uint8_t, LLVM_BLAKE3_OUT_LEN> digest = hasher.final();
+  std::array<uint64_t, 4> words{};
+  for (unsigned w = 0; w < 4; ++w)
+    for (unsigned b = 0; b < 8; ++b)
+      words[w] |= static_cast<uint64_t>(digest[w * 8 + b]) << (8 * b);
+  return words;
+}
+
+/// The base-62 digits (`0-9a-zA-Z`, most significant first) of a 256-bit
+/// number given word 0 most significant.
+inline std::string base62Digits(std::array<uint64_t, 4> words) {
+  static constexpr char alphabet[] =
+      "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  // APInt's array constructor takes the least-significant word first.
+  llvm::APInt value(256, {words[3], words[2], words[1], words[0]});
+  if (value.isZero())
+    return std::string(1, alphabet[0]);
+  std::string digits;
+  while (!value.isZero()) {
+    uint64_t rem;
+    llvm::APInt::udivrem(value, 62, value, rem);
+    digits.push_back(alphabet[rem]);
+  }
+  std::reverse(digits.begin(), digits.end());
+  return digits;
+}
+
+/// The mangled symbol for already-hashed words. The `_` separator appears
+/// only when the leading digit is numeric (a v0 identifier cannot start with
+/// a digit), and the digit count excludes it — mirroring
+/// `StringToken::mangle` on the Rust side.
+inline std::string mangledBlake3Symbol(llvm::StringRef nameSpace,
+                                       std::array<uint64_t, 4> words) {
+  std::string digits = base62Digits(words);
+  const char *sep = (digits[0] >= '0' && digits[0] <= '9') ? "_" : "";
+  return "_RNvC" + std::to_string(nameSpace.size()) + nameSpace.str() +
+         std::to_string(digits.size()) + sep + digits;
+}
+
+/// The mangled symbol for a single payload string.
+inline std::string mangledBlake3Symbol(llvm::StringRef nameSpace,
+                                       llvm::StringRef payload) {
+  llvm::BLAKE3 hasher;
+  hasher.update(payload);
+  return mangledBlake3Symbol(nameSpace, blake3Words(hasher));
+}
+
+} // namespace reussir
+
+#endif // REUSSIR_CONVERSION_BLAKE3SYMBOL_H

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -14,7 +14,7 @@
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/LogicalResult.h>
-#include <llvm/Support/xxhash.h>
+#include <llvm/Support/BLAKE3.h>
 #include <llvm/TargetParser/Triple.h>
 #include <mlir/Analysis/DataLayoutAnalysis.h>
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
@@ -64,6 +64,10 @@
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/TypeSize.h"
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <utility>
 
 namespace reussir {
 #define GEN_PASS_DEF_REUSSIRBASICOPSLOWERINGPASS
@@ -102,6 +106,68 @@ mlir::DataLayout getDataLayout(const mlir::LLVMTypeConverter &converter,
   return mlir::DataLayout::closest(op);
 }
 
+std::pair<uint64_t, uint64_t> divMod62Word(uint64_t carry, uint64_t word) {
+  constexpr uint64_t quotientCarry = 297528130221121800ULL;
+  constexpr uint64_t remainderCarry = 16ULL;
+  uint64_t qPart1 = carry * quotientCarry;
+  uint64_t rPart1 = carry * remainderCarry;
+  uint64_t qPart2 = word / 62;
+  uint64_t rPart2 = word % 62;
+  uint64_t rSum = rPart1 + rPart2;
+  uint64_t qAdj = rSum >= 62 ? rSum / 62 : 0;
+  uint64_t rFinal = rSum >= 62 ? rSum % 62 : rSum;
+  return {qPart1 + qPart2 + qAdj, rFinal};
+}
+
+std::pair<std::array<uint64_t, 4>, unsigned>
+divMod62(std::array<uint64_t, 4> words) {
+  auto [q0, r0] = divMod62Word(0, words[0]);
+  auto [q1, r1] = divMod62Word(r0, words[1]);
+  auto [q2, r2] = divMod62Word(r1, words[2]);
+  auto [q3, r3] = divMod62Word(r2, words[3]);
+  return {{{q0, q1, q2, q3}}, static_cast<unsigned>(r3)};
+}
+
+bool isZero(std::array<uint64_t, 4> words) {
+  return words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0;
+}
+
+char b62Digit(unsigned digit) {
+  if (digit < 10)
+    return static_cast<char>('0' + digit);
+  if (digit < 36)
+    return static_cast<char>('a' + digit - 10);
+  return static_cast<char>('A' + digit - 36);
+}
+
+std::string b62Encode(std::array<uint64_t, 4> words) {
+  if (isZero(words))
+    return "0";
+  std::string out;
+  while (!isZero(words)) {
+    auto [quotient, digit] = divMod62(words);
+    out.push_back(b62Digit(digit));
+    words = quotient;
+  }
+  std::reverse(out.begin(), out.end());
+  return out;
+}
+
+std::array<uint64_t, 4> blake3Words(llvm::StringRef payload) {
+  llvm::BLAKE3 blake3;
+  blake3.update(payload);
+  auto result = blake3.final();
+  return std::bit_cast<std::array<uint64_t, 4>>(result);
+}
+
+std::string mangledBlake3Name(llvm::StringRef nameSpace,
+                              llvm::StringRef payload) {
+  std::string digits = b62Encode(blake3Words(payload));
+  const char *sep = (digits[0] >= '0' && digits[0] <= '9') ? "_" : "";
+  return "_RNvC" + std::to_string(nameSpace.size()) + nameSpace.str() +
+         std::to_string(digits.size()) + sep + digits;
+}
+
 template <typename Op>
 void addLifetimeOrInvariantOp(
     mlir::OpBuilder &rewriter, mlir::Location loc,
@@ -129,12 +195,9 @@ struct ReussirPanicConversionPattern
     // Get the panic message
     llvm::StringRef message = op.getMessage();
 
-    // Create a unique symbol name for the global string using xxh128
-    llvm::ArrayRef<uint8_t> messageBytes(
-        reinterpret_cast<const uint8_t *>(message.data()), message.size());
-    llvm::XXH128_hash_t hash = llvm::xxh3_128bits(messageBytes);
-    std::string globalName = "__panic_message_" + llvm::utohexstr(hash.high64) +
-                             "_" + llvm::utohexstr(hash.low64);
+    // Create a stable symbol name for the global string using BLAKE3.
+    std::string globalName =
+        mangledBlake3Name("REUSSIR_PANIC_MESSAGE", message);
 
     // Get or create the global string constant
     auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
@@ -2256,13 +2319,9 @@ struct ReussirStrUnsafeStartWithOpConversionPattern
         rewriter, loc, adaptor.getStr(), llvm::ArrayRef<int64_t>{0});
 
     // Use memcmp for all prefix lengths as LLVM optimizes it well.
-    // 1. Create global string for prefix
-    // Use hash to avoid duplicate strings (similar to PanicOp)
-    llvm::ArrayRef<uint8_t> messageBytes(
-        reinterpret_cast<const uint8_t *>(prefix.data()), prefix.size());
-    llvm::XXH128_hash_t hash = llvm::xxh3_128bits(messageBytes);
-    std::string globalName = "__str_prefix_" + llvm::utohexstr(hash.high64) +
-                             "_" + llvm::utohexstr(hash.low64);
+    // 1. Create a deduplicated global string for the prefix.
+    std::string globalName =
+        mangledBlake3Name("REUSSIR_STRING_PREFIX", prefix);
 
     auto existingGlobal = module.lookupSymbol<mlir::LLVM::GlobalOp>(globalName);
     if (!existingGlobal) {

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -2186,6 +2186,18 @@ struct ReussirStrLiteralOpConversionPattern
   }
 };
 
+struct ReussirStrCastOpConversionPattern
+    : public mlir::OpConversionPattern<ReussirStrCastOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirStrCastOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOp(op, adaptor.getGlobalStr());
+    return mlir::success();
+  }
+};
+
 struct ReussirStrLenOpConversionPattern
     : public mlir::OpConversionPattern<ReussirStrLenOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -2789,8 +2801,9 @@ struct ReussirConvertToLLVMPatternInterface
         ReussirClosureCursorOp, ReussirClosureInstantiateOp,
         ReussirClosureVtableOp, ReussirClosureCreateOp, ReussirRcFetchOp,
         ReussirRcSetOp, ReussirStrGlobalOp, ReussirStrLiteralOp,
-        ReussirStrLenOp, ReussirStrUnsafeByteAtOp, ReussirStrUnsafeStartWithOp,
-        ReussirStrSliceOp, ReussirTrampolineOp, ReussirTokenLaunderOp>();
+        ReussirStrCastOp, ReussirStrLenOp, ReussirStrUnsafeByteAtOp,
+        ReussirStrUnsafeStartWithOp, ReussirStrSliceOp, ReussirTrampolineOp,
+        ReussirTokenLaunderOp>();
   }
 };
 
@@ -2902,7 +2915,7 @@ void populateBasicOpsLoweringToLLVMConversionPatterns(
       ReussirRcReinterpretConversionPattern, ReussirRcFetchConversionPattern,
       ReussirRcSetConversionPattern, ReussirStrGlobalOpConversionPattern,
       ReussirStrLiteralOpConversionPattern, ReussirPanicConversionPattern,
-      ReussirStrLenOpConversionPattern,
+      ReussirStrCastOpConversionPattern, ReussirStrLenOpConversionPattern,
       ReussirStrUnsafeByteAtOpConversionPattern,
       ReussirStrUnsafeStartWithOpConversionPattern,
       ReussirStrSliceOpConversionPattern, ReussirTrampolineOpConversionPattern,

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -14,7 +14,6 @@
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/LogicalResult.h>
-#include <llvm/Support/BLAKE3.h>
 #include <llvm/TargetParser/Triple.h>
 #include <mlir/Analysis/DataLayoutAnalysis.h>
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
@@ -52,6 +51,7 @@
 #include <mlir/Transforms/DialectConversion.h>
 
 #include "Reussir/Conversion/BasicOpsLowering.h"
+#include "Reussir/Conversion/Blake3Symbol.h"
 #include "Reussir/Conversion/CABISignatureConversion.h"
 #include "Reussir/Conversion/TypeConverter.h"
 #include "Reussir/IR/ReussirAttrs.h"
@@ -64,10 +64,6 @@
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/TypeSize.h"
-#include <algorithm>
-#include <array>
-#include <bit>
-#include <utility>
 
 namespace reussir {
 #define GEN_PASS_DEF_REUSSIRBASICOPSLOWERINGPASS
@@ -106,68 +102,6 @@ mlir::DataLayout getDataLayout(const mlir::LLVMTypeConverter &converter,
   return mlir::DataLayout::closest(op);
 }
 
-std::pair<uint64_t, uint64_t> divMod62Word(uint64_t carry, uint64_t word) {
-  constexpr uint64_t quotientCarry = 297528130221121800ULL;
-  constexpr uint64_t remainderCarry = 16ULL;
-  uint64_t qPart1 = carry * quotientCarry;
-  uint64_t rPart1 = carry * remainderCarry;
-  uint64_t qPart2 = word / 62;
-  uint64_t rPart2 = word % 62;
-  uint64_t rSum = rPart1 + rPart2;
-  uint64_t qAdj = rSum >= 62 ? rSum / 62 : 0;
-  uint64_t rFinal = rSum >= 62 ? rSum % 62 : rSum;
-  return {qPart1 + qPart2 + qAdj, rFinal};
-}
-
-std::pair<std::array<uint64_t, 4>, unsigned>
-divMod62(std::array<uint64_t, 4> words) {
-  auto [q0, r0] = divMod62Word(0, words[0]);
-  auto [q1, r1] = divMod62Word(r0, words[1]);
-  auto [q2, r2] = divMod62Word(r1, words[2]);
-  auto [q3, r3] = divMod62Word(r2, words[3]);
-  return {{{q0, q1, q2, q3}}, static_cast<unsigned>(r3)};
-}
-
-bool isZero(std::array<uint64_t, 4> words) {
-  return words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0;
-}
-
-char b62Digit(unsigned digit) {
-  if (digit < 10)
-    return static_cast<char>('0' + digit);
-  if (digit < 36)
-    return static_cast<char>('a' + digit - 10);
-  return static_cast<char>('A' + digit - 36);
-}
-
-std::string b62Encode(std::array<uint64_t, 4> words) {
-  if (isZero(words))
-    return "0";
-  std::string out;
-  while (!isZero(words)) {
-    auto [quotient, digit] = divMod62(words);
-    out.push_back(b62Digit(digit));
-    words = quotient;
-  }
-  std::reverse(out.begin(), out.end());
-  return out;
-}
-
-std::array<uint64_t, 4> blake3Words(llvm::StringRef payload) {
-  llvm::BLAKE3 blake3;
-  blake3.update(payload);
-  auto result = blake3.final();
-  return std::bit_cast<std::array<uint64_t, 4>>(result);
-}
-
-std::string mangledBlake3Name(llvm::StringRef nameSpace,
-                              llvm::StringRef payload) {
-  std::string digits = b62Encode(blake3Words(payload));
-  const char *sep = (digits[0] >= '0' && digits[0] <= '9') ? "_" : "";
-  return "_RNvC" + std::to_string(nameSpace.size()) + nameSpace.str() +
-         std::to_string(digits.size()) + sep + digits;
-}
-
 template <typename Op>
 void addLifetimeOrInvariantOp(
     mlir::OpBuilder &rewriter, mlir::Location loc,
@@ -197,7 +131,7 @@ struct ReussirPanicConversionPattern
 
     // Create a stable symbol name for the global string using BLAKE3.
     std::string globalName =
-        mangledBlake3Name("REUSSIR_PANIC_MESSAGE", message);
+        mangledBlake3Symbol("REUSSIR_PANIC_MESSAGE", message);
 
     // Get or create the global string constant
     auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
@@ -2321,7 +2255,7 @@ struct ReussirStrUnsafeStartWithOpConversionPattern
     // Use memcmp for all prefix lengths as LLVM optimizes it well.
     // 1. Create a deduplicated global string for the prefix.
     std::string globalName =
-        mangledBlake3Name("REUSSIR_STRING_PREFIX", prefix);
+        mangledBlake3Symbol("REUSSIR_STRING_PREFIX", prefix);
 
     auto existingGlobal = module.lookupSymbol<mlir::LLVM::GlobalOp>(globalName);
     if (!existingGlobal) {

--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -58,7 +58,7 @@ namespace {
 
 std::string b62encode(llvm::APInt value) {
   const char *alphabet =
-      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+      "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   if (value.isZero())
     return std::string(1, alphabet[0]);
 

--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -7,13 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/SCFOpsLowering.h"
+#include "Reussir/Conversion/Blake3Symbol.h"
 #include "Reussir/Conversion/RcDecrementExpansion.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirEnumAttrs.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
-#include <algorithm>
-#include <format>
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/MapVector.h>
 #include <llvm/ADT/SmallVector.h>
@@ -25,9 +24,9 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Bufferization/IR/Bufferization.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
-#include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
@@ -56,38 +55,12 @@ namespace {
 /// Hashing / naming
 /// =======================
 
-std::string b62encode(llvm::APInt value) {
-  const char *alphabet =
-      "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  if (value.isZero())
-    return std::string(1, alphabet[0]);
-
-  std::string result;
-  while (!value.isZero()) {
-    uint64_t rem;
-    llvm::APInt::udivrem(value, 62, value, rem);
-    result.push_back(alphabet[rem]);
-  }
-  std::reverse(result.begin(), result.end());
-  return result;
-}
-
-llvm::APInt blakeHashedPattern(mlir::ArrayAttr pattern) {
-  llvm::BLAKE3 blake3;
-  for (auto attr : pattern.getValue()) {
-    if (auto s = llvm::dyn_cast<mlir::StringAttr>(attr))
-      blake3.update(s.getValue());
-  }
-  auto result = blake3.final();
-  auto data = std::bit_cast<std::array<uint64_t, 4>>(result);
-  return llvm::APInt(256, data);
-}
-
 std::string decisionFunctionName(mlir::ArrayAttr patterns) {
-  std::string hash = b62encode(blakeHashedPattern(patterns));
-  const char *sep = (hash[0] >= '0' && hash[0] <= '9') ? "_" : "";
-  return std::format("_RNvC25REUSSIR_STRING_DISPATCHER{}{}{}", hash.size(), sep,
-                     hash);
+  llvm::BLAKE3 hasher;
+  for (auto attr : patterns.getValue())
+    if (auto s = llvm::dyn_cast<mlir::StringAttr>(attr))
+      hasher.update(s.getValue());
+  return mangledBlake3Symbol("REUSSIR_STRING_DISPATCHER", blake3Words(hasher));
 }
 
 struct PatternInfo {


### PR DESCRIPTION
Stack:
1. #319: syntax/parser support for char literals
2. #320: semantic wiring, lossless HIR/MIR, and codegen for string/char matches
3. This PR: migrate string-related backend C++ hashing/mangling to BLAKE3

Summary:
- Replace string-related `xxh3_128bits` global-name generation in backend lowering with BLAKE3.
- Use the same Rust-style base62 mangling scheme for panic-message and string-prefix globals.
- Align the string dispatcher base62 alphabet with the Rust mangling scheme.
- Leave the remaining `xxhash` use in token reuse alone because it is not string-related.

Validation:
- `ninja -C build check` on `codex/290-string-blake3`: 258 passed, 4 unsupported
- `../../bin/reussir-ut` from `build/tests/unittest`: 17 passed
- Earlier stack checks: `cargo test -p reussir-syntax -p reussir-core`; `direnv exec . cargo test -p reussir-backend -p reussir-codegen -p reussir-compiler --no-run`
