### PR TITLE
[backend] fused 8-byte rc box header: i32 count + i32 tag in one word

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -174,6 +174,13 @@ unsafe extern "C" {
         triple: *const c_char,
     ) -> bool;
 
+    /// Sets whether compound record members are laid out in packed physical
+    /// order (descending storage alignment) rather than declaration order. On
+    /// by default. A whole-compilation layout contract held on the
+    /// context-loaded Reussir dialect; set it once before the lowering pipeline
+    /// computes any layout.
+    pub fn reussirContextSetPackRecordMembers(context: MlirContext, enable: bool);
+
     //==-- LLVM-side codegen helpers (Jit.h) --==//
 
     /// Runs the Reussir LLVM optimization pipeline on `module` in place at the

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -79,6 +79,11 @@ pub struct LoweringOptions {
     pub nullary_variant_encoding: NullaryVariantEncoding,
     /// Run the invariant-group analysis pass.
     pub enable_invariant_analysis: bool,
+    /// Lay out compound record members in packed physical order (descending
+    /// storage alignment) rather than declaration order. On by default — the
+    /// layout contract external consumers compile against; `rrc` exposes the
+    /// off switch as `--no-pack-record-members`.
+    pub pack_record_members: bool,
 }
 
 impl Default for LoweringOptions {
@@ -93,6 +98,9 @@ impl Default for LoweringOptions {
             // Off by default, mirroring the C++ `createLoweringPipeline`
             // (`enableInvariantAnalysis = false`).
             enable_invariant_analysis: false,
+            // On by default: packed layout is the shipped default and the
+            // layout contract; only an explicit driver flag turns it off.
+            pack_record_members: true,
         }
     }
 }
@@ -179,8 +187,17 @@ pub fn run_lowering_pipeline(
         reuse_token_across_call = options.reuse_token_across_call,
         enable_invariant_analysis = options.enable_invariant_analysis,
         nullary_variant_encoding = ?options.nullary_variant_encoding,
+        pack_record_members = options.pack_record_members,
     )
     .entered();
+
+    // Record-member packing is a whole-compilation layout contract held on the
+    // context-loaded dialect; set it once before any pass computes a layout.
+    // SAFETY: `context` is live for the call; the CAPI only loads the Reussir
+    // dialect and sets a bool on it.
+    unsafe {
+        sys::reussirContextSetPackRecordMembers(context.to_raw(), options.pack_record_members);
+    }
 
     let manager = PassManager::new(context);
 

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -190,6 +190,13 @@ struct Cli {
     #[arg(long = "reuse-across-call")]
     reuse_across_call: bool,
 
+    /// Lay out compound record members in declaration order instead of the
+    /// default packed order (members sorted by descending storage alignment,
+    /// eliminating inter-member padding). Packing is the shipped default and
+    /// the layout contract; this restores the unpacked layout.
+    #[arg(long = "no-pack-record-members")]
+    no_pack_record_members: bool,
+
     /// Run the MLIR backend single-threaded (disable its thread pool). Useful for
     /// deterministic diagnostics and for debugging under tools that dislike the
     /// backend's worker threads (e.g. some sanitizers/debuggers).
@@ -580,6 +587,7 @@ fn backend_module(
         opt,
         reuse_token_across_call: cli.reuse_across_call,
         nullary_variant_encoding: cli.nullary_variant_encoding.resolve(machine.triple()),
+        pack_record_members: !cli.no_pack_record_members,
         ..LoweringOptions::default()
     };
     let optimize_ffi = !matches!(opt, OptLevel::None);

--- a/crates/reussir-repl/src/reflect.rs
+++ b/crates/reussir-repl/src/reflect.rs
@@ -44,6 +44,20 @@ fn variant_tag_size(arms: usize) -> u64 {
     }
 }
 
+/// Tag offset/width and payload header size of a variant record (mirrors the
+/// backend layout): a shared/regional variant carries the fused 8-byte box
+/// header `{i32 count slot, i32 tag}`, so the tag reads at offset 4 and the
+/// payload starts past 8 bytes; a [value] variant is `{minimal tag @ 0,
+/// payload}`.
+fn variant_tag_layout(cap: DefaultCap, arms: usize) -> (u64, u64, u64) {
+    if cap == DefaultCap::Value {
+        let tag = variant_tag_size(arms);
+        (0, tag, tag)
+    } else {
+        (4, 4, 8)
+    }
+}
+
 /// Packed physical member order (mirrors `RecordType::getPackedOrder`):
 /// member indices sorted by descending storage alignment, stable on
 /// declaration order.
@@ -218,9 +232,10 @@ pub fn inline_size_align<'tcx>(
                 ShapeLayout::Compound(fields) => compound_size_align(fields, shapes),
                 ShapeLayout::Variants(variants) => {
                     let payload = variants_payload_size_align(variants, shapes)?;
-                    let tag = variant_tag_size(variants.len());
-                    let payload_offset = align_to(tag, payload.align);
-                    let align = payload.align.max(tag);
+                    let (_, tag_size, header) =
+                        variant_tag_layout(shape.default_cap, variants.len());
+                    let payload_offset = align_to(header, payload.align);
+                    let align = payload.align.max(if header == 8 { 8 } else { tag_size });
                     Ok(SizeAlign {
                         size: align_to(payload_offset + payload.size, align),
                         align,
@@ -232,8 +247,8 @@ pub fn inline_size_align<'tcx>(
     }
 }
 
-/// The payload address inside a **shared** rc box (`{ count: usize, T }`,
-/// payload at `align_to(usize, align(T))`). Used by the value caller to
+/// The payload address inside a **shared** rc box (`{ count: i32, T }`,
+/// payload at `align_to(4, align(T))`). Used by the value caller to
 /// reach the `__ReplBox` payload without walking the box as a record.
 ///
 /// # Safety
@@ -245,7 +260,7 @@ pub unsafe fn shared_box_payload<'tcx>(
     shapes: &ShapeTable<'tcx>,
 ) -> Result<*const u8, String> {
     let inner = inline_size_align(box_ty, shapes)?;
-    Ok(unsafe { boxed.add(align_to(WORD, inner.align) as usize) })
+    Ok(unsafe { boxed.add(align_to(4, inner.align) as usize) })
 }
 
 /// Packed layout of a member list (descending storage alignment, stable on
@@ -498,9 +513,15 @@ impl<'tcx> Walker<'_, 'tcx> {
                         return Ok(());
                     }
                     let inner = inline_size_align(ty, self.shapes)?;
+                    let fused_variant =
+                        matches!(shape.layout, ShapeLayout::Variants(_))
+                            && shape.default_cap != DefaultCap::Value;
                     let header = match shape.default_cap {
-                        DefaultCap::Value => WORD, // unreachable in practice
-                        DefaultCap::Shared => WORD,
+                        DefaultCap::Value => 4, // unreachable in practice
+                        // A shared variant box IS the record: the refcount
+                        // overlays the record's leading count slot.
+                        DefaultCap::Shared if fused_variant => 0,
+                        DefaultCap::Shared => 4,
                         DefaultCap::Regional => 3 * WORD,
                     };
                     let payload = boxed.add(align_to(header, inner.align) as usize);
@@ -527,10 +548,13 @@ impl<'tcx> Walker<'_, 'tcx> {
                 unsafe { self.render_fields(payload, fields, depth, out) }
             }
             ShapeLayout::Variants(variants) => {
-                let tag = match variant_tag_size(variants.len()) {
-                    1 => unsafe { payload.cast::<u8>().read_unaligned() as usize },
-                    2 => unsafe { payload.cast::<u16>().read_unaligned() as usize },
-                    _ => unsafe { payload.cast::<u32>().read_unaligned() as usize },
+                let (tag_offset, tag_size, _) =
+                    variant_tag_layout(shape.default_cap, variants.len());
+                let tag_addr = unsafe { payload.add(tag_offset as usize) };
+                let tag = match tag_size {
+                    1 => unsafe { tag_addr.cast::<u8>().read_unaligned() as usize },
+                    2 => unsafe { tag_addr.cast::<u16>().read_unaligned() as usize },
+                    _ => unsafe { tag_addr.cast::<u32>().read_unaligned() as usize },
                 };
                 let Some(variant) = variants.get(tag) else {
                     return Err(format!("corrupt enum tag {tag} for `{}`", shape.name));
@@ -551,9 +575,10 @@ impl<'tcx> Walker<'_, 'tcx> {
                     })
                     .collect();
                 let payload_area = variants_payload_size_align(variants, self.shapes)?;
-                let tag_size = variant_tag_size(variants.len());
+                let (_, _, header) =
+                    variant_tag_layout(shape.default_cap, variants.len());
                 let base =
-                    unsafe { payload.add(align_to(tag_size, payload_area.align) as usize) };
+                    unsafe { payload.add(align_to(header, payload_area.align) as usize) };
                 unsafe { self.render_fields(base, &fields, depth, out) }
             }
         }

--- a/crates/reussir-rt/src/rc.rs
+++ b/crates/reussir-rt/src/rc.rs
@@ -6,7 +6,9 @@ use std::{
 
 #[repr(C)]
 struct RcBox<T> {
-    count: Cell<usize>,
+    // Mirrors the compiler's box header: an i32 refcount, with the payload
+    // at `align_to(4, align(T))` (repr(C) gives exactly that).
+    count: Cell<u32>,
     data: UnsafeCell<T>,
 }
 
@@ -44,7 +46,7 @@ impl<T> Rc<T> {
     pub unsafe fn data_mut(&mut self) -> &mut T {
         unsafe { &mut *self.get_box().as_mut().data.get() }
     }
-    pub fn count_ref(&self) -> &Cell<usize> {
+    pub fn count_ref(&self) -> &Cell<u32> {
         unsafe { &self.get_box().as_ref().count }
     }
     pub fn is_unique(&self) -> bool {

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -111,6 +111,13 @@ int reussirHasTPDE(void);
 bool reussirModuleAttachTargetSpec(MlirModule module, const char *dataLayout,
                                    const char *triple);
 
+// Sets whether compound record members are laid out in packed physical order
+// (descending storage alignment) rather than declaration order. On by default.
+// This is a whole-compilation layout contract held on the context-loaded
+// Reussir dialect, so set it once before the lowering pipeline computes any
+// layout. Loads the Reussir dialect into `context` if not already loaded.
+void reussirContextSetPackRecordMembers(MlirContext context, bool enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/Reussir/IR/ReussirDialect.td
+++ b/include/Reussir/IR/ReussirDialect.td
@@ -49,10 +49,19 @@ def ReussirDialect : Dialect {
     void registerOperations();
     // Register interfaces.
     void registerInterfaces();
+    // Whether compound record members are laid out in packed physical order
+    // (descending storage alignment) rather than declaration order. On by
+    // default. This is a whole-compilation layout contract, held on the
+    // context-loaded dialect so `RecordType::getPackedOrder` can read it, and
+    // set once by the lowering driver before any layout is computed.
+    bool packRecordMembers = true;
   public:
+    void setPackRecordMembers(bool enable) { packRecordMembers = enable; }
+    bool getPackRecordMembers() const { return packRecordMembers; }
+
     mlir::Type parseType(mlir::DialectAsmParser &parser) const override;
     void printType(mlir::Type ty, mlir::DialectAsmPrinter &p) const override;
- 
+
     mlir::Attribute parseAttribute(mlir::DialectAsmParser &parser,
                                    mlir::Type type) const override;
     void printAttribute(mlir::Attribute attr,

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -143,7 +143,15 @@ def ReussirRecordType
         mlir::Type memberWithLargestAlignment;
       };
       LayoutInfo getElementRegionLayoutInfo(const mlir::DataLayout &dataLayout) const;
-      // The discriminant type of a variant record: the narrowest integer
+      // A shared/regional variant record carries a fused 8-byte box header:
+      // `{4-byte count slot, i32 tag, payload}`. When rc-boxed, the box IS
+      // the record — the refcount overlays the leading slot, so the rc
+      // pointer equals the record pointer. [value] variants (never a box
+      // element; shared records embed as pointers) keep the compact
+      // `{minimal-width tag, payload}` layout instead.
+      bool hasFusedHeader() const;
+      // The discriminant type of a variant record: i32 for fused-header
+      // (shared/regional) variants, otherwise the narrowest integer
       // covering the arm count (i8/i16/i32).
       mlir::IntegerType getTagType() const;
       // Physical member order of a compound record: member indices sorted by
@@ -409,8 +417,14 @@ def ReussirRcBoxType
   let extraClassDeclaration = [{
     mlir::Type getElementType() const { return getEleTy(); }
     bool isRegional() const { return getRegional(); }
+    // Whether the box IS its element: a non-regional box of a fused-header
+    // variant overlays the refcount on the element's leading count slot, so
+    // box pointer == element pointer.
+    bool isHeaderFused() const;
     size_t getElementIndex() const {
-      return isRegional() ? 3 : 1;
+      if (isRegional())
+        return 3;
+      return isHeaderFused() ? 0 : 1;
     }
   }];
 }

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -34,6 +34,7 @@
 #include "Reussir/Conversion/BasicOpsLowering.h"
 #include "Reussir/Conversion/Passes.h"
 #include "Reussir/Conversion/SCFOpsLowering.h"
+#include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/Transformation/Passes.h"
 #include "Reussir/Transformation/SpecialPointerTag.h"
@@ -215,4 +216,9 @@ bool reussirModuleAttachTargetSpec(MlirModule module, const char *dataLayout,
   moduleOp->setAttr(mlir::DLTIDialect::kDataLayoutAttrName,
                     mlir::DataLayoutSpecAttr::get(context, entries));
   return true;
+}
+
+void reussirContextSetPackRecordMembers(MlirContext context, bool enable) {
+  mlir::MLIRContext *ctx = unwrap(context);
+  ctx->getOrLoadDialect<reussir::ReussirDialect>()->setPackRecordMembers(enable);
 }

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -139,13 +139,10 @@ TagEncoding specialPtrTagEncoding(mlir::Operation *op) {
 // sized to the target's index width. Loads and increments through a tagged
 // value land here and observe a well-formed shared box header carrying the
 // immediate's own tag; the refcount stays pinned because `rc.set` never
-// writes it (see above). Records read their tag at the minimal width
-// (i8/i16/i32) from the same offset; on a little-endian target that read
-// sees the low bytes of the full-width tag word stored here, so one
-// index-wide dummy serves every tag width.
+// writes it (see above). The dummy mirrors the fused box header exactly:
+// an i32 count and the i32 tag sharing one 8-byte word.
 mlir::LLVM::GlobalOp tagDummyBox(mlir::ModuleOp module, mlir::Location loc,
                                  uint64_t tag, TagEncoding encoding,
-                                 mlir::IntegerType indexTy,
                                  mlir::OpBuilder &builder) {
   // Content-addressed v0 name, like every other lowering-generated global
   // (namespace + the decimal tag as payload).
@@ -155,14 +152,15 @@ mlir::LLVM::GlobalOp tagDummyBox(mlir::ModuleOp module, mlir::Location loc,
   if (!global) {
     mlir::OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(module.getBody());
-    auto arrTy = mlir::LLVM::LLVMArrayType::get(indexTy, 2);
-    uint64_t refCount = encoding == TagEncoding::Immortal
-                            ? immortalRefCount(indexTy.getWidth())
-                            : 2;
+    // The fused box header: {i32 count, i32 tag} in one 8-byte word.
+    auto countTy = mlir::IntegerType::get(module.getContext(), 32);
+    auto arrTy = mlir::LLVM::LLVMArrayType::get(countTy, 2);
+    uint64_t refCount =
+        encoding == TagEncoding::Immortal ? immortalRefCount(32) : 2;
     auto init = mlir::DenseElementsAttr::get(
-        mlir::RankedTensorType::get({2}, indexTy),
-        llvm::ArrayRef<llvm::APInt>{llvm::APInt(indexTy.getWidth(), refCount),
-                                    llvm::APInt(indexTy.getWidth(), tag)});
+        mlir::RankedTensorType::get({2}, countTy),
+        llvm::ArrayRef<llvm::APInt>{llvm::APInt(32, refCount),
+                                    llvm::APInt(32, tag)});
     global = mlir::LLVM::GlobalOp::create(
         builder, loc, arrTy,
         /*isConstant=*/false, mlir::LLVM::Linkage::Internal, name, init);
@@ -451,9 +449,14 @@ struct ReussirRcFetchConversionPattern
     // hits the dummy box's refcount, which is pinned >= 2 — exactly what
     // routes the expanded decrement to its shared branch and answers
     // `is_unique` with false (see the special-pointer-tag notes above).
-    mlir::Value loaded =
-        mlir::LLVM::LoadOp::create(rewriter, loc, indexTy, adaptor.getRcPtr());
-    rewriter.replaceOp(op, loaded);
+    mlir::Value loaded = mlir::LLVM::LoadOp::create(
+        rewriter, loc, rewriter.getI32Type(), adaptor.getRcPtr());
+    mlir::Value widened =
+        llvm::cast<mlir::IntegerType>(indexTy).getWidth() > 32
+            ? mlir::LLVM::ZExtOp::create(rewriter, loc, indexTy, loaded)
+                  .getResult()
+            : loaded;
+    rewriter.replaceOp(op, widened);
     return mlir::success();
   }
 };
@@ -466,6 +469,13 @@ struct ReussirRcSetConversionPattern
   matchAndRewrite(ReussirRcSetOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Value addr = adaptor.getRcPtr();
+    mlir::Value narrowCount =
+        adaptor.getRefCount().getType().getIntOrFloatBitWidth() > 32
+            ? mlir::LLVM::TruncOp::create(rewriter, op.getLoc(),
+                                          rewriter.getI32Type(),
+                                          adaptor.getRefCount())
+                  .getResult()
+            : adaptor.getRefCount();
     // `rc.set` is the one store that can lower a refcount, so it must not
     // reach the dummy box (its count would eventually decay to 1 and send an
     // immediate down the unique branch). Steer a recognized-immediate access
@@ -483,12 +493,11 @@ struct ReussirRcSetConversionPattern
         mlir::Value top = topByteOf(addr, op.getLoc(), rewriter);
         tagged = isTaggedImmediate(top, op.getLoc(), rewriter);
       } else {
-        tagged = isImmortalCount(adaptor.getRefCount(), op.getLoc(), rewriter);
+        tagged = isImmortalCount(narrowCount, op.getLoc(), rewriter);
       }
       addr = guardedAddr(op, tagged, addr, op.getLoc(), rewriter);
     }
-    rewriter.replaceOpWithNewOp<mlir::LLVM::StoreOp>(op, adaptor.getRefCount(),
-                                                     addr);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::StoreOp>(op, narrowCount, addr);
     return mlir::success();
   }
 };
@@ -859,17 +868,21 @@ struct ReussirRecordVariantConversionPattern
         rewriter, loc, ptrType, llvmStructType, one, alignment);
     addLifetimeOrInvariantOp<mlir::LLVM::LifetimeStartOp>(
         rewriter, loc, llvmStructType, allocaOp, *converter, op.getOperation());
-    // Get a pointer to the tag field (index 0) and store the tag
+    // Store the tag (past the count slot for fused-header variants).
+    bool fused = recordType.hasFusedHeader();
+    int32_t tagField = fused ? 1 : 0;
+    int32_t valueField = fused ? 2 : 1;
     auto tagPtr = mlir::LLVM::GEPOp::create(
         rewriter, loc, ptrType, llvmStructType, allocaOp,
-        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, tagField});
     mlir::LLVM::StoreOp::create(rewriter, loc, tag, tagPtr);
 
-    // Get a pointer to the value field (index 1) and store the value
-    if (llvmStructType.getSubelementIndexMap()->size() > 1) {
+    // Store the payload value when the variant has one.
+    if (llvmStructType.getSubelementIndexMap()->size() >
+        static_cast<size_t>(valueField)) {
       auto valuePtr = mlir::LLVM::GEPOp::create(
           rewriter, loc, ptrType, llvmStructType, allocaOp,
-          llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1});
+          llvm::ArrayRef<mlir::LLVM::GEPArg>{0, valueField});
       mlir::LLVM::StoreOp::create(rewriter, loc, value, valuePtr);
     }
     // Load the complete struct from the allocated space
@@ -1112,12 +1125,13 @@ struct ReussirRecordTagConversionPattern
     // Get the index type for the result
     auto indexType = converter->getIndexType();
 
-    // Create GEP operation to get the tag field pointer (index 0, 0)
-    // For variant records, the tag is always at the first field
+    // The discriminant field: past the count slot for fused-header
+    // variants, first field otherwise.
+    int32_t tagField = recordType.hasFusedHeader() ? 1 : 0;
     auto tagPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
     auto tagPtr = mlir::LLVM::GEPOp::create(
         rewriter, loc, tagPtrType, elementType, refPtr,
-        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, tagField});
 
     // Load the tag value at the record's minimal tag width and widen it to
     // the op's index result. Under the special-pointer-tag scheme a tagged
@@ -1230,22 +1244,18 @@ struct ReussirRcIncConversionPattern
     // dummy could actually be grown past wrap-around within a program's
     // lifetime: there the increment's store is steered to the scratch word
     // instead (the load stays plain, so nothing on the read path changes).
-    auto indexType =
-        static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter())
-            ->getIndexType();
+    auto countType = rewriter.getI32Type();
     TagEncoding encoding = specialPtrTagEncoding(op);
-    bool steerNarrowImmortal =
-        encoding == TagEncoding::Immortal &&
-        llvm::cast<mlir::IntegerType>(indexType).getWidth() < 64 &&
-        rcPtrTy.mayCarrySpecialPointerTag();
+    bool steerNarrowImmortal = encoding == TagEncoding::Immortal &&
+                               rcPtrTy.mayCarrySpecialPointerTag();
     auto one = mlir::arith::ConstantOp::create(
-        rewriter, op.getLoc(), mlir::IntegerAttr::get(indexType, 1));
+        rewriter, op.getLoc(), mlir::IntegerAttr::get(countType, 1));
     mlir::Value oldRefCnt;
     if (rcPtrTy.getAtomicKind() == AtomicKind::normal) {
-      oldRefCnt = mlir::LLVM::LoadOp::create(rewriter, op.getLoc(), indexType,
+      oldRefCnt = mlir::LLVM::LoadOp::create(rewriter, op.getLoc(), countType,
                                              refcntPtr);
       auto newRefCnt = mlir::arith::AddIOp::create(rewriter, op.getLoc(),
-                                                   indexType, oldRefCnt, one);
+                                                   countType, oldRefCnt, one);
       mlir::Value storeAddr = refcntPtr;
       if (steerNarrowImmortal) {
         mlir::Value immortal =
@@ -1274,7 +1284,19 @@ struct RcCreateStorageInfo {
   mlir::Value token;
   mlir::Value elementPtr;
   bool regional;
+  // Non-null when the pattern must store the refcount AFTER initializing the
+  // element: with a fused header a whole-value store would clobber the
+  // count slot it overlays.
+  mlir::Value countPtr;
 };
+
+// Stores `1` (i32) to a box's refcount slot.
+void storeInitialRcCount(mlir::Value countPtr, mlir::Location loc,
+                         mlir::ConversionPatternRewriter &rewriter) {
+  auto one = mlir::arith::ConstantOp::create(
+      rewriter, loc, mlir::IntegerAttr::get(rewriter.getI32Type(), 1));
+  mlir::LLVM::StoreOp::create(rewriter, loc, one, countPtr);
+}
 
 template <typename OpT, typename AdaptorT>
 mlir::FailureOr<RcCreateStorageInfo>
@@ -1287,24 +1309,20 @@ initializeRcCreateStorage(OpT op, AdaptorT adaptor,
     return op->emitError("TODO: atomic rc create"), mlir::failure();
 
   auto convertedBoxType = typeConverter->convertType(rcBoxType);
-  auto indexType = static_cast<const mlir::LLVMTypeConverter *>(typeConverter)
-                       ->getIndexType();
   auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
   auto token = adaptor.getToken();
 
   if (!rcBoxType.isRegional()) {
-    if (!op.getSkipRc()) {
-      auto one = mlir::arith::ConstantOp::create(
-          rewriter, op.getLoc(), mlir::IntegerAttr::get(indexType, 1));
-      auto refcntPtr = mlir::LLVM::GEPOp::create(
+    mlir::Value countPtr;
+    if (!op.getSkipRc())
+      countPtr = mlir::LLVM::GEPOp::create(
           rewriter, op.getLoc(), llvmPtrType, convertedBoxType, token,
           llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
-      mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), one, refcntPtr);
-    }
     auto elementPtr = mlir::LLVM::GEPOp::create(
         rewriter, op.getLoc(), llvmPtrType, convertedBoxType, token,
-        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1});
-    return RcCreateStorageInfo{token, elementPtr, false};
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{
+            0, static_cast<int32_t>(rcBoxType.getElementIndex())});
+    return RcCreateStorageInfo{token, elementPtr, false, countPtr};
   }
 
   if (!op.getToken())
@@ -1342,7 +1360,7 @@ initializeRcCreateStorage(OpT op, AdaptorT adaptor,
       mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), vtable, vtablePtr);
   vtableStore.setInvariantGroup(true);
   mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), token, regionPtr);
-  return RcCreateStorageInfo{token, elementPtr, true};
+  return RcCreateStorageInfo{token, elementPtr, true, /*countPtr=*/{}};
 }
 } // namespace
 
@@ -1361,6 +1379,8 @@ struct ReussirRcCreateOpConversionPattern
         rewriter, op.getLoc(), adaptor.getValue(), storage->elementPtr);
     if (!storage->regional)
       objectStore.setInvariantGroup(true);
+    if (storage->countPtr)
+      storeInitialRcCount(storage->countPtr, op.getLoc(), rewriter);
     rewriter.replaceOp(op, storage->token);
     return mlir::success();
   }
@@ -1407,6 +1427,8 @@ struct ReussirRcCreateCompoundOpConversionPattern
           mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), field, fieldPtr);
       store.setInvariantGroup(true);
     }
+    if (storage->countPtr)
+      storeInitialRcCount(storage->countPtr, op.getLoc(), rewriter);
     rewriter.replaceOp(op, results);
     return mlir::success();
   }
@@ -1434,7 +1456,7 @@ struct ReussirRcTaggedConversionPattern
     TagEncoding encoding = specialPtrTagEncoding(op);
     auto dummy =
         tagDummyBox(op->getParentOfType<mlir::ModuleOp>(), loc,
-                    op.getTag().getZExtValue(), encoding, indexTy, rewriter);
+                    op.getTag().getZExtValue(), encoding, rewriter);
     mlir::Value base = mlir::LLVM::AddressOfOp::create(rewriter, loc, ptrTy,
                                                        dummy.getSymName());
     if (encoding != TagEncoding::TBI) {
@@ -1479,23 +1501,28 @@ struct ReussirRcCreateVariantOpConversionPattern
     if (!llvmVariantType)
       return op.emitOpError("failed to convert record type to LLVM type");
 
+    bool fused = op.getRecordType().hasFusedHeader();
+    int32_t tagField = fused ? 1 : 0;
+    int32_t payloadField = fused ? 2 : 1;
     auto tag = mlir::arith::ConstantOp::create(
         rewriter, op.getLoc(),
         mlir::IntegerAttr::get(op.getRecordType().getTagType(),
                                op.getTag().getZExtValue()));
     auto tagPtr = mlir::LLVM::GEPOp::create(
         rewriter, op.getLoc(), llvmPtrType, llvmVariantType,
-        storage->elementPtr, llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
+        storage->elementPtr, llvm::ArrayRef<mlir::LLVM::GEPArg>{0, tagField});
     auto tagStore =
         mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), tag, tagPtr);
     tagStore.setInvariantGroup(true);
 
     llvm::SmallVector<mlir::Value> results;
     results.push_back(storage->token);
-    if (llvmVariantType.getSubelementIndexMap()->size() > 1) {
+    if (llvmVariantType.getSubelementIndexMap()->size() >
+        static_cast<size_t>(payloadField)) {
       auto payloadPtr = mlir::LLVM::GEPOp::create(
           rewriter, op.getLoc(), llvmPtrType, llvmVariantType,
-          storage->elementPtr, llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1});
+          storage->elementPtr,
+          llvm::ArrayRef<mlir::LLVM::GEPArg>{0, payloadField});
       if (op.getValue()) {
         auto payloadStore = mlir::LLVM::StoreOp::create(
             rewriter, op.getLoc(), adaptor.getValue(), payloadPtr);
@@ -1529,6 +1556,8 @@ struct ReussirRcCreateVariantOpConversionPattern
       }
     }
 
+    if (storage->countPtr)
+      storeInitialRcCount(storage->countPtr, op.getLoc(), rewriter);
     rewriter.replaceOp(op, results);
     return mlir::success();
   }
@@ -1586,18 +1615,22 @@ struct ReussirRecordCoerceConversionPattern
     RefType refType = op.getVariant().getType();
     auto elementType = llvm::cast<mlir::LLVM::LLVMStructType>(
         converter->convertType(refType.getElementType()));
+    auto variantRecord =
+        llvm::cast<RecordType>(refType.getElementType());
+    int32_t payloadField = variantRecord.hasFusedHeader() ? 2 : 1;
     bool variantHasNonZeroChild =
-        elementType.getSubelementIndexMap()->size() > 1;
+        elementType.getSubelementIndexMap()->size() >
+        static_cast<size_t>(payloadField);
 
     // Get the result type (should be a pointer type after conversion)
     mlir::Type resultType = converter->convertType(op.getCoerced().getType());
 
-    // Create GEP operation to get the value field pointer (index 0, 1)
-    // For variant records, the value is at the second field (index 1)
+    // The payload field follows the header (count slot + tag for fused
+    // variants, just the tag otherwise).
     if (variantHasNonZeroChild)
       rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
           op, resultType, elementType, variantPtr,
-          llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1});
+          llvm::ArrayRef<mlir::LLVM::GEPArg>{0, payloadField});
     else
       rewriter.replaceOpWithNewOp<mlir::ub::PoisonOp>(op, resultType);
     return mlir::success();
@@ -1773,9 +1806,7 @@ struct ReussirClosureCreateOpConversionPattern
     auto refcntPtr = mlir::LLVM::GEPOp::create(
         rewriter, loc, llvmPtrType, convertedRcBoxType, tokenPtr,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
-    auto one = mlir::arith::ConstantOp::create(
-        rewriter, loc, mlir::IntegerAttr::get(indexType, 1));
-    mlir::LLVM::StoreOp::create(rewriter, loc, one, refcntPtr);
+    storeInitialRcCount(refcntPtr, loc, rewriter);
 
     // 2. Assign vtable (GEP[0, 1, 0]) to address of the vtable
     auto vtablePtrSlot = mlir::LLVM::GEPOp::create(
@@ -1929,12 +1960,13 @@ struct ReussirRcIsUniqueOpConversionPattern
     // No guard for tagged immediates: the load reads the dummy box's
     // refcount, pinned above the unique/shared decision point, so
     // uniqueness is naturally false there.
+    auto countType = rewriter.getI32Type();
     auto refcnt =
-        mlir::LLVM::LoadOp::create(rewriter, loc, indexType, refcntPtr);
+        mlir::LLVM::LoadOp::create(rewriter, loc, countType, refcntPtr);
     if (outCount)
       *outCount = refcnt;
     auto one = mlir::arith::ConstantOp::create(
-        rewriter, loc, mlir::IntegerAttr::get(indexType, 1));
+        rewriter, loc, mlir::IntegerAttr::get(countType, 1));
     mlir::Value isOne = mlir::arith::CmpIOp::create(
         rewriter, loc, mlir::arith::CmpIPredicate::eq, refcnt, one);
     return isOne;

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -96,8 +96,12 @@ convertRecordType(mlir::LLVMTypeConverter &converter,
 
   llvm::SmallVector<mlir::Type> members;
   if (type.getKind() == reussir::RecordKind::variant) {
-    // The discriminant is the record's minimal-width tag type; the payload
-    // lands at its natural alignment boundary after it.
+    // A fused-header variant is `{i32 count slot, i32 tag, payload}` — the
+    // rc box overlays its refcount on field 0. Value variants carry just
+    // their minimal-width tag; either way the payload lands at its natural
+    // alignment boundary after the header.
+    if (type.hasFusedHeader())
+      members.push_back(mlir::IntegerType::get(type.getContext(), 32));
     members.push_back(type.getTagType());
     auto [size, _unused, representative] =
         type.getElementRegionLayoutInfo(dataLayout);
@@ -221,7 +225,12 @@ void populateReussirToLLVMTypeConversions(mlir::LLVMTypeConverter &converter) {
     return converter.convertType(type.getPtrTy());
   });
 
-  converter.addConversion([&converter](RcBoxType type) {
+  converter.addConversion([&converter](RcBoxType type) -> mlir::Type {
+    // A box of a fused-header variant IS the variant record: its refcount
+    // lives in the record's leading count slot.
+    if (auto recordTy = llvm::dyn_cast<RecordType>(type.getElementType());
+        recordTy && recordTy.hasFusedHeader() && !type.isRegional())
+      return converter.convertType(recordTy);
     llvm::SmallVector<mlir::Type> members;
     auto ptrTy = mlir::LLVM::LLVMPointerType::get(type.getContext());
     if (type.isRegional()) {
@@ -229,7 +238,7 @@ void populateReussirToLLVMTypeConversions(mlir::LLVMTypeConverter &converter) {
       members.push_back(ptrTy);
       members.push_back(ptrTy);
     } else
-      members.push_back(converter.getIndexType());
+      members.push_back(mlir::IntegerType::get(type.getContext(), 32));
     members.push_back(converter.convertType(type.getElementType()));
     return mlir::LLVM::LLVMStructType::getLiteral(type.getContext(), members);
   });

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -570,7 +570,18 @@ void RecordType::complete(llvm::ArrayRef<mlir::Type> members,
 //===----------------------------------------------------------------------===//
 // RecordType GetElementRegionSizeAndAlignment
 //===----------------------------------------------------------------------===//
+bool RcBoxType::isHeaderFused() const {
+  auto recordTy = llvm::dyn_cast<RecordType>(getEleTy());
+  return recordTy && recordTy.hasFusedHeader() && !isRegional();
+}
+
+bool RecordType::hasFusedHeader() const {
+  return isVariant() && getDefaultCapability() != Capability::value;
+}
+
 mlir::IntegerType RecordType::getTagType() const {
+  if (hasFusedHeader())
+    return mlir::IntegerType::get(getContext(), 32);
   size_t arms = getMembers().size();
   unsigned width = arms <= (1u << 8) ? 8 : arms <= (1u << 16) ? 16 : 32;
   return mlir::IntegerType::get(getContext(), width);
@@ -654,6 +665,15 @@ RecordType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
   if (isCompound())
     return size * 8; // Convert to bits
 
+  if (hasFusedHeader()) {
+    // {4-byte count slot, i32 tag, payload}: an 8-byte header the rc box
+    // overlays its refcount onto; the payload sits at its natural boundary
+    // past it.
+    llvm::Align finalAlign = std::max(align, llvm::Align(8));
+    llvm::TypeSize headerSize =
+        llvm::alignTo(llvm::TypeSize::getFixed(8), align.value());
+    return llvm::alignTo(size + headerSize, finalAlign.value()) * 8;
+  }
   mlir::IntegerType tagType = getTagType();
   llvm::TypeSize tagSize = dataLayout.getTypeSize(tagType);
   llvm::Align tagAlign{dataLayout.getTypeABIAlignment(tagType)};
@@ -673,6 +693,8 @@ RecordType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
   if (isCompound())
     return align.value();
 
+  if (hasFusedHeader())
+    return std::max<uint64_t>(align.value(), 8);
   mlir::IntegerType tagType = getTagType();
   uint64_t tagAlignment = dataLayout.getTypeABIAlignment(tagType);
   uint64_t finalAlignment = std::max(align.value(), tagAlignment);
@@ -934,13 +956,20 @@ void RcBoxType::print(mlir::AsmPrinter &printer) const {
 llvm::TypeSize
 RcBoxType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
                              mlir::DataLayoutEntryListRef params) const {
-  mlir::IndexType type = mlir::IndexType::get(getContext());
+  // A box whose element carries a fused header IS the element: the refcount
+  // overlays the element's leading count slot.
+  if (auto recordTy = llvm::dyn_cast<RecordType>(getEleTy());
+      recordTy && recordTy.hasFusedHeader() && !isRegional())
+    return dataLayout.getTypeSizeInBits(recordTy);
+  mlir::IndexType ptrWord = mlir::IndexType::get(getContext());
+  mlir::IntegerType countType = mlir::IntegerType::get(getContext(), 32);
   auto derived =
       isRegional()
           ? deriveCompoundSizeAndAlignment(
-                getContext(), {type, type, type, getEleTy()},
+                getContext(), {ptrWord, ptrWord, ptrWord, getEleTy()},
                 {false, false, false, false}, dataLayout, true)
-          : deriveCompoundSizeAndAlignment(getContext(), {type, getEleTy()},
+          : deriveCompoundSizeAndAlignment(getContext(),
+                                           {countType, getEleTy()},
                                            {false, false}, dataLayout, true);
   if (!derived)
     llvm_unreachable("RcBoxType must have a fixed size");
@@ -950,13 +979,18 @@ RcBoxType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
 
 uint64_t RcBoxType::getABIAlignment(const mlir::DataLayout &dataLayout,
                                     mlir::DataLayoutEntryListRef params) const {
-  mlir::IndexType type = mlir::IndexType::get(getContext());
+  if (auto recordTy = llvm::dyn_cast<RecordType>(getEleTy());
+      recordTy && recordTy.hasFusedHeader() && !isRegional())
+    return dataLayout.getTypeABIAlignment(recordTy);
+  mlir::IndexType ptrWord = mlir::IndexType::get(getContext());
+  mlir::IntegerType countType = mlir::IntegerType::get(getContext(), 32);
   auto derived =
       isRegional()
           ? deriveCompoundSizeAndAlignment(
-                getContext(), {type, type, type, getEleTy()},
+                getContext(), {ptrWord, ptrWord, ptrWord, getEleTy()},
                 {false, false, false, false}, dataLayout, true)
-          : deriveCompoundSizeAndAlignment(getContext(), {type, getEleTy()},
+          : deriveCompoundSizeAndAlignment(getContext(),
+                                           {countType, getEleTy()},
                                            {false, false}, dataLayout, true);
   if (!derived)
     llvm_unreachable("RcBoxType must have a fixed alignment");

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -594,6 +594,11 @@ RecordType::getPackedOrder(const mlir::DataLayout &dataLayout) const {
     order[i] = i;
   if (!isCompound())
     return order;
+  // Packing is a whole-compilation layout contract toggled on the loaded
+  // dialect (on by default). When off, members keep declaration order.
+  if (auto *dialect = getContext()->getLoadedDialect<ReussirDialect>();
+      dialect && !dialect->getPackRecordMembers())
+    return order;
   llvm::SmallVector<uint64_t> aligns(order.size());
   for (uint32_t i = 0; i < order.size(); ++i) {
     mlir::Type storage = memberStorageType(getContext(), getMembers()[i],

--- a/lib/IR/ReussirTypesScanner.cpp
+++ b/lib/IR/ReussirTypesScanner.cpp
@@ -82,8 +82,15 @@ RecordType::emitScannerInstructions(llvm::SmallVectorImpl<int32_t> &buffer,
   size_t scannedBytes = EmitState.scannedBytes;
   size_t cursorPosition = EmitState.cursorPosition;
   auto tagSize = dataLayout.getTypeSize(getTagType()).getFixedValue();
+  // A fused-header variant keeps its tag past the 4-byte count slot; move
+  // the cursor onto it before the variant read.
+  size_t tagOffset = scannedBytes + (hasFusedHeader() ? 4 : 0);
+  if (cursorPosition < tagOffset) {
+    buffer.push_back(advance(tagOffset - cursorPosition));
+    cursorPosition = tagOffset;
+  }
   buffer.push_back(variant(tagSize));
-  scannedBytes += tagSize;
+  scannedBytes = tagOffset + tagSize;
   auto layoutInfo = getElementRegionLayoutInfo(dataLayout);
   scannedBytes = llvm::alignTo(scannedBytes, layoutInfo.alignment);
   size_t currentSkip = buffer.size();

--- a/tests/integration/basic/success/record_create.mlir
+++ b/tests/integration/basic/success/record_create.mlir
@@ -8,10 +8,10 @@ module {
   func.func @cons(%fst : i32, %tail : !reussir.rc<!list>) -> !reussir.rc<!list> {
     %0 = reussir.record.compound(%fst, %tail : i32, !reussir.rc<!list>) : !cons
     %1 = reussir.record.variant [0] (%0 : !cons) : !list
-    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 24>
     %rc = reussir.rc.create 
         value(%1 : !list) 
-        token(%token : !reussir.token<align: 8, size: 32>) : !reussir.rc<!list>
+        token(%token : !reussir.token<align: 8, size: 24>) : !reussir.rc<!list>
     return %rc : !reussir.rc<!list>
   }
 }

--- a/tests/integration/conversion/closure_apply.mlir
+++ b/tests/integration/conversion/closure_apply.mlir
@@ -6,7 +6,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
   
   // Test function that accepts a closure and applies an argument to it
   // CHECK-LABEL: define ptr @apply_to_closure(ptr %0, i32 %1) {
-  // CHECK: %3 = getelementptr { i64, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %3 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %4 = load ptr, ptr %3, align 8
   // CHECK: %5 = ptrtoint ptr %4 to i64
   // CHECK: %6 = sub i64 0, %5
@@ -26,7 +26,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
   // Test function that applies multiple arguments to a closure
   // CHECK-LABEL: define ptr @apply_multiple_args(ptr %0, i32 %1, i64 %2) {
-  // CHECK: %4 = getelementptr { i64, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %4 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %5 = load ptr, ptr %4, align 8
   // CHECK: %6 = ptrtoint ptr %5 to i64
   // CHECK: %7 = sub i64 0, %6
@@ -38,7 +38,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
   // CHECK: %12 = add nuw i64 %11, 4
   // CHECK: %13 = inttoptr i64 %12 to ptr
   // CHECK: store ptr %13, ptr %4, align 8
-  // CHECK: %14 = getelementptr { i64, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %14 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %15 = load ptr, ptr %14, align 8
   // CHECK: %16 = ptrtoint ptr %15 to i64
   // CHECK: %17 = sub i64 0, %16
@@ -59,7 +59,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
   // Test function that applies an argument to a closure with no return value
   // CHECK-LABEL: define ptr @apply_void_closure(ptr %0, i32 %1) {
-  // CHECK: %3 = getelementptr { i64, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %3 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %4 = load ptr, ptr %3, align 8
   // CHECK: %5 = ptrtoint ptr %4 to i64
   // CHECK: %6 = sub i64 0, %5
@@ -79,7 +79,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
   // Test function that applies a small type (i8) to verify alignment handling
   // CHECK-LABEL: define ptr @apply_small_type(ptr %0, i8 %1) {
-  // CHECK: %3 = getelementptr { i64, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %3 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %4 = load ptr, ptr %3, align 8
   // CHECK: store i8 %1, ptr %4, align 1
   // CHECK: %5 = ptrtoint ptr %4 to i64

--- a/tests/integration/conversion/closure_uniqify_2.mlir
+++ b/tests/integration/conversion/closure_uniqify_2.mlir
@@ -13,20 +13,20 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 }
 
 // CHECK: llvm.func @test_closure_uniqify_with_input(%[[INPUT:.*]]: !llvm.ptr) -> !llvm.ptr {
-// CHECK:   %[[GEP_REFCNT:.*]] = llvm.getelementptr %[[INPUT]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, struct<(ptr, ptr)>)>
-// CHECK:   %[[REFCNT:.*]] = llvm.load %[[GEP_REFCNT]] : !llvm.ptr -> i64
-// CHECK:   %[[ONE:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK:   %[[IS_UNIQUE:.*]] = llvm.icmp "eq" %[[REFCNT]], %[[ONE]] : i64
+// CHECK:   %[[GEP_REFCNT:.*]] = llvm.getelementptr %[[INPUT]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr)>)>
+// CHECK:   %[[REFCNT:.*]] = llvm.load %[[GEP_REFCNT]] : !llvm.ptr -> i32
+// CHECK:   %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:   %[[IS_UNIQUE:.*]] = llvm.icmp "eq" %[[REFCNT]], %[[ONE]] : i32
 // CHECK:   llvm.cond_br %[[IS_UNIQUE]], ^[[THEN:bb[0-9]+]], ^[[ELSE:bb[0-9]+]]
 // CHECK: ^[[THEN]]:  // pred: ^bb0
 // CHECK:   llvm.br ^[[JOIN:bb[0-9]+]](%[[INPUT]] : !llvm.ptr)
 // CHECK: ^[[ELSE]]:  // pred: ^bb0
-// CHECK:   %[[GEP_VTABLE:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, struct<(ptr, ptr)>)>
+// CHECK:   %[[GEP_VTABLE:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr)>)>
 // CHECK:   %[[VTABLE:.*]] = llvm.load %[[GEP_VTABLE]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[GEP_CLONE:.*]] = llvm.getelementptr %[[VTABLE]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr, ptr)>
 // CHECK:   %[[CLONE_FUNC:.*]] = llvm.load %[[GEP_CLONE]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[CLONED:.*]] = llvm.call %[[CLONE_FUNC]](%[[INPUT]]) : !llvm.ptr, (!llvm.ptr) -> !llvm.ptr
-// CHECK:   %[[GEP_VTABLE2:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, struct<(ptr, ptr)>)>
+// CHECK:   %[[GEP_VTABLE2:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr)>)>
 // CHECK:   %[[VTABLE2:.*]] = llvm.load %[[GEP_VTABLE2]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[GEP_DROP:.*]] = llvm.getelementptr %[[VTABLE2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr, ptr)>
 // CHECK:   %[[DROP_FUNC:.*]] = llvm.load %[[GEP_DROP]] invariant_group : !llvm.ptr -> !llvm.ptr

--- a/tests/integration/conversion/inc_dec_cancellation.mlir
+++ b/tests/integration/conversion/inc_dec_cancellation.mlir
@@ -21,7 +21,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
           %tail_ref = reussir.ref.project (%cons : !reussir.ref<!list_cons shared>) [1] : !reussir.ref<!reussir.rc<!list> shared>
           %tail = reussir.ref.load (%tail_ref : !reussir.ref<!reussir.rc<!list> shared>) : !reussir.rc<!list>
           reussir.rc.inc (%tail : !reussir.rc<!list>)
-          %token = reussir.rc.dec (%arg0 : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 32>>
+          %token = reussir.rc.dec (%arg0 : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
           // We currently don't free the token here
           reussir.scf.yield %tail : !reussir.rc<!list>
       }

--- a/tests/integration/conversion/list_map.mlir
+++ b/tests/integration/conversion/list_map.mlir
@@ -31,7 +31,7 @@
 !token_rc_i64 = !reussir.token<align: 8, size: 16>
 !token_rc_list = !reussir.token<align: 8, size: 24>
 !token_closure = !reussir.token<align: 8, size: 40>
-!nullable_token_rc_list = !reussir.nullable<!reussir.token<align: 8, size: 32>>
+!nullable_token_rc_list = !reussir.nullable<!reussir.token<align: 8, size: 24>>
 !closure = !reussir.rc<!reussir.closure<(!rc_i64) -> !rc_i64>>
 module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"} 
 {

--- a/tests/integration/conversion/nullable_dispatch_ops.mlir
+++ b/tests/integration/conversion/nullable_dispatch_ops.mlir
@@ -78,7 +78,7 @@ module {
 // CHECK-LABEL: define i32 @test_nullable_unwrap_or_default(ptr %0)
 // CHECK: icmp ne ptr %0, null
 // CHECK: br i1
-// CHECK: getelementptr { i64, i32 }, ptr %0, i32 0, i32 1
+// CHECK: getelementptr { i32, i32 }, ptr %0, i32 0, i32 1
 // CHECK: load i32, ptr
 // CHECK: phi i32 [ 0
 // CHECK: ret i32
@@ -99,7 +99,7 @@ module {
 // CHECK-LABEL: define void @test_void_nullable_dispatch(ptr %0)
 // CHECK: icmp ne ptr %0, null
 // CHECK: br i1
-// CHECK: getelementptr { i64, i32 }, ptr %0, i32 0, i32 1
+// CHECK: getelementptr { i32, i32 }, ptr %0, i32 0, i32 1
 // CHECK: load i32, ptr
 // CHECK: mul i32
 // CHECK: ret void

--- a/tests/integration/conversion/option_like_ops.mlir
+++ b/tests/integration/conversion/option_like_ops.mlir
@@ -122,9 +122,9 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 }
 
 // CHECK-LABEL: define i32 @option_unwrap_or_default(ptr %0, i32 %1)
-// CHECK: getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: load i8, ptr
-// CHECK: zext i8
+// CHECK: getelementptr %Option, ptr %0, i32 0, i32 1
+// CHECK: load i32, ptr
+// CHECK: zext i32
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label
@@ -135,9 +135,9 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK: ret i32
 
 // CHECK-LABEL: define i32 @option_unwrap_or_compute(ptr %0)
-// CHECK: getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: load i8, ptr
-// CHECK: zext i8
+// CHECK: getelementptr %Option, ptr %0, i32 0, i32 1
+// CHECK: load i32, ptr
+// CHECK: zext i32
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label
@@ -148,9 +148,9 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK: ret i32
 
 // CHECK-LABEL: define i32 @result_unwrap_or_error(ptr %0)
-// CHECK: getelementptr %Result, ptr %0, i32 0, i32 0
-// CHECK: load i8, ptr
-// CHECK: zext i8
+// CHECK: getelementptr %Result, ptr %0, i32 0, i32 1
+// CHECK: load i32, ptr
+// CHECK: zext i32
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label
@@ -165,7 +165,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK-LABEL: define i32 @nullable_unwrap_or_default(ptr %0, i32 %1)
 // CHECK: icmp ne ptr %0, null
 // CHECK: br i1
-// CHECK: getelementptr { i64, i32 }, ptr %0, i32 0, i32 1
+// CHECK: getelementptr { i32, i32 }, ptr %0, i32 0, i32 1
 // CHECK: load i32, ptr
 // CHECK: phi i32 [ %1
 // CHECK: ret i32

--- a/tests/integration/conversion/rc_assume_unique.mlir
+++ b/tests/integration/conversion/rc_assume_unique.mlir
@@ -3,9 +3,9 @@
 
 module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
   // CHECK-LABEL: define void @rc_assume_unique(ptr %0) {
-  // CHECK: %2 = getelementptr { i64, i64 }, ptr %0, i32 0, i32 0
-  // CHECK: %3 = load i64, ptr %2, align 8
-  // CHECK: %4 = icmp eq i64 %3, 1
+  // CHECK: %2 = getelementptr { i32, i64 }, ptr %0, i32 0, i32 0
+  // CHECK: %3 = load i32, ptr %2, align 4
+  // CHECK: %4 = icmp eq i32 %3, 1
   // CHECK: call void @llvm.assume(i1 %4)
   func.func @rc_assume_unique(%rc: !reussir.rc<i64>) {
     reussir.rc.assume_unique(%rc : !reussir.rc<i64>)

--- a/tests/integration/conversion/rc_create_fused_lowering.mlir
+++ b/tests/integration/conversion/rc_create_fused_lowering.mlir
@@ -54,9 +54,9 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
     %field1 = reussir.ref.load (%field1_ref : !reussir.ref<i64>) : i64
     %c = reussir.record.compound(%field0, %field1 : i32, i64) : !cons
     %v = reussir.record.variant [0] (%c : !cons) : !list
-    %token0 = reussir.rc.reinterpret (%rc : !reussir.rc<!list>) : !reussir.token<align: 8, size: 32>
-    %token = reussir.token.launder (%token0 : !reussir.token<align: 8, size: 32>) : !reussir.token<align: 8, size: 32>
-    %new = reussir.rc.create value(%v : !list) token(%token : !reussir.token<align: 8, size: 32>) skip_rc : !reussir.rc<!list>
+    %token0 = reussir.rc.reinterpret (%rc : !reussir.rc<!list>) : !reussir.token<align: 8, size: 24>
+    %token = reussir.token.launder (%token0 : !reussir.token<align: 8, size: 24>) : !reussir.token<align: 8, size: 24>
+    %new = reussir.rc.create value(%v : !list) token(%token : !reussir.token<align: 8, size: 24>) skip_rc : !reussir.rc<!list>
     return %new : !reussir.rc<!list>
   }
 
@@ -69,9 +69,9 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
     %field1 = reussir.ref.load (%field1_ref : !reussir.ref<i64>) : i64
     %c = reussir.record.compound(%field0, %field1 : i32, i64) : !cons
     %v = reussir.record.variant [0] (%c : !cons) : !list_alt
-    %token0 = reussir.rc.reinterpret (%rc : !reussir.rc<!list_alt>) : !reussir.token<align: 8, size: 32>
-    %token = reussir.token.launder (%token0 : !reussir.token<align: 8, size: 32>) : !reussir.token<align: 8, size: 32>
-    %new = reussir.rc.create value(%v : !list_alt) token(%token : !reussir.token<align: 8, size: 32>) skip_rc : !reussir.rc<!list_alt>
+    %token0 = reussir.rc.reinterpret (%rc : !reussir.rc<!list_alt>) : !reussir.token<align: 8, size: 24>
+    %token = reussir.token.launder (%token0 : !reussir.token<align: 8, size: 24>) : !reussir.token<align: 8, size: 24>
+    %new = reussir.rc.create value(%v : !list_alt) token(%token : !reussir.token<align: 8, size: 24>) skip_rc : !reussir.rc<!list_alt>
     return %new : !reussir.rc<!list_alt>
   }
 
@@ -84,9 +84,9 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
     %field1 = reussir.ref.load (%field1_ref : !reussir.ref<i64>) : i64
     %c = reussir.record.compound(%field0, %field1 : i32, i64) : !cons
     %v = reussir.record.variant [0] (%c : !cons) : !list_alt
-    %token0 = reussir.rc.reinterpret (%rc : !reussir.rc<!list_clone>) : !reussir.token<align: 8, size: 32>
-    %token = reussir.token.launder (%token0 : !reussir.token<align: 8, size: 32>) : !reussir.token<align: 8, size: 32>
-    %new = reussir.rc.create value(%v : !list_alt) token(%token : !reussir.token<align: 8, size: 32>) skip_rc : !reussir.rc<!list_alt>
+    %token0 = reussir.rc.reinterpret (%rc : !reussir.rc<!list_clone>) : !reussir.token<align: 8, size: 24>
+    %token = reussir.token.launder (%token0 : !reussir.token<align: 8, size: 24>) : !reussir.token<align: 8, size: 24>
+    %new = reussir.rc.create value(%v : !list_alt) token(%token : !reussir.token<align: 8, size: 24>) skip_rc : !reussir.rc<!list_alt>
     return %new : !reussir.rc<!list_alt>
   }
 
@@ -99,9 +99,9 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
     %field1 = reussir.ref.load (%field1_ref : !reussir.ref<i64>) : i64
     %c = reussir.record.compound(%field0, %field1, %tail : i32, i64, !reussir.rc<!list_alt>) : !triple_cons
     %v = reussir.record.variant [0] (%c : !triple_cons) : !triple
-    %token0 = reussir.rc.reinterpret (%rc : !reussir.rc<!triple_clone>) : !reussir.token<align: 8, size: 40>
-    %token = reussir.token.launder (%token0 : !reussir.token<align: 8, size: 40>) : !reussir.token<align: 8, size: 40>
-    %new = reussir.rc.create value(%v : !triple) token(%token : !reussir.token<align: 8, size: 40>) skip_rc : !reussir.rc<!triple>
+    %token0 = reussir.rc.reinterpret (%rc : !reussir.rc<!triple_clone>) : !reussir.token<align: 8, size: 32>
+    %token = reussir.token.launder (%token0 : !reussir.token<align: 8, size: 32>) : !reussir.token<align: 8, size: 32>
+    %new = reussir.rc.create value(%v : !triple) token(%token : !reussir.token<align: 8, size: 32>) skip_rc : !reussir.rc<!triple>
     return %new : !reussir.rc<!triple>
   }
 }
@@ -109,28 +109,30 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK-LABEL: define ptr @mk_compound
 // CHECK-NOT: alloca %"List::Cons"
 // CHECK: %[[ALLOC:.*]] = call ptr @__reussir_allocate(i64 8, i64 24)
-// CHECK: %[[COUNT:.*]] = getelementptr { i64, %"List::Cons" }, ptr %[[ALLOC]], i32 0, i32 0
-// CHECK: store i64 1, ptr %[[COUNT]], align 8
-// CHECK: %[[PAYLOAD:.*]] = getelementptr { i64, %"List::Cons" }, ptr %[[ALLOC]], i32 0, i32 1
+// CHECK: %[[COUNT:.*]] = getelementptr { i32, %"List::Cons" }, ptr %[[ALLOC]], i32 0, i32 0
+// CHECK: %[[PAYLOAD:.*]] = getelementptr { i32, %"List::Cons" }, ptr %[[ALLOC]], i32 0, i32 1
 // CHECK: %[[FIELD0:.*]] = getelementptr %"List::Cons", ptr %[[PAYLOAD]], i32 0, i32 0
 // CHECK: store i32 %0, ptr %[[FIELD0]], align 4, !invariant.group
 // CHECK: %[[FIELD1:.*]] = getelementptr %"List::Cons", ptr %[[PAYLOAD]], i32 0, i32 1
 // CHECK: store i64 %1, ptr %[[FIELD1]], align 8, !invariant.group
+// CHECK: store i32 1, ptr %[[COUNT]], align 4
 
 // CHECK-LABEL: define ptr @mk_variant
 // CHECK-NOT: alloca %List
 // CHECK-NOT: alloca %"List::Cons"
-// CHECK: %[[ALLOC:.*]] = call ptr @__reussir_allocate(i64 8, i64 32)
-// CHECK: %[[COUNT:.*]] = getelementptr { i64, %List }, ptr %[[ALLOC]], i32 0, i32 0
-// CHECK: store i64 1, ptr %[[COUNT]], align 8
-// CHECK: %[[VARIANT:.*]] = getelementptr { i64, %List }, ptr %[[ALLOC]], i32 0, i32 1
-// CHECK: %[[TAGPTR:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 0
-// CHECK: store i8 0, ptr %[[TAGPTR]], align 1
-// CHECK: %[[PAYLOAD:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 1
+// The box IS the fused-header variant: the count overlays field 0 and is
+// stored after the element is initialized.
+// CHECK: %[[ALLOC:.*]] = call ptr @__reussir_allocate(i64 8, i64 24)
+// CHECK: %[[COUNT:.*]] = getelementptr %List, ptr %[[ALLOC]], i32 0, i32 0
+// CHECK: %[[VARIANT:.*]] = getelementptr %List, ptr %[[ALLOC]], i32 0, i32 0
+// CHECK: %[[TAGPTR:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 1
+// CHECK: store i32 0, ptr %[[TAGPTR]], align 4
+// CHECK: %[[PAYLOAD:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 2
 // CHECK: %[[FIELD0:.*]] = getelementptr %"List::Cons", ptr %[[PAYLOAD]], i32 0, i32 0
 // CHECK: store i32 %0, ptr %[[FIELD0]], align 4, !invariant.group
 // CHECK: %[[FIELD1:.*]] = getelementptr %"List::Cons", ptr %[[PAYLOAD]], i32 0, i32 1
 // CHECK: store i64 %1, ptr %[[FIELD1]], align 8, !invariant.group
+// CHECK: store i32 1, ptr %[[COUNT]], align 4
 
 // FUSION-LABEL: func.func @reuse_compound
 // FUSION: reussir.rc.create_compound
@@ -154,43 +156,43 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
 // CHECK-LABEL: define ptr @reuse_compound
 // CHECK: call void @llvm.assume
-// CHECK: %[[PAYLOAD:.*]] = getelementptr { i64, %"List::Cons" }, ptr %{{.*}}, i32 0, i32 1
+// CHECK: %[[PAYLOAD:.*]] = getelementptr { i32, %"List::Cons" }, ptr %{{.*}}, i32 0, i32 1
 // CHECK-NOT: getelementptr %"List::Cons", ptr %[[PAYLOAD]]
 // CHECK: ret ptr
 
 // CHECK-LABEL: define ptr @reuse_variant
 // CHECK: call void @llvm.assume
-// CHECK: %[[VARIANT:.*]] = getelementptr { i64, %List }, ptr %{{.*}}, i32 0, i32 1
-// CHECK: %[[TAGPTR:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 0
-// CHECK: store i8 0, ptr %[[TAGPTR]], align 1
-// CHECK: %[[PAYLOAD:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 1
+// CHECK: %[[VARIANT:.*]] = getelementptr %List, ptr %{{.*}}, i32 0, i32 0
+// CHECK: %[[TAGPTR:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 1
+// CHECK: store i32 0, ptr %[[TAGPTR]], align 4
+// CHECK: %[[PAYLOAD:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 2
 // CHECK-NOT: getelementptr %"List::Cons", ptr %[[PAYLOAD]]
 // CHECK: ret ptr
 
 // CHECK-LABEL: define ptr @reuse_variant_other_tag
 // CHECK: call void @llvm.assume
-// CHECK: %[[VARIANT2:.*]] = getelementptr { i64, %ListAlt }, ptr %{{.*}}, i32 0, i32 1
-// CHECK: %[[TAGPTR2:.*]] = getelementptr %ListAlt, ptr %[[VARIANT2]], i32 0, i32 0
-// CHECK: store i8 0, ptr %[[TAGPTR2]], align 1
-// CHECK: %[[PAYLOAD2:.*]] = getelementptr %ListAlt, ptr %[[VARIANT2]], i32 0, i32 1
+// CHECK: %[[VARIANT2:.*]] = getelementptr %ListAlt, ptr %{{.*}}, i32 0, i32 0
+// CHECK: %[[TAGPTR2:.*]] = getelementptr %ListAlt, ptr %[[VARIANT2]], i32 0, i32 1
+// CHECK: store i32 0, ptr %[[TAGPTR2]], align 4
+// CHECK: %[[PAYLOAD2:.*]] = getelementptr %ListAlt, ptr %[[VARIANT2]], i32 0, i32 2
 // CHECK-NOT: getelementptr %"List::Cons", ptr %[[PAYLOAD2]]
 // CHECK: ret ptr
 
 // CHECK-LABEL: define ptr @reuse_variant_other_type
 // CHECK: call void @llvm.assume
-// CHECK: %[[VARIANT3:.*]] = getelementptr { i64, %ListAlt }, ptr %{{.*}}, i32 0, i32 1
-// CHECK: %[[TAGPTR3:.*]] = getelementptr %ListAlt, ptr %[[VARIANT3]], i32 0, i32 0
-// CHECK: store i8 0, ptr %[[TAGPTR3]], align 1
-// CHECK: %[[PAYLOAD3:.*]] = getelementptr %ListAlt, ptr %[[VARIANT3]], i32 0, i32 1
+// CHECK: %[[VARIANT3:.*]] = getelementptr %ListAlt, ptr %{{.*}}, i32 0, i32 0
+// CHECK: %[[TAGPTR3:.*]] = getelementptr %ListAlt, ptr %[[VARIANT3]], i32 0, i32 1
+// CHECK: store i32 0, ptr %[[TAGPTR3]], align 4
+// CHECK: %[[PAYLOAD3:.*]] = getelementptr %ListAlt, ptr %[[VARIANT3]], i32 0, i32 2
 // CHECK-NOT: getelementptr %"List::Cons", ptr %[[PAYLOAD3]]
 // CHECK: ret ptr
 
 // CHECK-LABEL: define ptr @reuse_variant_prefix
 // CHECK: call void @llvm.assume
-// CHECK: %[[VARIANT4:.*]] = getelementptr { i64, %Triple }, ptr %{{.*}}, i32 0, i32 1
-// CHECK: %[[TAGPTR4:.*]] = getelementptr %Triple, ptr %[[VARIANT4]], i32 0, i32 0
-// CHECK: store i8 0, ptr %[[TAGPTR4]], align 1
-// CHECK: %[[PAYLOAD4:.*]] = getelementptr %Triple, ptr %[[VARIANT4]], i32 0, i32 1
+// CHECK: %[[VARIANT4:.*]] = getelementptr %Triple, ptr %{{.*}}, i32 0, i32 0
+// CHECK: %[[TAGPTR4:.*]] = getelementptr %Triple, ptr %[[VARIANT4]], i32 0, i32 1
+// CHECK: store i32 0, ptr %[[TAGPTR4]], align 4
+// CHECK: %[[PAYLOAD4:.*]] = getelementptr %Triple, ptr %[[VARIANT4]], i32 0, i32 2
 // CHECK-NOT: getelementptr %"Triple::Cons", ptr %[[PAYLOAD4]], i32 0, i32 0
 // CHECK-NOT: getelementptr %"Triple::Cons", ptr %[[PAYLOAD4]], i32 0, i32 1
 // CHECK: %[[FIELD24:.*]] = getelementptr %"Triple::Cons", ptr %[[PAYLOAD4]], i32 0, i32 2

--- a/tests/integration/conversion/rc_dec_expansion.mlir
+++ b/tests/integration/conversion/rc_dec_expansion.mlir
@@ -21,8 +21,8 @@
 
 module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> }  {
   func.func @test_rc_dec_expansion(%arg0: !reussir.rc<!list>) {
-    %token = reussir.rc.dec (%arg0 : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 32>>
-    reussir.token.free (%token :  !reussir.nullable<!reussir.token<align: 8, size: 32>>)
+    %token = reussir.rc.dec (%arg0 : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
+    reussir.token.free (%token :  !reussir.nullable<!reussir.token<align: 8, size: 24>>)
     return
   }
 }

--- a/tests/integration/conversion/rc_dispatch_fusion.mlir
+++ b/tests/integration/conversion/rc_dispatch_fusion.mlir
@@ -12,7 +12,7 @@
 !consty = !reussir.record<compound "list.cons" [value] {i64, !reussir.record<variant "list" incomplete>}>
 !listty = !reussir.record<variant "list" {!consty, !nilty}>
 !rclist = !reussir.rc<!listty>
-!tk = !reussir.token<align: 8, size: 32>
+!tk = !reussir.token<align: 8, size: 24>
 
 module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-i64:64-n8:16:32:64-S128"} {
   // The bound retain is fused away and the release learns the arm: on the

--- a/tests/integration/conversion/rc_is_unique.mlir
+++ b/tests/integration/conversion/rc_is_unique.mlir
@@ -6,9 +6,9 @@
 module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
   
   // CHECK-LABEL: define i1 @rc_is_unique_shared(ptr %0) {
-  // CHECK: %2 = getelementptr { i64, i64 }, ptr %0, i32 0, i32 0
-  // CHECK: %3 = load i64, ptr %2, align 8
-  // CHECK: %4 = icmp eq i64 %3, 1
+  // CHECK: %2 = getelementptr { i32, i64 }, ptr %0, i32 0, i32 0
+  // CHECK: %3 = load i32, ptr %2, align 4
+  // CHECK: %4 = icmp eq i32 %3, 1
   // CHECK: ret i1 %4
   func.func @rc_is_unique_shared(%rc: !reussir.rc<i64>) -> i1 {
     %is_unique = reussir.rc.is_unique (%rc : !reussir.rc<i64>) : i1
@@ -17,9 +17,9 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
 
   // Test with a more complex type
   // CHECK-LABEL: define i1 @rc_is_unique_struct(ptr %0) {
-  // CHECK: %2 = getelementptr { i64, %TestStruct }, ptr %0, i32 0, i32 0
-  // CHECK: %3 = load i64, ptr %2, align 8
-  // CHECK: %4 = icmp eq i64 %3, 1
+  // CHECK: %2 = getelementptr { i32, %TestStruct }, ptr %0, i32 0, i32 0
+  // CHECK: %3 = load i32, ptr %2, align 4
+  // CHECK: %4 = icmp eq i32 %3, 1
   // CHECK: ret i1 %4
   func.func @rc_is_unique_struct(%rc: !reussir.rc<!test_struct>) -> i1 {
     %is_unique = reussir.rc.is_unique (%rc : !reussir.rc<!test_struct>) : i1

--- a/tests/integration/conversion/rc_ops.mlir
+++ b/tests/integration/conversion/rc_ops.mlir
@@ -9,11 +9,11 @@
 !list = !reussir.record<variant "List" {!cons, !nil, !padding}>
 module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
   // CHECK-LABEL: define void @rc_inc(ptr %0) {
-  // CHECK: %2 = getelementptr { i64, i64 }, ptr %0, i32 0, i32 0
-  // CHECK: %3 = load i64, ptr %2, align 8
-  // CHECK: %4 = add i64 %3, 1
-  // CHECK: store i64 %4, ptr %2, align 8
-  // CHECK: %5 = icmp uge i64 %3, 1
+  // CHECK: %2 = getelementptr { i32, i64 }, ptr %0, i32 0, i32 0
+  // CHECK: %3 = load i32, ptr %2, align 4
+  // CHECK: %4 = add i32 %3, 1
+  // CHECK: store i32 %4, ptr %2, align 4
+  // CHECK: %5 = icmp uge i32 %3, 1
   // CHECK: call void @llvm.assume(i1 %5)
   func.func @rc_inc(%rc: !reussir.rc<i64>){
     reussir.rc.inc (%rc : !reussir.rc<i64>)
@@ -21,9 +21,9 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
   }
 
   // CHECK-LABEL: define void @rc_inc_atomic(ptr %0) {
-  // CHECK: %2 = getelementptr { i64, i64 }, ptr %0, i32 0, i32 0
-  // CHECK: %3 = atomicrmw add ptr %2, i64 1 monotonic, align 8
-  // CHECK: %4 = icmp uge i64 %3, 1
+  // CHECK: %2 = getelementptr { i32, i64 }, ptr %0, i32 0, i32 0
+  // CHECK: %3 = atomicrmw add ptr %2, i32 1 monotonic, align 4
+  // CHECK: %4 = icmp uge i32 %3, 1
   // CHECK: call void @llvm.assume(i1 %4)
   func.func @rc_inc_atomic(%rc: !reussir.rc<i64 atomic>){
     reussir.rc.inc (%rc : !reussir.rc<i64 atomic>)
@@ -37,15 +37,17 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
   }
 
   // CHECK-LABEL: define i64 @rc_fetch(ptr %0) {
-  // CHECK: %2 = load i64, ptr %0, align 8
-  // CHECK: ret i64 %2
+  // CHECK: %2 = load i32, ptr %0, align 4
+  // CHECK: %3 = zext i32 %2 to i64
+  // CHECK: ret i64 %3
   func.func @rc_fetch(%rc: !reussir.rc<i64>) -> index {
     %count = reussir.rc.fetch (%rc : !reussir.rc<i64>) : index
     return %count : index
   }
 
   // CHECK-LABEL: define void @rc_set(ptr %0, i64 %1) {
-  // CHECK: store i64 %1, ptr %0, align 8
+  // CHECK: %3 = trunc i64 %1 to i32
+  // CHECK: store i32 %3, ptr %0, align 4
   // CHECK: ret void
   func.func @rc_set(%rc: !reussir.rc<i64>, %count: index) {
     reussir.rc.set (%rc : !reussir.rc<i64>, %count : index)
@@ -62,10 +64,10 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
 
   // CHECK-LABEL: define ptr @rc_create(fp128 %0)
   // CHECK: %2 = call ptr @__reussir_allocate(i64 16, i64 32)
-  // CHECK: %3 = getelementptr { i64, fp128 }, ptr %2, i32 0, i32 0
-  // CHECK: store i64 1, ptr %3, align 8
-  // CHECK: %4 = getelementptr { i64, fp128 }, ptr %2, i32 0, i32 1
+  // CHECK: %3 = getelementptr { i32, fp128 }, ptr %2, i32 0, i32 0
+  // CHECK: %4 = getelementptr { i32, fp128 }, ptr %2, i32 0, i32 1
   // CHECK: store fp128 %0, ptr %4, align 16
+  // CHECK: store i32 1, ptr %3, align 4
   func.func @rc_create(%value: f128) -> !reussir.rc<f128> {
     %token = reussir.token.alloc : !reussir.token<align: 16, size: 32>
     %rc = reussir.rc.create 
@@ -75,7 +77,7 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
   }
 
   // CHECK-LABEL: define fp128 @rc_borrow_then_load_0(ptr %0) {
-  // CHECK: %2 = getelementptr { i64, fp128 }, ptr %0, i32 0, i32 1
+  // CHECK: %2 = getelementptr { i32, fp128 }, ptr %0, i32 0, i32 1
   // CHECK: %3 = load fp128, ptr %2, align 16
   // CHECK: ret fp128 %3
   func.func @rc_borrow_then_load_0(%rc : !reussir.rc<f128>) -> f128 {

--- a/tests/integration/conversion/record_coerce.mlir
+++ b/tests/integration/conversion/record_coerce.mlir
@@ -5,28 +5,28 @@
 
 module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>>} {
   func.func @record_coerce_first_variant(%variant_ref : !reussir.ref<!variant_record>) -> !reussir.ref<i32> {
-    // CHECK: %[[GEP:.*]] = getelementptr %test_variant, ptr %0, i32 0, i32 1
+    // CHECK: %[[GEP:.*]] = getelementptr %test_variant, ptr %0, i32 0, i32 2
     // CHECK: ret ptr %[[GEP]]
     %coerced = reussir.record.coerce[0](%variant_ref : !reussir.ref<!variant_record>) : !reussir.ref<i32>
     return %coerced : !reussir.ref<i32>
   }
 
   func.func @record_coerce_second_variant(%variant_ref : !reussir.ref<!variant_record>) -> !reussir.ref<i64> {
-    // CHECK: %[[GEP:.*]] = getelementptr %test_variant, ptr %0, i32 0, i32 1
+    // CHECK: %[[GEP:.*]] = getelementptr %test_variant, ptr %0, i32 0, i32 2
     // CHECK: ret ptr %[[GEP]]
     %coerced = reussir.record.coerce[1](%variant_ref : !reussir.ref<!variant_record>) : !reussir.ref<i64>
     return %coerced : !reussir.ref<i64>
   }
 
   func.func @record_coerce_third_variant(%variant_ref : !reussir.ref<!variant_record>) -> !reussir.ref<f32> {
-    // CHECK: %[[GEP:.*]] = getelementptr %test_variant, ptr %0, i32 0, i32 1
+    // CHECK: %[[GEP:.*]] = getelementptr %test_variant, ptr %0, i32 0, i32 2
     // CHECK: ret ptr %[[GEP]]
     %coerced = reussir.record.coerce[2](%variant_ref : !reussir.ref<!variant_record>) : !reussir.ref<f32>
     return %coerced : !reussir.ref<f32>
   }
 
   func.func @record_coerce_with_capabilities(%variant_ref : !reussir.ref<!variant_record shared>) -> !reussir.ref<i32 shared> {
-    // CHECK: %[[GEP:.*]] = getelementptr %test_variant, ptr %0, i32 0, i32 1
+    // CHECK: %[[GEP:.*]] = getelementptr %test_variant, ptr %0, i32 0, i32 2
     // CHECK: ret ptr %[[GEP]]
     %coerced = reussir.record.coerce[0](%variant_ref : !reussir.ref<!variant_record shared>) : !reussir.ref<i32 shared>
     return %coerced : !reussir.ref<i32 shared>

--- a/tests/integration/conversion/record_dispatch_ops.mlir
+++ b/tests/integration/conversion/record_dispatch_ops.mlir
@@ -89,9 +89,9 @@ module {
 }
 
 // CHECK-LABEL: define i32 @test_option_unwrap_or_default(ptr %0)
-// CHECK: getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: load i8, ptr
-// CHECK: zext i8
+// CHECK: getelementptr %Option, ptr %0, i32 0, i32 1
+// CHECK: load i32, ptr
+// CHECK: zext i32
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label
@@ -102,9 +102,9 @@ module {
 // CHECK: ret i32
 
 // CHECK-LABEL: define i32 @test_result_unwrap_or_error_code(ptr %0)
-// CHECK: getelementptr %Result, ptr %0, i32 0, i32 0
-// CHECK: load i8, ptr
-// CHECK: zext i8
+// CHECK: getelementptr %Result, ptr %0, i32 0, i32 1
+// CHECK: load i32, ptr
+// CHECK: zext i32
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label
@@ -115,9 +115,9 @@ module {
 // CHECK: ret i32
 
 // CHECK-LABEL: define void @test_void_dispatch_with_side_effects(ptr %0)
-// CHECK: getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: load i8, ptr
-// CHECK: zext i8
+// CHECK: getelementptr %Option, ptr %0, i32 0, i32 1
+// CHECK: load i32, ptr
+// CHECK: zext i32
 // CHECK: trunc i64
 // CHECK: switch i32
 // CHECK: i32 0, label

--- a/tests/integration/conversion/record_ops.mlir
+++ b/tests/integration/conversion/record_ops.mlir
@@ -18,10 +18,10 @@ module {
   func.func @cons(%fst : i32, %tail : !reussir.rc<!list>) -> !reussir.rc<!list> {
     %0 = reussir.record.compound(%fst, %tail : i32, !reussir.rc<!list>) : !cons
     %1 = reussir.record.variant [0] (%0 : !cons) : !list
-    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 24>
     %rc = reussir.rc.create 
         value(%1 : !list) 
-        token(%token : !reussir.token<align: 8, size: 32>) : !reussir.rc<!list>
+        token(%token : !reussir.token<align: 8, size: 24>) : !reussir.rc<!list>
     return %rc : !reussir.rc<!list>
   }
 
@@ -37,9 +37,10 @@ module {
 }
 
 // Members are packed by descending alignment (the tail pointer precedes the
-// i32 head) and the variant tag is the minimal-width integer (2 arms -> i8).
+// i32 head); a shared variant carries the fused 8-byte box header
+// {i32 count slot, i32 tag} and the box IS the record.
 // CHECK: %"List::Cons" = type { ptr, i32, [4 x i8] }
-// CHECK: %List = type { i8, %"List::Cons" }
+// CHECK: %List = type { i32, i32, %"List::Cons" }
 
 // CHECK-LABEL: define ptr @cons(i32 %0, ptr %1)
 // CHECK: %[[cons_alloca:[0-9]+]] = alloca %"List::Cons", align 8
@@ -50,27 +51,27 @@ module {
 // CHECK: %[[cons_loaded:[0-9]+]] = load %"List::Cons", ptr %[[cons_alloca]], align 8
 // CHECK: %[[alloca:[0-9]+]] = alloca %List, i64 1, align 8
 // CHECK: call void @llvm.lifetime.start.p0({{.*}}ptr %[[alloca]])
-// CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %List, ptr %[[alloca]], i32 0, i32 0
-// CHECK: store i8 0, ptr %[[tag_ptr]], align 1
-// CHECK: %[[value_ptr:[0-9]+]] = getelementptr %List, ptr %[[alloca]], i32 0, i32 1
+// CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %List, ptr %[[alloca]], i32 0, i32 1
+// CHECK: store i32 0, ptr %[[tag_ptr]], align 4
+// CHECK: %[[value_ptr:[0-9]+]] = getelementptr %List, ptr %[[alloca]], i32 0, i32 2
 // CHECK: store %"List::Cons" %[[cons_loaded]], ptr %[[value_ptr]], align 8
 // CHECK: %[[loaded:[0-9]+]] = load %List, ptr %[[alloca]], align 8
 // CHECK: call void @llvm.lifetime.end.p0({{.*}}ptr %[[alloca]])
-// CHECK: %[[allocated:[0-9]+]] = call ptr @__reussir_allocate(i64 8, i64 32)
-// CHECK: %[[rc_tag_ptr:[0-9]+]] = getelementptr { i64, %List }, ptr %[[allocated]], i32 0, i32 0
-// CHECK: store i64 1, ptr %[[rc_tag_ptr]], align 4
-// CHECK: %[[rc_value_ptr:[0-9]+]] = getelementptr { i64, %List }, ptr %[[allocated]], i32 0, i32 1
-// CHECK: store %List %[[loaded]], ptr %[[rc_value_ptr]], align 8
+// CHECK: %[[allocated:[0-9]+]] = call ptr @__reussir_allocate(i64 8, i64 24)
+// CHECK: %[[count_ptr:[0-9]+]] = getelementptr %List, ptr %[[allocated]], i32 0, i32 0
+// CHECK: %[[box_ptr:[0-9]+]] = getelementptr %List, ptr %[[allocated]], i32 0, i32 0
+// CHECK: store %List %[[loaded]], ptr %[[box_ptr]], align 8
+// CHECK: store i32 1, ptr %[[count_ptr]], align 4
 // CHECK: ret ptr %[[allocated]]
 
 // CHECK-LABEL: define i64 @test_option_tag(ptr %0)
-// CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %Option, ptr %0, i32 0, i32 0
-// CHECK: %[[narrow_tag:[0-9]+]] = load i8, ptr %[[tag_ptr]], align 1
-// CHECK: %[[tag_value:[0-9]+]] = zext i8 %[[narrow_tag]] to i64
+// CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %Option, ptr %0, i32 0, i32 1
+// CHECK: %[[narrow_tag:[0-9]+]] = load i32, ptr %[[tag_ptr]], align 4
+// CHECK: %[[tag_value:[0-9]+]] = zext i32 %[[narrow_tag]] to i64
 // CHECK: ret i64 %[[tag_value]]
 
 // CHECK-LABEL: define i64 @test_result_tag(ptr %0)
-// CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %Result, ptr %0, i32 0, i32 0
-// CHECK: %[[narrow_tag:[0-9]+]] = load i8, ptr %[[tag_ptr]], align 1
-// CHECK: %[[tag_value:[0-9]+]] = zext i8 %[[narrow_tag]] to i64
+// CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %Result, ptr %0, i32 0, i32 1
+// CHECK: %[[narrow_tag:[0-9]+]] = load i32, ptr %[[tag_ptr]], align 4
+// CHECK: %[[tag_value:[0-9]+]] = zext i32 %[[narrow_tag]] to i64
 // CHECK: ret i64 %[[tag_value]]

--- a/tests/integration/conversion/special_pointer_tag_lowering.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering.mlir
@@ -14,7 +14,7 @@
 !rclist = !reussir.rc<!list>
 
 // CHECK-DAG: @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2 = internal global i64 0
-// CHECK-DAG: @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX = internal global [2 x i64] [i64 2, i64 1]
+// CHECK-DAG: @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX = internal global [2 x i32] [i32 2, i32 1]
 module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
 
   // Immediate materialization: dummy address | (tag + 1) << 56, no
@@ -32,8 +32,9 @@ module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.
   // CHECK-LABEL: define i64 @fetch(ptr %0)
   // CHECK-NOT: lshr
   // CHECK-NOT: select
-  // CHECK: %[[CNT:.+]] = load i64, ptr
-  // CHECK: ret i64 %[[CNT]]
+  // CHECK: %[[CNT:.+]] = load i32, ptr
+  // CHECK: %[[CNTW:.+]] = zext i32 %[[CNT]] to i64
+  // CHECK: ret i64 %[[CNTW]]
   func.func @fetch(%rc: !rclist) -> index {
     %cnt = reussir.rc.fetch (%rc : !rclist) : index
     return %cnt : index
@@ -44,8 +45,8 @@ module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.
   // CHECK-LABEL: define i64 @tag(ptr %0)
   // CHECK-NOT: lshr
   // CHECK-NOT: select
-  // CHECK: %[[TAG:.+]] = load i8, ptr
-  // CHECK: %[[WIDE:.+]] = zext i8 %[[TAG]] to i64
+  // CHECK: %[[TAG:.+]] = load i32, ptr
+  // CHECK: %[[WIDE:.+]] = zext i32 %[[TAG]] to i64
   // CHECK: ret i64 %[[WIDE]]
   func.func @tag(%ref: !reussir.ref<!list shared>) -> index {
     %tag = reussir.record.tag(%ref : !reussir.ref<!list shared>) : index
@@ -55,11 +56,12 @@ module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.
   // The decrementing store: a tagged access is steered to the scratch word
   // so the dummy refcount can never decay below 2.
   // CHECK-LABEL: define void @set(ptr %0, i64 %1)
+  // CHECK: %[[NARROW:.+]] = trunc i64 %1 to i32
   // CHECK: %[[INT:.+]] = ptrtoint ptr %0 to i64
   // CHECK: %[[TOP:.+]] = lshr i64 %[[INT]], 56
   // CHECK: %[[ISTAG:.+]] = icmp ne i64 %[[TOP]], 0
   // CHECK: %[[ADDR:.+]] = select i1 %[[ISTAG]], ptr @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2, ptr %0
-  // CHECK: store i64 %1, ptr %[[ADDR]]
+  // CHECK: store i32 %[[NARROW]], ptr %[[ADDR]]
   func.func @set(%rc: !rclist, %v: index) {
     reussir.rc.set(%rc : !rclist, %v : index)
     return

--- a/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
@@ -14,7 +14,7 @@
 !rclist = !reussir.rc<!list>
 
 // CHECK-DAG: @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2 = internal global i64 0
-// CHECK-DAG: @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX = internal global [2 x i64] [i64 -4611686018427387904, i64 1]
+// CHECK-DAG: @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX = internal global [2 x i32] [i32 -1073741824, i32 1]
 module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
 
   // Immediate materialization: the plain dummy address — no or/inttoptr.
@@ -31,8 +31,9 @@ module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #
   // CHECK-LABEL: define i64 @fetch(ptr %0)
   // CHECK-NOT: lshr
   // CHECK-NOT: select
-  // CHECK: %[[CNT:.+]] = load i64, ptr
-  // CHECK: ret i64 %[[CNT]]
+  // CHECK: %[[CNT:.+]] = load i32, ptr
+  // CHECK: %[[CNTW:.+]] = zext i32 %[[CNT]] to i64
+  // CHECK: ret i64 %[[CNTW]]
   func.func @fetch(%rc: !rclist) -> index {
     %cnt = reussir.rc.fetch (%rc : !rclist) : index
     return %cnt : index
@@ -43,8 +44,8 @@ module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #
   // CHECK-LABEL: define i64 @tag(ptr %0)
   // CHECK-NOT: lshr
   // CHECK-NOT: select
-  // CHECK: %[[TAG:.+]] = load i8, ptr
-  // CHECK: %[[WIDE:.+]] = zext i8 %[[TAG]] to i64
+  // CHECK: %[[TAG:.+]] = load i32, ptr
+  // CHECK: %[[WIDE:.+]] = zext i32 %[[TAG]] to i64
   // CHECK: ret i64 %[[WIDE]]
   func.func @tag(%ref: !reussir.ref<!list shared>) -> index {
     %tag = reussir.record.tag(%ref : !reussir.ref<!list shared>) : index
@@ -56,9 +57,10 @@ module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #
   // store is steered to the scratch word so the dummy never decays.
   // CHECK-LABEL: define void @set(ptr %0, i64 %1)
   // CHECK-NOT: lshr
-  // CHECK: %[[ISDUMMY:.+]] = icmp uge i64 %1, -9223372036854775808
+  // CHECK: %[[NARROW:.+]] = trunc i64 %1 to i32
+  // CHECK: %[[ISDUMMY:.+]] = icmp uge i32 %[[NARROW]], -2147483648
   // CHECK: %[[ADDR:.+]] = select i1 %[[ISDUMMY]], ptr @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2, ptr %0
-  // CHECK: store i64 %1, ptr %[[ADDR]]
+  // CHECK: store i32 %[[NARROW]], ptr %[[ADDR]]
   func.func @set(%rc: !rclist, %v: index) {
     reussir.rc.set(%rc : !rclist, %v : index)
     return

--- a/tests/integration/conversion/tag_inference.mlir
+++ b/tests/integration/conversion/tag_inference.mlir
@@ -13,8 +13,8 @@ module {
     ) {
         %ref = reussir.rc.borrow(%rc : !reussir.rc<!list>) : !reussir.ref<!list>
         %ref_ = reussir.record.coerce [1] (%ref : !reussir.ref<!list>) : !reussir.ref<!list_cons>
-        %token = reussir.rc.dec (%rc : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 32>>
-        reussir.token.free (%token : !reussir.nullable<!reussir.token<align: 8, size: 32>>)
+        %token = reussir.rc.dec (%rc : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
+        reussir.token.free (%token : !reussir.nullable<!reussir.token<align: 8, size: 24>>)
         return
     }
 
@@ -27,16 +27,16 @@ module {
             // CHECK-SAME: variant[0]
             [0] -> {
                 ^bb0(%nil_ref : !reussir.ref<!list_nil>):
-                    %token = reussir.rc.dec (%rc : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 32>>
-                    reussir.token.free (%token : !reussir.nullable<!reussir.token<align: 8, size: 32>>)
+                    %token = reussir.rc.dec (%rc : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
+                    reussir.token.free (%token : !reussir.nullable<!reussir.token<align: 8, size: 24>>)
                     reussir.scf.yield
             }
             // CHECK-LABEL: reussir.ref.drop
             // CHECK-SAME: variant[1]
             [1] -> {
                 ^bb0(%cons_ref : !reussir.ref<!list_cons>):
-                    %token = reussir.rc.dec (%rc : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 32>>
-                    reussir.token.free (%token : !reussir.nullable<!reussir.token<align: 8, size: 32>>)
+                    %token = reussir.rc.dec (%rc : !reussir.rc<!list>) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
+                    reussir.token.free (%token : !reussir.nullable<!reussir.token<align: 8, size: 24>>)
                     reussir.scf.yield
             }
         }

--- a/tests/integration/conversion/unique_carrying_soundness.mlir
+++ b/tests/integration/conversion/unique_carrying_soundness.mlir
@@ -14,7 +14,7 @@
 !consty = !reussir.record<compound "list.cons" [value] {i64, !reussir.record<variant "list" incomplete>}>
 !listty = !reussir.record<variant "list" {!consty, !nilty}>
 !rclist = !reussir.rc<!listty>
-!tk = !reussir.token<align: 8, size: 32>
+!tk = !reussir.token<align: 8, size: 24>
 
 module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-i64:64-n8:16:32:64-S128"} {
   // Completeness: results flowing through dispatch arms (a fresh create in

--- a/tests/integration/frontend/rbtree.c
+++ b/tests/integration/frontend/rbtree.c
@@ -3,12 +3,11 @@
 #include <stdlib.h>
 
 typedef struct rc_list {
-    int64_t refcount;
-    uint8_t tag;      /* minimal-width variant tag (2 arms -> i8) */
-    uint8_t _pad[7];
+    uint32_t refcount; /* fused 8-byte header: i32 count + i32 tag */
+    uint32_t tag;
     struct rc_list *tail; /* members are packed by descending alignment */
     int32_t head;
-    int32_t _pad2;
+    int32_t _pad;
 } rc_list_t;
 
 #define LIST_NIL 0

--- a/tests/integration/frontend/rbtree_to_list.c
+++ b/tests/integration/frontend/rbtree_to_list.c
@@ -8,11 +8,11 @@
  * The Reussir runtime allocates an RC box whose first word is the
  * reference count, followed by the variant record:
  *
- *   offset  0:  int64_t  refcount
- *   offset  8:  uint8_t  tag         (0 = Nil, 1 = Cons; minimal width)
- *   offset 16:  void*    tail        (valid when tag == 1, next RC<List>)
+ *   offset  0:  uint32_t refcount
+ *   offset  4:  uint32_t tag         (0 = Nil, 1 = Cons; fused header)
+ *   offset  8:  void*    tail        (valid when tag == 1, next RC<List>)
  *   offset 20:  (padding, 4 bytes)
- *   offset 24:  int32_t  head        (valid when tag == 1)
+ *   offset 16:  int32_t  head        (valid when tag == 1)
  *
  * Total allocation: 32 bytes  (__reussir_allocate(align=8, size=32))
  *
@@ -20,12 +20,11 @@
  * structure live (refcount >= 1) so we can safely inspect it here.
  */
 typedef struct rc_list {
-    int64_t          refcount;
-    uint8_t          tag;      /* minimal-width variant tag (2 arms -> i8) */
-    uint8_t          _pad[7];
+    uint32_t         refcount; /* fused 8-byte header: i32 count + i32 tag */
+    uint32_t         tag;
     struct rc_list  *tail;     /* members are packed by descending alignment */
     int32_t          head;
-    int32_t          _pad2;
+    int32_t          _pad;
 } rc_list_t;
 
 #define LIST_NIL  0

--- a/tests/integration/frontend/record_packing.rr
+++ b/tests/integration/frontend/record_packing.rr
@@ -1,0 +1,25 @@
+// Compound record members are laid out in packed physical order (descending
+// storage alignment) by default; `--no-pack-record-members` restores the
+// declaration-order layout. Both are valid — the field projection stays
+// correct — so the choice only changes the physical struct shape.
+
+// RUN: %rrc %s -o %t.packed.ll --emit llvm-ir -O none
+// RUN: %FileCheck %s --check-prefix=PACKED < %t.packed.ll
+// RUN: %rrc %s -o %t.unpacked.ll --emit llvm-ir -O none --no-pack-record-members
+// RUN: %FileCheck %s --check-prefix=UNPACKED < %t.unpacked.ll
+
+// Sorted by descending alignment: the i64 leads, then the two i8s, then tail
+// padding — 16 bytes, no inter-member padding.
+// PACKED: %_RC1S = type { i64, i8, i8, [6 x i8] }
+
+// Declaration order (a: i8, b: i64, c: i8): `a` is widened to i64 to carry the
+// padding that aligns `b` — 24 bytes.
+// UNPACKED: %_RC1S = type { i64, i64, i8, [7 x i8] }
+
+struct [value] S { a: i8, b: i64, c: i8 }
+
+pub fn use_s(x: i64) -> i64 {
+    let s = S { a: 1, b: x, c: 2 };
+    s.b
+}
+extern "C" trampoline "use_s_ffi" = use_s;

--- a/tests/integration/sanitizer/rbtree-harness.c
+++ b/tests/integration/sanitizer/rbtree-harness.c
@@ -3,11 +3,11 @@
 #include <stdlib.h>
 
 typedef struct rc_list {
-    int64_t refcount;
-    int64_t tag;
+    uint32_t refcount; /* fused 8-byte header: i32 count + i32 tag */
+    uint32_t tag;
+    struct rc_list *tail; /* members are packed by descending alignment */
     int32_t head;
     int32_t _pad;
-    struct rc_list *tail;
 } rc_list_t;
 
 #define LIST_NIL 0

--- a/tests/unittest/cases/scanner.cpp
+++ b/tests/unittest/cases/scanner.cpp
@@ -13,7 +13,7 @@ TEST_F(ReussirTest, SimpleRecordScanner) {
         mlir::DataLayout dataLayout = mlir::DataLayout(module);
         type.emitScannerInstructions(buffer, dataLayout, {});
         llvm::SmallVector<int32_t> expected = {
-            scanner::advance(16), scanner::field(), scanner::end()};
+            scanner::advance(8), scanner::field(), scanner::end()};
         EXPECT_EQ(buffer, expected);
       });
 }
@@ -36,7 +36,7 @@ TEST_F(ReussirTest, NestedRecordScanner) {
         mlir::DataLayout dataLayout = mlir::DataLayout(module);
         type.emitScannerInstructions(buffer, dataLayout, {});
         llvm::SmallVector<int32_t> expected = {
-            scanner::advance(24), scanner::field(), scanner::advance(24),
+            scanner::advance(24), scanner::field(), scanner::advance(16),
             scanner::field(), scanner::end()};
         EXPECT_EQ(buffer, expected);
       });
@@ -64,23 +64,25 @@ TEST_F(ReussirTest, VariantRecordScanner) {
         mlir::DataLayout dataLayout = mlir::DataLayout(module);
         type.emitScannerInstructions(buffer, dataLayout, {});
         llvm::SmallVector<int32_t> expected = {
-            scanner::variant(),
+            // Fused header: advance past the i32 count slot to the i32 tag,
+            // then read the 4-byte tag.
+            scanner::advance(4), scanner::variant(4),
             // skip table
             scanner::skip(5), scanner::skip(8), scanner::skip(9),
             scanner::skip(12), scanner::skip(13),
             // first variant
-            scanner::advance(16), scanner::field(), scanner::advance(48),
+            scanner::advance(12), scanner::field(), scanner::advance(32),
             scanner::skip(14),
             // second variant
-            scanner::advance(64), scanner::skip(12),
+            scanner::advance(44), scanner::skip(12),
             // third variant
-            scanner::advance(24), scanner::field(), scanner::advance(40),
+            scanner::advance(12), scanner::field(), scanner::advance(32),
             scanner::skip(8),
             // fourth variant
-            scanner::advance(64), scanner::skip(6),
+            scanner::advance(44), scanner::skip(6),
             // fifth variant
-            scanner::advance(16), scanner::field(), scanner::advance(32),
-            scanner::field(), scanner::advance(16),
+            scanner::advance(28), scanner::field(), scanner::advance(8),
+            scanner::field(), scanner::advance(8),
             // final end
             scanner::end()};
         EXPECT_EQ(buffer, expected);


### PR DESCRIPTION
Second of the three layout/ownership PRs (stacked on #340; borrow inference follows).

## Design

The key structural move that makes Koka-style header fusion tractable in a language with first-class value semantics: **shared/regional variant records carry their box header themselves**. Their layout is `{4-byte count slot, i32 tag, payload}`, and a non-regional rc box of such a record *is* the record — the refcount overlays the leading slot, the rc pointer equals the record pointer, and `rc.borrow` lowers to the identity. Stack temporaries of such records use the same layout (count slot uninitialized until boxed), so every `ref<variant>` — borrowed or spilled — addresses tags and payloads identically. `[value]` variants keep the compact `{minimal-width tag, payload}` layout from #340: they are never a box element, since shared records embed in other records as pointers.

All other boxes shrink too: the refcount is i32 everywhere (`{i32 count, elem @ alignTo(4, align)}` for compounds/closures).

Mechanical consequences handled:
- rc.create stores the element **first**, count second — a whole-value store would clobber the overlaid count.
- Width adapters at the SSA boundary are conditional (wasm32's i32 index would otherwise produce `zext i32→i32`; the rrc wasm driver test covers this).
- The tagged-immediate dummy box becomes the literal fused header `{i32 count, i32 tag}`; immortal threshold moves to width 32.
- The region scanner advances onto the tag (offset 4) before the variant read.
- Runtime `RcBox` count mirrors i32; repl reflection follows all rules.

## Measured (aarch64, n=4.2M, xLTO + static mimalloc; harness rbtree keys aligned to Koka's int32 — apples-to-apples now)

| | before (on #340) | after | Koka |
|---|---|---|---|
| rbtree node | 40 B (48 B block) | **32 B (32 B block)** | 32 B |
| rbtree LLd misses | 6.33M | **4.219M** | 4.225M — **parity** |
| rbtree RSS | 199 MB | **133.4 MB** | 133.9 MB — **parity** |
| rbtree wall | 0.45 s | **0.43 s (1.11×)** | 0.38 s |
| nbe-hoas RSS | 386 MB | **252 MB (−35%)** | 159 MB |
| nbe-hoas LLd | 14.9M | **10.1M** | 6.5M |
| nbe-hoas wall | 0.235 s | **0.21 s (1.27×)** | 0.165 s |

The rbtree memory system is now byte-for-byte and miss-for-miss at Koka parity (two nodes per cache line), exactly as the #325 line-footprint model predicted; the residual 1.11× is instructions (1.12×). nbe's remaining footprint delta is closure boxes and Env conses — the borrow-inference PR attacks the phantom-realloc share of that.

## Validation

Full lit 288/288 (incl. asan/lsan/msan/tsan executing gates — leak-free with the overlay), rrc-test (incl. wasm32), jit, repl, rt unit tests, fold-correctness on all three benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785875991&installation_id=144622820&pr_number=341&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F341&signature=a9fbb824158936723458d5651c171086323d6a2e960003f71ab24638e7df3167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->