### PR TITLE
[backend] drop two unused indexType locals (fix -Werror pedantic build)

### DIFF
--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -1793,7 +1793,6 @@ struct ReussirClosureCreateOpConversionPattern
     auto converter =
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
     auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
-    auto indexType = converter->getIndexType();
 
     // Get the RcBox<ClosureBox> type
     RcBoxType rcBoxType = op.getRcClosureBoxType();
@@ -1951,8 +1950,6 @@ struct ReussirRcIsUniqueOpConversionPattern
     RcBoxType rcBoxType = rcPtrTy.getInnerBoxType();
     auto convertedBoxType = typeConverter->convertType(rcBoxType);
     auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
-    auto indexType = static_cast<const mlir::LLVMTypeConverter *>(typeConverter)
-                         ->getIndexType();
 
     auto refcntPtr = mlir::LLVM::GEPOp::create(
         rewriter, loc, llvmPtrType, convertedBoxType, rcPtr,


### PR DESCRIPTION
## Problem
`#341` (fused 8-byte rc header) merged with two dead `indexType` locals in `BasicOpsLowering.cpp` — leftovers from moving refcounts to i32. CI builds with `-DREUSSIR_ENABLE_PEDANTIC=ON` (`-Werror -Wunused-variable`), so these are hard errors, and the C++ build **fails on all four platforms** (Linux MultiArch, macOS, Windows MSVC, Nightly) at the identical spot:

```
BasicOpsLowering.cpp:1796:10: error: unused variable 'indexType' [-Werror,-Wunused-variable]
BasicOpsLowering.cpp:1954:10: error: unused variable 'indexType' [-Werror,-Wunused-variable]
```

A non-pedantic local build only warns, which is how it slipped through review.

## Fix
Remove both dead declarations (the closure-create lowering and `buildUniquenessCondition`). The other 11 `indexType` locals are used and untouched.

## Verification
The Reussir C++ targets (`ReussirCAPI`, `reussir-opt`, `reussir-translate` — which recompile `BasicOpsLowering.cpp`) build clean with `-DREUSSIR_ENABLE_PEDANTIC=ON` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785904559&installation_id=144622820&pr_number=346&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F346&signature=e85ca5217f20daa598ed2160c32658169f850b8c37a6d9ad9607ca1126f6d794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->