### PR TITLE
[frontend] lift named functions to closures (value use + partial application)

### DIFF
--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -285,6 +285,46 @@ fn runs_a_closure_with_a_captured_value() {
 }
 
 #[test]
+fn runs_a_lifted_named_function() {
+    // A bare `fn` name used where a closure is expected lifts to a closure that
+    // forwards to the function (`|x| double(x)`). It evaluates like any other
+    // closure value, so the arithmetic comes back exact.
+    let src = r#"
+        fn double(x: i64) -> i64 { x * 2 }
+        fn apply(f: i64 -> i64, x: i64) -> i64 { f(x) }
+        pub fn run(n: i64) -> i64 { apply(double, n) }
+        extern "C" trampoline "run_ffi" = run;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("run_ffi").expect("lookup run_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        assert_eq!(f(21), 42);
+        assert_eq!(f(-5), -10);
+    });
+}
+
+#[test]
+fn runs_a_partially_applied_named_function() {
+    // Calling a two-parameter function with one argument lifts it and partially
+    // applies: `add(5)` is a residual `i64 -> i64` closure, evaluated later.
+    let src = r#"
+        fn add(a: i64, b: i64) -> i64 { a + b }
+        fn apply(f: i64 -> i64, x: i64) -> i64 { f(x) }
+        pub fn run(n: i64) -> i64 {
+            let add5 = add(5);
+            apply(add5, n)
+        }
+        extern "C" trampoline "run_ffi" = run;
+    "#;
+    jit_run(src, |jit| {
+        let a = jit.lookup("run_ffi").expect("lookup run_ffi");
+        let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(a as usize) };
+        assert_eq!(f(37), 42);
+        assert_eq!(f(-5), 0);
+    });
+}
+
+#[test]
 fn runs_a_closure_capturing_a_shared_record() {
     // The captured value is a heap-allocated `[shared]` record, so the closure
     // box holds an `rc` pointer in its payload. Evaluating the closure hands the

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1107,6 +1107,71 @@ mod tests {
         assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
     }
 
+    // ----- named-function lifting (a `fn` used as a closure value) -----
+
+    #[test]
+    fn lifts_a_named_function_used_as_a_value() {
+        // A bare `fn` name in argument position lifts to a closure of the
+        // function's type, matching the expected `i32 -> i32` parameter.
+        check(
+            "fn double(x: i32) -> i32 { x * 2 }\n\
+             fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }\n\
+             pub fn run() -> i32 { apply(double, 21) }",
+            |elab, _| {
+                assert!(!elab.has_errors(), "{:#?}", elab.reports);
+                // The lifted argument is a `Closure`, not a bare reference.
+                use crate::semi::hir::ExprKind;
+                let run = elab
+                    .elaborated
+                    .iter()
+                    .find(|f| elab.resolver.resolve(f.name) == "run")
+                    .expect("run is elaborated");
+                let ExprKind::FuncCall { args, .. } = &run.body.as_ref().unwrap().kind else {
+                    panic!("run body is a call to apply");
+                };
+                assert!(
+                    matches!(args[0].kind, ExprKind::Closure(_)),
+                    "the `double` argument lifted to a closure, got {:#?}",
+                    args[0].kind
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn partially_applies_a_named_function() {
+        // Calling a two-parameter `fn` with one argument lifts it and applies
+        // the argument, yielding a residual `i32 -> i32` closure.
+        let src = "fn add(a: i32, b: i32) -> i32 { a + b }\n\
+                   fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }\n\
+                   pub fn run() -> i32 { let g = add(5); apply(g, 37) }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn lifts_a_generic_function_at_the_expected_type() {
+        // Lifting an unapplied generic `fn` leaves holes for its type parameters;
+        // the expected closure type (`i32 -> i32`) then solves them.
+        let src = "fn id<T>(x: T) -> T { x }\n\
+                   fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }\n\
+                   pub fn run() -> i32 { apply(id, 42) }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn rejects_regional_function_as_a_closure_value() {
+        // A regional function takes an implicit region handle, so it has no
+        // plain closure type to lift to.
+        let src = "regional fn helper(x: i32) -> i32 { x }\n\
+                   fn apply(f: i32 -> i32, x: i32) -> i32 { f(x) }\n\
+                   pub fn run() -> i32 { apply(helper, 1) }";
+        assert!(
+            has_error(src, "regional function as a closure value"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
     // ----- collect-trampoline-roots -----
 
     #[test]

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -7,7 +7,7 @@ use crate::semi::traits::{Obligation, TraitId, TraitRef};
 use crate::semi::ty::{DefId, Flexivity, GenericId, Ty, TyKind};
 use crate::surface::{self, BinOp, Const, Span, UnaryOp};
 
-use super::ctxt::{Elaborator, RecordFields};
+use super::ctxt::{Elaborator, FuncProto, RecordFields};
 use super::fulfill::{collect_holes, ty_has_hole};
 use super::hir::{ArithOp, ClosureExpr, CmpOp, Expr, ExprKind, Function, VarId};
 
@@ -248,6 +248,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.record_use(path.basename);
                 return self.mk_expr(ExprKind::Var(id), ty, span);
             }
+            // A bare name that is not a local may be a `fn` used as a value:
+            // lift it to a closure. A local binding shadows a same-named
+            // function (checked first above), matching `infer_func_call`.
+            if let Some(def) = self.resolve_function_ref(path) {
+                self.record_use(path.basename);
+                let proto = self.functions[&def].clone();
+                let inst = self.instantiate(&proto.generics, &[], span);
+                return self.lift_function(def, &proto, &inst, span);
+            }
             let hint = self.variable_suggestion(path.basename);
             self.error(
                 span,
@@ -483,7 +492,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
         let inst = self.instantiate(&proto.generics, &fc.ty_args, span);
 
-        if fc.args.len() != proto.params.len() {
+        // Partial application: fewer arguments than parameters lifts the
+        // function to a closure and applies the supplied arguments, yielding a
+        // residual closure over the rest (`add(5)` : `i32 -> i32`).
+        if fc.args.len() < proto.params.len() {
+            let lifted = self.lift_function(def, &proto, &inst, span);
+            return self.closure_apply(lifted, &fc.args, span);
+        }
+        if fc.args.len() > proto.params.len() {
             self.error(
                 span,
                 format!(
@@ -579,6 +595,65 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 args: out,
             },
             result,
+            span,
+        )
+    }
+
+    /// (LIFT) Reify a named function `def` as a first-class closure value —
+    /// `|p₀,…,pₙ| def(p₀,…,pₙ)` — so a bare `fn` name can appear in value
+    /// position and a `fn` can be partially applied. A top-level function
+    /// closes over nothing, so the closure has no captures; its parameter and
+    /// return types come from the prototype instantiated at `inst` (holes for
+    /// an unapplied generic, which the surrounding context then solves). This
+    /// reuses the ordinary closure path, so ownership and codegen need no
+    /// special case.
+    fn lift_function(
+        &mut self,
+        def: DefId,
+        proto: &FuncProto<'tcx>,
+        inst: &Instantiation<'tcx>,
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
+        // A regional function takes an implicit region handle, so it has no
+        // plain closure type to lift to.
+        if proto.is_regional {
+            self.error(span, "cannot use a regional function as a closure value");
+            return self.poison(span);
+        }
+        // One fresh parameter per function parameter, at the instantiated type;
+        // the body forwards them to a direct call. The params are scoped to the
+        // synthesized body alone (mark/restore), never the enclosing block.
+        let mark = self.vars.mark();
+        let mut params = Vec::with_capacity(proto.params.len());
+        let mut args = Vec::with_capacity(proto.params.len());
+        for (name, pty) in &proto.params {
+            let ty = self.infer.instantiate_ty(*pty, inst);
+            let var = self.vars.fresh(*name, ty, span);
+            params.push((var, ty));
+            args.push(self.mk_expr(ExprKind::Var(var), ty, span));
+        }
+        self.vars.restore(mark);
+        let ty_args = self.inst_args(&proto.generics, inst);
+        let ret = self.infer.instantiate_ty(proto.return_ty, inst);
+        let body = self.mk_expr(
+            ExprKind::FuncCall {
+                target: def,
+                ty_args,
+                args,
+                regional: false,
+            },
+            ret,
+            span,
+        );
+        let param_tys: Vec<Ty<'tcx>> = params.iter().map(|(_, t)| *t).collect();
+        let ty = self.tcx.mk_closure(&param_tys, ret);
+        self.mk_expr(
+            ExprKind::Closure(ClosureExpr {
+                captures: Vec::new(),
+                params,
+                body: Box::new(body),
+            }),
+            ty,
             span,
         )
     }

--- a/tests/integration/frontend/fn_lift.rr
+++ b/tests/integration/frontend/fn_lift.rr
@@ -1,8 +1,6 @@
 // Function-to-closure lifting: a bare named function used where a closure is
-// expected, and partial application of a named function. rrc's frontend does
-// not implement this yet (only explicit `|x| …` closures), so this is expected
-// to fail until it does. Tracked for PR1; drop the XFAIL once rrc lifts.
-// XFAIL: *
+// expected (as an argument or struct field), and partial application of a
+// named function — both desugar to a closure that forwards to the function.
 // RUN: %rrc %s -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/fn_lift.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe


### PR DESCRIPTION
PR1 of the Haskell retirement. Implements function-to-closure lifting in rrc's frontend, flipping `fn_lift.rr` from the XFAIL added in #332 to a passing e2e test.

## Problem
rrc only accepted explicit `|x| …` closures. A bare `fn` name used as a value, or a `fn` applied to fewer args than it takes, errored:
```
Error: unknown variable `double`
Error: `add` expects 2 argument(s), got 1
Error: type mismatch: expected `i32 -> i32`, found `i32`
```

## Approach — desugar to a closure that forwards to the function
- **`lift_function`** reifies a named function `def` as `|p₀,…,pₙ| def(p₀,…,pₙ)` — a capture-free closure at the function's (instantiated) param/return types. Reuses the ordinary closure path, so **ownership and codegen need no special case**.
- **`infer_var`**: a bare name that isn't a local but resolves to a function lifts to that closure (a local binding still shadows it).
- **`infer_func_call`**: fewer args than params lifts + closure-applies → residual closure (`add(5)` : `i32 -> i32`). Exact arity stays a direct `FuncCall`; over-application is still an error.
- Regional functions (implicit region handle) have no plain closure type → diagnostic.
- **Generics** lift too: an unapplied generic leaves inference holes the context solves (`apply(id, 42)` fixes `T` to `i32`).

## Tests
- Elaboration unit tests (semi.rs): value use, partial application, generic lift at the expected type, regional rejection.
- JIT e2e tests (frontend_e2e.rs): run a lifted call and a partial application.
- `frontend/fn_lift.rr` XFAIL dropped — passes under rrc (covers struct-field lift + generic lift/partial e2e).

## Validation
- `cargo test -p reussir-core -p reussir-codegen` — 235 core (+4), 21 JIT (+2), all pass.
- `ninja -C build check` — 286/286 (fn_lift now PASS).

## Next
**PR2 — the nuke:** delete the Haskell frontend (incl. `reussir-lsp`), the `reussir-vscode` module, clean up the Haskell build targets/paths in CMake (keeping the lit/CMake test infra), and migrate CI/CD to the Rust-only toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)