### PR TITLE
[backend] TBI tagged-pointer immediates

### DIFF
--- a/crates/reussir-backend-sys/build.rs
+++ b/crates/reussir-backend-sys/build.rs
@@ -37,6 +37,7 @@ const REUSSIR_ARCHIVES: &[&str] = &[
     "MLIRReussirInferVariantTag",
     "MLIRReussirIncDecCancellation",
     "MLIRReussirTokenReuse",
+    "MLIRReussirSpecialPointerTag",
     "MLIRReussirInvariantGroupAnalysis",
     "MLIRReussirUniqueCarryingRecursionAnalysis",
     "MLIRReussirTRMCRecursionAnalysis",

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -112,9 +112,11 @@ unsafe extern "C" {
 
     /// Encodes nullary variants of shared rc-boxed enums as tagged pointer
     /// immediates (top byte = tag + 1) and stamps the module so the LLVM
-    /// lowering guards refcount/tag accesses. Only added when the scheme is
-    /// enabled (aarch64 targets / TBI by default).
-    pub fn reussirCreateSpecialPointerTagPass() -> MlirPass;
+    /// lowering steers refcount stores away from the dummy boxes. Only added
+    /// when the scheme is enabled; `arch_independent` selects the encoding:
+    /// false = `tbi` (top-byte tag, aarch64), true = `immortal` (plain dummy
+    /// address with an immortal refcount, any target).
+    pub fn reussirCreateSpecialPointerTagPass(arch_independent: bool) -> MlirPass;
     pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;
     pub fn reussirCreateCompilePolymorphicFFIPass(optimized: bool) -> MlirPass;

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -109,6 +109,12 @@ unsafe extern "C" {
     pub fn reussirCreateInferVariantTagPass() -> MlirPass;
     pub fn reussirCreateSCFOpsLoweringPass() -> MlirPass;
     pub fn reussirCreateRcCreateSinkPass() -> MlirPass;
+
+    /// Encodes nullary variants of shared rc-boxed enums as tagged pointer
+    /// immediates (top byte = tag + 1) and stamps the module so the LLVM
+    /// lowering guards refcount/tag accesses. Only added when the scheme is
+    /// enabled (aarch64 targets / TBI by default).
+    pub fn reussirCreateSpecialPointerTagPass() -> MlirPass;
     pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;
     pub fn reussirCreateCompilePolymorphicFFIPass(optimized: bool) -> MlirPass;

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -49,6 +49,23 @@ impl OptLevel {
     }
 }
 
+/// How nullary variants of shared rc-boxed enums are represented.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NullaryVariantEncoding {
+    /// Legacy layout: every construction heap-allocates a refcounted box.
+    Boxed,
+    /// Unboxed immediate whose top byte is `tag + 1` and whose low bits
+    /// point at a per-tag dummy box. Hard-depends on the hardware ignoring
+    /// the pointer's top byte on data accesses (aarch64 TBI); the top byte
+    /// doubles as a dereference-free FFI tag decode.
+    Tbi,
+    /// Unboxed immediate that *is* the per-tag dummy box address, with an
+    /// immortal refcount recognized by magnitude. No architectural
+    /// dependency (works on any target, including wasm32); foreign code
+    /// sees a layout-compatible box.
+    Immortal,
+}
+
 /// Knobs for [`run_lowering_pipeline`].
 #[derive(Clone, Copy, Debug)]
 pub struct LoweringOptions {
@@ -56,13 +73,10 @@ pub struct LoweringOptions {
     pub opt: OptLevel,
     /// Allow the token-reuse pass to reuse tokens across function calls.
     pub reuse_token_across_call: bool,
-    /// Encode nullary variants of rc-boxed enums as tagged pointer
-    /// immediates (top byte = tag + 1, no allocation). Sound only where a
-    /// stray dereference of such a value cannot be architecturally masked —
-    /// the driver enables it for aarch64 targets (TBI) and `rrc` exposes
-    /// `--disable-special-pointer-tag` to opt out. Changes the C ABI of
-    /// returned enum values: a non-zero top byte is an immediate.
-    pub special_pointer_tag: bool,
+    /// How nullary variants of shared rc-boxed enums are encoded. `rrc`
+    /// exposes this as `--nullary-variant-encoding`; embedders (REPL/JIT,
+    /// tests) default to [`NullaryVariantEncoding::Boxed`].
+    pub nullary_variant_encoding: NullaryVariantEncoding,
     /// Run the invariant-group analysis pass.
     pub enable_invariant_analysis: bool,
 }
@@ -72,9 +86,10 @@ impl Default for LoweringOptions {
         Self {
             opt: OptLevel::Default,
             reuse_token_across_call: false,
-            // Off by default: only target-aware drivers (rrc) turn it on, so
-            // embedders (REPL/JIT, tests) keep the boxed layout untouched.
-            special_pointer_tag: false,
+            // Boxed by default: only target-aware drivers (rrc) pick an
+            // immediate encoding, so embedders (REPL/JIT, tests) keep the
+            // boxed layout untouched.
+            nullary_variant_encoding: NullaryVariantEncoding::Boxed,
             // Off by default, mirroring the C++ `createLoweringPipeline`
             // (`enableInvariantAnalysis = false`).
             enable_invariant_analysis: false,
@@ -163,7 +178,7 @@ pub fn run_lowering_pipeline(
         opt = ?options.opt,
         reuse_token_across_call = options.reuse_token_across_call,
         enable_invariant_analysis = options.enable_invariant_analysis,
-        special_pointer_tag = options.special_pointer_tag,
+        nullary_variant_encoding = ?options.nullary_variant_encoding,
     )
     .entered();
 
@@ -174,8 +189,10 @@ pub fn run_lowering_pipeline(
         // immediates. Must run before any uniqueness/token pass so no
         // provenance or allocation token is ever attached to a rewritten
         // construction.
-        if options.special_pointer_tag => {
-            module: sys::reussirCreateSpecialPointerTagPass();
+        if options.nullary_variant_encoding != NullaryVariantEncoding::Boxed => {
+            module: sys::reussirCreateSpecialPointerTagPass(
+                options.nullary_variant_encoding == NullaryVariantEncoding::Immortal,
+            );
         }
 
         // Optimization-only prologue.

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -56,6 +56,13 @@ pub struct LoweringOptions {
     pub opt: OptLevel,
     /// Allow the token-reuse pass to reuse tokens across function calls.
     pub reuse_token_across_call: bool,
+    /// Encode nullary variants of rc-boxed enums as tagged pointer
+    /// immediates (top byte = tag + 1, no allocation). Sound only where a
+    /// stray dereference of such a value cannot be architecturally masked —
+    /// the driver enables it for aarch64 targets (TBI) and `rrc` exposes
+    /// `--disable-special-pointer-tag` to opt out. Changes the C ABI of
+    /// returned enum values: a non-zero top byte is an immediate.
+    pub special_pointer_tag: bool,
     /// Run the invariant-group analysis pass.
     pub enable_invariant_analysis: bool,
 }
@@ -65,6 +72,9 @@ impl Default for LoweringOptions {
         Self {
             opt: OptLevel::Default,
             reuse_token_across_call: false,
+            // Off by default: only target-aware drivers (rrc) turn it on, so
+            // embedders (REPL/JIT, tests) keep the boxed layout untouched.
+            special_pointer_tag: false,
             // Off by default, mirroring the C++ `createLoweringPipeline`
             // (`enableInvariantAnalysis = false`).
             enable_invariant_analysis: false,
@@ -153,12 +163,21 @@ pub fn run_lowering_pipeline(
         opt = ?options.opt,
         reuse_token_across_call = options.reuse_token_across_call,
         enable_invariant_analysis = options.enable_invariant_analysis,
+        special_pointer_tag = options.special_pointer_tag,
     )
     .entered();
 
     let manager = PassManager::new(context);
 
     lowering_pipeline!(manager,
+        // Nullary variants of shared rc-boxed enums become tagged pointer
+        // immediates. Must run before any uniqueness/token pass so no
+        // provenance or allocation token is ever attached to a rewritten
+        // construction.
+        if options.special_pointer_tag => {
+            module: sys::reussirCreateSpecialPointerTagPass();
+        }
+
         // Optimization-only prologue.
         if options.opt.runs_optimization() => {
             if options.opt == OptLevel::Aggressive => {

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -65,7 +65,7 @@ enum Stage {
 /// CLI surface for [`NullaryVariantEncoding`], with the extra
 /// `arch-dependent` value that resolves per target triple.
 #[derive(Clone, Copy, PartialEq, Eq, palc::ValueEnum)]
-enum NullaryVariantEncodingArg {
+enum VariantEncoding {
     /// Best encoding the target supports: TBI on aarch64 (LAM and friends
     /// may follow), the arch-independent form elsewhere.
     ArchDependent,
@@ -76,19 +76,19 @@ enum NullaryVariantEncodingArg {
     Boxed,
 }
 
-impl NullaryVariantEncodingArg {
+impl VariantEncoding {
     /// Resolves the CLI choice against the target `triple`.
     fn resolve(self, triple: &str) -> NullaryVariantEncoding {
         match self {
-            NullaryVariantEncodingArg::ArchDependent => {
+            VariantEncoding::ArchDependent => {
                 if triple.starts_with("aarch64") {
                     NullaryVariantEncoding::Tbi
                 } else {
                     NullaryVariantEncoding::Immortal
                 }
             }
-            NullaryVariantEncodingArg::ArchIndependent => NullaryVariantEncoding::Immortal,
-            NullaryVariantEncodingArg::Boxed => NullaryVariantEncoding::Boxed,
+            VariantEncoding::ArchIndependent => NullaryVariantEncoding::Immortal,
+            VariantEncoding::Boxed => NullaryVariantEncoding::Boxed,
         }
     }
 }
@@ -196,8 +196,8 @@ struct Cli {
     /// itself, with an immortal refcount — foreign code sees a
     /// layout-compatible box. `boxed` keeps the legacy heap-boxed layout.
     #[arg(long = "nullary-variant-encoding", value_enum,
-          default_value_t = NullaryVariantEncodingArg::ArchDependent)]
-    nullary_variant_encoding: NullaryVariantEncodingArg,
+          default_value_t = VariantEncoding::ArchDependent)]
+    nullary_variant_encoding: VariantEncoding,
 
     /// Omit source locations (the file table and `[start..end]` spans) from
     /// `hir`/`mir` text dumps. The default dump is lossless — it round-trips

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -155,6 +155,16 @@ struct Cli {
     #[arg(short = 'g', long = "debug")]
     debug: bool,
 
+    /// Keep nullary enum variants heap-boxed instead of encoding them as
+    /// tagged pointer immediates. The tagged encoding (top byte = tag + 1,
+    /// no allocation, no reference counting) is on by default for aarch64
+    /// targets, where TBI (top-byte ignore) additionally guarantees a stray
+    /// data access through such a value is architecturally masked. Note the
+    /// FFI contract: a returned enum value with a non-zero top byte is an
+    /// immediate, not a box.
+    #[arg(long = "disable-special-pointer-tag")]
+    disable_special_pointer_tag: bool,
+
     /// Omit source locations (the file table and `[start..end]` spans) from
     /// `hir`/`mir` text dumps. The default dump is lossless — it round-trips
     /// spans and file attribution — but structural readers (FileCheck tests,
@@ -390,6 +400,12 @@ fn run(cli: &Cli) -> Result<bool, String> {
     let options = LoweringOptions {
         opt,
         reuse_token_across_call: cli.reuse_across_call,
+        // Tagged nullary-variant immediates default on where the target's
+        // pointer semantics cover them (aarch64: TBI ignores the top byte on
+        // data access); other targets keep the boxed layout until an
+        // equivalent (e.g. x86 LAM) is wired up.
+        special_pointer_tag: machine.triple().starts_with("aarch64")
+            && !cli.disable_special_pointer_tag,
         ..LoweringOptions::default()
     };
     let optimize_ffi = !matches!(opt, OptLevel::None);

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -21,7 +21,7 @@ use palc::Parser;
 
 use reussir_backend::llvm::LlvmLowering;
 use reussir_backend::melior::ir::Module;
-use reussir_backend::pipeline::{self, LoweringOptions, OptLevel};
+use reussir_backend::pipeline::{self, LoweringOptions, NullaryVariantEncoding, OptLevel};
 use reussir_codegen::lower::lower_program;
 use reussir_codegen::source::{FileId, SourceCache};
 use reussir_compiler::{
@@ -60,6 +60,37 @@ enum Stage {
     Asm,
     /// A relocatable object file (`.o`).
     Obj,
+}
+
+/// CLI surface for [`NullaryVariantEncoding`], with the extra
+/// `arch-dependent` value that resolves per target triple.
+#[derive(Clone, Copy, PartialEq, Eq, palc::ValueEnum)]
+enum NullaryVariantEncodingArg {
+    /// Best encoding the target supports: TBI on aarch64 (LAM and friends
+    /// may follow), the arch-independent form elsewhere.
+    ArchDependent,
+    /// The immortal dummy-box encoding — no TBI/LAM pointer tricks, works
+    /// on any target (including wasm32).
+    ArchIndependent,
+    /// Legacy heap-boxed layout; no immediates.
+    Boxed,
+}
+
+impl NullaryVariantEncodingArg {
+    /// Resolves the CLI choice against the target `triple`.
+    fn resolve(self, triple: &str) -> NullaryVariantEncoding {
+        match self {
+            NullaryVariantEncodingArg::ArchDependent => {
+                if triple.starts_with("aarch64") {
+                    NullaryVariantEncoding::Tbi
+                } else {
+                    NullaryVariantEncoding::Immortal
+                }
+            }
+            NullaryVariantEncodingArg::ArchIndependent => NullaryVariantEncoding::Immortal,
+            NullaryVariantEncodingArg::Boxed => NullaryVariantEncoding::Boxed,
+        }
+    }
 }
 
 impl Stage {
@@ -155,15 +186,18 @@ struct Cli {
     #[arg(short = 'g', long = "debug")]
     debug: bool,
 
-    /// Keep nullary enum variants heap-boxed instead of encoding them as
-    /// tagged pointer immediates. The tagged encoding (top byte = tag + 1,
-    /// no allocation, no reference counting) is on by default for aarch64
-    /// targets, where TBI (top-byte ignore) additionally guarantees a stray
-    /// data access through such a value is architecturally masked. Note the
-    /// FFI contract: a returned enum value with a non-zero top byte is an
-    /// immediate, not a box.
-    #[arg(long = "disable-special-pointer-tag")]
-    disable_special_pointer_tag: bool,
+    /// How nullary enum variants are represented. `arch-dependent` picks
+    /// the best encoding the target supports: on aarch64 the TBI form (top
+    /// byte = tag + 1, low bits = a per-tag dummy box; hardware top-byte
+    /// ignore masks stray dereferences, and foreign code may decode the tag
+    /// from the pointer without dereferencing); elsewhere it falls back to
+    /// the arch-independent form. `arch-independent` uses no TBI/LAM-style
+    /// pointer tricks on any target: the immediate is the dummy box address
+    /// itself, with an immortal refcount — foreign code sees a
+    /// layout-compatible box. `boxed` keeps the legacy heap-boxed layout.
+    #[arg(long = "nullary-variant-encoding", value_enum,
+          default_value_t = NullaryVariantEncodingArg::ArchDependent)]
+    nullary_variant_encoding: NullaryVariantEncodingArg,
 
     /// Omit source locations (the file table and `[start..end]` spans) from
     /// `hir`/`mir` text dumps. The default dump is lossless — it round-trips
@@ -400,12 +434,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
     let options = LoweringOptions {
         opt,
         reuse_token_across_call: cli.reuse_across_call,
-        // Tagged nullary-variant immediates default on where the target's
-        // pointer semantics cover them (aarch64: TBI ignores the top byte on
-        // data access); other targets keep the boxed layout until an
-        // equivalent (e.g. x86 LAM) is wired up.
-        special_pointer_tag: machine.triple().starts_with("aarch64")
-            && !cli.disable_special_pointer_tag,
+        nullary_variant_encoding: cli.nullary_variant_encoding.resolve(machine.triple()),
         ..LoweringOptions::default()
     };
     let optimize_ffi = !matches!(opt, OptLevel::None);

--- a/crates/reussir-rt/Cargo.toml
+++ b/crates/reussir-rt/Cargo.toml
@@ -16,6 +16,7 @@ stacker.workspace = true
 [features]
 default = ["snmalloc"]
 snmalloc = ["snmalloc-rs"]
+mimalloc = ["dep:mimalloc"]
 
 [lib]
 crate-type = ["dylib", "lib", "staticlib"]

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -39,6 +39,12 @@ MlirPass reussirCreateRcDecrementExpansionPass(void);
 MlirPass reussirCreateInferVariantTagPass(void);
 MlirPass reussirCreateSCFOpsLoweringPass(void);
 MlirPass reussirCreateRcCreateSinkPass(void);
+
+/// Encodes nullary variants of shared rc-boxed enums as tagged pointer
+/// immediates (top byte = tag + 1) and stamps the module so the LLVM
+/// lowering guards refcount/tag accesses. Add only for targets where the
+/// scheme is enabled (aarch64 / TBI by default).
+MlirPass reussirCreateSpecialPointerTagPass(void);
 MlirPass reussirCreateRcCreateFusionPass(void);
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void);
 MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized);

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -42,9 +42,11 @@ MlirPass reussirCreateRcCreateSinkPass(void);
 
 /// Encodes nullary variants of shared rc-boxed enums as tagged pointer
 /// immediates (top byte = tag + 1) and stamps the module so the LLVM
-/// lowering guards refcount/tag accesses. Add only for targets where the
-/// scheme is enabled (aarch64 / TBI by default).
-MlirPass reussirCreateSpecialPointerTagPass(void);
+/// lowering steers refcount stores away from the dummy boxes. Add only when
+/// the scheme is enabled; `archIndependent` selects the encoding: false =
+/// `tbi` (top-byte tag, requires hardware top-byte-ignore, aarch64), true =
+/// `immortal` (plain dummy address with an immortal refcount, any target).
+MlirPass reussirCreateSpecialPointerTagPass(bool archIndependent);
 MlirPass reussirCreateRcCreateFusionPass(void);
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void);
 MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized);

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -611,6 +611,32 @@ def ReussirRcCreateVariantOp : ReussirRcOp<"create_variant", [
   }];
 }
 
+def ReussirRcTaggedOp : ReussirRcOp<"tagged", [Pure]> {
+  let summary = "Materialize a nullary variant as a tagged pointer immediate";
+  let description = [{
+    `reussir.rc.tagged` produces an rc pointer encoding a *nullary* variant
+    (an arm whose payload is an empty compound) as an unboxed immediate: the
+    pointer's top byte is `tag + 1` and its low bits hold the address of a
+    per-tag dummy box `{refcount = 2, tag}`. No allocation takes place, and
+    no observable reference counting: because the target's TBI ignores the
+    top byte on data accesses, refcount/uniqueness/tag reads through the
+    value land in the dummy box and observe a well-formed shared header,
+    so the hot lowerings need no immediate-checks at all. Only introduced
+    when the special-pointer-tag scheme is enabled (aarch64 targets, whose
+    TBI the encoding hard-depends on).
+    ```mlir
+    %leaf = reussir.rc.tagged tag(1) : !reussir.rc<!reussir.record<...>>
+    ```
+  }];
+
+  let arguments = (ins Arg<IndexAttr, "tag">:$tag);
+  let results = (outs Res<ReussirRcType, "tagged immediate">:$rcPtr);
+  let assemblyFormat = [{
+    `tag` `(` $tag `)` `:` qualified(type($rcPtr)) attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
 def ReussirRcReinterpretOp : ReussirRcOp<"reinterpret", []> {
   let summary = "Reinterpret a Rc pointer into a token";
   let description = [{

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -230,6 +230,12 @@ def ReussirRcType
              getCapability() == Capability::rigid;
     }
     RcBoxType getInnerBoxType() const;
+    /// Whether values of this type may be special-pointer-tag immediates
+    /// (see `reussir.rc.tagged`): a shared-capability box of a complete
+    /// variant record with at least one nullary arm whose `tag + 1` fits the
+    /// top byte. Refcount/tag accesses on such values must be guarded when
+    /// the scheme is enabled.
+    bool mayCarrySpecialPointerTag() const;
   }];
 }
 //===----------------------------------------------------------------------===//

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -233,8 +233,8 @@ def ReussirRcType
     /// Whether values of this type may be special-pointer-tag immediates
     /// (see `reussir.rc.tagged`): a shared-capability box of a complete
     /// variant record with at least one nullary arm whose `tag + 1` fits the
-    /// top byte. Refcount/tag accesses on such values must be guarded when
-    /// the scheme is enabled.
+    /// top byte, and a nonatomic refcount. Decrementing refcount stores on
+    /// such values must be steered when the scheme is enabled.
     bool mayCarrySpecialPointerTag() const;
   }];
 }

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -23,12 +23,17 @@ def ReussirSpecialPointerTagPass
   let summary = "encode nullary variants as tagged pointer immediates";
   let description = [{
     `reussir-special-pointer-tag` rewrites nullary variant constructions of
-    shared rc-boxed enums into `reussir.rc.tagged` immediates (top byte =
-    tag + 1, low bits = a per-tag dummy box, no allocation) and stamps the
-    module so the LLVM lowering steers refcount stores away from the dummy
-    box on taggable types. Only added to the pipeline for targets with TBI,
-    which the encoding hard-depends on (aarch64 by default).
+    shared rc-boxed enums into `reussir.rc.tagged` immediates pointing at
+    per-tag dummy boxes (no allocation) and stamps the module with the
+    chosen encoding so the LLVM lowering steers refcount stores away from
+    the dummy boxes on taggable types. Two encodings exist: `tbi` (top byte
+    = tag + 1; hard-depends on hardware top-byte-ignore, aarch64) and
+    `immortal` (plain dummy address with an immortal refcount; no
+    architectural dependency).
   }];
+  let options = [Option<"encoding", "encoding", "std::string",
+                        /*default=*/"\"tbi\"",
+                        "Immediate encoding: 'tbi' or 'immortal'">];
   let dependentDialects = ["::reussir::ReussirDialect"];
 }
 

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -16,6 +16,23 @@
 include "mlir/Pass/PassBase.td"
 
 //===----------------------------------------------------------------------===//
+// SpecialPointerTag
+//===----------------------------------------------------------------------===//
+def ReussirSpecialPointerTagPass
+    : Pass<"reussir-special-pointer-tag", "::mlir::ModuleOp"> {
+  let summary = "encode nullary variants as tagged pointer immediates";
+  let description = [{
+    `reussir-special-pointer-tag` rewrites nullary variant constructions of
+    shared rc-boxed enums into `reussir.rc.tagged` immediates (top byte =
+    tag + 1, low bits = a per-tag dummy box, no allocation) and stamps the
+    module so the LLVM lowering steers refcount stores away from the dummy
+    box on taggable types. Only added to the pipeline for targets with TBI,
+    which the encoding hard-depends on (aarch64 by default).
+  }];
+  let dependentDialects = ["::reussir::ReussirDialect"];
+}
+
+//===----------------------------------------------------------------------===//
 // RcCreateSink
 //===----------------------------------------------------------------------===//
 def ReussirRcCreateSinkPass

--- a/include/Reussir/Transformation/SpecialPointerTag.h
+++ b/include/Reussir/Transformation/SpecialPointerTag.h
@@ -13,11 +13,22 @@
 
 namespace reussir {
 
-/// Module unit attribute set when the special-pointer-tag scheme is enabled:
-/// nullary variants of shared rc-boxed enums are encoded as immediates whose
-/// top byte is `tag + 1` (low 56 bits zero). The LLVM lowering patterns read
-/// it to guard refcount and tag-word accesses on taggable types.
+/// Module string attribute set when the special-pointer-tag scheme is
+/// enabled: nullary variants of shared rc-boxed enums are encoded as
+/// unboxed immediates pointing at per-tag dummy boxes. Its value selects
+/// the encoding (`kSpecialPtrTagTBI` or `kSpecialPtrTagImmortal`); the LLVM
+/// lowering patterns read it to pick the guard strategy on taggable types.
 constexpr llvm::StringLiteral kSpecialPtrTagAttr = "reussir.special_ptr_tag";
+
+/// TBI encoding (aarch64): the immediate's top byte is `tag + 1` and its low
+/// bits hold the dummy box address; hardware top-byte-ignore makes accesses
+/// through the value land in the dummy box. Guards test the top byte.
+constexpr llvm::StringLiteral kSpecialPtrTagTBI = "tbi";
+
+/// Arch-independent encoding: the immediate *is* the dummy box address (no
+/// pointer bit tricks). The dummy refcount is initialized to an immortal
+/// value (2^62); guards test refcount magnitude instead of pointer bits.
+constexpr llvm::StringLiteral kSpecialPtrTagImmortal = "immortal";
 
 } // namespace reussir
 

--- a/include/Reussir/Transformation/SpecialPointerTag.h
+++ b/include/Reussir/Transformation/SpecialPointerTag.h
@@ -1,0 +1,24 @@
+//===-- SpecialPointerTag.h - Nullary variants as immediates ----*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 With LLVM Exceptions OR MIT
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef REUSSIR_TRANSFORMATION_SPECIALPOINTERTAG_H
+#define REUSSIR_TRANSFORMATION_SPECIALPOINTERTAG_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace reussir {
+
+/// Module unit attribute set when the special-pointer-tag scheme is enabled:
+/// nullary variants of shared rc-boxed enums are encoded as immediates whose
+/// top byte is `tag + 1` (low 56 bits zero). The LLVM lowering patterns read
+/// it to guard refcount and tag-word accesses on taggable types.
+constexpr llvm::StringLiteral kSpecialPtrTagAttr = "reussir.special_ptr_tag";
+
+} // namespace reussir
+
+#endif // REUSSIR_TRANSFORMATION_SPECIALPOINTERTAG_H

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -32,6 +32,7 @@
 #include "Reussir/Conversion/SCFOpsLowering.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/Transformation/Passes.h"
+#include "Reussir/Transformation/SpecialPointerTag.h"
 
 using namespace mlir;
 
@@ -78,8 +79,11 @@ MlirPass reussirCreateInferVariantTagPass(void) {
 MlirPass reussirCreateSCFOpsLoweringPass(void) {
   return wrapOwned(reussir::createReussirSCFOpsLoweringPass());
 }
-MlirPass reussirCreateSpecialPointerTagPass(void) {
-  return wrapOwned(reussir::createReussirSpecialPointerTagPass());
+MlirPass reussirCreateSpecialPointerTagPass(bool archIndependent) {
+  reussir::ReussirSpecialPointerTagPassOptions options;
+  options.encoding = archIndependent ? reussir::kSpecialPtrTagImmortal.str()
+                                     : reussir::kSpecialPtrTagTBI.str();
+  return wrapOwned(reussir::createReussirSpecialPointerTagPass(options));
 }
 
 MlirPass reussirCreateRcCreateSinkPass(void) {

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -78,6 +78,10 @@ MlirPass reussirCreateInferVariantTagPass(void) {
 MlirPass reussirCreateSCFOpsLoweringPass(void) {
   return wrapOwned(reussir::createReussirSCFOpsLoweringPass());
 }
+MlirPass reussirCreateSpecialPointerTagPass(void) {
+  return wrapOwned(reussir::createReussirSpecialPointerTagPass());
+}
+
 MlirPass reussirCreateRcCreateSinkPass(void) {
   return wrapOwned(reussir::createReussirRcCreateSinkPass());
 }

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -81,54 +81,99 @@ namespace {
 // Special pointer tag support
 //===----------------------------------------------------------------------===//
 // When `reussir-special-pointer-tag` ran (module carries kSpecialPtrTagAttr),
-// a value of a taggable shared rc<variant> type may be an unboxed immediate:
-// top byte = tag + 1, low bits = the address of a per-tag *dummy box*
-// (`{refcount = 2, tag}`). This is where TBI does the heavy lifting: on the
-// aarch64 targets the scheme is enabled for, the hardware ignores the top
-// byte on data accesses, so refcount loads/increments, uniqueness reads,
-// and even the variant-tag read through a tagged value simply hit the dummy
-// box — which answers with a pinned shared refcount and the *real* tag. The
-// hot paths (match dispatch, rc.inc, rc.fetch, rc.is_unique) therefore lower
-// exactly as without the scheme: plain loads, zero guards. Two invariants
-// keep that sound:
-//   * the dummy's refcount is pinned >= 2 (only `rc.inc` writes it, and it
-//     only adds), so an immediate's decrement always takes the *shared*
-//     branch (no field drop, no token, no free of the dummy) and
-//     `rc.is_unique` answers false;
-//   * `rc.set` — the one decrementing store — steers a tagged access to a
-//     separate scratch word (an address select off the critical path), so
-//     the dummy count can never decay to 1.
-// The top byte itself is read only by `rc.set`/`rc.assume_unique` (which
-// must recognize immediates; an `assume(false)` would be unsound) and by
-// foreign code, which may decode `tag = top - 1` without dereferencing.
+// a value of a taggable shared rc<variant> type may be an unboxed immediate
+// pointing at a per-tag *dummy box* — a well-formed shared box header the
+// hot accesses land in, so refcount loads/increments, uniqueness reads, and
+// even the variant-tag read through a tagged value lower exactly as without
+// the scheme: plain loads, zero guards. The attribute's value selects one of
+// two encodings, differing only in how the cold guards recognize immediates:
+//   * `tbi` (aarch64): top byte = tag + 1, low bits = the dummy address;
+//     the hardware ignores the top byte on data accesses. The dummy count is
+//     initialized to 2 and guards test the pointer's top byte. Foreign code
+//     may decode `tag = top - 1` without dereferencing.
+//   * `immortal` (any target, including 32-bit ones like wasm32): the
+//     immediate *is* the dummy address — no pointer bit tricks. For a w-bit
+//     refcount word the dummy count is initialized to 3 * 2^(w-2) and guards
+//     test refcount magnitude: a real box can never reach the 2^(w-1)
+//     threshold (each reference occupies >= 4 bytes of address space, so
+//     fewer than 2^(w-2) can exist). Foreign code sees a layout-compatible
+//     box.
+// Two invariants keep both encodings sound:
+//   * the dummy's refcount is pinned above the shared/unique decision point,
+//     so an immediate's decrement always takes the *shared* branch (no field
+//     drop, no token, no free of the dummy) and `rc.is_unique` answers
+//     false. In the immortal encoding on targets narrower than 64 bits,
+//     `rc.inc`'s store is steered away from a recognized dummy as well —
+//     2^(w-2) unbalanced increments would otherwise be reachable and wrap
+//     the count. (With w = 64 that is > 4 * 10^18 increments: unreachable,
+//     so the increment stays guard-free on 64-bit targets.)
+//   * `rc.set` — the one decrementing store — steers a recognized-immediate
+//     access to a separate scratch word (an address select off the critical
+//     path), so the dummy count can never decay to 1.
+// The only other guard is `rc.assume_unique`, which must neutralize its
+// assumption for immediates (an `assume(false)` would be unsound).
 
-bool specialPtrTagEnabled(mlir::Operation *op) {
-  auto module = op->getParentOfType<mlir::ModuleOp>();
-  return module && module->hasAttr(kSpecialPtrTagAttr);
+enum class TagEncoding { None, TBI, Immortal };
+
+// The immortal encoding's dummy refcount initializer and recognition
+// threshold for a `width`-bit refcount word.
+uint64_t immortalRefCount(unsigned width) {
+  return (uint64_t(3) << (width - 2)) & llvm::maskTrailingOnes<uint64_t>(width);
+}
+uint64_t immortalThreshold(unsigned width) {
+  return uint64_t(1) << (width - 1);
 }
 
-// The per-tag dummy box a tagged immediate points at: `{refcount = 2, tag}`.
-// Loads and increments through a tagged value land here (TBI masks the top
-// byte) and observe a well-formed shared box header carrying the immediate's
-// own tag; the refcount stays >= 2 because `rc.set` never writes it (see
-// below).
+TagEncoding specialPtrTagEncoding(mlir::Operation *op) {
+  auto module = op->getParentOfType<mlir::ModuleOp>();
+  if (!module)
+    return TagEncoding::None;
+  auto attr = module->getAttrOfType<mlir::StringAttr>(kSpecialPtrTagAttr);
+  if (!attr)
+    return TagEncoding::None;
+  return attr.getValue() == kSpecialPtrTagImmortal ? TagEncoding::Immortal
+                                                   : TagEncoding::TBI;
+}
+
+// The per-tag dummy box a tagged immediate points at: `{refcount, tag}`,
+// sized to the target's index width. Loads and increments through a tagged
+// value land here and observe a well-formed shared box header carrying the
+// immediate's own tag; the refcount stays pinned because `rc.set` never
+// writes it (see above).
 mlir::LLVM::GlobalOp tagDummyBox(mlir::ModuleOp module, mlir::Location loc,
-                                 uint64_t tag, mlir::OpBuilder &builder) {
+                                 uint64_t tag, TagEncoding encoding,
+                                 mlir::IntegerType indexTy,
+                                 mlir::OpBuilder &builder) {
   std::string name = ("__reussir_tag_dummy_" + llvm::Twine(tag)).str();
   auto global = module.lookupSymbol<mlir::LLVM::GlobalOp>(name);
   if (!global) {
     mlir::OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(module.getBody());
-    auto i64Ty = builder.getI64Type();
-    auto arrTy = mlir::LLVM::LLVMArrayType::get(i64Ty, 2);
+    auto arrTy = mlir::LLVM::LLVMArrayType::get(indexTy, 2);
+    uint64_t refCount = encoding == TagEncoding::Immortal
+                            ? immortalRefCount(indexTy.getWidth())
+                            : 2;
     auto init = mlir::DenseElementsAttr::get(
-        mlir::RankedTensorType::get({2}, i64Ty),
-        llvm::ArrayRef<int64_t>{2, static_cast<int64_t>(tag)});
+        mlir::RankedTensorType::get({2}, indexTy),
+        llvm::ArrayRef<llvm::APInt>{llvm::APInt(indexTy.getWidth(), refCount),
+                                    llvm::APInt(indexTy.getWidth(), tag)});
     global = mlir::LLVM::GlobalOp::create(
         builder, loc, arrTy,
         /*isConstant=*/false, mlir::LLVM::Linkage::Internal, name, init);
   }
   return global;
+}
+
+// `count >= immortalThreshold` — the value under the immortal encoding is a
+// dummy box (a real refcount can never reach the threshold).
+mlir::Value isImmortalCount(mlir::Value count, mlir::Location loc,
+                            mlir::OpBuilder &builder) {
+  auto intTy = llvm::cast<mlir::IntegerType>(count.getType());
+  auto threshold = mlir::LLVM::ConstantOp::create(
+      builder, loc, intTy,
+      builder.getIntegerAttr(intTy, immortalThreshold(intTy.getWidth())));
+  return mlir::LLVM::ICmpOp::create(
+      builder, loc, mlir::LLVM::ICmpPredicate::uge, count, threshold);
 }
 
 // The per-module scratch word guarded accesses are steered to.
@@ -417,12 +462,23 @@ struct ReussirRcSetConversionPattern
     mlir::Value addr = adaptor.getRcPtr();
     // `rc.set` is the one store that can lower a refcount, so it must not
     // reach the dummy box (its count would eventually decay to 1 and send an
-    // immediate down the unique branch). Steer a tagged access to the scratch
-    // word instead; the address select is off any result's critical path.
-    if (specialPtrTagEnabled(op) &&
+    // immediate down the unique branch). Steer a recognized-immediate access
+    // to the scratch word instead; the address select is off any result's
+    // critical path. TBI recognizes immediates by the pointer's top byte,
+    // the immortal encoding by the magnitude of the count being stored (the
+    // dummy's decremented count still clears the threshold: it starts at
+    // 3 * 2^(w-2) and never actually decreases, since this very steering
+    // keeps every decrementing store away from it).
+    TagEncoding encoding = specialPtrTagEncoding(op);
+    if (encoding != TagEncoding::None &&
         op.getRcPtr().getType().mayCarrySpecialPointerTag()) {
-      mlir::Value top = topByteOf(addr, op.getLoc(), rewriter);
-      mlir::Value tagged = isTaggedImmediate(top, op.getLoc(), rewriter);
+      mlir::Value tagged;
+      if (encoding == TagEncoding::TBI) {
+        mlir::Value top = topByteOf(addr, op.getLoc(), rewriter);
+        tagged = isTaggedImmediate(top, op.getLoc(), rewriter);
+      } else {
+        tagged = isImmortalCount(adaptor.getRefCount(), op.getLoc(), rewriter);
+      }
       addr = guardedAddr(op, tagged, addr, op.getLoc(), rewriter);
     }
     rewriter.replaceOpWithNewOp<mlir::LLVM::StoreOp>(op, adaptor.getRefCount(),
@@ -1099,12 +1155,21 @@ struct ReussirRcIncConversionPattern
           rewriter, op.getLoc(), llvmPtrType, convertedBoxType,
           adaptor.getRcPtr(), llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
     }
-    // No guard for tagged immediates: TBI masks the top byte, so the
-    // increment lands on the dummy box's refcount — a benign write that only
-    // ever grows it (rc.set, the sole decrementing store, is steered away).
+    // Usually no guard for tagged immediates: the increment lands on the
+    // dummy box's refcount — a benign write that only ever grows it (rc.set,
+    // the sole decrementing store, is steered away). The exception is the
+    // immortal encoding on refcount words narrower than 64 bits, where the
+    // dummy could actually be grown past wrap-around within a program's
+    // lifetime: there the increment's store is steered to the scratch word
+    // instead (the load stays plain, so nothing on the read path changes).
     auto indexType =
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter())
             ->getIndexType();
+    TagEncoding encoding = specialPtrTagEncoding(op);
+    bool steerNarrowImmortal =
+        encoding == TagEncoding::Immortal &&
+        llvm::cast<mlir::IntegerType>(indexType).getWidth() < 64 &&
+        rcPtrTy.mayCarrySpecialPointerTag();
     auto one = mlir::arith::ConstantOp::create(
         rewriter, op.getLoc(), mlir::IntegerAttr::get(indexType, 1));
     mlir::Value oldRefCnt;
@@ -1113,7 +1178,13 @@ struct ReussirRcIncConversionPattern
                                              refcntPtr);
       auto newRefCnt = mlir::arith::AddIOp::create(rewriter, op.getLoc(),
                                                    indexType, oldRefCnt, one);
-      mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), newRefCnt, refcntPtr);
+      mlir::Value storeAddr = refcntPtr;
+      if (steerNarrowImmortal) {
+        mlir::Value immortal =
+            isImmortalCount(oldRefCnt, op.getLoc(), rewriter);
+        storeAddr = guardedAddr(op, immortal, refcntPtr, op.getLoc(), rewriter);
+      }
+      mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), newRefCnt, storeAddr);
     } else {
       oldRefCnt = mlir::LLVM::AtomicRMWOp::create(
           rewriter, op.getLoc(), mlir::LLVM::AtomicBinOp::add, refcntPtr, one,
@@ -1277,23 +1348,40 @@ struct ReussirRcTaggedConversionPattern
   mlir::LogicalResult
   matchAndRewrite(ReussirRcTaggedOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    // The immediate encoding: top byte = tag + 1, low bits = the address of
-    // the per-tag dummy box `{2, tag}`. Refcount, uniqueness, and tag
-    // accesses through the value then hit the dummy box unguarded (TBI masks
-    // the top byte) and observe a well-formed shared header.
+    // The immediate is the per-tag dummy box's address; refcount,
+    // uniqueness, and tag accesses through the value hit the dummy box
+    // unguarded and observe a well-formed shared header. The TBI encoding
+    // additionally sets the top byte to `tag + 1` (masked by the hardware
+    // on data accesses) so foreign code and future inhabited-variant
+    // tagging can decode from the pointer; the immortal encoding uses the
+    // plain address.
     mlir::Location loc = op.getLoc();
-    auto i64Ty = rewriter.getI64Type();
+    auto indexTy = llvm::cast<mlir::IntegerType>(
+        static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter())
+            ->getIndexType());
     mlir::Type ptrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
-    auto dummy = tagDummyBox(op->getParentOfType<mlir::ModuleOp>(), loc,
-                             op.getTag().getZExtValue(), rewriter);
+    TagEncoding encoding = specialPtrTagEncoding(op);
+    auto dummy =
+        tagDummyBox(op->getParentOfType<mlir::ModuleOp>(), loc,
+                    op.getTag().getZExtValue(), encoding, indexTy, rewriter);
     mlir::Value base = mlir::LLVM::AddressOfOp::create(rewriter, loc, ptrTy,
                                                        dummy.getSymName());
+    if (encoding != TagEncoding::TBI) {
+      rewriter.replaceOp(op, base);
+      return mlir::success();
+    }
+    // The TBI encoding manipulates a 64-bit pointer's top byte; it is
+    // meaningless on narrower targets (use the immortal encoding there).
+    if (indexTy.getWidth() != 64)
+      return op.emitOpError(
+          "the TBI encoding requires a 64-bit target; use the "
+          "arch-independent encoding instead");
     mlir::Value baseInt =
-        mlir::LLVM::PtrToIntOp::create(rewriter, loc, i64Ty, base);
+        mlir::LLVM::PtrToIntOp::create(rewriter, loc, indexTy, base);
     uint64_t encoded = (op.getTag().getZExtValue() + 1) << 56;
     mlir::Value tagBits = mlir::LLVM::ConstantOp::create(
-        rewriter, loc, i64Ty,
-        rewriter.getI64IntegerAttr(static_cast<int64_t>(encoded)));
+        rewriter, loc, indexTy,
+        rewriter.getIntegerAttr(indexTy, static_cast<int64_t>(encoded)));
     mlir::Value imm = mlir::LLVM::OrOp::create(rewriter, loc, baseInt, tagBits);
     rewriter.replaceOpWithNewOp<mlir::LLVM::IntToPtrOp>(op, ptrTy, imm);
     return mlir::success();
@@ -1747,11 +1835,15 @@ struct ReussirRcIsUniqueOpConversionPattern
     : public mlir::OpConversionPattern<ReussirRcIsUniqueOp> {
   using OpConversionPattern::OpConversionPattern;
 
+  // Builds `refcount == 1`; when `outCount` is non-null it receives the
+  // loaded refcount so callers can post-process the condition (see
+  // rc.assume_unique's immortal neutralization).
   static mlir::Value
   buildUniquenessCondition(mlir::Location loc, RcType rcPtrTy,
                            mlir::Value rcPtr,
                            const mlir::TypeConverter *typeConverter,
-                           mlir::ConversionPatternRewriter &rewriter) {
+                           mlir::ConversionPatternRewriter &rewriter,
+                           mlir::Value *outCount = nullptr) {
     RcBoxType rcBoxType = rcPtrTy.getInnerBoxType();
     auto convertedBoxType = typeConverter->convertType(rcBoxType);
     auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
@@ -1762,10 +1854,12 @@ struct ReussirRcIsUniqueOpConversionPattern
         rewriter, loc, llvmPtrType, convertedBoxType, rcPtr,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
     // No guard for tagged immediates: the load reads the dummy box's
-    // refcount (TBI masks the top byte), pinned >= 2, so uniqueness is
-    // naturally false there.
+    // refcount, pinned above the unique/shared decision point, so
+    // uniqueness is naturally false there.
     auto refcnt =
         mlir::LLVM::LoadOp::create(rewriter, loc, indexType, refcntPtr);
+    if (outCount)
+      *outCount = refcnt;
     auto one = mlir::arith::ConstantOp::create(
         rewriter, loc, mlir::IntegerAttr::get(indexType, 1));
     mlir::Value isOne = mlir::arith::CmpIOp::create(
@@ -1792,16 +1886,25 @@ struct ReussirRcAssumeUniqueOpConversionPattern
   matchAndRewrite(ReussirRcAssumeUniqueOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     // NOTE: for a tagged immediate the condition reads the dummy box's
-    // refcount (>= 2) and is `false`; asserting `assume(false)` would be
-    // unsound, so neutralize the assumption on that path.
+    // refcount and is `false`; asserting `assume(false)` would be unsound,
+    // so neutralize the assumption on that path. TBI recognizes immediates
+    // by the pointer's top byte, the immortal encoding by the loaded
+    // count's magnitude.
     RcType rcPtrTy = op.getRcPtr().getType();
+    mlir::Value count;
     mlir::Value isUnique =
         ReussirRcIsUniqueOpConversionPattern::buildUniquenessCondition(
             op.getLoc(), rcPtrTy, adaptor.getRcPtr(), getTypeConverter(),
-            rewriter);
-    if (specialPtrTagEnabled(op) && rcPtrTy.mayCarrySpecialPointerTag()) {
-      mlir::Value top = topByteOf(adaptor.getRcPtr(), op.getLoc(), rewriter);
-      mlir::Value tagged = isTaggedImmediate(top, op.getLoc(), rewriter);
+            rewriter, &count);
+    TagEncoding encoding = specialPtrTagEncoding(op);
+    if (encoding != TagEncoding::None && rcPtrTy.mayCarrySpecialPointerTag()) {
+      mlir::Value tagged;
+      if (encoding == TagEncoding::TBI) {
+        mlir::Value top = topByteOf(adaptor.getRcPtr(), op.getLoc(), rewriter);
+        tagged = isTaggedImmediate(top, op.getLoc(), rewriter);
+      } else {
+        tagged = isImmortalCount(count, op.getLoc(), rewriter);
+      }
       auto vTrue = mlir::LLVM::ConstantOp::create(rewriter, op.getLoc(),
                                                   rewriter.getI1Type(),
                                                   rewriter.getBoolAttr(true));

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -59,6 +59,7 @@
 #include "Reussir/IR/ReussirEnumAttrs.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
+#include "Reussir/Transformation/SpecialPointerTag.h"
 #include "mlir/IR/Location.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/BinaryFormat/Dwarf.h"
@@ -75,6 +76,104 @@ namespace reussir {
 //===----------------------------------------------------------------------===//
 
 namespace {
+
+//===----------------------------------------------------------------------===//
+// Special pointer tag support
+//===----------------------------------------------------------------------===//
+// When `reussir-special-pointer-tag` ran (module carries kSpecialPtrTagAttr),
+// a value of a taggable shared rc<variant> type may be an unboxed immediate:
+// top byte = tag + 1, low bits = the address of a per-tag *dummy box*
+// (`{refcount = 2, tag}`). This is where TBI does the heavy lifting: on the
+// aarch64 targets the scheme is enabled for, the hardware ignores the top
+// byte on data accesses, so refcount loads/increments, uniqueness reads,
+// and even the variant-tag read through a tagged value simply hit the dummy
+// box — which answers with a pinned shared refcount and the *real* tag. The
+// hot paths (match dispatch, rc.inc, rc.fetch, rc.is_unique) therefore lower
+// exactly as without the scheme: plain loads, zero guards. Two invariants
+// keep that sound:
+//   * the dummy's refcount is pinned >= 2 (only `rc.inc` writes it, and it
+//     only adds), so an immediate's decrement always takes the *shared*
+//     branch (no field drop, no token, no free of the dummy) and
+//     `rc.is_unique` answers false;
+//   * `rc.set` — the one decrementing store — steers a tagged access to a
+//     separate scratch word (an address select off the critical path), so
+//     the dummy count can never decay to 1.
+// The top byte itself is read only by `rc.set`/`rc.assume_unique` (which
+// must recognize immediates; an `assume(false)` would be unsound) and by
+// foreign code, which may decode `tag = top - 1` without dereferencing.
+
+bool specialPtrTagEnabled(mlir::Operation *op) {
+  auto module = op->getParentOfType<mlir::ModuleOp>();
+  return module && module->hasAttr(kSpecialPtrTagAttr);
+}
+
+// The per-tag dummy box a tagged immediate points at: `{refcount = 2, tag}`.
+// Loads and increments through a tagged value land here (TBI masks the top
+// byte) and observe a well-formed shared box header carrying the immediate's
+// own tag; the refcount stays >= 2 because `rc.set` never writes it (see
+// below).
+mlir::LLVM::GlobalOp tagDummyBox(mlir::ModuleOp module, mlir::Location loc,
+                                 uint64_t tag, mlir::OpBuilder &builder) {
+  std::string name = ("__reussir_tag_dummy_" + llvm::Twine(tag)).str();
+  auto global = module.lookupSymbol<mlir::LLVM::GlobalOp>(name);
+  if (!global) {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(module.getBody());
+    auto i64Ty = builder.getI64Type();
+    auto arrTy = mlir::LLVM::LLVMArrayType::get(i64Ty, 2);
+    auto init = mlir::DenseElementsAttr::get(
+        mlir::RankedTensorType::get({2}, i64Ty),
+        llvm::ArrayRef<int64_t>{2, static_cast<int64_t>(tag)});
+    global = mlir::LLVM::GlobalOp::create(
+        builder, loc, arrTy,
+        /*isConstant=*/false, mlir::LLVM::Linkage::Internal, name, init);
+  }
+  return global;
+}
+
+// The per-module scratch word guarded accesses are steered to.
+mlir::Value tagScratchAddr(mlir::ModuleOp module, mlir::Location loc,
+                           mlir::OpBuilder &builder) {
+  constexpr llvm::StringLiteral kName = "__reussir_tag_scratch";
+  auto global = module.lookupSymbol<mlir::LLVM::GlobalOp>(kName);
+  if (!global) {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(module.getBody());
+    auto i64Ty = builder.getI64Type();
+    global = mlir::LLVM::GlobalOp::create(
+        builder, loc, i64Ty, /*isConstant=*/false,
+        mlir::LLVM::Linkage::Internal, kName, builder.getI64IntegerAttr(0));
+  }
+  return mlir::LLVM::AddressOfOp::create(builder, loc, global);
+}
+
+// `ptr`'s top byte as an i64 (zero for any real heap pointer).
+mlir::Value topByteOf(mlir::Value ptr, mlir::Location loc,
+                      mlir::OpBuilder &builder) {
+  auto i64Ty = builder.getI64Type();
+  auto raw = mlir::LLVM::PtrToIntOp::create(builder, loc, i64Ty, ptr);
+  auto c56 = mlir::LLVM::ConstantOp::create(builder, loc, i64Ty,
+                                            builder.getI64IntegerAttr(56));
+  return mlir::LLVM::LShrOp::create(builder, loc, raw, c56);
+}
+
+// `top != 0` — the value is a tagged immediate.
+mlir::Value isTaggedImmediate(mlir::Value topByte, mlir::Location loc,
+                              mlir::OpBuilder &builder) {
+  auto zero = mlir::LLVM::ConstantOp::create(builder, loc, builder.getI64Type(),
+                                             builder.getI64IntegerAttr(0));
+  return mlir::LLVM::ICmpOp::create(builder, loc, mlir::LLVM::ICmpPredicate::ne,
+                                    topByte, zero);
+}
+
+// Steer `addr` to the scratch word when `isTagged` holds.
+mlir::Value guardedAddr(mlir::Operation *op, mlir::Value isTagged,
+                        mlir::Value addr, mlir::Location loc,
+                        mlir::OpBuilder &builder) {
+  auto scratch =
+      tagScratchAddr(op->getParentOfType<mlir::ModuleOp>(), loc, builder);
+  return mlir::LLVM::SelectOp::create(builder, loc, isTagged, scratch, addr);
+}
 
 void ensureRuntimeFunctions(mlir::ModuleOp module,
                             const mlir::LLVMTypeConverter &converter);
@@ -296,8 +395,13 @@ struct ReussirRcFetchConversionPattern
     auto indexTy =
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter())
             ->getIndexType();
-    mlir::Value loaded = mlir::LLVM::LoadOp::create(
-        rewriter, op.getLoc(), indexTy, adaptor.getRcPtr());
+    mlir::Location loc = op.getLoc();
+    // No guard for tagged immediates: TBI masks the top byte, so the load
+    // hits the dummy box's refcount, which is pinned >= 2 — exactly what
+    // routes the expanded decrement to its shared branch and answers
+    // `is_unique` with false (see the special-pointer-tag notes above).
+    mlir::Value loaded =
+        mlir::LLVM::LoadOp::create(rewriter, loc, indexTy, adaptor.getRcPtr());
     rewriter.replaceOp(op, loaded);
     return mlir::success();
   }
@@ -310,8 +414,19 @@ struct ReussirRcSetConversionPattern
   mlir::LogicalResult
   matchAndRewrite(ReussirRcSetOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
+    mlir::Value addr = adaptor.getRcPtr();
+    // `rc.set` is the one store that can lower a refcount, so it must not
+    // reach the dummy box (its count would eventually decay to 1 and send an
+    // immediate down the unique branch). Steer a tagged access to the scratch
+    // word instead; the address select is off any result's critical path.
+    if (specialPtrTagEnabled(op) &&
+        op.getRcPtr().getType().mayCarrySpecialPointerTag()) {
+      mlir::Value top = topByteOf(addr, op.getLoc(), rewriter);
+      mlir::Value tagged = isTaggedImmediate(top, op.getLoc(), rewriter);
+      addr = guardedAddr(op, tagged, addr, op.getLoc(), rewriter);
+    }
     rewriter.replaceOpWithNewOp<mlir::LLVM::StoreOp>(op, adaptor.getRefCount(),
-                                                     adaptor.getRcPtr());
+                                                     addr);
     return mlir::success();
   }
 };
@@ -889,8 +1004,11 @@ struct ReussirRecordTagConversionPattern
         rewriter, loc, tagPtrType, elementType, refPtr,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
 
-    // Load the tag value
-    auto tagValue =
+    // Load the tag value. Under the special-pointer-tag scheme a tagged
+    // immediate scrutinee needs no decode: the load lands in its per-tag
+    // dummy box (TBI masks the top byte) and reads the real tag — so the
+    // match hot path is identical with and without the scheme.
+    mlir::Value tagValue =
         rewriter.replaceOpWithNewOp<mlir::LLVM::LoadOp>(op, indexType, tagPtr);
 
     // Assume that the tag is always in bounds
@@ -981,6 +1099,9 @@ struct ReussirRcIncConversionPattern
           rewriter, op.getLoc(), llvmPtrType, convertedBoxType,
           adaptor.getRcPtr(), llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
     }
+    // No guard for tagged immediates: TBI masks the top byte, so the
+    // increment lands on the dummy box's refcount — a benign write that only
+    // ever grows it (rc.set, the sole decrementing store, is steered away).
     auto indexType =
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter())
             ->getIndexType();
@@ -998,7 +1119,9 @@ struct ReussirRcIncConversionPattern
           rewriter, op.getLoc(), mlir::LLVM::AtomicBinOp::add, refcntPtr, one,
           mlir::LLVM::AtomicOrdering::monotonic);
     }
-    auto geOne = mlir::LLVM::ICmpOp::create(
+    // Valid for immediates too: the dummy box's count starts at 2 and only
+    // ever grows, so `old >= 1` holds on that path as well.
+    mlir::Value geOne = mlir::LLVM::ICmpOp::create(
         rewriter, op.getLoc(), mlir::LLVM::ICmpPredicate::uge, oldRefCnt, one);
     mlir::LLVM::AssumeOp::create(rewriter, op.getLoc(), geOne);
 
@@ -1143,6 +1266,36 @@ struct ReussirRcCreateCompoundOpConversionPattern
       store.setInvariantGroup(true);
     }
     rewriter.replaceOp(op, results);
+    return mlir::success();
+  }
+};
+
+struct ReussirRcTaggedConversionPattern
+    : public mlir::OpConversionPattern<ReussirRcTaggedOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirRcTaggedOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    // The immediate encoding: top byte = tag + 1, low bits = the address of
+    // the per-tag dummy box `{2, tag}`. Refcount, uniqueness, and tag
+    // accesses through the value then hit the dummy box unguarded (TBI masks
+    // the top byte) and observe a well-formed shared header.
+    mlir::Location loc = op.getLoc();
+    auto i64Ty = rewriter.getI64Type();
+    mlir::Type ptrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    auto dummy = tagDummyBox(op->getParentOfType<mlir::ModuleOp>(), loc,
+                             op.getTag().getZExtValue(), rewriter);
+    mlir::Value base = mlir::LLVM::AddressOfOp::create(rewriter, loc, ptrTy,
+                                                       dummy.getSymName());
+    mlir::Value baseInt =
+        mlir::LLVM::PtrToIntOp::create(rewriter, loc, i64Ty, base);
+    uint64_t encoded = (op.getTag().getZExtValue() + 1) << 56;
+    mlir::Value tagBits = mlir::LLVM::ConstantOp::create(
+        rewriter, loc, i64Ty,
+        rewriter.getI64IntegerAttr(static_cast<int64_t>(encoded)));
+    mlir::Value imm = mlir::LLVM::OrOp::create(rewriter, loc, baseInt, tagBits);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::IntToPtrOp>(op, ptrTy, imm);
     return mlir::success();
   }
 };
@@ -1608,12 +1761,16 @@ struct ReussirRcIsUniqueOpConversionPattern
     auto refcntPtr = mlir::LLVM::GEPOp::create(
         rewriter, loc, llvmPtrType, convertedBoxType, rcPtr,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
+    // No guard for tagged immediates: the load reads the dummy box's
+    // refcount (TBI masks the top byte), pinned >= 2, so uniqueness is
+    // naturally false there.
     auto refcnt =
         mlir::LLVM::LoadOp::create(rewriter, loc, indexType, refcntPtr);
     auto one = mlir::arith::ConstantOp::create(
         rewriter, loc, mlir::IntegerAttr::get(indexType, 1));
-    return mlir::arith::CmpIOp::create(
+    mlir::Value isOne = mlir::arith::CmpIOp::create(
         rewriter, loc, mlir::arith::CmpIPredicate::eq, refcnt, one);
+    return isOne;
   }
 
   mlir::LogicalResult
@@ -1634,10 +1791,23 @@ struct ReussirRcAssumeUniqueOpConversionPattern
   mlir::LogicalResult
   matchAndRewrite(ReussirRcAssumeUniqueOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto isUnique =
+    // NOTE: for a tagged immediate the condition reads the dummy box's
+    // refcount (>= 2) and is `false`; asserting `assume(false)` would be
+    // unsound, so neutralize the assumption on that path.
+    RcType rcPtrTy = op.getRcPtr().getType();
+    mlir::Value isUnique =
         ReussirRcIsUniqueOpConversionPattern::buildUniquenessCondition(
-            op.getLoc(), op.getRcPtr().getType(), adaptor.getRcPtr(),
-            getTypeConverter(), rewriter);
+            op.getLoc(), rcPtrTy, adaptor.getRcPtr(), getTypeConverter(),
+            rewriter);
+    if (specialPtrTagEnabled(op) && rcPtrTy.mayCarrySpecialPointerTag()) {
+      mlir::Value top = topByteOf(adaptor.getRcPtr(), op.getLoc(), rewriter);
+      mlir::Value tagged = isTaggedImmediate(top, op.getLoc(), rewriter);
+      auto vTrue = mlir::LLVM::ConstantOp::create(rewriter, op.getLoc(),
+                                                  rewriter.getI1Type(),
+                                                  rewriter.getBoolAttr(true));
+      isUnique = mlir::LLVM::SelectOp::create(rewriter, op.getLoc(), tagged,
+                                              vTrue, isUnique);
+    }
     mlir::LLVM::AssumeOp::create(rewriter, op.getLoc(), isUnique);
     rewriter.eraseOp(op);
     return mlir::success();
@@ -2783,20 +2953,20 @@ struct ReussirConvertToLLVMPatternInterface
         ReussirRefFromMemrefOp, ReussirRefDiffOp, ReussirRefCmpOp,
         ReussirRefMemcpyOp, ReussirNullableCheckOp, ReussirNullableCreateOp,
         ReussirNullableCoerceOp, ReussirRcIncOp, ReussirRcCreateOp,
-        ReussirRcCreateCompoundOp, ReussirRcCreateVariantOp, ReussirRcDecOp,
-        ReussirRcBorrowOp, ReussirRcIsUniqueOp, ReussirRcAssumeUniqueOp,
-        ReussirRecordCompoundOp, ReussirRecordVariantOp, ReussirRefProjectOp,
-        ReussirArrayProjectOp, ReussirArrayViewOp, ReussirRecordTagOp,
-        ReussirRecordExtractOp, ReussirRecordCoerceOp, ReussirRegionVTableOp,
-        ReussirRcFreezeOp, ReussirRegionCleanupOp, ReussirRegionCreateOp,
-        ReussirRcReinterpretOp, ReussirClosureApplyOp, ReussirClosureCloneOp,
-        ReussirClosureEvalOp, ReussirClosureInspectPayloadOp,
-        ReussirClosureCursorOp, ReussirClosureInstantiateOp,
-        ReussirClosureVtableOp, ReussirClosureCreateOp, ReussirRcFetchOp,
-        ReussirRcSetOp, ReussirStrGlobalOp, ReussirStrLiteralOp,
-        ReussirStrCastOp, ReussirStrLenOp, ReussirStrUnsafeByteAtOp,
-        ReussirStrUnsafeStartWithOp, ReussirStrSliceOp, ReussirTrampolineOp,
-        ReussirTokenLaunderOp>();
+        ReussirRcCreateCompoundOp, ReussirRcCreateVariantOp, ReussirRcTaggedOp,
+        ReussirRcDecOp, ReussirRcBorrowOp, ReussirRcIsUniqueOp,
+        ReussirRcAssumeUniqueOp, ReussirRecordCompoundOp,
+        ReussirRecordVariantOp, ReussirRefProjectOp, ReussirArrayProjectOp,
+        ReussirArrayViewOp, ReussirRecordTagOp, ReussirRecordExtractOp,
+        ReussirRecordCoerceOp, ReussirRegionVTableOp, ReussirRcFreezeOp,
+        ReussirRegionCleanupOp, ReussirRegionCreateOp, ReussirRcReinterpretOp,
+        ReussirClosureApplyOp, ReussirClosureCloneOp, ReussirClosureEvalOp,
+        ReussirClosureInspectPayloadOp, ReussirClosureCursorOp,
+        ReussirClosureInstantiateOp, ReussirClosureVtableOp,
+        ReussirClosureCreateOp, ReussirRcFetchOp, ReussirRcSetOp,
+        ReussirStrGlobalOp, ReussirStrLiteralOp, ReussirStrCastOp,
+        ReussirStrLenOp, ReussirStrUnsafeByteAtOp, ReussirStrUnsafeStartWithOp,
+        ReussirStrSliceOp, ReussirTrampolineOp, ReussirTokenLaunderOp>();
   }
 };
 
@@ -2881,7 +3051,8 @@ void populateBasicOpsLoweringToLLVMConversionPatterns(
       ReussirNullableCheckConversionPattern,
       ReussirNullableCreateConversionPattern,
       ReussirNullableCoerceConversionPattern, ReussirRcIncConversionPattern,
-      ReussirRcDecOpConversionPattern, ReussirRcCreateOpConversionPattern,
+      ReussirRcTaggedConversionPattern, ReussirRcDecOpConversionPattern,
+      ReussirRcCreateOpConversionPattern,
       ReussirRcCreateCompoundOpConversionPattern,
       ReussirRcCreateVariantOpConversionPattern,
       ReussirRcBorrowOpConversionPattern, ReussirRcIsUniqueOpConversionPattern,

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -144,7 +144,10 @@ mlir::LLVM::GlobalOp tagDummyBox(mlir::ModuleOp module, mlir::Location loc,
                                  uint64_t tag, TagEncoding encoding,
                                  mlir::IntegerType indexTy,
                                  mlir::OpBuilder &builder) {
-  std::string name = ("__reussir_tag_dummy_" + llvm::Twine(tag)).str();
+  // Content-addressed v0 name, like every other lowering-generated global
+  // (namespace + the decimal tag as payload).
+  std::string name =
+      mangledBlake3Symbol("REUSSIR_TAG_DUMMY", llvm::Twine(tag).str());
   auto global = module.lookupSymbol<mlir::LLVM::GlobalOp>(name);
   if (!global) {
     mlir::OpBuilder::InsertionGuard guard(builder);
@@ -179,7 +182,7 @@ mlir::Value isImmortalCount(mlir::Value count, mlir::Location loc,
 // The per-module scratch word guarded accesses are steered to.
 mlir::Value tagScratchAddr(mlir::ModuleOp module, mlir::Location loc,
                            mlir::OpBuilder &builder) {
-  constexpr llvm::StringLiteral kName = "__reussir_tag_scratch";
+  std::string kName = mangledBlake3Symbol("REUSSIR_TAG_SCRATCH", "");
   auto global = module.lookupSymbol<mlir::LLVM::GlobalOp>(kName);
   if (!global) {
     mlir::OpBuilder::InsertionGuard guard(builder);

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -50,7 +50,8 @@ namespace reussir {
 namespace {
 
 static mlir::MemRefType getArrayViewMemRefType(ArrayType arrayType) {
-  return mlir::MemRefType::get(arrayType.getShape(), arrayType.getElementType());
+  return mlir::MemRefType::get(arrayType.getShape(),
+                               arrayType.getElementType());
 }
 
 static mlir::RankedTensorType getArrayViewTensorType(ArrayType arrayType) {
@@ -66,9 +67,9 @@ static mlir::LogicalResult verifyZeroRankMemRefType(mlir::Operation *op,
   if (!memrefType || memrefType.getRank() != 0)
     return op->emitOpError(valueName) << " must be a zero-rank memref";
   if (memrefType.getElementType() != elementType)
-    return op->emitOpError(valueName) << " element type mismatch: expected "
-                                      << elementType << ", got "
-                                      << memrefType.getElementType();
+    return op->emitOpError(valueName)
+           << " element type mismatch: expected " << elementType << ", got "
+           << memrefType.getElementType();
   return mlir::success();
 }
 
@@ -78,17 +79,17 @@ static mlir::LogicalResult verifyArrayViewType(mlir::Operation *op,
                                                llvm::StringRef valueName) {
   if (auto memrefType = llvm::dyn_cast<mlir::MemRefType>(type)) {
     if (memrefType != getArrayViewMemRefType(arrayType))
-      return op->emitOpError(valueName) << " type mismatch: expected "
-                                        << getArrayViewMemRefType(arrayType)
-                                        << ", got " << memrefType;
+      return op->emitOpError(valueName)
+             << " type mismatch: expected " << getArrayViewMemRefType(arrayType)
+             << ", got " << memrefType;
     return mlir::success();
   }
 
   if (auto tensorType = llvm::dyn_cast<mlir::RankedTensorType>(type)) {
     if (tensorType != getArrayViewTensorType(arrayType))
-      return op->emitOpError(valueName) << " type mismatch: expected "
-                                        << getArrayViewTensorType(arrayType)
-                                        << ", got " << tensorType;
+      return op->emitOpError(valueName)
+             << " type mismatch: expected " << getArrayViewTensorType(arrayType)
+             << ", got " << tensorType;
     return mlir::success();
   }
 
@@ -115,7 +116,8 @@ mlir::LogicalResult verifyRcCreateLikeOp(mlir::Operation *op, RcType rcType,
     return mlir::success();
 
   TokenType tokenType = llvm::cast<TokenType>(token.getType());
-  auto rcBoxType = RcBoxType::get(op->getContext(), valueType, region != nullptr);
+  auto rcBoxType =
+      RcBoxType::get(op->getContext(), valueType, region != nullptr);
   auto dataLayout = mlir::DataLayout::closest(op);
   auto alignment = dataLayout.getTypeABIAlignment(rcBoxType);
   auto size = dataLayout.getTypeSize(rcBoxType);
@@ -151,12 +153,14 @@ verifyRcCreateLikeSymbolUses(mlir::Operation *op, mlir::Value region,
 
   mlir::Type vtableType = vtableOp.getTypeAttr().getValue();
   if (vtableType != valueType)
-    return op->emitOpError("vtable type attribute must match value input type, ")
+    return op->emitOpError(
+               "vtable type attribute must match value input type, ")
            << "vtable type: " << vtableType << ", value type: " << valueType;
   return mlir::success();
 }
 
-mlir::LogicalResult verifyCompoundFields(mlir::Operation *op, RecordType recordType,
+mlir::LogicalResult verifyCompoundFields(mlir::Operation *op,
+                                         RecordType recordType,
                                          mlir::ValueRange fields) {
   if (!recordType)
     return op->emitOpError("RC element type must be a record type");
@@ -166,8 +170,8 @@ mlir::LogicalResult verifyCompoundFields(mlir::Operation *op, RecordType recordT
     return op->emitOpError("RC element type must be a compound record");
   if (recordType.getMembers().size() != fields.size())
     return op->emitOpError("number of fields must match number of members");
-  for (auto [field, member, memberCapability] :
-       llvm::zip(fields, recordType.getMembers(), recordType.getMemberIsField())) {
+  for (auto [field, member, memberCapability] : llvm::zip(
+           fields, recordType.getMembers(), recordType.getMemberIsField())) {
     mlir::Type projectedType =
         reussir::getProjectedType(member, memberCapability, Capability::flex);
     if (projectedType != field.getType())
@@ -178,7 +182,8 @@ mlir::LogicalResult verifyCompoundFields(mlir::Operation *op, RecordType recordT
   return mlir::success();
 }
 
-mlir::LogicalResult verifySkippedFields(mlir::Operation *op, size_t fieldCount) {
+mlir::LogicalResult verifySkippedFields(mlir::Operation *op,
+                                        size_t fieldCount) {
   auto skippedFields = op->getAttrOfType<mlir::DenseI64ArrayAttr>("skipFields");
   if (!skippedFields)
     return mlir::success();
@@ -454,8 +459,9 @@ mlir::LogicalResult ReussirRcCreateCompoundOp::verify() {
 // RcCreateCompoundOp TokenAcceptor Interface
 //===----------------------------------------------------------------------===//
 TokenType ReussirRcCreateCompoundOp::getTokenType() {
-  auto rcBoxType = RcBoxType::get(getContext(), getRcPtr().getType().getElementType(),
-                                  getRegion() != nullptr);
+  auto rcBoxType =
+      RcBoxType::get(getContext(), getRcPtr().getType().getElementType(),
+                     getRegion() != nullptr);
   auto dataLayout = mlir::DataLayout::closest(getOperation());
   auto alignment = dataLayout.getTypeABIAlignment(rcBoxType);
   auto size = dataLayout.getTypeSize(rcBoxType);
@@ -467,14 +473,34 @@ TokenType ReussirRcCreateCompoundOp::getTokenType() {
 //===----------------------------------------------------------------------===//
 mlir::LogicalResult ReussirRcCreateCompoundOp::verifySymbolUses(
     mlir::SymbolTableCollection &symbolTable) {
-  return verifyRcCreateLikeSymbolUses(
-      getOperation(), getRegion(), getRcPtr().getType().getElementType(),
-      getVtableAttr(), symbolTable);
+  return verifyRcCreateLikeSymbolUses(getOperation(), getRegion(),
+                                      getRcPtr().getType().getElementType(),
+                                      getVtableAttr(), symbolTable);
 }
 
 //===----------------------------------------------------------------------===//
 // RcCreateVariantOp verification
 //===----------------------------------------------------------------------===//
+mlir::LogicalResult ReussirRcTaggedOp::verify() {
+  RcType rcType = getRcPtr().getType();
+  if (rcType.getCapability() != Capability::shared &&
+      rcType.getCapability() != Capability::unspecified)
+    return emitOpError("tagged immediates require a plain shared box");
+  auto variantType = llvm::dyn_cast<RecordType>(rcType.getElementType());
+  if (!variantType || !variantType.isVariant() || !variantType.getComplete())
+    return emitOpError("RC element type must be a complete variant record");
+  size_t tag = getTag().getZExtValue();
+  if (tag >= variantType.getMembers().size())
+    return emitOpError("tag out of bounds");
+  // The encoding stores `tag + 1` in the pointer's top byte.
+  if (tag + 1 > 0xFF)
+    return emitOpError("tag does not fit the top-byte encoding");
+  auto arm = llvm::dyn_cast<RecordType>(variantType.getMembers()[tag]);
+  if (!arm || !arm.isCompound() || !arm.getMembers().empty())
+    return emitOpError("tagged immediates only encode nullary variants");
+  return mlir::success();
+}
+
 mlir::LogicalResult ReussirRcCreateVariantOp::verify() {
   RecordType variantType = getRecordType();
   if (!variantType)
@@ -520,8 +546,8 @@ mlir::LogicalResult ReussirRcCreateVariantOp::verify() {
   } else {
     auto compoundType = llvm::dyn_cast<RecordType>(targetVariantType);
     if (!compoundType || !compoundType.isCompound())
-      return emitOpError(
-          "compound fields payload requires the selected variant member to be a compound record");
+      return emitOpError("compound fields payload requires the selected "
+                         "variant member to be a compound record");
     if (failed(verifyCompoundFields(getOperation(), compoundType, getFields())))
       return mlir::failure();
     if (failed(verifyHoleFields(getOperation(), getFields().getTypes(),
@@ -539,8 +565,9 @@ mlir::LogicalResult ReussirRcCreateVariantOp::verify() {
 // RcCreateVariantOp TokenAcceptor Interface
 //===----------------------------------------------------------------------===//
 TokenType ReussirRcCreateVariantOp::getTokenType() {
-  auto rcBoxType = RcBoxType::get(getContext(), getRcPtr().getType().getElementType(),
-                                  getRegion() != nullptr);
+  auto rcBoxType =
+      RcBoxType::get(getContext(), getRcPtr().getType().getElementType(),
+                     getRegion() != nullptr);
   auto dataLayout = mlir::DataLayout::closest(getOperation());
   auto alignment = dataLayout.getTypeABIAlignment(rcBoxType);
   auto size = dataLayout.getTypeSize(rcBoxType);
@@ -552,9 +579,9 @@ TokenType ReussirRcCreateVariantOp::getTokenType() {
 //===----------------------------------------------------------------------===//
 mlir::LogicalResult ReussirRcCreateVariantOp::verifySymbolUses(
     mlir::SymbolTableCollection &symbolTable) {
-  return verifyRcCreateLikeSymbolUses(
-      getOperation(), getRegion(), getRcPtr().getType().getElementType(),
-      getVtableAttr(), symbolTable);
+  return verifyRcCreateLikeSymbolUses(getOperation(), getRegion(),
+                                      getRcPtr().getType().getElementType(),
+                                      getVtableAttr(), symbolTable);
 }
 
 //===----------------------------------------------------------------------===//
@@ -809,7 +836,8 @@ mlir::LogicalResult ReussirArrayViewOp::verify() {
   RefType refType = getRef().getType();
   ArrayType arrayType = llvm::dyn_cast<ArrayType>(refType.getElementType());
   if (!arrayType)
-    return emitOpError("array.view input must be a reference to a reussir.array");
+    return emitOpError(
+        "array.view input must be a reference to a reussir.array");
   return verifyArrayViewType(getOperation(), getView().getType(), arrayType,
                              "array.view result");
 }
@@ -817,12 +845,13 @@ mlir::LogicalResult ReussirArrayViewOp::verify() {
 mlir::LogicalResult ReussirArrayProjectOp::verify() {
   auto memrefType = llvm::dyn_cast<mlir::MemRefType>(getView().getType());
   if (!memrefType)
-    return emitOpError("array.project input must be a statically shaped memref");
+    return emitOpError(
+        "array.project input must be a statically shaped memref");
   if (!memrefType.hasStaticShape() || !memrefType.getLayout().isIdentity())
     return emitOpError("array.project input memref must have a static "
                        "identity-layout type");
-  ArrayType arrayType =
-      ArrayType::get(getContext(), memrefType.getShape(), memrefType.getElementType());
+  ArrayType arrayType = ArrayType::get(getContext(), memrefType.getShape(),
+                                       memrefType.getElementType());
   if (arrayType.getRank() == 0)
     return emitOpError("array view must have at least one extent");
 
@@ -1404,8 +1433,9 @@ void ReussirRecordDispatchOp::print(mlir::OpAsmPrinter &p) {
 //===----------------------------------------------------------------------===//
 // Reussir Array WithUniqueView Op
 //===----------------------------------------------------------------------===//
-mlir::ParseResult ReussirArrayWithUniqueViewOp::parse(
-    mlir::OpAsmParser &parser, mlir::OperationState &result) {
+mlir::ParseResult
+ReussirArrayWithUniqueViewOp::parse(mlir::OpAsmParser &parser,
+                                    mlir::OperationState &result) {
   llvm::SMLoc operandLoc = parser.getCurrentLocation();
   mlir::OpAsmParser::UnresolvedOperand arrayOperand;
   RcType arrayType;
@@ -1525,7 +1555,8 @@ mlir::LogicalResult ReussirScfYieldOp::verify() {
     expectedType = recordParent.getValue() ? recordParent.getValue().getType()
                                            : mlir::Type{};
   else if (auto arrayParent =
-               getOperation()->getParentOfType<ReussirArrayWithUniqueViewOp>()) {
+               getOperation()
+                   ->getParentOfType<ReussirArrayWithUniqueViewOp>()) {
     expectedType = arrayParent.getResult() ? arrayParent.getResult().getType()
                                            : mlir::Type{};
     allowImplicitArrayResult =
@@ -2158,8 +2189,9 @@ mlir::LogicalResult ReussirPolyFFIOp::verify() {
 //===----------------------------------------------------------------------===//
 // emitOwnershipAcquisition
 //===----------------------------------------------------------------------===//
-static mlir::LogicalResult emitArrayOwnershipAcquisition(
-    mlir::Value view, mlir::OpBuilder &builder, mlir::Location loc);
+static mlir::LogicalResult
+emitArrayOwnershipAcquisition(mlir::Value view, mlir::OpBuilder &builder,
+                              mlir::Location loc);
 
 mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
                                              mlir::OpBuilder &builder,
@@ -2188,9 +2220,10 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
         }
 
         if (auto arrayType = llvm::dyn_cast<ArrayType>(elementType)) {
-          auto view = ReussirArrayViewOp::create(
-                          builder, loc, getArrayViewMemRefType(arrayType), value)
-                          .getView();
+          auto view =
+              ReussirArrayViewOp::create(
+                  builder, loc, getArrayViewMemRefType(arrayType), value)
+                  .getView();
           return emitArrayOwnershipAcquisition(view, builder, loc);
         }
 
@@ -2207,8 +2240,8 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
               if (isTriviallyCopyable(projectedType))
                 continue;
               auto fieldRef = ReussirRefProjectOp::create(
-                  builder,
-                  loc, RefType::get(builder.getContext(), projectedType), value,
+                  builder, loc,
+                  RefType::get(builder.getContext(), projectedType), value,
                   builder.getIndexAttr(i));
 
               if (emitOwnershipAcquisition(fieldRef, builder, loc).failed())
@@ -2226,8 +2259,7 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
             // Create the dispatch operation with the correct number of
             // regions
             auto dispatchOp = ReussirRecordDispatchOp::create(
-                builder,
-                loc, mlir::Type{}, value, tagSetsAttr,
+                builder, loc, mlir::Type{}, value, tagSetsAttr,
                 recordType.getMembers().size());
 
             // Create regions for each variant and apply ownership acquisition
@@ -2271,12 +2303,12 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
       .Default([&](mlir::Type) { return mlir::failure(); });
 }
 
-static mlir::LogicalResult emitArrayOwnershipAcquisition(
-    mlir::Value view, mlir::OpBuilder &builder, mlir::Location loc) {
+static mlir::LogicalResult
+emitArrayOwnershipAcquisition(mlir::Value view, mlir::OpBuilder &builder,
+                              mlir::Location loc) {
   auto viewType = llvm::cast<mlir::MemRefType>(view.getType());
-  ArrayType arrayType =
-      ArrayType::get(builder.getContext(), viewType.getShape(),
-                     viewType.getElementType());
+  ArrayType arrayType = ArrayType::get(
+      builder.getContext(), viewType.getShape(), viewType.getElementType());
   auto *context = builder.getContext();
   for (int64_t index : llvm::seq<int64_t>(0, arrayType.getShape().front())) {
     auto idx = mlir::arith::ConstantIndexOp::create(builder, loc, index);
@@ -2284,8 +2316,7 @@ static mlir::LogicalResult emitArrayOwnershipAcquisition(
       RefType projectedType = RefType::get(context, arrayType.getElementType(),
                                            Capability::unspecified);
       auto elementRef = ReussirArrayProjectOp::create(
-          builder,
-          loc, projectedType, view, idx.getResult());
+          builder, loc, projectedType, view, idx.getResult());
       if (emitOwnershipAcquisition(elementRef.getProjected(), builder, loc)
               .failed())
         return mlir::failure();
@@ -2293,9 +2324,8 @@ static mlir::LogicalResult emitArrayOwnershipAcquisition(
     }
 
     auto projectedType = getArrayViewMemRefType(arrayType.dropFront());
-    auto nestedView = ReussirArrayProjectOp::create(
-        builder,
-        loc, projectedType, view, idx.getResult());
+    auto nestedView = ReussirArrayProjectOp::create(builder, loc, projectedType,
+                                                    view, idx.getResult());
     if (emitArrayOwnershipAcquisition(nestedView.getProjected(), builder, loc)
             .failed())
       return mlir::failure();
@@ -2319,10 +2349,9 @@ mlir::func::FuncOp createDtorIfNotExists(mlir::ModuleOp moduleOp,
   mlir::OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(moduleOp.getBody());
   RefType refType = builder.getType<RefType>(type);
-  auto dtor = mlir::func::FuncOp::create(
-      builder,
-      builder.getUnknownLoc(), funcName,
-      builder.getFunctionType({refType}, {}));
+  auto dtor =
+      mlir::func::FuncOp::create(builder, builder.getUnknownLoc(), funcName,
+                                 builder.getFunctionType({refType}, {}));
   dtor.setPrivate();
   dtor->setAttr("llvm.linkage", builder.getAttr<mlir::LLVM::LinkageAttr>(
                                     mlir::LLVM::linkage::Linkage::LinkonceODR));
@@ -2362,10 +2391,9 @@ mlir::func::FuncOp emitOwnershipAcquisitionFuncIfNotExists(
   // Construct RefType from RecordType
   RefType refType = builder.getType<RefType>(type);
 
-  auto funcOp = mlir::func::FuncOp::create(
-      builder,
-      builder.getUnknownLoc(), funcName,
-      builder.getFunctionType({refType}, {}));
+  auto funcOp =
+      mlir::func::FuncOp::create(builder, builder.getUnknownLoc(), funcName,
+                                 builder.getFunctionType({refType}, {}));
   funcOp.setPrivate();
   funcOp->setAttr("llvm.linkage",
                   builder.getAttr<mlir::LLVM::LinkageAttr>(

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -486,6 +486,8 @@ mlir::LogicalResult ReussirRcTaggedOp::verify() {
   if (rcType.getCapability() != Capability::shared &&
       rcType.getCapability() != Capability::unspecified)
     return emitOpError("tagged immediates require a plain shared box");
+  if (rcType.getAtomicKind() != AtomicKind::normal)
+    return emitOpError("tagged immediates require a nonatomic box");
   auto variantType = llvm::dyn_cast<RecordType>(rcType.getElementType());
   if (!variantType || !variantType.isVariant() || !variantType.getComplete())
     return emitOpError("RC element type must be a complete variant record");

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -41,9 +41,9 @@
 #include "Reussir/IR/ReussirEnumAttrs.h"
 #include "Reussir/IR/ReussirTypes.h"
 
-// The `DataLayoutTypeInterface` no longer carries `getPreferredAlignment`, so the
-// generated declarations omit it; this elides our out-of-line definitions to
-// match.
+// The `DataLayoutTypeInterface` no longer carries `getPreferredAlignment`, so
+// the generated declarations omit it; this elides our out-of-line definitions
+// to match.
 #define MLIR_DATA_LAYOUT_EXPAND_PREFERRED_ALIGN(...)
 
 #define GET_TYPEDEF_CLASSES
@@ -184,8 +184,7 @@ bool isNonNullPointerType(mlir::Type type) {
     return false;
   return llvm::TypeSwitch<mlir::Type, bool>(type)
       .Case<TokenType, RcType, RecordType, RawPtrType, RefType, HoleType,
-            ClosureType, ViewType>(
-          [](auto) { return true; })
+            ClosureType, ViewType>([](auto) { return true; })
       .Default([](mlir::Type) { return false; });
 }
 //===----------------------------------------------------------------------===//
@@ -749,6 +748,26 @@ RcBoxType RcType::getInnerBoxType() const {
   return RcBoxType::get(getContext(), getEleTy(), isFlexOrRigid);
 }
 
+bool RcType::mayCarrySpecialPointerTag() const {
+  // Plain shared boxes only: the frontend leaves their capability
+  // `unspecified` (regional flavors are the annotated ones), and every other
+  // capability has a different header or lifecycle.
+  if (getCapability() != Capability::shared &&
+      getCapability() != Capability::unspecified)
+    return false;
+  auto variantType = llvm::dyn_cast<RecordType>(getElementType());
+  if (!variantType || !variantType.isVariant() || !variantType.getComplete())
+    return false;
+  for (auto [idx, member] : llvm::enumerate(variantType.getMembers())) {
+    if (idx + 1 > 0xFF)
+      break;
+    auto arm = llvm::dyn_cast<RecordType>(member);
+    if (arm && arm.isCompound() && arm.getMembers().empty())
+      return true;
+  }
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // RcType DataLayoutInterface
 //===----------------------------------------------------------------------===//
@@ -962,7 +981,8 @@ ArrayType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
 
 ArrayType ArrayType::dropFront() const {
   assert(getShape().size() > 1 && "cannot drop the last array extent");
-  return ArrayType::get(getContext(), getShape().drop_front(), getElementType());
+  return ArrayType::get(getContext(), getShape().drop_front(),
+                        getElementType());
 }
 
 ArrayType ArrayType::cloneWith(std::optional<llvm::ArrayRef<int64_t>> shape,
@@ -977,9 +997,8 @@ mlir::Type ArrayType::parse(mlir::AsmParser &parser) {
       mlir::failed(parseShapeAndElementType(parser, shape, elementType)) ||
       parser.parseGreater())
     return {};
-  return ArrayType::getChecked(
-      parser.getEncodedSourceLoc(parser.getNameLoc()), parser.getContext(),
-      shape, elementType);
+  return ArrayType::getChecked(parser.getEncodedSourceLoc(parser.getNameLoc()),
+                               parser.getContext(), shape, elementType);
 }
 
 void ArrayType::print(mlir::AsmPrinter &printer) const {
@@ -1035,9 +1054,9 @@ mlir::Type ViewType::parse(mlir::AsmParser &parser) {
       parser.parseGreater())
     return {};
 
-  auto arrayType = ArrayType::getChecked(
-      parser.getEncodedSourceLoc(parser.getNameLoc()), parser.getContext(),
-      shape, elementType);
+  auto arrayType =
+      ArrayType::getChecked(parser.getEncodedSourceLoc(parser.getNameLoc()),
+                            parser.getContext(), shape, elementType);
   if (!arrayType)
     return {};
   return ViewType::get(parser.getContext(), isMutable, arrayType);

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -751,7 +751,12 @@ RcBoxType RcType::getInnerBoxType() const {
 bool RcType::mayCarrySpecialPointerTag() const {
   // Plain shared boxes only: the frontend leaves their capability
   // `unspecified` (regional flavors are the annotated ones), and every other
-  // capability has a different header or lifecycle.
+  // capability has a different header or lifecycle. Atomic boxes are also
+  // excluded: an immediate's increments would contend on one shared dummy
+  // box cache line, and the immortal encoding's narrow-width store steering
+  // cannot be expressed around an atomicrmw.
+  if (getAtomicKind() != AtomicKind::normal)
+    return false;
   if (getCapability() != Capability::shared &&
       getCapability() != Capability::unspecified)
     return false;

--- a/lib/Transformation/CMakeLists.txt
+++ b/lib/Transformation/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(RcCreateFusion)
 add_subdirectory(InferVariantTag)
 add_subdirectory(IncDecCancellation)
 add_subdirectory(TokenReuse)
+add_subdirectory(SpecialPointerTag)
 add_subdirectory(InvariantGroupAnalysis)
 add_subdirectory(UniqueCarryingRecursionAnalysis)
 add_subdirectory(TRMCRecursionAnalysis)
@@ -13,6 +14,7 @@ set(REUSSIR_TRANSFORMATION_AGGREGATE_LIBS
   MLIRReussirInferVariantTag
   MLIRReussirIncDecCancellation
   MLIRReussirTokenReuse
+  MLIRReussirSpecialPointerTag
   MLIRReussirInvariantGroupAnalysis
   MLIRReussirUniqueCarryingRecursionAnalysis
   MLIRReussirTRMCRecursionAnalysis

--- a/lib/Transformation/SpecialPointerTag/CMakeLists.txt
+++ b/lib/Transformation/SpecialPointerTag/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_library(MLIRReussirSpecialPointerTag
+  SpecialPointerTag.cpp
+
+  DEPENDS
+  MLIRReussirTransformationPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRReussir
+  MLIRFuncDialect
+  MLIRPass
+)

--- a/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
+++ b/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
@@ -1,0 +1,95 @@
+//===-- SpecialPointerTag.cpp - Nullary variants as immediates --*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 With LLVM Exceptions OR MIT
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/Transformation/SpecialPointerTag.h"
+#include "Reussir/IR/ReussirDialect.h"
+#include "Reussir/IR/ReussirOps.h"
+#include "Reussir/IR/ReussirTypes.h"
+
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+namespace reussir {
+#define GEN_PASS_DEF_REUSSIRSPECIALPOINTERTAGPASS
+#include "Reussir/Transformation/Passes.h.inc"
+
+// Rewrites every *nullary* variant construction of a taggable shared rc-boxed
+// enum into a `reussir.rc.tagged` immediate — no token, no allocation, no
+// observable reference count — and stamps the module with
+// `kSpecialPtrTagAttr` so the LLVM lowering steers the few stores that must
+// not reach an immediate's dummy box (see BasicOpsLowering's
+// special-pointer-tag notes; the hot reads need no guard at all).
+//
+// The driver adds this pass only when the scheme is enabled (aarch64
+// targets by default). The encoding hard-depends on TBI: loads through a
+// tagged value are expected to reach the per-tag dummy box, i.e. the
+// hardware must ignore the pointer's top byte on data accesses. It must run
+// BEFORE token instantiation, so no allocation token is ever attached to a
+// rewritten construction.
+
+namespace {
+// The frontend boxes a variant as `record.compound {} → record.variant →
+// rc.create`; the fused `rc.create_variant` only appears much later
+// (RcCreateFusion), after tokens are already attached — so the nullary
+// rewrite matches the unfused chain here, before token instantiation. The
+// dead `record.variant`/`record.compound` producers are cleaned up by the
+// greedy driver.
+struct NullaryVariantPattern
+    : public mlir::OpRewritePattern<ReussirRcCreateOp> {
+  using mlir::OpRewritePattern<ReussirRcCreateOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirRcCreateOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    // Region-allocated boxes have a different header and lifecycle; a token
+    // already attached means instantiation ran — too late to rewrite.
+    if (op.getRegion() || op.getToken() || op.getSkipRc())
+      return mlir::failure();
+    RcType rcType = op.getRcPtr().getType();
+    if (!rcType.mayCarrySpecialPointerTag())
+      return mlir::failure();
+    auto variant = op.getValue().getDefiningOp<ReussirRecordVariantOp>();
+    if (!variant)
+      return mlir::failure();
+    // The payload must be a *nullary* arm: an empty compound record.
+    auto payloadTy = llvm::dyn_cast<RecordType>(variant.getValue().getType());
+    if (!payloadTy || !payloadTy.isCompound() ||
+        !payloadTy.getMembers().empty())
+      return mlir::failure();
+    size_t tag = variant.getTag().getZExtValue();
+    if (tag + 1 > 0xFF)
+      return mlir::failure();
+    auto variantType = llvm::dyn_cast<RecordType>(rcType.getElementType());
+    if (tag >= variantType.getMembers().size())
+      return mlir::failure();
+    auto arm = llvm::dyn_cast<RecordType>(variantType.getMembers()[tag]);
+    if (!arm || !arm.isCompound() || !arm.getMembers().empty())
+      return mlir::failure();
+    rewriter.replaceOpWithNewOp<ReussirRcTaggedOp>(op, rcType,
+                                                   variant.getTagAttr());
+    return mlir::success();
+  }
+};
+
+struct SpecialPointerTagPass
+    : public impl::ReussirSpecialPointerTagPassBase<SpecialPointerTagPass> {
+  using Base::Base;
+  void runOnOperation() override {
+    mlir::ModuleOp module = getOperation();
+    module->setAttr(kSpecialPtrTagAttr,
+                    mlir::UnitAttr::get(module.getContext()));
+    mlir::RewritePatternSet patterns(&getContext());
+    patterns.add<NullaryVariantPattern>(&getContext());
+    if (mlir::failed(mlir::applyPatternsGreedily(module, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+} // namespace
+} // namespace reussir

--- a/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
+++ b/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
@@ -10,6 +10,7 @@
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
+#include "Reussir/Transformation/Passes.h"
 
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/PatternMatch.h>
@@ -23,16 +24,17 @@ namespace reussir {
 // Rewrites every *nullary* variant construction of a taggable shared rc-boxed
 // enum into a `reussir.rc.tagged` immediate — no token, no allocation, no
 // observable reference count — and stamps the module with
-// `kSpecialPtrTagAttr` so the LLVM lowering steers the few stores that must
-// not reach an immediate's dummy box (see BasicOpsLowering's
-// special-pointer-tag notes; the hot reads need no guard at all).
+// `kSpecialPtrTagAttr` carrying the chosen encoding, so the LLVM lowering
+// steers the few stores that must not reach an immediate's dummy box (see
+// BasicOpsLowering's special-pointer-tag notes; the hot reads need no guard
+// at all).
 //
-// The driver adds this pass only when the scheme is enabled (aarch64
-// targets by default). The encoding hard-depends on TBI: loads through a
-// tagged value are expected to reach the per-tag dummy box, i.e. the
-// hardware must ignore the pointer's top byte on data accesses. It must run
-// BEFORE token instantiation, so no allocation token is ever attached to a
-// rewritten construction.
+// Encodings: `tbi` puts `tag + 1` in the pointer's top byte (hard-depends
+// on the hardware ignoring the top byte on data accesses — aarch64);
+// `immortal` uses the plain dummy address with an immortal refcount and has
+// no architectural dependency. The rewrite itself is encoding-agnostic. It
+// must run BEFORE token instantiation, so no allocation token is ever
+// attached to a rewritten construction.
 
 namespace {
 // The frontend boxes a variant as `record.compound {} → record.variant →
@@ -83,8 +85,12 @@ struct SpecialPointerTagPass
   using Base::Base;
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
+    if (encoding != kSpecialPtrTagTBI && encoding != kSpecialPtrTagImmortal) {
+      module.emitError("unknown special-pointer-tag encoding: ") << encoding;
+      return signalPassFailure();
+    }
     module->setAttr(kSpecialPtrTagAttr,
-                    mlir::UnitAttr::get(module.getContext()));
+                    mlir::StringAttr::get(module.getContext(), encoding));
     mlir::RewritePatternSet patterns(&getContext());
     patterns.add<NullaryVariantPattern>(&getContext());
     if (mlir::failed(mlir::applyPatternsGreedily(module, std::move(patterns))))

--- a/tests/integration/conversion/special_pointer_tag.mlir
+++ b/tests/integration/conversion/special_pointer_tag.mlir
@@ -1,0 +1,41 @@
+// RUN: %reussir-opt %s --reussir-special-pointer-tag | %FileCheck %s
+
+// The special-pointer-tag pass rewrites nullary variant constructions of
+// taggable shared rc-boxed enums into `reussir.rc.tagged` immediates. It
+// must match the *unfused* frontend chain (`record.compound {}` →
+// `record.variant` → `rc.create`), because the fused `rc.create_variant`
+// form only appears after token instantiation — too late to elide the
+// allocation. The module is stamped with `reussir.special_ptr_tag` so the
+// LLVM lowering knows immediates may flow.
+
+!list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Nil" [value] {}>}>
+!nil = !reussir.record<compound "List.Nil" [value] {}>
+!cons = !reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List" {!reussir.record<compound "List.Cons">, !reussir.record<compound "List.Nil" [value] {}>}>}>
+!rclist = !reussir.rc<!list>
+
+// CHECK: module @test attributes {{{.*}}reussir.special_ptr_tag{{.*}}}
+module @test {
+  // The nullary arm becomes an immediate; no box is created.
+  // CHECK-LABEL: func.func @make_nil
+  // CHECK: %[[IMM:.+]] = reussir.rc.tagged tag(1) : !reussir.rc<!reussir.record<variant "List"
+  // CHECK-NOT: reussir.rc.create
+  // CHECK: return %[[IMM]]
+  func.func @make_nil() -> !rclist {
+    %0 = reussir.record.compound : !nil
+    %1 = reussir.record.variant[1] (%0 : !nil) : !list
+    %2 = reussir.rc.create value(%1 : !list) : !rclist
+    return %2 : !rclist
+  }
+
+  // An inhabited arm keeps its ordinary boxed construction.
+  // CHECK-LABEL: func.func @make_cons
+  // CHECK: reussir.record.variant
+  // CHECK: reussir.rc.create value
+  // CHECK-NOT: reussir.rc.tagged
+  func.func @make_cons(%head: i64, %tail: !rclist) -> !rclist {
+    %0 = reussir.record.compound(%head, %tail : i64, !rclist) : !cons
+    %1 = reussir.record.variant[0] (%0 : !cons) : !list
+    %2 = reussir.rc.create value(%1 : !list) : !rclist
+    return %2 : !rclist
+  }
+}

--- a/tests/integration/conversion/special_pointer_tag.mlir
+++ b/tests/integration/conversion/special_pointer_tag.mlir
@@ -1,7 +1,11 @@
-// RUN: %reussir-opt %s --reussir-special-pointer-tag | %FileCheck %s
+// RUN: %reussir-opt %s --reussir-special-pointer-tag | %FileCheck %s --check-prefixes=CHECK,TBI
+// RUN: %reussir-opt %s --reussir-special-pointer-tag="encoding=immortal" | \
+// RUN:   %FileCheck %s --check-prefixes=CHECK,IMMORTAL
 
 // The special-pointer-tag pass rewrites nullary variant constructions of
-// taggable shared rc-boxed enums into `reussir.rc.tagged` immediates. It
+// taggable shared rc-boxed enums into `reussir.rc.tagged` immediates — the
+// rewrite is identical for both encodings; only the stamped attribute (and
+// later the LLVM lowering) differs. It
 // must match the *unfused* frontend chain (`record.compound {}` →
 // `record.variant` → `rc.create`), because the fused `rc.create_variant`
 // form only appears after token instantiation — too late to elide the
@@ -13,7 +17,8 @@
 !cons = !reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List" {!reussir.record<compound "List.Cons">, !reussir.record<compound "List.Nil" [value] {}>}>}>
 !rclist = !reussir.rc<!list>
 
-// CHECK: module @test attributes {{{.*}}reussir.special_ptr_tag{{.*}}}
+// TBI: module @test attributes {{{.*}}reussir.special_ptr_tag = "tbi"{{.*}}}
+// IMMORTAL: module @test attributes {{{.*}}reussir.special_ptr_tag = "immortal"{{.*}}}
 module @test {
   // The nullary arm becomes an immediate; no box is created.
   // CHECK-LABEL: func.func @make_nil

--- a/tests/integration/conversion/special_pointer_tag_lowering.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering.mlir
@@ -13,14 +13,14 @@
 !list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Nil" [value] {}>}>
 !rclist = !reussir.rc<!list>
 
-// CHECK-DAG: @__reussir_tag_scratch = internal global i64 0
-// CHECK-DAG: @__reussir_tag_dummy_1 = internal global [2 x i64] [i64 2, i64 1]
+// CHECK-DAG: @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2 = internal global i64 0
+// CHECK-DAG: @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX = internal global [2 x i64] [i64 2, i64 1]
 module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
 
   // Immediate materialization: dummy address | (tag + 1) << 56, no
   // allocation. (2 << 56 = 144115188075855872.)
   // CHECK-LABEL: define ptr @make_nil()
-  // CHECK: %[[ENC:.+]] = or i64 ptrtoint (ptr @__reussir_tag_dummy_1 to i64), 144115188075855872
+  // CHECK: %[[ENC:.+]] = or i64 ptrtoint (ptr @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX to i64), 144115188075855872
   // CHECK: %[[PTR:.+]] = inttoptr i64 %[[ENC]] to ptr
   // CHECK: ret ptr %[[PTR]]
   func.func @make_nil() -> !rclist {
@@ -57,7 +57,7 @@ module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.
   // CHECK: %[[INT:.+]] = ptrtoint ptr %0 to i64
   // CHECK: %[[TOP:.+]] = lshr i64 %[[INT]], 56
   // CHECK: %[[ISTAG:.+]] = icmp ne i64 %[[TOP]], 0
-  // CHECK: %[[ADDR:.+]] = select i1 %[[ISTAG]], ptr @__reussir_tag_scratch, ptr %0
+  // CHECK: %[[ADDR:.+]] = select i1 %[[ISTAG]], ptr @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2, ptr %0
   // CHECK: store i64 %1, ptr %[[ADDR]]
   func.func @set(%rc: !rclist, %v: index) {
     reussir.rc.set(%rc : !rclist, %v : index)

--- a/tests/integration/conversion/special_pointer_tag_lowering.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering.mlir
@@ -15,7 +15,7 @@
 
 // CHECK-DAG: @__reussir_tag_scratch = internal global i64 0
 // CHECK-DAG: @__reussir_tag_dummy_1 = internal global [2 x i64] [i64 2, i64 1]
-module @test attributes { reussir.special_ptr_tag, dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
 
   // Immediate materialization: dummy address | (tag + 1) << 56, no
   // allocation. (2 << 56 = 144115188075855872.)

--- a/tests/integration/conversion/special_pointer_tag_lowering.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering.mlir
@@ -1,0 +1,66 @@
+// RUN: %reussir-opt %s --convert-to-llvm | \
+// RUN: %reussir-translate --mlir-to-llvmir | %FileCheck %s
+
+// LLVM lowering under the special-pointer-tag scheme (module stamped with
+// `reussir.special_ptr_tag`). A tagged immediate's top byte is `tag + 1`
+// and its low bits hold the address of the per-tag dummy box
+// `{refcount = 2, tag}`. TBI makes loads through the tagged value land in
+// the dummy box, so the hot reads (rc.fetch, rc.is_unique, record.tag)
+// lower to plain loads with no immediate-check; only `rc.set` — the one
+// store that could decay the dummy's refcount to 1 — steers a tagged
+// access to the scratch word.
+
+!list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Nil" [value] {}>}>
+!rclist = !reussir.rc<!list>
+
+// CHECK-DAG: @__reussir_tag_scratch = internal global i64 0
+// CHECK-DAG: @__reussir_tag_dummy_1 = internal global [2 x i64] [i64 2, i64 1]
+module @test attributes { reussir.special_ptr_tag, dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+
+  // Immediate materialization: dummy address | (tag + 1) << 56, no
+  // allocation. (2 << 56 = 144115188075855872.)
+  // CHECK-LABEL: define ptr @make_nil()
+  // CHECK: %[[ENC:.+]] = or i64 ptrtoint (ptr @__reussir_tag_dummy_1 to i64), 144115188075855872
+  // CHECK: %[[PTR:.+]] = inttoptr i64 %[[ENC]] to ptr
+  // CHECK: ret ptr %[[PTR]]
+  func.func @make_nil() -> !rclist {
+    %0 = reussir.rc.tagged tag(1) : !rclist
+    return %0 : !rclist
+  }
+
+  // Hot read: plain refcount load, no top-byte decode, no select.
+  // CHECK-LABEL: define i64 @fetch(ptr %0)
+  // CHECK-NOT: lshr
+  // CHECK-NOT: select
+  // CHECK: %[[CNT:.+]] = load i64, ptr
+  // CHECK: ret i64 %[[CNT]]
+  func.func @fetch(%rc: !rclist) -> index {
+    %cnt = reussir.rc.fetch (%rc : !rclist) : index
+    return %cnt : index
+  }
+
+  // Hot read: plain tag load — a tagged immediate's load lands in its
+  // per-tag dummy box and reads the real tag, so no decode is emitted.
+  // CHECK-LABEL: define i64 @tag(ptr %0)
+  // CHECK-NOT: lshr
+  // CHECK-NOT: select
+  // CHECK: %[[TAG:.+]] = load i64, ptr
+  // CHECK: ret i64 %[[TAG]]
+  func.func @tag(%ref: !reussir.ref<!list shared>) -> index {
+    %tag = reussir.record.tag(%ref : !reussir.ref<!list shared>) : index
+    return %tag : index
+  }
+
+  // The decrementing store: a tagged access is steered to the scratch word
+  // so the dummy refcount can never decay below 2.
+  // CHECK-LABEL: define void @set(ptr %0, i64 %1)
+  // CHECK: %[[INT:.+]] = ptrtoint ptr %0 to i64
+  // CHECK: %[[TOP:.+]] = lshr i64 %[[INT]], 56
+  // CHECK: %[[ISTAG:.+]] = icmp ne i64 %[[TOP]], 0
+  // CHECK: %[[ADDR:.+]] = select i1 %[[ISTAG]], ptr @__reussir_tag_scratch, ptr %0
+  // CHECK: store i64 %1, ptr %[[ADDR]]
+  func.func @set(%rc: !rclist, %v: index) {
+    reussir.rc.set(%rc : !rclist, %v : index)
+    return
+  }
+}

--- a/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
@@ -1,0 +1,65 @@
+// RUN: %reussir-opt %s --convert-to-llvm | \
+// RUN: %reussir-translate --mlir-to-llvmir | %FileCheck %s
+
+// LLVM lowering under the *arch-independent* (immortal) special-pointer-tag
+// encoding (module stamped `reussir.special_ptr_tag = "immortal"`). The
+// immediate is the per-tag dummy box's address itself — no TBI/LAM pointer
+// tricks — and the dummy's refcount is initialized to the immortal value
+// 3 * 2^62 = 0xC000000000000000 for a 64-bit refcount word. Hot reads
+// (rc.fetch, rc.is_unique, record.tag) are plain loads; `rc.set` recognizes
+// a dummy by the magnitude of the stored count (>= 2^63; a real refcount
+// can never get there) and steers it to the scratch word.
+
+!list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Nil" [value] {}>}>
+!rclist = !reussir.rc<!list>
+
+// CHECK-DAG: @__reussir_tag_scratch = internal global i64 0
+// CHECK-DAG: @__reussir_tag_dummy_1 = internal global [2 x i64] [i64 -4611686018427387904, i64 1]
+module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+
+  // Immediate materialization: the plain dummy address — no or/inttoptr.
+  // CHECK-LABEL: define ptr @make_nil()
+  // CHECK-NOT: or i64
+  // CHECK-NOT: inttoptr
+  // CHECK: ret ptr @__reussir_tag_dummy_1
+  func.func @make_nil() -> !rclist {
+    %0 = reussir.rc.tagged tag(1) : !rclist
+    return %0 : !rclist
+  }
+
+  // Hot read: plain refcount load, no pointer decode, no select.
+  // CHECK-LABEL: define i64 @fetch(ptr %0)
+  // CHECK-NOT: lshr
+  // CHECK-NOT: select
+  // CHECK: %[[CNT:.+]] = load i64, ptr
+  // CHECK: ret i64 %[[CNT]]
+  func.func @fetch(%rc: !rclist) -> index {
+    %cnt = reussir.rc.fetch (%rc : !rclist) : index
+    return %cnt : index
+  }
+
+  // Hot read: plain tag load — an immediate's load lands in its per-tag
+  // dummy box and reads the real tag.
+  // CHECK-LABEL: define i64 @tag(ptr %0)
+  // CHECK-NOT: lshr
+  // CHECK-NOT: select
+  // CHECK: %[[TAG:.+]] = load i64, ptr
+  // CHECK: ret i64 %[[TAG]]
+  func.func @tag(%ref: !reussir.ref<!list shared>) -> index {
+    %tag = reussir.record.tag(%ref : !reussir.ref<!list shared>) : index
+    return %tag : index
+  }
+
+  // The decrementing store: a count at or above 2^63 identifies a dummy
+  // (its stored value is `immortal - 1`, still over the threshold), and the
+  // store is steered to the scratch word so the dummy never decays.
+  // CHECK-LABEL: define void @set(ptr %0, i64 %1)
+  // CHECK-NOT: lshr
+  // CHECK: %[[ISDUMMY:.+]] = icmp uge i64 %1, -9223372036854775808
+  // CHECK: %[[ADDR:.+]] = select i1 %[[ISDUMMY]], ptr @__reussir_tag_scratch, ptr %0
+  // CHECK: store i64 %1, ptr %[[ADDR]]
+  func.func @set(%rc: !rclist, %v: index) {
+    reussir.rc.set(%rc : !rclist, %v : index)
+    return
+  }
+}

--- a/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
@@ -13,15 +13,15 @@
 !list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Nil" [value] {}>}>
 !rclist = !reussir.rc<!list>
 
-// CHECK-DAG: @__reussir_tag_scratch = internal global i64 0
-// CHECK-DAG: @__reussir_tag_dummy_1 = internal global [2 x i64] [i64 -4611686018427387904, i64 1]
+// CHECK-DAG: @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2 = internal global i64 0
+// CHECK-DAG: @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX = internal global [2 x i64] [i64 -4611686018427387904, i64 1]
 module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
 
   // Immediate materialization: the plain dummy address — no or/inttoptr.
   // CHECK-LABEL: define ptr @make_nil()
   // CHECK-NOT: or i64
   // CHECK-NOT: inttoptr
-  // CHECK: ret ptr @__reussir_tag_dummy_1
+  // CHECK: ret ptr @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX
   func.func @make_nil() -> !rclist {
     %0 = reussir.rc.tagged tag(1) : !rclist
     return %0 : !rclist
@@ -56,7 +56,7 @@ module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #
   // CHECK-LABEL: define void @set(ptr %0, i64 %1)
   // CHECK-NOT: lshr
   // CHECK: %[[ISDUMMY:.+]] = icmp uge i64 %1, -9223372036854775808
-  // CHECK: %[[ADDR:.+]] = select i1 %[[ISDUMMY]], ptr @__reussir_tag_scratch, ptr %0
+  // CHECK: %[[ADDR:.+]] = select i1 %[[ISDUMMY]], ptr @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2, ptr %0
   // CHECK: store i64 %1, ptr %[[ADDR]]
   func.func @set(%rc: !rclist, %v: index) {
     reussir.rc.set(%rc : !rclist, %v : index)

--- a/tests/integration/frontend/rbtree.c
+++ b/tests/integration/frontend/rbtree.c
@@ -13,6 +13,19 @@ typedef struct rc_list {
 #define LIST_NIL 0
 #define LIST_CONS 1
 
+/*
+ * Special pointer tag (aarch64 default): a nullary variant may be encoded as
+ * an unboxed immediate — a pointer whose top byte is `tag + 1` (the low bits
+ * point at a compiler-internal dummy box, so on-target dereferences still
+ * see the right tag under TBI). Portable foreign code should decode the tag
+ * from the pointer itself without dereferencing. A zero top byte means an
+ * ordinary RC box (also the layout with --disable-special-pointer-tag).
+ */
+static inline int64_t list_tag(const rc_list_t *p) {
+    uint64_t top = (uint64_t)(uintptr_t)p >> 56;
+    return top != 0 ? (int64_t)(top - 1) : p->tag;
+}
+
 extern rc_list_t *make_tree_to_list_ffi(int32_t size);
 
 int main(void) {
@@ -20,7 +33,7 @@ int main(void) {
     rc_list_t *p = make_tree_to_list_ffi(n);
 
     for (int32_t i = 0; i < n; ++i) {
-        if (p->tag != LIST_CONS) {
+        if (list_tag(p) != LIST_CONS) {
             fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", (int)i);
             abort();
         }
@@ -31,8 +44,8 @@ int main(void) {
         p = p->tail;
     }
 
-    if (p->tag != LIST_NIL) {
-        fprintf(stderr, "FAIL: expected Nil terminator, got tag=%ld\n", (long)p->tag);
+    if (list_tag(p) != LIST_NIL) {
+        fprintf(stderr, "FAIL: expected Nil terminator, got tag=%ld\n", (long)list_tag(p));
         abort();
     }
 

--- a/tests/integration/frontend/rbtree_to_list.c
+++ b/tests/integration/frontend/rbtree_to_list.c
@@ -30,6 +30,19 @@ typedef struct rc_list {
 #define LIST_NIL  0
 #define LIST_CONS 1
 
+/*
+ * Special pointer tag (aarch64 default): a nullary variant may be encoded as
+ * an unboxed immediate — a pointer whose top byte is `tag + 1` (the low bits
+ * point at a compiler-internal dummy box, so on-target dereferences still
+ * see the right tag under TBI). Portable foreign code should decode the tag
+ * from the pointer itself without dereferencing. A zero top byte means an
+ * ordinary RC box (also the layout with --disable-special-pointer-tag).
+ */
+static inline int64_t list_tag(const rc_list_t *p) {
+    uint64_t top = (uint64_t)(uintptr_t)p >> 56;
+    return top != 0 ? (int64_t)(top - 1) : p->tag;
+}
+
 extern rc_list_t *test_to_list_ffi(void);
 
 int main(void) {
@@ -39,15 +52,14 @@ int main(void) {
     printf("List structure (RC layout):\n");
     rc_list_t *p = list;
     int idx = 0;
-    while (p->tag == LIST_CONS) {
+    while (list_tag(p) == LIST_CONS) {
         printf("  [%d] @%p  rc=%ld  tag=%ld (Cons)  head=%d  tail=%p\n",
-               idx, (void *)p, (long)p->refcount, (long)p->tag,
+               idx, (void *)p, (long)p->refcount, (long)list_tag(p),
                p->head, (void *)p->tail);
         p = p->tail;
         idx++;
     }
-    printf("  [%d] @%p  rc=%ld  tag=%ld (Nil)\n",
-           idx, (void *)p, (long)p->refcount, (long)p->tag);
+    printf("  [%d] @%p  tag=%ld (Nil)\n", idx, (void *)p, (long)list_tag(p));
 
     /* ---- verify: expect [1, 2, 3, 4, 5, 6, 7, 8, 9] ---- */
     int expected[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -55,7 +67,7 @@ int main(void) {
 
     p = list;
     for (int i = 0; i < n; i++) {
-        if (p->tag != LIST_CONS) {
+        if (list_tag(p) != LIST_CONS) {
             fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", i);
             abort();
         }
@@ -67,9 +79,9 @@ int main(void) {
         p = p->tail;
     }
 
-    if (p->tag != LIST_NIL) {
+    if (list_tag(p) != LIST_NIL) {
         fprintf(stderr, "FAIL: expected Nil at end, got tag %ld\n",
-                (long)p->tag);
+                (long)list_tag(p));
         abort();
     }
 

--- a/tool/reussir-opt/main.cpp
+++ b/tool/reussir-opt/main.cpp
@@ -70,6 +70,9 @@ int main(int argc, char **argv) {
     return reussir::createReussirTokenReusePass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return reussir::createReussirSpecialPointerTagPass();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return reussir::createReussirAttachNativeTargetPass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {


### PR DESCRIPTION
Stacked on #326 (P1). Implements P2 of #325: nullary variant arms of shared rc-boxed enums no longer heap-allocate.

## Design

A new `reussir-special-pointer-tag` pass (aarch64 targets by default, run **before** token instantiation) rewrites the unfused nullary construction chain `record.compound {} → record.variant → rc.create` into `reussir.rc.tagged`, an unboxed immediate:

```
top byte = tag + 1
low bits = &__reussir_tag_dummy_<tag>   // internal global {refcount = 2, tag}
```

### TBI research: why the dummy box

ARMv8 **Top-Byte Ignore** is unconditionally enabled for userspace data accesses on aarch64 Linux (`TCR_EL1.TBI0 = 1`; the Android tagged-pointer and HWASan ecosystems rely on it) and Apple platforms. That means a load/store through a tagged immediate is not merely *safe* — it can be **aimed**: pointing the low bits at a per-tag dummy box makes every dereference observe a well-formed shared box header carrying the immediate's real tag.

Consequently the hot lowerings are **bit-identical to the untagged scheme** — zero guards, zero selects:

| op | behavior on an immediate |
|---|---|
| `rc.fetch` | plain load → reads dummy refcount (pinned ≥ 2) → expanded dec takes the shared branch: no field drop, no token, no free |
| `rc.inc` | plain load/add/store (or atomicrmw) → benignly grows the dummy count |
| `rc.is_unique` | plain load → `count == 1` is naturally false |
| `record.tag` | plain load → reads the *real* tag from the dummy box |
| `rc.set` | **guarded**: address-select steers a tagged store to a scratch word, so the dummy count can never decay to 1 (off any result's critical path) |
| `rc.assume_unique` | **guarded**: neutralizes the assumption (`assume(false)` would be unsound) |

Two soundness invariants: the dummy refcount only ever grows (`rc.inc` is the only writer; `rc.set` is steered away), so immediates always take the shared decrement branch and can never reach the unique/reinterpret/free path; and nullary arms have no payload, so no lowering ever reads past the dummy's 16 bytes.

Earlier iterations measured here for the record: a branchless select-to-scratch guard on *every* refcount/tag access cost ~30% on rbtree-zipper (the select serializes into every load's address dependency); decoding the tag as `select(top != 0, top - 1, load)` still cost ~3 cycles per match. The dummy-box encoding eliminates both.

### ABI boundaries

- **Eligibility** (`RcType::mayCarrySpecialPointerTag`): plain shared boxes only (`shared`/`unspecified` capability), complete variant, ≥ 1 empty-compound arm, `tag + 1 ≤ 0xFF`. Value/flex/field/rigid layouts, region-allocated objects, and closures are untouched.
- **FFI**: a returned enum value with a non-zero top byte is an immediate, `tag = top − 1`. On-target dereference of the tag word also works (TBI + dummy box), but portable foreign code should decode from the pointer. Test drivers (`rbtree.c`, `rbtree_to_list.c`) document the contract.
- **REPL/JIT**: `LoweringOptions::default()` keeps the scheme off; the reflect/retain machinery never sees immediates. Teaching the reflector the encoding is a prerequisite for ever enabling it there.
- **DWARF**: with `-g`, a variable *holding* an immediate makes the debugger's boxed-payload `DIExpression` (deref + offset) read the dummy box instead of a real payload — for a nullary arm there is no payload, so this only affects raw-pointer display. Documented as a known `-g` cosmetic limitation rather than degrading debug info for all boxed variants.
- **Gating**: default on iff the target triple starts with `aarch64`; `--disable-special-pointer-tag` restores the boxed layout (bit-identical output to before this PR, verified). Non-TBI 64-bit targets cannot opt in — the encoding hard-depends on TBI. LAM/x86 variants can revisit later.

## Performance (aarch64 host, rbtree n = 4.2M, koka reference: 391 ms / 134 MB)

Allocation counts: rbtree 54.6M → **50.4M** (all 8.4M Leaf boxes gone; +4.2M creates that previously reused a dropped leaf's token), zipper 12.6M → **4.2M** (exactly one alloc per insert), instructions (cachegrind, zipper) **−32%**.

| bench | alloc | off | on | Δ time | RSS off → on |
|---|---|---|---|---|---|
| rbtree | snmalloc | 962 ms | 902 ms | **−6.3%** | 598 → 302 MB (**−49%**) |
| rbtree | mimalloc | 1010 ms | 962 ms | **−4.8%** | 529 → 266 MB |
| rbtree-zipper | snmalloc | 600 ms | 776 ms | **+29%** ⚠ | 599 → 268 MB (**−55%**) |
| rbtree-zipper | mimalloc | 558 ms | **428 ms** | **−23%** | 529 → 266 MB |
| rbtree-zipper | glibc | 1082 ms | 867 ms | **−20%** | — |
| nbe-hoas | snmalloc | 297 ms | 292 ms | flat | — |

The zipper + snmalloc regression is an allocator interaction, not codegen: P2 executes 32% fewer instructions and has fewer absolute cache misses, and wins on both other allocators (mimalloc-P2 is the fastest zipper configuration measured, beating snmalloc-off by 29%). Pre-P2, snmalloc's recycle path (a leaf freed and immediately re-popped by a same-size malloc) was nearly free and effectively subsidized the leaf churn; post-P2 the single net allocation per insert goes through snmalloc's fresh-slab path, which measures worse per byte on this machine. Worth a snmalloc-side look (or revisiting the default allocator) but orthogonal to this change; filed under the #325 P4 allocator-boundary item.

## Testing

- New lit tests: `conversion/special_pointer_tag.mlir` (pass rewrites the unfused chain, inhabited arms untouched, module stamped), `conversion/special_pointer_tag_lowering.mlir` (dummy-box globals, immediate encoding, unguarded hot loads, guarded `rc.set`).
- Frontend e2e drivers `rbtree.c` / `rbtree_to_list.c` decode encoding-agnostically and run with the scheme default-on for the aarch64 lit host.
- Full integration suite 263/263; `rrc-test`, backend/codegen/jit and REPL cargo suites green.
- `--disable-special-pointer-tag` verified to reproduce the P1 allocation profile (54,577,451 allocs) exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2