### PR TITLE
[backend] never call the allocator to free a null token (#325 P1)

### DIFF
--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -771,6 +771,44 @@ struct ReussirTokenEnsureOpRewritePattern
   }
 };
 
+/// `token.free` of a *nullable* token lowers to an unconditional
+/// `__reussir_deallocate` call whose null guard lives inside the runtime — so
+/// the null case (the shared branch of an expanded rc decrement) still pays a
+/// full call to do nothing. Guard it here, while structured control flow is
+/// still available: coerce and free only when non-null. Plain-token frees are
+/// left for the basic-ops lowering (their pointer is statically non-null).
+struct ReussirNullableTokenFreeOpRewritePattern
+    : public mlir::OpConversionPattern<ReussirTokenFreeOp> {
+  using OpConversionPattern::OpConversionPattern;
+  mlir::LogicalResult
+  matchAndRewrite(ReussirTokenFreeOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto nullableType = llvm::dyn_cast<NullableType>(op.getToken().getType());
+    if (!nullableType)
+      return mlir::failure();
+    auto tokenType = llvm::dyn_cast<TokenType>(nullableType.getPtrTy());
+    if (!tokenType)
+      return mlir::failure();
+    mlir::Location loc = op.getLoc();
+    // `nullable.check`'s flag is true when non-null (the dispatch lowering
+    // above routes the non-null region through the then-branch the same way).
+    mlir::Value flag =
+        reussir::ReussirNullableCheckOp::create(rewriter, loc, op.getToken());
+    auto ifOp = mlir::scf::IfOp::create(rewriter, loc, mlir::TypeRange{}, flag,
+                                        /*addThenRegion=*/true,
+                                        /*addElseRegion=*/false);
+    {
+      rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+      auto coerced = reussir::ReussirNullableCoerceOp::create(
+          rewriter, loc, tokenType, op.getToken());
+      ReussirTokenFreeOp::create(rewriter, loc, coerced);
+      mlir::scf::YieldOp::create(rewriter, loc);
+    }
+    rewriter.eraseOp(op);
+    return mlir::success();
+  }
+};
+
 struct ReussirStrByteAtOpRewritePattern
     : public mlir::OpConversionPattern<ReussirStrByteAtOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -906,6 +944,12 @@ struct SCFOpsLoweringPass
         [](ReussirArrayViewOp op) {
           return llvm::isa<mlir::MemRefType>(op.getView().getType());
         });
+    // A free of a still-nullable token must be null-guarded here; a free of a
+    // plain token is legal and lowers to the runtime call directly.
+    target.addDynamicallyLegalOp<ReussirTokenFreeOp>(
+        [](ReussirTokenFreeOp op) {
+          return llvm::isa<TokenType>(op.getToken().getType());
+        });
 
     target.addIllegalOp<ReussirNullableDispatchOp, ReussirRecordDispatchOp,
                         ReussirScfYieldOp, ReussirClosureUniqifyOp,
@@ -930,6 +974,7 @@ void populateSCFOpsLoweringConversionPatterns(
            ReussirClosureUniqifyOpRewritePattern,
            ReussirArrayWithUniqueViewOpRewritePattern,
            ReussirScfYieldOpRewritePattern, ReussirTokenEnsureOpRewritePattern,
+           ReussirNullableTokenFreeOpRewritePattern,
            ReussirStrByteAtOpRewritePattern, ReussirStrSelectOpRewritePattern,
            ReussirStrStartWithOpRewritePattern>(patterns.getContext());
 }

--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -449,7 +449,38 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
       rewriter.eraseOp(allocOp);
     }
 
+    // A free of an *expanded decrement*'s token pays for a nullable nobody
+    // consumes: the unique (rc==1) branch wraps the reinterpreted pointer
+    // only so a later `token.free` can test it for null again — and on the
+    // common shared branch the token is null, so the whole dance produces a
+    // runtime call that does nothing. When the decrement's result is used by
+    // nothing but frees (a consumed token would carry an ensure/realloc use
+    // by now — reuses were rewritten above), sink one statically non-null
+    // free into the unique branch instead: the shared path stops touching
+    // the allocator entirely and the nullable result dies as a dead phi.
+    // Sibling-exit records of the same token collapse into the single sunk
+    // free — the producer dominates every path the records covered.
+    llvm::DenseSet<mlir::Value> sunkTokens;
     for (const auto &free : frees) {
+      auto scfIf = llvm::dyn_cast_if_present<mlir::scf::IfOp>(
+          free.token.getDefiningOp());
+      if (scfIf && scfIf->hasAttr(kExpandedDecrementAttr) &&
+          free.token.use_empty()) {
+        if (!sunkTokens.insert(free.token).second)
+          continue; // already sunk via an earlier record of this token
+        mlir::Operation *thenYield =
+            scfIf.getThenRegion().back().getTerminator();
+        auto nonNull = llvm::dyn_cast_if_present<ReussirNullableCreateOp>(
+            thenYield->getOperand(0).getDefiningOp());
+        if (nonNull && nonNull.getPtr()) {
+          rewriter.setInsertionPoint(thenYield);
+          ReussirTokenFreeOp::create(rewriter, thenYield->getLoc(),
+                                     nonNull.getPtr());
+          continue;
+        }
+        // Unexpected branch shape: fall back to the guarded top-level free.
+        sunkTokens.erase(free.token);
+      }
       rewriter.setInsertionPoint(free.anchor);
       ReussirTokenFreeOp::create(rewriter, free.anchor->getLoc(), free.token);
     }

--- a/tests/integration/conversion/free_token_sunk_into_unique_branch.mlir
+++ b/tests/integration/conversion/free_token_sunk_into_unique_branch.mlir
@@ -1,0 +1,25 @@
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-rc-decrement-expansion,func.func(reussir-token-reuse))' | %FileCheck %s
+
+// A dropped-but-never-reused token used to surface as a top-level
+// `token.free` of the expanded decrement's *nullable* result — a runtime
+// call even on the common shared (rc > 1) branch, where the token is null.
+// Token reuse now sinks a statically non-null free into the unique branch
+// instead: the shared branch no longer touches the allocator, and the
+// nullable result is dead.
+
+!rc64 = !reussir.rc<i64>
+module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"} {
+// CHECK: func.func @unused_dec(%[[rc:[a-z0-9]+]]: !reussir.rc<i64>)
+// CHECK: scf.if
+// CHECK:   reussir.ref.drop
+// CHECK:   %[[tok:[a-z0-9]+]] = reussir.rc.reinterpret(%[[rc]] : !reussir.rc<i64>) : !reussir.token<align : 8, size : 16>
+// CHECK:   reussir.token.free(%[[tok]] : !reussir.token<align : 8, size : 16>)
+// CHECK: } else {
+// CHECK:   reussir.rc.set
+// CHECK-NOT: reussir.token.free
+// CHECK: return
+    func.func @unused_dec(%0: !rc64) {
+        %1 = reussir.rc.dec (%0 : !rc64) : !reussir.nullable<!reussir.token<align: 8, size: 16>>
+        return
+    }
+}

--- a/tests/integration/conversion/token_free_null_guard.mlir
+++ b/tests/integration/conversion/token_free_null_guard.mlir
@@ -1,0 +1,29 @@
+// RUN: %reussir-opt %s --reussir-lowering-scf-ops | %FileCheck %s
+
+// A free of a *nullable* token must be guarded before it reaches the runtime
+// call: the null case (the shared branch of an expanded rc decrement) must
+// not pay a `__reussir_deallocate` call just to return. A plain-token free
+// is statically non-null and stays a direct free.
+
+module @test {
+// CHECK: func.func @free_nullable(%[[t:[a-z0-9]+]]: !reussir.nullable<!reussir.token<align : 8, size : 16>>)
+// CHECK:   %[[flag:[a-z0-9]+]] = reussir.nullable.check(%[[t]] : <!reussir.token<align : 8, size : 16>>) : i1
+// CHECK:   scf.if %[[flag]] {
+// CHECK:     %[[tok:[a-z0-9]+]] = reussir.nullable.coerce(%[[t]] : <!reussir.token<align : 8, size : 16>>) : !reussir.token<align : 8, size : 16>
+// CHECK:     reussir.token.free(%[[tok]] : !reussir.token<align : 8, size : 16>)
+// CHECK:   }
+// CHECK:   return
+    func.func @free_nullable(%t: !reussir.nullable<!reussir.token<align: 8, size: 16>>) {
+        reussir.token.free (%t : !reussir.nullable<!reussir.token<align: 8, size: 16>>)
+        return
+    }
+
+// CHECK: func.func @free_plain(%[[p:[a-z0-9]+]]: !reussir.token<align : 8, size : 16>)
+// CHECK-NOT: reussir.nullable.check
+// CHECK:   reussir.token.free(%[[p]] : !reussir.token<align : 8, size : 16>)
+// CHECK:   return
+    func.func @free_plain(%t: !reussir.token<align: 8, size: 16>) {
+        reussir.token.free (%t : !reussir.token<align: 8, size: 16>)
+        return
+    }
+}


### PR DESCRIPTION
First item of the #325 performance plan. On rbtree (4.2M inserts, the Koka-comparison harness), **92.4M of 147M `__reussir_deallocate` calls passed null**: every shared-branch rc decrement (rc > 1) yields a null token, and when nobody reuses it, `token.free` lowered to an unconditional runtime call whose null guard lives inside the callee — a full PLT call/ret per shared drop to do nothing.

## Changes

1. **TokenReuse — sink the free into the unique branch.** When an *expanded decrement*'s token is used by nothing but frees (a consumed token carries an ensure/realloc use by the time frees are emitted), emit one statically non-null `token.free` inside the `rc == 1` branch instead of freeing the nullable result at the top level. The shared branch stops touching the allocator entirely and the nullable result dies as a dead phi (LLVM removes it). Sibling-exit free records of the same token collapse into the single sunk free — the producer dominates every path they covered.
2. **SCFOpsLowering — null-guard any remaining nullable free.** Frees of still-nullable tokens (unexpanded `rc.dec` producers: rigid/FFI/closure element types) lower to `nullable.check` + `scf.if` + `nullable.coerce` + a plain-token free, mirroring the `ensure` lowering; `ReussirTokenFreeOp` is dynamically legal only on plain tokens there. Plain-token frees (e.g. from ClosureOutlining) are unchanged.

## Performance

Measured with the side-by-side harness (`~/Documents/benchmark`), hyperfine (10 runs, 3 warmup), clang-22 `-O2`, snmalloc runtime:

| bench | before | after | Δ | dealloc calls before → after |
|---|---|---|---|---|
| rbtree `-Oaggressive --reuse-across-call` | 1041 ms | **967 ms** | **−7.1 %** | 147.0 M (92.4 M null) → **54.6 M (0 null, == allocs)** |
| rbtree `-Oaggressive` | 1191 ms | 1157 ms | −2.9 % | 231 M → allocs-equal |
| rbtree-zipper `+rac` | 601 ms | 592 ms | −1.6 % | 12.6 M → 12.6 M (had no null frees — unchanged, as expected) |
| nbe-hoas `-Oaggressive` | 340 ms | **302 ms** | **−11.0 %** | 66.5 M → 17.4 M (0 null) |

Koka 3.2.2 context on the same machine: rbtree 391 ms, nbe-hoas 166 ms — this closes the rbtree gap from 2.66× to 2.47× and nbe-hoas from 2.05× to 1.82×. The remaining items (nullary-constructor immediates, token-passing ABI, allocation fast-path inlining, matcher type-domain bias) are tracked in #325.

## Verification

- Two new lit tests pin the shapes: `conversion/free_token_sunk_into_unique_branch.mlir` (rc-decrement-expansion + token-reuse → in-branch plain free, nothing at top level) and `conversion/token_free_null_guard.mlir` (nullable free → check/if/coerce/free; plain free stays direct).
- Full lit suite: 261 passed / 19 unsupported / 0 failed. Pipeline-exercising cargo tests (codegen/repl/jit) green.
- Dynamic verification via an `LD_PRELOAD` interposer: post-change `null_dealloc = 0` on all benches; benchmark outputs still validate (drivers assert results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2