### PR TITLE
capi: gate stripInvariantGroupBarriers behind REUSSIR_HAS_TPDE

### DIFF
--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -65,6 +65,7 @@ void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt)
   mpm.run(m, mam);
 }
 
+#ifdef REUSSIR_HAS_TPDE
 namespace {
 /// TPDE has no lowering for the invariant.group barrier intrinsics the
 /// frozen/shared payload loads carry (`llvm.launder.invariant.group`,
@@ -89,6 +90,7 @@ void stripInvariantGroupBarriers(llvm::Module &m) {
   }
 }
 } // namespace
+#endif // REUSSIR_HAS_TPDE
 
 LLVMMemoryBufferRef
 reussirTpdeCompileToObject(LLVMModuleRef module, const char *dataLayout,


### PR DESCRIPTION
The macOS Homebrew CI job (no TPDE) has been red on main for the last three pushes:

```
lib/CAPI/Jit.cpp:75:6: error: unused function 'stripInvariantGroupBarriers' [-Werror,-Wunused-function]
```

`stripInvariantGroupBarriers` is only called inside the `#ifdef REUSSIR_HAS_TPDE` block of `reussirTpdeCompileToObject`, so on non-TPDE configurations the anonymous-namespace helper is unused. This moves its definition inside the same guard. Verified the TPDE-enabled side still compiles locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lyv7Gnx2BPF7N85xhmPS5J