### PR TITLE
Statically shaped arrays, Phase A (#344)

### DIFF
--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -487,6 +487,65 @@ pub fn record_dispatch<'c>(
 /// melior's generated builder takes only `(context, location)` — it exposes no
 /// parameter for it, so it can build only a value-less yield. The value is absent
 /// for a void dispatch.
+/// `scf.for %iv = %lb to %ub step %step iter_args(…) -> (tys…)`.
+///
+/// melior's [`scf::r#for`](melior::dialect::scf::r#for) takes no init operands
+/// or result types, so it cannot express a loop-carried value (a fold
+/// accumulator). The body region's entry block must take the induction
+/// variable (`index`) followed by one argument per init operand, and terminate
+/// with an `scf.yield` of the next iteration's carried values.
+pub fn scf_for_iter<'c>(
+    lower: Value<'c, '_>,
+    upper: Value<'c, '_>,
+    step: Value<'c, '_>,
+    inits: &[Value<'c, '_>],
+    result_types: &[Type<'c>],
+    body: Region<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("scf.for", location)
+        .add_operands(&[lower, upper, step])
+        .add_operands(inits)
+        .add_results(result_types)
+        .add_regions([body])
+        .build()
+        .expect("valid scf.for with iter_args")
+}
+
+/// `reussir.array.with_unique_view (%array : rc) -> rc { ^bb(%view: memref): … }`
+/// — uniqify (clone-if-shared) an rc array and run `body` with a mutable view
+/// of its payload. With an empty terminating `reussir.scf.yield`, the op's
+/// *implicit* result is the uniquified array itself, which is the only form
+/// the code generator emits.
+///
+/// Built raw because the op has a custom assembly format and an optional
+/// result, which the generated builder does not surface.
+pub fn array_with_unique_view<'c>(
+    array: Value<'c, '_>,
+    result_type: Type<'c>,
+    body: Region<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.array.with_unique_view", location)
+        .add_operands(&[array])
+        .add_results(&[result_type])
+        .add_regions([body])
+        .build()
+        .expect("valid reussir.array.with_unique_view")
+}
+
+/// `reussir.panic "<message>"` — abort through the runtime with a diagnostic
+/// message (used on the cold side of a bounds check).
+pub fn panic<'c>(context: &'c Context, message: &str, location: Location<'c>) -> Operation<'c> {
+    OperationBuilder::new("reussir.panic", location)
+        .add_attributes(&[(
+            Identifier::new(context, "message"),
+            StringAttribute::new(context, message).into(),
+        )])
+        .build()
+        .expect("valid reussir.panic")
+}
+
 pub fn scf_yield<'c>(value: Option<Value<'c, '_>>, location: Location<'c>) -> Operation<'c> {
     let mut builder = OperationBuilder::new("reussir.scf.yield", location);
     if let Some(value) = value {

--- a/crates/reussir-backend/src/lib.rs
+++ b/crates/reussir-backend/src/lib.rs
@@ -63,6 +63,8 @@ pub fn context() -> Context {
     context.get_or_load_dialect("reussir");
     context.get_or_load_dialect("func");
     context.get_or_load_dialect("cf");
+    // The array ops (issue #344) build `memref` views/loads/stores directly.
+    context.get_or_load_dialect("memref");
     context
 }
 

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -23,19 +23,19 @@ use reussir_backend::dialect;
 use reussir_backend::dialect::ty::{ReussirCapability, ReussirLifeScope};
 use reussir_backend::melior::Context;
 use reussir_backend::melior::dialect::arith::{self, CmpfPredicate, CmpiPredicate};
-use reussir_backend::melior::dialect::{func, scf};
+use reussir_backend::melior::dialect::{func, memref, scf};
 use reussir_backend::melior::ir::attribute::{
     Attribute, DenseI64ArrayAttribute, FlatSymbolRefAttribute, IntegerAttribute, StringAttribute,
     TypeAttribute,
 };
-use reussir_backend::melior::ir::r#type::{FunctionType, IntegerType};
+use reussir_backend::melior::ir::r#type::{FunctionType, IntegerType, MemRefType};
 use reussir_backend::melior::ir::{
     Block, BlockLike, Identifier, Location, Operation, Region, RegionLike, Type, Value,
 };
 
 use reussir_core::full::mir::{self, DecisionTree, Expr, ExprKind, SwitchCases};
 use reussir_core::full::ownership::{OwnershipTable, RcOp, RecordTable, analyze_function};
-use reussir_core::intrinsic::IntrinsicOp;
+use reussir_core::intrinsic::{ArrayFn, IntrinsicOp};
 use reussir_core::literal::{self, Integer};
 use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use reussir_core::semi::ty::{Flexivity, IntTy, Ty, TyCtxt, TyKind};
@@ -688,6 +688,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             NullableCall(inner) => self.nullable_call(block, env, e, *inner).map(Some),
             Closure(c) => self.closure(block, env, c).map(Some),
             ClosureCall { target, args } => self.closure_call(block, env, target, args),
+            ArrayOp { op, args, kernel } => self.lower_array_op(block, env, e, *op, args, *kernel),
             GlobalStr(token) => self.global_str(block, e, *token).map(Some),
             Poison => err("poison expression reached lowering"),
         }
@@ -2652,5 +2653,384 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let region = Region::new();
         region.append_block(block);
         Ok(region)
+    }
+
+    // ----- built-in array operations (issue #344) -----
+
+    /// Lower an [`ArrayOp`](ExprKind::ArrayOp). The shapes:
+    ///
+    /// * `get` — borrow + view + bounds-checked `memref.load`;
+    /// * `set` — bounds checks, then `array.with_unique_view` storing the
+    ///   element (the empty-yield implicit result is the updated array);
+    /// * `splat`/`tabulate` — a fresh `rc.create` over a poison payload
+    ///   (uniquely owned by construction, so a plain borrow + view is a
+    ///   mutable view), filled by an `scf.for` nest with **no** bounds checks
+    ///   (the loops iterate exactly the extents);
+    /// * `fold` — borrow + view and an `scf.for` nest threading the
+    ///   accumulator through `iter_args`.
+    ///
+    /// Kernel bodies are inlined: their params bind to the loop induction
+    /// variables (cast `index → i64`) or the loaded element/accumulator, and
+    /// the body lowers against the enclosing environment (its free variables
+    /// are read-only borrows — the ownership analysis emits no rc ops inside).
+    fn lower_array_op<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        e: &Expr<'tcx>,
+        op: ArrayFn,
+        args: &'tcx [Expr<'tcx>],
+        kernel: Option<&'tcx mir::Kernel<'tcx>>,
+    ) -> Result<Option<Value<'c, 'b>>> {
+        match op {
+            ArrayFn::Get => self.array_get(block, env, args).map(Some),
+            ArrayFn::Set => self.array_set(block, env, args).map(Some),
+            ArrayFn::Splat => self.array_splat(block, env, e, args).map(Some),
+            ArrayFn::Tabulate => self
+                .array_tabulate(block, env, e, kernel.expect("tabulate has a kernel"))
+                .map(Some),
+            ArrayFn::Fold => self
+                .array_fold(block, env, e, args, kernel.expect("fold has a kernel"))
+                .map(Some),
+        }
+    }
+
+    /// The extents of an array-typed MIR type.
+    fn array_dims(ty: Ty<'tcx>) -> Result<&'tcx [u64]> {
+        match *ty.kind() {
+            TyKind::Array { dims, .. } => Ok(dims),
+            _ => err("array operation on a non-array type"),
+        }
+    }
+
+    /// The `memref<dims x elem>` view type of an array-typed `ty`.
+    fn memref_of(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
+        let TyKind::Array { elem, dims } = *ty.kind() else {
+            return err("array view requested for a non-array type");
+        };
+        let elem = self.tys.mlir_ty(elem)?;
+        let shape: Vec<i64> = dims.iter().map(|&d| d as i64).collect();
+        Ok(MemRefType::new(elem, &shape, None, None).into())
+    }
+
+    /// Borrow an rc array and materialize the memref view of its payload.
+    fn array_view_of<'b>(
+        &self,
+        block: &'b Block<'c>,
+        rc_val: Value<'c, 'b>,
+        arr_ty: Ty<'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let inner = self.tys.array_inner_of(arr_ty)?;
+        let ref_ty = self.tys.unspecified_ref_type(inner);
+        let borrowed = self.append(
+            block,
+            dialect::rc_borrow(self.context, ref_ty, rc_val, loc).into(),
+        );
+        let view_ty = self.memref_of(arr_ty)?;
+        Ok(self.append(
+            block,
+            dialect::array_view(self.context, view_ty, borrowed, loc).into(),
+        ))
+    }
+
+    /// Lower `i64` index expressions and bounds-check them against `dims`:
+    /// each index is cast to `index` (a negative value wraps to a huge
+    /// unsigned one), compared `ult` against its extent, the verdicts are
+    /// and-reduced, and the failure branch panics. Statically provable checks
+    /// fold away downstream (the comparisons are against constant extents).
+    fn checked_indices<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        idx_exprs: &'tcx [Expr<'tcx>],
+        dims: &[u64],
+    ) -> Result<Vec<Value<'c, 'b>>> {
+        let loc = self.loc();
+        let index_ty = Type::index(self.context);
+        let mut idxs = Vec::with_capacity(idx_exprs.len());
+        let mut ok: Option<Value<'c, 'b>> = None;
+        for (ie, &d) in idx_exprs.iter().zip(dims) {
+            let raw = self
+                .expr(block, env, ie)?
+                .ok_or_else(|| LoweringError("array index is unit".into()))?;
+            let idx = self.append(block, arith::index_cast(raw, index_ty, loc));
+            let ext = self.index_const(block, d as i64);
+            let in_range = self.append(
+                block,
+                arith::cmpi(self.context, CmpiPredicate::Ult, idx, ext, loc),
+            );
+            ok = Some(match ok {
+                None => in_range,
+                Some(acc) => self.append(block, arith::andi(acc, in_range, loc)),
+            });
+            idxs.push(idx);
+        }
+        if let Some(ok) = ok {
+            let then_block = Block::new(&[]);
+            then_block.append_operation(scf::r#yield(&[], loc));
+            let then_region = Region::new();
+            then_region.append_block(then_block);
+            let else_block = Block::new(&[]);
+            else_block.append_operation(builders::panic(
+                self.context,
+                "array index out of bounds",
+                loc,
+            ));
+            else_block.append_operation(scf::r#yield(&[], loc));
+            let else_region = Region::new();
+            else_region.append_block(else_block);
+            block.append_operation(scf::r#if(ok, &[], then_region, else_region, loc));
+        }
+        Ok(idxs)
+    }
+
+    fn array_get<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    ) -> Result<Value<'c, 'b>> {
+        let base = &args[0];
+        let dims = Self::array_dims(base.ty)?;
+        let rc_val = self
+            .expr(block, env, base)?
+            .ok_or_else(|| LoweringError("array base is unit".into()))?;
+        // A temporary base (e.g. `tabulate(…).get(i)`) is released *after*
+        // this node by a value-keyed drop; stash it where that op looks.
+        self.remember_temp(env, base, rc_val);
+        let view = self.array_view_of(block, rc_val, base.ty)?;
+        let idxs = self.checked_indices(block, env, &args[1..], dims)?;
+        Ok(self.append(block, memref::load(view, &idxs, self.loc())))
+    }
+
+    fn array_set<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let base = &args[0];
+        let dims = Self::array_dims(base.ty)?;
+        let rank = dims.len();
+        let rc_val = self
+            .expr(block, env, base)?
+            .ok_or_else(|| LoweringError("array base is unit".into()))?;
+        let idxs = self.checked_indices(block, env, &args[1..=rank], dims)?;
+        let value = self
+            .expr(block, env, &args[rank + 1])?
+            .ok_or_else(|| LoweringError("array element is unit".into()))?;
+        let body = Block::new(&[(self.memref_of(base.ty)?, loc)]);
+        let view = body
+            .argument(0)
+            .expect("with_unique_view body takes the view")
+            .into();
+        body.append_operation(memref::store(value, view, &idxs, loc));
+        body.append_operation(builders::scf_yield(None, loc));
+        let region = Region::new();
+        region.append_block(body);
+        let rc_ty = self.tys.mlir_ty(base.ty)?;
+        let op = block.append_operation(builders::array_with_unique_view(
+            rc_val, rc_ty, region, loc,
+        ));
+        Ok(op.result(0).expect("with_unique_view result").into())
+    }
+
+    /// A fresh, uniquely-owned rc array over an uninitialized (poison)
+    /// payload; the caller fills every element before the value escapes.
+    fn fresh_array<'b>(&self, block: &'b Block<'c>, arr_ty: Ty<'tcx>) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let inner = self.tys.array_inner_of(arr_ty)?;
+        let rc_ty = self.tys.mlir_ty(arr_ty)?;
+        let poison = self.append(block, builders::poison(self.context, inner, loc));
+        Ok(self.append(block, builders::rc_create(self.context, poison, rc_ty, loc)))
+    }
+
+    fn array_splat<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        e: &Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    ) -> Result<Value<'c, 'b>> {
+        let value = self
+            .expr(block, env, &args[0])?
+            .ok_or_else(|| LoweringError("array element is unit".into()))?;
+        let rc_val = self.fresh_array(block, e.ty)?;
+        let view = self.array_view_of(block, rc_val, e.ty)?;
+        let dims = Self::array_dims(e.ty)?;
+        self.splat_nest(block, view, value, dims, Vec::new())?;
+        Ok(rc_val)
+    }
+
+    /// The `scf.for` nest of `splat`: store `value` at every index tuple.
+    fn splat_nest<'b>(
+        &self,
+        block: &'b Block<'c>,
+        view: Value<'c, 'b>,
+        value: Value<'c, 'b>,
+        dims: &[u64],
+        ivs: Vec<Value<'c, 'b>>,
+    ) -> Result<()> {
+        let loc = self.loc();
+        if dims.is_empty() {
+            block.append_operation(memref::store(value, view, &ivs, loc));
+            return Ok(());
+        }
+        let lb = self.index_const(block, 0);
+        let ub = self.index_const(block, dims[0] as i64);
+        let step = self.index_const(block, 1);
+        let inner = Block::new(&[(Type::index(self.context), loc)]);
+        {
+            let iv = inner.argument(0).expect("loop induction variable").into();
+            let mut ivs2: Vec<Value<'c, '_>> = ivs.iter().copied().collect();
+            ivs2.push(iv);
+            self.splat_nest(&inner, view, value, &dims[1..], ivs2)?;
+            inner.append_operation(scf::r#yield(&[], loc));
+        }
+        let region = Region::new();
+        region.append_block(inner);
+        block.append_operation(scf::r#for(lb, ub, step, region, loc));
+        Ok(())
+    }
+
+    fn array_tabulate<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        e: &Expr<'tcx>,
+        kernel: &'tcx mir::Kernel<'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        let rc_val = self.fresh_array(block, e.ty)?;
+        let view = self.array_view_of(block, rc_val, e.ty)?;
+        let dims = Self::array_dims(e.ty)?;
+        self.tabulate_nest(block, env, view, dims, kernel, Vec::new())?;
+        Ok(rc_val)
+    }
+
+    /// The `scf.for` nest of `tabulate`: in the innermost body, bind each
+    /// kernel param to its induction variable (cast to `i64`), lower the
+    /// kernel body inline, and store its value.
+    fn tabulate_nest<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        view: Value<'c, 'b>,
+        dims: &[u64],
+        kernel: &'tcx mir::Kernel<'tcx>,
+        ivs: Vec<Value<'c, 'b>>,
+    ) -> Result<()> {
+        let loc = self.loc();
+        if dims.is_empty() {
+            let i64_ty: Type<'c> = IntegerType::new(self.context, 64).into();
+            let mark = env.vars.len();
+            for (&(v, _), &iv) in kernel.params.iter().zip(&ivs) {
+                let as_i64 = self.append(block, arith::index_cast(iv, i64_ty, loc));
+                env.vars.insert(v, as_i64);
+            }
+            let val = self
+                .expr(block, env, kernel.body)?
+                .ok_or_else(|| LoweringError("array kernel produced no value".into()))?;
+            env.vars.truncate(mark);
+            block.append_operation(memref::store(val, view, &ivs, loc));
+            return Ok(());
+        }
+        let lb = self.index_const(block, 0);
+        let ub = self.index_const(block, dims[0] as i64);
+        let step = self.index_const(block, 1);
+        let inner = Block::new(&[(Type::index(self.context), loc)]);
+        {
+            let iv = inner.argument(0).expect("loop induction variable").into();
+            let mut ivs2: Vec<Value<'c, '_>> = ivs.iter().copied().collect();
+            ivs2.push(iv);
+            env.subscope(|scope| self.tabulate_nest(&inner, scope, view, &dims[1..], kernel, ivs2))?;
+            inner.append_operation(scf::r#yield(&[], loc));
+        }
+        let region = Region::new();
+        region.append_block(inner);
+        block.append_operation(scf::r#for(lb, ub, step, region, loc));
+        Ok(())
+    }
+
+    fn array_fold<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        e: &Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+        kernel: &'tcx mir::Kernel<'tcx>,
+    ) -> Result<Value<'c, 'b>> {
+        let base = &args[0];
+        let dims = Self::array_dims(base.ty)?;
+        let rc_val = self
+            .expr(block, env, base)?
+            .ok_or_else(|| LoweringError("array base is unit".into()))?;
+        // A temporary base (e.g. `tabulate(…).fold(…)`) is released *after*
+        // this node by a value-keyed drop; stash it where that op looks.
+        self.remember_temp(env, base, rc_val);
+        let view = self.array_view_of(block, rc_val, base.ty)?;
+        let init = self
+            .expr(block, env, &args[1])?
+            .ok_or_else(|| LoweringError("fold accumulator is unit".into()))?;
+        let acc_ty = self.tys.mlir_ty(e.ty)?;
+        self.fold_nest(block, env, view, dims, kernel, acc_ty, init, Vec::new())
+    }
+
+    /// The `scf.for` nest of `fold`: the accumulator threads every level as an
+    /// `iter_args`; the innermost body loads the element, binds the kernel
+    /// params to `(acc, elem)`, and yields the kernel body's value.
+    #[allow(clippy::too_many_arguments)]
+    fn fold_nest<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        view: Value<'c, 'b>,
+        dims: &[u64],
+        kernel: &'tcx mir::Kernel<'tcx>,
+        acc_ty: Type<'c>,
+        acc_in: Value<'c, 'b>,
+        ivs: Vec<Value<'c, 'b>>,
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        if dims.is_empty() {
+            let elem = self.append(block, memref::load(view, &ivs, loc));
+            let mark = env.vars.len();
+            env.vars.insert(kernel.params[0].0, acc_in);
+            env.vars.insert(kernel.params[1].0, elem);
+            let out = self
+                .expr(block, env, kernel.body)?
+                .ok_or_else(|| LoweringError("fold kernel produced no value".into()))?;
+            env.vars.truncate(mark);
+            return Ok(out);
+        }
+        let lb = self.index_const(block, 0);
+        let ub = self.index_const(block, dims[0] as i64);
+        let step = self.index_const(block, 1);
+        let inner = Block::new(&[(Type::index(self.context), loc), (acc_ty, loc)]);
+        {
+            let iv = inner.argument(0).expect("loop induction variable").into();
+            let acc_arg = inner.argument(1).expect("loop-carried accumulator").into();
+            let mut ivs2: Vec<Value<'c, '_>> = ivs.iter().copied().collect();
+            ivs2.push(iv);
+            env.subscope(|scope| {
+                let next =
+                    self.fold_nest(&inner, scope, view, &dims[1..], kernel, acc_ty, acc_arg, ivs2)?;
+                inner.append_operation(scf::r#yield(&[next], loc));
+                Ok::<_, LoweringError>(())
+            })?;
+        }
+        let region = Region::new();
+        region.append_block(inner);
+        let op = block.append_operation(builders::scf_for_iter(
+            lb,
+            ub,
+            step,
+            &[acc_in],
+            &[acc_ty],
+            region,
+            loc,
+        ));
+        Ok(op.result(0).expect("loop-carried result").into())
     }
 }

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -27,8 +27,8 @@ use std::cell::RefCell;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use reussir_backend::dialect::ty::{
-    ReussirAtomicKind, ReussirCapability, ReussirLifeScope, ReussirRecordKind, closure, nullable,
-    rc, record_complete_in_place, record_incomplete, record_is_complete, r#ref, region,
+    ReussirAtomicKind, ReussirCapability, ReussirLifeScope, ReussirRecordKind, array, closure,
+    nullable, rc, record_complete_in_place, record_incomplete, record_is_complete, r#ref, region,
     str as str_type,
 };
 use reussir_backend::melior::Context;
@@ -113,7 +113,10 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
     /// This is the complement, among reference-counted values, of an inline
     /// `[value]` record — which is acquired/dropped through a reference instead.
     pub(super) fn is_managed_rc(&self, ty: Ty<'tcx>) -> bool {
-        self.is_shared_record(ty) || self.is_regional_record(ty) || is_closure(ty)
+        self.is_shared_record(ty)
+            || self.is_regional_record(ty)
+            || is_closure(ty)
+            || matches!(ty.kind(), TyKind::Array { .. })
     }
 
     /// Lower a ground type to MLIR: records resolve through the layout table, a
@@ -139,6 +142,9 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             // A closure value is a shared `rc<closure<params -> ret>>`; captures
             // have already been supplied (see [`closure_type`](Self::closure_type)).
             TyKind::Closure { params, ret } => self.closure_type(params, ret),
+            // A statically shaped array is one shared `rc` box holding the whole
+            // payload (`!reussir.rc<!reussir.array<dims x elem>>`); see #344.
+            TyKind::Array { .. } => Ok(self.rc_type(self.array_inner_of(ty)?)),
             _ => scalar_ty(self.context, ty),
         }
     }
@@ -352,6 +358,17 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         Ok(closure(self.context, &input_tys, output))
     }
 
+    /// The `!reussir.array<dims x elem>` payload type of an array-typed `ty`
+    /// (the type inside its `rc` box, and the element type of its views).
+    pub(super) fn array_inner_of(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
+        let TyKind::Array { elem, dims } = *ty.kind() else {
+            return err("array payload requested for a non-array type");
+        };
+        let elem = scalar_ty(self.context, elem)?;
+        let shape: Vec<i64> = dims.iter().map(|&d| d as i64).collect();
+        Ok(array(&shape, elem))
+    }
+
     /// `!reussir.rc<inner, shared>` — the pointer type for a heap-allocated,
     /// reference-counted value with the default (non-atomic) box layout.
     pub(super) fn rc_type(&self, inner: Type<'c>) -> Type<'c> {
@@ -466,6 +483,7 @@ fn scalar_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
         TyKind::Unit => err("unit has no MLIR value type"),
         TyKind::Str => Ok(str_type(context, ReussirLifeScope::Global)),
         TyKind::Record { .. } => err("record type reached scalar lowering without a layout"),
+        TyKind::Array { .. } => err("array type reached scalar lowering without its rc wrapper"),
         TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),
         // Intercepted by [`TypeCtx::mlir_ty`]; reaching here is a bug.
         TyKind::Closure { .. } => err("closure type reached scalar lowering without an rc wrapper"),

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -145,6 +145,18 @@ impl<'a> Mangler<'a> {
                 // to its inner type.
                 self.path_with_args_segs(out, &["Nullable"], &[inner]);
             }
+            TyKind::Array { elem, dims } => {
+                // An array mangles as a synthetic record whose identifier
+                // carries the extents (`Array512x512`), applied to the element.
+                let mut name = String::from("Array");
+                for (i, d) in dims.iter().enumerate() {
+                    if i > 0 {
+                        name.push('x');
+                    }
+                    name.push_str(&d.to_string());
+                }
+                self.path_with_args_segs(out, &[&name], &[elem]);
+            }
             TyKind::Record { def, args, .. } => {
                 // The per-use capability (`flex`) is irrelevant to the ABI.
                 self.path_with_args(out, def, args);

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -255,9 +255,29 @@ pub enum ExprKind<'tcx> {
         target: &'tcx Expr<'tcx>,
         args: &'tcx [Expr<'tcx>],
     },
+    /// A built-in operation on a statically shaped array, mirroring
+    /// [`crate::semi::hir::ExprKind::ArrayOp`]: the resolved op, its value
+    /// operands, and — for `Tabulate`/`Fold` — an inline kernel. The kernel is
+    /// not a closure: its body references enclosing bindings directly
+    /// (read-only borrows for the op's duration) and codegen inlines it into
+    /// the element loop nest.
+    ArrayOp {
+        op: crate::intrinsic::ArrayFn,
+        args: &'tcx [Expr<'tcx>],
+        kernel: Option<&'tcx Kernel<'tcx>>,
+    },
     Match(&'tcx Expr<'tcx>, DecisionTree<'tcx>),
     /// Error-recovery placeholder.
     Poison,
+}
+
+/// The inline kernel of an [`ArrayOp`](ExprKind::ArrayOp); see
+/// [`crate::semi::hir::Kernel`]. The type checker guarantees the body is
+/// rc-free (plain-typed throughout, except `get` reads of enclosing arrays).
+#[derive(Clone, Copy, Debug)]
+pub struct Kernel<'tcx> {
+    pub params: &'tcx [(VarId, Ty<'tcx>)],
+    pub body: &'tcx Expr<'tcx>,
 }
 
 /// A pattern binding: a local variable bound to a scrutinee [`Path`].

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -679,10 +679,11 @@ mod tests {
         // The `array<f64, 8>` type and all five `array#…` ops, including
         // kernels with their params.
         roundtrip(
-            "pub fn make() -> Array<f64, 8> { Array::tabulate<f64, 8>(|i| i as f64) } \
-             pub fn ones() -> Array<f64, 8> { Array::splat<f64, 8>(1.0) } \
-             pub fn s(a: Array<f64, 8>) -> f64 { a.fold(0.0, |acc, x| acc + x) } \
-             pub fn b(a: Array<f64, 8>, i: i64, v: f64) -> Array<f64, 8> { a.set(i, a.get(i) + v) }",
+            "pub fn make() -> Array<f64, 8> { core::intrinsic::array::tabulate<f64, 8>(|i| i as f64) } \
+             pub fn ones() -> Array<f64, 8> { core::intrinsic::array::splat<f64, 8>(1.0) } \
+             pub fn s(a: Array<f64, 8>) -> f64 { core::intrinsic::array::fold(a, 0.0, |acc, x| acc + x) } \
+             pub fn b(a: Array<f64, 8>, i: i64, v: f64) -> Array<f64, 8> { \
+             core::intrinsic::array::set(a, i, core::intrinsic::array::get(a, i) + v) }",
         );
     }
 

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -256,6 +256,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let ret = self.ty(ret);
                 self.tcx.mk_closure(&params, ret)
             }
+            raw::Ty::Array { elem, dims } => {
+                let elem = self.ty(elem);
+                self.tcx.mk_array(elem, dims)
+            }
         }
     }
 
@@ -445,6 +449,29 @@ impl<'tcx> Builder<'_, 'tcx> {
                     .expect("known intrinsic in machine-emitted IR"),
                 args: self.expr_slice(args),
             },
+            raw::Kind::ArrayOp {
+                op,
+                args,
+                kernel_params,
+                kernel,
+            } => {
+                let args = self.expr_slice(args);
+                let kernel = kernel.as_ref().map(|body| {
+                    let params: Vec<(VarId, Ty<'tcx>)> = kernel_params
+                        .iter()
+                        .map(|(v, t)| (VarId(*v), self.ty(t)))
+                        .collect();
+                    let params = self.tcx.alloc_slice(&params);
+                    let body = self.expr_ref(body);
+                    &*self.tcx.alloc(mir::Kernel { params, body })
+                });
+                M::ArrayOp {
+                    op: crate::intrinsic::ArrayFn::parse(op)
+                        .expect("known array op in machine-emitted IR"),
+                    args,
+                    kernel,
+                }
+            }
             raw::Kind::NullableCall(inner) => {
                 M::NullableCall(inner.as_ref().map(|x| self.expr_ref(x)))
             }
@@ -644,6 +671,18 @@ mod tests {
             "pub fn fib(n: u64) -> u64 { \
              let m = n + 1; \
              if n <= 1 { m } else { fib(n - 1) + fib(n - 2) } }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_arrays() {
+        // The `array<f64, 8>` type and all five `array#…` ops, including
+        // kernels with their params.
+        roundtrip(
+            "pub fn make() -> Array<f64, 8> { Array::tabulate<f64, 8>(|i| i as f64) } \
+             pub fn ones() -> Array<f64, 8> { Array::splat<f64, 8>(1.0) } \
+             pub fn s(a: Array<f64, 8>) -> f64 { a.fold(0.0, |acc, x| acc + x) } \
+             pub fn b(a: Array<f64, 8>, i: i64, v: f64) -> Array<f64, 8> { a.set(i, a.get(i) + v) }",
         );
     }
 

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -102,6 +102,8 @@ Ty: raw::Ty = {
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
     <cap:Cap> <path:TyPathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
+    "array" "<" <elem:Ty> <dims:("," <"int">)+> ">"
+        => raw::Ty::Array { elem: Box::new(elem), dims: dims.iter().map(raw::small_u64).collect() },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };
@@ -188,6 +190,10 @@ Atom: raw::Kind = {
         => raw::Kind::Variant { symbol, variant: raw::small_usize(&v), args },
     "intrinsic" "#" <family:"ident"> "#" <name:"ident"> "#" <imm:"int"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::Intrinsic { family: family.to_string(), name: name.to_string(), imm: raw::small_u32(&imm), args },
+    "array" "#" <op:"ident"> "(" <args:Comma<Expr>> ")"
+        => raw::Kind::ArrayOp { op: op.to_string(), args, kernel_params: vec![], kernel: None },
+    "array" "#" <op:"ident"> "(" <args:Comma<Expr>> ")" "kernel" "(" <params:Comma<ClosureParam>> ")" "{" <body:Expr> "}"
+        => raw::Kind::ArrayOp { op: op.to_string(), args, kernel_params: params, kernel: Some(body) },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"
@@ -317,6 +323,8 @@ extern {
         "rigid" => Token::Rigid,
         "proj" => Token::Proj,
         "intrinsic" => Token::Intrinsic,
+        "array" => Token::Array,
+        "kernel" => Token::Kernel,
         "assign" => Token::Assign,
         "Nullable" => Token::Nullable,
         "NonNull" => Token::NonNull,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -225,6 +225,13 @@ impl Render<'_> {
             TyKind::Unit => text("()"),
             TyKind::Bottom => text("!"),
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
+            TyKind::Array { elem, dims } => {
+                let mut d = text("array<") + self.ty(elem);
+                for extent in dims {
+                    d = d + text(format!(", {extent}"));
+                }
+                d + text(">")
+            }
             TyKind::Record { def, args, flex } => {
                 let mut d = match flex {
                     Flexivity::Flex | Flexivity::Rigid | Flexivity::Regional => {
@@ -429,6 +436,24 @@ impl Render<'_> {
                     + text(") { ")
                     + self.value(c.body)
                     + text(" }")
+            }
+            ArrayOp { op, args, kernel } => {
+                let mut d =
+                    text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")");
+                if let Some(k) = kernel {
+                    let params: Vec<Doc<'static>> = k
+                        .params
+                        .iter()
+                        .map(|(v, t)| var(*v) + text(": ") + self.ty(*t))
+                        .collect();
+                    d = d
+                        + text(" kernel(")
+                        + comma_sep(params)
+                        + text(") { ")
+                        + self.value(k.body)
+                        + text(" }");
+                }
+                d
             }
             Let { .. } | Seq(_) | If(..) | Match(..) => {
                 unreachable!("structural forms are rendered by `value`")

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -202,6 +202,11 @@ pub enum Ty {
         params: Vec<Ty>,
         ret: Box<Ty>,
     },
+    /// `array<elem, extents…>` — a statically shaped array.
+    Array {
+        elem: Box<Ty>,
+        dims: Vec<u64>,
+    },
 }
 
 /// The per-use capability prefix printed before a record type (absent = value).
@@ -340,6 +345,13 @@ pub enum Kind {
         captures: Vec<(u32, Ty)>,
         params: Vec<(u32, Ty)>,
         body: Expr,
+    },
+    /// `array#<op>(args…) [kernel(params…) { body }]` — a built-in array op.
+    ArrayOp {
+        op: String,
+        args: Vec<Expr>,
+        kernel_params: Vec<(u32, Ty)>,
+        kernel: Option<Expr>,
     },
     Match(Expr, Box<Tree>),
 }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -342,6 +342,7 @@ const RECURSION_LIMIT: usize = 128;
 fn ty_depth(ty: Ty<'_>) -> usize {
     match *ty.kind() {
         TyKind::Nullable(inner) => 1 + ty_depth(inner),
+        TyKind::Array { elem, .. } => 1 + ty_depth(elem),
         TyKind::Record { args, .. } => 1 + args.iter().map(|&a| ty_depth(a)).max().unwrap_or(0),
         TyKind::Closure { params, ret } => {
             1 + params
@@ -474,6 +475,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 self.note_records(ret);
             }
             TyKind::Nullable(inner) => self.note_records(inner),
+            TyKind::Array { elem, .. } => self.note_records(elem),
             _ => {}
         }
     }
@@ -507,6 +509,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 self.discover_records(ret, worklist);
             }
             TyKind::Nullable(inner) => self.discover_records(inner, worklist),
+            TyKind::Array { elem, .. } => self.discover_records(elem, worklist),
             _ => {}
         }
     }
@@ -734,6 +737,15 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 args: self.lower_slice(args, subst),
             },
             ExprKind::Closure(c) => M::Closure(self.lower_closure(c, subst)),
+            ExprKind::ArrayOp { op, args, kernel } => M::ArrayOp {
+                op: *op,
+                args: self.lower_slice(args, subst),
+                kernel: kernel.as_ref().map(|k| {
+                    let params = self.lower_var_tys(&k.params, subst);
+                    let body = self.lower_ref(&k.body, subst);
+                    &*self.tcx.alloc(mir::Kernel { params, body })
+                }),
+            },
             ExprKind::Match(scrut, tree) => {
                 M::Match(self.lower_ref(scrut, subst), self.lower_tree(tree, subst))
             }
@@ -1212,6 +1224,7 @@ mod tests {
                 params.iter().all(|&p| is_ground(p)) && is_ground(ret)
             }
             TyKind::Nullable(inner) => is_ground(inner),
+            TyKind::Array { elem, .. } => is_ground(elem),
             _ => true,
         }
     }
@@ -1220,6 +1233,7 @@ mod tests {
     fn children<'tcx>(e: &mir::Expr<'tcx>) -> Vec<&'tcx mir::Expr<'tcx>> {
         use mir::ExprKind::*;
         match e.kind {
+            ArrayOp { args, kernel, .. } => args.iter().chain(kernel.map(|k| k.body)).collect(),
             GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
             | Poison => vec![],
             Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -307,6 +307,9 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
         // Overwritten with the real answer below.
         self.memo.borrow_mut().insert(ty, false);
         let b = match *ty.kind() {
+            // An array is one rc-managed box regardless of its (Plain)
+            // element type.
+            TyKind::Array { .. } => true,
             // The management class is the record table's call (keyed by the
             // canonical, flexivity-erased type); the per-use flexivity then refines
             // the one case where it matters — a regional record.
@@ -512,7 +515,29 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                     s.union_with(&self.free(arg));
                 }
             }
+            // An array op uses its value operands, plus every enclosing var the
+            // inline kernel body reads (the kernel's own params are binders).
+            ExprKind::ArrayOp { args, kernel, .. } => {
+                for arg in args {
+                    s.union_with(&self.free(arg));
+                }
+                if let Some(k) = kernel {
+                    s.union_with(&self.kernel_free(k));
+                }
+            }
         }
+        s
+    }
+
+    /// The free RR variables of an [`ArrayOp`](ExprKind::ArrayOp) kernel body,
+    /// minus the kernel's own parameters.
+    fn kernel_free(&mut self, k: &mir::Kernel<'tcx>) -> VarSet {
+        let mut s = self.free(k.body);
+        let mut params = VarSet::default();
+        for &(p, _) in k.params {
+            params.insert(p);
+        }
+        s.subtract(&params);
         s
     }
 
@@ -617,6 +642,82 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             ExprKind::Closure(c) => self.place_closure(e.id, &c, live_after),
             ExprKind::ClosureCall { target, args } => {
                 self.place_closure_call(target, args, live_after)
+            }
+            ExprKind::ArrayOp { op, args, kernel } => {
+                self.place_array_op(e, op, args, kernel, live_after)
+            }
+        }
+    }
+
+    /// Place an [`ArrayOp`](ExprKind::ArrayOp)'s operands and kernel.
+    ///
+    /// Ownership contract per op (see [`ArrayFn`](crate::intrinsic::ArrayFn)):
+    /// `Set` and `Splat` treat their operands like call arguments (the `Set`
+    /// base is consumed — the op returns the updated array); `Get` and `Fold`
+    /// only *borrow* their array operand; and a kernel body's free vars are
+    /// read-only borrows for the whole op (the type checker restricts kernel
+    /// bodies to be rc-free, so RR vars appear there only as `get` bases).
+    ///
+    /// Borrowed vars take no rc op at their use; instead, like a `Proj` base,
+    /// any of them that is dead downstream is dropped right after the op. A
+    /// non-`Var` borrowed base is a temporary: placed as a value and its
+    /// result dropped after the op ([`RcOp::DropValue`]).
+    fn place_array_op(
+        &mut self,
+        e: &Expr<'tcx>,
+        op: crate::intrinsic::ArrayFn,
+        args: &'tcx [Expr<'tcx>],
+        kernel: Option<&'tcx mir::Kernel<'tcx>>,
+        live_after: &VarSet,
+    ) {
+        use crate::intrinsic::ArrayFn;
+        let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold);
+
+        // Everything the op borrows rather than consumes: kernel-read vars,
+        // plus a `Var` base of a borrowing op.
+        let mut borrowed = VarSet::default();
+        if let Some(k) = kernel {
+            borrowed.union_with(&self.kernel_free(k));
+        }
+        let mut base_is_borrowed_var = false;
+        if borrows_base
+            && self.rr.is_rr(args[0].ty)
+            && let ExprKind::Var(x) = args[0].kind
+        {
+            borrowed.insert(x);
+            base_is_borrowed_var = true;
+        }
+
+        // Value operands, left-to-right with standard liveness threading, all
+        // under `live_after ∪ borrowed` so nothing borrowed is treated as dead.
+        let mut live = live_after.clone();
+        live.union_with(&borrowed);
+        let n = args.len();
+        for i in 0..n {
+            if i == 0 && base_is_borrowed_var {
+                continue; // a borrowed base takes no rc op at its use
+            }
+            let mut la = live.clone();
+            for later in &args[i + 1..] {
+                la.union_with(&self.free(later));
+            }
+            self.place(&args[i], &la);
+            if i == 0 && borrows_base && self.rr.is_rr(args[0].ty) {
+                // A temporary base is borrowed for the op, then released.
+                self.add_after(e.id, RcOp::DropValue(args[0].id));
+            }
+        }
+
+        // The kernel body: every free var is in `live`, so its placement adds
+        // no consuming ops (its RR uses are `get` bases, which borrow).
+        if let Some(k) = kernel {
+            self.place(k.body, &live);
+        }
+
+        // Borrowed vars whose last use is this op die here.
+        for v in borrowed.iter() {
+            if !live_after.contains(v) {
+                self.add_after(e.id, RcOp::Drop(v));
             }
         }
     }

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -415,6 +415,7 @@ fn kind_name(kind: &ExprKind<'_>) -> &'static str {
         ExprKind::NullableCall(_) => "NullableCall",
         ExprKind::Closure(_) => "Closure",
         ExprKind::ClosureCall { .. } => "ClosureCall",
+        ExprKind::ArrayOp { .. } => "ArrayOp",
         ExprKind::Match(..) => "Match",
         ExprKind::Poison => "Poison",
     }
@@ -806,6 +807,26 @@ fn interp<'tcx>(
                 interp(a, ot, rr, rc);
             }
         }
+        // An array op consumes its operands like call args, except a
+        // borrowing op's (`get`/`fold`) array base, which follows the `Proj`
+        // borrow rule. A kernel body only reads enclosing vars — interpreting
+        // it must leave ownership untouched.
+        ExprKind::ArrayOp { op, args, kernel } => {
+            use crate::intrinsic::ArrayFn;
+            let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold);
+            for (i, a) in args.iter().enumerate() {
+                if i == 0 && borrows_base {
+                    interp_borrow(a, ot, rr, rc);
+                } else {
+                    interp(a, ot, rr, rc);
+                }
+            }
+            if let Some(k) = kernel {
+                let before = rc.clone();
+                interp(k.body, ot, rr, rc);
+                assert_eq!(before, *rc, "kernel body must not change ownership");
+            }
+        }
         ExprKind::GlobalStr(_)
         | ExprKind::ConstChar(_)
         | ExprKind::ConstInt(_)
@@ -921,6 +942,7 @@ fn uses_var(e: &Expr<'_>, y: VarId) -> bool {
 fn children<'tcx>(e: &Expr<'tcx>) -> Vec<&'tcx Expr<'tcx>> {
     use ExprKind::*;
     match e.kind {
+        ArrayOp { args, kernel, .. } => args.iter().chain(kernel.map(|k| k.body)).collect(),
         GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
         | Poison => vec![],
         Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],

--- a/crates/reussir-core/src/full/subst.rs
+++ b/crates/reussir-core/src/full/subst.rs
@@ -35,6 +35,7 @@ pub fn subst_ty<'tcx>(tcx: &TyCtxt<'tcx>, ty: Ty<'tcx>, subst: &Subst<'tcx>) -> 
             tcx.mk_closure(&params, subst_ty(tcx, ret, subst))
         }
         TyKind::Nullable(inner) => tcx.mk_nullable(subst_ty(tcx, inner, subst)),
+        TyKind::Array { elem, dims } => tcx.mk_array(subst_ty(tcx, elem, subst), dims),
         TyKind::Int(_)
         | TyKind::Fp(_)
         | TyKind::Bool

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -151,6 +151,61 @@ impl FastMath {
     }
 }
 
+/// A built-in operation on a statically shaped array (`TyKind::Array`, issue
+/// #344). Unlike [`IntrinsicOp`], these are not spelled under `core::intrinsic`
+/// — `Splat`/`Tabulate` are `Array::<fn>` path calls and the rest are
+/// method-style calls on an array-typed receiver — and they carry their own
+/// HIR/MIR node (`ExprKind::ArrayOp`) because `Tabulate`/`Fold` hold an inline
+/// kernel body, which the generic `Intrinsic` node cannot.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ArrayFn {
+    /// `Array::splat(v)`: every element is `v`. Value operands: `[v]`.
+    Splat,
+    /// `Array::tabulate(|i, …| e)`: element at each index tuple is the kernel
+    /// applied to the (row-major) indices. No value operands.
+    Tabulate,
+    /// `a.get(i, …)`: checked element read. Value operands: `[a, i…]`; `a` is
+    /// borrowed, not consumed.
+    Get,
+    /// `a.set(i, …, v)`: checked element write, consuming `a` and returning
+    /// the updated array (copy-on-write when shared). Value operands:
+    /// `[a, i…, v]`.
+    Set,
+    /// `a.fold(init, |acc, x| e)`: row-major reduction. Value operands:
+    /// `[a, init]`; `a` is borrowed, not consumed.
+    Fold,
+}
+
+impl ArrayFn {
+    /// Parse a surface / textual-IR name.
+    pub fn parse(name: &str) -> Option<ArrayFn> {
+        match name {
+            "splat" => Some(ArrayFn::Splat),
+            "tabulate" => Some(ArrayFn::Tabulate),
+            "get" => Some(ArrayFn::Get),
+            "set" => Some(ArrayFn::Set),
+            "fold" => Some(ArrayFn::Fold),
+            _ => None,
+        }
+    }
+
+    /// The surface name, also used by the textual IR (`array#<name>`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ArrayFn::Splat => "splat",
+            ArrayFn::Tabulate => "tabulate",
+            ArrayFn::Get => "get",
+            ArrayFn::Set => "set",
+            ArrayFn::Fold => "fold",
+        }
+    }
+
+    /// Whether the op takes an inline kernel body.
+    pub fn has_kernel(self) -> bool {
+        matches!(self, ArrayFn::Tabulate | ArrayFn::Fold)
+    }
+}
+
 /// A resolved intrinsic operation: which family, which op within it, and the
 /// family's compile-time immediates. One generic `Intrinsic` IR node carries
 /// this through HIR/MIR, so the node itself — and its traversal, ownership, and

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -68,6 +68,10 @@ pub enum Token<'a> {
     Proj,
     #[token("intrinsic")]
     Intrinsic,
+    #[token("array")]
+    Array,
+    #[token("kernel")]
+    Kernel,
     #[token("assign")]
     Assign,
     #[token("scrut")]

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -475,6 +475,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         if let Some(done) = self.infer_intrinsic(fc, span) {
             return done;
         }
+        // The built-in `Array` head (reserved by the type namespace):
+        // `Array::splat<T, extents…>(v)` / `Array::tabulate<T, extents…>(|i…| e)`
+        // construct statically shaped arrays (issue #344).
+        if fc.name.segments.len() == 1 && self.sym(fc.name.segments[0]) == "Array" {
+            return self.infer_array_ctor(fc, span);
+        }
         let Some(def) = self.resolve_function_ref(&fc.name) else {
             let hint = if fc.name.segments.is_empty() {
                 self.function_suggestion(fc.name.basename)
@@ -538,6 +544,30 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         args: &[surface::Expr],
         span: Option<Span>,
     ) -> Expr<'tcx> {
+        // `base.get(…)` / `base.set(…)` / `base.fold(…)` on an array-typed base
+        // are built-in array operations, not closure-field applications. The
+        // base (with any leading field accesses) is inferred once; if it is not
+        // an array, the trailing access resumes the ordinary projection + apply
+        // path, so records with closure fields named `get` still work.
+        if let surface::ExprKind::AccessChain(base, accs) = callee.kind()
+            && let Some(surface::Access::Named(name)) = accs.last()
+        {
+            let method = self.sym(*name).to_string();
+            if matches!(method.as_str(), "get" | "set" | "fold") {
+                let lead = &accs[..accs.len() - 1];
+                let base = if lead.is_empty() {
+                    self.infer_expr(&base)
+                } else {
+                    let b = self.infer_expr(&base);
+                    self.project_access(b, lead, span)
+                };
+                if let TyKind::Array { .. } = self.infer.shallow_resolve(base.ty).kind() {
+                    return self.infer_array_method(base, &method, args, span);
+                }
+                let callee = self.project_access(base, &accs[accs.len() - 1..], span);
+                return self.closure_apply(callee, args, span);
+            }
+        }
         let callee = self.infer_expr(callee);
         self.closure_apply(callee, args, span)
     }
@@ -846,6 +876,18 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         span: Option<Span>,
     ) -> Expr<'tcx> {
         let base = self.infer_expr(base);
+        self.project_access(base, accs, span)
+    }
+
+    /// The projection half of (PROJ), over an already-inferred base — shared
+    /// with the array-method routing in `infer_closure_call`, which must infer
+    /// the base once before deciding how to interpret the trailing access.
+    fn project_access(
+        &mut self,
+        base: Expr<'tcx>,
+        accs: &[surface::Access],
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
         let mut cur = self.infer.shallow_resolve(base.ty);
         let mut indices = Vec::new();
         for acc in accs {
@@ -1027,6 +1069,374 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
         let op = IntrinsicOp::Math { func, flag };
         self.mk_expr(ExprKind::Intrinsic { op, args }, result, span)
+    }
+
+    /// (ARR-CTOR) `Array::splat<T, extents…>(v)` / `Array::tabulate<T,
+    /// extents…>(|i…| e)`. The explicit type arguments carry the array shape
+    /// (they are required — there is nothing to infer them from); `splat`
+    /// checks its one argument against the element type, `tabulate` checks a
+    /// literal kernel lambda of one `i64` parameter per dimension against it.
+    fn infer_array_ctor(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
+        use crate::intrinsic::ArrayFn;
+        let method = self.sym(fc.name.basename).to_string();
+        let op = match ArrayFn::parse(&method) {
+            Some(op @ (ArrayFn::Splat | ArrayFn::Tabulate)) => op,
+            _ => {
+                self.error(
+                    span,
+                    format!(
+                        "`Array` has no constructor `{method}` (expected `splat` or `tabulate`)"
+                    ),
+                );
+                return self.poison(span);
+            }
+        };
+        if fc.ty_args.is_empty() {
+            self.error(
+                span,
+                format!(
+                    "`Array::{method}` requires explicit type arguments — an element \
+                     type and extents, e.g. `Array::{method}<f64, 512>(…)`"
+                ),
+            );
+            return self.poison(span);
+        }
+        let mut targs = Vec::with_capacity(fc.ty_args.len());
+        for t in &fc.ty_args {
+            let Some(t) = t else {
+                self.error(
+                    span,
+                    format!("`Array::{method}` type arguments cannot be `_`: the array shape must be explicit"),
+                );
+                return self.poison(span);
+            };
+            targs.push(t.clone());
+        }
+        let tspan = targs[0].span();
+        let arr = self.eval_array_args(&targs, tspan);
+        let TyKind::Array { elem, dims } = *arr.kind() else {
+            // `eval_array_args` already reported why.
+            return self.poison(span);
+        };
+        if fc.args.len() != 1 {
+            self.error(
+                span,
+                format!("`Array::{method}` expects exactly one argument"),
+            );
+            return self.poison(span);
+        }
+        match op {
+            ArrayFn::Splat => {
+                let v = self.check_expr(&fc.args[0], elem);
+                self.mk_expr(
+                    ExprKind::ArrayOp {
+                        op,
+                        args: vec![v],
+                        kernel: None,
+                    },
+                    arr,
+                    span,
+                )
+            }
+            ArrayFn::Tabulate => {
+                let i64_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Signed(64));
+                let param_tys = vec![i64_ty; dims.len()];
+                let Some(kernel) = self.check_kernel(&fc.args[0], &param_tys, elem, &method) else {
+                    return self.poison(span);
+                };
+                self.mk_expr(
+                    ExprKind::ArrayOp {
+                        op,
+                        args: Vec::new(),
+                        kernel: Some(Box::new(kernel)),
+                    },
+                    arr,
+                    span,
+                )
+            }
+            _ => unreachable!("filtered above"),
+        }
+    }
+
+    /// (ARR-METHOD) `a.get(i…)` / `a.set(i…, v)` / `a.fold(init, |acc, x| e)`
+    /// on an array-typed base. Indices are `i64` (checked against the extents
+    /// at runtime); `get` borrows and yields the element, `set` consumes the
+    /// array and yields the updated one, `fold` borrows and reduces row-major.
+    fn infer_array_method(
+        &mut self,
+        base: Expr<'tcx>,
+        method: &str,
+        args: &[surface::Expr],
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
+        use crate::intrinsic::ArrayFn;
+        let bty = self.infer.shallow_resolve(base.ty);
+        let TyKind::Array { elem, dims } = *bty.kind() else {
+            unreachable!("routed here only for array bases");
+        };
+        let rank = dims.len();
+        let i64_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Signed(64));
+        match method {
+            "get" => {
+                if args.len() != rank {
+                    self.error(
+                        span,
+                        format!(
+                            "`get` on `{}` expects {rank} index argument(s), got {}",
+                            self.ty_display(bty),
+                            args.len()
+                        ),
+                    );
+                    return self.poison(span);
+                }
+                let mut hargs = vec![base];
+                for a in args {
+                    hargs.push(self.check_expr(a, i64_ty));
+                }
+                self.mk_expr(
+                    ExprKind::ArrayOp {
+                        op: ArrayFn::Get,
+                        args: hargs,
+                        kernel: None,
+                    },
+                    elem,
+                    span,
+                )
+            }
+            "set" => {
+                if args.len() != rank + 1 {
+                    self.error(
+                        span,
+                        format!(
+                            "`set` on `{}` expects {rank} index argument(s) and a value, got {} argument(s)",
+                            self.ty_display(bty),
+                            args.len()
+                        ),
+                    );
+                    return self.poison(span);
+                }
+                let mut hargs = vec![base];
+                for a in &args[..rank] {
+                    hargs.push(self.check_expr(a, i64_ty));
+                }
+                hargs.push(self.check_expr(&args[rank], elem));
+                self.mk_expr(
+                    ExprKind::ArrayOp {
+                        op: ArrayFn::Set,
+                        args: hargs,
+                        kernel: None,
+                    },
+                    bty,
+                    span,
+                )
+            }
+            "fold" => {
+                if args.len() != 2 {
+                    self.error(
+                        span,
+                        "`fold` expects an initial accumulator and a kernel lambda",
+                    );
+                    return self.poison(span);
+                }
+                let init = self.infer_expr(&args[0]);
+                let acc_ty = init.ty;
+                let Some(kernel) = self.check_kernel(&args[1], &[acc_ty, elem], acc_ty, "fold")
+                else {
+                    return self.poison(span);
+                };
+                self.mk_expr(
+                    ExprKind::ArrayOp {
+                        op: ArrayFn::Fold,
+                        args: vec![base, init],
+                        kernel: Some(Box::new(kernel)),
+                    },
+                    acc_ty,
+                    span,
+                )
+            }
+            _ => unreachable!("routed here only for get/set/fold"),
+        }
+    }
+
+    /// Check an [`ArrayOp`](ExprKind::ArrayOp) kernel: a *literal* lambda whose
+    /// parameters take the given types and whose body checks against `ret`.
+    /// The body is checked in the enclosing scope with only the params added —
+    /// free variables reference enclosing bindings directly (no captures) —
+    /// and the rc-free body restriction is enforced after zonking, once types
+    /// are resolved (see `enforce_kernel_expr`).
+    fn check_kernel(
+        &mut self,
+        arg: &surface::Expr,
+        param_tys: &[Ty<'tcx>],
+        ret: Ty<'tcx>,
+        what: &str,
+    ) -> Option<super::hir::Kernel<'tcx>> {
+        let span = Some(arg.span());
+        let surface::ExprKind::Lambda(lam) = arg.kind() else {
+            self.error(
+                span,
+                format!("`{what}` requires a literal lambda kernel (e.g. `|i| …`)"),
+            );
+            return None;
+        };
+        if lam.args.len() != param_tys.len() {
+            self.error(
+                span,
+                format!(
+                    "`{what}` kernel takes {} parameter(s), got {}",
+                    param_tys.len(),
+                    lam.args.len()
+                ),
+            );
+            return None;
+        }
+        let mark = self.vars.mark();
+        let mut params = Vec::new();
+        for ((name, ann), &pty) in lam.args.iter().zip(param_tys) {
+            if let Some(t) = ann {
+                let t = self.eval_type(t);
+                self.expect(t, pty, span);
+            }
+            let var = self.vars.fresh(*name, pty, None);
+            params.push((var, pty));
+        }
+        if let Some(rt) = &lam.ret_ty {
+            let rt = self.eval_type(rt);
+            self.expect(rt, ret, span);
+        }
+        let body = self.check_expr(&lam.body, ret);
+        self.vars.restore(mark);
+        Some(super::hir::Kernel {
+            params,
+            body: Box::new(body),
+        })
+    }
+
+    /// Whether a type may appear in an array-kernel body: a plain scalar (or a
+    /// deferred generic, matching the element-type rule), plus `Unit` for
+    /// statement positions. Managed values would need per-iteration rc ops in
+    /// the inlined loop body, defeating the point of the kernel form.
+    fn kernel_ty_allowed(&mut self, ty: Ty<'tcx>) -> bool {
+        let ty = self.infer.resolve(ty);
+        matches!(ty.kind(), TyKind::Unit) || crate::semi::ty_eval::is_plain_scalar_or_deferred(ty)
+    }
+
+    /// Enforce the kernel-body restriction on a zonked kernel body: every
+    /// subexpression computes a plain scalar; the only managed values are
+    /// enclosing arrays read through nested `get`s on plain variables. This is
+    /// what lets ownership treat kernel free vars as read-only borrows and
+    /// codegen inline the body into a loop with no rc traffic.
+    fn enforce_kernel_expr(&mut self, e: &Expr<'tcx>) {
+        use crate::intrinsic::ArrayFn;
+        match &e.kind {
+            ExprKind::ArrayOp {
+                op: ArrayFn::Get,
+                args,
+                ..
+            } => {
+                if !matches!(args[0].kind, ExprKind::Var(_)) {
+                    self.error(
+                        args[0].span,
+                        "an array read inside a kernel must be on an array variable",
+                    );
+                }
+                for a in &args[1..] {
+                    self.enforce_kernel_expr(a);
+                }
+                return;
+            }
+            ExprKind::ArrayOp { op, .. } => {
+                self.error(
+                    e.span,
+                    format!(
+                        "`{}` is not allowed inside an array kernel (only `get` reads are)",
+                        op.as_str()
+                    ),
+                );
+                return;
+            }
+            _ => {}
+        }
+        if !self.kernel_ty_allowed(e.ty) {
+            let shown = self.infer.resolve(e.ty);
+            self.error(
+                e.span,
+                format!(
+                    "array kernel bodies are restricted to plain scalar computation; \
+                     a value of type `{}` is not allowed here",
+                    self.ty_display(shown)
+                ),
+            );
+            return; // don't cascade into children of an already-rejected node
+        }
+        match &e.kind {
+            ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => {
+                self.enforce_kernel_expr(x)
+            }
+            ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
+                self.enforce_kernel_expr(l);
+                self.enforce_kernel_expr(r);
+            }
+            ExprKind::If(c, t, f) => {
+                self.enforce_kernel_expr(c);
+                self.enforce_kernel_expr(t);
+                self.enforce_kernel_expr(f);
+            }
+            ExprKind::Let { value, .. } => self.enforce_kernel_expr(value),
+            ExprKind::Seq(es) => es.iter().for_each(|e| self.enforce_kernel_expr(e)),
+            ExprKind::FuncCall { args, .. } | ExprKind::Intrinsic { args, .. } => {
+                args.iter().for_each(|e| self.enforce_kernel_expr(e))
+            }
+            ExprKind::Proj(base, _) => self.enforce_kernel_expr(base),
+            ExprKind::Match(scrut, tree) => {
+                self.enforce_kernel_expr(scrut);
+                self.enforce_kernel_tree(tree);
+            }
+            // Leaves, or forms whose own (already-allowed) type makes their
+            // children irrelevant here.
+            _ => {}
+        }
+    }
+
+    fn enforce_kernel_tree(&mut self, tree: &super::hir::DecisionTree<'tcx>) {
+        use super::hir::{DecisionTree, SwitchCases};
+        match tree {
+            DecisionTree::Uncovered | DecisionTree::Unreachable => {}
+            DecisionTree::Leaf { body, .. } => self.enforce_kernel_expr(body),
+            DecisionTree::Guard {
+                guard,
+                success,
+                failure,
+                ..
+            } => {
+                self.enforce_kernel_expr(guard);
+                self.enforce_kernel_tree(success);
+                self.enforce_kernel_tree(failure);
+            }
+            DecisionTree::Switch { cases, .. } => match cases {
+                SwitchCases::Int { cases, default } => {
+                    cases.iter().for_each(|(_, t)| self.enforce_kernel_tree(t));
+                    self.enforce_kernel_tree(default);
+                }
+                SwitchCases::Bool { if_true, if_false } => {
+                    self.enforce_kernel_tree(if_true);
+                    self.enforce_kernel_tree(if_false);
+                }
+                SwitchCases::Char { cases, default } => {
+                    cases.iter().for_each(|(_, t)| self.enforce_kernel_tree(t));
+                    self.enforce_kernel_tree(default);
+                }
+                SwitchCases::Ctor(subs) => subs.iter().for_each(|t| self.enforce_kernel_tree(t)),
+                SwitchCases::String { cases, default } => {
+                    cases.iter().for_each(|(_, t)| self.enforce_kernel_tree(t));
+                    self.enforce_kernel_tree(default);
+                }
+                SwitchCases::Nullable { non_null, null } => {
+                    self.enforce_kernel_tree(non_null);
+                    self.enforce_kernel_tree(null);
+                }
+            },
+        }
     }
 
     /// Dispatch a constructor path: `Nullable::…` → [`Self::infer_nullable`]; a
@@ -1579,6 +1989,23 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 body: zb(self, c.body),
             }),
             Match(scrut, tree) => Match(zb(self, scrut), self.zonk_tree(tree)),
+            ArrayOp { op, args, kernel } => {
+                let args = args.into_iter().map(|e| self.zonk_expr(e)).collect();
+                let kernel = kernel.map(|k| {
+                    let k = super::hir::Kernel {
+                        params: k
+                            .params
+                            .into_iter()
+                            .map(|(v, t)| (v, self.zonk_ty(t, span)))
+                            .collect(),
+                        body: zb(self, k.body),
+                    };
+                    // Types are resolved now — enforce the rc-free body rule.
+                    self.enforce_kernel_expr(&k.body);
+                    Box::new(k)
+                });
+                ArrayOp { op, args, kernel }
+            }
             other => other,
         }
     }
@@ -1653,6 +2080,19 @@ fn free_vars<'tcx>(e: &Expr<'tcx>, out: &mut Vec<VarId>) {
             args.iter().for_each(|e| free_vars(e, out));
         }
         Closure(c) => free_vars(&c.body, out),
+        ArrayOp { args, kernel, .. } => {
+            args.iter().for_each(|e| free_vars(e, out));
+            if let Some(k) = kernel {
+                // Kernel params are binders, not free uses.
+                let mut body = Vec::new();
+                free_vars(&k.body, &mut body);
+                for v in body {
+                    if !k.params.iter().any(|&(p, _)| p == v) {
+                        push(out, v);
+                    }
+                }
+            }
+        }
         Match(scrut, _) => free_vars(scrut, out),
         GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Poison => {}
     }

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -475,12 +475,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         if let Some(done) = self.infer_intrinsic(fc, span) {
             return done;
         }
-        // The built-in `Array` head (reserved by the type namespace):
-        // `Array::splat<T, extents…>(v)` / `Array::tabulate<T, extents…>(|i…| e)`
-        // construct statically shaped arrays (issue #344).
-        if fc.name.segments.len() == 1 && self.sym(fc.name.segments[0]) == "Array" {
-            return self.infer_array_ctor(fc, span);
-        }
         let Some(def) = self.resolve_function_ref(&fc.name) else {
             let hint = if fc.name.segments.is_empty() {
                 self.function_suggestion(fc.name.basename)
@@ -544,30 +538,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         args: &[surface::Expr],
         span: Option<Span>,
     ) -> Expr<'tcx> {
-        // `base.get(…)` / `base.set(…)` / `base.fold(…)` on an array-typed base
-        // are built-in array operations, not closure-field applications. The
-        // base (with any leading field accesses) is inferred once; if it is not
-        // an array, the trailing access resumes the ordinary projection + apply
-        // path, so records with closure fields named `get` still work.
-        if let surface::ExprKind::AccessChain(base, accs) = callee.kind()
-            && let Some(surface::Access::Named(name)) = accs.last()
-        {
-            let method = self.sym(*name).to_string();
-            if matches!(method.as_str(), "get" | "set" | "fold") {
-                let lead = &accs[..accs.len() - 1];
-                let base = if lead.is_empty() {
-                    self.infer_expr(&base)
-                } else {
-                    let b = self.infer_expr(&base);
-                    self.project_access(b, lead, span)
-                };
-                if let TyKind::Array { .. } = self.infer.shallow_resolve(base.ty).kind() {
-                    return self.infer_array_method(base, &method, args, span);
-                }
-                let callee = self.project_access(base, &accs[accs.len() - 1..], span);
-                return self.closure_apply(callee, args, span);
-            }
-        }
         let callee = self.infer_expr(callee);
         self.closure_apply(callee, args, span)
     }
@@ -876,18 +846,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         span: Option<Span>,
     ) -> Expr<'tcx> {
         let base = self.infer_expr(base);
-        self.project_access(base, accs, span)
-    }
-
-    /// The projection half of (PROJ), over an already-inferred base — shared
-    /// with the array-method routing in `infer_closure_call`, which must infer
-    /// the base once before deciding how to interpret the trailing access.
-    fn project_access(
-        &mut self,
-        base: Expr<'tcx>,
-        accs: &[surface::Access],
-        span: Option<Span>,
-    ) -> Expr<'tcx> {
         let mut cur = self.infer.shallow_resolve(base.ty);
         let mut indices = Vec::new();
         for acc in accs {
@@ -977,6 +935,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
         match *family {
             "math" => Some(self.infer_math_intrinsic(fc, span)),
+            "array" => Some(self.infer_array_intrinsic(fc, span)),
             other => {
                 self.error(
                     span,
@@ -1071,32 +1030,82 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.mk_expr(ExprKind::Intrinsic { op, args }, result, span)
     }
 
-    /// (ARR-CTOR) `Array::splat<T, extents…>(v)` / `Array::tabulate<T,
-    /// extents…>(|i…| e)`. The explicit type arguments carry the array shape
-    /// (they are required — there is nothing to infer them from); `splat`
-    /// checks its one argument against the element type, `tabulate` checks a
-    /// literal kernel lambda of one `i64` parameter per dimension against it.
+    /// (ARR) The `core::intrinsic::array` family (issue #344) — special
+    /// *vararg* functions over statically shaped arrays:
+    ///
+    /// * `splat<T, extents…>(v)` / `tabulate<T, extents…>(|i…| e)` construct
+    ///   an array; the explicit type arguments carry the shape (there is
+    ///   nothing to infer them from);
+    /// * `get(a, i…)` / `set(a, i…, v)` / `fold(a, init, |acc, x| e)` take the
+    ///   array as their first argument and one `i64` index per dimension.
+    fn infer_array_intrinsic(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
+        use crate::intrinsic::ArrayFn;
+        let name = self.sym(fc.name.basename).to_string();
+        match ArrayFn::parse(&name) {
+            Some(ArrayFn::Splat | ArrayFn::Tabulate) => self.infer_array_ctor(fc, span),
+            Some(_) => {
+                if !fc.ty_args.is_empty() {
+                    self.error(
+                        span,
+                        format!(
+                            "`core::intrinsic::array::{name}` takes no type arguments \
+                             (the shape comes from its array argument)"
+                        ),
+                    );
+                    return self.poison(span);
+                }
+                if fc.args.is_empty() {
+                    self.error(
+                        span,
+                        format!(
+                            "`core::intrinsic::array::{name}` expects an array as its \
+                             first argument"
+                        ),
+                    );
+                    return self.poison(span);
+                }
+                let base = self.infer_expr(&fc.args[0]);
+                if !matches!(
+                    self.infer.shallow_resolve(base.ty).kind(),
+                    TyKind::Array { .. }
+                ) {
+                    let shown = self.infer.resolve(base.ty);
+                    self.error(
+                        span,
+                        format!(
+                            "`core::intrinsic::array::{name}` expects an array as its \
+                             first argument, found `{}`",
+                            self.ty_display(shown)
+                        ),
+                    );
+                    return self.poison(span);
+                }
+                self.infer_array_op(base, &name, &fc.args[1..], span)
+            }
+            None => {
+                self.error(
+                    span,
+                    format!("unknown array intrinsic `core::intrinsic::array::{name}`"),
+                );
+                self.poison(span)
+            }
+        }
+    }
+
+    /// The constructing array intrinsics: `splat` checks its one argument
+    /// against the element type, `tabulate` checks a literal kernel lambda of
+    /// one `i64` parameter per dimension against it.
     fn infer_array_ctor(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
         use crate::intrinsic::ArrayFn;
         let method = self.sym(fc.name.basename).to_string();
-        let op = match ArrayFn::parse(&method) {
-            Some(op @ (ArrayFn::Splat | ArrayFn::Tabulate)) => op,
-            _ => {
-                self.error(
-                    span,
-                    format!(
-                        "`Array` has no constructor `{method}` (expected `splat` or `tabulate`)"
-                    ),
-                );
-                return self.poison(span);
-            }
-        };
+        let op = ArrayFn::parse(&method).expect("routed here for splat/tabulate only");
         if fc.ty_args.is_empty() {
             self.error(
                 span,
                 format!(
-                    "`Array::{method}` requires explicit type arguments — an element \
-                     type and extents, e.g. `Array::{method}<f64, 512>(…)`"
+                    "`core::intrinsic::array::{method}` requires explicit type arguments — \
+                     an element type and extents, e.g. \
+                     `core::intrinsic::array::{method}<f64, 512>(…)`"
                 ),
             );
             return self.poison(span);
@@ -1106,7 +1115,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             let Some(t) = t else {
                 self.error(
                     span,
-                    format!("`Array::{method}` type arguments cannot be `_`: the array shape must be explicit"),
+                    format!(
+                        "`core::intrinsic::array::{method}` type arguments cannot be `_`: \
+                         the array shape must be explicit"
+                    ),
                 );
                 return self.poison(span);
             };
@@ -1121,7 +1133,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         if fc.args.len() != 1 {
             self.error(
                 span,
-                format!("`Array::{method}` expects exactly one argument"),
+                format!("`core::intrinsic::array::{method}` expects exactly one argument"),
             );
             return self.poison(span);
         }
@@ -1158,11 +1170,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
     }
 
-    /// (ARR-METHOD) `a.get(i…)` / `a.set(i…, v)` / `a.fold(init, |acc, x| e)`
-    /// on an array-typed base. Indices are `i64` (checked against the extents
-    /// at runtime); `get` borrows and yields the element, `set` consumes the
-    /// array and yields the updated one, `fold` borrows and reduces row-major.
-    fn infer_array_method(
+    /// The accessing array intrinsics over an already-inferred array `base`:
+    /// `get(a, i…)`, `set(a, i…, v)`, `fold(a, init, |acc, x| e)`. Indices are
+    /// `i64` (checked against the extents at runtime); `get` borrows and
+    /// yields the element, `set` consumes the array and yields the updated
+    /// one, `fold` borrows and reduces row-major.
+    fn infer_array_op(
         &mut self,
         base: Expr<'tcx>,
         method: &str,

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -430,6 +430,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.push_ty_display(out, inner);
                 out.push('>');
             }
+            TyKind::Array { elem, dims } => {
+                out.push_str("Array<");
+                self.push_ty_display(out, elem);
+                for extent in dims {
+                    let _ = write!(out, ", {extent}");
+                }
+                out.push('>');
+            }
             TyKind::Record { def, args, flex } => {
                 match flex {
                     Flexivity::Flex => out.push_str("[flex] "),
@@ -928,6 +936,18 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .collect()
     }
 
+    /// Phase A of the array design (issue #344) supports arrays as locals,
+    /// parameters, and returns only — a record member of array type has no
+    /// dialect-level member representation yet.
+    fn reject_array_member(&mut self, fty: Ty<'tcx>, span: Option<Span>) {
+        if matches!(fty.kind(), crate::semi::ty::TyKind::Array { .. }) {
+            self.error(
+                span,
+                "an array cannot be a record member in this version (see issue #344)",
+            );
+        }
+    }
+
     fn populate_record(&mut self, rec: &surface::Record, def: DefId) {
         let Some(record) = self.records.get(&def) else {
             return;
@@ -950,6 +970,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (name, ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
+                        self.reject_array_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -962,6 +983,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
+                        self.reject_array_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -975,7 +997,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         let (name, tys) = &v.value;
                         Variant {
                             name: *name,
-                            fields: tys.iter().map(|t| self.eval_type(t)).collect(),
+                            fields: tys
+                                .iter()
+                                .map(|t| {
+                                    let fty = self.eval_type(t);
+                                    self.reject_array_member(fty, span);
+                                    fty
+                                })
+                                .collect(),
                         }
                     })
                     .collect(),

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -270,6 +270,7 @@ pub(super) fn ty_has_hole(ty: crate::semi::ty::Ty<'_>) -> bool {
             params.iter().any(|p| ty_has_hole(*p)) || ty_has_hole(*ret)
         }
         TyKind::Nullable(inner) => ty_has_hole(*inner),
+        TyKind::Array { elem, .. } => ty_has_hole(*elem),
         _ => false,
     }
 }
@@ -287,6 +288,7 @@ pub(super) fn collect_holes(ty: crate::semi::ty::Ty<'_>, out: &mut Vec<HoleId>) 
             collect_holes(*ret, out);
         }
         TyKind::Nullable(inner) => collect_holes(*inner, out),
+        TyKind::Array { elem, .. } => collect_holes(*elem, out),
         _ => {}
     }
 }

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -151,8 +151,33 @@ pub enum ExprKind<'tcx> {
         target: Box<Expr<'tcx>>,
         args: Vec<Expr<'tcx>>,
     },
+    /// A built-in operation on a statically shaped array (issue #344): the
+    /// resolved op, its value operands (see [`crate::intrinsic::ArrayFn`] for
+    /// each op's operand list), and — for `Tabulate`/`Fold` — an inline kernel.
+    ///
+    /// The kernel is *not* a closure: its body is checked in the enclosing
+    /// scope with only the kernel params added, so free variables reference
+    /// enclosing bindings directly (read-only for the op's duration) and no
+    /// capture list exists. Codegen inlines the body into the loop nest.
+    ArrayOp {
+        op: crate::intrinsic::ArrayFn,
+        args: Vec<Expr<'tcx>>,
+        kernel: Option<Box<Kernel<'tcx>>>,
+    },
     /// Error-recovery placeholder.
     Poison,
+}
+
+/// The inline kernel of an [`ArrayOp`](ExprKind::ArrayOp): parameters bound
+/// per element/iteration (`Tabulate`: one `i64` per dimension; `Fold`:
+/// `(acc, elem)`) and the body producing the element / next accumulator.
+/// The type checker restricts the body to be rc-free — every subexpression is
+/// of plain (unmanaged) type except array reads (`get`) of enclosing arrays —
+/// so inlining it into a loop introduces no per-iteration ownership work.
+#[derive(Clone, Debug)]
+pub struct Kernel<'tcx> {
+    pub params: Vec<(VarId, Ty<'tcx>)>,
+    pub body: Box<Expr<'tcx>>,
 }
 
 // ===== decision trees (compiled pattern matches) =====

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -300,6 +300,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let ret = self.ty(ret);
                 self.tcx.mk_closure(&params, ret)
             }
+            raw::Ty::Array { elem, dims } => {
+                let elem = self.ty(elem);
+                self.tcx.mk_array(elem, dims)
+            }
         }
     }
 
@@ -406,6 +410,30 @@ impl<'tcx> Builder<'_, 'tcx> {
                     .expect("known intrinsic in machine-emitted IR"),
                 args: self.exprs(args),
             },
+            raw::Kind::ArrayOp {
+                op,
+                args,
+                kernel_params,
+                kernel,
+            } => {
+                let args = self.exprs(args);
+                let kernel = kernel.as_ref().map(|body| {
+                    let params = kernel_params
+                        .iter()
+                        .map(|(v, t)| (VarId(*v), self.ty(t)))
+                        .collect();
+                    Box::new(crate::semi::hir::Kernel {
+                        params,
+                        body: self.boxed(body),
+                    })
+                });
+                ExprKind::ArrayOp {
+                    op: crate::intrinsic::ArrayFn::parse(op)
+                        .expect("known array op in machine-emitted IR"),
+                    args,
+                    kernel,
+                }
+            }
             raw::Kind::NullableCall(inner) => {
                 ExprKind::NullableCall(inner.as_ref().map(|x| self.boxed(x)))
             }
@@ -709,6 +737,18 @@ mod tests {
         roundtrip_with_locations(
             "enum Opt { None, Some(i64) }\n\
              pub fn g(o: Opt) -> i64 { match o { Opt::None => 0, Opt::Some(x) => { let y = x; y } } }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_arrays() {
+        // The `array<f64, 8>` type and all five `array#…` ops, including
+        // kernels with their params.
+        roundtrip(
+            "pub fn make() -> Array<f64, 8> { Array::tabulate<f64, 8>(|i| i as f64) } \
+             pub fn ones() -> Array<f64, 8> { Array::splat<f64, 8>(1.0) } \
+             pub fn s(a: Array<f64, 8>) -> f64 { a.fold(0.0, |acc, x| acc + x) } \
+             pub fn b(a: Array<f64, 8>, i: i64, v: f64) -> Array<f64, 8> { a.set(i, a.get(i) + v) }",
         );
     }
 

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -745,10 +745,11 @@ mod tests {
         // The `array<f64, 8>` type and all five `array#…` ops, including
         // kernels with their params.
         roundtrip(
-            "pub fn make() -> Array<f64, 8> { Array::tabulate<f64, 8>(|i| i as f64) } \
-             pub fn ones() -> Array<f64, 8> { Array::splat<f64, 8>(1.0) } \
-             pub fn s(a: Array<f64, 8>) -> f64 { a.fold(0.0, |acc, x| acc + x) } \
-             pub fn b(a: Array<f64, 8>, i: i64, v: f64) -> Array<f64, 8> { a.set(i, a.get(i) + v) }",
+            "pub fn make() -> Array<f64, 8> { core::intrinsic::array::tabulate<f64, 8>(|i| i as f64) } \
+             pub fn ones() -> Array<f64, 8> { core::intrinsic::array::splat<f64, 8>(1.0) } \
+             pub fn s(a: Array<f64, 8>) -> f64 { core::intrinsic::array::fold(a, 0.0, |acc, x| acc + x) } \
+             pub fn b(a: Array<f64, 8>, i: i64, v: f64) -> Array<f64, 8> { \
+             core::intrinsic::array::set(a, i, core::intrinsic::array::get(a, i) + v) }",
         );
     }
 

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -161,6 +161,8 @@ Ty: raw::Ty = {
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
     <cap:Cap> "#" <path:PathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
+    "array" "<" <elem:Ty> <dims:("," <"int">)+> ">"
+        => raw::Ty::Array { elem: Box::new(elem), dims: dims.iter().map(raw::small_u64).collect() },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };
@@ -228,6 +230,10 @@ Atom: raw::Kind = {
         => raw::Kind::VariantCall { path: path.0, ty_args: path.1, variant: raw::small_usize(&v), args },
     "intrinsic" "#" <family:"ident"> "#" <name:"ident"> "#" <imm:"int"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::Intrinsic { family: family.to_string(), name: name.to_string(), imm: raw::small_u32(&imm), args },
+    "array" "#" <op:"ident"> "(" <args:Comma<Expr>> ")"
+        => raw::Kind::ArrayOp { op: op.to_string(), args, kernel_params: vec![], kernel: None },
+    "array" "#" <op:"ident"> "(" <args:Comma<Expr>> ")" "kernel" "(" <params:Comma<ClosureParam>> ")" "{" <body:Expr> "}"
+        => raw::Kind::ArrayOp { op: op.to_string(), args, kernel_params: params, kernel: Some(body) },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"
@@ -353,6 +359,8 @@ extern {
         "rigid" => Token::Rigid,
         "proj" => Token::Proj,
         "intrinsic" => Token::Intrinsic,
+        "array" => Token::Array,
+        "kernel" => Token::Kernel,
         "assign" => Token::Assign,
         "Nullable" => Token::Nullable,
         "NonNull" => Token::NonNull,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -280,6 +280,13 @@ impl<'a> Printer<'a> {
             TyKind::Generic(g) => text(format!("${}", g.0)),
             TyKind::Hole(_) => unreachable!("a fully elaborated HIR carries no inference holes"),
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
+            TyKind::Array { elem, dims } => {
+                let mut d = text("array<") + self.ty(elem);
+                for extent in dims {
+                    d = d + text(format!(", {extent}"));
+                }
+                d + text(">")
+            }
             TyKind::Record { def, args, flex } => {
                 let mut d = match flex {
                     Flexivity::Flex | Flexivity::Rigid | Flexivity::Regional => {
@@ -496,6 +503,24 @@ impl<'a> Printer<'a> {
                     + text(") { ")
                     + self.value(&c.body)
                     + text(" }")
+            }
+            ExprKind::ArrayOp { op, args, kernel } => {
+                let mut d =
+                    text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")");
+                if let Some(k) = kernel {
+                    let params: Vec<Doc<'static>> = k
+                        .params
+                        .iter()
+                        .map(|(v, t)| var(*v) + text(": ") + self.ty(*t))
+                        .collect();
+                    d = d
+                        + text(" kernel(")
+                        + comma_sep(params)
+                        + text(") { ")
+                        + self.value(&k.body)
+                        + text(" }");
+                }
+                d
             }
             ExprKind::Let { .. } | ExprKind::Seq(_) | ExprKind::If(..) | ExprKind::Match(..) => {
                 unreachable!("structural forms are rendered by `value`")

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -169,6 +169,11 @@ pub enum Ty {
         params: Vec<Ty>,
         ret: Box<Ty>,
     },
+    /// `array<elem, extents…>` — a statically shaped array.
+    Array {
+        elem: Box<Ty>,
+        dims: Vec<u64>,
+    },
 }
 
 /// The four raw words of an interned `StringToken`.
@@ -262,6 +267,13 @@ pub enum Kind {
         captures: Vec<(u32, Ty)>,
         params: Vec<(u32, Ty)>,
         body: Expr,
+    },
+    /// `array#<op>(args…) [kernel(params…) { body }]` — a built-in array op.
+    ArrayOp {
+        op: String,
+        args: Vec<Expr>,
+        kernel_params: Vec<(u32, Ty)>,
+        kernel: Option<Expr>,
     },
     Match(Expr, Box<Tree>),
 }

--- a/crates/reussir-core/src/semi/infer.rs
+++ b/crates/reussir-core/src/semi/infer.rs
@@ -209,6 +209,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let inner = self.resolve(*inner);
                 self.tcx.mk_nullable(inner)
             }
+            TyKind::Array { elem, dims } => {
+                let elem = self.resolve(*elem);
+                self.tcx.mk_array(elem, dims)
+            }
             _ => ty,
         }
     }
@@ -295,6 +299,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.unify(*r1, *r2)
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify(*x, *y),
+            (TyKind::Array { elem: e1, dims: d1 }, TyKind::Array { elem: e2, dims: d2 })
+                if d1 == d2 =>
+            {
+                self.unify(*e1, *e2)
+            }
 
             (TyKind::Int(x), TyKind::Int(y)) if x == y => Ok(()),
             (TyKind::Fp(x), TyKind::Fp(y)) if x == y => Ok(()),
@@ -343,6 +352,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.occurs(h, *ret)
             }
             TyKind::Nullable(inner) => self.occurs(h, *inner),
+            TyKind::Array { elem, .. } => self.occurs(h, *elem),
             _ => false,
         }
     }
@@ -493,6 +503,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.unify_instantiated(*r1, inst, *r2)
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify_instantiated(*x, inst, *y),
+            (TyKind::Array { elem: e1, dims: d1 }, TyKind::Array { elem: e2, dims: d2 })
+                if d1 == d2 =>
+            {
+                self.unify_instantiated(*e1, inst, *e2)
+            }
 
             (TyKind::Int(x), TyKind::Int(y)) if x == y => Ok(()),
             (TyKind::Fp(x), TyKind::Fp(y)) if x == y => Ok(()),
@@ -545,6 +560,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             TyKind::Nullable(inner) => {
                 let inner = self.materialize(*inner, inst);
                 self.tcx.mk_nullable(inner)
+            }
+            TyKind::Array { elem, dims } => {
+                let elem = self.materialize(*elem, inst);
+                self.tcx.mk_array(elem, dims)
             }
             _ => template,
         }

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -139,6 +139,13 @@ pub enum TyKind<'tcx> {
         params: &'tcx [Ty<'tcx>],
         ret: Ty<'tcx>,
     },
+    /// A statically shaped multidimensional array of `Plain` elements,
+    /// reference counted as a whole; the extents are part of the type
+    /// (`Array<f64, 512, 512>`). See issue #344.
+    Array {
+        elem: Ty<'tcx>,
+        dims: &'tcx [u64],
+    },
     Nullable(Ty<'tcx>),
     /// A rigid type parameter in scope.
     Generic(GenericId),
@@ -253,6 +260,11 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn mk_hole(&self, hole: HoleId) -> Ty<'tcx> {
         self.mk(TyKind::Hole(hole))
+    }
+
+    pub fn mk_array(&self, elem: Ty<'tcx>, dims: &[u64]) -> Ty<'tcx> {
+        let dims = self.alloc_slice(dims);
+        self.mk(TyKind::Array { elem, dims })
     }
 
     pub fn mk_nullable(&self, inner: Ty<'tcx>) -> Ty<'tcx> {

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -69,6 +69,13 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.tcx.mk_closure(&args, ret)
             }
             TypeKind::TypeExpr(path, args) => self.eval_type_expr(path, args, ty.span()),
+            TypeKind::TypeConst(_) => {
+                self.error(
+                    Some(ty.span()),
+                    "an integer extent is only valid as an `Array` type argument",
+                );
+                self.tcx.mk(TyKind::Bottom)
+            }
         }
     }
 
@@ -123,8 +130,79 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             };
         }
 
+        // The built-in statically shaped array type: an element type followed
+        // by one or more integer extents (`Array<f64, 512, 512>`); see #344.
+        if path.segments.is_empty() && self.sym(key) == "Array" {
+            return self.eval_array_args(args, span);
+        }
+
         // A user record, resolved to its def — bare in the current module, or
         // module-qualified (`utils::math::Cell`, `root::…`, `super::…`).
+        return self.eval_record_type_expr(path, args, span, key);
+    }
+
+    /// Evaluate the type arguments of the built-in `Array` head — an element
+    /// type followed by one or more integer extents — into a
+    /// [`TyKind::Array`]. Shared between the type grammar (`Array<f64, 512>`)
+    /// and the `Array::splat`/`Array::tabulate` constructor calls, whose
+    /// explicit type arguments have the same form.
+    pub(crate) fn eval_array_args(
+        &mut self,
+        args: &[surface::Type],
+        span: surface::Span,
+    ) -> Ty<'tcx> {
+        if args.len() < 2 {
+            self.error(
+                Some(span),
+                "`Array` takes an element type and at least one integer extent",
+            );
+            return self.tcx.mk(TyKind::Bottom);
+        }
+        let elem = self.eval_type(&args[0]);
+        // Phase A restricts elements to plain scalars: views over the
+        // payload must be free of reference-count traffic.
+        if !is_plain_scalar_or_deferred(elem) {
+            self.error(
+                Some(span),
+                format!(
+                    "array elements must be plain scalars (integers, floats, bool, char); `{}` is not",
+                    self.ty_display(elem)
+                ),
+            );
+        }
+        let mut dims = Vec::with_capacity(args.len() - 1);
+        let mut product: u128 = 1;
+        for arg in &args[1..] {
+            match arg.kind() {
+                TypeKind::TypeConst(extent) => {
+                    if extent == 0 {
+                        self.error(Some(span), "array extents must be positive");
+                    }
+                    product = product.saturating_mul(u128::from(extent.max(1)));
+                    dims.push(extent.max(1));
+                }
+                _ => {
+                    self.error(
+                        Some(span),
+                        "array extents must be integer literals in this version",
+                    );
+                    dims.push(1);
+                }
+            }
+        }
+        if product > (1u128 << 32) {
+            self.error(Some(span), "array is too large (more than 2^32 elements)");
+        }
+        self.tcx.mk_array(elem, &dims)
+    }
+
+    fn eval_record_type_expr(
+        &mut self,
+        path: &surface::Path,
+        args: &[surface::Type],
+        span: surface::Span,
+        key: reussir_syntax::kind::TokenKey,
+    ) -> Ty<'tcx> {
         let Some(def) = self.resolve_record_ref(path) else {
             let hint = if path.segments.is_empty() {
                 self.record_suggestion(key)
@@ -214,6 +292,21 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 /// rejected; `Record`/`Closure` are valid inners, and `Generic`/`Hole`/`Bottom`
 /// are deferred (resolved/checked later) so this never reports a false positive
 /// on a not-yet-ground type.
+/// Whether `t` qualifies as a Phase-A array element: a plain scalar, or a
+/// generic/hole deferred to the monomorphization-time groundness check.
+pub(crate) fn is_plain_scalar_or_deferred(t: Ty<'_>) -> bool {
+    matches!(
+        t.kind(),
+        TyKind::Int(_)
+            | TyKind::Fp(_)
+            | TyKind::Bool
+            | TyKind::Char
+            | TyKind::Generic(_)
+            | TyKind::Hole(_)
+            | TyKind::Bottom
+    )
+}
+
 fn is_concretely_non_pointer(t: Ty<'_>) -> bool {
     matches!(
         t.kind(),

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -217,7 +217,10 @@ fn is_expr_kind(kind: SyntaxKind) -> bool {
 }
 
 fn is_type_kind(kind: SyntaxKind) -> bool {
-    matches!(kind, PrimType | PathType | ArrowType | ParenTypeList)
+    matches!(
+        kind,
+        PrimType | PathType | ArrowType | ParenTypeList | SyntaxKind::ConstType
+    )
 }
 
 fn expr_children(node: &ResolvedNode) -> impl Iterator<Item = &ResolvedNode> {
@@ -323,6 +326,12 @@ fn int_value(text: &str) -> i64 {
     i64::try_from(&literal::parse_int(text)).unwrap_or(i64::MAX)
 }
 
+/// An array extent in type-argument position; clamped rather than failed —
+/// the elaborator range-checks and reports.
+fn parse_extent(text: &str) -> u64 {
+    u64::try_from(&literal::parse_int(text)).unwrap_or(u64::MAX)
+}
+
 fn binary_op(kind: SyntaxKind) -> Option<BinOp> {
     Some(match kind {
         Plus => BinOp::Add,
@@ -382,6 +391,8 @@ pub enum TypeKind {
     TypeExpr(Path, SmallVec<[Type; 2]>),
     /// A closure type: argument types and a result.
     TypeArrow(SmallVec<[Type; 2]>, Type),
+    /// An integer literal in type-argument position (an array extent).
+    TypeConst(u64),
 }
 
 /// A type expression (a view over a `PrimType` / `PathType` / `ArrowType` node).
@@ -412,6 +423,10 @@ impl Type {
         let node = &self.node;
         match node.kind() {
             PrimType => prim_type(tokens(node).next().expect("prim type token").text()),
+            SyntaxKind::ConstType => {
+                let text = tokens(node).next().expect("const type token").text();
+                TypeKind::TypeConst(parse_extent(text))
+            }
             PathType => {
                 let path = child_node(node, PathKind).expect("type path");
                 let args = child_node(node, TypeArgList)

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -622,6 +622,14 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             TyKind::Nullable(inner) => {
                 format!("Nullable<{}>", Self::render_ty_with(elab, inner))
             }
+            TyKind::Array { elem, dims } => {
+                let dims: Vec<String> = dims.iter().map(|d| d.to_string()).collect();
+                format!(
+                    "Array<{}, {}>",
+                    Self::render_ty_with(elab, elem),
+                    dims.join(", ")
+                )
+            }
             TyKind::Record { def, args, .. } => {
                 let mut out = elab.defs.path(def).display(elab.resolver);
                 if !args.is_empty() {

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -150,6 +150,8 @@ pub enum SyntaxKind {
     TypeArgList,
     /// `_` placeholder inside a type argument list.
     InferType,
+    /// An integer literal in type-argument position (an array extent).
+    ConstType,
 
     // ===== Nodes: expressions =====
     BlockExpr,

--- a/crates/reussir-syntax/src/parser/expr.rs
+++ b/crates/reussir-syntax/src/parser/expr.rs
@@ -527,6 +527,12 @@ impl Parser<'_> {
                 let h = self.start();
                 self.bump();
                 h.complete(self, InferType);
+            } else if self.at(IntLit) {
+                // An integer extent in a call's type arguments
+                // (`Array::splat<f64, 512>(…)`).
+                let h = self.start();
+                self.bump();
+                h.complete(self, ConstType);
             } else {
                 self.type_();
             }

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -404,15 +404,27 @@ impl Parser<'_> {
             // In type position `<` always opens type arguments.
             let args = self.start();
             self.bump();
-            self.type_();
+            self.type_arg();
             while self.at(Comma) {
                 self.bump();
-                self.type_();
+                self.type_arg();
             }
             self.expect(RAngle);
             args.complete(self, TypeArgList);
         }
         Some(m.complete(self, PathType))
+    }
+
+    /// A type argument: a type, or an integer literal (an array extent such
+    /// as the `512` in `Array<f64, 512>`).
+    fn type_arg(&mut self) {
+        if self.at(IntLit) {
+            let m = self.start();
+            self.bump();
+            m.complete(self, ConstType);
+            return;
+        }
+        self.type_();
     }
 
     // ===== Patterns =====

--- a/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
@@ -264,6 +264,26 @@ llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
         break;
       if (llvm::isa<ReussirRegionCleanupOp>(next))
         break;
+      // Count-*observing* ops: `array.with_unique_view`, `closure.uniqify`
+      // and a standalone `rc.is_unique` read `count == 1` to decide between
+      // in-place mutation and a defensive clone. The inc/dec pair around them
+      // is not redundant — it is exactly what makes the count observation see
+      // the value as shared — so cancelling across them would turn a
+      // copy-on-write into an in-place mutation of a live shared value.
+      if (auto viewOp = llvm::dyn_cast<ReussirArrayWithUniqueViewOp>(next);
+          viewOp && aliasAnalysis.alias(op.getRcPtr(), viewOp.getArray()) !=
+                        mlir::AliasResult::NoAlias)
+        break;
+      if (auto uniqifyOp = llvm::dyn_cast<ReussirClosureUniqifyOp>(next);
+          uniqifyOp &&
+          aliasAnalysis.alias(op.getRcPtr(), uniqifyOp.getClosure()) !=
+              mlir::AliasResult::NoAlias)
+        break;
+      if (auto isUniqueOp = llvm::dyn_cast<ReussirRcIsUniqueOp>(next);
+          isUniqueOp &&
+          aliasAnalysis.alias(op.getRcPtr(), isUniqueOp.getRcPtr()) !=
+              mlir::AliasResult::NoAlias)
+        break;
       // `closure.apply`/`closure.eval` consume/mutate only their own closure
       // operand, so they are risky only when that operand may alias the
       // incremented pointer; an application of an unrelated closure is harmless

--- a/tests/integration/conversion/inc_dec_cancellation_count_observing.mlir
+++ b/tests/integration/conversion/inc_dec_cancellation_count_observing.mlir
@@ -1,0 +1,68 @@
+// RUN: %reussir-opt %s --reussir-inc-dec-cancellation | %FileCheck %s
+
+// Regression for a copy-on-write miscompile (issue #344): an inc/dec pair
+// around a count-*observing* op — `reussir.array.with_unique_view`,
+// `reussir.closure.uniqify`, or a standalone `reussir.rc.is_unique` — is not
+// redundant: the extra count is exactly what makes the observation see the
+// value as shared and take the defensive-clone path. Cancelling across it
+// turned `let b = a.set(…)` with `a` still live into an in-place mutation of
+// `a`. The pass must keep the pair when the observing op's operand may alias
+// the incremented pointer, and may still cancel across observations of
+// *unrelated* values.
+
+!arr = !reussir.array<4 x f64>
+!rc_arr = !reussir.rc<!arr>
+!clo = !reussir.closure<(f64) -> f64>
+!rc_clo = !reussir.rc<!clo>
+
+module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+  // CHECK-LABEL: @cow_set
+  // CHECK: reussir.rc.inc
+  // CHECK: reussir.array.with_unique_view
+  // CHECK: reussir.rc.dec
+  func.func @cow_set(%a: !rc_arr) -> !rc_arr {
+    reussir.rc.inc (%a : !rc_arr)
+    %b = reussir.array.with_unique_view (%a : !rc_arr) -> !rc_arr {
+      ^bb0(%view: memref<4xf64>):
+        %c0 = arith.constant 0 : index
+        %v = arith.constant 9.9e+01 : f64
+        memref.store %v, %view[%c0] : memref<4xf64>
+        reussir.scf.yield
+    }
+    %tk = reussir.rc.dec (%a : !rc_arr) : !reussir.nullable<!reussir.token<align: 8, size: 40>>
+    return %b : !rc_arr
+  }
+
+  // CHECK-LABEL: @observed_unique
+  // CHECK: reussir.rc.inc
+  // CHECK: reussir.rc.is_unique
+  // CHECK: reussir.rc.dec
+  func.func @observed_unique(%a: !rc_arr) -> i1 {
+    reussir.rc.inc (%a : !rc_arr)
+    %u = reussir.rc.is_unique (%a : !rc_arr) : i1
+    %tk = reussir.rc.dec (%a : !rc_arr) : !reussir.nullable<!reussir.token<align: 8, size: 40>>
+    return %u : i1
+  }
+
+  // CHECK-LABEL: @uniqify_blocks
+  // CHECK: reussir.rc.inc
+  // CHECK: reussir.closure.uniqify
+  // CHECK: reussir.rc.dec
+  func.func @uniqify_blocks(%f: !rc_clo) -> !rc_clo {
+    reussir.rc.inc (%f : !rc_clo)
+    %u = reussir.closure.uniqify (%f : !rc_clo) : !rc_clo
+    reussir.rc.dec (%f : !rc_clo)
+    return %u : !rc_clo
+  }
+
+  // An adjacent inc/dec pair with nothing observing in between still cancels
+  // (the barrier is the observing op, not the array type).
+  // CHECK-LABEL: @plain_pair_still_cancels
+  // CHECK-NOT: reussir.rc.inc
+  // CHECK-NOT: reussir.rc.dec
+  func.func @plain_pair_still_cancels(%a: !rc_arr) {
+    reussir.rc.inc (%a : !rc_arr)
+    %tk = reussir.rc.dec (%a : !rc_arr) : !reussir.nullable<!reussir.token<align: 8, size: 40>>
+    return
+  }
+}

--- a/tests/integration/frontend/array.rr
+++ b/tests/integration/frontend/array.rr
@@ -1,0 +1,46 @@
+// Statically shaped arrays (issue #344, Phase A): the `Array<elem, extents…>`
+// type, the `Array::splat`/`Array::tabulate` constructors, and the
+// `get`/`set`/`fold` methods, as elaborated into the HIR `array#…` forms.
+
+// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+
+// CHECK: pub fn #make() -> array<f64, 8>
+// CHECK: array#tabulate() kernel(v{{[0-9]+}}: i64) {
+pub fn make() -> Array<f64, 8> {
+    Array::tabulate<f64, 8>(|i| i as f64)
+}
+
+// CHECK: pub fn #splat_ones() -> array<i32, 4, 4>
+// CHECK: array#splat(1 : i32
+pub fn splat_ones() -> Array<i32, 4, 4> {
+    Array::splat<i32, 4, 4>(1)
+}
+
+// CHECK: pub fn #sum(v0 (a): array<f64, 8>) -> f64
+// CHECK: array#fold(v0 : array<f64, 8> {{.*}}, 0.0 : f64 {{.*}}) kernel(v{{[0-9]+}}: f64, v{{[0-9]+}}: f64) {
+pub fn sum(a : Array<f64, 8>) -> f64 {
+    a.fold(0.0, |acc, x| acc + x)
+}
+
+// CHECK: pub fn #bump(v0 (a): array<f64, 8>, v1 (i): i64, v2 (v): f64) -> array<f64, 8>
+// CHECK: array#set(v0 : array<f64, 8> {{.*}}, v1 : i64 {{.*}}, (array#get(v0
+pub fn bump(a : Array<f64, 8>, i : i64, v : f64) -> Array<f64, 8> {
+    a.set(i, a.get(i) + v)
+}
+
+// A rank-2 access takes one index per dimension, row-major.
+// CHECK: pub fn #cell(v0 (m): array<i32, 4, 4>, v1 (i): i64, v2 (j): i64) -> i32
+// CHECK: array#get(v0 : array<i32, 4, 4> {{.*}}, v1 : i64 {{.*}}, v2 : i64
+pub fn cell(m : Array<i32, 4, 4>, i : i64, j : i64) -> i32 {
+    m.get(i, j)
+}
+
+// Kernels may read enclosing arrays (a stencil): the reads reference the
+// enclosing binding directly — no closure, no captures.
+// CHECK: pub fn #blur(v0 (x): array<f64, 8>) -> array<f64, 8>
+// CHECK: array#tabulate() kernel(v{{[0-9]+}}: i64) {
+// CHECK: array#get(v0
+pub fn blur(x : Array<f64, 8>) -> Array<f64, 8> {
+    Array::tabulate<f64, 8>(|i|
+        if i == 0 { x.get(i) } else { (x.get(i - 1) + x.get(i)) / 2.0 })
+}

--- a/tests/integration/frontend/array.rr
+++ b/tests/integration/frontend/array.rr
@@ -1,38 +1,38 @@
 // Statically shaped arrays (issue #344, Phase A): the `Array<elem, extents…>`
-// type, the `Array::splat`/`Array::tabulate` constructors, and the
-// `get`/`set`/`fold` methods, as elaborated into the HIR `array#…` forms.
+// type and the `core::intrinsic::array` family — special vararg intrinsics —
+// as elaborated into the HIR `array#…` forms.
 
 // RUN: %rrc %s --emit hir -o - | %FileCheck %s
 
 // CHECK: pub fn #make() -> array<f64, 8>
 // CHECK: array#tabulate() kernel(v{{[0-9]+}}: i64) {
 pub fn make() -> Array<f64, 8> {
-    Array::tabulate<f64, 8>(|i| i as f64)
+    core::intrinsic::array::tabulate<f64, 8>(|i| i as f64)
 }
 
 // CHECK: pub fn #splat_ones() -> array<i32, 4, 4>
 // CHECK: array#splat(1 : i32
 pub fn splat_ones() -> Array<i32, 4, 4> {
-    Array::splat<i32, 4, 4>(1)
+    core::intrinsic::array::splat<i32, 4, 4>(1)
 }
 
 // CHECK: pub fn #sum(v0 (a): array<f64, 8>) -> f64
 // CHECK: array#fold(v0 : array<f64, 8> {{.*}}, 0.0 : f64 {{.*}}) kernel(v{{[0-9]+}}: f64, v{{[0-9]+}}: f64) {
 pub fn sum(a : Array<f64, 8>) -> f64 {
-    a.fold(0.0, |acc, x| acc + x)
+    core::intrinsic::array::fold(a, 0.0, |acc, x| acc + x)
 }
 
 // CHECK: pub fn #bump(v0 (a): array<f64, 8>, v1 (i): i64, v2 (v): f64) -> array<f64, 8>
 // CHECK: array#set(v0 : array<f64, 8> {{.*}}, v1 : i64 {{.*}}, (array#get(v0
 pub fn bump(a : Array<f64, 8>, i : i64, v : f64) -> Array<f64, 8> {
-    a.set(i, a.get(i) + v)
+    core::intrinsic::array::set(a, i, core::intrinsic::array::get(a, i) + v)
 }
 
 // A rank-2 access takes one index per dimension, row-major.
 // CHECK: pub fn #cell(v0 (m): array<i32, 4, 4>, v1 (i): i64, v2 (j): i64) -> i32
 // CHECK: array#get(v0 : array<i32, 4, 4> {{.*}}, v1 : i64 {{.*}}, v2 : i64
 pub fn cell(m : Array<i32, 4, 4>, i : i64, j : i64) -> i32 {
-    m.get(i, j)
+    core::intrinsic::array::get(m, i, j)
 }
 
 // Kernels may read enclosing arrays (a stencil): the reads reference the
@@ -41,6 +41,7 @@ pub fn cell(m : Array<i32, 4, 4>, i : i64, j : i64) -> i32 {
 // CHECK: array#tabulate() kernel(v{{[0-9]+}}: i64) {
 // CHECK: array#get(v0
 pub fn blur(x : Array<f64, 8>) -> Array<f64, 8> {
-    Array::tabulate<f64, 8>(|i|
-        if i == 0 { x.get(i) } else { (x.get(i - 1) + x.get(i)) / 2.0 })
+    core::intrinsic::array::tabulate<f64, 8>(|i|
+        if i == 0 { core::intrinsic::array::get(x, i) }
+        else { (core::intrinsic::array::get(x, i - 1) + core::intrinsic::array::get(x, i)) / 2.0 })
 }

--- a/tests/integration/frontend/array_e2e.c
+++ b/tests/integration/frontend/array_e2e.c
@@ -1,0 +1,44 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Float results cross the C-ABI trampoline via an out-parameter (only
+   void/integer/pointer returns are direct). */
+extern void test_tabulate_sum_ffi(double *);
+extern int64_t test_splat_get_ffi(void);
+extern void test_unique_update_ffi(double *);
+extern void test_cow_ffi(double *);
+extern int64_t test_rank2_ffi(void);
+extern void test_stencil_ffi(double *);
+
+static int check_f64(const char *name, void (*fn)(double *), double want) {
+  double got = 0.0;
+  fn(&got);
+  if (got != want) {
+    fprintf(stderr, "%s: got %f, want %f\n", name, got, want);
+    return 1;
+  }
+  return 0;
+}
+
+static int check_i64(const char *name, int64_t got, int64_t want) {
+  if (got != want) {
+    fprintf(stderr, "%s: got %lld, want %lld\n", name, (long long)got,
+            (long long)want);
+    return 1;
+  }
+  return 0;
+}
+
+int main(void) {
+  int failures = 0;
+  failures += check_f64("tabulate_sum", test_tabulate_sum_ffi, 28.0);
+  failures += check_i64("splat_get", test_splat_get_ffi(), 7);
+  failures += check_f64("unique_update", test_unique_update_ffi, 38.0);
+  failures += check_f64("cow", test_cow_ffi, 100.0);
+  /* sum(i*10+j over 4x4) = 10*6*4 + 6*4 = 264; m[2][3] = 23 => 287 */
+  failures += check_i64("rank2", test_rank2_ffi(), 287);
+  /* y[0] = 3, y[1..7] = 3 => 24 */
+  failures += check_f64("stencil", test_stencil_ffi, 24.0);
+  return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/array_e2e.rr
+++ b/tests/integration/frontend/array_e2e.rr
@@ -1,4 +1,4 @@
-// End-to-end semantics of the Phase A array operations (issue #344):
+// End-to-end semantics of the Phase A array intrinsics (issue #344):
 // construction, reads/writes, folds, rank-2 indexing, copy-on-write on a
 // shared array, and in-place update of a unique one.
 
@@ -11,49 +11,53 @@
 
 // tabulate + fold: sum of 0..7 = 28.
 pub fn test_tabulate_sum() -> f64 {
-    Array::tabulate<f64, 8>(|i| i as f64).fold(0.0, |acc, x| acc + x)
+    core::intrinsic::array::fold(
+        core::intrinsic::array::tabulate<f64, 8>(|i| i as f64),
+        0.0, |acc, x| acc + x)
 }
 extern "C" trampoline "test_tabulate_sum_ffi" = test_tabulate_sum;
 
 // splat + get.
 pub fn test_splat_get() -> i64 {
-    let a = Array::splat<i64, 16>(7);
-    a.get(15)
+    let a = core::intrinsic::array::splat<i64, 16>(7);
+    core::intrinsic::array::get(a, 15)
 }
 extern "C" trampoline "test_splat_get_ffi" = test_splat_get;
 
 // A unique array updates in place through a call boundary.
 fn bump(a : Array<f64, 8>, i : i64, v : f64) -> Array<f64, 8> {
-    a.set(i, a.get(i) + v)
+    core::intrinsic::array::set(a, i, core::intrinsic::array::get(a, i) + v)
 }
 pub fn test_unique_update() -> f64 {
-    let a = Array::tabulate<f64, 8>(|i| i as f64);
-    bump(a, 3, 10.0).fold(0.0, |acc, x| acc + x)
+    let a = core::intrinsic::array::tabulate<f64, 8>(|i| i as f64);
+    core::intrinsic::array::fold(bump(a, 3, 10.0), 0.0, |acc, x| acc + x)
 }
 extern "C" trampoline "test_unique_update_ffi" = test_unique_update;
 
 // Copy-on-write: `a` is still live across the `set`, so the update must
 // clone; the original observes its old value. 1.0 + 99.0 = 100.0.
 pub fn test_cow() -> f64 {
-    let a = Array::splat<f64, 4>(1.0);
-    let b = a.set(0, 99.0);
-    a.get(0) + b.get(0)
+    let a = core::intrinsic::array::splat<f64, 4>(1.0);
+    let b = core::intrinsic::array::set(a, 0, 99.0);
+    core::intrinsic::array::get(a, 0) + core::intrinsic::array::get(b, 0)
 }
 extern "C" trampoline "test_cow_ffi" = test_cow;
 
 // Rank-2: m[i][j] = i * 10 + j, summed row-major; checked against the
 // closed form.
 pub fn test_rank2() -> i64 {
-    let m = Array::tabulate<i64, 4, 4>(|i, j| i * 10 + j);
-    m.fold(0, |acc, x| acc + x) + m.get(2, 3)
+    let m = core::intrinsic::array::tabulate<i64, 4, 4>(|i, j| i * 10 + j);
+    core::intrinsic::array::fold(m, 0, |acc, x| acc + x)
+        + core::intrinsic::array::get(m, 2, 3)
 }
 extern "C" trampoline "test_rank2_ffi" = test_rank2;
 
 // A stencil kernel reading the enclosing array.
 pub fn test_stencil() -> f64 {
-    let x = Array::splat<f64, 8>(3.0);
-    let y = Array::tabulate<f64, 8>(|i|
-        if i == 0 { x.get(i) } else { (x.get(i - 1) + x.get(i)) / 2.0 });
-    y.fold(0.0, |acc, v| acc + v)
+    let x = core::intrinsic::array::splat<f64, 8>(3.0);
+    let y = core::intrinsic::array::tabulate<f64, 8>(|i|
+        if i == 0 { core::intrinsic::array::get(x, i) }
+        else { (core::intrinsic::array::get(x, i - 1) + core::intrinsic::array::get(x, i)) / 2.0 });
+    core::intrinsic::array::fold(y, 0.0, |acc, v| acc + v)
 }
 extern "C" trampoline "test_stencil_ffi" = test_stencil;

--- a/tests/integration/frontend/array_e2e.rr
+++ b/tests/integration/frontend/array_e2e.rr
@@ -1,0 +1,59 @@
+// End-to-end semantics of the Phase A array operations (issue #344):
+// construction, reads/writes, folds, rank-2 indexing, copy-on-write on a
+// shared array, and in-place update of a unique one.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/array_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/array_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+// tabulate + fold: sum of 0..7 = 28.
+pub fn test_tabulate_sum() -> f64 {
+    Array::tabulate<f64, 8>(|i| i as f64).fold(0.0, |acc, x| acc + x)
+}
+extern "C" trampoline "test_tabulate_sum_ffi" = test_tabulate_sum;
+
+// splat + get.
+pub fn test_splat_get() -> i64 {
+    let a = Array::splat<i64, 16>(7);
+    a.get(15)
+}
+extern "C" trampoline "test_splat_get_ffi" = test_splat_get;
+
+// A unique array updates in place through a call boundary.
+fn bump(a : Array<f64, 8>, i : i64, v : f64) -> Array<f64, 8> {
+    a.set(i, a.get(i) + v)
+}
+pub fn test_unique_update() -> f64 {
+    let a = Array::tabulate<f64, 8>(|i| i as f64);
+    bump(a, 3, 10.0).fold(0.0, |acc, x| acc + x)
+}
+extern "C" trampoline "test_unique_update_ffi" = test_unique_update;
+
+// Copy-on-write: `a` is still live across the `set`, so the update must
+// clone; the original observes its old value. 1.0 + 99.0 = 100.0.
+pub fn test_cow() -> f64 {
+    let a = Array::splat<f64, 4>(1.0);
+    let b = a.set(0, 99.0);
+    a.get(0) + b.get(0)
+}
+extern "C" trampoline "test_cow_ffi" = test_cow;
+
+// Rank-2: m[i][j] = i * 10 + j, summed row-major; checked against the
+// closed form.
+pub fn test_rank2() -> i64 {
+    let m = Array::tabulate<i64, 4, 4>(|i, j| i * 10 + j);
+    m.fold(0, |acc, x| acc + x) + m.get(2, 3)
+}
+extern "C" trampoline "test_rank2_ffi" = test_rank2;
+
+// A stencil kernel reading the enclosing array.
+pub fn test_stencil() -> f64 {
+    let x = Array::splat<f64, 8>(3.0);
+    let y = Array::tabulate<f64, 8>(|i|
+        if i == 0 { x.get(i) } else { (x.get(i - 1) + x.get(i)) / 2.0 });
+    y.fold(0.0, |acc, v| acc + v)
+}
+extern "C" trampoline "test_stencil_ffi" = test_stencil;

--- a/tests/integration/frontend/array_errors.rr
+++ b/tests/integration/frontend/array_errors.rr
@@ -18,26 +18,29 @@ fn zero_extent(a : Array<f64, 0>) -> i64 { 0 }
 // CHECK-DAG: an integer extent is only valid as an `Array` type argument
 fn stray_const(x : Nullable<4>) -> i64 { 0 }
 
-// CHECK: `Array::splat` requires explicit type arguments
-fn no_ty_args() -> Array<f64, 4> { Array::splat(0.0) }
+// CHECK: `core::intrinsic::array::splat` requires explicit type arguments
+fn no_ty_args() -> Array<f64, 4> { core::intrinsic::array::splat(0.0) }
 
-// CHECK: `Array` has no constructor `build`
-fn bad_ctor() -> Array<f64, 4> { Array::build<f64, 4>(0.0) }
+// CHECK: unknown array intrinsic `core::intrinsic::array::build`
+fn bad_ctor() -> Array<f64, 4> { core::intrinsic::array::build<f64, 4>(0.0) }
 
 // CHECK: `get` on `Array<f64, 4, 4>` expects 2 index argument(s), got 1
-fn rank_mismatch(m : Array<f64, 4, 4>) -> f64 { m.get(0) }
+fn rank_mismatch(m : Array<f64, 4, 4>) -> f64 { core::intrinsic::array::get(m, 0) }
+
+// CHECK: `core::intrinsic::array::get` expects an array as its first argument, found `i64`
+fn not_an_array(x : i64) -> i64 { core::intrinsic::array::get(x, 0) }
 
 // CHECK: `tabulate` requires a literal lambda kernel
-fn make_it(f : i64 -> f64) -> Array<f64, 4> { Array::tabulate<f64, 4>(f) }
+fn make_it(f : i64 -> f64) -> Array<f64, 4> { core::intrinsic::array::tabulate<f64, 4>(f) }
 
 // CHECK: `fold` kernel takes 2 parameter(s), got 1
-fn short_kernel(a : Array<f64, 4>) -> f64 { a.fold(0.0, |acc| acc) }
+fn short_kernel(a : Array<f64, 4>) -> f64 { core::intrinsic::array::fold(a, 0.0, |acc| acc) }
 
 // A kernel body may not create managed values (here: a boxed list).
 enum List { Cons(i64), Nil() }
 // CHECK: array kernel bodies are restricted to plain scalar computation
 fn managed_kernel(a : Array<i64, 4>) -> i64 {
-    a.fold(0, |acc, x| {
+    core::intrinsic::array::fold(a, 0, |acc, x| {
         let v = List::Cons{x};
         match v { List::Cons(h) => acc + h, List::Nil() => acc }
     })
@@ -46,11 +49,15 @@ fn managed_kernel(a : Array<i64, 4>) -> i64 {
 // Only `get` is allowed inside a kernel.
 // CHECK: `set` is not allowed inside an array kernel
 fn set_in_kernel(a : Array<f64, 4>, b : Array<f64, 4>) -> f64 {
-    a.fold(0.0, |acc, x| { let c = b.set(0, x); acc })
+    core::intrinsic::array::fold(a, 0.0, |acc, x| {
+        let c = core::intrinsic::array::set(b, 0, x);
+        acc
+    })
 }
 
 // A nested kernel read must be directly on an array variable.
 // CHECK: an array read inside a kernel must be on an array variable
 fn temp_get_in_kernel(a : Array<f64, 4>) -> f64 {
-    a.fold(0.0, |acc, x| Array::splat<f64, 4>(x).get(0) + acc)
+    core::intrinsic::array::fold(a, 0.0, |acc, x|
+        core::intrinsic::array::get(core::intrinsic::array::splat<f64, 4>(x), 0) + acc)
 }

--- a/tests/integration/frontend/array_errors.rr
+++ b/tests/integration/frontend/array_errors.rr
@@ -1,0 +1,56 @@
+// Diagnostics for the Phase A array restrictions (issue #344). Declaration
+// (type/record) errors surface during scanning, before any function body is
+// checked, so the CHECKs are grouped: `CHECK-DAG` for the scan phase,
+// ordered `CHECK`s for the body phase.
+
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+// CHECK-DAG: array elements must be plain scalars
+struct S { x: i32 }
+fn bad_elem(a : Array<S, 4>) -> i64 { 0 }
+
+// CHECK-DAG: an array cannot be a record member in this version
+struct Holder { data: Array<f64, 4> }
+
+// CHECK-DAG: array extents must be positive
+fn zero_extent(a : Array<f64, 0>) -> i64 { 0 }
+
+// CHECK-DAG: an integer extent is only valid as an `Array` type argument
+fn stray_const(x : Nullable<4>) -> i64 { 0 }
+
+// CHECK: `Array::splat` requires explicit type arguments
+fn no_ty_args() -> Array<f64, 4> { Array::splat(0.0) }
+
+// CHECK: `Array` has no constructor `build`
+fn bad_ctor() -> Array<f64, 4> { Array::build<f64, 4>(0.0) }
+
+// CHECK: `get` on `Array<f64, 4, 4>` expects 2 index argument(s), got 1
+fn rank_mismatch(m : Array<f64, 4, 4>) -> f64 { m.get(0) }
+
+// CHECK: `tabulate` requires a literal lambda kernel
+fn make_it(f : i64 -> f64) -> Array<f64, 4> { Array::tabulate<f64, 4>(f) }
+
+// CHECK: `fold` kernel takes 2 parameter(s), got 1
+fn short_kernel(a : Array<f64, 4>) -> f64 { a.fold(0.0, |acc| acc) }
+
+// A kernel body may not create managed values (here: a boxed list).
+enum List { Cons(i64), Nil() }
+// CHECK: array kernel bodies are restricted to plain scalar computation
+fn managed_kernel(a : Array<i64, 4>) -> i64 {
+    a.fold(0, |acc, x| {
+        let v = List::Cons{x};
+        match v { List::Cons(h) => acc + h, List::Nil() => acc }
+    })
+}
+
+// Only `get` is allowed inside a kernel.
+// CHECK: `set` is not allowed inside an array kernel
+fn set_in_kernel(a : Array<f64, 4>, b : Array<f64, 4>) -> f64 {
+    a.fold(0.0, |acc, x| { let c = b.set(0, x); acc })
+}
+
+// A nested kernel read must be directly on an array variable.
+// CHECK: an array read inside a kernel must be on an array variable
+fn temp_get_in_kernel(a : Array<f64, 4>) -> f64 {
+    a.fold(0.0, |acc, x| Array::splat<f64, 4>(x).get(0) + acc)
+}


### PR DESCRIPTION
Phase A of the array design (#344): the `Array<elem, extents…>` frontend type and five built-in operations exposed as `core::intrinsic::array::*` **vararg intrinsics** (no syntax sugar in this patch), end to end from surface syntax to vectorizable LLVM IR.

## Surface

```rust
let a = core::intrinsic::array::tabulate<f64, 4096>(|i| i as f64);
let b = core::intrinsic::array::splat<f64, 64, 64>(0.0);            // rank-2
let v = core::intrinsic::array::get(a, i);                          // checked read (borrows)
let c = core::intrinsic::array::set(a, i, v + 1.0);                 // consumes; clones when shared (COW)
let s = core::intrinsic::array::fold(a, 0.0, |acc, x| acc + x);     // row-major reduction (borrows)
```

`get`/`set`/`fold` take the array as their first argument and one `i64` index per dimension (arity checked against the rank). `splat`/`tabulate` require explicit `<elem, extents…>` type arguments — the shape has nothing to be inferred from. Extents are integer literals in type/turbofish position (`ConstType`), positive, product ≤ 2^32.

## Semantics and representation

- `TyKind::Array` is one shared rc box over a `!reussir.array<dims x elem>` payload; `is_rr` = true, counts managed with plain `rc.inc`/`rc.dec` (no drop glue — elements are Plain scalars, a Phase A restriction along with no-arrays-as-record-members).
- **Kernels are not closures.** `tabulate`/`fold` bodies are checked in the enclosing scope with only the kernel params bound, and restricted (post-zonk) to rc-free plain-scalar computation; the only managed reads are nested `get`s on array variables. Codegen inlines them into `scf.for` nests over `memref` views, so loops carry **zero per-iteration rc traffic**.
- Ownership: `get`/`fold` borrow their array argument (early drop after the op, like `Proj`); `set` consumes it (dup-if-live makes the COW decision observable to `array.with_unique_view`); kernel free vars are read-only borrows for the op's duration, enforced by the checker and validated by the ownership interpreter tests.
- Bounds checks (tier 2/3 of the design): each explicit index is `index_cast` + `cmpi ult` against its constant extent with a cold `reussir.panic` arm; a negative index wraps to a huge unsigned value so one compare covers both sides. Constant indices fold away at canonicalization; `splat`/`tabulate`/`fold` loops are check-free by construction (tier 1).

## Soundness fix (first commit)

`IncDecCancellation` cancelled inc/dec pairs across **count-observing** ops. `array.with_unique_view` (and `closure.uniqify`, standalone `rc.is_unique`) read `count == 1` to pick in-place vs clone — the pair is what makes a shared value look shared, so cancelling it turned copy-on-write into in-place mutation of a live original (`test_cow` returned 198 instead of 100 at `-Odefault`). Such ops now block cancellation when their operand may alias the incremented pointer; regression test pins all three plus the still-cancels case.

## Performance validation

`opt -O2` remarks on `-Oaggressive` output (aarch64): `saxpy` (tabulate) and `dot` (tabulate+fold) fully vectorize (`width: 2, interleaved: 2`); a branchy stencil kernel does not yet (its interior `get`s keep panic-guarded control flow — a Phase B target once range facts can discharge the checks before if-conversion).

## Known Phase A limits

- `rc.create` over a `ub.poison` payload emits a dead aggregate store for `splat`/`tabulate`; instcombine removes it at `-O2`, but an `array.uninit_create` form would help `-O0`/TPDE.
- Deferred (generic) array element types are accepted at type formation but not re-validated at instantiation — pre-existing gap shared with the element rule, noted for Phase B.
- No `modify`, no sugar (method calls / indexing / `Array::` ctors deliberately omitted), no dynamic extents, no views-as-values (Phases B–D per #344).

## Testing

- `tests/integration/frontend/array.rr` — HIR forms; `array_errors.rr` — 13 diagnostics; `array_e2e.rr` — tabulate/splat/rank-2/COW/unique-in-place/stencil executed at `-O0` and `-Oaggressive`.
- `inc_dec_cancellation_count_observing.mlir` — the soundness fix.
- HIR+MIR textual round-trip tests (`roundtrips_arrays`); ownership interpreter arms.
- Full suite: lit 293/293, reussir-core 237, reussir-syntax 34. Valgrind on the e2e binaries: 0 leaks, 0 errors.

First step of #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwRV7vMvVkXLwcc2VzbF2
