### PR TITLE
[backend] token reuse: same-nominal-type domain bias (P7 experiment, default off)

### DIFF
--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -105,6 +105,12 @@ def ReussirTokenReusePass
   let options = [
     Option<"reuseAcrossCall", "reuse-across-call", "bool", /*default=*/"false",
         "allow token reuse across function calls (may increase peak heap usage)">,
+    Option<"domainBias", "domain-bias", "std::string", /*default=*/"\"none\"",
+        "same-nominal-type bias in the token matcher: 'none' (pure "
+        "size/locality scoring), 'lookahead' (skip a cross-domain assignment "
+        "once when a later same-domain consumer in the block would take the "
+        "token), or 'two-phase' (match same-domain pairs first, then fall "
+        "back)">,
   ];
 
   let dependentDialects = ["::reussir::ReussirDialect"];

--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -15,6 +15,8 @@
 #include "Reussir/IR/ReussirTypes.h"
 
 #include <bit>
+#include <optional>
+#include <tuple>
 #include <cstddef>
 #include <functional>
 #pragma GCC diagnostic push
@@ -196,6 +198,60 @@ int hueristic(TokenType producedType, mlir::TypedValue<RcType> producerRc,
                                                                           : -1;
 }
 
+// The (token type, producing rc value) pair behind an available token, for
+// both producer shapes the matcher understands: a `reussir.rc.dec` that
+// yields its box as a nullable token, and an *expanded* decrement (an
+// `scf.if` tagged kExpandedDecrementAttr whose condition tests the fetched
+// refcount of the decremented box).
+struct ProducedToken {
+  TokenType type{};
+  mlir::TypedValue<RcType> rc{};
+};
+std::optional<ProducedToken> describeToken(mlir::Value tokenVal) {
+  if (auto producer =
+          dyn_cast_or_null<TokenProducer>(tokenVal.getDefiningOp())) {
+    ReussirRcDecOp dec = dyn_cast<ReussirRcDecOp>(producer.getOperation());
+    return ProducedToken{producer.getTokenType(),
+                         dec ? dec.getRcPtr() : nullptr};
+  }
+  if (auto scfIf =
+          dyn_cast_or_null<mlir::scf::IfOp>(tokenVal.getDefiningOp())) {
+    if (!scfIf->hasAttr(kExpandedDecrementAttr))
+      return std::nullopt;
+    auto nullableType = dyn_cast<NullableType>(scfIf.getResult(0).getType());
+    if (!nullableType)
+      return std::nullopt;
+    auto producedType = dyn_cast<TokenType>(nullableType.getPtrTy());
+    if (!producedType)
+      return std::nullopt;
+    auto expectOp = dyn_cast_or_null<ReussirExpectOp>(
+        scfIf.getCondition().getDefiningOp());
+    if (!expectOp)
+      return std::nullopt;
+    auto cmp = dyn_cast_or_null<mlir::arith::CmpIOp>(
+        expectOp.getCondition().getDefiningOp());
+    if (!cmp)
+      return std::nullopt;
+    auto rcFetch = llvm::dyn_cast_if_present<ReussirRcFetchOp>(
+        cmp.getLhs().getDefiningOp());
+    return ProducedToken{producedType, rcFetch ? rcFetch.getRcPtr() : nullptr};
+  }
+  return std::nullopt;
+}
+
+// The nominal type domain of a producer/consumer: the rc element type. Two
+// dead boxes of the same record are interchangeable in every respect; a
+// same-domain reuse is exactly the in-place update Koka's reuse analysis
+// aims for. Null when the shape is unknown.
+mlir::Type producerDomain(const ProducedToken &produced) {
+  return produced.rc ? produced.rc.getType().getElementType() : mlir::Type{};
+}
+mlir::Type acceptorDomain(TokenAcceptor acceptor) {
+  if (auto create = dyn_cast<ReussirRcCreateOp>(acceptor.getOperation()))
+    return create.getRcPtr().getType().getElementType();
+  return {};
+}
+
 struct ValueHash {
   uint64_t operator()(mlir::Value v) const {
     void *ptr = v.getAsOpaquePointer();
@@ -239,6 +295,110 @@ struct Free {
 };
 struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
   using Base::Base;
+
+  // Same-nominal-type bias strategy (the `domain-bias` option).
+  enum class DomainBias { None, Lookahead, TwoPhase };
+  // Which matches the current walk may form: everything admissible, or only
+  // same-domain pairs (the first walk of the two-phase strategy).
+  enum class MatchMode { Full, DomainOnly };
+
+  DomainBias biasKind = DomainBias::None;
+  MatchMode mode = MatchMode::Full;
+  // Cross-walk state for the two-phase strategy: pairs formed in the
+  // domain-only walk stay fixed and are *replayed* by the fallback walk when
+  // it reaches each assigned acceptor. Consumption must stay path-local:
+  // sibling branches of an scf.if each see the token as available (they are
+  // mutually exclusive), so phase one may assign one token to an acceptor in
+  // every sibling arm, and the replay erases it from each arm's own
+  // availability copy. `reservedTokens` keeps the fallback matcher from
+  // handing a phase-one token to an *earlier* unassigned acceptor, which
+  // would double-consume it along the path to its reserved consumer.
+  llvm::DenseMap<mlir::Operation *, mlir::Value> phaseOneAssignments;
+  llvm::DenseSet<mlir::Value> reservedTokens;
+
+  struct Candidate {
+    mlir::Value token{};
+    int score = -1;
+    bool realloc = false;
+    bool sameDomain = false;
+  };
+
+  // The best admissible token for `acceptor` under the current mode and bias,
+  // ignoring `exclude`. Ranking: with a domain bias, same-domain first, then
+  // the locality/size score, then recency (DFS order); without, the original
+  // score-then-recency ranking.
+  Candidate pickBest(const ValueSet &availableTokens, TokenAcceptor acceptor,
+                     mlir::AliasAnalysis &aliasAnalyzer,
+                     const mlir::DenseMap<mlir::Operation *, unsigned> &dfsOrder,
+                     MatchMode mode, mlir::Value exclude) {
+    mlir::Type consumerDomain = acceptorDomain(acceptor);
+    Candidate best;
+    for (auto tokenVal : availableTokens) {
+      if (tokenVal == exclude)
+        continue;
+      // A token reserved by the domain-only walk belongs to its downstream
+      // consumer; the fallback walk must not hand it out again.
+      if (mode == MatchMode::Full && reservedTokens.contains(tokenVal))
+        continue;
+      auto produced = describeToken(tokenVal);
+      if (!produced)
+        continue;
+      int score =
+          hueristic(produced->type, produced->rc, acceptor, aliasAnalyzer);
+      if (score < 0)
+        continue;
+      mlir::Type domain = producerDomain(*produced);
+      bool sameDomain = domain && consumerDomain && domain == consumerDomain;
+      if (mode == MatchMode::DomainOnly && !sameDomain)
+        continue;
+      bool better;
+      if (!best.token) {
+        better = true;
+      } else if (biasKind == DomainBias::None) {
+        better = score > best.score ||
+                 (score == best.score &&
+                  getDfsOrder(dfsOrder, tokenVal) >
+                      getDfsOrder(dfsOrder, best.token));
+      } else {
+        better = std::tuple(sameDomain, score,
+                            getDfsOrder(dfsOrder, tokenVal)) >
+                 std::tuple(best.sameDomain, best.score,
+                            getDfsOrder(dfsOrder, best.token));
+      }
+      if (better)
+        best = Candidate{tokenVal, score, score == 0, sameDomain};
+    }
+    return best;
+  }
+
+  // Whether a later acceptor in the same block wants a token of `domain`.
+  // Conservative and block-local: stops at anything that kills or may
+  // conditionally consume the token (loops, region-bearing ops, and calls
+  // when reuse does not cross calls) — mirroring the walk's own barriers.
+  bool blockHasLaterSameDomainConsumer(mlir::Operation *from,
+                                       mlir::Type domain) {
+    for (mlir::Operation *op = from->getNextNode(); op;
+         op = op->getNextNode()) {
+      if (isa<mlir::LoopLikeOpInterface>(*op) || op->getNumRegions() > 0)
+        return false;
+      if (isa<mlir::CallOpInterface>(*op) && !reuseAcrossCall) {
+        mlir::func::CallOp funcCall = llvm::dyn_cast<mlir::func::CallOp>(*op);
+        if (!funcCall ||
+            !funcCall.getCallee().starts_with("core::intrinsic::"))
+          return false;
+      }
+      if (auto acceptor = dyn_cast<TokenAcceptor>(op)) {
+        auto alloc = llvm::dyn_cast_if_present<ReussirTokenAllocOp>(
+            acceptor.getToken().getDefiningOp());
+        if (alloc && alloc.getToken().hasOneUse() &&
+            !phaseOneAssignments.contains(op) &&
+            acceptorDomain(acceptor) == domain)
+          return true;
+      }
+    }
+    return false;
+  }
+
   ValueSet oneShotTokenReuse(
       mlir::Region &region, ValueSet availableTokens,
       llvm::SmallVectorImpl<Reuse> &reuses, llvm::SmallVectorImpl<Free> &frees,
@@ -317,71 +477,42 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
 
         auto allocOp = llvm::dyn_cast_if_present<ReussirTokenAllocOp>(
             acceptor.getToken().getDefiningOp());
-        if (allocOp && allocOp.getToken().hasOneUse()) {
-          int bestScore = -1;
-          mlir::Value bestToken{};
-          bool bestRealloc = false;
+        auto preAssigned = phaseOneAssignments.find(acceptor.getOperation());
+        if (allocOp && allocOp.getToken().hasOneUse() &&
+            preAssigned != phaseOneAssignments.end() &&
+            mode == MatchMode::Full) {
+          // Replay a phase-one pair: consume the reserved token along this
+          // path (the reuse itself was already recorded by phase one).
+          availableTokens = availableTokens.erase(preAssigned->second);
+        } else if (allocOp && allocOp.getToken().hasOneUse() &&
+                   preAssigned == phaseOneAssignments.end()) {
+          Candidate best =
+              pickBest(availableTokens, acceptor, aliasAnalyzer, dfsOrder,
+                       mode, /*exclude=*/{});
 
-          for (auto tokenVal : availableTokens) {
-            if (auto producer =
-                    dyn_cast_or_null<TokenProducer>(tokenVal.getDefiningOp())) {
-              ReussirRcDecOp producerAsDec =
-                  dyn_cast<ReussirRcDecOp>(producer.getOperation());
-              mlir::TypedValue<RcType> producerRc =
-                  producerAsDec ? producerAsDec.getRcPtr() : nullptr;
-              int score = hueristic(producer.getTokenType(), producerRc,
-                                    acceptor, aliasAnalyzer);
-              if (score >= 0 && (score > bestScore ||
-                                 (score == bestScore && bestToken &&
-                                  getDfsOrder(dfsOrder, tokenVal) >
-                                      getDfsOrder(dfsOrder, bestToken)))) {
-                bestScore = score;
-                bestToken = tokenVal;
-                bestRealloc = (score == 0);
-              }
-            }
-            if (auto scfIf = dyn_cast_or_null<mlir::scf::IfOp>(
-                    tokenVal.getDefiningOp())) {
-              if (scfIf->hasAttr(kExpandedDecrementAttr)) {
-                auto nullableType =
-                    dyn_cast<NullableType>(scfIf.getResult(0).getType());
-                if (!nullableType)
-                  continue;
-                auto producedType =
-                    dyn_cast<TokenType>(nullableType.getPtrTy());
-                if (!producedType)
-                  continue;
-                mlir::Value condition = scfIf.getCondition();
-                auto expectOp = dyn_cast_or_null<ReussirExpectOp>(
-                    condition.getDefiningOp());
-                if (!expectOp)
-                  continue;
-                auto cmp = dyn_cast_or_null<mlir::arith::CmpIOp>(
-                    expectOp.getCondition().getDefiningOp());
-                if (!cmp)
-                  continue;
-                auto rcFetch = llvm::dyn_cast_if_present<ReussirRcFetchOp>(
-                    cmp.getLhs().getDefiningOp());
-                mlir::TypedValue<RcType> producerRc =
-                    rcFetch ? rcFetch.getRcPtr() : nullptr;
-                int score = hueristic(producedType, producerRc, acceptor,
-                                      aliasAnalyzer);
-                if (score >= 0 && (score > bestScore ||
-                                   (score == bestScore && bestToken &&
-                                    getDfsOrder(dfsOrder, tokenVal) >
-                                        getDfsOrder(dfsOrder, bestToken)))) {
-                  bestScore = score;
-                  bestToken = tokenVal;
-                  bestRealloc = (score == 0);
-                }
-              }
-            }
+          // Lookahead bias: giving this token to a cross-domain consumer
+          // starves any same-domain consumer further down the block, and a
+          // same-domain reuse is strictly better (in-place update, no
+          // realloc, hot cache line). Skip the assignment once and reselect
+          // without the token; the downstream consumer picks it up when the
+          // walk reaches it.
+          if (best.token && !best.sameDomain &&
+              biasKind == DomainBias::Lookahead) {
+            mlir::Type tokenDomain;
+            if (auto produced = describeToken(best.token))
+              tokenDomain = producerDomain(*produced);
+            if (tokenDomain && blockHasLaterSameDomainConsumer(&op, tokenDomain))
+              best = pickBest(availableTokens, acceptor, aliasAnalyzer,
+                              dfsOrder, mode, /*exclude=*/best.token);
           }
 
-          if (bestToken) {
-            mlir::Value selectedToken = bestToken;
-            availableTokens = availableTokens.erase(bestToken);
-            reuses.push_back({selectedToken, bestRealloc, acceptor});
+          if (best.token) {
+            availableTokens = availableTokens.erase(best.token);
+            reuses.push_back({best.token, best.realloc, acceptor});
+            if (mode == MatchMode::DomainOnly) {
+              phaseOneAssignments[acceptor.getOperation()] = best.token;
+              reservedTokens.insert(best.token);
+            }
           }
         }
         // ReussirClosureCreateOp is a kind of acceptor.
@@ -413,6 +544,20 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
   }
 
   void runOnOperation() override {
+    if (domainBias != "none" && domainBias != "lookahead" &&
+        domainBias != "two-phase") {
+      getOperation()->emitError()
+          << "invalid domain-bias '" << domainBias
+          << "'; expected 'none', 'lookahead' or 'two-phase'";
+      return signalPassFailure();
+    }
+    biasKind = domainBias == "lookahead"    ? DomainBias::Lookahead
+               : domainBias == "two-phase" ? DomainBias::TwoPhase
+                                           : DomainBias::None;
+    mode = MatchMode::Full;
+    phaseOneAssignments.clear();
+    reservedTokens.clear();
+
     llvm::SmallVector<Reuse> reuses;
     llvm::SmallVector<Free> frees;
     mlir::AliasAnalysis aliasAnalyzer(getOperation());
@@ -424,6 +569,21 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
     unsigned counter = 0;
     getOperation()->walk<mlir::WalkOrder::PreOrder>(
         [&](mlir::Operation *op) { dfsOrder[op] = counter++; });
+
+    // Two-phase bias: a first walk forms only same-domain pairs — the
+    // matches worth protecting — so a cross-domain consumer earlier in
+    // program order can no longer starve a same-domain consumer behind it.
+    // The second (normal) walk matches what remains around the fixed pairs;
+    // the first walk's frees are discarded, the fallback walk re-derives
+    // the full free set with phase-one consumptions out of availability.
+    if (biasKind == DomainBias::TwoPhase) {
+      mode = MatchMode::DomainOnly;
+      llvm::SmallVector<Free> discardedFrees;
+      for (auto &region : getOperation()->getRegions())
+        oneShotTokenReuse(region, {}, reuses, discardedFrees, aliasAnalyzer,
+                          domInfo, dfsOrder);
+      mode = MatchMode::Full;
+    }
 
     for (auto &region : getOperation()->getRegions()) {
       oneShotTokenReuse(region, {}, reuses, frees, aliasAnalyzer, domInfo,

--- a/tests/integration/conversion/token_reuse_domain_bias.mlir
+++ b/tests/integration/conversion/token_reuse_domain_bias.mlir
@@ -1,0 +1,40 @@
+// RUN: %reussir-opt %s -reussir-token-reuse | %FileCheck %s --check-prefix=NONE
+// RUN: %reussir-opt %s -reussir-token-reuse="domain-bias=two-phase" | \
+// RUN:   %FileCheck %s --check-prefix=DOMAIN
+
+// Two records with identical layout ("A" and "B") produce identical token
+// types, so a dead "A" box is a *perfect-size* candidate for a "B" create.
+// Without a domain bias, the greedy in-order matcher hands the token to the
+// first consumer — the cross-domain "B" — starving the same-domain "A"
+// consumer right behind it. The two-phase bias forms same-domain pairs first,
+// so the "A" box is recycled into the new "A" and the "B" allocates fresh.
+
+!recA = !reussir.record<compound "A" {i64, i64}>
+!recB = !reussir.record<compound "B" {i64, i64}>
+!rcA = !reussir.rc<!recA>
+!rcB = !reussir.rc<!recB>
+!tk = !reussir.token<align: 8, size: 24>
+
+module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-i64:64-n8:16:32:64-S128"} {
+    // NONE-LABEL: func.func @bias
+    // NONE: %[[T:.+]] = reussir.token.ensure
+    // NONE-NEXT: reussir.rc.create value(%{{.+}} : !reussir.record<compound "B"
+    // NONE-SAME: token(%[[T]]
+    // NONE: reussir.token.alloc
+    // NONE-NEXT: reussir.rc.create value(%{{.+}} : !reussir.record<compound "A"
+
+    // DOMAIN-LABEL: func.func @bias
+    // DOMAIN: reussir.token.alloc
+    // DOMAIN-NEXT: reussir.rc.create value(%{{.+}} : !reussir.record<compound "B"
+    // DOMAIN: %[[T:.+]] = reussir.token.ensure
+    // DOMAIN-NEXT: reussir.rc.create value(%{{.+}} : !reussir.record<compound "A"
+    // DOMAIN-SAME: token(%[[T]]
+    func.func @bias(%dead: !rcA, %va: !recA, %vb: !recB) -> (!rcB, !rcA) {
+        %t = reussir.rc.dec (%dead : !rcA) : !reussir.nullable<!tk>
+        %tkb = reussir.token.alloc : !tk
+        %b = reussir.rc.create value(%vb : !recB) token(%tkb : !tk) : !rcB
+        %tka = reussir.token.alloc : !tk
+        %a = reussir.rc.create value(%va : !recA) token(%tka : !tk) : !rcA
+        return %b, %a : !rcB, !rcA
+    }
+}


### PR DESCRIPTION
Evaluates the two P7 candidate strategies from #325 head-to-head, lands both behind `reussir-token-reuse{domain-bias=none|lookahead|two-phase}` (default `none` = bit-identical to today), and records the verdict.

## The two strategies

**`lookahead`** (skip a cross-domain assignment once when a later same-domain consumer in the block would take the token): structurally ineffective in our IR — it changes **zero bytes** of output on all three benchmarks. After SCF lowering, the competing consumers sit in *sibling match-arm regions*, not later in the same block, and the scan must stop at region-bearing ops since tokens flow into nested regions and are consumed conditionally. Extending its reach means simulating the region walk — i.e., reimplementing two-phase.

**`two-phase`** (domain-only matching walk first, fallback walk second): the sound mechanism. Two implementation subtleties matter:
- consumption must be **path-local** — sibling `scf.if` arms are mutually exclusive and each may reuse the same token, so phase one records `(acceptor → token)` pairs and the fallback walk *replays* the erase at each acceptor rather than filtering globally. The naive global consumed-set starved every sibling arm: rbtree-zipper exploded to 2.9 s / **8.1 GB** RSS;
- phase-one tokens are excluded from fallback matching (`reservedTokens`) so an earlier consumer cannot double-consume a token reserved for a downstream same-domain pair.

## Measurements (xLTO + static mimalloc, n = 4.2 M, sequential)

| config | none | lookahead | two-phase |
|---|---|---|---|
| nbe-hoas +rac | 0.235 s | = none (never fires) | 0.24 s |
| nbe-hoas −rac | 0.235 s | = | 0.235 s |
| rbtree +rac | 0.49 s | = | 0.49 s |
| rbtree-zipper +rac | 0.42 s | = | **1.01 s (−2.4×)** |

## Verdict

1. Between the two: **two-phase** is the right mechanism (lookahead cannot see across regions at all).
2. But **neither should be on by default**: two-phase is noise-level where it was supposed to help and a 2.4× regression on zipper — whose optimization *is* cross-domain recycling (dead `Tree` boxes rebuilt as same-sized `Zipper` boxes and back). Same-nominal-type-first is the wrong global priority when same-size cross-type reuse is legitimate and intended.
3. The motivating symptom is gone: the nbe rac/nrac flip (438 ms vs 321 ms at #325 filing) no longer reproduces — 10-run medians are 0.235 s vs 0.235 s on current main. #328 (inliner) and #330 (cctx TRMC) reshaped the token landscape. nbe+rac also no longer overflows the default stack at this workload (the P8 symptom).

So the default stays `none`; the option preserves the experiment for when a program with a genuine domain-starvation profile shows up, and the `describeToken`/`pickBest` refactor stands on its own. A lit test pins both semantics on a minimal two-domain case. Full lit suite (270) + unit suites pass.

Suggested follow-up for #325: re-scope P7 to "re-validate on a workload that still exhibits domain starvation; consider defaulting `--reuse-across-call` on instead, since rac is now ≥ nrac on all three benchmarks" (P8's executing-lit-test gate still applies before flipping that default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2