### PR TITLE
[frontend] borrowed-parameter inference for pure readers (P9)

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -34,7 +34,9 @@ use reussir_backend::melior::ir::{
 };
 
 use reussir_core::full::mir::{self, DecisionTree, Expr, ExprKind, SwitchCases};
-use reussir_core::full::ownership::{OwnershipTable, RcOp, RecordTable, analyze_function};
+use reussir_core::full::ownership::{
+    BorrowMasks, OwnershipTable, RcOp, RecordTable, analyze_function, borrow_masks,
+};
 use reussir_core::intrinsic::IntrinsicOp;
 use reussir_core::literal::{self, Integer};
 use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
@@ -217,6 +219,9 @@ pub(super) struct Lowerer<'c, 'p, 'tcx> {
     /// enables DWARF variable/type emission. See [`debug`](super::debug).
     pub(super) names: Option<&'p dyn Resolver<TokenKey>>,
     ownership: RefCell<OwnershipTable>,
+    /// Every function's borrowed-parameter convention (see
+    /// `reussir_core::full::borrow`), consulted at call sites.
+    borrow_masks: BorrowMasks,
     var_tys: RefCell<FxHashMap<VarId, Ty<'tcx>>>,
     /// Ground types of the temporary expressions currently held in
     /// [`Env::temps`], so a reference-count op the ownership pass keyed to such a
@@ -261,6 +266,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             source,
             names,
             ownership: RefCell::new(OwnershipTable::default()),
+            borrow_masks: borrow_masks(program),
             var_tys: RefCell::new(FxHashMap::default()),
             temp_tys: RefCell::new(FxHashMap::default()),
             cur_loc: RefCell::new(Location::unknown(context)),
@@ -359,7 +365,8 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
 
         // Reset the per-function side-tables, then run the ownership analysis for
         // this body so the tree-walk can emit each node's reference-count ops.
-        *self.ownership.borrow_mut() = analyze_function(self.tcx, func, &self.records);
+        *self.ownership.borrow_mut() =
+            analyze_function(self.tcx, func, &self.records, &self.borrow_masks);
         self.var_tys.borrow_mut().clear();
         self.temp_tys.borrow_mut().clear();
 
@@ -407,6 +414,31 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         // linkage is external either way, which is what cross-unit resolution
         // needs).
         let mut attributes = Vec::new();
+        // Borrowed-parameter positions (see `reussir_core::full::borrow`), as
+        // an array attribute backend passes consult: IncDecCancellation may
+        // cancel an inc/dec pair around a call that only lends the value, and
+        // TRMC must not reorder a lent argument's settle-dec across the call.
+        let borrowed: Vec<i64> = func
+            .params
+            .iter()
+            .enumerate()
+            .filter_map(|(i, p)| p.borrowed.then_some(i as i64))
+            .collect();
+        if !borrowed.is_empty() {
+            let rendered = format!(
+                "array<i64: {}>",
+                borrowed
+                    .iter()
+                    .map(|i| i.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            attributes.push((
+                Identifier::new(self.context, "reussir.borrowed_params"),
+                Attribute::parse(self.context, &rendered)
+                    .unwrap_or_else(|| panic!("malformed borrowed attribute {rendered}")),
+            ));
+        }
         if !emit_body || (func.visibility == Visibility::Private && !self.unit.is_split()) {
             attributes.push((
                 Identifier::new(self.context, "sym_visibility"),
@@ -651,10 +683,16 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     })?);
                 }
                 for a in args.iter() {
-                    operands.push(
-                        self.expr(block, env, a)?
-                            .ok_or_else(|| LoweringError("call argument is unit".into()))?,
-                    );
+                    let val = self
+                        .expr(block, env, a)?
+                        .ok_or_else(|| LoweringError("call argument is unit".into()))?;
+                    // A temporary lent to a borrowed parameter is released
+                    // AFTER the call (the ownership pass keys a `DropValue`
+                    // to this call node); stash it so that op can find it.
+                    if !matches!(a.kind, ExprKind::Var(_)) {
+                        self.remember_temp(env, a, val);
+                    }
+                    operands.push(val);
                 }
                 let result_tys = if is_unit(e.ty) {
                     Vec::new()

--- a/crates/reussir-core/src/full.rs
+++ b/crates/reussir-core/src/full.rs
@@ -13,6 +13,7 @@
 //!
 //! [`semi`]: crate::semi
 
+pub mod borrow;
 pub mod mangle;
 pub mod mir;
 pub mod mono;

--- a/crates/reussir-core/src/full/borrow.rs
+++ b/crates/reussir-core/src/full/borrow.rs
@@ -1,0 +1,274 @@
+//! Borrowed-parameter inference over the monomorphized MIR.
+//!
+//! A parameter is **borrowed** when the callee is a *pure reader*: every
+//! occurrence of the parameter variable in the body is a match scrutinee or
+//! the root of a projection chain — positions the ownership analysis treats
+//! as borrows already — **and the function allocates nothing reference
+//! counted**. Such a function (an `is_red`/`fold`-style predicate or
+//! accessor) never consumes, returns, stores, or passes the value on, so
+//! the owned convention only produces a caller-side `dup` paired with a
+//! callee-side `drop`. Marking the parameter borrowed removes both: the
+//! caller passes the value without a `dup`, keeps ownership, and settles it
+//! after the call when the call was its last use; the callee never releases
+//! it.
+//!
+//! The allocates-nothing restriction is what keeps this compatible with
+//! reuse: an update-shaped function (rbtree's `ins`, nbe's `quote`) also
+//! only *reads* its parameter syntactically, but consuming it is what feeds
+//! every reuse token in its constructor chain — borrowing there trades
+//! in-place spine updates for full path copies. A function that allocates
+//! nothing has no reuse to lose, and the caller-side settle-dec it produces
+//! is itself a reuse token in the caller.
+//!
+//! The verdict is a pure function of the function's own body — deliberately
+//! **not** interprocedural — so every codegen unit, and every repl
+//! re-monomorphization of the same instance, computes the same convention
+//! for the same symbol. Passing a value to another function's parameter
+//! (borrowed or not) therefore counts as a consuming use here; the fixpoint
+//! refinement is future work.
+//!
+//! Exclusions: trampoline targets keep the owned convention (their C callers
+//! transfer ownership) and regional functions are skipped wholesale (region
+//! bookkeeping has its own discipline).
+
+use rustc_hash::FxHashSet;
+
+use crate::semi::hir::VarId;
+use crate::semi::ty::TyCtxt;
+
+use super::mir::{DecisionTree, Expr, ExprKind, Program, SwitchCases};
+use super::ownership::{RecordTable, Rr};
+
+/// Infer and record the borrowed convention for every eligible parameter of
+/// every function in `program`. Runs once at the end of monomorphization.
+pub fn infer_borrowed_params<'tcx>(tcx: &TyCtxt<'tcx>, program: &mut Program<'tcx>) {
+    let excluded: FxHashSet<_> = program.trampolines.iter().map(|t| t.target).collect();
+    let table = RecordTable::from_records(&program.records);
+    let rr = Rr::new(tcx, &table);
+    for func in &mut program.functions {
+        if func.is_regional || excluded.contains(&func.symbol) {
+            continue;
+        }
+        let Some(body) = func.body else { continue };
+        if allocates(body) || calls(body, func.symbol) {
+            continue;
+        }
+        for param in &mut func.params {
+            // Only resource-relevant parameters carry reference counts; the
+            // convention is meaningless (and noisy) for scalars.
+            param.borrowed = rr.is_rr(param.ty) && only_read(body, param.var);
+        }
+    }
+}
+
+/// Whether the body contains a direct call to `symbol`. A self-recursive
+/// reader is excluded from borrowing: with an owned parameter its walk
+/// releases the structure incrementally (one node per level, a loop after
+/// TRMC/tail lowering), while a borrowed parameter defers the whole release
+/// to the caller's settle-dec — a single *recursive* drop whose depth is the
+/// structure's depth, a stack overflow on long lists and app-chains.
+fn calls(e: &Expr<'_>, symbol: super::mir::Symbol) -> bool {
+    let mut found = false;
+    walk(e, &mut |x| {
+        found |= matches!(x.kind, ExprKind::Call { callee, .. } if callee == symbol);
+    });
+    found
+}
+
+/// Whether the body can allocate a reference-counted box: any constructor,
+/// closure, or string literal. (Value-capability records still count — a
+/// value record materialized here may be boxed by the caller's create chain
+/// after inlining; staying conservative keeps every reuse token intact.)
+fn allocates(e: &Expr<'_>) -> bool {
+    let mut found = false;
+    walk(e, &mut |x| {
+        found |= matches!(
+            x.kind,
+            ExprKind::Ctor { .. }
+                | ExprKind::Variant { .. }
+                | ExprKind::Closure(_)
+                | ExprKind::GlobalStr(_)
+        );
+    });
+    found
+}
+
+/// Generic pre-order walk over an expression tree, including match arms.
+fn walk(e: &Expr<'_>, f: &mut impl FnMut(&Expr<'_>)) {
+    f(e);
+    match e.kind {
+        ExprKind::Var(_)
+        | ExprKind::GlobalStr(_)
+        | ExprKind::ConstChar(_)
+        | ExprKind::ConstInt(_)
+        | ExprKind::ConstFloat(_)
+        | ExprKind::ConstBool(_)
+        | ExprKind::Poison => {}
+        ExprKind::Negate(a) | ExprKind::Not(a) | ExprKind::Cast(a, _) => walk(a, f),
+        ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
+            walk(l, f);
+            walk(r, f);
+        }
+        ExprKind::Let { value, .. } => walk(value, f),
+        ExprKind::Seq(es) => es.iter().for_each(|s| walk(s, f)),
+        ExprKind::Call { args, .. }
+        | ExprKind::Ctor { args, .. }
+        | ExprKind::Variant { args, .. }
+        | ExprKind::Intrinsic { args, .. } => args.iter().for_each(|a| walk(a, f)),
+        ExprKind::NullableCall(opt) => {
+            if let Some(a) = opt {
+                walk(a, f)
+            }
+        }
+        ExprKind::If(c, t, e2) => {
+            walk(c, f);
+            walk(t, f);
+            walk(e2, f);
+        }
+        ExprKind::Match(scrut, ref tree) => {
+            walk(scrut, f);
+            walk_tree(tree, f);
+        }
+        ExprKind::Proj(base, _) => walk(base, f),
+        ExprKind::Assign(dst, _, src) => {
+            walk(dst, f);
+            walk(src, f);
+        }
+        ExprKind::RegionRun(inner) => walk(inner, f),
+        ExprKind::Closure(c) => walk(c.body, f),
+        ExprKind::ClosureCall { target, args } => {
+            walk(target, f);
+            args.iter().for_each(|a| walk(a, f));
+        }
+    }
+}
+
+fn walk_tree(tree: &DecisionTree<'_>, f: &mut impl FnMut(&Expr<'_>)) {
+    match *tree {
+        DecisionTree::Uncovered | DecisionTree::Unreachable => {}
+        DecisionTree::Leaf { body, .. } => walk(body, f),
+        DecisionTree::Guard {
+            guard,
+            ref success,
+            ref failure,
+            ..
+        } => {
+            walk(guard, f);
+            walk_tree(success, f);
+            walk_tree(failure, f);
+        }
+        DecisionTree::Switch { ref cases, .. } => match *cases {
+            SwitchCases::Int { cases, default } => {
+                cases.iter().for_each(|(_, t)| walk_tree(t, f));
+                walk_tree(default, f);
+            }
+            SwitchCases::Char { cases, default } => {
+                cases.iter().for_each(|(_, t)| walk_tree(t, f));
+                walk_tree(default, f);
+            }
+            SwitchCases::String { cases, default } => {
+                cases.iter().for_each(|(_, t)| walk_tree(t, f));
+                walk_tree(default, f);
+            }
+            SwitchCases::Bool { if_true, if_false } => {
+                walk_tree(if_true, f);
+                walk_tree(if_false, f);
+            }
+            SwitchCases::Nullable { non_null, null } => {
+                walk_tree(non_null, f);
+                walk_tree(null, f);
+            }
+            SwitchCases::Ctor(arms) => arms.iter().for_each(|t| walk_tree(t, f)),
+        },
+    }
+}
+
+/// Whether every occurrence of `x` in `e` is a read: a match scrutinee or a
+/// projection-chain root. Any other occurrence (call/ctor argument, closure
+/// capture, result position, assignment, …) makes the parameter owned.
+fn only_read(e: &Expr<'_>, x: VarId) -> bool {
+    match e.kind {
+        ExprKind::Var(v) => v != x,
+        ExprKind::GlobalStr(_)
+        | ExprKind::ConstChar(_)
+        | ExprKind::ConstInt(_)
+        | ExprKind::ConstFloat(_)
+        | ExprKind::ConstBool(_)
+        | ExprKind::Poison => true,
+        ExprKind::Negate(a) | ExprKind::Not(a) | ExprKind::Cast(a, _) => only_read(a, x),
+        ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
+            only_read(l, x) && only_read(r, x)
+        }
+        ExprKind::Let { value, .. } => only_read(value, x),
+        ExprKind::Seq(es) => es.iter().all(|s| only_read(s, x)),
+        ExprKind::Call { args, .. }
+        | ExprKind::Ctor { args, .. }
+        | ExprKind::Variant { args, .. }
+        | ExprKind::Intrinsic { args, .. } => args.iter().all(|a| only_read(a, x)),
+        ExprKind::NullableCall(opt) => opt.as_ref().is_none_or(|a| only_read(a, x)),
+        ExprKind::If(c, t, e2) => only_read(c, x) && only_read(t, x) && only_read(e2, x),
+        // The scrutinee position itself is a borrow; look through it when it
+        // is the plain variable, but its subexpressions (if any) are ordinary
+        // uses. Arm bodies and guards are walked for other occurrences.
+        ExprKind::Match(scrut, ref tree) => {
+            let scrut_ok = matches!(scrut.kind, ExprKind::Var(v) if v == x)
+                || only_read(scrut, x);
+            scrut_ok && tree_only_read(tree, x)
+        }
+        // A projection reads its base: accept `x` as the chain root.
+        ExprKind::Proj(base, _) => proj_base_only_read(base, x),
+        ExprKind::Assign(dst, _, src) => only_read(dst, x) && only_read(src, x),
+        ExprKind::RegionRun(inner) => only_read(inner, x),
+        ExprKind::Closure(c) => {
+            // A capture takes ownership of the variable by name, not through
+            // an `Expr`; the body of the closure references the capture, not
+            // the original parameter.
+            c.captures.iter().all(|&(v, _)| v != x) && only_read(c.body, x)
+        }
+        ExprKind::ClosureCall { target, args } => {
+            only_read(target, x) && args.iter().all(|a| only_read(a, x))
+        }
+    }
+}
+
+/// A projection chain (`Proj(Proj(..(root)..))`) whose root is `x` is a read;
+/// any other base shape is walked normally.
+fn proj_base_only_read(base: &Expr<'_>, x: VarId) -> bool {
+    match base.kind {
+        // The chain root is read in place — `x` here is fine.
+        ExprKind::Var(_) => true,
+        ExprKind::Proj(inner, _) => proj_base_only_read(inner, x),
+        _ => only_read(base, x),
+    }
+}
+
+fn tree_only_read(tree: &DecisionTree<'_>, x: VarId) -> bool {
+    match *tree {
+        DecisionTree::Uncovered | DecisionTree::Unreachable => true,
+        DecisionTree::Leaf { body, .. } => only_read(body, x),
+        DecisionTree::Guard {
+            guard,
+            ref success,
+            ref failure,
+            ..
+        } => only_read(guard, x) && tree_only_read(success, x) && tree_only_read(failure, x),
+        DecisionTree::Switch { ref cases, .. } => match *cases {
+            SwitchCases::Int { cases, default } => {
+                cases.iter().all(|(_, t)| tree_only_read(t, x)) && tree_only_read(default, x)
+            }
+            SwitchCases::Char { cases, default } => {
+                cases.iter().all(|(_, t)| tree_only_read(t, x)) && tree_only_read(default, x)
+            }
+            SwitchCases::String { cases, default } => {
+                cases.iter().all(|(_, t)| tree_only_read(t, x)) && tree_only_read(default, x)
+            }
+            SwitchCases::Bool { if_true, if_false } => {
+                tree_only_read(if_true, x) && tree_only_read(if_false, x)
+            }
+            SwitchCases::Nullable { non_null, null } => {
+                tree_only_read(non_null, x) && tree_only_read(null, x)
+            }
+            SwitchCases::Ctor(arms) => arms.iter().all(|t| tree_only_read(t, x)),
+        },
+    }
+}

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -92,6 +92,12 @@ pub struct Param<'tcx> {
     pub name: TokenKey,
     pub var: VarId,
     pub ty: Ty<'tcx>,
+    /// Inferred borrowed calling convention: the callee only reads the value
+    /// (match scrutinee / projection base) and neither consumes nor returns
+    /// it, so callers pass without a dup and keep ownership (see
+    /// [`super::borrow`]). Deterministic from the body alone, so every
+    /// codegen unit and repl re-monomorphization agrees.
+    pub borrowed: bool,
 }
 
 /// A ground record instance whose layout the backend materializes. Keyed by

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -207,6 +207,7 @@ impl<'tcx> Builder<'_, 'tcx> {
                     name,
                     var: VarId(p.var),
                     ty: self.ty(&p.ty),
+                    borrowed: p.borrowed,
                 }
             })
             .collect();

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -83,8 +83,8 @@ Body: Option<raw::Expr> = {
 };
 
 Param: raw::Param =
-    <var:"var"> "(" <name:"ident"> ")" ":" <ty:Ty>
-    => raw::Param { var, name: name.into(), ty };
+    <var:"var"> "(" <name:"ident"> ")" ":" <b:"borrowed"?> <ty:Ty>
+    => raw::Param { var, name: name.into(), ty, borrowed: b.is_some() };
 
 // ----- types -----
 
@@ -299,6 +299,7 @@ extern {
         "shared" => Token::Shared,
         "field" => Token::Field,
         "extern" => Token::Extern,
+        "borrowed" => Token::Borrowed,
         "trampoline" => Token::Trampoline,
         "let" => Token::Let,
         "if" => Token::If,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -189,9 +189,10 @@ impl Render<'_> {
             .iter()
             .map(|p| {
                 text(format!(
-                    "v{} ({}): ",
+                    "v{} ({}): {}",
                     p.var.0,
-                    self.resolver.resolve(p.name)
+                    self.resolver.resolve(p.name),
+                    if p.borrowed { "borrowed " } else { "" }
                 )) + self.ty(p.ty)
             })
             .collect();

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -170,6 +170,7 @@ pub struct Param {
     pub var: u32,
     pub name: String,
     pub ty: Ty,
+    pub borrowed: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -162,6 +162,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
                     name: *name,
                     var: *var,
                     ty,
+                    borrowed: false,
                 }
             })
             .collect();
@@ -255,12 +256,16 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         symbols, reports, ..
     } = driver;
     (
-        mir::Program {
-            functions,
-            records,
-            trampolines,
-            string_literals: input.strings.clone(),
-            symbols,
+        {
+            let mut program = mir::Program {
+                functions,
+                records,
+                trampolines,
+                string_literals: input.strings.clone(),
+                symbols,
+            };
+            super::borrow::infer_borrowed_params(tcx, &mut program);
+            program
         },
         reports,
     )

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -111,6 +111,8 @@ use crate::utils::bitset::HybridBitSet;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
+use crate::full::mir::Symbol;
+
 use crate::full::mir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::hir::{ExprId, VarId};
 use crate::semi::ty::{Flexivity, Ty, TyCtxt, TyKind};
@@ -386,26 +388,54 @@ impl VarSet {
 // The analyzer
 // ---------------------------------------------------------------------------
 
+/// Per-function borrowed-parameter masks, keyed by symbol: `masks[sym][i]`
+/// is true when the callee's i-th parameter uses the borrowed convention
+/// (see [`super::borrow`]). Callers consult this to pass such arguments
+/// without transferring ownership.
+pub type BorrowMasks = FxHashMap<Symbol, smallvec::SmallVec<[bool; 8]>>;
+
+/// Collect the borrowed-parameter masks of every function in `program`.
+pub fn borrow_masks<'tcx>(program: &crate::full::mir::Program<'tcx>) -> BorrowMasks {
+    program
+        .functions
+        .iter()
+        .map(|f| (f.symbol, f.params.iter().map(|p| p.borrowed).collect()))
+        .collect()
+}
+
 /// Analyze one function body, returning the rc ops it needs. `table` classifies
 /// every ground record the body mentions (value vs shared + value-record fields).
+/// `masks` carries every callee's borrowed-parameter convention.
 pub fn analyze_function<'tcx>(
     tcx: &TyCtxt<'tcx>,
     func: &Function<'tcx>,
     table: &RecordTable<'tcx>,
+    masks: &BorrowMasks,
 ) -> OwnershipTable {
     let mut a = Analyzer {
         rr: Rr::new(tcx, table),
         free_memo: FxHashMap::default(),
         actions: FxHashMap::default(),
+        masks,
     };
     if let Some(body) = func.body {
-        // Top-level continuation is empty: the return value is moved to the
-        // caller, everything else must be settled within the body.
-        a.place(body, &VarSet::default());
-        // [Param-Unused]: an RR parameter never used anywhere is dead on entry.
+        // Top-level continuation contains the borrowed parameters: they are
+        // never consumed here (the caller owns them), so every use inside the
+        // body sees them live — a match borrows them in place, a projection
+        // reads them, and no branch settles them. Everything else must be
+        // settled within the body; the return value is moved to the caller.
+        let mut root_live = VarSet::default();
+        for p in &func.params {
+            if p.borrowed {
+                root_live.insert(p.var);
+            }
+        }
+        a.place(body, &root_live);
+        // [Param-Unused]: an owned RR parameter never used anywhere is dead on
+        // entry. (A borrowed one belongs to the caller either way.)
         let body_free = a.free(body);
         for p in &func.params {
-            if a.rr.is_rr(p.ty) && !body_free.contains(p.var) {
+            if !p.borrowed && a.rr.is_rr(p.ty) && !body_free.contains(p.var) {
                 a.add_before(body.id, RcOp::Drop(p.var));
             }
         }
@@ -419,6 +449,8 @@ struct Analyzer<'a, 'tcx> {
     /// threading `live_after` top-down.
     free_memo: FxHashMap<ExprId, VarSet>,
     actions: FxHashMap<ExprId, Action>,
+    /// Every callee's borrowed-parameter convention.
+    masks: &'a BorrowMasks,
 }
 
 impl<'tcx> Analyzer<'_, 'tcx> {
@@ -590,8 +622,10 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 }
             }
             ExprKind::Seq(es) => self.place_seq(es, live_after),
-            ExprKind::Call { args, .. }
-            | ExprKind::Ctor { args, .. }
+            ExprKind::Call { callee, args, .. } => {
+                self.place_call(e.id, callee, args, live_after)
+            }
+            ExprKind::Ctor { args, .. }
             | ExprKind::Variant { args, .. }
             | ExprKind::Intrinsic { args, .. } => self.place_args(args, live_after),
             ExprKind::NullableCall(opt) => {
@@ -977,6 +1011,84 @@ impl<'tcx> Analyzer<'_, 'tcx> {
         }
         for (i, arg) in args.iter().enumerate() {
             self.place(arg, &afters[i]);
+        }
+    }
+
+    /// [Args] with the callee's borrowed positions honored: an argument in a
+    /// borrowed position is passed without transferring ownership — no dup,
+    /// no move — and the caller settles it after the call when the call was
+    /// its last use. Timeline: `[args left→right] → call → [after]`, so a
+    /// borrowed value must survive until the call itself.
+    fn place_call(
+        &mut self,
+        call_id: ExprId,
+        callee: Symbol,
+        args: &'tcx [Expr<'tcx>],
+        live_after: &VarSet,
+    ) {
+        let Some(mask) = self.masks.get(&callee).cloned() else {
+            return self.place_args(args, live_after);
+        };
+        let mask: SmallVec<[bool; 8]> = mask;
+        let n = args.len();
+        if n == 0 {
+            return;
+        }
+        let mut afters = SmallVec::<[_; 4]>::with_capacity(n);
+        afters.resize_with(n, VarSet::default);
+        afters[n - 1] = live_after.clone();
+        for i in (0..n - 1).rev() {
+            let mut s = self.free(&args[i + 1]);
+            s.union_with(&afters[i + 1]);
+            afters[i] = s;
+        }
+        // Borrowed-position `Var` arguments are set aside and settled per
+        // distinct variable below; everything else follows [Args]. Their
+        // occurrences still count in `free()`, so an owned use of the same
+        // variable elsewhere in this call sees it live and dups.
+        let mut lent: SmallVec<[VarId; 4]> = SmallVec::new();
+        for (i, arg) in args.iter().enumerate() {
+            let borrowed = mask.get(i).copied().unwrap_or(false);
+            if borrowed && self.rr.is_rr(arg.ty) {
+                match arg.kind {
+                    ExprKind::Var(x) => {
+                        if !lent.contains(&x) {
+                            lent.push(x);
+                        }
+                        continue;
+                    }
+                    _ => {
+                        // A temporary: evaluate it owned, lend it to the
+                        // call, and release it afterwards.
+                        self.place(arg, &afters[i]);
+                        self.add_after(call_id, RcOp::DropValue(arg.id));
+                        continue;
+                    }
+                }
+            }
+            self.place(arg, &afters[i]);
+        }
+        for x in lent {
+            // An owned occurrence of `x` elsewhere in this same call (an
+            // argument subexpression that consumes it while the arguments
+            // evaluate) would invalidate the lent pointer before the call
+            // runs: pin `x` for the duration with a dup ahead of every
+            // argument and release it after the call.
+            let owned_elsewhere = args.iter().enumerate().any(|(k, a)| {
+                let borrowed_var = mask.get(k).copied().unwrap_or(false)
+                    && matches!(a.kind, ExprKind::Var(v) if v == x);
+                !borrowed_var && self.free(a).contains(x)
+            });
+            if owned_elsewhere {
+                self.add_before(args[0].id, RcOp::Dup(x));
+                self.add_after(call_id, RcOp::Drop(x));
+            } else if !live_after.contains(x) {
+                // The call is the last use: the caller keeps ownership
+                // across it and settles the value right after — exactly
+                // once, however many positions borrowed it.
+                self.add_after(call_id, RcOp::Drop(x));
+            }
+            // Else: still owned and live downstream — nothing to do.
         }
     }
 }

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -347,6 +347,7 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
             name: dummy_tok(),
             var: v,
             ty,
+            borrowed: false,
         }
     }
 
@@ -963,7 +964,7 @@ fn run<'tcx>(
     func: &Function<'tcx>,
     builder: &MirBuilder<'_, 'tcx>,
 ) -> OwnershipTable {
-    let ot = analyze_function(tcx, func, &builder.table);
+    let ot = analyze_function(tcx, func, &builder.table, &Default::default());
     println!("{}", render(func, &ot, &builder.symbols));
     let rr = Rr::new(tcx, &builder.table);
     check_balanced(func, &ot, &rr);

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -36,6 +36,8 @@ pub enum Token<'a> {
     Field,
     #[token("extern")]
     Extern,
+    #[token("borrowed")]
+    Borrowed,
     #[token("trampoline")]
     Trampoline,
     #[token("let")]

--- a/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
@@ -13,7 +13,9 @@
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
 
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Dominance.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Visitors.h>
@@ -197,7 +199,64 @@ bool cancelIntoDispatch(ReussirRcIncOp incOp,
 
 } // namespace
 
+// Whether a value of `container` may transitively hold a reference of
+// `needle`'s type: walks record members, rc/nullable payloads, and treats
+// closures as universal containers (their captures are type-erased).
+// Conservative `true` when unsure; memoized against nominal recursion.
+static bool mayTransitivelyContain(mlir::Type container, mlir::Type needle,
+                                   llvm::SmallPtrSetImpl<const void *> &seen) {
+  if (container == needle)
+    return true;
+  if (!seen.insert(container.getAsOpaquePointer()).second)
+    return false;
+  if (llvm::isa<ClosureType>(container))
+    return true;
+  if (auto rc = llvm::dyn_cast<RcType>(container))
+    return mayTransitivelyContain(rc.getElementType(), needle, seen);
+  if (auto nullable = llvm::dyn_cast<NullableType>(container))
+    return mayTransitivelyContain(nullable.getPtrTy(), needle, seen);
+  if (auto record = llvm::dyn_cast<RecordType>(container)) {
+    if (record.getMembers().empty())
+      return true; // incomplete view: assume the worst
+    for (mlir::Type member : record.getMembers())
+      if (member && mayTransitivelyContain(member, needle, seen))
+        return true;
+    return false;
+  }
+  // Scalars and tokens cannot hold references.
+  return !llvm::isa<mlir::IntegerType, mlir::FloatType, mlir::IndexType>(
+      container);
+}
+
+// A `func.call` is transparent to an inc/dec cancellation of `rcPtr` when it
+// provably neither consumes nor releases that value: every argument position
+// either merely lends its value (a declared borrowed parameter of the
+// callee) or is an owned value whose type cannot transitively contain
+// `rcPtr`'s type (so consuming it cannot release `rcPtr`).
+static bool callOnlyBorrows(mlir::func::CallOp call, mlir::Value rcPtr,
+                            mlir::SymbolTableCollection &symbols) {
+  auto callee = symbols.lookupNearestSymbolFrom<mlir::func::FuncOp>(
+      call, call.getCalleeAttr());
+  if (!callee)
+    return false;
+  auto borrowed =
+      callee->getAttrOfType<mlir::DenseI64ArrayAttr>("reussir.borrowed_params");
+  if (!borrowed)
+    return false;
+  for (auto [i, operand] : llvm::enumerate(call.getArgOperands())) {
+    if (llvm::is_contained(borrowed.asArrayRef(), static_cast<int64_t>(i)))
+      continue;
+    if (operand == rcPtr)
+      return false;
+    llvm::SmallPtrSet<const void *, 16> seen;
+    if (mayTransitivelyContain(operand.getType(), rcPtr.getType(), seen))
+      return false;
+  }
+  return true;
+}
+
 llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
+  mlir::SymbolTableCollection symbolTables;
   mlir::AliasAnalysis aliasAnalysis(func);
   registerAliasAnalysisImplementations(aliasAnalysis);
   mlir::PostDominanceInfo postDominanceInfo(func);
@@ -239,9 +298,17 @@ llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
       // it could drop a live reference. Guard on the call-site interface —
       // *not* `CallableOpInterface`, which is the call *target* (`func.func`)
       // and never appears mid-block. A control-flow op with regions is likewise
-      // opaque.
-      if (llvm::isa<mlir::CallOpInterface>(next))
-        break;
+      // opaque. Exception: a `func.call` that provably only borrows relative
+      // to the incremented value (declared borrowed parameters; owned
+      // arguments type-disjoint from it) neither consumes nor releases it,
+      // so the walk continues across it.
+      if (llvm::isa<mlir::CallOpInterface>(next)) {
+        auto funcCall = llvm::dyn_cast<mlir::func::CallOp>(next);
+        if (!funcCall || !callOnlyBorrows(funcCall, op.getRcPtr(), symbolTables))
+          break;
+        next = next->getNextNode();
+        continue;
+      }
       if (auto dispatch = llvm::dyn_cast<ReussirRecordDispatchOp>(next)) {
         cancelIntoDispatch(op, dispatch, aliasAnalysis);
         break;

--- a/lib/Transformation/TRMCRecursionAnalysis/TRMCRecursionAnalysis.cpp
+++ b/lib/Transformation/TRMCRecursionAnalysis/TRMCRecursionAnalysis.cpp
@@ -286,6 +286,17 @@ static TrmcPlan buildPlan(mlir::func::FuncOp funcOp, llvm::StringRef callee) {
     for (mlir::Operation *user : call->getUsers())
       if (!candidates.contains(user) || !isSameCreateSite(create, user, callee))
         return false;
+    // The rewrite puts the recursive call in tail position: everything
+    // currently sequenced after it runs BEFORE the moved call. An op after
+    // the call that touches one of its operands — e.g. the settle-dec of an
+    // argument lent to a borrowed parameter — would then act on the value
+    // while the callee still reads it. Bail on such leaves (the ordinary
+    // cctx.apply fallback keeps them correct).
+    for (mlir::Operation *op = call->getNextNode(); op; op = op->getNextNode())
+      if (!candidates.contains(op))
+        for (mlir::Value operand : op->getOperands())
+          if (llvm::is_contained(call.getArgOperands(), operand))
+            return false;
     return true;
   };
 

--- a/tests/integration/frontend/closure_call_expr.rr
+++ b/tests/integration/frontend/closure_call_expr.rr
@@ -56,6 +56,6 @@ fn test_field_call(s : HasClosure, x : i32) -> i32 {
 // FULL-NEXT:     apply(closure[](v1: i32) { (v1 : i32 + 1 : i32) : i32 } : (i32) -> i32, v0 : i32) : i32
 // FULL-NEXT: }
 // FULL-EMPTY:
-// FULL-NEXT: fn @_RC15test_field_call(v0 (s): HasClosure, v1 (x): i32) -> i32 {
+// FULL-NEXT: fn @_RC15test_field_call(v0 (s): borrowed HasClosure, v1 (x): i32) -> i32 {
 // FULL-NEXT:     apply(proj(v0 : HasClosure, 0) : (i32) -> i32, v1 : i32) : i32
 // FULL-NEXT: }

--- a/tests/integration/frontend/list_append.rr
+++ b/tests/integration/frontend/list_append.rr
@@ -21,7 +21,6 @@ fn append(a : List<i32>, b : List<i32>) -> List<i32> {
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec a, yield b (ownership of b transfers to caller)
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec(%arg0 :
 // CHECK-MLIR:       reussir.scf.yield %arg1 :
 // Cons(x, xs): load x, load xs, inc xs, dec a, build Cons{x, append(xs, b)}
 // CHECK-MLIR:       [1] ->
@@ -30,7 +29,6 @@ fn append(a : List<i32>, b : List<i32>) -> List<i32> {
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0 :
 // CHECK-MLIR:       call @_RC6append
 // CHECK-MLIR:       reussir.record.compound
 // CHECK-MLIR:       reussir.record.variant

--- a/tests/integration/frontend/list_empty.rr
+++ b/tests/integration/frontend/list_empty.rr
@@ -53,12 +53,10 @@ pub fn empty2(list : List<i32>) -> bool {
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec scrutinee, yield true
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       arith.constant true
 // Cons: dec scrutinee, yield false (no pattern bindings extracted)
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       arith.constant false
 
 // empty2: match with explicit Cons(..)
@@ -66,9 +64,7 @@ pub fn empty2(list : List<i32>) -> bool {
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec, yield true
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // Cons: dec, yield false (no pattern bindings extracted)
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       arith.constant false

--- a/tests/integration/frontend/list_length.rr
+++ b/tests/integration/frontend/list_length.rr
@@ -19,15 +19,13 @@ fn length(list : List<i32>) -> i32 {
 // CHECK-MLIR-LABEL: func.func private @_RC6length(%arg0
 // CHECK-MLIR:       reussir.rc.borrow(%arg0 :
 // CHECK-MLIR:       reussir.record.dispatch
-// Nil: dec list, yield 0
+// Nil: yield 0
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec(%arg0 :
 // CHECK-MLIR:       arith.constant 0 : i32
 // CHECK-MLIR:       reussir.scf.yield
-// Cons(_, xs): load xs (RC), inc xs, dec list, recurse
+// Cons(_, xs): load xs (RC), inc xs, recurse (borrowed), settle xs
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0 :
 // CHECK-MLIR:       call @_RC6length

--- a/tests/integration/frontend/list_nth.rr
+++ b/tests/integration/frontend/list_nth.rr
@@ -33,7 +33,6 @@ fn nth(list : List<i32>, n : i32) -> Option<i32> {
 // CHECK-MLIR:       reussir.record.dispatch
 // Nil: dec list, return None
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       reussir.record.compound
 // CHECK-MLIR:       reussir.record.variant
 // Cons(x, xs): extract fields (head then tail), inc tail, dec list, check index
@@ -43,7 +42,6 @@ fn nth(list : List<i32>, n : i32) -> Option<i32> {
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // n==0 branch: dec xs, return Some(x)
 // CHECK-MLIR:       reussir.rc.dec
 // CHECK-MLIR:       reussir.record.compound

--- a/tests/integration/frontend/list_sum.rr
+++ b/tests/integration/frontend/list_sum.rr
@@ -18,17 +18,15 @@ fn sum(list : List<i32>) -> i32 {
 // CHECK-MLIR-LABEL: func.func private @_RC3sum(%arg0
 // CHECK-MLIR:       reussir.rc.borrow(%arg0 :
 // CHECK-MLIR:       reussir.record.dispatch
-// Nil: dec list, yield 0
+// Nil: yield 0
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec(%arg0 :
 // CHECK-MLIR:       arith.constant 0 : i32
 // CHECK-MLIR:       reussir.scf.yield
-// Cons: load x (i32), load xs (RC), inc xs, dec list, recurse
+// Cons: load x (i32), load xs (RC), inc xs, recurse (borrowed), settle xs
 // CHECK-MLIR:       [1] ->
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0 :
 // CHECK-MLIR:       call @_RC3sum

--- a/tests/integration/frontend/nat_even.rr
+++ b/tests/integration/frontend/nat_even.rr
@@ -42,7 +42,6 @@ fn even(n : Nat) -> bool {
 // CHECK-MLIR:       reussir.record.dispatch
 // Zero branch: dec scrutinee, yield true
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       arith.constant true
 // CHECK-MLIR:       reussir.scf.yield
 // Succ branch: intermediate lookup (no inc needed), nested dispatch
@@ -54,7 +53,6 @@ fn even(n : Nat) -> bool {
 // CHECK-MLIR:       reussir.record.dispatch
 // Succ(Zero): dec base scrutinee, yield false
 // CHECK-MLIR:       [0] ->
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       arith.constant false
 // CHECK-MLIR:       reussir.scf.yield
 // Succ(Succ(m)): load deepest binding, inc it, dec base scrutinee, call even
@@ -62,5 +60,4 @@ fn even(n : Nat) -> bool {
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       call @_RC4even

--- a/tests/integration/frontend/nullable.rr
+++ b/tests/integration/frontend/nullable.rr
@@ -40,7 +40,7 @@ fn baz(reg : RegBox) -> Nullable<Data> {
 
 // An unannotated regional parameter is pinned rigid; the `[field]` link
 // projects at the base's (frozen) view.
-// CHECK: fn @_RC3baz(v0 (reg): [rigid] RegBox) -> Nullable<[rigid] Data> {
+// CHECK: fn @_RC3baz(v0 (reg): borrowed [rigid] RegBox) -> Nullable<[rigid] Data> {
 // CHECK-NEXT: proj(v0 : [rigid] RegBox, 0) : Nullable<[rigid] Data>
 // CHECK-NEXT: }
 

--- a/tests/integration/frontend/pattern_bool_nested.rr
+++ b/tests/integration/frontend/pattern_bool_nested.rr
@@ -49,7 +49,7 @@ fn test(x : Pair) -> i32 {
 
 // FULL: record @_RC4Pair : shared enum Pair { @_RNvC4Pair6MkPair MkPair(bool, bool) };
 // FULL-EMPTY:
-// FULL-NEXT: fn @_RC4test(v0 (x): Pair) -> i32 {
+// FULL-NEXT: fn @_RC4test(v0 (x): borrowed Pair) -> i32 {
 // FULL-NEXT:     match v0 : Pair {
 // FULL-NEXT:         switch scrut {
 // FULL-NEXT:             #0 => {

--- a/tests/integration/frontend/pattern_ctor_sugar_match.rr
+++ b/tests/integration/frontend/pattern_ctor_sugar_match.rr
@@ -71,7 +71,7 @@ fn map_to_none(x : Option<i32>) -> Option<i32> {
 // FULL-NEXT:     } : Option::<i32>
 // FULL-NEXT: }
 // FULL-EMPTY:
-// FULL-NEXT: fn @_RC7is_some(v0 (x): Option::<i32>) -> bool {
+// FULL-NEXT: fn @_RC7is_some(v0 (x): borrowed Option::<i32>) -> bool {
 // FULL-NEXT:     match v0 : Option::<i32> {
 // FULL-NEXT:         switch scrut {
 // FULL-NEXT:             #0 => {

--- a/tests/integration/frontend/pattern_int_nested.rr
+++ b/tests/integration/frontend/pattern_int_nested.rr
@@ -42,7 +42,7 @@ fn test(x : Wrapper) -> i32 {
 
 // FULL: record @_RC7Wrapper : shared enum Wrapper { @_RNvC7Wrapper3Val Val(i32), @_RNvC7Wrapper4None None() };
 // FULL-EMPTY:
-// FULL-NEXT: fn @_RC4test(v0 (x): Wrapper) -> i32 {
+// FULL-NEXT: fn @_RC4test(v0 (x): borrowed Wrapper) -> i32 {
 // FULL-NEXT:     match v0 : Wrapper {
 // FULL-NEXT:         switch scrut {
 // FULL-NEXT:             #0 => {

--- a/tests/integration/frontend/pattern_mixed_ctor_int.rr
+++ b/tests/integration/frontend/pattern_mixed_ctor_int.rr
@@ -46,7 +46,7 @@ fn test(x : Result) -> i32 {
 
 // FULL: record @_RC6Result : shared enum Result { @_RNvC6Result2Ok Ok(i32), @_RNvC6Result3Err Err(i32) };
 // FULL-EMPTY:
-// FULL-NEXT: fn @_RC4test(v0 (x): Result) -> i32 {
+// FULL-NEXT: fn @_RC4test(v0 (x): borrowed Result) -> i32 {
 // FULL-NEXT:     match v0 : Result {
 // FULL-NEXT:         switch scrut {
 // FULL-NEXT:             #0 => {

--- a/tests/integration/frontend/projection.rr
+++ b/tests/integration/frontend/projection.rr
@@ -19,19 +19,19 @@
 // CHECK-EMPTY:
 // CHECK: record @_RIC5RcBoxmE : shared struct RcBox::<u32> { "val": u32 };
 // CHECK-EMPTY:
-// CHECK: pub fn @_RC10rc_project(v0 (rc): RcBox::<u32>) -> u32 {
+// CHECK: pub fn @_RC10rc_project(v0 (rc): borrowed RcBox::<u32>) -> u32 {
 // CHECK-NEXT: proj(v0 : RcBox::<u32>, 0) : u32
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK: pub fn @_RC11mixed_chain(v0 (rc): Box::<RcBox::<RcBox::<RcBox::<Box::<Box::<u32>>>>>>) -> u32 {
+// CHECK: pub fn @_RC11mixed_chain(v0 (rc): borrowed Box::<RcBox::<RcBox::<RcBox::<Box::<Box::<u32>>>>>>) -> u32 {
 // CHECK-NEXT: proj(v0 : Box::<RcBox::<RcBox::<RcBox::<Box::<Box::<u32>>>>>>, 0, 0, 0, 0, 0, 0) : u32
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK: pub fn @_RC18rc_project_chained(v0 (rc): RcBox::<RcBox::<u32>>) -> u32 {
+// CHECK: pub fn @_RC18rc_project_chained(v0 (rc): borrowed RcBox::<RcBox::<u32>>) -> u32 {
 // CHECK-NEXT: proj(v0 : RcBox::<RcBox::<u32>>, 0, 0) : u32
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK: pub fn @_RC20rc_project_chained_2(v0 (rc): RcBox::<RcBox::<RcBox::<u32>>>) -> u32 {
+// CHECK: pub fn @_RC20rc_project_chained_2(v0 (rc): borrowed RcBox::<RcBox::<RcBox::<u32>>>) -> u32 {
 // CHECK-NEXT: proj(v0 : RcBox::<RcBox::<RcBox::<u32>>>, 0, 0, 0) : u32
 // CHECK-NEXT: }
 

--- a/tests/integration/frontend/tree_count_leaves.rr
+++ b/tests/integration/frontend/tree_count_leaves.rr
@@ -22,7 +22,6 @@ fn count_leaves(t : Tree) -> i32 {
 // Leaf(_): ignore value, dec scrutinee, return 1
 // CHECK-MLIR:       [0] ->
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       arith.constant 1 : i32
 // CHECK-MLIR:       reussir.scf.yield
 // Node(l, r): inc both children, dec scrutinee, recurse on both
@@ -33,6 +32,5 @@ fn count_leaves(t : Tree) -> i32 {
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       call @_RC12count_leaves
 // CHECK-MLIR:       call @_RC12count_leaves

--- a/tests/integration/frontend/tree_mirror.rr
+++ b/tests/integration/frontend/tree_mirror.rr
@@ -25,7 +25,6 @@ fn mirror(t : Tree) -> Tree {
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       reussir.record.compound
 // CHECK-MLIR:       reussir.record.variant
 // CHECK-MLIR:       reussir.rc.create
@@ -37,7 +36,6 @@ fn mirror(t : Tree) -> Tree {
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // Recursive calls in swapped order: mirror(r) then mirror(l)
 // CHECK-MLIR:       call @_RC6mirror
 // CHECK-MLIR:       call @_RC6mirror

--- a/tests/integration/frontend/tree_sum.rr
+++ b/tests/integration/frontend/tree_sum.rr
@@ -25,7 +25,6 @@ fn tree_sum(t : Tree) -> i32 {
 // CHECK-MLIR:       reussir.ref.project
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR-NOT:   reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       reussir.scf.yield
 // Node(l, r): both children are RC, both need inc, then dec scrutinee
 // CHECK-MLIR:       [1] ->
@@ -35,6 +34,5 @@ fn tree_sum(t : Tree) -> i32 {
 // CHECK-MLIR:       reussir.ref.load
 // CHECK-MLIR:       reussir.rc.inc
 // CHECK-MLIR:       reussir.rc.inc
-// CHECK-MLIR:       reussir.rc.dec(%arg0
 // CHECK-MLIR:       call @_RC8tree_sum
 // CHECK-MLIR:       call @_RC8tree_sum


### PR DESCRIPTION
Third of the three layout/ownership PRs (stacked on #341 → #340).

## What

Infers the **borrowed calling convention** for parameters of *pure readers*: every use of the parameter is a match scrutinee or projection-chain root, the body allocates no rc value, and the function is not directly self-recursive. `is_red`-style predicates and accessors stop paying the caller-dup + callee-release round trip — the caller lends the value and settles it after the call only when the call was its last use.

The verdict is deliberately a pure function of the function's own body, computed once at the end of monomorphization — every codegen unit and repl re-monomorphization derives the same convention for the same symbol (no interprocedural fixpoint, no cross-CGU divergence). It round-trips the textual MIR (`borrowed` on params) and reaches the backend as `reussir.borrowed_params` on `func.func`. Trampoline targets and regional functions are excluded.

## The two guards (each bought with a measured failure)

- **allocates-nothing**: update-shaped functions (rbtree `ins`, nbe `quote`) also only *read* their parameter syntactically — but consuming it feeds every reuse token in their constructor chains. Borrowing `ins` measured **3× slower** (25.5G instructions, reuse fully dead, 4.7G in the allocator + 3.8G in recursive drops) before this guard.
- **non-self-recursive**: an owned recursive walker releases its structure incrementally; a borrowed one defers the whole release to one caller-side settle-dec — a *recursive* drop as deep as the structure (a 74k-frame stack overflow on nbe's app-chain before this guard).

## Backend hardening for the new `inc x; call f(x lent); dec x` shape

- **IncDecCancellation** now cancels across a `func.call` that provably only borrows relative to the incremented value (declared borrowed positions; remaining operands type-disjoint via a conservative transitive-containment walk — closures count as universal containers). The settle-pair dissolves before later passes see it.
- **TRMC** vetoes Class-A rewriting when a post-call op references the recursive call's operands: the rewrite tail-positions the call, and the reordered settle-dec would free a value the callee still reads. Found the hard way — as a use-after-free through the token-realloc path, diagnosed with valgrind on the system-allocator runtime.
- Call sites settle lent arguments **per distinct variable** (a variable lent in two positions settles once; a sibling argument that may consume it forces a pin: dup before the arguments, drop after the call).

## Measured (aarch64, n=4.2M, xLTO + static mimalloc)

| | on #341 | this PR |
|---|---|---|
| rbtree | 0.43 s | **0.42 s** |
| rbtree-zipper | 0.40 s | 0.40 s |
| nbe-hoas | 0.21 s | 0.21 s |

Neutral-to-slightly-positive on the trio (their hot paths are consuming/reuse-shaped by design — exactly what the guards protect); the win is the removed rc traffic on predicate-shaped calls plus the infrastructure for extending P9 (interprocedural refinement, borrowed match bindings for tail walkers) with the failure modes now documented in the module docs.

## Validation

Full lit 288/288 (incl. asan/lsan/msan/tsan executing gates), ownership unit tests, rrc-test (incl. wasm32), jit/repl tests, fold-correctness + valgrind-clean nbe reproducers at `-Onone`/`-Odefault`/`-Oaggressive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785881670&installation_id=144622820&pr_number=342&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F342&signature=a3e8cc2217e1a180a7d3ee218a9fcd7141fbe96dafc28b47f898f6091ce02ee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->