### PR TITLE
[backend] token reuse: escape member tokens trapped in expanded decrements

### DIFF
--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -737,14 +737,25 @@ struct ReussirTokenEnsureOpRewritePattern
       if (auto scfIf = mlir::dyn_cast_if_present<mlir::scf::IfOp>(
               op.getNullableToken().getDefiningOp()))
         if (scfIf->getAttr(kExpandedDecrementAttr)) {
+          // Trace the *matching result* of the expanded decrement — an
+          // escaped nested token rides along as an extra result, and
+          // rebuilding it from result 0's box would alias two creates onto
+          // one allocation. When the traced operand is not a direct
+          // reinterpret (e.g. it is a nested decrement's result), keep the
+          // dispatched payload argument, which is always correct.
+          unsigned resultIndex =
+              llvm::cast<mlir::OpResult>(op.getNullableToken())
+                  .getResultNumber();
           auto thenYieldOp = mlir::dyn_cast_if_present<mlir::scf::YieldOp>(
               scfIf.getThenRegion().back().getTerminator());
           auto nullCreateOp =
               mlir::dyn_cast_if_present<reussir::ReussirNullableCreateOp>(
-                  thenYieldOp->getOperands()[0].getDefiningOp());
+                  thenYieldOp->getOperands()[resultIndex].getDefiningOp());
           auto reinterpretOp =
-              mlir::dyn_cast_if_present<reussir::ReussirRcReinterpretOp>(
-                  nullCreateOp.getPtr().getDefiningOp());
+              nullCreateOp
+                  ? mlir::dyn_cast_if_present<reussir::ReussirRcReinterpretOp>(
+                        nullCreateOp.getPtr().getDefiningOp())
+                  : nullptr;
           // it is safe since RC must dominate this path
           if (reinterpretOp)
             tokenSrc = reussir::ReussirRcReinterpretOp::create(rewriter, 

--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -228,6 +228,126 @@ getDfsOrder(const mlir::DenseMap<mlir::Operation *, unsigned> &dfsOrder,
   return 0;
 }
 
+// A member decrement expands *inside* its owner's expanded decrement: the
+// owner's unique branch releases its fields, so a pattern-destructured child
+// box dies — and yields its reuse token — two regions deep. That token's SSA
+// value cannot be named after the owner's join, so the matcher can only free
+// it, while a same-shaped create right below the join allocates fresh
+// memory. Escape such tokens by widening the enclosing expanded decrement:
+// the region holding the trapped producer yields the token through an extra
+// result, every sibling region yields a null nullable, and the token becomes
+// matchable at the owner's level. Iterating to a fixed point bubbles tokens
+// out of arbitrarily deep member chains one join at a time.
+bool isEscapableTokenResult(mlir::OpResult result) {
+  if (!result.use_empty())
+    return false;
+  auto nullableType = mlir::dyn_cast<NullableType>(result.getType());
+  return nullableType && mlir::isa<TokenType>(nullableType.getPtrTy());
+}
+
+// The rc value an expanded decrement's token result came from. Result 0 is
+// the decrement's own box (recoverable from its refcount condition); an
+// escaped result traces through the home region's yield to the trapped
+// producer it was widened from. Null when the chain is unrecognizable —
+// scoring then works on the token type alone.
+mlir::TypedValue<RcType> expandedDecProducerRc(mlir::scf::IfOp scfIf,
+                                               unsigned resultIndex) {
+  if (resultIndex == 0) {
+    auto expectOp = dyn_cast_or_null<ReussirExpectOp>(
+        scfIf.getCondition().getDefiningOp());
+    if (!expectOp)
+      return nullptr;
+    auto cmp = dyn_cast_or_null<mlir::arith::CmpIOp>(
+        expectOp.getCondition().getDefiningOp());
+    if (!cmp)
+      return nullptr;
+    auto rcFetch = llvm::dyn_cast_if_present<ReussirRcFetchOp>(
+        cmp.getLhs().getDefiningOp());
+    return rcFetch ? rcFetch.getRcPtr() : nullptr;
+  }
+  for (mlir::Region &region : scfIf->getRegions()) {
+    if (region.empty())
+      continue;
+    mlir::Value yielded =
+        region.front().getTerminator()->getOperand(resultIndex);
+    auto inner =
+        dyn_cast_or_null<mlir::scf::IfOp>(yielded.getDefiningOp());
+    if (inner && inner->hasAttr(kExpandedDecrementAttr))
+      return expandedDecProducerRc(
+          inner, llvm::cast<mlir::OpResult>(yielded).getResultNumber());
+  }
+  return nullptr;
+}
+
+bool escapeTrappedTokensOnce(mlir::func::FuncOp func) {
+  llvm::SmallVector<mlir::scf::IfOp> worklist;
+  func.walk([&](mlir::scf::IfOp op) {
+    if (op->hasAttr(kExpandedDecrementAttr))
+      worklist.push_back(op);
+  });
+  for (mlir::scf::IfOp outer : worklist) {
+    // Trapped producers: expanded decrements sitting directly in one of the
+    // outer decrement's blocks, with unconsumed token results.
+    llvm::SmallVector<mlir::Value> escaped;
+    mlir::Block *homeBlock = nullptr;
+    for (mlir::Region &region : outer->getRegions()) {
+      for (mlir::Operation &op : region.front()) {
+        auto inner = llvm::dyn_cast<mlir::scf::IfOp>(op);
+        if (!inner || !inner->hasAttr(kExpandedDecrementAttr))
+          continue;
+        for (mlir::OpResult result : inner.getResults())
+          if (isEscapableTokenResult(result)) {
+            if (homeBlock && homeBlock != &region.front())
+              continue; // one home region per widening round; rare
+            homeBlock = &region.front();
+            escaped.push_back(result);
+          }
+      }
+    }
+    if (escaped.empty())
+      continue;
+
+    mlir::OpBuilder builder(outer);
+    llvm::SmallVector<mlir::Type> resultTypes(outer.getResultTypes().begin(),
+                                              outer.getResultTypes().end());
+    for (mlir::Value token : escaped)
+      resultTypes.push_back(token.getType());
+    auto widened = mlir::scf::IfOp::create(
+        builder, outer.getLoc(), resultTypes, outer.getCondition(),
+        /*addThenRegion=*/true, /*addElseRegion=*/true);
+    widened->setAttrs(outer->getAttrs());
+    widened.getThenRegion().takeBody(outer.getThenRegion());
+    widened.getElseRegion().takeBody(outer.getElseRegion());
+
+    for (mlir::Region &region : widened->getRegions()) {
+      mlir::Operation *yield = region.front().getTerminator();
+      llvm::SmallVector<mlir::Value> operands(yield->getOperands());
+      if (&region.front() == homeBlock) {
+        operands.append(escaped.begin(), escaped.end());
+      } else {
+        builder.setInsertionPoint(yield);
+        for (mlir::Value token : escaped)
+          operands.push_back(ReussirNullableCreateOp::create(
+              builder, outer.getLoc(), token.getType(), nullptr));
+      }
+      builder.setInsertionPoint(yield);
+      mlir::scf::YieldOp::create(builder, yield->getLoc(), operands);
+      yield->erase();
+    }
+
+    for (auto [index, oldResult] : llvm::enumerate(outer.getResults()))
+      oldResult.replaceAllUsesWith(widened.getResult(index));
+    outer.erase();
+    return true;
+  }
+  return false;
+}
+
+void escapeTrappedTokens(mlir::func::FuncOp func) {
+  while (escapeTrappedTokensOnce(func)) {
+  }
+}
+
 struct Reuse {
   mlir::Value token;
   bool realloc;
@@ -295,8 +415,10 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
           availableTokens = intersection;
         }
         if (auto scfIf = dyn_cast<mlir::scf::IfOp>(op))
-          if (scfIf->hasAttr(kExpandedDecrementAttr) && scfIf->use_empty())
-            availableTokens = availableTokens.insert(scfIf.getResult(0));
+          if (scfIf->hasAttr(kExpandedDecrementAttr))
+            for (mlir::OpResult result : scfIf.getResults())
+              if (isEscapableTokenResult(result))
+                availableTokens = availableTokens.insert(result);
       }
 
       if (auto producer = dyn_cast<TokenProducer>(op)) {
@@ -343,27 +465,17 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
             if (auto scfIf = dyn_cast_or_null<mlir::scf::IfOp>(
                     tokenVal.getDefiningOp())) {
               if (scfIf->hasAttr(kExpandedDecrementAttr)) {
-                auto nullableType =
-                    dyn_cast<NullableType>(scfIf.getResult(0).getType());
+                auto nullableType = dyn_cast<NullableType>(tokenVal.getType());
                 if (!nullableType)
                   continue;
                 auto producedType =
                     dyn_cast<TokenType>(nullableType.getPtrTy());
                 if (!producedType)
                   continue;
-                mlir::Value condition = scfIf.getCondition();
-                auto expectOp = dyn_cast_or_null<ReussirExpectOp>(
-                    condition.getDefiningOp());
-                if (!expectOp)
-                  continue;
-                auto cmp = dyn_cast_or_null<mlir::arith::CmpIOp>(
-                    expectOp.getCondition().getDefiningOp());
-                if (!cmp)
-                  continue;
-                auto rcFetch = llvm::dyn_cast_if_present<ReussirRcFetchOp>(
-                    cmp.getLhs().getDefiningOp());
                 mlir::TypedValue<RcType> producerRc =
-                    rcFetch ? rcFetch.getRcPtr() : nullptr;
+                    expandedDecProducerRc(scfIf, llvm::cast<mlir::OpResult>(
+                                                     tokenVal)
+                                                     .getResultNumber());
                 int score = hueristic(producedType, producerRc, acceptor,
                                       aliasAnalyzer);
                 if (score >= 0 && (score > bestScore ||
@@ -413,6 +525,8 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
   }
 
   void runOnOperation() override {
+    escapeTrappedTokens(getOperation());
+
     llvm::SmallVector<Reuse> reuses;
     llvm::SmallVector<Free> frees;
     mlir::AliasAnalysis aliasAnalyzer(getOperation());
@@ -468,10 +582,12 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
           free.token.use_empty()) {
         if (!sunkTokens.insert(free.token).second)
           continue; // already sunk via an earlier record of this token
+        unsigned index =
+            llvm::cast<mlir::OpResult>(free.token).getResultNumber();
         mlir::Operation *thenYield =
             scfIf.getThenRegion().back().getTerminator();
         auto nonNull = llvm::dyn_cast_if_present<ReussirNullableCreateOp>(
-            thenYield->getOperand(0).getDefiningOp());
+            thenYield->getOperand(index).getDefiningOp());
         if (nonNull && nonNull.getPtr()) {
           rewriter.setInsertionPoint(thenYield);
           ReussirTokenFreeOp::create(rewriter, thenYield->getLoc(),

--- a/tests/integration/conversion/token_reuse_escape.mlir
+++ b/tests/integration/conversion/token_reuse_escape.mlir
@@ -1,0 +1,71 @@
+// RUN: %reussir-opt %s -reussir-token-reuse | %FileCheck %s
+
+// A member decrement expands *inside* its owner's expanded decrement (the
+// owner's unique branch releases its fields), so the member's reuse token is
+// born one region deep and — by SSA dominance — dies at the owner's join,
+// while same-shaped creates right below allocate fresh memory. TokenReuse's
+// escape pre-phase widens the owner: the trapped token rides out through an
+// extra result (null on the shared path) and both dead boxes feed the two
+// creates. No token.alloc survives.
+
+!inner = !reussir.record<compound "pair" {i64, i64}>
+!rcInner = !reussir.rc<!inner>
+!outer = !reussir.record<compound "node" {!inner, i64}>
+!rcOuter = !reussir.rc<!outer>
+!tk = !reussir.token<align: 8, size: 24>
+
+module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-i64:64-n8:16:32:64-S128"} {
+    // CHECK-LABEL: func.func @escape
+    // The owner's expanded decrement is widened with the escaped member
+    // token; the shared path yields null for it.
+    // CHECK: %[[TOKS:.+]]:2 = scf.if %{{.+}} -> (!reussir.nullable<!reussir.token<align : 8, size : 24>>, !reussir.nullable<!reussir.token<align : 8, size : 24>>)
+    // CHECK: scf.yield %{{.+}}, %{{.+}} :
+    // CHECK: } else {
+    // CHECK: scf.yield %{{.+}}, %{{.+}} :
+    // CHECK: } {reussir.expanded_decrement}
+    // Both creates reuse: one token each, no fresh allocation.
+    // CHECK: reussir.token.ensure
+    // CHECK-NEXT: reussir.rc.create
+    // CHECK: reussir.token.ensure
+    // CHECK-NEXT: reussir.rc.create
+    // CHECK-NOT: reussir.token.alloc
+    func.func @escape(%o: !rcOuter, %va: !inner, %vb: !inner) -> (!rcInner, !rcInner) {
+        %prev = reussir.rc.fetch (%o : !rcOuter) : index
+        %c1 = arith.constant 1 : index
+        %isOne = arith.cmpi eq, %prev, %c1 : index
+        %unique = reussir.expect (%isOne : i1, true) : i1
+        %t = scf.if %unique -> (!reussir.nullable<!tk>) {
+            // unique: release the member (its own expanded decrement — the
+            // trapped producer), then take the owner's box.
+            %ref = reussir.rc.borrow (%o : !rcOuter) : !reussir.ref<!outer>
+            %slot = reussir.ref.project (%ref : !reussir.ref<!outer>) [0] : !reussir.ref<!rcInner>
+            %m = reussir.ref.load (%slot : !reussir.ref<!rcInner>) : !rcInner
+            %mprev = reussir.rc.fetch (%m : !rcInner) : index
+            %misOne = arith.cmpi eq, %mprev, %c1 : index
+            %munique = reussir.expect (%misOne : i1, true) : i1
+            %mt = scf.if %munique -> (!reussir.nullable<!tk>) {
+                %mtok = reussir.rc.reinterpret (%m : !rcInner) : !tk
+                %mnn = reussir.nullable.create (%mtok : !tk) : !reussir.nullable<!tk>
+                scf.yield %mnn : !reussir.nullable<!tk>
+            } else {
+                %mdec = arith.subi %mprev, %c1 : index
+                reussir.rc.set (%m : !rcInner, %mdec : index)
+                %mnull = reussir.nullable.create : !reussir.nullable<!tk>
+                scf.yield %mnull : !reussir.nullable<!tk>
+            } {reussir.expanded_decrement}
+            %tok = reussir.rc.reinterpret (%o : !rcOuter) : !tk
+            %nn = reussir.nullable.create (%tok : !tk) : !reussir.nullable<!tk>
+            scf.yield %nn : !reussir.nullable<!tk>
+        } else {
+            %dec = arith.subi %prev, %c1 : index
+            reussir.rc.set (%o : !rcOuter, %dec : index)
+            %null = reussir.nullable.create : !reussir.nullable<!tk>
+            scf.yield %null : !reussir.nullable<!tk>
+        } {reussir.expanded_decrement}
+        %tka = reussir.token.alloc : !tk
+        %a = reussir.rc.create value(%va : !inner) token(%tka : !tk) : !rcInner
+        %tkb = reussir.token.alloc : !tk
+        %b = reussir.rc.create value(%vb : !inner) token(%tkb : !tk) : !rcInner
+        return %a, %b : !rcInner, !rcInner
+    }
+}


### PR DESCRIPTION
The concrete outcome of the "token produced from different sources never joins along control flow" discussion: the **degenerate-join escape** (`token | null` through the owner's join — provenance stays singular, so copy avoidance and everything identity-based is untouched), which turns out to be where the entire remaining rbtree allocation excess lived.

## The trap

A pattern-destructured child box dies inside its owner's expanded decrement: the owner's unique branch releases its members, so the member's expanded dec — and its reuse token — sits one region deep. By SSA dominance that token cannot be named after the owner's join; the matcher could only free it, while a same-shaped create right below allocated fresh. On rbtree's rotation arm: three boxes die, three nodes are built, two tokens arrive — **+1 alloc and +1 free per insert** (measured: half of the total 8.4M allocations, with the sunk `token.free` sitting directly above the fresh allocation).

## The escape

A pre-phase in TokenReuse widens any expanded decrement that directly contains another expanded decrement with unconsumed token results: the trapped tokens ride out through extra results, the sibling region yields null, and a fixed point bubbles tokens out of arbitrarily deep member chains one join at a time. Path-by-path semantics are unchanged — wherever the old program had a token the new one has the same token; the shared path stays null and `ensure` falls back to allocation exactly as before.

## Three result-0 assumptions had to die

Widening makes "expanded decrement" a multi-token producer, and three downstream spots hardcoded result 0:

1. the walk's availability insertion (now inserts every unconsumed nullable-token result);
2. the sunk-free rewrite (indexes the then-yield by the freed result's number);
3. **the `token.ensure` lowering's dominance-based rebuild** — it peers through an expanded-dec producer and reconstructs the token as `reinterpret` of *the decrement's own box*. With escaped results, it rebuilt the member token from the owner's box: two creates aliased one allocation and rbtree built a **cyclic tree with a leaked box** — no UAF, invisible to ASan, diagnosed by shrinking to n = 4 (both rotation ensures returned the same pointer) and reading the final phi (`%182/%183` both `%109`). It now traces the matching result and keeps the always-correct dispatched payload when the chain isn't a direct reinterpret.

## Results (aarch64, n = 4.2 M, sequential)

| metric | before | after |
|---|---|---|
| rbtree allocations | 8.40 M (2.0/insert) | **4.20 M (1.0/insert — Koka's count)** |
| rbtree deallocations | 8.40 M | 4.20 M |
| remaining alloc sites | 2 | **1** (the freshly inserted node — irreducible) |
| rbtree wall (xLTO+mimalloc) | 0.49 s | 0.48 s (Koka 0.385 s → gap **1.25×**) |
| rbtree-zipper / nbe-hoas | — | unchanged (0.41 s / 0.225 s) |

The wall-time delta is modest because the inlined mimalloc fast path had already made the redundant alloc/free cheap — but the allocator traffic halving is structural (it compounds with any allocator, shows up in RSS churn, and closes the P5-shaped item in #325 without any token-passing ABI).

New targeted test `token_reuse_escape.mlir` pins the widening + double reuse (`CHECK-NOT: token.alloc`); the full lit suite (270) and all unit suites pass; rbtree/rbtree2/nbe e2e execute and validate (they were the crash reproducers during development).

Follow-ups deliberately not in this PR: the general multi-source phi-join (anonymous-token tier) — no benchmark currently needs it; and the consuming-dispatch fusion architecture (fuse → match → un-fuse sandwich) discussed in #325, which subsumes this mechanism at the op level and additionally elides the unique-path field incs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2