### PR TITLE
frontend: field shorthand auto-forward; migrate field_shorthand + sanitizer lits to rrc

### DIFF
--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1018,9 +1018,28 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
         }
         // Named arguments are matched by field name (an interned key compare);
-        // positional by order.
-        let named = args.iter().any(|(f, _)| f.is_some());
-        let arg_fields: Vec<Option<TokenKey>> = args.iter().map(|(f, _)| *f).collect();
+        // positional by order. Field shorthand auto-forwards: a bare in-scope
+        // variable whose name matches a field acts as that named argument, so
+        // `Point { y, x }` is order-independent and composes with explicit
+        // named arguments (`Point { x, y: 10 }`).
+        let arg_fields: Vec<Option<TokenKey>> = args
+            .iter()
+            .map(|(f, e)| {
+                f.or_else(|| match e.kind() {
+                    surface::ExprKind::Var(path)
+                        if path.segments.is_empty()
+                            && field_tys
+                                .iter()
+                                .any(|(fname, _)| *fname == Some(path.basename))
+                            && self.vars.lookup(path.basename).is_some() =>
+                    {
+                        Some(path.basename)
+                    }
+                    _ => None,
+                })
+            })
+            .collect();
+        let named = arg_fields.iter().any(|f| f.is_some());
         let mut out = Vec::new();
         if named {
             for (fname, fty) in field_tys {

--- a/tests/integration/frontend/field_shorthand.rr
+++ b/tests/integration/frontend/field_shorthand.rr
@@ -1,5 +1,6 @@
-// RUN: %reussir-elab --mode semi %s
-// RUN: %reussir-elab --mode full %s | %FileCheck %s
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
+// RUN: %rrc %s -o %t.o
 
 // Test: auto-forward field shorthand syntax
 // When a constructor argument is a simple variable reference matching
@@ -16,24 +17,15 @@ fn make_point(x: i32, y: i32) -> Point {
     Point { x, y }
 }
 
-// CHECK-DAG: fn _RC10make_point(x: i32, y: i32) -> Rc<{{.*}}Point{{.*}}> {
-// CHECK-DAG: compound
-
 // Test: mixed shorthand and explicit
 fn make_point_mixed(x: i32) -> Point {
     Point { x, y: 10 }
 }
 
-// CHECK-DAG: fn _RC16make_point_mixed(x: i32) -> Rc<{{.*}}Point{{.*}}> {
-// CHECK-DAG: compound
-
 // Test: order independence with shorthand
 fn make_point_reversed(x: i32, y: i32) -> Point {
     Point { y, x }
 }
-
-// CHECK-DAG: fn _RC19make_point_reversed(x: i32, y: i32) -> Rc<{{.*}}Point{{.*}}> {
-// CHECK-DAG: compound
 
 // Test: shorthand only applies when variable is in scope
 fn make_point_explicit() -> Point {
@@ -42,5 +34,44 @@ fn make_point_explicit() -> Point {
     Point { x, y }
 }
 
-// CHECK-DAG: fn _RC19make_point_explicit() -> Rc<{{.*}}Point{{.*}}> {
-// CHECK-DAG: compound
+// CHECK: [shared] struct #Point { "x": i32, "y": i32 };
+// CHECK-EMPTY:
+// CHECK-NEXT: fn #make_point(v0 (x): i32, v1 (y): i32) -> #Point {
+// CHECK-NEXT:     #Point{v0 : i32, v1 : i32} : #Point
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: fn #make_point_mixed(v0 (x): i32) -> #Point {
+// CHECK-NEXT:     #Point{v0 : i32, 10 : i32} : #Point
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// `Point { y, x }` still assigns `x` to field `x`: shorthand is matched by
+// name, not position.
+// CHECK-NEXT: fn #make_point_reversed(v0 (x): i32, v1 (y): i32) -> #Point {
+// CHECK-NEXT:     #Point{v0 : i32, v1 : i32} : #Point
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: fn #make_point_explicit() -> #Point {
+// CHECK-NEXT:     let v0 (x) = 5 : i32;
+// CHECK-NEXT:     let v1 (y) = 10 : i32;
+// CHECK-NEXT:     #Point{v0 : i32, v1 : i32} : #Point
+// CHECK-NEXT: }
+
+// FULL: record @_RC5Point : shared struct Point { "x": i32, "y": i32 };
+// FULL-EMPTY:
+// FULL-NEXT: fn @_RC10make_point(v0 (x): i32, v1 (y): i32) -> Point {
+// FULL-NEXT:     @_RC5Point{v0 : i32, v1 : i32} : Point
+// FULL-NEXT: }
+// FULL-EMPTY:
+// FULL-NEXT: fn @_RC16make_point_mixed(v0 (x): i32) -> Point {
+// FULL-NEXT:     @_RC5Point{v0 : i32, 10 : i32} : Point
+// FULL-NEXT: }
+// FULL-EMPTY:
+// FULL-NEXT: fn @_RC19make_point_explicit() -> Point {
+// FULL-NEXT:     let v0 (x) = 5 : i32;
+// FULL-NEXT:     let v1 (y) = 10 : i32;
+// FULL-NEXT:     @_RC5Point{v0 : i32, v1 : i32} : Point
+// FULL-NEXT: }
+// FULL-EMPTY:
+// FULL-NEXT: fn @_RC19make_point_reversed(v0 (x): i32, v1 (y): i32) -> Point {
+// FULL-NEXT:     @_RC5Point{v0 : i32, v1 : i32} : Point
+// FULL-NEXT: }

--- a/tests/integration/sanitizer/rbtree-asan.rr
+++ b/tests/integration/sanitizer/rbtree-asan.rr
@@ -1,5 +1,5 @@
 // REQUIRES: asan
-// RUN: %reussir-compiler %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %rrc %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
 // RUN: %cc %asan_flags -c -x ir %t.ll -o %t.o
 // RUN: %cc %asan_flags %t.o %S/rbtree2-harness.c %reussir_rt_asan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
 // RUN: %asan_env %t.exe

--- a/tests/integration/sanitizer/rbtree-lsan-leak.rr
+++ b/tests/integration/sanitizer/rbtree-lsan-leak.rr
@@ -1,5 +1,5 @@
 // REQUIRES: lsan
-// RUN: %reussir-compiler %S/../frontend/rbtree.rr -o %t.ll -t llvm-ir --relocation-mode pic
+// RUN: %rrc %S/../frontend/rbtree.rr -o %t.ll -t llvm-ir --relocation-mode pic
 // RUN: %cc %lsan_flags -c -x ir %t.ll -o %t.o
 // RUN: %cc %lsan_flags %t.o %S/rbtree-harness.c %reussir_rt_lsan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
 // RUN: %lsan_env %not --crash %t.exe

--- a/tests/integration/sanitizer/rbtree-msan.rr
+++ b/tests/integration/sanitizer/rbtree-msan.rr
@@ -1,5 +1,5 @@
 // REQUIRES: msan
-// RUN: %reussir-compiler %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %rrc %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
 // RUN: %cc %msan_flags -c -x ir %t.ll -o %t.o
 // RUN: %cc %msan_flags %t.o %S/rbtree2-harness.c %reussir_rt_msan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
 // RUN: %msan_env %t.exe

--- a/tests/integration/sanitizer/rbtree-tsan.rr
+++ b/tests/integration/sanitizer/rbtree-tsan.rr
@@ -1,5 +1,5 @@
 // REQUIRES: tsan
-// RUN: %reussir-compiler %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %rrc %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
 // RUN: %cc %tsan_flags -c -x ir %t.ll -o %t.o
 // RUN: %cc %tsan_flags %t.o %S/rbtree2-harness.c %reussir_rt_tsan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
 // RUN: %tsan_env %t.exe


### PR DESCRIPTION
Another round of the Haskell→Rust lit migration (#290).

## Field shorthand (`check_ctor_args`)

rrc *accepted* shorthand syntax but with the wrong semantics: a shorthand argument carried no field name, so it fell into **positional** matching. That made `Point { y, x }` silently swap the fields (confirmed: `p.x` returned the `y` argument), and `Point { x, y: 10 }` errored with `missing field x`.

This implements the auto-forward rule the original test documents: a bare **in-scope** variable argument whose name matches a field is treated as that named argument. Shorthand is now order-independent and composes with explicit named fields. Plain positional construction is unaffected (a bare var not matching any field name stays positional).

## Test migrations

- `frontend/field_shorthand.rr`: `%reussir-elab` → `%rrc`, with exact HIR/MIR FileCheck lines (the reversed case pins the by-name semantics) plus an object-emission RUN line.
- `sanitizer/rbtree-{asan,msan,tsan,lsan-leak}.rr`: `%reussir-compiler` → `%rrc`. The flags are identical (`-t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call`); both `rbtree.rr` and `rbtree2.rr` already compile with rrc (verified locally). These report UNSUPPORTED without sanitizer runtimes built, so CI with sanitizers is what exercises them end-to-end.

## Still blocked (probed on current main, unchanged)

- `fn_lift.rr` — function-to-closure lifting (`unknown variable `double``).
- `math.rr`, `repl/polymorphic.repl` — `core::intrinsic::math::*` not resolvable.
- `module_*.rr` (6) — rrc has no `--package-root`/`--package-name`.

`ninja check`: 258 pass / 4 unsupported (sanitizers, local); `cargo test -p reussir-core -p reussir-codegen -p reussir-compiler` all green; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lyv7Gnx2BPF7N85xhmPS5J