### PR TITLE
[backend] unique-carrying analysis: soundness, completeness, and a real spec

### DIFF
--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -150,12 +150,23 @@ def ReussirUniqueCarryingRecursionAnalysisPass
     : Pass<"reussir-unique-carrying-recursion-analysis", "::mlir::ModuleOp"> {
   let summary = "analyze uniqueness-carrying recursion and outline unique clones";
   let description = [{
-    `reussir-unique-carrying-recursion-analysis` uses sparse forward dataflow
-    with interprocedural propagation to mark RC-returning function and SCF
-    operations carrying uniqueness. When a carrying function is directly
-    self-recursive, the pass creates an internal `.unique` clone that asserts
-    RC argument uniqueness at entry and rewrites recursive calls to use the
-    specialized clone.
+    `reussir-unique-carrying-recursion-analysis` computes, per rc-typed
+    function result, whether the returned value is on every path either
+    fresh (an `rc.create*` with an initialized count, never shared
+    afterwards) or one of the function's own rc arguments passed through
+    unshared — a Kleene iteration over demand-driven provenance summaries.
+    Functions and structured-control-flow ops whose rc results all qualify
+    are marked `reussir.carrying_uniqueness`. When a carrying function is
+    directly self-recursive and a self call's carried arguments are provably
+    unique, the pass creates internal `.unique` clones (marked
+    `reussir.unique_clone`) that assert argument uniqueness at entry and
+    rewrites the provable self calls to use them, one clone per provable
+    assumption set. Provenance is traced only through region ops whose
+    results are exhaustively yield-defined (`scf.if`, `scf.index_switch`,
+    `scf.execute_region`, `reussir.record.dispatch`,
+    `reussir.array.with_unique_view`); values with retaining or multiple
+    consuming users are disqualified — see the pass source header for the
+    soundness argument.
   }];
   let dependentDialects = ["::reussir::ReussirDialect",
                            "::mlir::func::FuncDialect",

--- a/lib/Transformation/UniqueCarryingRecursionAnalysis/UniqueCarryingRecursionAnalysis.cpp
+++ b/lib/Transformation/UniqueCarryingRecursionAnalysis/UniqueCarryingRecursionAnalysis.cpp
@@ -5,6 +5,83 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
+//
+// Uniqueness-carrying analysis and `.unique` specialization.
+//
+// # The claim
+//
+// A function *carries uniqueness* when every rc-typed result it returns is,
+// on every path, either **fresh** (produced by an `rc.create*` whose count
+// is initialized to 1 and never shared afterwards) or **carried** (one of
+// the function's own rc arguments, passed through unshared). The payoff:
+// at a call site where every carried argument is *itself* proven unique,
+// the results are unique too — so a directly self-recursive carrying
+// function can run a specialized `.unique` clone that asserts argument
+// uniqueness at entry (`rc.assume_unique`, an `llvm.assume(count == 1)`
+// after lowering), letting the reuse machinery take unique fast paths
+// through the whole recursion.
+//
+// # Provenance lattice
+//
+// Per rc value: `Unknown` (bottom) or a pair `{fresh, carriedArgs}` meaning
+// "on some path this is a fresh create / argument i". Join is the pointwise
+// union: the value is unique iff every contributor is, so a joined value is
+// proven unique under an assumption set exactly when *all* its carried bits
+// are assumed (freshness needs no assumption). `Unknown` is absorbing in
+// proofs (never unique) and the identity of the join.
+//
+// # Sharing discipline (the part provenance alone cannot see)
+//
+// Freshness at the definition does not survive sharing: a created value
+// that is also retained elsewhere (`rc.inc`, a second consuming user)
+// reaches the recursive call with count > 1, and asserting uniqueness on
+// it would be undefined behavior. Provenance is therefore *disqualified*
+// (demoted to `Unknown`) when the value has any retaining user, or more
+// than one consuming user. Forwarding terminators (`scf.yield`,
+// `reussir.scf.yield`, `func.return`) and read-only observers (`rc.borrow`,
+// `rc.fetch`, `rc.is_unique`, `rc.assume_unique`) do not count: forwards
+// sit on mutually exclusive paths (their sharing is checked at the level of
+// the forwarded result), and reads do not retain. This is conservative —
+// consuming uses on mutually exclusive paths are also rejected — but it is
+// what makes the entry assumption sound without a path-sensitive count
+// analysis. The frontend's ownership discipline guarantees any genuine
+// sharing materializes as an explicit `rc.inc`, which this check sees.
+//
+// # Control flow
+//
+// Region results are traced only through operations whose results are
+// *exhaustively* defined by their regions' yields: `scf.if`,
+// `scf.index_switch`, `scf.execute_region`, and `reussir.record.dispatch`.
+// Loop-carrying ops (`scf.for`, `scf.while`) are deliberately Unknown:
+// their results may come from the *init* operands on a zero-trip count, a
+// path the yield-only join would miss. `reussir.array.with_unique_view` is
+// fresh only in its implicit-result form (an empty yield returns the
+// uniquified array itself, count 1 by construction); an explicit yield is
+// traced like any other forward.
+//
+// # Fixpoint
+//
+// Function summaries start at bottom and are recomputed from the previous
+// round until stable — a Kleene iteration of a monotone map (joins only
+// accumulate bits, bounded by the argument count), so it terminates at the
+// least fixpoint. Optimism about recursion is sound coinductively: any
+// value a terminating execution actually returns is produced by a finite
+// chain of creates/argument passes, which some iteration covers.
+//
+// # Specialization
+//
+// For each carrying, directly self-recursive function, the set of provable
+// assumption vectors is closed off: starting from the empty assumption,
+// each self call contributes the argument subset it can prove, and each
+// discovered subset is re-run (the clone bodies are copies of the base, so
+// walking the base under the subset's assumptions is equivalent). Each
+// subset gets one clone (`f.unique` when it is the only one, else
+// `f.unique_<bits>`), marked private/internal and tagged
+// `reussir.unique_clone`; debug info is stripped (the clone has no distinct
+// source location). Reruns are idempotent: self calls are reset to the base
+// symbol before re-deciding, and existing clones are found by the marker.
+//
+//===----------------------------------------------------------------------===//
 
 #include "Reussir/Transformation/Passes.h"
 #include "Reussir/IR/ReussirDialect.h"
@@ -29,6 +106,7 @@ namespace {
 
 static constexpr llvm::StringLiteral kCarryingUniquenessAttr =
     "reussir.carrying_uniqueness";
+static constexpr llvm::StringLiteral kUniqueCloneAttr = "reussir.unique_clone";
 
 struct UniqueCarryingValue {
   bool unknown = true;
@@ -171,17 +249,54 @@ public:
           def, llvm::cast<mlir::OpResult>(value).getResultNumber());
     }
 
+    // Provenance does not survive sharing: a value retained elsewhere (an
+    // `rc.inc` alias) or consumed more than once reaches its consumer with
+    // count > 1 no matter how it was produced. See the sharing-discipline
+    // note in the file header.
+    if (result.isCarrying() && isSharedAfterDefinition(value))
+      result = UniqueCarryingValue::getUnknown();
+
     active.erase(value);
     cache[value] = result;
     return result;
   }
 
+  // Whether `value`'s uses can elevate its count on some path before its
+  // consumer runs. Forwarding terminators and read-only observers are
+  // harmless; an explicit retain always disqualifies; any second consuming
+  // user does too (conservatively, even on a mutually exclusive path).
+  static bool isSharedAfterDefinition(mlir::Value value) {
+    unsigned consumingUses = 0;
+    for (mlir::Operation *user : value.getUsers()) {
+      if (llvm::isa<ReussirRcIncOp>(user))
+        return true;
+      if (llvm::isa<mlir::scf::YieldOp, ReussirScfYieldOp,
+                    mlir::func::ReturnOp>(user))
+        continue;
+      if (llvm::isa<ReussirRcBorrowOp, ReussirRcFetchOp, ReussirRcIsUniqueOp,
+                    ReussirRcAssumeUniqueOp>(user))
+        continue;
+      if (++consumingUses > 1)
+        return true;
+    }
+    return false;
+  }
+
 private:
   UniqueCarryingValue evaluateResult(mlir::Operation *op,
                                      unsigned resultIndex) {
-    if (llvm::isa<ReussirRcCreateOp, ReussirRcCreateCompoundOp,
-                  ReussirRcCreateVariantOp>(op))
-      return UniqueCarryingValue::getFresh();
+    // A create initializes its count to 1 — unless `skip_rc` elides that
+    // initialization (reuse/TRMC machinery), in which case the box keeps
+    // whatever count it already had.
+    if (auto create = llvm::dyn_cast<ReussirRcCreateOp>(op))
+      return create.getSkipRc() ? UniqueCarryingValue::getUnknown()
+                                : UniqueCarryingValue::getFresh();
+    if (auto create = llvm::dyn_cast<ReussirRcCreateCompoundOp>(op))
+      return create.getSkipRc() ? UniqueCarryingValue::getUnknown()
+                                : UniqueCarryingValue::getFresh();
+    if (auto create = llvm::dyn_cast<ReussirRcCreateVariantOp>(op))
+      return create.getSkipRc() ? UniqueCarryingValue::getUnknown()
+                                : UniqueCarryingValue::getFresh();
 
     if (auto callOp = llvm::dyn_cast<mlir::func::CallOp>(op)) {
       auto it = summaries.find(callOp.getCallee());
@@ -204,36 +319,52 @@ private:
     }
 
     if (auto withUniqueView = llvm::dyn_cast<ReussirArrayWithUniqueViewOp>(op)) {
-      if (withUniqueView.getResult() &&
-          withUniqueView.getResult().getType() ==
-              withUniqueView.getArray().getType())
-        return UniqueCarryingValue::getFresh();
-      auto yieldOp =
-          llvm::dyn_cast<ReussirScfYieldOp>(withUniqueView.getBody().front().getTerminator());
+      auto yieldOp = llvm::dyn_cast<ReussirScfYieldOp>(
+          withUniqueView.getBody().front().getTerminator());
       if (!yieldOp)
         return UniqueCarryingValue::getUnknown();
+      // The implicit-result form (an empty yield) returns the uniquified
+      // array itself: count 1 by the op's contract. An explicit yield is an
+      // ordinary forward — same-typed or not, it need not be the array.
+      if (withUniqueView.getResult() && yieldOp.getNumOperands() == 0)
+        return UniqueCarryingValue::getFresh();
       if (resultIndex >= yieldOp.getNumOperands())
         return UniqueCarryingValue::getUnknown();
       return evaluate(yieldOp.getOperand(resultIndex));
     }
 
-    auto *dialect = op->getDialect();
-    if (dialect && dialect->getNamespace() == "scf") {
-      UniqueCarryingValue joined = UniqueCarryingValue::getUnknown();
-      for (mlir::Region &region : op->getRegions()) {
-        if (region.empty())
-          continue;
-        auto yieldOp =
-            llvm::dyn_cast<mlir::scf::YieldOp>(region.front().getTerminator());
-        if (!yieldOp || resultIndex >= yieldOp.getNumOperands())
-          continue;
-        joined = UniqueCarryingValue::join(
-            joined, evaluate(yieldOp.getOperand(resultIndex)));
-      }
-      return joined;
-    }
+    // A variant dispatch's results are exhaustively defined by its arms'
+    // yields — the dominant control-flow shape of frontend-emitted code
+    // (every `match`).
+    if (llvm::isa<ReussirRecordDispatchOp>(op))
+      return joinRegionYields<ReussirScfYieldOp>(op, resultIndex);
+
+    // Only structured ops whose results come *exclusively* from region
+    // yields may be traced this way. Loop ops are excluded on purpose:
+    // `scf.for`/`scf.while` results can be the init operands (a zero-trip
+    // loop), a path a yield-only join would silently miss.
+    if (llvm::isa<mlir::scf::IfOp, mlir::scf::IndexSwitchOp,
+                  mlir::scf::ExecuteRegionOp>(op))
+      return joinRegionYields<mlir::scf::YieldOp>(op, resultIndex);
 
     return UniqueCarryingValue::getUnknown();
+  }
+
+  template <typename YieldOpT>
+  UniqueCarryingValue joinRegionYields(mlir::Operation *op,
+                                       unsigned resultIndex) {
+    UniqueCarryingValue joined = UniqueCarryingValue::getUnknown();
+    for (mlir::Region &region : op->getRegions()) {
+      if (region.empty())
+        continue;
+      auto yieldOp =
+          llvm::dyn_cast<YieldOpT>(region.front().getTerminator());
+      if (!yieldOp || resultIndex >= yieldOp->getNumOperands())
+        return UniqueCarryingValue::getUnknown();
+      joined = UniqueCarryingValue::join(
+          joined, evaluate(yieldOp->getOperand(resultIndex)));
+    }
+    return joined;
   }
 
   const FunctionSummaryMap &summaries;
@@ -327,8 +458,11 @@ static bool hasSelfRecursiveCall(mlir::func::FuncOp funcOp) {
   return found;
 }
 
-static bool isUniqueCloneName(llvm::StringRef name) {
-  return name.contains(".unique");
+// A clone is recognized by its marker attribute; the name check is a
+// belt-and-suspenders fallback for IR that predates the marker.
+static bool isUniqueClone(mlir::func::FuncOp funcOp) {
+  return funcOp->hasAttr(kUniqueCloneAttr) ||
+         funcOp.getName().contains(".unique");
 }
 
 static bool isUniqueCloneOf(llvm::StringRef baseName, llvm::StringRef callee) {
@@ -506,6 +640,8 @@ static mlir::func::FuncOp getOrCreateUniqueClone(
   uniqueFunc->setAttr("llvm.linkage",
                       mlir::LLVM::LinkageAttr::get(
                           funcOp.getContext(), mlir::LLVM::Linkage::Internal));
+  uniqueFunc->setAttr(kUniqueCloneAttr,
+                      mlir::UnitAttr::get(funcOp.getContext()));
   stripCloneDebugInfo(uniqueFunc);
   symbolTable.insert(uniqueFunc);
 
@@ -578,7 +714,7 @@ struct UniqueCarryingRecursionAnalysisPass
     llvm::SmallVector<mlir::func::FuncOp> recursiveFunctions;
     moduleOp.walk([&](mlir::func::FuncOp funcOp) {
       if (!funcOp->hasAttr(kCarryingUniquenessAttr) || funcOp.isDeclaration() ||
-          isUniqueCloneName(funcOp.getName()) || !hasSelfRecursiveCall(funcOp))
+          isUniqueClone(funcOp) || !hasSelfRecursiveCall(funcOp))
         return;
       if (!collectCarriedRcArguments(funcOp, summaries).any())
         return;

--- a/tests/integration/conversion/unique_carrying_recursion.mlir
+++ b/tests/integration/conversion/unique_carrying_recursion.mlir
@@ -76,7 +76,7 @@ module {
   }
 
   // CHECK-LABEL: func.func private @loop.unique(
-  // CHECK: attributes {llvm.linkage = #llvm.linkage<internal>, reussir.carrying_uniqueness}
+  // CHECK: attributes {llvm.linkage = #llvm.linkage<internal>, reussir.carrying_uniqueness, reussir.unique_clone}
   // CHECK: reussir.rc.assume_unique(%arg0 : !reussir.rc<i64>)
   // CHECK: %[[NEXT2:.+]] = reussir.rc.create value(%arg1 : i64) : !reussir.rc<i64>
   // CHECK: %[[RECURSE2:.+]] = func.call @loop.unique(%[[NEXT2]], %{{.+}}) : (!reussir.rc<i64>, i64) -> !reussir.rc<i64>

--- a/tests/integration/conversion/unique_carrying_soundness.mlir
+++ b/tests/integration/conversion/unique_carrying_soundness.mlir
@@ -1,0 +1,112 @@
+// RUN: %reussir-opt %s --reussir-unique-carrying-recursion-analysis | %FileCheck %s
+
+// Regression tests for the soundness and completeness rules of the
+// uniqueness-carrying analysis (see the pass source header):
+//   - provenance is disqualified by sharing (an rc.inc alias or a second
+//     consuming user): asserting uniqueness on such a value would be UB;
+//   - results are traced through `reussir.record.dispatch` arms (match-based
+//     recursion, the dominant frontend shape);
+//   - loop-carrying scf ops stay Unknown (their results may be the init
+//     operands on a zero-trip count);
+//   - `skip_rc` creates are not fresh (their count is not initialized here).
+
+!nilty = !reussir.record<compound "list.nil" [value] {}>
+!consty = !reussir.record<compound "list.cons" [value] {i64, !reussir.record<variant "list" incomplete>}>
+!listty = !reussir.record<variant "list" {!consty, !nilty}>
+!rclist = !reussir.rc<!listty>
+!tk = !reussir.token<align: 8, size: 32>
+
+module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-i64:64-n8:16:32:64-S128"} {
+  // Completeness: results flowing through dispatch arms (a fresh create in
+  // one arm, a carried argument in the other) make the function carrying,
+  // and a self call on a fresh, unshared argument specializes.
+  // CHECK-LABEL: func.func private @through_dispatch(
+  // CHECK: attributes {llvm.linkage = #llvm.linkage<internal>, reussir.carrying_uniqueness}
+  // CHECK: func.call @through_dispatch.unique(
+  func.func private @through_dispatch(%l: !rclist, %n: i64) -> !rclist attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %ref = reussir.rc.borrow (%l : !rclist) : !reussir.ref<!listty>
+    %r = reussir.record.dispatch (%ref : !reussir.ref<!listty>) -> !rclist {
+      [0] -> {
+        ^bb0(%cons: !reussir.ref<!consty>):
+        %tag = reussir.record.compound : !nilty
+        %v = reussir.record.variant [1] (%tag : !nilty) : !listty
+        %fresh = reussir.rc.create value(%v : !listty) : !rclist
+        %rec = func.call @through_dispatch(%fresh, %n) : (!rclist, i64) -> !rclist
+        reussir.scf.yield %rec : !rclist
+      }
+      [1] -> {
+        ^bb1(%nil: !reussir.ref<!nilty>):
+        reussir.scf.yield %l : !rclist
+      }
+    }
+    return %r : !rclist
+  }
+
+  // Soundness: the created value is retained (`rc.inc`) before the self
+  // call — its count is 2 at the call, so no uniqueness may be assumed and
+  // no specialization is created.
+  // CHECK-LABEL: func.func private @shared_by_inc(
+  // CHECK-NOT: func.call @shared_by_inc.unique
+  // CHECK: return
+  func.func private @shared_by_inc(%l: !rclist, %n: i64) -> !rclist attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %c0 = arith.constant 0 : i64
+    %cond = arith.cmpi eq, %n, %c0 : i64
+    %r = scf.if %cond -> (!rclist) {
+      scf.yield %l : !rclist
+    } else {
+      %tag = reussir.record.compound : !nilty
+      %v = reussir.record.variant [1] (%tag : !nilty) : !listty
+      %fresh = reussir.rc.create value(%v : !listty) : !rclist
+      reussir.rc.inc(%fresh : !rclist)
+      %rec = func.call @shared_by_inc(%fresh, %c0) : (!rclist, i64) -> !rclist
+      reussir.rc.dec(%fresh : !rclist) : !reussir.nullable<!tk>
+      scf.yield %rec : !rclist
+    }
+    return %r : !rclist
+  }
+
+  // Soundness: the created value has a second consuming user (another call)
+  // besides the self call — conservatively rejected.
+  // CHECK-LABEL: func.func private @shared_by_second_consumer(
+  // CHECK-NOT: func.call @shared_by_second_consumer.unique
+  // CHECK: return
+  func.func private @sink(%l: !rclist) -> i64 attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %c0 = arith.constant 0 : i64
+    reussir.rc.dec(%l : !rclist) : !reussir.nullable<!tk>
+    return %c0 : i64
+  }
+  func.func private @shared_by_second_consumer(%l: !rclist, %n: i64) -> !rclist attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %c0 = arith.constant 0 : i64
+    %cond = arith.cmpi eq, %n, %c0 : i64
+    %r = scf.if %cond -> (!rclist) {
+      scf.yield %l : !rclist
+    } else {
+      %tag = reussir.record.compound : !nilty
+      %v = reussir.record.variant [1] (%tag : !nilty) : !listty
+      %fresh = reussir.rc.create value(%v : !listty) : !rclist
+      %ignored = func.call @sink(%fresh) : (!rclist) -> i64
+      %rec = func.call @shared_by_second_consumer(%fresh, %c0) : (!rclist, i64) -> !rclist
+      scf.yield %rec : !rclist
+    }
+    return %r : !rclist
+  }
+
+  // Soundness: a result flowing through `scf.for` is Unknown — on a
+  // zero-trip count the loop returns its init operand, a path a yield-only
+  // join would miss. The function must not be marked carrying.
+  // CHECK-LABEL: func.func private @through_for(
+  // CHECK-NOT: reussir.carrying_uniqueness
+  // CHECK: return
+  func.func private @through_for(%l: !rclist, %n: index) -> !rclist attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %r = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %l) -> (!rclist) {
+      %tag = reussir.record.compound : !nilty
+      %v = reussir.record.variant [1] (%tag : !nilty) : !listty
+      %fresh = reussir.rc.create value(%v : !listty) : !rclist
+      reussir.rc.dec(%acc : !rclist) : !reussir.nullable<!tk>
+      scf.yield %fresh : !rclist
+    }
+    return %r : !rclist
+  }
+}


### PR DESCRIPTION
Audit of `UniqueCarryingRecursionAnalysis`, in parallel with the #340/#341 stack (based on main; no overlap with those changes). The pass creates `.unique` clones that assert `count == 1` at entry — an `llvm.assume` after lowering — so any hole in the provenance reasoning is undefined behavior, not a missed optimization. The pass source now opens with a full specification (claim, lattice, sharing discipline, control-flow rules, fixpoint argument, specialization/idempotency), and `Passes.td` describes what the pass actually does.

## Soundness fixes (each was a path to asserting uniqueness on a shared box)

1. **Sharing disqualification.** Provenance was def-only: a fresh create that was *also* retained (`rc.inc`) or consumed by a second user before the recursive call still "proved" unique. Values now demote to Unknown on any retaining user or a second consuming user; forwarding terminators and read-only observers (`borrow`/`fetch`/`is_unique`/`assume_unique`) are exempt. Conservative across mutually exclusive paths; relies on the ownership discipline surfacing genuine sharing as an explicit `rc.inc`.
2. **Loop ops excluded.** The blanket "any `scf` op" join read region yields only — but `scf.for`/`scf.while` results can be the **init operands** on a zero-trip count. Region tracing is now an allowlist of exhaustively-yield-defined ops (`scf.if`, `scf.index_switch`, `scf.execute_region`), and a region with an unexpected terminator poisons the whole op instead of being silently skipped (the old `continue` dropped unanalyzed paths from the join).
3. **`array.with_unique_view`** is fresh only in the implicit-result form (empty yield ⇒ the uniquified array itself, count 1 by the op's contract). The old check was mere *type equality* with the array — it also blessed explicit yields of arbitrary same-typed values.
4. **`skip_rc` creates are not fresh** — their count is deliberately not initialized by the create.

## Completeness

Results are now traced through **`reussir.record.dispatch`** arms. Every `match`-shaped function — the dominant frontend shape — was previously invisible (dispatch results evaluated to Unknown), so the analysis effectively never saw frontend-generated recursion. With the fix, nbe's `names_of_env` specializes on its fresh accumulator (`.unique` clone, previously impossible); rbtree's `ins` is correctly *not* specialized (its recursive arguments are loaded members whose uniqueness genuinely doesn't follow). Benchmarks: neutral (rbtree 0.45 s, nbe 0.23–0.25 s, both same as main).

## Cleanups

- Clones carry a `reussir.unique_clone` marker attribute; the ad hoc `.unique` name-contains detection remains only as a fallback for pre-marker IR.
- New lit test (`unique_carrying_soundness.mlir`) pins each rule: inc-shared and double-consumed values do not specialize, `scf.for` results are not carrying, dispatch results are.

## Validation

Full lit suite 289/289 (incl. the asan/lsan/msan/tsan executing gates and the array unique-carrying e2e tests), plus benchmark correctness/perf spot checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785884872&installation_id=144622820&pr_number=343&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F343&signature=839a7726594cf58d388095b665a9613f984f757711e69c2aeb72974614b48099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->