### PR TITLE
tests: ASan/LSan e2e gates + regional cyclic-graph coverage

### DIFF
--- a/tests/integration/frontend/regional_cycle.c
+++ b/tests/integration/frontend/regional_cycle.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern uint64_t ring3_sum_ffi(uint64_t rounds);
+extern uint64_t ring_n_sum_ffi(uint64_t n, uint64_t rounds);
+extern uint64_t make_and_drop_ffi(uint64_t n);
+
+static void expect(const char *what, uint64_t got, uint64_t want) {
+    if (got != want) {
+        fprintf(stderr, "FAIL: %s = %llu, want %llu\n", what,
+                (unsigned long long)got, (unsigned long long)want);
+        abort();
+    }
+}
+
+int main(void) {
+    expect("ring3_sum(4)", ring3_sum_ffi(4), 4 * (1 + 2 + 3));
+    expect("ring_n_sum(100, 3)", ring_n_sum_ffi(100, 3), 3 * (100 * 101 / 2));
+    expect("make_and_drop(64)", make_and_drop_ffi(64), 1);
+    return 0;
+}

--- a/tests/integration/frontend/regional_cycle.rr
+++ b/tests/integration/frontend/regional_cycle.rr
@@ -1,0 +1,92 @@
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/regional_cycle.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// Cyclic graph inside a region: `[field]` link assignment closes a ring, the
+// region freezes it to a rigid strongly-connected component, and the frozen
+// cycle is traversed (link reads through `Nullable` dispatch) and dropped.
+// Plain reference counting cannot collect a cycle, so dropping the ring
+// exercises the region scanner's SCC handling — the companion sanitizer/e2e
+// test checks the drop is leak-free under ASan/LSan.
+
+struct [regional] Node {
+    val: u64,
+    next: [field] Node
+}
+
+regional fn new_node(v: u64) -> [flex] Node {
+    Node { val: v, next: Nullable::Null {} }
+}
+
+// A minimal ring: 1 -> 2 -> 3 -> back to 1.
+regional fn make_ring3() -> [flex] Node {
+    let a = new_node(1);
+    let b = new_node(2);
+    let c = new_node(3);
+    a->next := Nullable::NonNull{b};
+    b->next := Nullable::NonNull{c};
+    c->next := Nullable::NonNull{a};
+    a
+}
+
+// Prepend nodes k, k-1, .., 1 in front of `head`.
+regional fn chain(k: u64, head: [flex] Node) -> [flex] Node {
+    if k == 0 {
+        head
+    } else {
+        let m = new_node(k);
+        m->next := Nullable::NonNull{head};
+        chain(k - 1, m)
+    }
+}
+
+// A ring of n nodes valued 1..n (one larger strongly-connected component).
+regional fn make_ring_n(n: u64) -> [flex] Node {
+    let last = new_node(n);
+    let head = chain(n - 1, last);
+    last->next := Nullable::NonNull{head};
+    head
+}
+
+fn freeze_ring3() -> Node {
+    regional { make_ring3() }
+}
+
+fn freeze_ring_n(n: u64) -> Node {
+    regional { make_ring_n(n) }
+}
+
+// Walk k links through the frozen cycle, summing the values passed.
+fn walk(n: Node, k: u64, acc: u64) -> u64 {
+    if k == 0 {
+        acc
+    } else {
+        match n.next {
+            Nullable::NonNull(m) => walk(m, k - 1, acc + n.val),
+            Nullable::Null => acc
+        }
+    }
+}
+
+// rounds full laps of the 3-ring: expect rounds * (1+2+3).
+pub fn ring3_sum(rounds: u64) -> u64 {
+    let ring = freeze_ring3();
+    walk(ring, rounds * 3, 0)
+}
+
+// rounds full laps of an n-ring: expect rounds * n*(n+1)/2.
+pub fn ring_n_sum(n: u64, rounds: u64) -> u64 {
+    let ring = freeze_ring_n(n);
+    walk(ring, rounds * n, 0)
+}
+
+// Freeze a cycle and drop it immediately after one read: the whole SCC must
+// be reclaimed even though every node still holds a reference to the next.
+pub fn make_and_drop(n: u64) -> u64 {
+    let ring = freeze_ring_n(n);
+    ring.val
+}
+
+extern "C" trampoline "ring3_sum_ffi" = ring3_sum;
+extern "C" trampoline "ring_n_sum_ffi" = ring_n_sum;
+extern "C" trampoline "make_and_drop_ffi" = make_and_drop;

--- a/tests/integration/sanitizer/e2e/closure_e2e.rr
+++ b/tests/integration/sanitizer/e2e/closure_e2e.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/closure_e2e.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/closure_e2e.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/closure_e2e.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/closure_e2e.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/closure_e2e.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/closure_e2e.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/closure_e2e.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/closure_multiplicity.rr
+++ b/tests/integration/sanitizer/e2e/closure_multiplicity.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/closure_multiplicity.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/closure_multiplicity.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/closure_multiplicity.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/closure_multiplicity.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/closure_multiplicity.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/closure_multiplicity.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/closure_multiplicity.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/closure_nested_capture.rr
+++ b/tests/integration/sanitizer/e2e/closure_nested_capture.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/closure_nested_capture.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/closure_nested_capture.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/closure_nested_capture.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/closure_nested_capture.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/closure_nested_capture.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/closure_nested_capture.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/closure_nested_capture.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/closure_struct_materialize.rr
+++ b/tests/integration/sanitizer/e2e/closure_struct_materialize.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/closure_struct_materialize.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/closure_struct_materialize.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/closure_struct_materialize.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/closure_struct_materialize.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/closure_struct_materialize.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/closure_struct_materialize.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/closure_struct_materialize.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/fibonacci-generic.rr
+++ b/tests/integration/sanitizer/e2e/fibonacci-generic.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/fibonacci-generic.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/fibonacci-generic.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/fibonacci.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/fibonacci-generic.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/fibonacci.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/fibonacci-generic.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/fibonacci.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/fibonacci-shared.rr
+++ b/tests/integration/sanitizer/e2e/fibonacci-shared.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/fibonacci-shared.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/fibonacci-shared.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/fibonacci.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/fibonacci-shared.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/fibonacci.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/fibonacci-shared.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/fibonacci.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/fibonacci.rr
+++ b/tests/integration/sanitizer/e2e/fibonacci.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/fibonacci.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/fibonacci.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/fibonacci.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/fibonacci.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/fibonacci.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/fibonacci.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/fibonacci.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/huge_value_struct_call_and_return.rr
+++ b/tests/integration/sanitizer/e2e/huge_value_struct_call_and_return.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/huge_value_struct_call_and_return.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/huge_value_struct_call_and_return.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/huge_value_struct_call_and_return.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/huge_value_struct_call_and_return.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/huge_value_struct_call_and_return.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/huge_value_struct_call_and_return.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/huge_value_struct_call_and_return.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/nbe-hoas.rr
+++ b/tests/integration/sanitizer/e2e/nbe-hoas.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/nbe-hoas.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/nbe-hoas.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/nbe.rr.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/nbe-hoas.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/nbe.rr.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/nbe-hoas.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/nbe.rr.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/nbe.rr
+++ b/tests/integration/sanitizer/e2e/nbe.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/nbe.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/nbe.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/nbe.rr.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/nbe.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/nbe.rr.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/nbe.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/nbe.rr.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/nullable_match.rr
+++ b/tests/integration/sanitizer/e2e/nullable_match.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/nullable_match.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/nullable_match.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/nullable_match.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/nullable_match.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/nullable_match.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/nullable_match.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/nullable_match.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/rbtree-zipper.rr
+++ b/tests/integration/sanitizer/e2e/rbtree-zipper.rr
@@ -1,0 +1,11 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/rbtree-zipper.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+// Heavy test: only exercised at -Oaggressive (deep recursion overflows the
+// ASan-instrumented stack at lower optimization levels).
+
+// RUN: %rrc %S/../../frontend/rbtree-zipper.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/rbtree2.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/regional_cycle.rr
+++ b/tests/integration/sanitizer/e2e/regional_cycle.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/regional_cycle.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/regional_cycle.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/regional_cycle.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/regional_cycle.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/regional_cycle.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/regional_cycle.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/regional_cycle.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/regional_member_projection.rr
+++ b/tests/integration/sanitizer/e2e/regional_member_projection.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/regional_member_projection.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/regional_member_projection.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/regional_member_projection.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/regional_member_projection.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/regional_member_projection.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/regional_member_projection.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/regional_member_projection.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/vapp.rr
+++ b/tests/integration/sanitizer/e2e/vapp.rr
@@ -1,0 +1,19 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/vapp.rr. Its FFI returns only scalars, so
+// the compiled code must free every allocation itself: any leak (or ASan
+// error) reported here is a real ownership/lowering/backend bug.
+
+// RUN: %rrc %S/../../frontend/vapp.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/vapp.rr.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/vapp.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/vapp.rr.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/vapp.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/vapp.rr.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe


### PR DESCRIPTION
Follow-up to the empirical leak audit of the ownership analysis (context in #290's sanitizer notes).

## sanitizer/e2e/ — leak gates over the executing corpus

One wrapper per executing frontend test whose FFI returns **only scalars** — for those, the compiled Reussir code must free every allocation itself, so any LSan leak or ASan error is a genuine ownership/lowering/backend bug (value-checking alone is blind to leaks: the legacy frontend leaked every `[shared]` closure box without any test noticing).

- 14 tests run at **-Onone, -Odefault, and -Oaggressive --reuse-across-call** — the backend rc passes (IncDecCancellation, TokenReuse, …) differ per level, and each has had level-specific bugs.
- **rbtree-zipper runs at -Oaggressive only** (heavy: deep recursion overflows the ASan-instrumented stack at lower levels).
- `rbtree`/`rbtree_to_list` are excluded: their harnesses intentionally abandon the FFI-returned list (that's the existing lsan-leak canary's job).
- Gated on `REQUIRES: asan` — active when configured with `-DREUSSIR_RUNTIME_SANITIZERS=address` (no CI job sets this today; the suite reports UNSUPPORTED otherwise).

## frontend/regional_cycle.rr — first executing cyclic-graph test

The corpus had no executing test building a **cycle inside a region** — the one shape plain reference counting cannot collect, and exactly what the region scanner's SCC machinery exists for. The new test:

- closes a 3-ring and an n-ring (n=100/64) via `[field]` assignment,
- freezes them to rigid SCCs,
- traverses the frozen cycles through `Nullable` link reads (multiple full laps), and
- drops whole SCCs immediately after a single read.

Its `sanitizer/e2e` twin verifies the cyclic drops are leak-free at all three opt levels.

## Verification

`ninja check` with `REUSSIR_RUNTIME_SANITIZERS="address;leak;memory;thread"`: **278/278 pass** (the 15 new e2e gates plus `regional_cycle` all execute for real; the lsan canary confirms the sanitizers observe runtime allocations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lyv7Gnx2BPF7N85xhmPS5J