### PR TITLE
[backend] record layout: pack members by alignment; minimal-width variant tags

### DIFF
--- a/crates/reussir-repl/src/reflect.rs
+++ b/crates/reussir-repl/src/reflect.rs
@@ -9,7 +9,8 @@
 //! - C-style sequential struct layout; a member is stored as a *pointer*
 //!   when it is a `[field]` link, a shared/regional record, or a closure;
 //!   everything else is inline.
-//! - An enum (variant record) is `{ tag: usize @ 0, payload }` with the
+//! - An enum (variant record) is `{ tag @ 0, payload }` — the tag is the
+//!   minimal-width integer covering the arm count (u8/u16/u32) — with the
 //!   payload at `align_to(tag_size, payload_align)` and the total aligned to
 //!   `max(tag_align, payload_align)`; the payload area is the largest
 //!   variant. No niche optimizations exist.
@@ -30,6 +31,34 @@ use reussir_core::semi::ty::{DefId, FpTy, IntTy, Ty, TyKind};
 
 /// The pointer/`usize` width of the JIT host.
 const WORD: u64 = std::mem::size_of::<usize>() as u64;
+
+/// The minimal-width tag of a variant record (mirrors
+/// `RecordType::getTagType`): u8 up to 256 arms, then u16, then u32.
+fn variant_tag_size(arms: usize) -> u64 {
+    if arms <= 1 << 8 {
+        1
+    } else if arms <= 1 << 16 {
+        2
+    } else {
+        4
+    }
+}
+
+/// Packed physical member order (mirrors `RecordType::getPackedOrder`):
+/// member indices sorted by descending storage alignment, stable on
+/// declaration order.
+fn packed_order<'tcx>(
+    fields: &[FieldShape<'tcx>],
+    shapes: &ShapeTable<'tcx>,
+) -> Result<Vec<usize>, String> {
+    let mut aligns = Vec::with_capacity(fields.len());
+    for field in fields {
+        aligns.push(member_size_align(field.ty, field.is_field, shapes)?.align);
+    }
+    let mut order: Vec<usize> = (0..fields.len()).collect();
+    order.sort_by(|&a, &b| aligns[b].cmp(&aligns[a]).then(a.cmp(&b)));
+    Ok(order)
+}
 
 /// Ground record shapes keyed by the nominal identity (`def` + ground args).
 pub type ShapeTable<'tcx> = FxHashMap<(DefId, &'tcx [Ty<'tcx>]), RecordShape<'tcx>>;
@@ -189,8 +218,9 @@ pub fn inline_size_align<'tcx>(
                 ShapeLayout::Compound(fields) => compound_size_align(fields, shapes),
                 ShapeLayout::Variants(variants) => {
                     let payload = variants_payload_size_align(variants, shapes)?;
-                    let payload_offset = align_to(WORD, payload.align);
-                    let align = payload.align.max(WORD);
+                    let tag = variant_tag_size(variants.len());
+                    let payload_offset = align_to(tag, payload.align);
+                    let align = payload.align.max(tag);
                     Ok(SizeAlign {
                         size: align_to(payload_offset + payload.size, align),
                         align,
@@ -218,14 +248,16 @@ pub unsafe fn shared_box_payload<'tcx>(
     Ok(unsafe { boxed.add(align_to(WORD, inner.align) as usize) })
 }
 
-/// Sequential (C-style) layout of a member list: total size/align.
+/// Packed layout of a member list (descending storage alignment, stable on
+/// declaration order): total size/align.
 fn compound_size_align<'tcx>(
     fields: &[FieldShape<'tcx>],
     shapes: &ShapeTable<'tcx>,
 ) -> Result<SizeAlign, String> {
     let mut size = 0u64;
     let mut align = 1u64;
-    for field in fields {
+    for &logical in &packed_order(fields, shapes)? {
+        let field = &fields[logical];
         let member = member_size_align(field.ty, field.is_field, shapes)?;
         size = align_to(size, member.align) + member.size;
         align = align.max(member.align);
@@ -236,17 +268,18 @@ fn compound_size_align<'tcx>(
     })
 }
 
-/// Byte offset of each member in a sequential layout.
+/// Byte offset of each (logical) member in the packed layout.
 fn member_offsets<'tcx>(
     fields: &[FieldShape<'tcx>],
     shapes: &ShapeTable<'tcx>,
 ) -> Result<Vec<u64>, String> {
-    let mut offsets = Vec::with_capacity(fields.len());
+    let mut offsets = vec![0u64; fields.len()];
     let mut size = 0u64;
-    for field in fields {
+    for &logical in &packed_order(fields, shapes)? {
+        let field = &fields[logical];
         let member = member_size_align(field.ty, field.is_field, shapes)?;
         let offset = align_to(size, member.align);
-        offsets.push(offset);
+        offsets[logical] = offset;
         size = offset + member.size;
     }
     Ok(offsets)
@@ -494,7 +527,11 @@ impl<'tcx> Walker<'_, 'tcx> {
                 unsafe { self.render_fields(payload, fields, depth, out) }
             }
             ShapeLayout::Variants(variants) => {
-                let tag = unsafe { payload.cast::<usize>().read_unaligned() };
+                let tag = match variant_tag_size(variants.len()) {
+                    1 => unsafe { payload.cast::<u8>().read_unaligned() as usize },
+                    2 => unsafe { payload.cast::<u16>().read_unaligned() as usize },
+                    _ => unsafe { payload.cast::<u32>().read_unaligned() as usize },
+                };
                 let Some(variant) = variants.get(tag) else {
                     return Err(format!("corrupt enum tag {tag} for `{}`", shape.name));
                 };
@@ -514,7 +551,9 @@ impl<'tcx> Walker<'_, 'tcx> {
                     })
                     .collect();
                 let payload_area = variants_payload_size_align(variants, self.shapes)?;
-                let base = unsafe { payload.add(align_to(WORD, payload_area.align) as usize) };
+                let tag_size = variant_tag_size(variants.len());
+                let base =
+                    unsafe { payload.add(align_to(tag_size, payload_area.align) as usize) };
                 unsafe { self.render_fields(base, &fields, depth, out) }
             }
         }

--- a/crates/reussir-rt/src/region/rusty.rs
+++ b/crates/reussir-rt/src/region/rusty.rs
@@ -238,7 +238,9 @@ mod tests {
 
     #[repr(C)]
     struct Variants {
-        tag: usize,
+        // Mirrors the compiler's minimal-width variant tag (i8 for <= 256
+        // arms), with the payload at its natural alignment boundary.
+        tag: u8,
         storage: VariantsStorage,
     }
 
@@ -261,7 +263,7 @@ mod tests {
 
     unsafe impl RegionalObjectTrait for Variants {
         const SCAN_INSTRS: &'static [PackedInstr] = &[
-            Instruction::Variant.pack(),
+            Instruction::Variant(1).pack(),
             Instruction::Jump(3).pack(), // Goto Foo
             Instruction::Jump(5).pack(), // Goto Bar
             Instruction::End.pack(),     // Goto Baz, but no fields to scan

--- a/crates/reussir-rt/src/region/scanner.rs
+++ b/crates/reussir-rt/src/region/scanner.rs
@@ -7,9 +7,10 @@ pub enum Instruction {
     /// Load and yield current position as a header pointer,
     /// then advance the instr pointer by 1.
     Field,
-    /// Load current position as a usize variant index,
-    /// advance the instr pointer by (index + 1).
-    Variant,
+    /// Load current position as a variant index of the given byte width
+    /// (1, 2, or 4 — the record's minimal tag width), then advance the
+    /// instr pointer by (index + 1).
+    Variant(u32),
     /// Scanner ended.
     End,
     /// Advance the cursor by the given number of bytes.
@@ -19,8 +20,11 @@ pub enum Instruction {
 }
 
 const END_VALUE: i32 = 0;
-const VARIANT_VALUE: i32 = -1;
+const VARIANT8_VALUE: i32 = -1;
 const FIELD_VALUE: i32 = -2;
+const VARIANT16_VALUE: i32 = -3;
+const VARIANT32_VALUE: i32 = -4;
+const JUMP_BASE: i32 = -5;
 
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -37,10 +41,12 @@ impl From<PackedInstr> for Instruction {
     fn from(value: PackedInstr) -> Self {
         match value.0 {
             END_VALUE => Instruction::End,
-            VARIANT_VALUE => Instruction::Variant,
+            VARIANT8_VALUE => Instruction::Variant(1),
             FIELD_VALUE => Instruction::Field,
+            VARIANT16_VALUE => Instruction::Variant(2),
+            VARIANT32_VALUE => Instruction::Variant(4),
             val if val > 0 => Instruction::Advance(val as u32),
-            val => Instruction::Jump((-val) as u32 - 3),
+            val => Instruction::Jump((val - JUMP_BASE).unsigned_abs()),
         }
     }
 }
@@ -55,7 +61,12 @@ impl Instruction {
     pub const fn pack(self) -> PackedInstr {
         match self {
             Instruction::End => PackedInstr(END_VALUE),
-            Instruction::Variant => PackedInstr(VARIANT_VALUE),
+            Instruction::Variant(width) => match width {
+                1 => PackedInstr(VARIANT8_VALUE),
+                2 => PackedInstr(VARIANT16_VALUE),
+                4 => PackedInstr(VARIANT32_VALUE),
+                _ => panic!("unsupported variant tag width"),
+            },
             Instruction::Field => PackedInstr(FIELD_VALUE),
             Instruction::Advance(bytes) => {
                 debug_assert!(bytes > 0);
@@ -63,7 +74,7 @@ impl Instruction {
             }
             Instruction::Jump(instrs) => {
                 debug_assert!(instrs > 0);
-                PackedInstr(-(instrs as i32) - 3)
+                PackedInstr(JUMP_BASE - (instrs as i32))
             }
         }
     }
@@ -88,8 +99,12 @@ impl Scanner {
                             return Some(child);
                         }
                     }
-                    Instruction::Variant => {
-                        let index = self.cursor.cast::<usize>().read();
+                    Instruction::Variant(width) => {
+                        let index = match width {
+                            1 => self.cursor.cast::<u8>().read() as usize,
+                            2 => self.cursor.cast::<u16>().read() as usize,
+                            _ => self.cursor.cast::<u32>().read() as usize,
+                        };
                         self.instr = self.instr.add(index + 1);
                     }
                     Instruction::Advance(bytes) => {

--- a/include/Reussir/IR/ReussirTypes.h
+++ b/include/Reussir/IR/ReussirTypes.h
@@ -37,13 +37,27 @@ deriveCompoundSizeAndAlignment(mlir::MLIRContext *context,
 bool isNonNullPointerType(mlir::Type type);
 bool isTriviallyCopyable(mlir::Type type);
 mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap);
+mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
+                             bool isField, bool memBoxInternal = false);
 
 namespace scanner {
+// Encoding shared with reussir-rt's region scanner interpreter
+// (crates/reussir-rt/src/region/scanner.rs): 0 = end, -1/-3/-4 = variant tag
+// read of 1/2/4 bytes, -2 = field, > 0 = advance, <= -5 = jump.
 inline int32_t end() {
   return 0; // Assuming 0 represents the 'end' instruction
 }
-inline int32_t variant() {
-  return -1; // Assuming 1 represents the 'variant' instruction
+inline int32_t variant(uint64_t tagByteWidth) {
+  switch (tagByteWidth) {
+  case 1:
+    return -1;
+  case 2:
+    return -3;
+  case 4:
+    return -4;
+  default:
+    llvm_unreachable("unsupported variant tag width");
+  }
 }
 inline int32_t field() { return -2; }
 inline int32_t advance(uint32_t bytes) {
@@ -51,11 +65,13 @@ inline int32_t advance(uint32_t bytes) {
   return static_cast<int32_t>(bytes);
 }
 inline int32_t skip(size_t count) {
-  assert(count <= INT32_MAX - 3 && "skip count must fit in int32");
-  return static_cast<int32_t>(-3 - count);
+  assert(count <= INT32_MAX - 5 && "skip count must fit in int32");
+  return static_cast<int32_t>(-5 - count);
 }
 struct End {};
-struct Variant {};
+struct Variant {
+  uint64_t tagByteWidth;
+};
 struct Field {};
 struct Advance {
   uint32_t bytes;
@@ -68,11 +84,15 @@ inline Instr decode(int32_t code) {
   if (code == 0)
     return End{};
   else if (code == -1)
-    return Variant{};
+    return Variant{1};
   else if (code == -2)
     return Field{};
-  else if (code <= -3)
-    return Skip{static_cast<size_t>(-3 - code)};
+  else if (code == -3)
+    return Variant{2};
+  else if (code == -4)
+    return Variant{4};
+  else if (code <= -5)
+    return Skip{static_cast<size_t>(-5 - code)};
   else
     return Advance{static_cast<uint32_t>(code)};
 }

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -143,6 +143,16 @@ def ReussirRecordType
         mlir::Type memberWithLargestAlignment;
       };
       LayoutInfo getElementRegionLayoutInfo(const mlir::DataLayout &dataLayout) const;
+      // The discriminant type of a variant record: the narrowest integer
+      // covering the arm count (i8/i16/i32).
+      mlir::IntegerType getTagType() const;
+      // Physical member order of a compound record: member indices sorted by
+      // descending storage alignment (stable on declaration order), so no
+      // padding ever appears between members. Identity for variants.
+      llvm::SmallVector<uint32_t> getPackedOrder(const mlir::DataLayout &dataLayout) const;
+      // Position of logical member `index` in the packed physical order —
+      // i.e. the GEP field index of that member in the converted LLVM struct.
+      uint32_t getPhysicalMemberIndex(const mlir::DataLayout &dataLayout, uint32_t index) const;
       ::mlir::FlatSymbolRefAttr getDtorName() const;
       ::mlir::FlatSymbolRefAttr getAcquireName() const;
       size_t emitScannerInstructions(

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -139,7 +139,10 @@ TagEncoding specialPtrTagEncoding(mlir::Operation *op) {
 // sized to the target's index width. Loads and increments through a tagged
 // value land here and observe a well-formed shared box header carrying the
 // immediate's own tag; the refcount stays pinned because `rc.set` never
-// writes it (see above).
+// writes it (see above). Records read their tag at the minimal width
+// (i8/i16/i32) from the same offset; on a little-endian target that read
+// sees the low bytes of the full-width tag word stored here, so one
+// index-wide dummy serves every tag width.
 mlir::LLVM::GlobalOp tagDummyBox(mlir::ModuleOp module, mlir::Location loc,
                                  uint64_t tag, TagEncoding encoding,
                                  mlir::IntegerType indexTy,
@@ -728,12 +731,14 @@ struct ReussirRecordCompoundConversionPattern
     auto fieldValues = adaptor.getFields();
 
     // Insert each field using GEP + store
+    auto dataLayout = getDataLayout(*converter, op.getOperation());
     for (size_t i = 0; i < fieldValues.size(); ++i) {
       // GEP indices:
       // 0 -> Dereference the base pointer (step into the allocated element)
-      // i -> Access the i-th field of the struct
-      llvm::SmallVector<mlir::LLVM::GEPArg, 2> gepArgs{0,
-                                                       static_cast<int32_t>(i)};
+      // then the packed physical position of the i-th logical member
+      llvm::SmallVector<mlir::LLVM::GEPArg, 2> gepArgs{
+          0, static_cast<int32_t>(recordType.getPhysicalMemberIndex(
+                 dataLayout, static_cast<uint32_t>(i)))};
 
       mlir::Value fieldPtr = mlir::LLVM::GEPOp::create(
           rewriter, loc, ptrType, llvmStructType, alloca, gepArgs);
@@ -789,8 +794,16 @@ struct ReussirRecordExtractConversionPattern
     // 2. Store the entire struct value into the allocated memory
     mlir::LLVM::StoreOp::create(rewriter, loc, adaptor.getRecord(), alloca);
 
-    // 3. GEP: Calculate the memory address of the specific field
+    // 3. GEP: Calculate the memory address of the specific field, mapping
+    // the logical member index to its packed physical position.
     int32_t fieldIndex = static_cast<int32_t>(op.getIndex().getZExtValue());
+    if (auto recordType =
+            llvm::dyn_cast<RecordType>(op.getRecord().getType());
+        recordType && recordType.isCompound()) {
+      auto dataLayout = getDataLayout(*converter, op.getOperation());
+      fieldIndex = static_cast<int32_t>(recordType.getPhysicalMemberIndex(
+          dataLayout, static_cast<uint32_t>(fieldIndex)));
+    }
     llvm::SmallVector<mlir::LLVM::GEPArg, 2> gepArgs{0, fieldIndex};
 
     mlir::Value fieldPtr = mlir::LLVM::GEPOp::create(
@@ -827,10 +840,12 @@ struct ReussirRecordVariantConversionPattern
     if (!llvmStructType)
       return op.emitOpError("failed to convert record type to LLVM type");
     auto indexType = converter->getIndexType();
-    // Get the tag and value (already converted by the type converter)
+    // Get the tag (at the record's minimal tag width) and value (already
+    // converted by the type converter)
     mlir::Value tag = mlir::arith::ConstantOp::create(
         rewriter, loc,
-        mlir::IntegerAttr::get(indexType, op.getTag().getZExtValue()));
+        mlir::IntegerAttr::get(recordType.getTagType(),
+                               op.getTag().getZExtValue()));
     mlir::Value value = adaptor.getValue();
 
     // Get the preferred alignment for the struct type
@@ -957,12 +972,20 @@ struct ReussirReferenceProjectConversionPattern
     RefType refType = op.getRef().getType();
     mlir::Type elementType = converter->convertType(refType.getElementType());
 
+    // Logical member indices map to packed physical struct fields.
+    int32_t fieldIndex = static_cast<int32_t>(op.getIndex().getZExtValue());
+    if (auto recordType =
+            llvm::dyn_cast<RecordType>(refType.getElementType());
+        recordType && recordType.isCompound()) {
+      auto dataLayout = getDataLayout(*converter, op.getOperation());
+      fieldIndex = static_cast<int32_t>(recordType.getPhysicalMemberIndex(
+          dataLayout, static_cast<uint32_t>(fieldIndex)));
+    }
+
     // Create GEP operation to get the field pointer
-    llvm::SmallVector<mlir::LLVM::GEPArg> gepArgs;
     auto gepOp = mlir::LLVM::GEPOp::create(
         rewriter, loc, llvmPtrType, elementType, refPtr,
-        llvm::ArrayRef<mlir::LLVM::GEPArg>{
-            0, static_cast<int>(op.getIndex().getZExtValue())});
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, fieldIndex});
 
     rewriter.replaceOp(op, gepOp);
     return mlir::success();
@@ -1096,12 +1119,21 @@ struct ReussirRecordTagConversionPattern
         rewriter, loc, tagPtrType, elementType, refPtr,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
 
-    // Load the tag value. Under the special-pointer-tag scheme a tagged
+    // Load the tag value at the record's minimal tag width and widen it to
+    // the op's index result. Under the special-pointer-tag scheme a tagged
     // immediate scrutinee needs no decode: the load lands in its per-tag
     // dummy box (TBI masks the top byte) and reads the real tag — so the
     // match hot path is identical with and without the scheme.
+    mlir::IntegerType tagType = recordType.getTagType();
+    mlir::Value narrowTag =
+        mlir::LLVM::LoadOp::create(rewriter, loc, tagType, tagPtr);
     mlir::Value tagValue =
-        rewriter.replaceOpWithNewOp<mlir::LLVM::LoadOp>(op, indexType, tagPtr);
+        tagType.getWidth() <
+                llvm::cast<mlir::IntegerType>(indexType).getWidth()
+            ? mlir::LLVM::ZExtOp::create(rewriter, loc, indexType, narrowTag)
+                  .getResult()
+            : narrowTag;
+    rewriter.replaceOp(op, tagValue);
 
     // Assume that the tag is always in bounds
     auto numberMembers = mlir::arith::ConstantOp::create(
@@ -1350,6 +1382,7 @@ struct ReussirRcCreateCompoundOpConversionPattern
     auto converter =
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
     auto llvmRecordType = converter->convertType(op.getRecordType());
+    auto dataLayout = getDataLayout(*converter, op.getOperation());
     llvm::SmallVector<mlir::Value> results;
     results.push_back(storage->token);
     for (auto [index, field] : llvm::enumerate(adaptor.getFields())) {
@@ -1363,7 +1396,9 @@ struct ReussirRcCreateCompoundOpConversionPattern
       auto fieldPtr = mlir::LLVM::GEPOp::create(
           rewriter, op.getLoc(), llvmPtrType, llvmRecordType,
           storage->elementPtr,
-          llvm::ArrayRef<mlir::LLVM::GEPArg>{0, static_cast<int32_t>(index)});
+          llvm::ArrayRef<mlir::LLVM::GEPArg>{
+              0, static_cast<int32_t>(op.getRecordType().getPhysicalMemberIndex(
+                     dataLayout, static_cast<uint32_t>(index)))});
       if (isHoleField)
         results.push_back(fieldPtr);
       if (skipStore)
@@ -1444,10 +1479,10 @@ struct ReussirRcCreateVariantOpConversionPattern
     if (!llvmVariantType)
       return op.emitOpError("failed to convert record type to LLVM type");
 
-    auto indexType = converter->getIndexType();
     auto tag = mlir::arith::ConstantOp::create(
         rewriter, op.getLoc(),
-        mlir::IntegerAttr::get(indexType, op.getTag().getZExtValue()));
+        mlir::IntegerAttr::get(op.getRecordType().getTagType(),
+                               op.getTag().getZExtValue()));
     auto tagPtr = mlir::LLVM::GEPOp::create(
         rewriter, op.getLoc(), llvmPtrType, llvmVariantType,
         storage->elementPtr, llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
@@ -1469,6 +1504,7 @@ struct ReussirRcCreateVariantOpConversionPattern
         auto payloadType = llvm::cast<RecordType>(
             op.getRecordType().getMembers()[op.getTag().getZExtValue()]);
         auto llvmPayloadType = converter->convertType(payloadType);
+        auto dataLayout = getDataLayout(*converter, op.getOperation());
         for (auto [index, field] : llvm::enumerate(adaptor.getFields())) {
           bool isHoleField = hasIndexedFieldAttr(
               op.getOperation(), "holeFields", static_cast<int64_t>(index));
@@ -1479,8 +1515,9 @@ struct ReussirRcCreateVariantOpConversionPattern
             continue;
           auto fieldPtr = mlir::LLVM::GEPOp::create(
               rewriter, op.getLoc(), llvmPtrType, llvmPayloadType, payloadPtr,
-              llvm::ArrayRef<mlir::LLVM::GEPArg>{0,
-                                                 static_cast<int32_t>(index)});
+              llvm::ArrayRef<mlir::LLVM::GEPArg>{
+                  0, static_cast<int32_t>(payloadType.getPhysicalMemberIndex(
+                         dataLayout, static_cast<uint32_t>(index)))});
           if (isHoleField)
             results.push_back(fieldPtr);
           if (skipStore)

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -96,7 +96,9 @@ convertRecordType(mlir::LLVMTypeConverter &converter,
 
   llvm::SmallVector<mlir::Type> members;
   if (type.getKind() == reussir::RecordKind::variant) {
-    members.push_back(converter.getIndexType());
+    // The discriminant is the record's minimal-width tag type; the payload
+    // lands at its natural alignment boundary after it.
+    members.push_back(type.getTagType());
     auto [size, _unused, representative] =
         type.getElementRegionLayoutInfo(dataLayout);
     if (representative) {
@@ -110,8 +112,12 @@ convertRecordType(mlir::LLVMTypeConverter &converter,
   } else {
     size_t expectedTotalSize = dataLayout.getTypeSize(type);
     size_t currentSize = 0;
-    for (auto [member, capability] :
-         llvm::zip(type.getMembers(), type.getMemberIsField())) {
+    // Struct fields are emitted in packed physical order (descending storage
+    // alignment, stable on declaration order); lowerings translate logical
+    // member indices through getPhysicalMemberIndex.
+    for (uint32_t logical : type.getPackedOrder(dataLayout)) {
+      mlir::Type member = type.getMembers()[logical];
+      bool capability = type.getMemberIsField()[logical];
       mlir::Type projectedType =
           getProjectedType(member, capability, Capability::unspecified);
       auto align = dataLayout.getTypeABIAlignment(projectedType);

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -236,6 +236,31 @@ bool isTriviallyCopyable(mlir::Type type) {
       .Default([](mlir::Type type) { return false; });
 }
 //===----------------------------------------------------------------------===//
+// memberStorageType
+//===----------------------------------------------------------------------===//
+// The type a member occupies in storage. A member is stored as a pointer if:
+// 1. it is a mutable field (isField == true)
+// 2. it is a referential record (either shared or regional)
+// 3. it is a closure
+// unless this layout is derived for memory box internal layout, which forces
+// the structure to expand in place.
+mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
+                             bool isField, bool memBoxInternal) {
+  auto ptrTy = mlir::LLVM::LLVMPointerType::get(context);
+  mlir::Type member = rawMember;
+  auto recordTy = llvm::dyn_cast<RecordType>(rawMember);
+  if (!memBoxInternal &&
+      (isField ||
+       (recordTy &&
+        (recordTy.getDefaultCapability() == Capability::shared ||
+         recordTy.getDefaultCapability() == Capability::regional))))
+    member = ptrTy;
+  if (llvm::isa<ClosureType>(member))
+    member = ptrTy;
+  return member;
+}
+
+//===----------------------------------------------------------------------===//
 // deriveCompoundSizeAndAlignment
 //===----------------------------------------------------------------------===//
 std::optional<std::tuple<llvm::TypeSize, llvm::Align, mlir::Type>>
@@ -244,7 +269,6 @@ deriveCompoundSizeAndAlignment(mlir::MLIRContext *context,
                                llvm::ArrayRef<bool> memberIsField,
                                const mlir::DataLayout &dataLayout,
                                bool memBoxInternal) {
-  auto ptrTy = mlir::LLVM::LLVMPointerType::get(context);
   llvm::TypeSize resultSize = llvm::TypeSize::getFixed(0);
   llvm::Align resultAlignment{1};
   mlir::Type memberWithLargestAlignment;
@@ -254,24 +278,8 @@ deriveCompoundSizeAndAlignment(mlir::MLIRContext *context,
   for (auto [rawMember, isField] : llvm::zip(members, memberIsField)) {
     if (!rawMember)
       continue;
-    mlir::Type member = rawMember;
-    auto recordTy = llvm::dyn_cast<RecordType>(rawMember);
-    // A member is stored as a pointer if:
-    // 1. it is a mutable field (isField == true)
-    // 2. it is a referential record (either shared or regional)
-    // 3. if this layout is derived for memory box internal layout, we force
-    //    expand the structure in place.
-    if (!memBoxInternal &&
-        (isField ||
-         (recordTy &&
-          (recordTy.getDefaultCapability() == Capability::shared ||
-           recordTy.getDefaultCapability() == Capability::regional))))
-      member = ptrTy;
-
-    // Additionally, closure type is also stored as a pointer
-    if (auto closureTy = llvm::dyn_cast<ClosureType>(member))
-      member = ptrTy;
-
+    mlir::Type member =
+        memberStorageType(context, rawMember, isField, memBoxInternal);
     llvm::TypeSize memberSize = dataLayout.getTypeSize(member);
     if (!memberSize.isFixed())
       return std::nullopt;
@@ -562,11 +570,53 @@ void RecordType::complete(llvm::ArrayRef<mlir::Type> members,
 //===----------------------------------------------------------------------===//
 // RecordType GetElementRegionSizeAndAlignment
 //===----------------------------------------------------------------------===//
+mlir::IntegerType RecordType::getTagType() const {
+  size_t arms = getMembers().size();
+  unsigned width = arms <= (1u << 8) ? 8 : arms <= (1u << 16) ? 16 : 32;
+  return mlir::IntegerType::get(getContext(), width);
+}
+
+llvm::SmallVector<uint32_t>
+RecordType::getPackedOrder(const mlir::DataLayout &dataLayout) const {
+  llvm::SmallVector<uint32_t> order(getMembers().size());
+  for (uint32_t i = 0; i < order.size(); ++i)
+    order[i] = i;
+  if (!isCompound())
+    return order;
+  llvm::SmallVector<uint64_t> aligns(order.size());
+  for (uint32_t i = 0; i < order.size(); ++i) {
+    mlir::Type storage = memberStorageType(getContext(), getMembers()[i],
+                                           getMemberIsField()[i]);
+    aligns[i] = dataLayout.getTypeABIAlignment(storage);
+  }
+  llvm::stable_sort(order,
+                    [&](uint32_t a, uint32_t b) { return aligns[a] > aligns[b]; });
+  return order;
+}
+
+uint32_t
+RecordType::getPhysicalMemberIndex(const mlir::DataLayout &dataLayout,
+                                   uint32_t index) const {
+  llvm::SmallVector<uint32_t> order = getPackedOrder(dataLayout);
+  auto *it = llvm::find(order, index);
+  assert(it != order.end() && "member index out of range");
+  return static_cast<uint32_t>(it - order.begin());
+}
+
 RecordType::LayoutInfo RecordType::getElementRegionLayoutInfo(
     const mlir::DataLayout &dataLayout) const {
   if (isCompound()) {
-    auto derived = deriveCompoundSizeAndAlignment(
-        getContext(), getMembers(), getMemberIsField(), dataLayout);
+    // Iterate members in packed physical order so offsets (and the total
+    // size) match the converted LLVM struct.
+    llvm::SmallVector<uint32_t> order = getPackedOrder(dataLayout);
+    llvm::SmallVector<mlir::Type> members(order.size());
+    llvm::SmallVector<bool> memberIsField(order.size());
+    for (auto [physical, logical] : llvm::enumerate(order)) {
+      members[physical] = getMembers()[logical];
+      memberIsField[physical] = getMemberIsField()[logical];
+    }
+    auto derived = deriveCompoundSizeAndAlignment(getContext(), members,
+                                                  memberIsField, dataLayout);
     if (!derived)
       llvm_unreachable("RecordType must have a fixed size");
     auto [sizeInBytes, alignment, memberWithLargestAlignment] = *derived;
@@ -604,8 +654,7 @@ RecordType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
   if (isCompound())
     return size * 8; // Convert to bits
 
-  mlir::IndexType tagType =
-      mlir::IndexType::get(getContext()); // Use IndexType for tag
+  mlir::IntegerType tagType = getTagType();
   llvm::TypeSize tagSize = dataLayout.getTypeSize(tagType);
   llvm::Align tagAlign{dataLayout.getTypeABIAlignment(tagType)};
   llvm::Align finalAlign =
@@ -624,8 +673,7 @@ RecordType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
   if (isCompound())
     return align.value();
 
-  mlir::IndexType tagType =
-      mlir::IndexType::get(getContext()); // Use IndexType for tag
+  mlir::IntegerType tagType = getTagType();
   uint64_t tagAlignment = dataLayout.getTypeABIAlignment(tagType);
   uint64_t finalAlignment = std::max(align.value(), tagAlignment);
   return finalAlignment;

--- a/lib/IR/ReussirTypesScanner.cpp
+++ b/lib/IR/ReussirTypesScanner.cpp
@@ -33,19 +33,14 @@ RecordType::emitScannerInstructions(llvm::SmallVectorImpl<int32_t> &buffer,
   if (isCompound()) {
     size_t scannedBytes = EmitState.scannedBytes;
     size_t cursorPosition = EmitState.cursorPosition;
-    for (auto [rawMember, isField] :
-         llvm::zip(getMembers(), getMemberIsField())) {
+    // Walk members in packed physical order: scan offsets must match the
+    // converted struct layout.
+    for (uint32_t logical : getPackedOrder(dataLayout)) {
+      mlir::Type rawMember = getMembers()[logical];
+      bool isField = getMemberIsField()[logical];
       if (!rawMember)
         continue;
-      mlir::Type member;
-      auto recordTy = llvm::dyn_cast<RecordType>(rawMember);
-      if (isField ||
-          (recordTy &&
-           (recordTy.getDefaultCapability() == Capability::shared ||
-            recordTy.getDefaultCapability() == Capability::regional)))
-        member = mlir::LLVM::LLVMPointerType::get(getContext());
-      else
-        member = rawMember;
+      mlir::Type member = memberStorageType(getContext(), rawMember, isField);
       // advance to the next field
       llvm::TypeSize memberSize = dataLayout.getTypeSize(member);
       if (!memberSize.isFixed())
@@ -86,10 +81,9 @@ RecordType::emitScannerInstructions(llvm::SmallVectorImpl<int32_t> &buffer,
   // | variant | skip | skip | skip | ... | end |
   size_t scannedBytes = EmitState.scannedBytes;
   size_t cursorPosition = EmitState.cursorPosition;
-  auto indexTy = mlir::IndexType::get(getContext());
-  auto indexSize = dataLayout.getTypeSize(indexTy).getFixedValue();
-  buffer.push_back(variant());
-  scannedBytes += indexSize;
+  auto tagSize = dataLayout.getTypeSize(getTagType()).getFixedValue();
+  buffer.push_back(variant(tagSize));
+  scannedBytes += tagSize;
   auto layoutInfo = getElementRegionLayoutInfo(dataLayout);
   scannedBytes = llvm::alignTo(scannedBytes, layoutInfo.alignment);
   size_t currentSkip = buffer.size();

--- a/tests/integration/conversion/option_like_ops.mlir
+++ b/tests/integration/conversion/option_like_ops.mlir
@@ -123,7 +123,8 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
 // CHECK-LABEL: define i32 @option_unwrap_or_default(ptr %0, i32 %1)
 // CHECK: getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: load i64, ptr
+// CHECK: load i8, ptr
+// CHECK: zext i8
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label
@@ -135,7 +136,8 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
 // CHECK-LABEL: define i32 @option_unwrap_or_compute(ptr %0)
 // CHECK: getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: load i64, ptr
+// CHECK: load i8, ptr
+// CHECK: zext i8
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label
@@ -147,7 +149,8 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
 // CHECK-LABEL: define i32 @result_unwrap_or_error(ptr %0)
 // CHECK: getelementptr %Result, ptr %0, i32 0, i32 0
-// CHECK: load i64, ptr
+// CHECK: load i8, ptr
+// CHECK: zext i8
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label

--- a/tests/integration/conversion/rc_create_fused_lowering.mlir
+++ b/tests/integration/conversion/rc_create_fused_lowering.mlir
@@ -125,7 +125,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK: store i64 1, ptr %[[COUNT]], align 8
 // CHECK: %[[VARIANT:.*]] = getelementptr { i64, %List }, ptr %[[ALLOC]], i32 0, i32 1
 // CHECK: %[[TAGPTR:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 0
-// CHECK: store i64 0, ptr %[[TAGPTR]], align 8
+// CHECK: store i8 0, ptr %[[TAGPTR]], align 1
 // CHECK: %[[PAYLOAD:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 1
 // CHECK: %[[FIELD0:.*]] = getelementptr %"List::Cons", ptr %[[PAYLOAD]], i32 0, i32 0
 // CHECK: store i32 %0, ptr %[[FIELD0]], align 4, !invariant.group
@@ -162,7 +162,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK: call void @llvm.assume
 // CHECK: %[[VARIANT:.*]] = getelementptr { i64, %List }, ptr %{{.*}}, i32 0, i32 1
 // CHECK: %[[TAGPTR:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 0
-// CHECK: store i64 0, ptr %[[TAGPTR]], align 8
+// CHECK: store i8 0, ptr %[[TAGPTR]], align 1
 // CHECK: %[[PAYLOAD:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 1
 // CHECK-NOT: getelementptr %"List::Cons", ptr %[[PAYLOAD]]
 // CHECK: ret ptr
@@ -171,7 +171,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK: call void @llvm.assume
 // CHECK: %[[VARIANT2:.*]] = getelementptr { i64, %ListAlt }, ptr %{{.*}}, i32 0, i32 1
 // CHECK: %[[TAGPTR2:.*]] = getelementptr %ListAlt, ptr %[[VARIANT2]], i32 0, i32 0
-// CHECK: store i64 0, ptr %[[TAGPTR2]], align 8
+// CHECK: store i8 0, ptr %[[TAGPTR2]], align 1
 // CHECK: %[[PAYLOAD2:.*]] = getelementptr %ListAlt, ptr %[[VARIANT2]], i32 0, i32 1
 // CHECK-NOT: getelementptr %"List::Cons", ptr %[[PAYLOAD2]]
 // CHECK: ret ptr
@@ -180,7 +180,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK: call void @llvm.assume
 // CHECK: %[[VARIANT3:.*]] = getelementptr { i64, %ListAlt }, ptr %{{.*}}, i32 0, i32 1
 // CHECK: %[[TAGPTR3:.*]] = getelementptr %ListAlt, ptr %[[VARIANT3]], i32 0, i32 0
-// CHECK: store i64 0, ptr %[[TAGPTR3]], align 8
+// CHECK: store i8 0, ptr %[[TAGPTR3]], align 1
 // CHECK: %[[PAYLOAD3:.*]] = getelementptr %ListAlt, ptr %[[VARIANT3]], i32 0, i32 1
 // CHECK-NOT: getelementptr %"List::Cons", ptr %[[PAYLOAD3]]
 // CHECK: ret ptr
@@ -189,7 +189,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK: call void @llvm.assume
 // CHECK: %[[VARIANT4:.*]] = getelementptr { i64, %Triple }, ptr %{{.*}}, i32 0, i32 1
 // CHECK: %[[TAGPTR4:.*]] = getelementptr %Triple, ptr %[[VARIANT4]], i32 0, i32 0
-// CHECK: store i64 0, ptr %[[TAGPTR4]], align 8
+// CHECK: store i8 0, ptr %[[TAGPTR4]], align 1
 // CHECK: %[[PAYLOAD4:.*]] = getelementptr %Triple, ptr %[[VARIANT4]], i32 0, i32 1
 // CHECK-NOT: getelementptr %"Triple::Cons", ptr %[[PAYLOAD4]], i32 0, i32 0
 // CHECK-NOT: getelementptr %"Triple::Cons", ptr %[[PAYLOAD4]], i32 0, i32 1

--- a/tests/integration/conversion/record_dispatch_ops.mlir
+++ b/tests/integration/conversion/record_dispatch_ops.mlir
@@ -90,7 +90,8 @@ module {
 
 // CHECK-LABEL: define i32 @test_option_unwrap_or_default(ptr %0)
 // CHECK: getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: load i64, ptr
+// CHECK: load i8, ptr
+// CHECK: zext i8
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label
@@ -102,7 +103,8 @@ module {
 
 // CHECK-LABEL: define i32 @test_result_unwrap_or_error_code(ptr %0)
 // CHECK: getelementptr %Result, ptr %0, i32 0, i32 0
-// CHECK: load i64, ptr
+// CHECK: load i8, ptr
+// CHECK: zext i8
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label
@@ -114,7 +116,8 @@ module {
 
 // CHECK-LABEL: define void @test_void_dispatch_with_side_effects(ptr %0)
 // CHECK: getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: load i64, ptr
+// CHECK: load i8, ptr
+// CHECK: zext i8
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label

--- a/tests/integration/conversion/record_ops.mlir
+++ b/tests/integration/conversion/record_ops.mlir
@@ -36,17 +36,22 @@ module {
   }
 }
 
+// Members are packed by descending alignment (the tail pointer precedes the
+// i32 head) and the variant tag is the minimal-width integer (2 arms -> i8).
+// CHECK: %"List::Cons" = type { ptr, i32, [4 x i8] }
+// CHECK: %List = type { i8, %"List::Cons" }
+
 // CHECK-LABEL: define ptr @cons(i32 %0, ptr %1)
 // CHECK: %[[cons_alloca:[0-9]+]] = alloca %"List::Cons", align 8
-// CHECK: %[[cons_ptr0:[0-9]+]] = getelementptr %"List::Cons", ptr %[[cons_alloca]], i32 0, i32 0
+// CHECK: %[[cons_ptr0:[0-9]+]] = getelementptr %"List::Cons", ptr %[[cons_alloca]], i32 0, i32 1
 // CHECK: store i32 %0, ptr %[[cons_ptr0]], align 4
-// CHECK: %[[cons_ptr1:[0-9]+]] = getelementptr %"List::Cons", ptr %[[cons_alloca]], i32 0, i32 1
+// CHECK: %[[cons_ptr1:[0-9]+]] = getelementptr %"List::Cons", ptr %[[cons_alloca]], i32 0, i32 0
 // CHECK: store ptr %1, ptr %[[cons_ptr1]], align 8
 // CHECK: %[[cons_loaded:[0-9]+]] = load %"List::Cons", ptr %[[cons_alloca]], align 8
 // CHECK: %[[alloca:[0-9]+]] = alloca %List, i64 1, align 8
 // CHECK: call void @llvm.lifetime.start.p0({{.*}}ptr %[[alloca]])
 // CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %List, ptr %[[alloca]], i32 0, i32 0
-// CHECK: store i64 0, ptr %[[tag_ptr]], align 4
+// CHECK: store i8 0, ptr %[[tag_ptr]], align 1
 // CHECK: %[[value_ptr:[0-9]+]] = getelementptr %List, ptr %[[alloca]], i32 0, i32 1
 // CHECK: store %"List::Cons" %[[cons_loaded]], ptr %[[value_ptr]], align 8
 // CHECK: %[[loaded:[0-9]+]] = load %List, ptr %[[alloca]], align 8
@@ -60,10 +65,12 @@ module {
 
 // CHECK-LABEL: define i64 @test_option_tag(ptr %0)
 // CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: %[[tag_value:[0-9]+]] = load i64, ptr %[[tag_ptr]], align 4
+// CHECK: %[[narrow_tag:[0-9]+]] = load i8, ptr %[[tag_ptr]], align 1
+// CHECK: %[[tag_value:[0-9]+]] = zext i8 %[[narrow_tag]] to i64
 // CHECK: ret i64 %[[tag_value]]
 
 // CHECK-LABEL: define i64 @test_result_tag(ptr %0)
 // CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %Result, ptr %0, i32 0, i32 0
-// CHECK: %[[tag_value:[0-9]+]] = load i64, ptr %[[tag_ptr]], align 4
+// CHECK: %[[narrow_tag:[0-9]+]] = load i8, ptr %[[tag_ptr]], align 1
+// CHECK: %[[tag_value:[0-9]+]] = zext i8 %[[narrow_tag]] to i64
 // CHECK: ret i64 %[[tag_value]]

--- a/tests/integration/conversion/special_pointer_tag_lowering.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering.mlir
@@ -44,8 +44,9 @@ module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.
   // CHECK-LABEL: define i64 @tag(ptr %0)
   // CHECK-NOT: lshr
   // CHECK-NOT: select
-  // CHECK: %[[TAG:.+]] = load i64, ptr
-  // CHECK: ret i64 %[[TAG]]
+  // CHECK: %[[TAG:.+]] = load i8, ptr
+  // CHECK: %[[WIDE:.+]] = zext i8 %[[TAG]] to i64
+  // CHECK: ret i64 %[[WIDE]]
   func.func @tag(%ref: !reussir.ref<!list shared>) -> index {
     %tag = reussir.record.tag(%ref : !reussir.ref<!list shared>) : index
     return %tag : index

--- a/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
@@ -43,8 +43,9 @@ module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #
   // CHECK-LABEL: define i64 @tag(ptr %0)
   // CHECK-NOT: lshr
   // CHECK-NOT: select
-  // CHECK: %[[TAG:.+]] = load i64, ptr
-  // CHECK: ret i64 %[[TAG]]
+  // CHECK: %[[TAG:.+]] = load i8, ptr
+  // CHECK: %[[WIDE:.+]] = zext i8 %[[TAG]] to i64
+  // CHECK: ret i64 %[[WIDE]]
   func.func @tag(%ref: !reussir.ref<!list shared>) -> index {
     %tag = reussir.record.tag(%ref : !reussir.ref<!list shared>) : index
     return %tag : index

--- a/tests/integration/frontend/rbtree.c
+++ b/tests/integration/frontend/rbtree.c
@@ -4,10 +4,11 @@
 
 typedef struct rc_list {
     int64_t refcount;
-    int64_t tag;
+    uint8_t tag;      /* minimal-width variant tag (2 arms -> i8) */
+    uint8_t _pad[7];
+    struct rc_list *tail; /* members are packed by descending alignment */
     int32_t head;
-    int32_t _pad;
-    struct rc_list *tail;
+    int32_t _pad2;
 } rc_list_t;
 
 #define LIST_NIL 0

--- a/tests/integration/frontend/rbtree_to_list.c
+++ b/tests/integration/frontend/rbtree_to_list.c
@@ -9,10 +9,10 @@
  * reference count, followed by the variant record:
  *
  *   offset  0:  int64_t  refcount
- *   offset  8:  int64_t  tag         (0 = Nil, 1 = Cons)
- *   offset 16:  int32_t  head        (valid when tag == 1)
+ *   offset  8:  uint8_t  tag         (0 = Nil, 1 = Cons; minimal width)
+ *   offset 16:  void*    tail        (valid when tag == 1, next RC<List>)
  *   offset 20:  (padding, 4 bytes)
- *   offset 24:  void*    tail        (valid when tag == 1, next RC<List>)
+ *   offset 24:  int32_t  head        (valid when tag == 1)
  *
  * Total allocation: 32 bytes  (__reussir_allocate(align=8, size=32))
  *
@@ -21,10 +21,11 @@
  */
 typedef struct rc_list {
     int64_t          refcount;
-    int64_t          tag;
+    uint8_t          tag;      /* minimal-width variant tag (2 arms -> i8) */
+    uint8_t          _pad[7];
+    struct rc_list  *tail;     /* members are packed by descending alignment */
     int32_t          head;
-    int32_t          _pad;
-    struct rc_list  *tail;
+    int32_t          _pad2;
 } rc_list_t;
 
 #define LIST_NIL  0


### PR DESCRIPTION
First of the three layout/ownership PRs from the #325 re-attribution (this one → fused 8-byte rc header → borrow inference).

## What

Two deterministic layout rules — each a pure function of the type declaration and target, identical across CGUs, packages, and opt levels (this is the layout contract FFI consumers compile against):

1. **Packed member order (compounds)**: members are laid out by descending storage alignment, stable on declaration order — no padding can appear between members, only at the tail. Frontend and all MLIR-level passes keep logical (declaration) indices; the LLVM lowering remaps at the GEP sites via the new `RecordType::getPhysicalMemberIndex` (project / compound / extract / fused creates / TRMC hole fields). **Closure boxes are exempt**: the capture/argument area stays in declaration order with well-defined alignment boundaries, since the apply cursor protocol writes arguments incrementally at fixed offsets.
2. **Minimal-width variant tags**: the discriminant shrinks from `index` to the narrowest integer covering the arm count (i8/i16/i32, via `RecordType::getTagType`). A nullary `[value]` enum like rbtree's `Color` drops 8 B → 1 B and packs into the parent payload next to other small members.

Supporting changes:
- The region scanner's `Variant` instruction now carries the tag width (encoding shared between `ReussirTypes.h` and `reussir-rt`: `-1/-3/-4` = 1/2/4-byte tag read, jump base moves to `-5`); the runtime interpreter reads u8/u16/u32 accordingly.
- Tagged-immediate dummy boxes: one index-wide dummy still serves narrow tag reads (little-endian low-byte aliasing; documented at `tagDummyBox`).
- The repl's reflection mirror (`reflect.rs`) follows both rules; rbtree C harnesses re-learn the layout once (`tag: u8`, tail before head).

## Measured (aarch64, n=4.2M, xLTO + static mimalloc, Koka same-day 0.38 s / 4.22M LLd)

| | before | after |
|---|---|---|
| rbtree (i64 keys) node | 56 B (64 B block) | **48 B (48 B block)** |
| rbtree LLd misses | 8.44M | **6.33M (−25%)** |
| rbtree RSS | 265 MB | **199 MB (−25%)** |
| rbtree wall | 0.45 s | 0.46 s (≈flat) |
| rbtree-zipper wall | 0.42 s | **0.40 s** |
| nbe-hoas | 0.24 s / 386 MB | unchanged |

Wall on rbtree is ~flat despite the miss drop (instructions +1.8% from tag zexts); the memory-system win is real and deterministic. The i32-key rbtree node shrinks 48→40 B and nbe's pointer-aligned payloads absorb the narrow tag into the same header slot — both stay inside their current mimalloc bin (16-grained above 32 B), exactly as the #325 analysis predicted. **They cross into the 32 B bin with the follow-up fused 8-byte rc header, which this change enables** (tag is now i32-or-smaller, ready to share one word with an i32 count).

Note discovered while measuring: the side-by-side harness pairs our `rbtree.rr` (i64 keys) against Koka's `rbtree.kk` (int32 keys) — the fair-key-width comparison is the in-repo `rbtree2.rr`. Worth aligning the harness sources at some point.

## Validation

Full lit suite 288/288 (incl. asan/lsan/msan/tsan executing gates), rt unit tests (scanner encoding round-trip + region scans), rrc-test, jit tests, repl tests, plus fold-correctness of all three benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2