### PR TITLE
[backend] transform-interpreter anchors in the lowering pipeline (#349 Phase 1, 1/2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,7 @@ dependencies = [
  "melior",
  "mlir-sys",
  "reussir-backend-sys",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -13,7 +13,7 @@ use core::ffi::{c_char, c_int};
 
 use mlir_sys::{
     MlirAttribute, MlirContext, MlirDialectHandle, MlirDialectRegistry, MlirModule, MlirPass,
-    MlirType,
+    MlirStringRef, MlirType,
 };
 
 //==-- Reussir type enums --==//
@@ -133,6 +133,23 @@ unsafe extern "C" {
     //==-- Upstream passes used by the pipeline --==//
 
     pub fn reussirCreateDefaultInlinerPass() -> MlirPass;
+
+    /// The upstream transform-dialect interpreter, applying the transform
+    /// named sequence `entry_point` to the payload module. The entry point is
+    /// resolved first in the payload module itself, then in the context's
+    /// transform library (populated by the preload pass below); the pass
+    /// fails if it is found in neither.
+    pub fn reussirCreateTransformInterpreterPass(entry_point: MlirStringRef) -> MlirPass;
+
+    /// The upstream transform-library preload pass: parses each of the
+    /// `n_paths` script files in `paths` and merges its transform named
+    /// sequences into the context-wide transform library consulted by the
+    /// interpreter. Merging reports a symbol clash, so distinct scripts must
+    /// use distinct entry points (one script per anchor).
+    pub fn reussirCreateTransformPreloadLibraryPass(
+        paths: *const MlirStringRef,
+        n_paths: isize,
+    ) -> MlirPass;
     pub fn reussirCreateCanonicalizerPass() -> MlirPass;
     pub fn reussirCreateCSEPass() -> MlirPass;
     pub fn reussirCreateControlFlowSinkPass() -> MlirPass;

--- a/crates/reussir-backend/Cargo.toml
+++ b/crates/reussir-backend/Cargo.toml
@@ -26,3 +26,8 @@ reussir-backend-sys = { path = "../reussir-backend-sys" }
 mlir-sys.workspace = true
 llvm-sys.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+# Auto-cleaned scratch files holding the transform scripts the pipeline
+# tests feed through `LoweringOptions::transform_scripts`.
+tempfile = "3"

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -6,6 +6,8 @@
 //! with `func.func`-nested passes placed in their original order so the
 //! interleaving with module-level passes is preserved.
 
+use std::path::PathBuf;
+
 use melior::Context;
 use melior::ir::Module;
 use melior::pass::{Pass, PassManager};
@@ -66,8 +68,60 @@ pub enum NullaryVariantEncoding {
     Immortal,
 }
 
+/// A named interception point in the lowering pipeline where user-supplied
+/// transform-dialect scripts run (issue #349). Each anchor is a documented,
+/// stable IR contract: scripts see the module at that abstraction level and
+/// must leave it consumable by the passes that follow.
+///
+/// A script targeting an anchor must define the anchor's entry point,
+/// `transform.named_sequence @__reussir_anchor_<name>(%payload)`, in a module
+/// carrying the `transform.with_named_sequence` attribute. Distinct anchors
+/// have distinct entry points, so scripts for several anchors can coexist in
+/// the context-wide transform library.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Anchor {
+    /// Before any Reussir pass: pure `reussir`-dialect IR straight from
+    /// codegen, no tokens instantiated yet. For whole-program structural
+    /// rewrites and custom analyses.
+    Entry,
+    /// After the Reussir-level passes (both `scf-ops-lowering` runs and the
+    /// polymorphic-FFI compile are done), before the LLVM descent begins:
+    /// array kernels are plain memref/scf/arith loop nests. The main
+    /// scheduling surface — tiling, unrolling, fusion.
+    Kernel,
+}
+
+impl Anchor {
+    /// The anchor's user-facing name, as written in `--transform-script
+    /// <file>@<name>`.
+    pub fn name(self) -> &'static str {
+        match self {
+            Anchor::Entry => "entry",
+            Anchor::Kernel => "kernel",
+        }
+    }
+
+    /// The transform entry point the interpreter runs at this anchor:
+    /// `__reussir_anchor_<name>`.
+    pub fn entry_point(self) -> &'static str {
+        match self {
+            Anchor::Entry => "__reussir_anchor_entry",
+            Anchor::Kernel => "__reussir_anchor_kernel",
+        }
+    }
+
+    /// Parses a user-facing anchor name (`entry`/`kernel`).
+    pub fn parse(name: &str) -> Option<Anchor> {
+        match name {
+            "entry" => Some(Anchor::Entry),
+            "kernel" => Some(Anchor::Kernel),
+            _ => None,
+        }
+    }
+}
+
 /// Knobs for [`run_lowering_pipeline`].
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct LoweringOptions {
     /// Optimization level.
     pub opt: OptLevel,
@@ -84,6 +138,10 @@ pub struct LoweringOptions {
     /// layout contract external consumers compile against; `rrc` exposes the
     /// off switch as `--no-pack-record-members`.
     pub pack_record_members: bool,
+    /// Transform-dialect scripts to run, each at its [`Anchor`]. Empty means
+    /// zero overhead: no transform pass is added and the pipeline is exactly
+    /// the fixed pass list. `rrc` exposes this as `--transform-script`.
+    pub transform_scripts: Vec<(Anchor, PathBuf)>,
 }
 
 impl Default for LoweringOptions {
@@ -101,6 +159,7 @@ impl Default for LoweringOptions {
             // On by default: packed layout is the shipped default and the
             // layout contract; only an explicit driver flag turns it off.
             pack_record_members: true,
+            transform_scripts: Vec::new(),
         }
     }
 }
@@ -136,6 +195,15 @@ pub fn attach_target_spec(module: &Module, data_layout: &str, triple: &str) -> R
 fn pass(raw: sys::mlir_sys::MlirPass) -> Pass {
     // SAFETY: the C API returns a freshly created, owned MlirPass.
     unsafe { Pass::from_raw(raw) }
+}
+
+// Views a string as the borrowed MlirStringRef the C API takes; `s` must
+// outlive every use of the result.
+fn string_ref(s: &str) -> sys::mlir_sys::MlirStringRef {
+    sys::mlir_sys::MlirStringRef {
+        data: s.as_ptr().cast(),
+        length: s.len(),
+    }
 }
 
 /// A small DSL describing the lowering pipeline as a declarative list of steps,
@@ -201,7 +269,36 @@ pub fn run_lowering_pipeline(
 
     let manager = PassManager::new(context);
 
+    // Transform scripts, marshalled for the C API: every script file is
+    // preloaded into the context's transform library up front (one pass, all
+    // paths), then each anchor with at least one script runs the interpreter
+    // with that anchor's `__reussir_anchor_<name>` entry point. The `String`s
+    // must stay alive until the factories below have copied them.
+    let script_paths: Vec<String> = options
+        .transform_scripts
+        .iter()
+        .map(|(_, path)| path.to_string_lossy().into_owned())
+        .collect();
+    let script_refs: Vec<sys::mlir_sys::MlirStringRef> =
+        script_paths.iter().map(|s| string_ref(s)).collect();
+    let at_anchor = |anchor: Anchor| options.transform_scripts.iter().any(|(a, _)| *a == anchor);
+
     lowering_pipeline!(manager,
+        if !script_refs.is_empty() => {
+            module: sys::reussirCreateTransformPreloadLibraryPass(
+                script_refs.as_ptr(),
+                script_refs.len() as isize,
+            );
+        }
+
+        // `entry` anchor: pure reussir-dialect IR straight from codegen,
+        // before any Reussir pass.
+        if at_anchor(Anchor::Entry) => {
+            module: sys::reussirCreateTransformInterpreterPass(
+                string_ref(Anchor::Entry.entry_point()),
+            );
+        }
+
         // Nullary variants of shared rc-boxed enums become tagged pointer
         // immediates. Must run before any uniqueness/token pass so no
         // provenance or allocation token is ever attached to a rewritten
@@ -245,6 +342,17 @@ pub fn run_lowering_pipeline(
         func:   sys::reussirCreateRcCreateFusionPass();
         module: sys::reussirCreateTRMCRecursionAnalysisPass();
         module: sys::reussirCreateCompilePolymorphicFFIPass(false);
+
+        // `kernel` anchor: the Reussir-level work is done (both
+        // scf-ops-lowering runs, FFI compiled) and the LLVM descent has not
+        // begun — array kernels are plain memref/scf/arith loop nests, the
+        // transform dialect's home turf. Runs before the invariant analysis
+        // so that pass sees the scheduled IR.
+        if at_anchor(Anchor::Kernel) => {
+            module: sys::reussirCreateTransformInterpreterPass(
+                string_ref(Anchor::Kernel.entry_point()),
+            );
+        }
 
         if options.enable_invariant_analysis => {
             func: sys::reussirCreateInvariantGroupAnalysisPass();
@@ -300,5 +408,119 @@ mod tests {
         // After lowering, the function is an llvm.func rather than a func.func.
         let rendered = module.as_operation().to_string();
         assert!(rendered.contains("llvm.func @answer"), "got:\n{rendered}");
+    }
+
+    // A loop-nest kernel of the shape the `kernel` anchor guarantees: by the
+    // time the anchor runs, this function is untouched memref/scf/arith IR.
+    const SUM_KERNEL: &str = r#"
+        module {
+          func.func @sum(%a: memref<4xi64>) -> i64 {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %c4 = arith.constant 4 : index
+            %zero = arith.constant 0 : i64
+            %r = scf.for %i = %c0 to %c4 step %c1
+                iter_args(%acc = %zero) -> (i64) {
+              %v = memref.load %a[%i] : memref<4xi64>
+              %s = arith.addi %acc, %v : i64
+              scf.yield %s : i64
+            }
+            func.return %r : i64
+          }
+        }
+    "#;
+
+    // Writes `script` to an auto-cleaned file and returns the handle; the
+    // preload pass reads the script from disk by path.
+    fn script_file(script: &str) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut file = tempfile::Builder::new()
+            .suffix(".transform.mlir")
+            .tempfile()
+            .expect("temp script file");
+        file.write_all(script.as_bytes()).expect("write script");
+        file
+    }
+
+    #[test]
+    fn kernel_anchor_script_schedules_the_loop() {
+        let context = crate::context();
+        let mut module = Module::parse(&context, SUM_KERNEL).expect("module should parse");
+
+        // Fully unroll the 4-trip loop at the kernel anchor.
+        let script = script_file(
+            r#"
+            module attributes {transform.with_named_sequence} {
+              transform.named_sequence @__reussir_anchor_kernel(
+                  %m: !transform.any_op {transform.readonly}) {
+                %loops = transform.structured.match ops{["scf.for"]} in %m
+                    : (!transform.any_op) -> !transform.op<"scf.for">
+                transform.loop.unroll %loops { factor = 4 } : !transform.op<"scf.for">
+                transform.yield
+              }
+            }
+            "#,
+        );
+        let options = LoweringOptions {
+            transform_scripts: vec![(Anchor::Kernel, script.path().to_path_buf())],
+            ..LoweringOptions::default()
+        };
+        run_lowering_pipeline(&context, &mut module, &options).expect("pipeline should succeed");
+
+        assert!(module.as_operation().verify());
+        // The unrolled (and then canonicalized) loop is straight-line code:
+        // four loads and no back edge.
+        let rendered = module.as_operation().to_string();
+        assert_eq!(
+            rendered.matches("llvm.load").count(),
+            4,
+            "expected the loop fully unrolled, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("llvm.br"),
+            "expected no loop back edge after full unroll, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn scriptless_options_add_no_transform_passes() {
+        // The baseline pipeline must not observe the transform machinery at
+        // all when no script is given — same behaviour as before the anchors
+        // existed, kernel loop intact.
+        let context = crate::context();
+        let mut module = Module::parse(&context, SUM_KERNEL).expect("module should parse");
+        run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
+            .expect("pipeline should succeed");
+        let rendered = module.as_operation().to_string();
+        assert_eq!(
+            rendered.matches("llvm.load").count(),
+            1,
+            "expected the loop untouched, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn script_missing_anchor_entry_point_fails_cleanly() {
+        // A script that never defines the anchor's entry point is a pipeline
+        // error (the interpreter cannot resolve `__reussir_anchor_kernel`),
+        // not a silent no-op and not a crash.
+        let context = crate::context();
+        let mut module = Module::parse(&context, SUM_KERNEL).expect("module should parse");
+        let script = script_file(
+            r#"
+            module attributes {transform.with_named_sequence} {
+              transform.named_sequence @some_other_sequence(
+                  %m: !transform.any_op {transform.readonly}) {
+                transform.yield
+              }
+            }
+            "#,
+        );
+        let options = LoweringOptions {
+            transform_scripts: vec![(Anchor::Kernel, script.path().to_path_buf())],
+            ..LoweringOptions::default()
+        };
+        run_lowering_pipeline(&context, &mut module, &options)
+            .expect_err("missing entry point should fail the pipeline");
     }
 }

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -69,6 +69,22 @@ MlirPass reussirCreateTokenReusePass(bool reuseAcrossCall);
 // The default inliner configured with a canonicalizer that does not simplify
 // regions, matching the C++ backend pipeline.
 MlirPass reussirCreateDefaultInlinerPass(void);
+
+// The upstream transform-dialect interpreter, applying the transform named
+// sequence `entryPoint` to the payload module. The entry point is resolved
+// first in the payload module itself, then in the context's transform
+// library (populated by the preload pass below); the pass fails if it is
+// found in neither. The pipeline runs one interpreter per anchor, each with
+// the anchor's `__reussir_anchor_<name>` entry point.
+MlirPass reussirCreateTransformInterpreterPass(MlirStringRef entryPoint);
+
+// The upstream transform-library preload pass: parses each of the `nPaths`
+// script files in `paths` and merges its transform named sequences into the
+// context-wide transform library consulted by the interpreter. Merging
+// reports a symbol clash, so distinct scripts must use distinct entry
+// points (one script per anchor).
+MlirPass reussirCreateTransformPreloadLibraryPass(MlirStringRef const *paths,
+                                                  intptr_t nPaths);
 MlirPass reussirCreateCanonicalizerPass(void);
 MlirPass reussirCreateCSEPass(void);
 MlirPass reussirCreateControlFlowSinkPass(void);

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -25,10 +25,14 @@
 #include <mlir/Dialect/DLTI/DLTI.h>
 #include <mlir/Dialect/Func/Extensions/InlinerExtension.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Func/TransformOps/FuncTransformOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/Dialect/Linalg/TransformOps/DialectExtension.h>
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/SCF/TransformOps/SCFTransformOps.h>
+#include <mlir/Dialect/Transform/IR/TransformDialect.h>
 #include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
@@ -60,6 +64,20 @@ void populateReussirRegistry(mlir::DialectRegistry &registry) {
   // separately registered extension; without it the inliner pass resolves no
   // `func.call` sites and silently inlines nothing.
   mlir::func::registerInlinerExtension(registry);
+
+  // The transform dialect carries user-authored schedules (issue #349): the
+  // lowering pipeline can run `transform-interpreter` at named anchors over
+  // scripts supplied by the driver (`rrc --transform-script`). Register the
+  // dialect plus the extensions schedules need — func/structured matching
+  // (`transform.structured.match`) and the scf loop transforms
+  // (`transform.loop.*`). This keeps the minimal-dialect policy above: none
+  // of it (nor the dialects the extensions declare) is loaded into a context
+  // until a schedule actually parses transform ops, so pipelines without
+  // scripts see the same loaded-dialect set as before.
+  registry.insert<mlir::transform::TransformDialect>();
+  mlir::func::registerTransformDialectExtension(registry);
+  mlir::linalg::registerTransformDialectExtension(registry);
+  mlir::scf::registerTransformDialectExtension(registry);
 
   // Register the ConvertToLLVMPatternInterface for exactly the dialects that can
   // reach the ConvertToLLVM pass, plus Reussir's own lowering interface. These

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -19,12 +19,14 @@
 #include <mlir/Bytecode/BytecodeImplementation.h>
 #include <mlir/CAPI/IR.h>
 #include <mlir/CAPI/Pass.h>
+#include <mlir/CAPI/Support.h>
 #include <mlir/Conversion/ConvertToLLVM/ToLLVMPass.h>
 #include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
 #include <mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h>
 #include <mlir/Dialect/DLTI/DLTI.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/Dialect/Transform/Transforms/Passes.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Target/LLVMIR/Import.h>
@@ -138,6 +140,19 @@ MlirPass reussirCreateDefaultInlinerPass(void) {
   llvm::StringMap<mlir::OpPassManager> pipelines;
   return wrapOwned(mlir::createInlinerPass(
       pipelines, addCanonicalizerWithoutRegionSimplification));
+}
+MlirPass reussirCreateTransformInterpreterPass(MlirStringRef entryPoint) {
+  mlir::transform::InterpreterPassOptions options;
+  options.entryPoint = unwrap(entryPoint).str();
+  return wrapOwned(mlir::transform::createInterpreterPass(options));
+}
+MlirPass reussirCreateTransformPreloadLibraryPass(MlirStringRef const *paths,
+                                                  intptr_t nPaths) {
+  mlir::transform::PreloadLibraryPassOptions options;
+  options.transformLibraryPaths.reserve(nPaths);
+  for (intptr_t i = 0; i < nPaths; ++i)
+    options.transformLibraryPaths.push_back(unwrap(paths[i]).str());
+  return wrapOwned(mlir::transform::createPreloadLibraryPass(options));
 }
 MlirPass reussirCreateCanonicalizerPass(void) {
   return wrapOwned(mlir::createCanonicalizerPass());

--- a/tests/integration/conversion/transform/embedded_schedule_unroll.mlir
+++ b/tests/integration/conversion/transform/embedded_schedule_unroll.mlir
@@ -1,0 +1,67 @@
+// Payload-embedded transform schedule (issue #349): the schedule lives in the
+// same module as the kernel — a `transform.named_sequence` discovered through
+// the module's `transform.with_named_sequence` attribute and the interpreter's
+// default `__transform_main` entry point. This is the shape the planned
+// frontend `transform <name> for <fn> { ... }` items codegen to, and it pins
+// the LLVM transform-op spellings (`transform.structured.match` with an
+// `attributes{...}` filter, `transform.loop.unroll`) the pipeline anchors
+// rely on.
+//
+// RUN: %reussir-opt %s --transform-interpreter -o - | %FileCheck %s
+
+!arr = !reussir.array<1024 x f64>
+!rc = !reussir.rc<!arr>
+
+module attributes {transform.with_named_sequence} {
+  // saxpy over refcounted arrays: y[i] = a * x[i] + y[i], reading x through a
+  // borrowed view and updating y in place through a unique view.
+  func.func @saxpy(%y: !rc, %x: !rc, %a: f64) -> !rc
+      attributes {reussir.kernel} {
+    %xb = reussir.rc.borrow (%x : !rc) : !reussir.ref<!arr>
+    %xv = reussir.array.view(%xb : !reussir.ref<!arr>) : memref<1024xf64>
+    %r = reussir.array.with_unique_view (%y : !rc) -> !rc {
+      ^bb0(%v: memref<1024xf64>):
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %n = arith.constant 1024 : index
+        scf.for %i = %c0 to %n step %c1 {
+          %xi = memref.load %xv[%i] : memref<1024xf64>
+          %yi = memref.load %v[%i] : memref<1024xf64>
+          %axi = arith.mulf %a, %xi : f64
+          %s = arith.addf %axi, %yi : f64
+          memref.store %s, %v[%i] : memref<1024xf64>
+        }
+        reussir.scf.yield
+    }
+    reussir.rc.dec (%x : !rc)
+    return %r : !rc
+  }
+
+  // The user-authored schedule, parameterized over the target function.
+  transform.named_sequence @saxpy_schedule(
+      %target: !transform.any_op {transform.readonly}) {
+    %loops = transform.structured.match ops{["scf.for"]} in %target
+        : (!transform.any_op) -> !transform.op<"scf.for">
+    transform.loop.unroll %loops { factor = 4 } : !transform.op<"scf.for">
+    transform.yield
+  }
+
+  // The entry point scopes matching to `reussir.kernel`-tagged functions and
+  // dispatches to the schedule, so untagged functions stay untouched.
+  transform.named_sequence @__transform_main(
+      %m: !transform.any_op {transform.readonly}) {
+    %f = transform.structured.match ops{["func.func"]}
+        attributes{reussir.kernel} in %m
+        : (!transform.any_op) -> !transform.any_op
+    transform.include @saxpy_schedule failures(propagate) (%f)
+        : (!transform.any_op) -> ()
+    transform.yield
+  }
+}
+
+// After unroll by 4: one loop stepping by 4 whose body carries four
+// multiply-add pairs.
+// CHECK: func.func @saxpy
+// CHECK: scf.for
+// CHECK-COUNT-4: arith.mulf
+// CHECK-NOT: arith.mulf


### PR DESCRIPTION
Part of #349 (AI-native transform pipeline) — the Phase 1 **pipeline** slice, split out for review size; the `rrc --transform-script` driver surface stacks on top in the follow-up PR (2/2). Together they make user-authored MLIR transform-dialect schedules run inside the production lowering pipeline (rrc/JIT/REPL), not just via `reussir-opt`.

## What this adds

- **Registry** (`lib/CAPI/Dialects.cpp`): the transform dialect plus the func/linalg/scf transform extensions (`transform.structured.match`, `transform.loop.*`) in `reussirPopulateRegistry`. Registration is load-lazy — pipelines without scripts keep exactly today's loaded-dialect set, honoring the existing minimal-dialect policy (verified: the `ReussirConvertToLLVMPass` promised-interface concern does not trigger when a schedule loads the extensions' dependent dialects).
- **C API** (`lib/CAPI/Passes.cpp`): `reussirCreateTransformInterpreterPass(entryPoint)` and `reussirCreateTransformPreloadLibraryPass(paths, nPaths)`, mirrored in `reussir-backend-sys`.
- **Pipeline** (`reussir-backend/src/pipeline.rs`): `Anchor { Entry, Kernel }` and `LoweringOptions::transform_scripts: Vec<(Anchor, PathBuf)>` (drops `Copy`, keeps `Clone`). All scripts are preloaded into the context transform library once; each anchor with a script runs the interpreter with that anchor's entry point:
  - `entry` — before any Reussir pass (pure `reussir` dialect IR from codegen);
  - `kernel` — after both `scf-ops-lowering` runs + polymorphic-FFI compile, before the LLVM descent (kernels are plain memref/scf/arith loop nests).

## Design decisions (deviations from the issue sketch, feedback welcome)

1. **Entry-point convention**: file scripts define `transform.named_sequence @__reussir_anchor_<anchor>` rather than `@__transform_main`. The preload library is context-global, so per-anchor entry names let scripts for several anchors coexist without symbol clashes; it also matches the entry points Phase 2 inline schedules will synthesize.
2. **Anchors shipped: `entry` + `kernel` only** — resolving open question 3 toward the minimal set; `pre-reuse` can be added on demand once a use case appears (each anchor is a frozen IR contract to maintain).

Out of scope (next PRs per the issue's breakdown): the driver flag + its e2e lit coverage (2/2, stacked), the `reussir-check-structural-invariants` gate (B3), `--dump-at`/`--list-anchors` (B4), frontend attributes + `transform NAME for TARGET` items (F1–F4), SMT/Lean validation (V1–V4).

## Testing

- Unit (`reussir-backend`): kernel-anchor script fully unrolls a loop through the whole pipeline to LLVM dialect; scriptless options add no transform passes (baseline IR unchanged); a script missing the anchor entry point fails the pipeline cleanly.
- Lit: `conversion/transform/embedded_schedule_unroll.mlir` — payload-embedded schedule through `reussir-opt --transform-interpreter` (pins the LLVM 22 transform-op spellings; the shape Phase 2 codegen will emit).
- `ninja check` green; `cargo test -p reussir-backend`: all green; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JE66sf9LGX3Px8A7LRLEod
