### PR TITLE
[rt] natural-bin mimalloc GlobalAlloc; make mimalloc the default allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,15 +1262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,7 +2098,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace",
  "hashbrown 0.16.1",
- "mimalloc",
+ "libmimalloc-sys",
  "num_enum",
  "smallvec",
  "snmalloc-rs",

--- a/crates/reussir-rt/Cargo.toml
+++ b/crates/reussir-rt/Cargo.toml
@@ -7,16 +7,16 @@ license.workspace = true
 [dependencies]
 backtrace = { version = "0.3.75" }
 hashbrown = { version = "0.16.0" }
-mimalloc = { version = "0.1", features = ["v3"], optional = true }
+libmimalloc-sys = { version = "0.1.44", features = ["v3"], optional = true }
 snmalloc-rs = { version = "0.7", optional = true }
 num_enum = "0.7.4"
 smallvec = "1.15.1"
 stacker.workspace = true
 
 [features]
-default = ["snmalloc"]
+default = ["mimalloc"]
 snmalloc = ["snmalloc-rs"]
-mimalloc = ["dep:mimalloc"]
+mimalloc = ["dep:libmimalloc-sys"]
 
 [lib]
 crate-type = ["dylib", "lib", "staticlib"]

--- a/crates/reussir-rt/src/alloc.rs
+++ b/crates/reussir-rt/src/alloc.rs
@@ -1,5 +1,79 @@
 use std::alloc::Layout;
 
+/// A `GlobalAlloc` over mimalloc's raw entry points.
+///
+/// The `mimalloc` crate routes every allocation through `mi_malloc_aligned`,
+/// and mimalloc v3 serves an aligned request from its natural size bins only
+/// when the rounded block size is a power of two; everything else takes the
+/// over-allocating aligned path, so e.g. a 48-byte rc box occupies a 64-byte
+/// block — growing every heap line the program touches — and pays the generic
+/// path's extra instructions on each call. Dispatch on the layout instead: a
+/// natural bin already satisfies `align` whenever `align <= 16`
+/// (`MI_MAX_ALIGN_SIZE`: bin sizes are multiples of 8 and, above 16, of 16,
+/// and a page's first block is 16-aligned) and `size` is a multiple of
+/// `align`, so such requests — every rc box among them — take the plain fast
+/// path.
+#[cfg(all(feature = "mimalloc", not(miri)))]
+pub mod mimalloc {
+    use std::alloc::{GlobalAlloc, Layout};
+
+    use libmimalloc_sys as ffi;
+
+    /// `MI_MAX_ALIGN_SIZE`: the alignment mimalloc's plain entry points
+    /// guarantee for naturally aligned sizes.
+    const MI_MAX_ALIGN_SIZE: usize = 16;
+
+    #[inline]
+    const fn naturally_aligned(size: usize, align: usize) -> bool {
+        align <= MI_MAX_ALIGN_SIZE && size % align == 0
+    }
+
+    pub struct MiMalloc;
+
+    unsafe impl GlobalAlloc for MiMalloc {
+        #[inline]
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            unsafe {
+                if naturally_aligned(layout.size(), layout.align()) {
+                    ffi::mi_malloc(layout.size()).cast()
+                } else {
+                    ffi::mi_malloc_aligned(layout.size(), layout.align()).cast()
+                }
+            }
+        }
+
+        #[inline]
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            unsafe {
+                if naturally_aligned(layout.size(), layout.align()) {
+                    ffi::mi_zalloc(layout.size()).cast()
+                } else {
+                    ffi::mi_zalloc_aligned(layout.size(), layout.align()).cast()
+                }
+            }
+        }
+
+        #[inline]
+        unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+            unsafe { ffi::mi_free(ptr.cast()) }
+        }
+
+        #[inline]
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            // The result only has to satisfy the (unchanged) alignment, so
+            // dispatch on the new size; mi_realloc accepts blocks from either
+            // path.
+            unsafe {
+                if naturally_aligned(new_size, layout.align()) {
+                    ffi::mi_realloc(ptr.cast(), new_size).cast()
+                } else {
+                    ffi::mi_realloc_aligned(ptr.cast(), new_size, layout.align()).cast()
+                }
+            }
+        }
+    }
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __reussir_allocate(align: usize, size: usize) -> *mut u8 {
     unsafe {

--- a/crates/reussir-rt/src/lib.rs
+++ b/crates/reussir-rt/src/lib.rs
@@ -2,9 +2,11 @@
 
 #[cfg(all(feature = "mimalloc", not(miri)))]
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: alloc::mimalloc::MiMalloc = alloc::mimalloc::MiMalloc;
 
-#[cfg(all(feature = "snmalloc", not(miri)))]
+// mimalloc is in the default feature set, so an additive `--features snmalloc`
+// would otherwise enable both and declare two global allocators.
+#[cfg(all(feature = "snmalloc", not(feature = "mimalloc"), not(miri)))]
 #[global_allocator]
 static GLOBAL: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 


### PR DESCRIPTION
## Problem

The `mimalloc` wrapper crate's `GlobalAlloc` routes **every** allocation through `mi_malloc_aligned`. mimalloc v3's `mi_malloc_is_naturally_aligned` only takes the plain path when the rounded block size is a **power of two**, so a 48-byte request (`mi_good_size(48) = 48`) falls into the over-allocating aligned-generic path: every 48-byte rc box occupies a **64-byte block**, and each call pays `mi_heap_malloc_zero_aligned_at_{generic,overalloc}` (~430M extra instructions on rbtree n=4.2M) instead of `mi_heap_malloc_small`.

Cachegrind attribution on rbtree shows the cost precisely — LLd misses obey `2 × nodes × blocksize/64` (validated within 1% on four configurations): the read half is the final fold over the tree, the write half is mimalloc's free-list initialization on heap growth. Inflating blocks 48→64B inflates both sides by 4/3.

## Fix

Implement the global allocator directly on `libmimalloc-sys`, dispatching on the layout: when `align <= 16` (`MI_MAX_ALIGN_SIZE`) and `size` is a multiple of `align`, a natural bin already satisfies the alignment — bin sizes are multiples of 8 (16-grained above 16, probed: 24→32, 40→48) and a page's first block is 16-aligned (`MI_PAGE_MIN_START_BLOCK_ALIGN`) — so the request takes plain `mi_malloc`/`mi_zalloc`/`mi_realloc`. Everything else keeps the aligned entry points; `mi_free` handles blocks from either path.

Also flips the default runtime feature to `mimalloc` (previously `snmalloc`); it now wins or ties on all benches with xLTO. `snmalloc` stays available opt-in, with its `#[global_allocator]` guarded on mimalloc being off so an additive `--features snmalloc` build doesn't declare two allocators. Sanitizer runtime variants keep building with `--no-default-features` (system allocator).

## Measurements (rbtree n=4.2M, xLTO + static rt, aarch64; Koka same-day baseline 0.39s)

| | before | after |
|---|---|---|
| block per 48B node | 64B | 48B |
| LLd misses | 8.45M | 6.34M |
| D1 misses | 76.6M | 32.1M |
| instructions | 7.68G | 7.28G |
| wall | 0.51s | 0.46–0.48s |

zipper: 0.46s → 0.44s. Remaining LLd gap vs Koka (6.34M vs 4.22M) is node size proper — their node is 32B (fused 8B header + 1-byte color/value); that's the P3 header-packing project, out of scope here.

## Validation

- block spacing and 8/16-alignment probed empirically through the new path
- full lit suite 288/288 including the asan/lsan/msan/tsan executing gates
- jit tests, rrc-test, syntax/core cargo tests green
- all three feature configs build: default (mimalloc), `--no-default-features --features snmalloc`, bare `--no-default-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2