### PR TITLE
[tests] pin the variant debug-info e2e test to -Onone

### DIFF
--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -226,7 +226,14 @@ fn lowers_variant_debug_info_through_the_pipeline() {
             .expect("variant lowering with debug info succeeds")
     });
 
-    run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
+    // Pin the optimization prologue off: the DI shapes under test hang off
+    // `describe`/`walk`'s parameters, and the inliner would dissolve those
+    // trivial single-caller functions and with them the variant composites.
+    let options = LoweringOptions {
+        opt: reussir_backend::pipeline::OptLevel::None,
+        ..LoweringOptions::default()
+    };
+    run_lowering_pipeline(&context, &mut module, &options)
         .expect("pipeline lowers variant debug info to LLVM");
 
     // The recursive `List` must lower to a DWARF type *cycle*: a `rec-self`


### PR DESCRIPTION
After #328 the optimization prologue's inliner actually runs, so the trivial single-caller `describe`/`walk` dissolve into `run` at the default opt level — and with them the only `List`/`Shape`-typed values. The recursive variant composite never reaches the DI conversion and the rec-self placeholder assertion in `lowers_variant_debug_info_through_the_pipeline` fails (`cargo test -p reussir-codegen` is red on main; the lit suite doesn't cover it).

The test covers DI lowering shapes, not the optimizer — pin the pipeline to `-Onone`, which is exactly the effective behavior it was written against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2