### PR TITLE
[backend] destructuring decrements: fuse pattern-match consumption (dropn_reuse)

### DIFF
--- a/crates/reussir-backend-sys/build.rs
+++ b/crates/reussir-backend-sys/build.rs
@@ -34,6 +34,7 @@ const REUSSIR_ARCHIVES: &[&str] = &[
     "MLIRReussirAttachNativeTarget",
     "MLIRReussirRcCreateSink",
     "MLIRReussirRcCreateFusion",
+    "MLIRReussirRcDispatchFusion",
     "MLIRReussirInferVariantTag",
     "MLIRReussirIncDecCancellation",
     "MLIRReussirTokenReuse",

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -117,6 +117,7 @@ unsafe extern "C" {
     /// false = `tbi` (top-byte tag, aarch64), true = `immortal` (plain dummy
     /// address with an immortal refcount, any target).
     pub fn reussirCreateSpecialPointerTagPass(arch_independent: bool) -> MlirPass;
+    pub fn reussirCreateRcDispatchFusionPass() -> MlirPass;
     pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;
     pub fn reussirCreateCompilePolymorphicFFIPass(optimized: bool) -> MlirPass;

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -207,6 +207,11 @@ pub fn run_lowering_pipeline(
         func:   sys::reussirCreateTokenInstantiationPass();
         module: sys::reussirCreateClosureOutliningPass();
         module: sys::reussirCreateRegionPatternsPass();
+        // Fuse pattern-match consumption into destructuring decrements before
+        // the cancellation pass (which cancels `inc; destructuring dec` into
+        // borrow semantics) and the decrement expansion (which expands the
+        // tagged decs shallowly).
+        func:   sys::reussirCreateRcDispatchFusionPass();
         func:   sys::reussirCreateIncDecCancellationPass();
         module: sys::reussirCreateRcDecrementExpansionPass();
         func:   sys::reussirCreateInferVariantTagPass();

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -47,6 +47,7 @@ MlirPass reussirCreateRcCreateSinkPass(void);
 /// `tbi` (top-byte tag, requires hardware top-byte-ignore, aarch64), true =
 /// `immortal` (plain dummy address with an immortal refcount, any target).
 MlirPass reussirCreateSpecialPointerTagPass(bool archIndependent);
+MlirPass reussirCreateRcDispatchFusionPass(void);
 MlirPass reussirCreateRcCreateFusionPass(void);
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void);
 MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized);

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -407,10 +407,25 @@ def ReussirRcDecOp : ReussirRcOp<"dec", [
   }];
 
   let arguments = (
-    ins Arg<ReussirRcType, "Reference to decrement">:$rcPtr
+    ins Arg<ReussirRcType, "Reference to decrement">:$rcPtr,
+    OptionalAttr<IndexAttr>:$destructureTag,
+    OptionalAttr<DenseI64ArrayAttr>:$boundMembers
   );
   let results =
       (outs Res<Optional<ReussirNullableTokenType>, "Nullable token">:$nullableToken);
+
+  let extraClassDeclaration = [{
+    /// Whether this decrement *destructures* its box: a pattern match on the
+    /// variant arm `destructureTag` consumed the box, taking ownership of the
+    /// `boundMembers` (their retain/release pairs were fused away). It
+    /// expands shallowly instead of through the transitive drop glue: on the
+    /// unique path the bound members transfer with the arm (only unbound rc
+    /// members are released) and the box becomes a token; on the shared path
+    /// the bound members are retained and the count drops. Introduced by
+    /// `reussir-rc-dispatch-fusion`; cancelled against a preceding increment
+    /// (bound retains rematerialize) by `reussir-inc-dec-cancellation`.
+    bool isDestructuring() { return getDestructureTagAttr() != nullptr; }
+  }];
 
   let assemblyFormat = [{
     `(` $rcPtr `:` qualified(type($rcPtr)) `)` 

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -66,6 +66,26 @@ def ReussirRcCreateFusionPass
 }
 
 //===----------------------------------------------------------------------===//
+// RcDispatchFusion
+//===----------------------------------------------------------------------===//
+def ReussirRcDispatchFusionPass
+    : Pass<"reussir-rc-dispatch-fusion", "::mlir::func::FuncOp"> {
+  let summary = "fuse pattern-match consumption into destructuring decrements";
+  let description = [{
+    `reussir-rc-dispatch-fusion` recognizes a borrowing `record.dispatch`
+    whose arm retains its bound members and then decrements the scrutinee,
+    erases the bound retains, and tags the decrement with the arm's tag and
+    bound member indices (Koka's `dropn_reuse` shape). The decrement
+    expansion then releases the box *shallowly*: on the unique path bound
+    members transfer with the arm and only unbound rc members are released;
+    on the shared path the bound members are retained. A preceding increment
+    cancels against the destructuring decrement in
+    `reussir-inc-dec-cancellation` by rematerializing the bound retains.
+  }];
+  let dependentDialects = ["::reussir::ReussirDialect"];
+}
+
+//===----------------------------------------------------------------------===//
 // InferVariantTag
 //===----------------------------------------------------------------------===//
 def ReussirInferVariantTagPass

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -42,6 +42,7 @@ set(REUSSIR_BACKEND_ARCHIVES
   # transformations
   MLIRReussirRcCreateSink
   MLIRReussirRcCreateFusion
+  MLIRReussirRcDispatchFusion
   MLIRReussirInferVariantTag
   MLIRReussirIncDecCancellation
   MLIRReussirTokenReuse

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -89,6 +89,9 @@ MlirPass reussirCreateSpecialPointerTagPass(bool archIndependent) {
 MlirPass reussirCreateRcCreateSinkPass(void) {
   return wrapOwned(reussir::createReussirRcCreateSinkPass());
 }
+MlirPass reussirCreateRcDispatchFusionPass(void) {
+  return wrapOwned(reussir::createReussirRcDispatchFusionPass());
+}
 MlirPass reussirCreateRcCreateFusionPass(void) {
   return wrapOwned(reussir::createReussirRcCreateFusionPass());
 }

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -105,7 +105,9 @@ private:
     }
     mlir::Value loaded =
         ReussirRefLoadOp::create(rewriter, op.getLoc(), rcType, op.getRef());
-    ReussirRcDecOp::create(rewriter, op.getLoc(), nullableType, loaded);
+    ReussirRcDecOp::create(rewriter, op.getLoc(), nullableType, loaded,
+                           /*destructureTag=*/mlir::IntegerAttr{},
+                           /*boundMembers=*/mlir::DenseI64ArrayAttr{});
     rewriter.eraseOp(op);
     return mlir::success();
   }
@@ -206,7 +208,9 @@ private:
         retNullableTy = NullableType::get(op.getContext(), tokenType);
       }
       ReussirRcDecOp::create(rewriter, op.getLoc(), retNullableTy,
-                                      nonNullBlock->getArgument(0));
+                                      nonNullBlock->getArgument(0),
+                             /*destructureTag=*/mlir::IntegerAttr{},
+                             /*boundMembers=*/mlir::DenseI64ArrayAttr{});
       ReussirScfYieldOp::create(rewriter, op.getLoc(), nullptr);
     }
     rewriter.eraseOp(op);

--- a/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
+++ b/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
@@ -76,11 +76,55 @@ struct RcDecrementExpansionPattern
         type.getElementType(), Capability::unspecified, type.getAtomicKind());
     TokenType tokenType = llvm::cast<TokenType>(
         llvm::cast<NullableType>(op.getNullableToken().getType()).getPtrTy());
+    // A *destructuring* decrement (see `reussir-rc-dispatch-fusion`) knows
+    // the pattern arm that consumed the box: bound members transfer with the
+    // arm, so the unique path releases only the *unbound* content and the
+    // shared path retains the bound members in place of the fused-away
+    // per-binding retains. Everything else expands through the transitive
+    // drop glue as before.
     {
       rewriter.setInsertionPointToStart(ifOp.thenBlock());
-      mlir::Value ref = ReussirRcBorrowOp::create(rewriter, 
-          op.getLoc(), borrowedRefType, op.getRcPtr());
-      ReussirRefDropOp::create(rewriter, op.getLoc(), ref);
+      if (op.isDestructuring()) {
+        int64_t tag = op.getDestructureTagAttr().getInt();
+        auto recordType = llvm::cast<RecordType>(type.getElementType());
+        auto payload = llvm::cast<RecordType>(recordType.getMembers()[tag]);
+        llvm::SmallDenseSet<int64_t> bound;
+        for (int64_t index : op.getBoundMembersAttr().asArrayRef())
+          bound.insert(index);
+        auto payloadRefType = rewriter.getType<RefType>(
+            payload, Capability::unspecified, type.getAtomicKind());
+        mlir::Value ref = ReussirRcBorrowOp::create(
+            rewriter, op.getLoc(), borrowedRefType, op.getRcPtr());
+        mlir::Value coerced = ReussirRecordCoerceOp::create(
+            rewriter, op.getLoc(), payloadRefType, rewriter.getIndexAttr(tag),
+            ref);
+        for (auto [idx, memberTy, memberIsField] : llvm::enumerate(
+                 payload.getMembers(), payload.getMemberIsField())) {
+          if (bound.contains(static_cast<int64_t>(idx)) || memberIsField)
+            continue;
+          auto projectedTy = getProjectedType(memberTy, memberIsField,
+                                              Capability::unspecified);
+          if (isTriviallyCopyable(projectedTy))
+            continue;
+          // Unbound members release through `ref.drop` — the same route the
+          // transitive glue took. The acquire/drop expansion later turns an
+          // rc slot's drop into a *plain* member decrement, which keeps it
+          // visible to the post-expansion cancellation window (`inc %m`
+          // against the unique-path release moves the retain to the shared
+          // branch); materializing the decrement here would see it expanded
+          // immediately and hide it from that optimization.
+          auto projectedRefTy = rewriter.getType<RefType>(
+              projectedTy, Capability::unspecified, type.getAtomicKind());
+          mlir::Value slot = ReussirRefProjectOp::create(
+              rewriter, op.getLoc(), projectedRefTy, coerced,
+              rewriter.getIndexAttr(idx));
+          ReussirRefDropOp::create(rewriter, op.getLoc(), slot);
+        }
+      } else {
+        mlir::Value ref = ReussirRcBorrowOp::create(rewriter, 
+            op.getLoc(), borrowedRefType, op.getRcPtr());
+        ReussirRefDropOp::create(rewriter, op.getLoc(), ref);
+      }
       mlir::Value token = ReussirRcReinterpretOp::create(rewriter, 
           op.getLoc(), tokenType, op.getRcPtr());
       mlir::Value nonnull = ReussirNullableCreateOp::create(rewriter, 
@@ -94,6 +138,33 @@ struct RcDecrementExpansionPattern
           mlir::arith::ConstantIndexOp::create(rewriter, op.getLoc(), 1));
       ReussirRcSetOp::create(rewriter, op.getLoc(), op.getRcPtr(),
                                       decremented.getResult());
+      if (op.isDestructuring()) {
+        // The shared path keeps the box alive, so the arm's bound members
+        // need their own references — the retains the fusion erased.
+        int64_t tag = op.getDestructureTagAttr().getInt();
+        auto recordType = llvm::cast<RecordType>(type.getElementType());
+        auto payload = llvm::cast<RecordType>(recordType.getMembers()[tag]);
+        auto payloadRefType = rewriter.getType<RefType>(
+            payload, Capability::unspecified, type.getAtomicKind());
+        mlir::Value ref = ReussirRcBorrowOp::create(
+            rewriter, op.getLoc(), borrowedRefType, op.getRcPtr());
+        mlir::Value coerced = ReussirRecordCoerceOp::create(
+            rewriter, op.getLoc(), payloadRefType, rewriter.getIndexAttr(tag),
+            ref);
+        for (int64_t idx : op.getBoundMembersAttr().asArrayRef()) {
+          auto projectedTy = getProjectedType(
+              payload.getMembers()[idx], payload.getMemberIsField()[idx],
+              Capability::unspecified);
+          auto projectedRefTy = rewriter.getType<RefType>(
+              projectedTy, Capability::unspecified, type.getAtomicKind());
+          mlir::Value slot = ReussirRefProjectOp::create(
+              rewriter, op.getLoc(), projectedRefTy, coerced,
+              rewriter.getIndexAttr(idx));
+          mlir::Value member = ReussirRefLoadOp::create(
+              rewriter, op.getLoc(), projectedTy, slot);
+          ReussirRcIncOp::create(rewriter, op.getLoc(), member);
+        }
+      }
       auto null = ReussirNullableCreateOp::create(rewriter, 
           op.getLoc(), op.getNullableToken().getType(), nullptr);
       mlir::scf::YieldOp::create(rewriter, op.getLoc(), null->getResults());

--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -555,8 +555,11 @@ struct ReussirClosureUniqifyOpRewritePattern
     rewriter.setInsertionPointToStart(&scfIfOp.getElseRegion().front());
     auto cloned = reussir::ReussirClosureCloneOp::create(rewriter, 
         op.getLoc(), op.getClosure().getType(), op.getClosure());
-    reussir::ReussirRcDecOp::create(rewriter, op.getLoc(), mlir::Type{},
-                                             op.getClosure());
+    reussir::ReussirRcDecOp::create(rewriter, op.getLoc(),
+                                    /*nullableToken=*/mlir::Type{},
+                                    op.getClosure(),
+                                    /*destructureTag=*/mlir::IntegerAttr{},
+                                    /*boundMembers=*/mlir::DenseI64ArrayAttr{});
     mlir::scf::YieldOp::create(rewriter, op.getLoc(), cloned.getResult());
 
     rewriter.replaceOp(op, scfIfOp);

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -305,6 +305,30 @@ mlir::LogicalResult ReussirRcDecOp::verify() {
   RcType RcType = getRcPtr().getType();
   if (RcType.getCapability() == reussir::Capability::flex)
     return emitOpError("cannot decrease reference count of a flex RC type");
+  if (bool(getDestructureTagAttr()) != bool(getBoundMembersAttr()))
+    return emitOpError(
+        "destructureTag and boundMembers must be set together");
+  if (isDestructuring()) {
+    if (RcType.getAtomicKind() != AtomicKind::normal)
+      return emitOpError("destructuring decrement requires a nonatomic box");
+    if (RcType.isRegional())
+      return emitOpError("destructuring decrement must not be regional");
+    auto recordType = llvm::dyn_cast<RecordType>(RcType.getElementType());
+    if (!recordType || !recordType.isVariant() || !recordType.getComplete())
+      return emitOpError(
+          "destructuring decrement requires a complete variant box");
+    int64_t tag = getDestructureTagAttr().getInt();
+    if (tag < 0 || static_cast<size_t>(tag) >= recordType.getMembers().size())
+      return emitOpError("destructure tag out of range: ") << tag;
+    auto payload =
+        llvm::dyn_cast<RecordType>(recordType.getMembers()[tag]);
+    if (!payload || !payload.getComplete())
+      return emitOpError("destructured arm must have a complete payload");
+    for (int64_t index : getBoundMembersAttr().asArrayRef())
+      if (index < 0 ||
+          static_cast<size_t>(index) >= payload.getMembers().size())
+        return emitOpError("bound member index out of range: ") << index;
+  }
   if (RcType.getCapability() == reussir::Capability::rigid) {
     if (getNullableToken() != nullptr)
       return emitOpError("rigid RC decrement cannot return a token");

--- a/lib/Transformation/CMakeLists.txt
+++ b/lib/Transformation/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(RcCreateSink)
 add_subdirectory(RcCreateFusion)
+add_subdirectory(RcDispatchFusion)
 add_subdirectory(InferVariantTag)
 add_subdirectory(IncDecCancellation)
 add_subdirectory(TokenReuse)
@@ -11,6 +12,7 @@ add_subdirectory(TRMCRecursionAnalysis)
 set(REUSSIR_TRANSFORMATION_AGGREGATE_LIBS
   MLIRReussirRcCreateSink
   MLIRReussirRcCreateFusion
+  MLIRReussirRcDispatchFusion
   MLIRReussirInferVariantTag
   MLIRReussirIncDecCancellation
   MLIRReussirTokenReuse

--- a/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
@@ -11,6 +11,7 @@
 #include "Reussir/Conversion/RcDecrementExpansion.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
+#include "Reussir/IR/ReussirTypes.h"
 
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Dominance.h>
@@ -68,6 +69,132 @@ void eraseOrReplaceDecOp(ReussirRcDecOp decOp) {
   }
 }
 
+// Whether `op` is a structured branch whose regions execute at most once
+// with exactly one region taken, and whose results are all trivial (their
+// validity cannot depend on the released box). Loops are excluded, as is an
+// `scf.if` without an else (its implicit empty path never releases).
+bool isSingleShotTrivialBranch(mlir::Operation *op) {
+  if (llvm::isa<mlir::LoopLikeOpInterface>(op))
+    return false;
+  if (auto ifOp = llvm::dyn_cast<mlir::scf::IfOp>(op)) {
+    if (ifOp.getElseRegion().empty())
+      return false;
+  } else if (!llvm::isa<mlir::scf::IndexSwitchOp, ReussirRecordDispatchOp,
+                        ReussirNullableDispatchOp>(op)) {
+    return false;
+  }
+  return llvm::all_of(op->getResultTypes(), [](mlir::Type type) {
+    return isTriviallyCopyable(type);
+  });
+}
+
+// Collects the release of `rcPtr` on *every* path through `region`: either a
+// direct release at the region's top level, or a nested single-shot branch
+// all of whose paths release. Everything before the release must leave the
+// box's count alone (borrows are fine; anything else touching the pointer,
+// or an opaque op, disqualifies the path).
+bool armReleasesOnAllPaths(mlir::Region &region,
+                           mlir::TypedValue<RcType> rcPtr,
+                           mlir::AliasAnalysis &aliasAnalysis,
+                           llvm::SmallVectorImpl<ReussirRcDecOp> &releases) {
+  if (!region.hasOneBlock())
+    return false;
+  for (mlir::Operation &op : region.front()) {
+    if (auto dec = llvm::dyn_cast<ReussirRcDecOp>(op)) {
+      if (aliasAnalysis.alias(dec.getRcPtr(), rcPtr) ==
+          mlir::AliasResult::MustAlias) {
+        releases.push_back(dec);
+        return true;
+      }
+      if (aliasAnalysis.alias(dec.getRcPtr(), rcPtr) !=
+          mlir::AliasResult::NoAlias)
+        return false;
+      continue;
+    }
+    if (isSingleShotTrivialBranch(&op)) {
+      llvm::SmallVector<ReussirRcDecOp> nested;
+      bool all = op.getNumRegions() > 0;
+      for (mlir::Region &inner : op.getRegions())
+        if (!armReleasesOnAllPaths(inner, rcPtr, aliasAnalysis, nested)) {
+          all = false;
+          break;
+        }
+      if (all) {
+        releases.append(nested.begin(), nested.end());
+        return true;
+      }
+      return false;
+    }
+    if (llvm::is_contained(op.getOperands(), mlir::Value(rcPtr)) &&
+        !llvm::isa<ReussirRcBorrowOp>(op))
+      return false;
+    if (op.getNumRegions() > 0 || llvm::isa<mlir::CallOpInterface>(op))
+      return false;
+  }
+  return false;
+}
+
+// `inc %v` followed by a dispatch over `%v` whose *every* arm releases the
+// box is borrow semantics in disguise: the increment and the arm releases
+// cancel. A destructuring release (see `reussir-rc-dispatch-fusion`)
+// additionally fused away the arm's bound-member retains — on the now
+// certainly-shared path the arm still needs its own references, so they are
+// rematerialized at the release's position. This is what reduces an inlined
+// read-only predicate (rbtree's `is_red`) to pure tag loads.
+bool cancelIntoDispatch(ReussirRcIncOp incOp,
+                        ReussirRecordDispatchOp dispatch,
+                        mlir::AliasAnalysis &aliasAnalysis) {
+  auto borrow = llvm::dyn_cast_if_present<ReussirRcBorrowOp>(
+      dispatch.getVariant().getDefiningOp());
+  if (!borrow || aliasAnalysis.alias(borrow.getRcPtr(), incOp.getRcPtr()) !=
+                     mlir::AliasResult::MustAlias)
+    return false;
+
+  llvm::SmallVector<ReussirRcDecOp> releases;
+  for (mlir::Region &region : dispatch.getRegions())
+    if (!armReleasesOnAllPaths(region, incOp.getRcPtr(), aliasAnalysis,
+                               releases))
+      return false;
+
+  for (ReussirRcDecOp dec : releases) {
+    if (dec.isDestructuring()) {
+      RcType rcType = dec.getRcPtr().getType();
+      auto recordType = llvm::cast<RecordType>(rcType.getElementType());
+      int64_t tag = dec.getDestructureTagAttr().getInt();
+      auto payload = llvm::cast<RecordType>(recordType.getMembers()[tag]);
+      mlir::OpBuilder builder(dec);
+      if (!dec.getBoundMembersAttr().empty()) {
+        auto refType = builder.getType<RefType>(recordType,
+                                                Capability::unspecified,
+                                                rcType.getAtomicKind());
+        auto payloadRefType = builder.getType<RefType>(
+            payload, Capability::unspecified, rcType.getAtomicKind());
+        mlir::Value ref = ReussirRcBorrowOp::create(builder, dec.getLoc(),
+                                                    refType, dec.getRcPtr());
+        mlir::Value coerced = ReussirRecordCoerceOp::create(
+            builder, dec.getLoc(), payloadRefType, builder.getIndexAttr(tag),
+            ref);
+        for (int64_t idx : dec.getBoundMembersAttr().asArrayRef()) {
+          auto projectedTy = getProjectedType(
+              payload.getMembers()[idx], payload.getMemberIsField()[idx],
+              Capability::unspecified);
+          auto projectedRefTy = builder.getType<RefType>(
+              projectedTy, Capability::unspecified, rcType.getAtomicKind());
+          mlir::Value slot = ReussirRefProjectOp::create(
+              builder, dec.getLoc(), projectedRefTy, coerced,
+              builder.getIndexAttr(idx));
+          mlir::Value member = ReussirRefLoadOp::create(
+              builder, dec.getLoc(), projectedTy, slot);
+          ReussirRcIncOp::create(builder, dec.getLoc(), member);
+        }
+      }
+    }
+    eraseOrReplaceDecOp(dec);
+  }
+  incOp.erase();
+  return true;
+}
+
 } // namespace
 
 llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
@@ -113,8 +240,13 @@ llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
       // *not* `CallableOpInterface`, which is the call *target* (`func.func`)
       // and never appears mid-block. A control-flow op with regions is likewise
       // opaque.
-      if (llvm::isa<mlir::CallOpInterface>(next) ||
-          llvm::isa<mlir::RegionBranchOpInterface>(next))
+      if (llvm::isa<mlir::CallOpInterface>(next))
+        break;
+      if (auto dispatch = llvm::dyn_cast<ReussirRecordDispatchOp>(next)) {
+        cancelIntoDispatch(op, dispatch, aliasAnalysis);
+        break;
+      }
+      if (llvm::isa<mlir::RegionBranchOpInterface>(next))
         break;
       // `reussir.ref.drop` releases every rc reachable *through* the referenced
       // value (the first cancellation run precedes acquire/drop expansion, so

--- a/lib/Transformation/RcDispatchFusion/CMakeLists.txt
+++ b/lib/Transformation/RcDispatchFusion/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_library(MLIRReussirRcDispatchFusion
+  RcDispatchFusion.cpp
+
+  DEPENDS
+  MLIRReussirTransformationPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRReussir
+  MLIRFuncDialect
+  MLIRPass
+)

--- a/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
+++ b/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
@@ -1,0 +1,161 @@
+//===-- RcDispatchFusion.cpp ------------------------------------*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// Fuses a pattern match's consumption of its scrutinee into a *destructuring*
+// decrement (Koka's `dropn_reuse` shape).
+//
+// The frontend lowers `match v { Ctor(a, b, ..) => .. }` into a borrowing
+// dispatch whose taken arm retains every bound member and then decrements the
+// scrutinee:
+//
+//   %ref = reussir.rc.borrow %v
+//   reussir.record.dispatch(%ref) {
+//     [k] -> ^arm(%payload):
+//       %a = ref.load(ref.project %payload [i])
+//       rc.inc %a                      // retain the binding
+//       ...
+//       rc.dec %v                      // release the box (transitive glue)
+//   }
+//
+// The retain/release pair over each bound member is pure count traffic on the
+// hot unique path: the box dies and its slots could simply transfer. This
+// pass erases the bound retains and tags the decrement with the arm's tag and
+// the bound member indices; `reussir-rc-decrement-expansion` then expands it
+// shallowly — unique: release only *unbound* rc members and take the box as a
+// token; shared: retain the bound members and drop the count. A preceding
+// increment cancels against the destructuring decrement in
+// `reussir-inc-dec-cancellation` by rematerializing the bound retains
+// (borrow semantics), which is what turns inlined read-only predicates like
+// rbtree's `is_red` into pure tag reads.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/Transformation/Passes.h"
+#include "Reussir/IR/ReussirDialect.h"
+#include "Reussir/IR/ReussirOps.h"
+#include "Reussir/IR/ReussirTypes.h"
+
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/Pass/Pass.h>
+
+namespace reussir {
+
+#define GEN_PASS_DEF_REUSSIRRCDISPATCHFUSIONPASS
+#include "Reussir/Transformation/Passes.h.inc"
+
+namespace {
+
+// The member index a retained value was extracted from, when `value` is a
+// direct `ref.load(ref.project(payload, i))` of the arm's payload reference.
+std::optional<int64_t> extractedMemberIndex(mlir::Value value,
+                                            mlir::Value payloadRef) {
+  auto load =
+      llvm::dyn_cast_if_present<ReussirRefLoadOp>(value.getDefiningOp());
+  if (!load)
+    return std::nullopt;
+  auto project = llvm::dyn_cast_if_present<ReussirRefProjectOp>(
+      load.getRef().getDefiningOp());
+  if (!project || project.getRef() != payloadRef)
+    return std::nullopt;
+  return project.getIndex().getSExtValue();
+}
+
+// Fuse one arm: find the scrutinee's release, collect the bound retains
+// before it, and rewrite. Returns whether the arm was fused.
+bool fuseArm(mlir::Region &region, int64_t tag,
+             mlir::TypedValue<RcType> scrutinee) {
+  if (!region.hasOneBlock() || region.front().getNumArguments() != 1)
+    return false;
+  mlir::Value payloadRef = region.front().getArgument(0);
+
+  // Locate the first release of the scrutinee at the arm's top level. Every
+  // op before it must leave the box's count alone: borrows, projections,
+  // loads, and retains of *other* values are fine; anything else that
+  // touches the scrutinee (or is opaque) aborts.
+  ReussirRcDecOp dec;
+  llvm::SmallVector<ReussirRcIncOp> boundIncs;
+  for (mlir::Operation &op : region.front()) {
+    if (auto candidate = llvm::dyn_cast<ReussirRcDecOp>(op)) {
+      if (candidate.getRcPtr() == scrutinee) {
+        dec = candidate;
+        break;
+      }
+      // A release of a value loaded from the scrutinee's box would race the
+      // shallow expansion; only accept releases of unrelated values.
+      if (extractedMemberIndex(candidate.getRcPtr(), payloadRef))
+        return false;
+      continue;
+    }
+    if (auto inc = llvm::dyn_cast<ReussirRcIncOp>(op)) {
+      if (extractedMemberIndex(inc.getRcPtr(), payloadRef))
+        boundIncs.push_back(inc);
+      continue;
+    }
+    if (llvm::is_contained(op.getOperands(), mlir::Value(scrutinee)) &&
+        !llvm::isa<ReussirRcBorrowOp>(op))
+      return false;
+    // Region-bearing or opaque ops before the release: bail (the release
+    // may be conditional or the box may escape).
+    if (op.getNumRegions() > 0 || llvm::isa<mlir::CallOpInterface>(op))
+      return false;
+  }
+  if (!dec || dec.isDestructuring())
+    return false;
+  if (dec.getNullableToken() && !dec.getNullableToken().use_empty())
+    return false;
+
+  llvm::SmallVector<int64_t> bound;
+  for (ReussirRcIncOp inc : boundIncs)
+    bound.push_back(*extractedMemberIndex(inc.getRcPtr(), payloadRef));
+
+  mlir::OpBuilder builder(dec);
+  dec.setDestructureTagAttr(builder.getIndexAttr(tag));
+  dec.setBoundMembersAttr(builder.getDenseI64ArrayAttr(bound));
+  for (ReussirRcIncOp inc : boundIncs)
+    inc.erase();
+  return true;
+}
+
+struct RcDispatchFusionPass
+    : public impl::ReussirRcDispatchFusionPassBase<RcDispatchFusionPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    getOperation()->walk([&](ReussirRecordDispatchOp dispatch) {
+      auto borrow = llvm::dyn_cast_if_present<ReussirRcBorrowOp>(
+          dispatch.getVariant().getDefiningOp());
+      if (!borrow)
+        return;
+      mlir::TypedValue<RcType> scrutinee = borrow.getRcPtr();
+      RcType rcType = scrutinee.getType();
+      if (rcType.getAtomicKind() != AtomicKind::normal || rcType.isRegional())
+        return;
+      auto recordType =
+          llvm::dyn_cast<RecordType>(rcType.getElementType());
+      if (!recordType || !recordType.isVariant() || !recordType.getComplete())
+        return;
+      for (auto [tagSetAttr, region] :
+           llvm::zip(dispatch.getTagSets(), dispatch.getRegions())) {
+        auto tagSet = llvm::cast<mlir::DenseI64ArrayAttr>(tagSetAttr);
+        if (tagSet.size() != 1)
+          continue;
+        // The arm's payload must be a plain record view: fused member
+        // handling only understands value/shared members.
+        auto payload = llvm::dyn_cast<RecordType>(
+            recordType.getMembers()[tagSet[0]]);
+        if (!payload || !payload.getComplete() || !payload.hasNoRegionalFields())
+          continue;
+        fuseArm(region, tagSet[0], scrutinee);
+      }
+    });
+  }
+};
+
+} // namespace
+} // namespace reussir

--- a/tests/integration/conversion/rc_dispatch_fusion.mlir
+++ b/tests/integration/conversion/rc_dispatch_fusion.mlir
@@ -1,0 +1,88 @@
+// RUN: %reussir-opt %s -reussir-rc-dispatch-fusion | %FileCheck %s --check-prefix=FUSE
+// RUN: %reussir-opt %s -reussir-rc-dispatch-fusion -reussir-inc-dec-cancellation | \
+// RUN:   %FileCheck %s --check-prefix=CANCEL
+// RUN: %reussir-opt %s -reussir-rc-dispatch-fusion -reussir-rc-decrement-expansion | \
+// RUN:   %FileCheck %s --check-prefix=EXPAND
+
+// Destructuring-decrement fusion (Koka's `dropn_reuse` shape). `take` binds
+// the cons cell's members and releases the box; `probe` borrows the box via
+// an increment that every arm balances with a release.
+
+!nilty = !reussir.record<compound "list.nil" [value] {}>
+!consty = !reussir.record<compound "list.cons" [value] {i64, !reussir.record<variant "list" incomplete>}>
+!listty = !reussir.record<variant "list" {!consty, !nilty}>
+!rclist = !reussir.rc<!listty>
+!tk = !reussir.token<align: 8, size: 32>
+
+module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-i64:64-n8:16:32:64-S128"} {
+  // The bound retain is fused away and the release learns the arm: on the
+  // unique path the tail transfers; on the shared path it is retained.
+  // FUSE-LABEL: func.func @take
+  // FUSE-NOT: reussir.rc.inc
+  // FUSE: reussir.rc.dec(%{{.+}} : {{.+}}) : {{.+}}boundMembers = array<i64: 1>, destructureTag = 0 : index}
+  //
+  // The expansion releases nothing on the unique path (the only rc member is
+  // bound and transfers) and retains the bound tail on the shared path.
+  // EXPAND-LABEL: func.func @take
+  // EXPAND: scf.if
+  // EXPAND-NOT: reussir.ref.drop
+  // EXPAND: reussir.rc.reinterpret
+  // EXPAND: } else {
+  // EXPAND: reussir.rc.set
+  // EXPAND: reussir.rc.inc
+  // EXPAND: } {reussir.expanded_decrement}
+  func.func @take(%l: !rclist) -> !rclist {
+    %ref = reussir.rc.borrow (%l : !rclist) : !reussir.ref<!listty>
+    %r = reussir.record.dispatch (%ref : !reussir.ref<!listty>) -> !rclist {
+      [0] -> {
+        ^bb0(%cons: !reussir.ref<!consty>):
+        %slot = reussir.ref.project (%cons : !reussir.ref<!consty>) [1] : !reussir.ref<!rclist>
+        %tail = reussir.ref.load (%slot : !reussir.ref<!rclist>) : !rclist
+        reussir.rc.inc (%tail : !rclist)
+        %t = reussir.rc.dec (%l : !rclist) : !reussir.nullable<!tk>
+        reussir.scf.yield %tail : !rclist
+      }
+      [1] -> {
+        ^bb1(%nil: !reussir.ref<!nilty>):
+        %t = reussir.rc.dec (%l : !rclist) : !reussir.nullable<!tk>
+        reussir.scf.yield %l : !rclist
+      }
+    }
+    return %r : !rclist
+  }
+
+  // A borrowing probe: the increment cancels against the per-arm releases —
+  // including one nested in an inner single-shot branch — and the fused-away
+  // bound retain rematerializes so the shared arm still owns its binding.
+  // CANCEL-LABEL: func.func @probe
+  // CANCEL-NOT: reussir.rc.dec
+  // CANCEL: reussir.record.dispatch
+  // CANCEL: reussir.rc.inc
+  // CANCEL-NOT: reussir.rc.dec
+  func.func @probe(%l: !rclist, %c: i1) -> !rclist {
+    reussir.rc.inc (%l : !rclist)
+    %ref = reussir.rc.borrow (%l : !rclist) : !reussir.ref<!listty>
+    %r = reussir.record.dispatch (%ref : !reussir.ref<!listty>) -> !rclist {
+      [0] -> {
+        ^bb0(%cons: !reussir.ref<!consty>):
+        %slot = reussir.ref.project (%cons : !reussir.ref<!consty>) [1] : !reussir.ref<!rclist>
+        %tail = reussir.ref.load (%slot : !reussir.ref<!rclist>) : !rclist
+        reussir.rc.inc (%tail : !rclist)
+        %t = reussir.rc.dec (%l : !rclist) : !reussir.nullable<!tk>
+        reussir.scf.yield %tail : !rclist
+      }
+      [1] -> {
+        ^bb1(%nil: !reussir.ref<!nilty>):
+        %b = scf.if %c -> i1 {
+          %t = reussir.rc.dec (%l : !rclist) : !reussir.nullable<!tk>
+          scf.yield %c : i1
+        } else {
+          %t = reussir.rc.dec (%l : !rclist) : !reussir.nullable<!tk>
+          scf.yield %c : i1
+        }
+        reussir.scf.yield %l : !rclist
+      }
+    }
+    return %r : !rclist
+  }
+}

--- a/tool/reussir-opt/main.cpp
+++ b/tool/reussir-opt/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char **argv) {
     return reussir::createReussirRcCreateFusionPass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return reussir::createReussirRcDispatchFusionPass();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return reussir::createReussirRegionPatternsPass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {


### PR DESCRIPTION
The consuming-dispatch design from the #325 discussion, landed as Koka's `dropn_reuse` shape. Stacked on #337 (the two compose: this pass gives flat scrutinee tokens + borrow cancellation + shared-path-only retains; the escape liberates the unbound destructured members' tokens).

## Design: attribute on the *release*, not the dispatch

Implementing the dispatch-level consume form exposed a read hazard: arms read members *before* the consumption point, so a token-at-arm-entry contract would put the unique-path release under live reads. The carrier that preserves position by construction is the arm's own `rc.dec`: two attributes (`destructureTag`, `boundMembers`) turn it into a **destructuring release**. The dispatch op is untouched, and the form lives in a tight pipeline window (fuse → cancel → expand), invisible to SCF lowering, TRMC, and TokenReuse.

## The sandwich

1. **`reussir-rc-dispatch-fusion`** (new): for each single-tag arm of a borrowing dispatch that releases the scrutinee at its top level — erase the arm's bound-member retains, tag the release with the arm's tag + bound indices.
2. **`reussir-inc-dec-cancellation`**: `inc %v` + dispatch whose **every path** releases `%v` (including releases nested in single-shot, trivially-typed inner branches — the is_red shape) ⇒ borrow semantics: erase the increment and every release, rematerializing each destructuring release's bound retains. The inlined `is_red` becomes pure tag loads — no header writes and, crucially, no phantom token producers.
3. **`reussir-rc-decrement-expansion`**: destructuring releases expand shallowly — unique: release only *unbound* rc members (recursively, so their tokens ride the #337 escape) and take the box as a token; shared: retain the bound members, drop the count. Answers the "how do you place it back" question: cancellation and expansion are both local inverses; nothing global to undo.

## A pre-existing trap this surfaced

Adding optional attributes to `rc.dec` re-routed three existing `create(...)` call sites onto the raw `TypeRange` overload — one passed `mlir::Type{}` and silently built a dec with a **null result type** (reussir-opt crashed in generated verifier code). All call sites now name every parameter. Worth knowing for any future ODS argument additions.

## Results (aarch64, rbtree n = 4.2 M, xLTO + static mimalloc, sequential; baseline = #337)

| metric | #337 | this PR | Koka |
|---|---|---|---|
| instructions | 7.29 B | **6.71 B** | 6.26 B (**1.07×**) |
| wall | 0.48 s | **0.455 s** | 0.385 s (**1.18×**, from 2.63× at filing) |
| allocations | 4.20 M (1.0/insert) | 4.20 M | ≈ same |

zipper/nbe unchanged. Interesting negative result recorded for honesty: the fusion's unique-path retain elision alone was wall-neutral — the existing post-expansion cancellation was already sinking those retains into the shared branch dynamically; the measured win comes from the nested-release cancellation (is_red), which neither the old adjacent-pair matcher nor the dispatch-level arm-top scan could reach.

Tests: full lit suite (271) + unit suites; new `rc_dispatch_fusion.mlir` pins all three phases; the n=4 structural probe validates tree shape under fusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2