### PR TITLE
[backend] register the func inliner extension — the pipeline inliner was silently dead

### DIFF
--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -20,6 +20,7 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/DLTI/DLTI.h>
+#include <mlir/Dialect/Func/Extensions/InlinerExtension.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/Math/IR/Math.h>
@@ -51,6 +52,11 @@ void populateReussirRegistry(mlir::DialectRegistry &registry) {
                   mlir::memref::MemRefDialect, mlir::scf::SCFDialect,
                   mlir::math::MathDialect, mlir::ub::UBDialect,
                   mlir::func::FuncDialect, mlir::cf::ControlFlowDialect>();
+
+  // Since MLIR 17 the func dialect's DialectInlinerInterface lives in a
+  // separately registered extension; without it the inliner pass resolves no
+  // `func.call` sites and silently inlines nothing.
+  mlir::func::registerInlinerExtension(registry);
 
   // Register the ConvertToLLVMPatternInterface for exactly the dialects that can
   // reach the ConvertToLLVM pass, plus Reussir's own lowering interface. These

--- a/tests/integration/frontend/inline_helper.rr
+++ b/tests/integration/frontend/inline_helper.rr
@@ -1,0 +1,34 @@
+// RUN: %rrc %s --emit mlir-llvm -O default -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+
+// The optimization prologue's inliner must dissolve small private helpers
+// into their callers. This regressed silently once before: the func
+// dialect's inliner interface is a separately registered MLIR *extension*
+// (`func::registerInlinerExtension`), and without it the inliner pass
+// resolves no `func.call` sites and inlines nothing — while reussir-opt,
+// which registers all extensions, still inlines. Guard the rrc pipeline.
+
+enum Nat {
+    Zero,
+    Succ(Nat)
+}
+
+fn is_zero(n: Nat) -> bool {
+    match n {
+        Nat::Zero => true,
+        _ => false
+    }
+}
+
+pub fn count_down(n: Nat) -> i32 {
+    if is_zero(n) { 0 } else {
+        match n {
+            Nat::Succ(m) => 1 + count_down(m),
+            Nat::Zero => 0
+        }
+    }
+}
+
+// The helper's body is absorbed into `count_down`; no call to it survives
+// anywhere in the module.
+// CHECK-NOT: llvm.call @_RC7is_zero


### PR DESCRIPTION
## Bug

Since MLIR 17 the func dialect's `DialectInlinerInterface` is a separately registered extension (`func::registerInlinerExtension`). `populateReussirRegistry` registered `FuncDialect` but not the extension, so the pipeline's `DefaultInlinerPass` (added in #255) resolved no `func.call` sites and **silently inlined nothing, at every opt level, since day one**. `reussir-opt` masked it: its `main()` calls `registerAllExtensions`, so `--inline` there fully dissolves the same calls that survive the rrc pipeline untouched.

Diagnosis: dumped the exact pipeline-input module from rrc, confirmed standalone `reussir-opt --inline` inlines it completely while the in-pipeline pass (and even melior's own `create_inliner` binding, injected diagnostically) does nothing → the divergence had to be registry state, not the pass.

## Fix

One registration line (+ include). `mlir-sys` links every `libMLIR*.a`, so `libMLIRFuncInlinerExtension.a` needs no build wiring. The new lit test guards the **rrc** pipeline specifically — reussir-opt-based tests cannot catch this class of registry divergence.

## Impact (aarch64, n = 4.2M, xLTO + static mimalloc, sequential runs)

| bench | before | after | Koka | gap |
|---|---|---|---|---|
| rbtree (+rac) | 0.90 s | **0.58 s (−36%)** | 0.386 s | 2.3× → **1.49×** |
| rbtree-zipper | 0.41 s | 0.41 s | — | — |
| nbe-hoas | 0.22 s | 0.22 s | 0.157 s | 1.40× |

The rbtree win is exactly the #325 P5 target: with `balance_left`/`balance_right` inlined into `ins`, `TokenReuse` finally sees the node `ins` just freed next to the balance arms' constructions, so the 37.8 M-allocation site (2 tokens for 3 creates, tokens unable to cross the call) collapses. Without `--reuse-across-call` the fix is time-neutral on rbtree (0.89 s), confirming the mechanism is reuse-through-inlining rather than call overhead. RSS is unchanged (transient balance nodes recycled by the allocator either way). All 265 supported lit tests pass.

Note for later: MLIR's inliner has no cost model — it inlines every legal site. Fine at current program sizes; a profitability threshold is worth considering as programs grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2