### PR TITLE
[backend] TRMC via first-class constructor contexts (!reussir.cctx)

### DIFF
--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -226,7 +226,14 @@ fn lowers_variant_debug_info_through_the_pipeline() {
             .expect("variant lowering with debug info succeeds")
     });
 
-    run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
+    // Pin the optimization prologue off: the DI shapes under test hang off
+    // `describe`/`walk`'s parameters, and the inliner would dissolve those
+    // trivial single-caller functions and with them the variant composites.
+    let options = LoweringOptions {
+        opt: reussir_backend::pipeline::OptLevel::None,
+        ..LoweringOptions::default()
+    };
+    run_lowering_pipeline(&context, &mut module, &options)
         .expect("pipeline lowers variant debug info to LLVM");
 
     // The recursive `List` must lower to a DWARF type *cycle*: a `rec-self`

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -58,51 +58,71 @@ def ReussirExpectOp : ReussirOp<"expect", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
-// Reussir Hole Operations
+// Reussir Constructor Context Operations
 //===----------------------------------------------------------------------===//
-class ReussirHoleOp<string mnemonic, list<Trait> traits>
-    : ReussirOp<"hole."#mnemonic, traits>;
+class ReussirCctxOp<string mnemonic, list<Trait> traits>
+    : ReussirOp<"cctx."#mnemonic, traits>;
 
-def ReussirHoleCreateOp : ReussirHoleOp<"create", []> {
-  let summary = "Create a stack hole";
+def ReussirCctxEmptyOp : ReussirCctxOp<"empty", [Pure]> {
+  let summary = "Create the empty constructor context";
   let description = [{
-    `reussir.hole.create` allocates a local destination slot for a value that
-    will be filled later by a TRMC-style helper.
+    `reussir.cctx.empty` produces the identity context: applying it to a value
+    yields the value itself, and extending it makes the plugged constructor
+    the context's root.
   }];
 
-  let results = (outs Res<ReussirHoleType, "created hole">:$hole);
+  let results = (outs Res<ReussirCctxType, "empty context">:$ctx);
   let assemblyFormat = [{
-    `:` qualified(type($hole)) attr-dict
+    `:` qualified(type($ctx)) attr-dict
   }];
 }
 
-def ReussirHoleLoadOp : ReussirHoleOp<"load", []> {
-  let summary = "Load from a hole";
+def ReussirCctxExtendOp : ReussirCctxOp<"extend", []> {
+  let summary = "Plug a constructor into a context and refocus on its hole";
   let description = [{
-    `reussir.hole.load` loads the value stored in a hole.
-  }];
+    `reussir.cctx.extend` plugs `rcPtr` — a constructor freshly created with a
+    hole (see the `holeFields` attribute on the fused `rc.create_*` ops) —
+    into the context's hole, and yields the context refocused on `hole`, one
+    of the plugged constructor's own holes. If the incoming context is empty,
+    the plugged constructor becomes the new context's root.
 
-  let arguments = (ins Arg<ReussirHoleType, "hole to load">:$hole);
-  let results = (outs Res<AnyType, "loaded value">:$value);
-  let assemblyFormat = [{
-    `(` $hole `:` qualified(type($hole)) `)` `:` type($value) attr-dict
-  }];
-  let hasVerifier = 1;
-}
-
-def ReussirHoleStoreOp : ReussirHoleOp<"store", []> {
-  let summary = "Store to a hole";
-  let description = [{
-    `reussir.hole.store` stores a value into a hole.
+    Both the incoming context and the hole are consumed: contexts are linear,
+    and the refocused hole must be filled exactly once through the resulting
+    context.
   }];
 
   let arguments = (ins
-      Arg<ReussirHoleType, "hole to store into">:$hole,
-      Arg<AnyType, "value to store">:$value);
-  let assemblyFormat = [{
-    `(` $hole `:` qualified(type($hole)) `)` `(` $value `:` type($value) `)` attr-dict
-  }];
+      Arg<ReussirCctxType, "context to extend">:$ctx,
+      Arg<ReussirRcType, "constructor plugged into the hole">:$rcPtr,
+      Arg<ReussirHoleType, "the plugged constructor's hole to refocus on">:$hole);
+  let results = (outs Res<ReussirCctxType, "extended context">:$newCtx);
   let hasVerifier = 1;
+  let assemblyFormat = [{
+    `(` $ctx `:` qualified(type($ctx)) `)`
+    `plug` `(` $rcPtr `:` qualified(type($rcPtr)) `)`
+    `hole` `(` $hole `:` qualified(type($hole)) `)`
+    `:` qualified(type($newCtx)) attr-dict
+  }];
+}
+
+def ReussirCctxApplyOp : ReussirCctxOp<"apply", []> {
+  let summary = "Complete a constructor context with a final value";
+  let description = [{
+    `reussir.cctx.apply` plugs `value` into the context's hole and yields the
+    context's root — the now-complete value. Applying the empty context
+    yields `value` itself. The context is consumed.
+  }];
+
+  let arguments = (ins
+      Arg<ReussirCctxType, "context to complete">:$ctx,
+      Arg<ReussirRcType, "value filling the final hole">:$value);
+  let results = (outs Res<ReussirRcType, "completed value">:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    `(` $ctx `:` qualified(type($ctx)) `)`
+    `(` $value `:` qualified(type($value)) `)`
+    `:` qualified(type($result)) attr-dict
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -316,6 +316,37 @@ def ReussirHoleType
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Reussir Constructor Context Type
+//===----------------------------------------------------------------------===//
+def ReussirCctxType
+    : ReussirType<"Cctx", "cctx"> {
+  let summary = "Reussir first-class constructor context";
+  let description = [{
+    `reussir.cctx` is a first-class constructor context (Koka-style `ctx`): a
+    tree of already-allocated constructors with exactly one unfilled hole. It
+    is represented as a `{root, hole}` pointer pair — the root of the partial
+    value and the address of the hole — with a null hole denoting the empty
+    (identity) context.
+
+    Contexts are linear values: each context is consumed exactly once, either
+    by `reussir.cctx.extend` (plugging a new constructor into the hole and
+    refocusing on one of the new constructor's holes) or by
+    `reussir.cctx.apply` (plugging a finished value into the hole and yielding
+    the completed root). The TRMC pass threads a context through
+    tail-recursion-modulo-constructor chains so every constructor arm becomes
+    a genuine tail call.
+  }];
+
+  let parameters = (ins "mlir::Type":$eleTy);
+  let assemblyFormat = "`<` $eleTy `>`";
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    RcType getElementType() const { return llvm::cast<RcType>(getEleTy()); }
+  }];
+}
+
 ///===----------------------------------------------------------------------===//
 // Reussir RcBox Type
 //===----------------------------------------------------------------------===//

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -145,17 +145,20 @@ def ReussirUniqueCarryingRecursionAnalysisPass
 
 def ReussirTRMCRecursionAnalysisPass
     : Pass<"reussir-trmc-recursion-analysis", "::mlir::ModuleOp"> {
-  let summary = "rewrite fused tail-recursive modulo cons patterns to hole-based helpers";
+  let summary = "tail recursion modulo constructors via first-class constructor contexts";
   let description = [{
-    `reussir-trmc-recursion-analysis` recognizes directly self-recursive
-    functions whose recursive result is embedded in a fused
-    `reussir.rc.create_compound` or `reussir.rc.create_variant` site.
-    It outlines an internal `.trmc` helper with an explicit `reussir.hole`
-    out-parameter and rewrites the recursive site to allocate the outer RC box
-    first, expose pending-field holes, and redirect the recursive fields
-    through the helper. When a fused create site contains multiple direct
-    self-calls, the pass forwards all of them through the generated holes while
-    still falling back to the original function for non-linear recursive sites.
+    `reussir-trmc-recursion-analysis` splits every directly self-recursive
+    function returning an rc-boxed value whose recursion feeds a fused
+    `reussir.rc.create_compound`/`reussir.rc.create_variant` field into a thin
+    wrapper and an internal `.trmc` helper threading a `!reussir.cctx`
+    accumulator. Constructor leaves allocate with holes, `cctx.extend` the
+    context, and tail-call the helper (a loop after lowering); plain self tail
+    calls thread the context through; every other leaf completes the context
+    with `cctx.apply`. Multiple recursive fields in one create recurse through
+    fresh single-node contexts, with the last field carrying the loop.
+    Because every return leaf has a sound rewrite, mixed functions — where
+    some arms pass the recursive result through another call first — keep
+    full coverage of their constructor arms.
   }];
   let dependentDialects = ["::reussir::ReussirDialect",
                            "::mlir::func::FuncDialect",

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -569,54 +569,87 @@ struct ReussirRefStoreConversionPattern
   }
 };
 
-struct ReussirHoleCreateConversionPattern
-    : public mlir::OpConversionPattern<ReussirHoleCreateOp> {
+//===----------------------------------------------------------------------===//
+// Constructor contexts lower to a {root, hole} pointer pair with a null hole
+// denoting the empty context. Extend and apply are compiled branch-free: the
+// store that plugs the hole is steered to the per-module scratch word when
+// the context is empty (the value lands in the root/result select instead),
+// mirroring the special-pointer-tag scratch steering.
+//===----------------------------------------------------------------------===//
+
+struct ReussirCctxEmptyConversionPattern
+    : public mlir::OpConversionPattern<ReussirCctxEmptyOp> {
   using OpConversionPattern::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(ReussirHoleCreateOp op, OpAdaptor adaptor,
+  matchAndRewrite(ReussirCctxEmptyOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto structTy = getTypeConverter()->convertType(op.getCtx().getType());
+    rewriter.replaceOpWithNewOp<mlir::LLVM::ZeroOp>(op, structTy);
+    return mlir::success();
+  }
+};
+
+struct ReussirCctxExtendConversionPattern
+    : public mlir::OpConversionPattern<ReussirCctxExtendOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirCctxExtendOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Location loc = op.getLoc();
-    auto converter =
-        static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
-    auto valueType =
-        converter->convertType(op.getHole().getType().getElementType());
-    auto llvmPtrType = converter->convertType(op.getHole().getType());
-    auto dataLayout = getDataLayout(*converter, op.getOperation());
-    auto alignment = dataLayout.getTypePreferredAlignment(valueType);
-    auto arraySize = mlir::arith::ConstantOp::create(
-        rewriter, loc, rewriter.getIntegerAttr(converter->getIndexType(), 1));
-    auto allocaOp = mlir::LLVM::AllocaOp::create(
-        rewriter, loc, llvmPtrType, valueType, arraySize, alignment);
-    rewriter.replaceOp(op, allocaOp);
+    auto ptrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    auto structTy = getTypeConverter()->convertType(op.getNewCtx().getType());
+
+    mlir::Value root = mlir::LLVM::ExtractValueOp::create(
+        rewriter, loc, adaptor.getCtx(), llvm::ArrayRef<int64_t>{0});
+    mlir::Value hole = mlir::LLVM::ExtractValueOp::create(
+        rewriter, loc, adaptor.getCtx(), llvm::ArrayRef<int64_t>{1});
+    mlir::Value null = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrTy);
+    mlir::Value isEmpty = mlir::LLVM::ICmpOp::create(
+        rewriter, loc, mlir::LLVM::ICmpPredicate::eq, hole, null);
+    mlir::Value scratch = tagScratchAddr(
+        op->getParentOfType<mlir::ModuleOp>(), loc, rewriter);
+    mlir::Value addr =
+        mlir::LLVM::SelectOp::create(rewriter, loc, isEmpty, scratch, hole);
+    mlir::LLVM::StoreOp::create(rewriter, loc, adaptor.getRcPtr(), addr);
+    mlir::Value newRoot = mlir::LLVM::SelectOp::create(
+        rewriter, loc, isEmpty, adaptor.getRcPtr(), root);
+
+    mlir::Value result = mlir::LLVM::UndefOp::create(rewriter, loc, structTy);
+    result = mlir::LLVM::InsertValueOp::create(rewriter, loc, result, newRoot,
+                                               llvm::ArrayRef<int64_t>{0});
+    result = mlir::LLVM::InsertValueOp::create(
+        rewriter, loc, result, adaptor.getHole(), llvm::ArrayRef<int64_t>{1});
+    rewriter.replaceOp(op, result);
     return mlir::success();
   }
 };
 
-struct ReussirHoleLoadConversionPattern
-    : public mlir::OpConversionPattern<ReussirHoleLoadOp> {
+struct ReussirCctxApplyConversionPattern
+    : public mlir::OpConversionPattern<ReussirCctxApplyOp> {
   using OpConversionPattern::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(ReussirHoleLoadOp op, OpAdaptor adaptor,
+  matchAndRewrite(ReussirCctxApplyOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto llvmValueType =
-        getTypeConverter()->convertType(op.getValue().getType());
-    rewriter.replaceOpWithNewOp<mlir::LLVM::LoadOp>(op, llvmValueType,
-                                                    adaptor.getHole());
-    return mlir::success();
-  }
-};
+    mlir::Location loc = op.getLoc();
+    auto ptrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
 
-struct ReussirHoleStoreConversionPattern
-    : public mlir::OpConversionPattern<ReussirHoleStoreOp> {
-  using OpConversionPattern::OpConversionPattern;
-
-  mlir::LogicalResult
-  matchAndRewrite(ReussirHoleStoreOp op, OpAdaptor adaptor,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<mlir::LLVM::StoreOp>(op, adaptor.getValue(),
-                                                     adaptor.getHole());
+    mlir::Value root = mlir::LLVM::ExtractValueOp::create(
+        rewriter, loc, adaptor.getCtx(), llvm::ArrayRef<int64_t>{0});
+    mlir::Value hole = mlir::LLVM::ExtractValueOp::create(
+        rewriter, loc, adaptor.getCtx(), llvm::ArrayRef<int64_t>{1});
+    mlir::Value null = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrTy);
+    mlir::Value isEmpty = mlir::LLVM::ICmpOp::create(
+        rewriter, loc, mlir::LLVM::ICmpPredicate::eq, hole, null);
+    mlir::Value scratch = tagScratchAddr(
+        op->getParentOfType<mlir::ModuleOp>(), loc, rewriter);
+    mlir::Value addr =
+        mlir::LLVM::SelectOp::create(rewriter, loc, isEmpty, scratch, hole);
+    mlir::LLVM::StoreOp::create(rewriter, loc, adaptor.getValue(), addr);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::SelectOp>(
+        op, isEmpty, adaptor.getValue(), root);
     return mlir::success();
   }
 };
@@ -3052,8 +3085,8 @@ struct ReussirConvertToLLVMPatternInterface
         patterns.getContext(), target, typeConverter, patterns);
     populateBasicOpsLoweringToLLVMConversionPatterns(typeConverter, patterns);
     target.addIllegalOp<
-        ReussirPanicOp, ReussirExpectOp, ReussirHoleCreateOp, ReussirHoleLoadOp,
-        ReussirHoleStoreOp, ReussirTokenAllocOp, ReussirTokenFreeOp,
+        ReussirPanicOp, ReussirExpectOp, ReussirCctxEmptyOp, ReussirCctxExtendOp,
+        ReussirCctxApplyOp, ReussirTokenAllocOp, ReussirTokenFreeOp,
         ReussirTokenReinterpretOp, ReussirTokenReallocOp, ReussirRefLoadOp,
         ReussirRefStoreOp, ReussirRefSpilledOp, ReussirRefToMemrefOp,
         ReussirRefFromMemrefOp, ReussirRefDiffOp, ReussirRefCmpOp,
@@ -3145,8 +3178,9 @@ void registerReussirBasicOpsLoweringInterface(mlir::DialectRegistry &registry) {
 void populateBasicOpsLoweringToLLVMConversionPatterns(
     mlir::LLVMTypeConverter &converter, mlir::RewritePatternSet &patterns) {
   patterns.add<
-      ReussirExpectConversionPattern, ReussirHoleCreateConversionPattern,
-      ReussirHoleLoadConversionPattern, ReussirHoleStoreConversionPattern,
+      ReussirExpectConversionPattern,
+      ReussirCctxEmptyConversionPattern, ReussirCctxExtendConversionPattern,
+      ReussirCctxApplyConversionPattern,
       ReussirTokenAllocConversionPattern, ReussirTokenFreeConversionPattern,
       ReussirTokenReinterpretConversionPattern,
       ReussirTokenReallocConversionPattern, ReussirRefLoadConversionPattern,

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -181,6 +181,13 @@ void populateReussirToLLVMTypeConversions(mlir::LLVMTypeConverter &converter) {
   converter.addConversion([](HoleType type) {
     return mlir::LLVM::LLVMPointerType::get(type.getContext());
   });
+  // A constructor context is a {root, hole} pointer pair; a null hole is the
+  // empty context.
+  converter.addConversion([](CctxType type) {
+    auto ptrTy = mlir::LLVM::LLVMPointerType::get(type.getContext());
+    return mlir::LLVM::LLVMStructType::getLiteral(type.getContext(),
+                                                  {ptrTy, ptrTy});
+  });
   converter.addConversion([](RegionType type) {
     return mlir::LLVM::LLVMPointerType::get(type.getContext());
   });

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -686,23 +686,35 @@ mlir::LogicalResult ReussirRcAssumeUniqueOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// Reussir Hole Operations
+// Reussir Constructor Context Operations
 //===----------------------------------------------------------------------===//
-mlir::LogicalResult ReussirHoleLoadOp::verify() {
-  auto holeType = getHole().getType();
-  if (holeType.getElementType() != getValue().getType())
-    return emitOpError("value type must match hole element type, ")
-           << "value type: " << getValue().getType()
-           << ", hole element type: " << holeType.getElementType();
+mlir::LogicalResult ReussirCctxExtendOp::verify() {
+  RcType eleTy = getCtx().getType().getElementType();
+  if (getNewCtx().getType() != getCtx().getType())
+    return emitOpError("extended context type must match the incoming "
+                       "context type, got ")
+           << getNewCtx().getType() << " from " << getCtx().getType();
+  if (getRcPtr().getType() != eleTy)
+    return emitOpError("plugged constructor type must match the context "
+                       "element type, got ")
+           << getRcPtr().getType() << " for " << eleTy;
+  if (getHole().getType().getElementType() != eleTy)
+    return emitOpError("refocused hole must hold the context element type, "
+                       "got ")
+           << getHole().getType().getElementType() << " for " << eleTy;
   return mlir::success();
 }
 
-mlir::LogicalResult ReussirHoleStoreOp::verify() {
-  auto holeType = getHole().getType();
-  if (holeType.getElementType() != getValue().getType())
-    return emitOpError("value type must match hole element type, ")
-           << "value type: " << getValue().getType()
-           << ", hole element type: " << holeType.getElementType();
+mlir::LogicalResult ReussirCctxApplyOp::verify() {
+  RcType eleTy = getCtx().getType().getElementType();
+  if (getValue().getType() != eleTy)
+    return emitOpError("applied value type must match the context element "
+                       "type, got ")
+           << getValue().getType() << " for " << eleTy;
+  if (getResult().getType() != eleTy)
+    return emitOpError("result type must match the context element type, "
+                       "got ")
+           << getResult().getType() << " for " << eleTy;
   return mlir::success();
 }
 

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -834,6 +834,19 @@ RefType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
 REUSSIR_POINTER_LIKE_DATA_LAYOUT_INTERFACE(HoleType)
 
 //===----------------------------------------------------------------------===//
+// Reussir Constructor Context Type
+//===----------------------------------------------------------------------===//
+mlir::LogicalResult
+CctxType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+                 mlir::Type eleTy) {
+  if (!llvm::isa<RcType>(eleTy)) {
+    emitError() << "cctx element type must be an rc type, got " << eleTy;
+    return mlir::failure();
+  }
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // Reussir Rc Box Type
 //===----------------------------------------------------------------------===//
 // RcBoxType Parse/Print

--- a/lib/Transformation/TRMCRecursionAnalysis/TRMCRecursionAnalysis.cpp
+++ b/lib/Transformation/TRMCRecursionAnalysis/TRMCRecursionAnalysis.cpp
@@ -5,6 +5,26 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
+//
+// Tail recursion modulo constructors via first-class constructor contexts.
+//
+// A self-recursive function returning an rc-boxed value is split into a thin
+// wrapper and a `.trmc` helper that threads a `!reussir.cctx` accumulator —
+// the partially built result with one unfilled hole. Every return-position
+// leaf of the helper is rewritten into exactly one of three shapes:
+//
+//   A. a constructor whose field is a direct self-call: allocate the
+//      constructor with a hole, `cctx.extend` the context with it, and
+//      tail-call the helper — the constructor chain becomes a loop;
+//   B. a plain self tail call: thread the context through unchanged;
+//   C. anything else: `cctx.apply` the context to the finished value.
+//
+// Because every leaf has a sound rewrite, eligibility is purely per-site: a
+// non-constructor arm (say, a rebalancing wrapper call around the recursion)
+// no longer disables the constructor arms next to it — it simply takes the
+// apply fallback, exactly like Koka's ctail compilation.
+//
+//===----------------------------------------------------------------------===//
 
 #include "Reussir/Transformation/Passes.h"
 #include "Reussir/IR/ReussirDialect.h"
@@ -33,15 +53,6 @@ struct RecursiveFieldInfo {
   mlir::func::CallOp call;
 };
 
-struct TrmcRewriteContext {
-  mlir::IRRewriter &rewriter;
-  mlir::func::FuncOp helperFunc;
-  mlir::Value outHole;
-  llvm::StringRef originalName;
-  llvm::StringRef helperName;
-  bool rewroteRecursiveSite = false;
-};
-
 static bool hasDirectSelfRecursiveCall(mlir::func::FuncOp funcOp) {
   bool found = false;
   llvm::StringRef name = funcOp.getName();
@@ -59,7 +70,7 @@ static void addOptionalAttr(mlir::OperationState &state, llvm::StringRef name,
 }
 
 static ReussirRcCreateCompoundOp createCompoundWithHoles(
-    mlir::IRRewriter &rewriter, mlir::Location loc, RcType rcType,
+    mlir::OpBuilder &builder, mlir::Location loc, RcType rcType,
     mlir::ValueRange fields, mlir::Value token, mlir::Value region,
     mlir::FlatSymbolRefAttr vtable, bool skipRc,
     mlir::DenseI64ArrayAttr skipFields, mlir::DenseI64ArrayAttr holeFields) {
@@ -75,31 +86,29 @@ static ReussirRcCreateCompoundOp createCompoundWithHoles(
   if (holeFields)
     for (int64_t index : holeFields.asArrayRef())
       resultTypes.push_back(HoleType::get(
-          rewriter.getContext(), fields[static_cast<size_t>(index)].getType()));
+          builder.getContext(), fields[static_cast<size_t>(index)].getType()));
   state.addTypes(resultTypes);
   state.addAttribute(
       "operandSegmentSizes",
-      rewriter.getDenseI32ArrayAttr({static_cast<int32_t>(fields.size()),
-                                     token ? 1 : 0, region ? 1 : 0}));
+      builder.getDenseI32ArrayAttr({static_cast<int32_t>(fields.size()),
+                                    token ? 1 : 0, region ? 1 : 0}));
   addOptionalAttr(state, "vtable", vtable);
   if (skipRc)
-    state.addAttribute("skipRc", rewriter.getUnitAttr());
+    state.addAttribute("skipRc", builder.getUnitAttr());
   addOptionalAttr(state, "skipFields", skipFields);
   addOptionalAttr(state, "holeFields", holeFields);
-  return llvm::cast<ReussirRcCreateCompoundOp>(rewriter.create(state));
+  return llvm::cast<ReussirRcCreateCompoundOp>(builder.create(state));
 }
 
 static ReussirRcCreateVariantOp
-createVariantWithHoles(mlir::IRRewriter &rewriter, mlir::Location loc,
-                       RcType rcType, mlir::IntegerAttr tag, mlir::Value value,
+createVariantWithHoles(mlir::OpBuilder &builder, mlir::Location loc,
+                       RcType rcType, mlir::IntegerAttr tag,
                        mlir::ValueRange fields, mlir::Value token,
                        mlir::Value region, mlir::FlatSymbolRefAttr vtable,
                        bool skipRc, mlir::DenseI64ArrayAttr skipFields,
                        mlir::DenseI64ArrayAttr holeFields) {
   mlir::OperationState state(loc, ReussirRcCreateVariantOp::getOperationName());
   state.addAttribute("tag", tag);
-  if (value)
-    state.addOperands(value);
   state.addOperands(fields);
   if (token)
     state.addOperands(token);
@@ -110,558 +119,332 @@ createVariantWithHoles(mlir::IRRewriter &rewriter, mlir::Location loc,
   if (holeFields)
     for (int64_t index : holeFields.asArrayRef())
       resultTypes.push_back(HoleType::get(
-          rewriter.getContext(), fields[static_cast<size_t>(index)].getType()));
+          builder.getContext(), fields[static_cast<size_t>(index)].getType()));
   state.addTypes(resultTypes);
   state.addAttribute("operandSegmentSizes",
-                     rewriter.getDenseI32ArrayAttr(
-                         {value ? 1 : 0, static_cast<int32_t>(fields.size()),
-                          token ? 1 : 0, region ? 1 : 0}));
+                     builder.getDenseI32ArrayAttr(
+                         {0, static_cast<int32_t>(fields.size()), token ? 1 : 0,
+                          region ? 1 : 0}));
   addOptionalAttr(state, "vtable", vtable);
   if (skipRc)
-    state.addAttribute("skipRc", rewriter.getUnitAttr());
+    state.addAttribute("skipRc", builder.getUnitAttr());
   addOptionalAttr(state, "skipFields", skipFields);
   addOptionalAttr(state, "holeFields", holeFields);
-  return llvm::cast<ReussirRcCreateVariantOp>(rewriter.create(state));
+  return llvm::cast<ReussirRcCreateVariantOp>(builder.create(state));
 }
 
-static mlir::LogicalResult replaceWithVoidTerminator(mlir::IRRewriter &rewriter,
-                                                     mlir::Operation *term) {
-  mlir::Location loc = term->getLoc();
-  rewriter.setInsertionPoint(term);
-  if (llvm::isa<mlir::func::ReturnOp>(term))
-    mlir::func::ReturnOp::create(rewriter, loc);
-  else if (llvm::isa<mlir::scf::YieldOp>(term))
-    mlir::scf::YieldOp::create(rewriter, loc);
-  else if (llvm::isa<ReussirScfYieldOp>(term))
-    ReussirScfYieldOp::create(rewriter, loc, mlir::Value{});
-  else
-    return mlir::failure();
-  rewriter.eraseOp(term);
-  return mlir::success();
-}
-
-static mlir::LogicalResult lowerValueIntoHole(mlir::Operation *terminator,
-                                              mlir::Value value,
-                                              TrmcRewriteContext &ctx);
-
-static void clearAndCloneBody(mlir::IRRewriter &rewriter, mlir::Region &dst,
-                              mlir::Region &src) {
-  mlir::Block *placeholder = dst.empty() ? nullptr : &dst.front();
-  rewriter.cloneRegionBefore(src, dst, dst.begin());
-  if (placeholder)
-    placeholder->erase();
-}
-
-static mlir::LogicalResult lowerRegionTerminator(mlir::Region &region,
-                                                 TrmcRewriteContext &ctx) {
-  mlir::Operation *terminator = region.front().getTerminator();
-  if (auto yield = llvm::dyn_cast<mlir::scf::YieldOp>(terminator)) {
-    if (yield.getNumOperands() != 1)
-      return mlir::failure();
-    return lowerValueIntoHole(terminator, yield.getOperand(0), ctx);
-  }
-  if (auto yield = llvm::dyn_cast<ReussirScfYieldOp>(terminator)) {
-    if (!yield.getValue())
-      return mlir::failure();
-    return lowerValueIntoHole(terminator, yield.getValue(), ctx);
-  }
-  return mlir::failure();
-}
-
-static mlir::LogicalResult lowerStructuredValue(mlir::Operation *terminator,
-                                                mlir::Value value,
-                                                TrmcRewriteContext &ctx) {
-  if (auto indexSwitch = llvm::dyn_cast_if_present<mlir::scf::IndexSwitchOp>(
-          value.getDefiningOp())) {
-    if (indexSwitch.getNumResults() != 1 || !value.hasOneUse())
-      return mlir::failure();
-    ctx.rewriter.setInsertionPoint(indexSwitch);
-    auto newIndexSwitch = mlir::scf::IndexSwitchOp::create(ctx.rewriter, 
-        indexSwitch.getLoc(), mlir::TypeRange{}, indexSwitch.getArg(),
-        indexSwitch.getCasesAttr(), indexSwitch.getCaseRegions().size());
-    clearAndCloneBody(ctx.rewriter, newIndexSwitch.getDefaultRegion(),
-                      indexSwitch.getDefaultRegion());
-    for (auto [oldRegion, newRegion] : llvm::zip(
-             indexSwitch.getCaseRegions(), newIndexSwitch.getCaseRegions())) {
-      clearAndCloneBody(ctx.rewriter, newRegion, oldRegion);
-    }
-    if (failed(lowerRegionTerminator(newIndexSwitch.getDefaultRegion(), ctx)))
-      return mlir::failure();
-    for (mlir::Region &region : newIndexSwitch.getCaseRegions())
-      if (failed(lowerRegionTerminator(region, ctx)))
-        return mlir::failure();
-    if (failed(replaceWithVoidTerminator(ctx.rewriter, terminator)))
-      return mlir::failure();
-    ctx.rewriter.eraseOp(indexSwitch);
-    return mlir::success();
-  }
-
-  if (auto ifOp =
-          llvm::dyn_cast_if_present<mlir::scf::IfOp>(value.getDefiningOp())) {
-    if (ifOp.getNumResults() != 1 || !value.hasOneUse())
-      return mlir::failure();
-    ctx.rewriter.setInsertionPoint(ifOp);
-    auto newIf = mlir::scf::IfOp::create(ctx.rewriter, 
-        ifOp.getLoc(), mlir::TypeRange{}, ifOp.getCondition(),
-        !ifOp.getElseRegion().empty());
-    clearAndCloneBody(ctx.rewriter, newIf.getThenRegion(),
-                      ifOp.getThenRegion());
-    if (!ifOp.getElseRegion().empty())
-      clearAndCloneBody(ctx.rewriter, newIf.getElseRegion(),
-                        ifOp.getElseRegion());
-    if (failed(lowerRegionTerminator(newIf.getThenRegion(), ctx)))
-      return mlir::failure();
-    if (!newIf.getElseRegion().empty() &&
-        failed(lowerRegionTerminator(newIf.getElseRegion(), ctx)))
-      return mlir::failure();
-    if (failed(replaceWithVoidTerminator(ctx.rewriter, terminator)))
-      return mlir::failure();
-    ctx.rewriter.eraseOp(ifOp);
-    return mlir::success();
-  }
-
-  if (auto dispatch = llvm::dyn_cast_if_present<ReussirRecordDispatchOp>(
-          value.getDefiningOp())) {
-    if (dispatch.getNumResults() != 1 || !value.hasOneUse())
-      return mlir::failure();
-    mlir::OperationState state(dispatch.getLoc(),
-                               ReussirRecordDispatchOp::getOperationName());
-    state.addOperands(dispatch.getVariant());
-    state.addAttribute("tagSets", dispatch.getTagSetsAttr());
-    for (size_t i = 0; i < dispatch->getNumRegions(); ++i)
-      state.addRegion();
-    ctx.rewriter.setInsertionPoint(dispatch);
-    auto newDispatch =
-        llvm::cast<ReussirRecordDispatchOp>(ctx.rewriter.create(state));
-    for (auto [oldRegion, newRegion] :
-         llvm::zip(dispatch.getRegions(), newDispatch.getRegions())) {
-      clearAndCloneBody(ctx.rewriter, newRegion, oldRegion);
-      if (failed(lowerRegionTerminator(newRegion, ctx)))
-        return mlir::failure();
-    }
-    if (failed(replaceWithVoidTerminator(ctx.rewriter, terminator)))
-      return mlir::failure();
-    ctx.rewriter.eraseOp(dispatch);
-    return mlir::success();
-  }
-
-  if (auto dispatch = llvm::dyn_cast_if_present<ReussirNullableDispatchOp>(
-          value.getDefiningOp())) {
-    if (dispatch.getNumResults() != 1 || !value.hasOneUse())
-      return mlir::failure();
-    mlir::OperationState state(dispatch.getLoc(),
-                               ReussirNullableDispatchOp::getOperationName());
-    state.addOperands(dispatch.getNullable());
-    state.addRegion();
-    state.addRegion();
-    ctx.rewriter.setInsertionPoint(dispatch);
-    auto newDispatch =
-        llvm::cast<ReussirNullableDispatchOp>(ctx.rewriter.create(state));
-    clearAndCloneBody(ctx.rewriter, newDispatch.getNonNullRegion(),
-                      dispatch.getNonNullRegion());
-    clearAndCloneBody(ctx.rewriter, newDispatch.getNullRegion(),
-                      dispatch.getNullRegion());
-    if (failed(lowerRegionTerminator(newDispatch.getNonNullRegion(), ctx)) ||
-        failed(lowerRegionTerminator(newDispatch.getNullRegion(), ctx)))
-      return mlir::failure();
-    if (failed(replaceWithVoidTerminator(ctx.rewriter, terminator)))
-      return mlir::failure();
-    ctx.rewriter.eraseOp(dispatch);
-    return mlir::success();
-  }
-
-  return mlir::failure();
-}
-
-static mlir::LogicalResult
-emitDirectRecursiveTailCall(mlir::Operation *terminator,
-                            mlir::func::CallOp call, TrmcRewriteContext &ctx) {
-  if (call.getCallee() != ctx.originalName)
-    return mlir::failure();
-  ctx.rewriter.setInsertionPoint(terminator);
-  llvm::SmallVector<mlir::Value> helperArgs(call.getOperands());
-  helperArgs.push_back(ctx.outHole);
-  mlir::func::CallOp::create(ctx.rewriter, call.getLoc(), ctx.helperName,
-                                          mlir::TypeRange{}, helperArgs);
-  ctx.rewroteRecursiveSite = true;
-  if (failed(replaceWithVoidTerminator(ctx.rewriter, terminator)))
-    return mlir::failure();
-  ctx.rewriter.eraseOp(call);
-  return mlir::success();
-}
-
-static std::optional<llvm::SmallVector<RecursiveFieldInfo>>
+// The candidate recursive fields of a fused create: fields whose value is
+// produced by a direct self-call. Whether such a call is actually
+// linearizable is a whole-function question answered by `TrmcPlan` — token
+// reuse duplicates one source-level constructor into sibling scf.if branches
+// (reuse-token vs fresh-alloc), so one call may legitimately feed several
+// same-site creates. A call feeding two fields of the *same* create can never
+// be linearized and is dropped here.
+static llvm::SmallVector<RecursiveFieldInfo>
 collectRecursiveFields(mlir::ValueRange fields, llvm::StringRef callee) {
   llvm::SmallVector<RecursiveFieldInfo> recursiveFields;
-  llvm::DenseSet<mlir::Operation *> seenCalls;
+  llvm::SmallDenseSet<mlir::Operation *> seenCalls;
+  llvm::SmallDenseSet<mlir::Operation *> duplicated;
   for (auto [index, field] : llvm::enumerate(fields)) {
     auto callOp =
         llvm::dyn_cast_if_present<mlir::func::CallOp>(field.getDefiningOp());
-    if (!callOp || callOp.getCallee() != callee)
+    if (!callOp || callOp.getCallee() != callee || callOp.getNumResults() != 1)
       continue;
-    if (!seenCalls.insert(callOp.getOperation()).second)
-      return std::nullopt;
+    if (!seenCalls.insert(callOp.getOperation()).second) {
+      duplicated.insert(callOp.getOperation());
+      continue;
+    }
     recursiveFields.push_back(
         RecursiveFieldInfo{static_cast<unsigned>(index), callOp});
   }
+  llvm::erase_if(recursiveFields, [&](RecursiveFieldInfo &info) {
+    return duplicated.contains(info.call.getOperation());
+  });
   return recursiveFields;
 }
 
-static std::optional<llvm::SmallVector<RecursiveFieldInfo>>
-collectRecursiveFields(mlir::Operation *createOp, llvm::StringRef callee) {
-  if (auto create = llvm::dyn_cast<ReussirRcCreateCompoundOp>(createOp))
-    return collectRecursiveFields(create.getFields(), callee);
-
-  auto create = llvm::dyn_cast<ReussirRcCreateVariantOp>(createOp);
-  if (!create || create.getValue())
-    return std::nullopt;
-  return collectRecursiveFields(create.getFields(), callee);
-}
-
-static llvm::SmallVector<int64_t>
-getRecursiveFieldIndices(llvm::ArrayRef<RecursiveFieldInfo> recursiveFields) {
-  llvm::SmallVector<int64_t> indices;
-  indices.reserve(recursiveFields.size());
-  for (const RecursiveFieldInfo &field : recursiveFields)
-    indices.push_back(static_cast<int64_t>(field.index));
-  return indices;
-}
-
-static bool isLinearizableCreateUser(mlir::Operation *user,
-                                     mlir::func::CallOp callOp,
-                                     llvm::StringRef callee) {
-  auto isRecursiveFieldUser = [&](mlir::ValueRange fields) {
-    auto recursiveFields = collectRecursiveFields(fields, callee);
-    if (!recursiveFields)
-      return false;
-    return llvm::any_of(*recursiveFields, [&](const RecursiveFieldInfo &field) {
-      return field.call == callOp;
-    });
-  };
-
-  if (auto create = llvm::dyn_cast<ReussirRcCreateCompoundOp>(user))
-    return isRecursiveFieldUser(create.getFields());
-  if (auto create = llvm::dyn_cast<ReussirRcCreateVariantOp>(user))
-    return !create.getValue() && isRecursiveFieldUser(create.getFields());
+// A fused, non-regional create usable as a class-A leaf shell.
+static bool isCandidateCreate(mlir::Value value) {
+  if (!value.hasOneUse())
+    return false;
+  if (auto create = llvm::dyn_cast_if_present<ReussirRcCreateCompoundOp>(
+          value.getDefiningOp()))
+    return !create.getRegion();
+  if (auto create = llvm::dyn_cast_if_present<ReussirRcCreateVariantOp>(
+          value.getDefiningOp()))
+    return !create.getValue() && !create.getRegion();
   return false;
 }
 
-static bool isCallOnlyUsedByLinearizableCreates(mlir::func::CallOp callOp,
-                                                llvm::StringRef callee) {
-  if (callOp.getCallee() != callee)
-    return false;
-  return llvm::all_of(callOp->getUsers(), [&](mlir::Operation *user) {
-    return isLinearizableCreateUser(user, callOp, callee);
-  });
+static mlir::ValueRange createFields(mlir::Operation *create) {
+  if (auto compound = llvm::dyn_cast<ReussirRcCreateCompoundOp>(create))
+    return compound.getFields();
+  return llvm::cast<ReussirRcCreateVariantOp>(create).getFields();
 }
 
-static bool regionHasDirectSelfCall(mlir::Region &region,
-                                    llvm::StringRef originalName) {
-  bool found = false;
-  region.walk([&](mlir::func::CallOp callOp) {
-    if (callOp.getCallee() == originalName)
-      found = true;
-  });
-  return found;
-}
-
-static bool regionHasNonLinearSelfCall(mlir::Region &region,
-                                       llvm::StringRef originalName) {
-  bool found = false;
-  region.walk([&](mlir::func::CallOp callOp) {
-    if (callOp.getCallee() != originalName)
-      return;
-    if (!isCallOnlyUsedByLinearizableCreates(callOp, originalName))
-      found = true;
-  });
-  return found;
-}
-
-static mlir::Operation *
-getUniqueLinearizableCreateUser(mlir::func::CallOp callOp,
-                                llvm::StringRef originalName) {
-  if (callOp.getCallee() != originalName || !callOp->hasOneUse())
-    return nullptr;
-  mlir::Operation *user = *callOp->user_begin();
-  if (!isLinearizableCreateUser(user, callOp, originalName))
-    return nullptr;
-  return user;
-}
-
-static bool isSameLinearizableCreateSite(mlir::Operation *lhs, mlir::Operation *rhs,
-                                         llvm::StringRef originalName) {
-  if (!lhs || !rhs || lhs == rhs)
-    return lhs == rhs;
+// Two creates are the same source-level site iff they agree on op kind,
+// location, tag, and recursive-field shape. Compiler duplication (token
+// reuse's scf.if dualization) produces exactly such clones, and the clones
+// live in mutually exclusive branches — which is what makes it sound to
+// consume one shared recursive call from each of them.
+static bool isSameCreateSite(mlir::Operation *lhs, mlir::Operation *rhs,
+                             llvm::StringRef callee) {
+  if (lhs == rhs)
+    return true;
   if (lhs->getName() != rhs->getName() || lhs->getLoc() != rhs->getLoc())
     return false;
-
-  auto sameRecursiveIndex = [&](mlir::ValueRange lhsFields,
-                                mlir::ValueRange rhsFields) {
-    auto lhsRecursiveFields = collectRecursiveFields(lhsFields, originalName);
-    auto rhsRecursiveFields = collectRecursiveFields(rhsFields, originalName);
-    return lhsRecursiveFields && rhsRecursiveFields &&
-           getRecursiveFieldIndices(*lhsRecursiveFields) ==
-               getRecursiveFieldIndices(*rhsRecursiveFields);
-  };
-
-  if (auto lhsCreate = llvm::dyn_cast<ReussirRcCreateCompoundOp>(lhs)) {
-    auto rhsCreate = llvm::dyn_cast<ReussirRcCreateCompoundOp>(rhs);
-    return rhsCreate &&
-           sameRecursiveIndex(lhsCreate.getFields(), rhsCreate.getFields());
-  }
-
-  auto lhsCreate = llvm::dyn_cast<ReussirRcCreateVariantOp>(lhs);
-  auto rhsCreate = llvm::dyn_cast<ReussirRcCreateVariantOp>(rhs);
-  return lhsCreate && rhsCreate && lhsCreate.getTagAttr() == rhsCreate.getTagAttr() &&
-         sameRecursiveIndex(lhsCreate.getFields(), rhsCreate.getFields());
-}
-
-static bool hasMeaningfulSiblingSelfCall(mlir::Region &region,
-                                         mlir::Operation *currentCreateOp,
-                                         llvm::StringRef originalName) {
-  bool found = false;
-  region.walk([&](mlir::func::CallOp callOp) {
-    if (found || callOp.getCallee() != originalName)
-      return;
-    mlir::Operation *user = getUniqueLinearizableCreateUser(callOp, originalName);
-    if (!user || !isSameLinearizableCreateSite(currentCreateOp, user, originalName))
-      found = true;
-  });
-  return found;
-}
-
-static bool isSiteEligibleForTrmc(mlir::Operation *createOp,
-                                  llvm::StringRef originalName) {
-  auto recursiveFields = collectRecursiveFields(createOp, originalName);
-  if (!recursiveFields || recursiveFields->empty())
-    return false;
-  for (const RecursiveFieldInfo &field : *recursiveFields)
-    if (!isCallOnlyUsedByLinearizableCreates(field.call, originalName))
+  if (auto lhsVariant = llvm::dyn_cast<ReussirRcCreateVariantOp>(lhs)) {
+    auto rhsVariant = llvm::cast<ReussirRcCreateVariantOp>(rhs);
+    if (lhsVariant.getTagAttr() != rhsVariant.getTagAttr())
       return false;
-
-  mlir::Region *currentRegion = createOp->getParentRegion();
-  mlir::Operation *parentOp =
-      currentRegion ? currentRegion->getParentOp() : nullptr;
-  while (parentOp && !llvm::isa<mlir::func::FuncOp>(parentOp)) {
-    if (parentOp->getNumRegions() > 1) {
-      for (mlir::Region &region : parentOp->getRegions()) {
-        if (&region == currentRegion)
-          continue;
-        if (!regionHasDirectSelfCall(region, originalName))
-          continue;
-        if (regionHasNonLinearSelfCall(region, originalName))
-          return false;
-        if (hasMeaningfulSiblingSelfCall(region, createOp, originalName))
-          return true;
-      }
-    }
-    currentRegion = parentOp->getParentRegion();
-    parentOp = currentRegion ? currentRegion->getParentOp() : nullptr;
   }
+  auto lhsFields = collectRecursiveFields(createFields(lhs), callee);
+  auto rhsFields = collectRecursiveFields(createFields(rhs), callee);
+  if (lhsFields.size() != rhsFields.size())
+    return false;
+  for (auto [l, r] : llvm::zip(lhsFields, rhsFields))
+    if (l.index != r.index)
+      return false;
   return true;
 }
 
-static mlir::LogicalResult
-emitRecursiveCreateIntoHole(mlir::Operation *terminator, mlir::Value value,
-                            TrmcRewriteContext &ctx) {
-  if (auto create = llvm::dyn_cast_if_present<ReussirRcCreateCompoundOp>(
-          value.getDefiningOp())) {
-    auto recursiveFields =
-        collectRecursiveFields(create.getOperation(), ctx.originalName);
-    if (!recursiveFields || recursiveFields->empty())
-      return mlir::failure();
-    if (!isSiteEligibleForTrmc(create.getOperation(), ctx.originalName))
-      return mlir::failure();
-    llvm::SmallVector<mlir::Value> fields(create.getFields().begin(),
-                                          create.getFields().end());
-    ctx.rewriter.setInsertionPoint(terminator);
-    for (const RecursiveFieldInfo &field : *recursiveFields)
-      fields[field.index] = mlir::ub::PoisonOp::create(ctx.rewriter, 
-          create.getLoc(), fields[field.index].getType());
-    auto holeFields =
-        ctx.rewriter.getDenseI64ArrayAttr(getRecursiveFieldIndices(*recursiveFields));
-    auto newCreate = createCompoundWithHoles(
-        ctx.rewriter, create.getLoc(), create.getRcPtr().getType(), fields,
-        create.getToken(), create.getRegion(), create.getVtableAttr(),
-        create.getSkipRc(), create.getSkipFieldsAttr(), holeFields);
-    ctx.rewriter.setInsertionPointAfter(newCreate);
-    auto store = ReussirHoleStoreOp::create(ctx.rewriter, 
-        create.getLoc(), ctx.outHole, newCreate.getRcPtr());
-    mlir::Operation *insertionPoint = store;
-    for (auto [field, hole] : llvm::zip(*recursiveFields, newCreate.getHoles())) {
-      llvm::SmallVector<mlir::Value> helperArgs(field.call.getOperands());
-      helperArgs.push_back(hole);
-      ctx.rewriter.setInsertionPointAfter(insertionPoint);
-      insertionPoint = mlir::func::CallOp::create(ctx.rewriter, 
-          field.call.getLoc(), ctx.helperName, mlir::TypeRange{}, helperArgs);
+struct LeafInfo {
+  mlir::Operation *terminator;
+  mlir::Value value;
+};
+
+// The per-function rewrite plan: every return-position leaf, plus the set of
+// class-A creates with their linearizable recursive fields.
+struct TrmcPlan {
+  llvm::SmallVector<LeafInfo> leaves;
+  llvm::SmallDenseMap<mlir::Operation *, llvm::SmallVector<RecursiveFieldInfo>>
+      constructorLeaves;
+};
+
+// Walks the value spine from a return down through single-result,
+// single-use structured control flow and invokes `visit` on every leaf
+// (terminator, yielded value) pair.
+static void
+forEachLeaf(mlir::Operation *terminator, mlir::Value value,
+            llvm::function_ref<void(mlir::Operation *, mlir::Value)> visit) {
+  mlir::Operation *def = value.getDefiningOp();
+  auto allRegionsHaveOneBlock = [](mlir::Operation *op) {
+    return llvm::all_of(op->getRegions(), [](mlir::Region &region) {
+      return region.hasOneBlock();
+    });
+  };
+  if (def && def->getNumResults() == 1 && value.hasOneUse() &&
+      llvm::isa<mlir::scf::IfOp, mlir::scf::IndexSwitchOp,
+                ReussirRecordDispatchOp, ReussirNullableDispatchOp>(def) &&
+      def->getNumRegions() > 0 && allRegionsHaveOneBlock(def) &&
+      llvm::none_of(def->getRegions(),
+                    [](mlir::Region &region) { return region.empty(); })) {
+    for (mlir::Region &region : def->getRegions()) {
+      mlir::Operation *nested = region.front().getTerminator();
+      mlir::Value yielded;
+      if (auto yield = llvm::dyn_cast<mlir::scf::YieldOp>(nested)) {
+        if (yield.getNumOperands() == 1)
+          yielded = yield.getOperand(0);
+      } else if (auto yield = llvm::dyn_cast<ReussirScfYieldOp>(nested)) {
+        yielded = yield.getValue();
+      }
+      if (!yielded) {
+        // A region that does not yield the spine value (e.g. it panics)
+        // contributes no leaf.
+        continue;
+      }
+      forEachLeaf(nested, yielded, visit);
     }
-    ctx.rewroteRecursiveSite = true;
-    if (failed(replaceWithVoidTerminator(ctx.rewriter, terminator)))
-      return mlir::failure();
-    ctx.rewriter.eraseOp(create);
-    for (RecursiveFieldInfo &field : *recursiveFields)
-      if (field.call.use_empty())
-        ctx.rewriter.eraseOp(field.call);
-    return mlir::success();
+    return;
   }
-
-  auto create = llvm::dyn_cast_if_present<ReussirRcCreateVariantOp>(
-      value.getDefiningOp());
-  if (!create || create.getValue())
-    return mlir::failure();
-
-  auto recursiveFields =
-      collectRecursiveFields(create.getOperation(), ctx.originalName);
-  if (!recursiveFields || recursiveFields->empty())
-    return mlir::failure();
-  if (!isSiteEligibleForTrmc(create.getOperation(), ctx.originalName))
-    return mlir::failure();
-  llvm::SmallVector<mlir::Value> fields(create.getFields().begin(),
-                                        create.getFields().end());
-  ctx.rewriter.setInsertionPoint(terminator);
-  for (const RecursiveFieldInfo &field : *recursiveFields)
-    fields[field.index] = mlir::ub::PoisonOp::create(ctx.rewriter, 
-        create.getLoc(), fields[field.index].getType());
-  auto holeFields =
-      ctx.rewriter.getDenseI64ArrayAttr(getRecursiveFieldIndices(*recursiveFields));
-  auto newCreate = createVariantWithHoles(
-      ctx.rewriter, create.getLoc(), create.getRcPtr().getType(),
-      create.getTagAttr(), create.getValue(), fields, create.getToken(),
-      create.getRegion(), create.getVtableAttr(), create.getSkipRc(),
-      create.getSkipFieldsAttr(), holeFields);
-  ctx.rewriter.setInsertionPointAfter(newCreate);
-  auto store = ReussirHoleStoreOp::create(ctx.rewriter, 
-      create.getLoc(), ctx.outHole, newCreate.getRcPtr());
-  mlir::Operation *insertionPoint = store;
-  for (auto [field, hole] : llvm::zip(*recursiveFields, newCreate.getHoles())) {
-    llvm::SmallVector<mlir::Value> helperArgs(field.call.getOperands());
-    helperArgs.push_back(hole);
-    ctx.rewriter.setInsertionPointAfter(insertionPoint);
-    insertionPoint = mlir::func::CallOp::create(ctx.rewriter, 
-        field.call.getLoc(), ctx.helperName, mlir::TypeRange{}, helperArgs);
-  }
-  ctx.rewroteRecursiveSite = true;
-  if (failed(replaceWithVoidTerminator(ctx.rewriter, terminator)))
-    return mlir::failure();
-  ctx.rewriter.eraseOp(create);
-  for (RecursiveFieldInfo &field : *recursiveFields)
-    if (field.call.use_empty())
-      ctx.rewriter.eraseOp(field.call);
-  return mlir::success();
+  visit(terminator, value);
 }
 
-static mlir::LogicalResult rewriteRecursiveCreateSite(
-    mlir::Operation *createOp, llvm::StringRef originalName,
-    llvm::StringRef helperName, mlir::IRRewriter &rewriter) {
-  if (auto create = llvm::dyn_cast<ReussirRcCreateCompoundOp>(createOp)) {
-    auto recursiveFields = collectRecursiveFields(create.getOperation(),
-                                                 originalName);
-    if (!recursiveFields || recursiveFields->empty())
-      return mlir::failure();
-    if (!isSiteEligibleForTrmc(create.getOperation(), originalName))
-      return mlir::failure();
-    llvm::SmallVector<mlir::Value> fields(create.getFields().begin(),
-                                          create.getFields().end());
-    rewriter.setInsertionPoint(create);
-    for (const RecursiveFieldInfo &field : *recursiveFields)
-      fields[field.index] = mlir::ub::PoisonOp::create(rewriter, 
-          create.getLoc(), fields[field.index].getType());
-    auto holeFields =
-        rewriter.getDenseI64ArrayAttr(getRecursiveFieldIndices(*recursiveFields));
-    auto newCreate = createCompoundWithHoles(
-        rewriter, create.getLoc(), create.getRcPtr().getType(), fields,
-        create.getToken(), create.getRegion(), create.getVtableAttr(),
-        create.getSkipRc(), create.getSkipFieldsAttr(), holeFields);
-    mlir::Operation *insertionPoint = newCreate;
-    for (auto [field, hole] : llvm::zip(*recursiveFields, newCreate.getHoles())) {
-      llvm::SmallVector<mlir::Value> helperArgs(field.call.getOperands());
-      helperArgs.push_back(hole);
-      rewriter.setInsertionPointAfter(insertionPoint);
-      insertionPoint = mlir::func::CallOp::create(rewriter, 
-          field.call.getLoc(), helperName, mlir::TypeRange{}, helperArgs);
-    }
-    create.getRcPtr().replaceAllUsesWith(newCreate.getRcPtr());
-    rewriter.eraseOp(create);
-    for (RecursiveFieldInfo &field : *recursiveFields)
-      if (field.call.use_empty())
-        rewriter.eraseOp(field.call);
-    return mlir::success();
-  }
-
-  auto create = llvm::dyn_cast<ReussirRcCreateVariantOp>(createOp);
-  if (!create || create.getValue())
-    return mlir::failure();
-
-  auto recursiveFields = collectRecursiveFields(create.getOperation(),
-                                               originalName);
-  if (!recursiveFields || recursiveFields->empty())
-    return mlir::failure();
-  if (!isSiteEligibleForTrmc(create.getOperation(), originalName))
-    return mlir::failure();
-  llvm::SmallVector<mlir::Value> fields(create.getFields().begin(),
-                                        create.getFields().end());
-  rewriter.setInsertionPoint(create);
-  for (const RecursiveFieldInfo &field : *recursiveFields)
-    fields[field.index] = mlir::ub::PoisonOp::create(rewriter, 
-        create.getLoc(), fields[field.index].getType());
-  auto holeFields =
-      rewriter.getDenseI64ArrayAttr(getRecursiveFieldIndices(*recursiveFields));
-  auto newCreate = createVariantWithHoles(
-      rewriter, create.getLoc(), create.getRcPtr().getType(),
-      create.getTagAttr(), create.getValue(), fields, create.getToken(),
-      create.getRegion(), create.getVtableAttr(), create.getSkipRc(),
-      create.getSkipFieldsAttr(), holeFields);
-  mlir::Operation *insertionPoint = newCreate;
-  for (auto [field, hole] : llvm::zip(*recursiveFields, newCreate.getHoles())) {
-    llvm::SmallVector<mlir::Value> helperArgs(field.call.getOperands());
-    helperArgs.push_back(hole);
-    rewriter.setInsertionPointAfter(insertionPoint);
-    insertionPoint = mlir::func::CallOp::create(rewriter, 
-        field.call.getLoc(), helperName, mlir::TypeRange{}, helperArgs);
-  }
-  create.getRcPtr().replaceAllUsesWith(newCreate.getRcPtr());
-  rewriter.eraseOp(create);
-  for (RecursiveFieldInfo &field : *recursiveFields)
-    if (field.call.use_empty())
-      rewriter.eraseOp(field.call);
-  return mlir::success();
-}
-
-static bool rewriteRecursiveCreateSitesInFunction(mlir::func::FuncOp funcOp,
-                                                  llvm::StringRef originalName,
-                                                  llvm::StringRef helperName);
-
-static void eraseUnusedCallsTo(mlir::func::FuncOp funcOp,
-                               llvm::StringRef callee) {
-  mlir::IRRewriter rewriter(funcOp.getContext());
-  llvm::SmallVector<mlir::func::CallOp> calls;
-  funcOp.walk([&](mlir::func::CallOp callOp) {
-    if (callOp.getCallee() == callee && callOp->use_empty())
-      calls.push_back(callOp);
+static TrmcPlan buildPlan(mlir::func::FuncOp funcOp, llvm::StringRef callee) {
+  TrmcPlan plan;
+  funcOp.walk([&](mlir::func::ReturnOp returnOp) {
+    if (returnOp.getNumOperands() != 1)
+      return;
+    forEachLeaf(returnOp, returnOp.getOperand(0),
+                [&](mlir::Operation *terminator, mlir::Value value) {
+                  plan.leaves.push_back(LeafInfo{terminator, value});
+                });
   });
 
-  for (mlir::func::CallOp callOp : calls)
-    rewriter.eraseOp(callOp);
+  // Candidate creates and their candidate recursive fields.
+  llvm::SmallDenseSet<mlir::Operation *> candidates;
+  for (LeafInfo &leaf : plan.leaves)
+    if (isCandidateCreate(leaf.value))
+      candidates.insert(leaf.value.getDefiningOp());
+
+  // A recursive call is linearizable iff every use feeds a candidate create
+  // of the same site: the branches consume the shared call exactly once each
+  // along mutually exclusive paths, so after every user is rewritten the
+  // call itself dies.
+  auto isLinearizable = [&](mlir::func::CallOp call,
+                            mlir::Operation *create) {
+    for (mlir::Operation *user : call->getUsers())
+      if (!candidates.contains(user) || !isSameCreateSite(create, user, callee))
+        return false;
+    return true;
+  };
+
+  for (mlir::Operation *create : candidates) {
+    llvm::SmallVector<RecursiveFieldInfo> fields =
+        collectRecursiveFields(createFields(create), callee);
+    llvm::erase_if(fields, [&](RecursiveFieldInfo &info) {
+      return !isLinearizable(info.call, create);
+    });
+    if (!fields.empty())
+      plan.constructorLeaves.try_emplace(create, std::move(fields));
+  }
+  return plan;
 }
 
-static mlir::LogicalResult lowerValueIntoHole(mlir::Operation *terminator,
-                                              mlir::Value value,
-                                              TrmcRewriteContext &ctx) {
-  if (succeeded(lowerStructuredValue(terminator, value, ctx)))
-    return mlir::success();
+struct TrmcRewriteContext {
+  mlir::IRRewriter &rewriter;
+  llvm::StringRef originalName;
+  llvm::StringRef helperName;
+  mlir::Value ctxArg;
+  CctxType ctxType;
+};
 
-  if (auto callOp =
-          llvm::dyn_cast_if_present<mlir::func::CallOp>(value.getDefiningOp());
-      callOp && succeeded(emitDirectRecursiveTailCall(terminator, callOp, ctx)))
-    return mlir::success();
+static void setLeafValue(mlir::Operation *terminator, mlir::Value oldValue,
+                         mlir::Value newValue) {
+  for (mlir::OpOperand &operand : terminator->getOpOperands())
+    if (operand.get() == oldValue)
+      operand.set(newValue);
+}
 
-  if (succeeded(emitRecursiveCreateIntoHole(terminator, value, ctx)))
-    return mlir::success();
+// Class A: rebuild the create with holes at every linearizable recursive
+// field, recurse into the non-designated fields through fresh single-node
+// contexts, and turn the designated (last) field into the context-threaded
+// tail call.
+static void
+rewriteConstructorLeaf(mlir::Operation *terminator, mlir::Value value,
+                       llvm::ArrayRef<RecursiveFieldInfo> planned,
+                       TrmcRewriteContext &ctx) {
+  mlir::Operation *def = value.getDefiningOp();
+  auto compound = llvm::dyn_cast_if_present<ReussirRcCreateCompoundOp>(def);
+  auto variant = llvm::dyn_cast_if_present<ReussirRcCreateVariantOp>(def);
 
-  ctx.rewriter.setInsertionPoint(terminator);
-  ReussirHoleStoreOp::create(ctx.rewriter, terminator->getLoc(), ctx.outHole,
-                                          value);
-  return replaceWithVoidTerminator(ctx.rewriter, terminator);
+  mlir::ValueRange fieldRange =
+      compound ? compound.getFields() : variant.getFields();
+  llvm::SmallVector<RecursiveFieldInfo> recursiveFields(planned.begin(),
+                                                        planned.end());
+
+  mlir::IRRewriter &rewriter = ctx.rewriter;
+  mlir::Location loc = def->getLoc();
+  rewriter.setInsertionPoint(terminator);
+
+  llvm::SmallVector<mlir::Value> fields(fieldRange.begin(), fieldRange.end());
+  llvm::SmallVector<int64_t> holeIndices;
+  holeIndices.reserve(recursiveFields.size());
+  for (RecursiveFieldInfo &field : recursiveFields) {
+    fields[field.index] = mlir::ub::PoisonOp::create(
+        rewriter, loc, fields[field.index].getType());
+    holeIndices.push_back(static_cast<int64_t>(field.index));
+  }
+  auto holeFields = rewriter.getDenseI64ArrayAttr(holeIndices);
+
+  mlir::Value rcPtr;
+  mlir::ValueRange holes;
+  if (compound) {
+    auto newCreate = createCompoundWithHoles(
+        rewriter, loc, compound.getRcPtr().getType(), fields,
+        compound.getToken(), compound.getRegion(), compound.getVtableAttr(),
+        compound.getSkipRc(), compound.getSkipFieldsAttr(), holeFields);
+    rcPtr = newCreate.getRcPtr();
+    holes = newCreate.getHoles();
+  } else {
+    auto newCreate = createVariantWithHoles(
+        rewriter, loc, variant.getRcPtr().getType(), variant.getTagAttr(),
+        fields, variant.getToken(), variant.getRegion(),
+        variant.getVtableAttr(), variant.getSkipRc(),
+        variant.getSkipFieldsAttr(), holeFields);
+    rcPtr = newCreate.getRcPtr();
+    holes = newCreate.getHoles();
+  }
+
+  mlir::Type resultType = ctx.ctxType.getElementType();
+  // Non-designated recursive fields recurse through fresh single-node
+  // contexts rooted at the new constructor; their (identical) results are
+  // discarded.
+  for (size_t i = 0; i + 1 < recursiveFields.size(); ++i) {
+    RecursiveFieldInfo &field = recursiveFields[i];
+    mlir::Value empty =
+        ReussirCctxEmptyOp::create(rewriter, field.call.getLoc(), ctx.ctxType);
+    mlir::Value sub = ReussirCctxExtendOp::create(
+        rewriter, field.call.getLoc(), ctx.ctxType, empty, rcPtr, holes[i]);
+    llvm::SmallVector<mlir::Value> args(field.call.getOperands());
+    args.push_back(sub);
+    mlir::func::CallOp::create(rewriter, field.call.getLoc(), ctx.helperName,
+                               mlir::TypeRange{resultType}, args);
+  }
+
+  // The designated (last) recursive field extends the incoming context and
+  // becomes the tail call whose result is the leaf's value.
+  RecursiveFieldInfo &designated = recursiveFields.back();
+  mlir::Value extended = ReussirCctxExtendOp::create(
+      rewriter, designated.call.getLoc(), ctx.ctxType, ctx.ctxArg, rcPtr,
+      holes[recursiveFields.size() - 1]);
+  llvm::SmallVector<mlir::Value> args(designated.call.getOperands());
+  args.push_back(extended);
+  auto tailCall =
+      mlir::func::CallOp::create(rewriter, designated.call.getLoc(),
+                                 ctx.helperName, mlir::TypeRange{resultType},
+                                 args);
+
+  setLeafValue(terminator, value, tailCall.getResult(0));
+  rewriter.eraseOp(def);
+  for (RecursiveFieldInfo &field : recursiveFields)
+    if (field.call->use_empty())
+      rewriter.eraseOp(field.call);
+}
+
+// Class B: a plain self tail call threads the context through unchanged.
+static bool rewriteTailCallLeaf(mlir::Operation *terminator, mlir::Value value,
+                                TrmcRewriteContext &ctx) {
+  auto call =
+      llvm::dyn_cast_if_present<mlir::func::CallOp>(value.getDefiningOp());
+  if (!call || call.getCallee() != ctx.originalName || !value.hasOneUse() ||
+      call.getNumResults() != 1)
+    return false;
+  mlir::IRRewriter &rewriter = ctx.rewriter;
+  rewriter.setInsertionPoint(terminator);
+  llvm::SmallVector<mlir::Value> args(call.getOperands());
+  args.push_back(ctx.ctxArg);
+  auto newCall = mlir::func::CallOp::create(
+      rewriter, call.getLoc(), ctx.helperName,
+      mlir::TypeRange{ctx.ctxType.getElementType()}, args);
+  setLeafValue(terminator, value, newCall.getResult(0));
+  rewriter.eraseOp(call);
+  return true;
+}
+
+// Class C: any other leaf completes the context with its value.
+static void rewriteApplyLeaf(mlir::Operation *terminator, mlir::Value value,
+                             TrmcRewriteContext &ctx) {
+  mlir::IRRewriter &rewriter = ctx.rewriter;
+  rewriter.setInsertionPoint(terminator);
+  auto apply = ReussirCctxApplyOp::create(rewriter, terminator->getLoc(),
+                                          ctx.ctxType.getElementType(),
+                                          ctx.ctxArg, value);
+  setLeafValue(terminator, value, apply.getResult());
+}
+
+static void rewriteLeaf(mlir::Operation *terminator, mlir::Value value,
+                        const TrmcPlan &plan, TrmcRewriteContext &ctx) {
+  if (mlir::Operation *def = value.getDefiningOp()) {
+    auto planned = plan.constructorLeaves.find(def);
+    if (planned != plan.constructorLeaves.end()) {
+      rewriteConstructorLeaf(terminator, value, planned->second, ctx);
+      return;
+    }
+  }
+  if (rewriteTailCallLeaf(terminator, value, ctx))
+    return;
+  rewriteApplyLeaf(terminator, value, ctx);
 }
 
 static void makeHelperInternal(mlir::func::FuncOp helperFunc,
@@ -673,89 +456,69 @@ static void makeHelperInternal(mlir::func::FuncOp helperFunc,
       mlir::LLVM::LinkageAttr::get(context, mlir::LLVM::Linkage::Internal));
 }
 
-static mlir::FailureOr<mlir::func::FuncOp>
-createTrmcHelper(mlir::func::FuncOp funcOp, mlir::SymbolTable &symbolTable) {
+static mlir::func::FuncOp createTrmcHelper(mlir::func::FuncOp funcOp,
+                                           mlir::SymbolTable &symbolTable,
+                                           CctxType ctxType) {
   auto *context = funcOp.getContext();
   std::string helperName = (funcOp.getName() + kTrmcSuffix).str();
   if (auto existing = symbolTable.lookup<mlir::func::FuncOp>(helperName))
     return existing;
 
   auto helperFunc = llvm::cast<mlir::func::FuncOp>(funcOp->clone());
-  auto destroyDetachedHelper = [&]() {
-    if (helperFunc && !helperFunc->getParentOp())
-      helperFunc->destroy();
-  };
-  auto resultType = llvm::dyn_cast<RcType>(funcOp.getResultTypes().front());
-  if (!resultType) {
-    destroyDetachedHelper();
-    return mlir::failure();
-  }
-
-  auto holeType = HoleType::get(context, resultType);
+  mlir::Type resultType = ctxType.getElementType();
   llvm::SmallVector<mlir::Type> inputs(helperFunc.getArgumentTypes().begin(),
                                        helperFunc.getArgumentTypes().end());
-  inputs.push_back(holeType);
+  inputs.push_back(ctxType);
   helperFunc.setName(helperName);
   helperFunc.setFunctionType(
-      mlir::FunctionType::get(context, inputs, llvm::ArrayRef<mlir::Type>{}));
-  helperFunc.getBody().front().addArgument(holeType, helperFunc.getLoc());
-  helperFunc.setArgAttr(helperFunc.getNumArguments() - 1, "llvm.noalias",
-                        mlir::UnitAttr::get(context));
-  helperFunc.setArgAttr(helperFunc.getNumArguments() - 1, "llvm.nonnull",
-                        mlir::UnitAttr::get(context));
+      mlir::FunctionType::get(context, inputs, {resultType}));
+  helperFunc.getBody().front().addArgument(ctxType, helperFunc.getLoc());
   helperFunc.setArgAttr(helperFunc.getNumArguments() - 1, "llvm.noundef",
                         mlir::UnitAttr::get(context));
   makeHelperInternal(helperFunc, context);
 
   mlir::IRRewriter rewriter(context);
   TrmcRewriteContext ctx{
-      rewriter,
-      helperFunc,
-      helperFunc.getArgument(helperFunc.getNumArguments() - 1),
-      funcOp.getName(),
-      helperFunc.getName(),
-      false};
+      rewriter, funcOp.getName(), helperFunc.getName(),
+      helperFunc.getArgument(helperFunc.getNumArguments() - 1), ctxType};
 
-  llvm::SmallVector<mlir::func::ReturnOp> returns;
-  helperFunc.walk(
-      [&](mlir::func::ReturnOp returnOp) { returns.push_back(returnOp); });
-  for (mlir::func::ReturnOp returnOp : returns) {
-    if (returnOp.getNumOperands() != 1 ||
-        failed(lowerValueIntoHole(returnOp, returnOp.getOperand(0), ctx))) {
-      destroyDetachedHelper();
-      return mlir::failure();
-    }
-  }
+  // Plan on the clone: the plan owns the leaf list and the batch decision of
+  // which shared recursive calls are linearizable, so rewrites can consume
+  // one shared call from each of its mutually exclusive same-site creates.
+  TrmcPlan plan = buildPlan(helperFunc, funcOp.getName());
+  for (LeafInfo &leaf : plan.leaves)
+    rewriteLeaf(leaf.terminator, leaf.value, plan, ctx);
 
-  eraseUnusedCallsTo(helperFunc, funcOp.getName());
-
-  if (!ctx.rewroteRecursiveSite) {
-    destroyDetachedHelper();
-    return mlir::failure();
-  }
   symbolTable.insert(helperFunc);
   return helperFunc;
 }
 
-static bool rewriteRecursiveCreateSitesInFunction(mlir::func::FuncOp funcOp,
-                                                  llvm::StringRef originalName,
-                                                  llvm::StringRef helperName) {
-  mlir::IRRewriter rewriter(funcOp.getContext());
-  llvm::SmallVector<mlir::Operation *> creates;
-  funcOp.walk([&](mlir::Operation *op) {
-    if (llvm::isa<ReussirRcCreateCompoundOp, ReussirRcCreateVariantOp>(op))
-      creates.push_back(op);
-  });
+// The original function becomes a thin wrapper: every caller enters the
+// context-threaded helper through the empty context.
+static void rewriteOriginalToWrapper(mlir::func::FuncOp funcOp,
+                                     llvm::StringRef helperName,
+                                     CctxType ctxType) {
+  mlir::Region &body = funcOp.getBody();
+  for (mlir::Block &block : body)
+    block.dropAllReferences();
 
-  bool rewroteAny = false;
-  for (mlir::Operation *op : creates) {
-    if (!op->getBlock())
-      continue;
-    if (succeeded(
-            rewriteRecursiveCreateSite(op, originalName, helperName, rewriter)))
-      rewroteAny = true;
-  }
-  return rewroteAny;
+  mlir::OpBuilder builder(funcOp.getContext());
+  llvm::SmallVector<mlir::Location> argLocs(funcOp.getNumArguments(),
+                                            funcOp.getLoc());
+  mlir::Block *entry = builder.createBlock(&body, body.begin(),
+                                           funcOp.getArgumentTypes(), argLocs);
+  while (&body.back() != entry)
+    body.back().erase();
+
+  builder.setInsertionPointToStart(entry);
+  mlir::Value empty =
+      ReussirCctxEmptyOp::create(builder, funcOp.getLoc(), ctxType);
+  llvm::SmallVector<mlir::Value> args(entry->getArguments());
+  args.push_back(empty);
+  auto call = mlir::func::CallOp::create(
+      builder, funcOp.getLoc(), helperName,
+      mlir::TypeRange{ctxType.getElementType()}, args);
+  mlir::func::ReturnOp::create(builder, funcOp.getLoc(), call.getResults());
 }
 
 struct TRMCRecursionAnalysisPass
@@ -776,19 +539,18 @@ struct TRMCRecursionAnalysisPass
         return;
       if (!hasDirectSelfRecursiveCall(funcOp))
         return;
+      if (buildPlan(funcOp, funcOp.getName()).constructorLeaves.empty())
+        return;
       candidates.push_back(funcOp);
     });
 
     for (mlir::func::FuncOp funcOp : candidates) {
-      auto helperOr = createTrmcHelper(funcOp, symbolTable);
-      if (failed(helperOr))
-        continue;
-      if (!rewriteRecursiveCreateSitesInFunction(funcOp, funcOp.getName(),
-                                                 helperOr->getName())) {
-        helperOr->erase();
-        continue;
-      }
-      eraseUnusedCallsTo(funcOp, funcOp.getName());
+      auto ctxType = CctxType::get(
+          funcOp.getContext(),
+          llvm::cast<RcType>(funcOp.getResultTypes().front()));
+      mlir::func::FuncOp helper =
+          createTrmcHelper(funcOp, symbolTable, ctxType);
+      rewriteOriginalToWrapper(funcOp, helper.getName(), ctxType);
     }
   }
 };

--- a/tests/integration/conversion/cctx_lowering.mlir
+++ b/tests/integration/conversion/cctx_lowering.mlir
@@ -1,0 +1,56 @@
+// RUN: %reussir-opt %s --convert-to-llvm | \
+// RUN: %reussir-translate --mlir-to-llvmir | %FileCheck %s
+
+// LLVM lowering of first-class constructor contexts: a `!reussir.cctx` is a
+// `{root, hole}` pointer pair with a null hole denoting the empty context.
+// Extend and apply are branch-free — the plugging store is steered to the
+// per-module scratch word when the context is empty, and the root/result
+// is selected instead.
+
+!list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Nil" [value] {}>}>
+!rclist = !reussir.rc<!list>
+!cctx = !reussir.cctx<!rclist>
+!hole = !reussir.hole<!rclist>
+
+// CHECK-DAG: @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2 = internal global i64 0
+module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+
+  // The empty context is all-null.
+  // CHECK-LABEL: define { ptr, ptr } @empty()
+  // CHECK: ret { ptr, ptr } zeroinitializer
+  func.func @empty() -> !cctx {
+    %0 = reussir.cctx.empty : !cctx
+    return %0 : !cctx
+  }
+
+  // Extend plugs the constructor into the hole (scratch-steered when empty),
+  // selects the new root, and refocuses on the constructor's own hole.
+  // CHECK-LABEL: define { ptr, ptr } @extend({ ptr, ptr } %0, ptr %1, ptr %2)
+  // CHECK: %[[ROOT0:.+]] = extractvalue { ptr, ptr } %0, 0
+  // CHECK: %[[HOLE0:.+]] = extractvalue { ptr, ptr } %0, 1
+  // CHECK: %[[ISEMPTY:.+]] = icmp eq ptr %[[HOLE0]], null
+  // CHECK: %[[ADDR:.+]] = select i1 %[[ISEMPTY]], ptr @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2, ptr %[[HOLE0]]
+  // CHECK: store ptr %1, ptr %[[ADDR]]
+  // CHECK: %[[ROOT:.+]] = select i1 %[[ISEMPTY]], ptr %1, ptr %[[ROOT0]]
+  // CHECK: insertvalue { ptr, ptr } undef, ptr %[[ROOT]], 0
+  // CHECK: insertvalue { ptr, ptr } {{.+}}, ptr %2, 1
+  func.func @extend(%ctx: !cctx, %rc: !rclist, %h: !hole) -> !cctx {
+    %0 = reussir.cctx.extend(%ctx : !cctx) plug(%rc : !rclist) hole(%h : !hole) : !cctx
+    return %0 : !cctx
+  }
+
+  // Apply plugs the final value (scratch-steered when empty) and yields the
+  // root — or the value itself for the empty context.
+  // CHECK-LABEL: define ptr @apply({ ptr, ptr } %0, ptr %1)
+  // CHECK: %[[AROOT:.+]] = extractvalue { ptr, ptr } %0, 0
+  // CHECK: %[[AHOLE:.+]] = extractvalue { ptr, ptr } %0, 1
+  // CHECK: %[[AEMPTY:.+]] = icmp eq ptr %[[AHOLE]], null
+  // CHECK: %[[AADDR:.+]] = select i1 %[[AEMPTY]], ptr @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2, ptr %[[AHOLE]]
+  // CHECK: store ptr %1, ptr %[[AADDR]]
+  // CHECK: %[[ARES:.+]] = select i1 %[[AEMPTY]], ptr %1, ptr %[[AROOT]]
+  // CHECK: ret ptr %[[ARES]]
+  func.func @apply(%ctx: !cctx, %v: !rclist) -> !rclist {
+    %0 = reussir.cctx.apply(%ctx : !cctx) (%v : !rclist) : !rclist
+    return %0 : !rclist
+  }
+}

--- a/tests/integration/conversion/trmc_recursion.mlir
+++ b/tests/integration/conversion/trmc_recursion.mlir
@@ -9,14 +9,12 @@
 !rc_list = !reussir.rc<!list>
 
 module {
+  // The original function becomes a thin wrapper entering the helper through
+  // the empty constructor context.
   // CHECK-LABEL: func.func @map_plus1(
-  // CHECK: %[[NEW:.+]], %[[TAILHOLE:.+]] = "reussir.rc.create_variant"(%{{.+}}, %{{.+}}) <{holeFields = array<i64: 1>, operandSegmentSizes = array<i32: 0, 2, 0, 0>, tag = 0 : index}>
-  // CHECK-SAME: : (i64, !reussir.rc<!reussir.record<variant "List"
-  // CHECK-SAME: -> (!reussir.rc<!reussir.record<variant "List"
-  // CHECK-SAME: !reussir.hole<!reussir.rc<!reussir.record<variant "List"
-  // CHECK: func.call @map_plus1.trmc(%{{.+}}, %[[TAILHOLE]]) : (!reussir.rc<!reussir.record<variant "List"
-  // CHECK-SAME: !reussir.hole<!reussir.rc<!reussir.record<variant "List"
-  // CHECK: reussir.scf.yield %[[NEW]] : !reussir.rc<!reussir.record<variant "List"
+  // CHECK: %[[EMPTY:.+]] = reussir.cctx.empty : !reussir.cctx<!reussir.rc<!reussir.record<variant "List"
+  // CHECK: %[[RES:.+]] = call @map_plus1.trmc(%{{.+}}, %[[EMPTY]])
+  // CHECK: return %[[RES]]
   func.func @map_plus1(%list: !rc_list) -> !rc_list {
     %list_ref = reussir.rc.borrow (%list : !rc_list) : !reussir.ref<!list>
     %result = reussir.record.dispatch (%list_ref : !reussir.ref<!list>) -> !rc_list {
@@ -43,18 +41,22 @@ module {
     return %result : !rc_list
   }
 
+  // The helper threads a `!reussir.cctx` accumulator: the constructor arm
+  // allocates with a hole, extends the context, and tail-calls itself; the
+  // base-case arm completes the context with `cctx.apply`.
   // CHECK-LABEL: func.func private @map_plus1.trmc(
   // CHECK-SAME: %[[LIST:.+]]: !reussir.rc<!reussir.record<variant "List"
-  // CHECK-SAME: %[[OUTARG:.+]]: !reussir.hole<!reussir.rc<!reussir.record<variant "List"
-  // CHECK-SAME: {llvm.noalias, llvm.nonnull, llvm.noundef}) attributes {llvm.linkage = #llvm.linkage<internal>}
+  // CHECK-SAME: %[[CTX:.+]]: !reussir.cctx<!reussir.rc<!reussir.record<variant "List"
+  // CHECK-SAME: {llvm.noundef})
+  // CHECK-SAME: attributes {llvm.linkage = #llvm.linkage<internal>}
   // CHECK: reussir.record.dispatch
   // CHECK: %[[NEW:.+]], %[[TAILHOLE:.+]] = "reussir.rc.create_variant"(%{{.+}}, %{{.+}}) <{holeFields = array<i64: 1>, operandSegmentSizes = array<i32: 0, 2, 0, 0>, tag = 0 : index}>
   // CHECK-SAME: : (i64, !reussir.rc<!reussir.record<variant "List"
   // CHECK-SAME: -> (!reussir.rc<!reussir.record<variant "List"
   // CHECK-SAME: !reussir.hole<!reussir.rc<!reussir.record<variant "List"
-  // CHECK: reussir.hole.store(%[[OUTARG]] : !reussir.hole<!reussir.rc<!reussir.record<variant "List"
-  // CHECK: func.call @map_plus1.trmc(%{{.+}}, %[[TAILHOLE]]) : (!reussir.rc<!reussir.record<variant "List"
-  // CHECK-SAME: !reussir.hole<!reussir.rc<!reussir.record<variant "List"
-  // CHECK: reussir.hole.store(%[[OUTARG]] : !reussir.hole<!reussir.rc<!reussir.record<variant "List"
-  // CHECK-SAME: (%[[LIST]] : !reussir.rc<!reussir.record<variant "List"
+  // CHECK: %[[EXT:.+]] = reussir.cctx.extend(%[[CTX]] : !reussir.cctx<{{.+}}) plug(%[[NEW]] : {{.+}}) hole(%[[TAILHOLE]] : {{.+}})
+  // CHECK: %[[TAIL:.+]] = func.call @map_plus1.trmc(%{{.+}}, %[[EXT]])
+  // CHECK: reussir.scf.yield %[[TAIL]]
+  // CHECK: %[[DONE:.+]] = reussir.cctx.apply(%[[CTX]] : !reussir.cctx<{{.+}}) (%[[LIST]] : {{.+}})
+  // CHECK: reussir.scf.yield %[[DONE]]
 }

--- a/tests/integration/frontend/list_inc1.rr
+++ b/tests/integration/frontend/list_inc1.rr
@@ -16,19 +16,21 @@ fn inc1(list : List<i32>) -> List<i32> {
 }
 
 // CHECK-TRMC-LABEL: func.func private @_RC4inc1(
-// CHECK-TRMC: %[[NEW:.+]], %[[TAILHOLE:.+]] = "reussir.rc.create_variant"(%{{.+}}, %{{.+}}) <{holeFields = array<i64: 1>
-// CHECK-TRMC: func.call @_RC4inc1.trmc(%{{.+}}, %[[TAILHOLE]]) : (!reussir.rc<!reussir.record<variant
-// CHECK-TRMC: scf.yield %[[NEW]] : !reussir.rc<!reussir.record<variant
+// CHECK-TRMC: %[[EMPTY:.+]] = reussir.cctx.empty : !reussir.cctx<!reussir.rc<!reussir.record<variant
+// CHECK-TRMC: %[[RES:.+]] = call @_RC4inc1.trmc(%{{.+}}, %[[EMPTY]])
+// CHECK-TRMC: return %[[RES]]
 
 // CHECK-TRMC-LABEL: func.func private @_RC4inc1.trmc(
 // CHECK-TRMC-SAME: %[[LIST:.+]]: !reussir.rc<!reussir.record<variant
-// CHECK-TRMC-SAME: %[[OUTARG:.+]]: !reussir.hole<!reussir.rc<!reussir.record<variant
-// CHECK-TRMC-SAME: {llvm.noalias, llvm.nonnull, llvm.noundef}) attributes {llvm.linkage = #llvm.linkage<internal>}
+// CHECK-TRMC-SAME: %[[CTX:.+]]: !reussir.cctx<!reussir.rc<!reussir.record<variant
+// CHECK-TRMC-SAME: {llvm.noundef})
+// CHECK-TRMC-SAME: attributes {llvm.linkage = #llvm.linkage<internal>}
 // CHECK-TRMC: reussir.record.dispatch
+// CHECK-TRMC: reussir.cctx.apply(%[[CTX]] : !reussir.cctx<!reussir.rc<!reussir.record<variant
 // CHECK-TRMC: %[[NEW:.+]], %[[TAILHOLE:.+]] = "reussir.rc.create_variant"(%{{.+}}, %{{.+}}) <{holeFields = array<i64: 1>, operandSegmentSizes = array<i32: 0, 2, 0, 0>, tag = 1 : index}>
 // CHECK-TRMC-SAME: : (i32, !reussir.rc<!reussir.record<variant
 // CHECK-TRMC-SAME: -> (!reussir.rc<!reussir.record<variant
 // CHECK-TRMC-SAME: !reussir.hole<!reussir.rc<!reussir.record<variant
-// CHECK-TRMC: reussir.hole.store(%[[OUTARG]] : !reussir.hole<!reussir.rc<!reussir.record<variant
-// CHECK-TRMC: func.call @_RC4inc1.trmc(%{{.+}}, %[[TAILHOLE]]) : (!reussir.rc<!reussir.record<variant
-// CHECK-TRMC-SAME: !reussir.hole<!reussir.rc<!reussir.record<variant
+// CHECK-TRMC: %[[EXT:.+]] = reussir.cctx.extend(%[[CTX]] : !reussir.cctx<{{.+}}) plug(%[[NEW]] : {{.+}}) hole(%[[TAILHOLE]] : {{.+}})
+// CHECK-TRMC: %[[TAIL:.+]] = func.call @_RC4inc1.trmc(%{{.+}}, %[[EXT]])
+// CHECK-TRMC: reussir.scf.yield %[[TAIL]]

--- a/tests/integration/frontend/quote_nonlinear.rr
+++ b/tests/integration/frontend/quote_nonlinear.rr
@@ -23,20 +23,30 @@ fn quote(v : Value) -> Term {
     }
 }
 
+// The wrapper enters the helper through the empty context.
 // CHECK-TRMC-LABEL: func.func private @_RC5quote(
-// CHECK-TRMC: %[[NEW:.+]], %[[HOLES:.+]]:2 = "reussir.rc.create_variant"(%{{.+}}, %{{.+}}) <{holeFields = array<i64: 0, 1>, operandSegmentSizes = array<i32: 0, 2, 0, 0>, tag = 1 : index}>
-// CHECK-TRMC: func.call @_RC5quote.trmc(%{{.+}}, %[[HOLES]]#0) : (!reussir.rc<!reussir.record<variant
-// CHECK-TRMC: func.call @_RC5quote.trmc(%{{.+}}, %[[HOLES]]#1) : (!reussir.rc<!reussir.record<variant
-// CHECK-TRMC: reussir.scf.yield %[[NEW]] : !reussir.rc<!reussir.record<variant
+// CHECK-TRMC: %[[EMPTY:.+]] = reussir.cctx.empty : !reussir.cctx<!reussir.rc<!reussir.record<variant
+// CHECK-TRMC: %[[RES:.+]] = call @_RC5quote.trmc(%{{.+}}, %[[EMPTY]])
+// CHECK-TRMC: return %[[RES]]
 
+// Both recursive fields of `Term::App` become holes: the first child
+// recurses through a fresh single-node context rooted at the new
+// constructor, and the second (designated) child extends the incoming
+// context and becomes the tail call.
 // CHECK-TRMC-LABEL: func.func private @_RC5quote.trmc(
 // CHECK-TRMC-SAME: %[[VALUE:.+]]: !reussir.rc<!reussir.record<variant
-// CHECK-TRMC-SAME: %[[OUTARG:.+]]: !reussir.hole<!reussir.rc<!reussir.record<variant
-// CHECK-TRMC-SAME: {llvm.noalias, llvm.nonnull, llvm.noundef}) attributes {llvm.linkage = #llvm.linkage<internal>}
-// CHECK-TRMC: %[[NEW2:.+]], %[[HOLES2:.+]]:2 = "reussir.rc.create_variant"(%{{.+}}, %{{.+}}) <{holeFields = array<i64: 0, 1>, operandSegmentSizes = array<i32: 0, 2, 0, 0>, tag = 1 : index}>
-// CHECK-TRMC: reussir.hole.store(%[[OUTARG]] : !reussir.hole<!reussir.rc<!reussir.record<variant
-// CHECK-TRMC: func.call @_RC5quote.trmc(%{{.+}}, %[[HOLES2]]#0) : (!reussir.rc<!reussir.record<variant
-// CHECK-TRMC: func.call @_RC5quote.trmc(%{{.+}}, %[[HOLES2]]#1) : (!reussir.rc<!reussir.record<variant
+// CHECK-TRMC-SAME: %[[CTX:.+]]: !reussir.cctx<!reussir.rc<!reussir.record<variant
+// CHECK-TRMC-SAME: {llvm.noundef})
+// CHECK-TRMC-SAME: attributes {llvm.linkage = #llvm.linkage<internal>}
+// CHECK-TRMC: %[[NEW:.+]], %[[HOLES:.+]]:2 = "reussir.rc.create_variant"(%{{.+}}, %{{.+}}) <{holeFields = array<i64: 0, 1>, operandSegmentSizes = array<i32: 0, 2, 0, 0>, tag = 1 : index}>
+// CHECK-TRMC: %[[SUBEMPTY:.+]] = reussir.cctx.empty
+// CHECK-TRMC: %[[SUB:.+]] = reussir.cctx.extend(%[[SUBEMPTY]] : !reussir.cctx<{{.+}}) plug(%[[NEW]] : {{.+}}) hole(%[[HOLES]]#0 : {{.+}})
+// CHECK-TRMC: func.call @_RC5quote.trmc(%{{.+}}, %[[SUB]])
+// CHECK-TRMC: %[[EXT:.+]] = reussir.cctx.extend(%[[CTX]] : !reussir.cctx<{{.+}}) plug(%[[NEW]] : {{.+}}) hole(%[[HOLES]]#1 : {{.+}})
+// CHECK-TRMC: %[[TAIL:.+]] = func.call @_RC5quote.trmc(%{{.+}}, %[[EXT]])
 
-// CHECK-LLVM-LABEL: define internal fastcc void @_RC5quote.trmc(
-// CHECK-LLVM-NOT: tail call ptr @_RC5quote(
+// The helper survives LLVM optimization as a value-returning loop: the
+// designated child is tail-recursion-eliminated; only the first child
+// remains a true recursive call, and nothing calls back into the wrapper.
+// CHECK-LLVM-LABEL: define internal fastcc ptr @_RC5quote.trmc(
+// CHECK-LLVM-NOT: call ptr @_RC5quote(


### PR DESCRIPTION
P6 of #325, replacing the hole-out-parameter TRMC with Koka-style first-class constructor contexts. Stacked on #329 (one test-fix commit); auto-retargets to `main` when that merges.

## Why

The old pass rewrote a site only when a whole-function sibling-region analysis approved it, and evaluated that analysis against partially-rewritten IR. On rbtree's `ins` (4 constructor arms + 2 `balance_*` rotation arms) the rotation arms vetoed everything they could see, and the order dependence lost even pure modulo-cons arms: **only 1 of the 4 constructor arms compiled to a loop**; the rest re-entered as true recursion. Koka's ctail compiles the same function with every constructor arm looping and only the rotation arms as real calls — that is exactly the shape this PR produces.

## The type and ops

`!reussir.cctx<T>` (T an rc type) is a **linear** constructor context: a tree of already-allocated constructors with exactly one unfilled hole, represented as a `{root, hole}` pointer pair; `hole == null` is the empty (identity) context.

- `reussir.cctx.empty : cctx<T>`
- `reussir.cctx.extend(ctx) plug(rc) hole(h) : cctx<T>` — plug a constructor freshly allocated with a hole (`holeFields` on the fused `rc.create_*`) into `ctx`'s hole; refocus on `h`, one of the new constructor's own holes. Empty ctx ⇒ the constructor becomes the root.
- `reussir.cctx.apply(ctx)(v) : T` — plug the finished value; yield the root (or `v` itself when empty).

Lowering is branch-free (`cctx_lowering.mlir`): the plugging store selects between the real hole and the per-module scratch word (shared with the special-pointer-tag machinery — a write-only garbage sink), and the root/result is a second select:

```llvm
; extend({root, hole}, rc, h)
%isEmpty = icmp eq ptr %hole, null
%addr    = select %isEmpty, @SCRATCH, %hole
store ptr %rc, ptr %addr
%root'   = select %isEmpty, %rc, %root
; result = {root', h}
```

## Analysis criteria

**Candidate function.** Not a `.trmc` helper; has a body; exactly one result of `RcType`; contains a direct self-call; and the plan (below) finds ≥ 1 constructor leaf.

**Leaf enumeration.** From each `func.return`'s operand, descend the *value spine*: while the value is the single-use, single-result output of structured control flow (`scf.if`, `scf.index_switch`, `reussir.record.dispatch`, `reussir.nullable.dispatch`) whose regions are all single-block and non-empty, recurse into each region's yielded value. Everything that terminates the descent is a **leaf** `(terminator, value)`. A region that doesn't yield the spine value (e.g. panics) contributes no leaf.

**Leaf classes.** Each leaf gets exactly one of three rewrites, so eligibility is purely local:

- **A (constructor):** the value is a fused `rc.create_compound`/`rc.create_variant` (fields form, no region operand, single use = the yield) with ≥ 1 *linearizable* recursive field;
- **B (pass-through):** the value is a single-use direct self-call — plain tail recursion;
- **C (apply):** anything else.

**Linearizability (the batch criterion).** A recursive call feeding a create field is linearizable iff *every* use of the call feeds a **same-site** candidate leaf create. This is what handles token reuse: TokenReuse dualizes one source-level constructor into sibling `scf.if` branches (reuse-token vs fresh-alloc), both consuming the *same* recursive call:

```mlir
%r = func.call @ins(%l, %k, %v)          // two uses!
%n = scf.if %has_token -> T {
  yield "rc.create_variant"(%r, ...) {skipRc, token}   // reuse branch
} else {
  yield "rc.create_variant"(%r, ...) {token}           // fresh branch
}
```

The branches are mutually exclusive, so each consumes the shared call once; after *all* of them are rewritten the call has no uses left and dies. "Same site" = same op kind, same source location, same variant tag, same recursive-field index shape — the signature of compiler duplication of a single source constructor. A call feeding two fields of one create, or escaping to a non-create user, is never linearized (rewriting it would duplicate an ownership-consuming call along one path).

## Algorithm

```
trmc(module):
  for F in module where candidate(F):
    ctxTy  = cctx<resultType(F)>
    H      = clone(F) renamed F.trmc, internal,
             params + (ctx : ctxTy), same result type
    plan   = buildPlan(H)                 # leaves + class-A map, on the clone
    for (term, v) in plan.leaves:
      rewriteLeaf(term, v, plan)
    body(F) = { return F.trmc(args..., cctx.empty) }   # thin wrapper

buildPlan(F):
  leaves     = spine-descend from every func.return
  candidates = { leaf.value | isCandidateCreate(leaf.value) }
  for create in candidates:
    fields = [ (i, call) | field i of create defined by direct self-call ]
    keep (i, call) iff ∀ user ∈ users(call):
        user ∈ candidates ∧ sameSite(create, user)
    if fields ≠ ∅: classA[create] = fields

rewriteLeaf(term, v, plan):
  if v ∈ plan.classA:            # A — constructor arm
    fields = plan.classA[v];  poison each recursive field
    new, holes... = create-with-holes(v.operands, holeFields = indices(fields))
    for (i, call) in fields[..-1]:               # extra recursive fields
      sub = cctx.extend(cctx.empty, new, holes[i])
      F.trmc(call.operands..., sub)              # real call, result (== new) discarded
    last = fields[-1]                            # designated field carries the loop
    ext  = cctx.extend(ctx, new, holes[-1])
    r    = F.trmc(last.operands..., ext)         # tail call ⇒ loop after TRE
    yield r;  erase v;  erase calls with no uses left
  elif v is single-use self-call:                # B — plain tail recursion
    yield F.trmc(v.operands..., ctx)
  else:                                          # C — finished value
    yield cctx.apply(ctx, v)
```

**Rewrite example** (rbtree `ins`, black arm — the case the old pass lost). Before, one leaf per branch of the is-red test:

```mlir
%t = scf.if %is_red -> T {
  %x = func.call @ins(%l, %k, %v)
  yield func.call @balance_left(%x, %kx, %vx, %r)   // leaf: class C
} else {
  %x = func.call @ins(%l, %k, %v)
  yield "rc.create_variant"(%c, %x, %kx, %vx, %r)   // leaf: class A
}
```

After (inside `ins.trmc`):

```mlir
%t = scf.if %is_red -> T {
  %x = func.call @ins(%l, %k, %v)                    // wrapper: fresh empty ctx
  %y = func.call @balance_left(%x, %kx, %vx, %r)
  yield reussir.cctx.apply(%ctx)(%y)                 // plug rotation result, done
} else {
  %new, %h = "rc.create_variant"(%c, <poison>, %kx, %vx, %r) {holeFields = [1]}
  %ext = reussir.cctx.extend(%ctx) plug(%new) hole(%h)
  yield func.call @ins.trmc(%l, %k, %v, %ext)        // tail call ⇒ loop
}
```

The rotation arm no longer influences the constructor arm at all. On the final rbtree LLVM IR: all 4 constructor arms fold into one `tailrecurse` loop; exactly 2 real recursive calls remain (the rotations, inherently non-loopable — Koka's `trmc_ins` has the same two). For multi-recursive-field creates (`quote`'s `Term::App{quote(v1), quote(v2)}`), both fields become holes: the first child recurses through `extend(empty, new, holes#0)` (a fresh single-node context — its returned root is discarded), the last child extends the incoming context and loops.

## Cleanup

The stack-hole ops `hole.create`/`hole.load`/`hole.store` lost their only user (the old pass's out-parameter plumbing) and are removed, along with their lowering patterns. `!reussir.hole` itself remains: it is the type of `rc.create_*` hole results and `cctx.extend`'s refocus operand.

## Results (aarch64, n = 4.2M, xLTO + static mimalloc, sequential; baseline = main with #328)

| bench | baseline | this PR | Koka (same session) | gap |
|---|---|---|---|---|
| rbtree (+rac) | 0.58 s | **0.49 s (−14%)** | 0.38 s | **1.29×** (2.63× at #325 filing) |
| nbe-hoas | 0.235 s | 0.215 s | 0.15 s | 1.43× |
| rbtree-zipper (+rac) | 0.41 s | 0.42 s | — | — |

RSS unchanged on all three. Tests: full lit suite (285) plus backend/codegen/jit/rrc unit tests pass; `trmc_recursion.mlir`, `list_inc1.rr`, `quote_nonlinear.rr` expectations updated to the cctx shapes; new `cctx_lowering.mlir` covers the LLVM lowering of all three ops.

Future work the type enables (not in this PR): mutual recursion (contexts across helpers), surface-level `ctx` expressions à la the PLDI'24 constructor-contexts paper, and composition (`cctx.compose`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2