### PR TITLE
[driver] rrc --transform-script: run schedules at pipeline anchors (#349 Phase 1, 2/2)

### DIFF
--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -21,7 +21,7 @@ use palc::Parser;
 
 use reussir_backend::llvm::LlvmLowering;
 use reussir_backend::melior::ir::Module;
-use reussir_backend::pipeline::{self, LoweringOptions, NullaryVariantEncoding, OptLevel};
+use reussir_backend::pipeline::{self, Anchor, LoweringOptions, NullaryVariantEncoding, OptLevel};
 use reussir_codegen::lower::{CodegenUnit, LinkagePolicy, lower_program, lower_unit};
 use reussir_codegen::source::{FileId, SourceCache};
 use reussir_compiler::package;
@@ -200,6 +200,15 @@ struct Cli {
     #[arg(long = "no-closure-wpd")]
     no_closure_wpd: bool,
 
+    /// Run a transform-dialect script at a named pipeline anchor:
+    /// `<file.mlir>[@<anchor>]`, where `<anchor>` is `entry` (pure Reussir IR,
+    /// before any pipeline pass) or `kernel` (loop nests as memref/scf/arith,
+    /// before the LLVM descent; the default). Repeatable. The script must
+    /// define `transform.named_sequence @__reussir_anchor_<anchor>` in a
+    /// module with the `transform.with_named_sequence` attribute.
+    #[arg(long = "transform-script")]
+    transform_script: Vec<String>,
+
     /// Lay out compound record members in declaration order instead of the
     /// default packed order (members sorted by descending storage alignment,
     /// eliminating inter-member padding). Packing is the shipped default and
@@ -295,6 +304,26 @@ fn parse_opt(s: &str) -> Result<OptLevel, String> {
         "size" => Ok(OptLevel::Size),
         other => Err(format!("unknown -O level `{other}`")),
     }
+}
+
+/// Parses the `--transform-script` specs: `<file>[@<anchor>]`, anchor
+/// defaulting to `kernel`. The anchor is whatever follows the *last* `@`, so
+/// a path may itself contain `@` as long as an explicit anchor is given.
+fn parse_transform_scripts(specs: &[String]) -> Result<Vec<(Anchor, PathBuf)>, String> {
+    specs
+        .iter()
+        .map(|spec| match spec.rsplit_once('@') {
+            Some((path, anchor)) => match Anchor::parse(anchor) {
+                Some(anchor) => Ok((anchor, PathBuf::from(path))),
+                None => Err(format!(
+                    "unknown anchor `{anchor}` in `--transform-script {spec}`: \
+                     expected `entry` or `kernel` (append `@kernel` explicitly \
+                     if the file name itself contains `@`)"
+                )),
+            },
+            None => Ok((Anchor::Kernel, PathBuf::from(spec))),
+        })
+        .collect()
 }
 
 fn parse_reloc(s: &str) -> Result<RelocMode, String> {
@@ -612,6 +641,7 @@ fn backend_module(
         nullary_variant_encoding: cli.nullary_variant_encoding.resolve(machine.triple()),
         pack_record_members: !cli.no_pack_record_members,
         closure_wpd,
+        transform_scripts: parse_transform_scripts(&cli.transform_script)?,
         ..LoweringOptions::default()
     };
     let optimize_ffi = !matches!(opt, OptLevel::None);

--- a/tests/integration/conversion/transform/Inputs/dot_unroll.transform.mlir
+++ b/tests/integration/conversion/transform/Inputs/dot_unroll.transform.mlir
@@ -1,0 +1,19 @@
+// File-based schedule consumed by `rrc --transform-script <this file>@kernel`
+// (issue #349). The driver preloads it into the context's transform library;
+// the interpreter then runs the anchor entry point
+// `@__reussir_anchor_kernel` over the payload module.
+//
+// Matching contract: schedules scope themselves to `reussir.kernel`-tagged
+// functions, keeping the blast radius limited to code that opted in.
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__reussir_anchor_kernel(
+      %m: !transform.any_op {transform.readonly}) {
+    %f = transform.structured.match ops{["func.func"]}
+        attributes{reussir.kernel} in %m
+        : (!transform.any_op) -> !transform.any_op
+    %loops = transform.structured.match ops{["scf.for"]} in %f
+        : (!transform.any_op) -> !transform.op<"scf.for">
+    transform.loop.unroll %loops { factor = 4 } : !transform.op<"scf.for">
+    transform.yield
+  }
+}

--- a/tests/integration/conversion/transform/Inputs/no_entry_point.transform.mlir
+++ b/tests/integration/conversion/transform/Inputs/no_entry_point.transform.mlir
@@ -1,0 +1,9 @@
+// A well-formed transform library that never defines any
+// `__reussir_anchor_<name>` entry point; the interpreter must fail with a
+// diagnostic naming the missing sequence rather than silently doing nothing.
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @some_other_sequence(
+      %m: !transform.any_op {transform.readonly}) {
+    transform.yield
+  }
+}

--- a/tests/integration/conversion/transform/dot_file_script_e2e.mlir
+++ b/tests/integration/conversion/transform/dot_file_script_e2e.mlir
@@ -1,0 +1,97 @@
+// `rrc --transform-script` end-to-end (issue #349): the integrated lowering
+// pipeline preloads the file-based schedule, runs the transform interpreter
+// at the `kernel` anchor, and continues through the ordinary LLVM descent —
+// reading MLIR and emitting the LLVM dialect, then a linked binary that
+// EXECUTES and checks the scheduled kernel still computes
+// dot(0..15, 1..16) = 1360.
+//
+// The schedule (Inputs/dot_unroll.transform.mlir) unrolls the dot loop by 4;
+// only the `reussir.kernel`-tagged function is matched, so `iota` keeps its
+// rolled loop. In the LLVM-dialect output that shows up as the four
+// multiplies of the unrolled body (the kernel is otherwise the only source
+// of integer multiplication).
+//
+// Both runs pin `-O none`: with optimization enabled the inliner runs long
+// before the `kernel` anchor, inlines the private `@dot` into `@main` and
+// erases it, so a schedule scoped to the tagged function finds no match and
+// (correctly) fails the build. Keeping scheduled kernels alive across the
+// optimization prologue is frontend work (`#[kernel]` in issue #349 Phase 2).
+//
+// RUN: %rrc %s --emit mlir-llvm -O none \
+// RUN:   --transform-script %S/Inputs/dot_unroll.transform.mlir@kernel -o - \
+// RUN:   | %FileCheck %s
+//
+// The anchor tag is optional and defaults to `kernel`.
+// RUN: %rrc %s -O none --transform-script %S/Inputs/dot_unroll.transform.mlir \
+// RUN:   -o %t.o
+// RUN: %cc %t.o -o %t.exe -L%library_path -lreussir_rt \
+// RUN:   %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+//
+// CHECK: llvm.func
+// CHECK-COUNT-4: llvm.mul
+// CHECK-NOT: llvm.mul
+
+!arr = !reussir.array<16 x i64>
+!rc = !reussir.rc<!arr>
+
+module {
+  // dot(a, b) = sum a[i] * b[i], reading both arrays through borrowed views.
+  func.func private @dot(%a: !rc, %b: !rc) -> i64
+      attributes {llvm.linkage = #llvm.linkage<internal>, reussir.kernel} {
+    %ab = reussir.rc.borrow (%a : !rc) : !reussir.ref<!arr>
+    %av = reussir.array.view(%ab : !reussir.ref<!arr>) : memref<16xi64>
+    %bb = reussir.rc.borrow (%b : !rc) : !reussir.ref<!arr>
+    %bv = reussir.array.view(%bb : !reussir.ref<!arr>) : memref<16xi64>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %n = arith.constant 16 : index
+    %zero = arith.constant 0 : i64
+    %r = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %zero) -> (i64) {
+      %ai = memref.load %av[%i] : memref<16xi64>
+      %bi = memref.load %bv[%i] : memref<16xi64>
+      %p = arith.muli %ai, %bi : i64
+      %s = arith.addi %acc, %p : i64
+      scf.yield %s : i64
+    }
+    reussir.rc.dec (%a : !rc)
+    reussir.rc.dec (%b : !rc)
+    return %r : i64
+  }
+
+  // iota(s)[i] = i + s.
+  func.func private @iota(%s: i64) -> !rc
+      attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %poison = ub.poison : !arr
+    %xs = reussir.rc.create value(%poison : !arr) : !rc
+    %filled = reussir.array.with_unique_view (%xs : !rc) -> !rc {
+      ^bb0(%v: memref<16xi64>):
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %n = arith.constant 16 : index
+        scf.for %i = %c0 to %n step %c1 {
+          %ii = arith.index_cast %i : index to i64
+          %val = arith.addi %ii, %s : i64
+          memref.store %val, %v[%i] : memref<16xi64>
+        }
+        reussir.scf.yield
+    }
+    return %filled : !rc
+  }
+
+  func.func @main() -> i32 {
+    %z = arith.constant 0 : i64
+    %one = arith.constant 1 : i64
+    %a = func.call @iota(%z) : (i64) -> !rc
+    %b = func.call @iota(%one) : (i64) -> !rc
+    %d = func.call @dot(%a, %b) : (!rc, !rc) -> i64
+    // sum_{i=0}^{15} i*(i+1) = 1360
+    %expected = arith.constant 1360 : i64
+    %fail = arith.cmpi ne, %d, %expected : i64
+    scf.if %fail {
+      reussir.panic "scheduled dot kernel produced a wrong result"
+    }
+    %c0i32 = arith.constant 0 : i32
+    return %c0i32 : i32
+  }
+}

--- a/tests/integration/conversion/transform/transform_script_errors.mlir
+++ b/tests/integration/conversion/transform/transform_script_errors.mlir
@@ -1,0 +1,28 @@
+// Failure modes of `rrc --transform-script` (issue #349): a bad schedule is
+// always a clean compile error naming the problem, never a silent no-op.
+//
+// An unknown anchor name is a driver usage error.
+// RUN: %not %rrc %s --emit mlir-llvm \
+// RUN:   --transform-script %S/Inputs/dot_unroll.transform.mlir@bogus -o - \
+// RUN:   2>&1 | %FileCheck %s --check-prefix=BADANCHOR
+// BADANCHOR: unknown anchor `bogus`
+//
+// A script that never defines the anchor's entry point fails the pipeline
+// with the interpreter's diagnostic naming the missing sequence.
+// RUN: %not %rrc %s --emit mlir-llvm \
+// RUN:   --transform-script %S/Inputs/no_entry_point.transform.mlir@entry -o - \
+// RUN:   2>&1 | %FileCheck %s --check-prefix=NOENTRY
+// NOENTRY: could not find a nested named sequence with name: __reussir_anchor_entry
+//
+// A script file that does not exist fails the preload pass.
+// RUN: %not %rrc %s --emit mlir-llvm \
+// RUN:   --transform-script %S/Inputs/does_not_exist.transform.mlir -o - \
+// RUN:   2>&1 | %FileCheck %s --check-prefix=NOFILE
+// NOFILE: does_not_exist.transform.mlir' is neither a file nor a directory
+
+module {
+  func.func @answer() -> i32 {
+    %0 = arith.constant 42 : i32
+    func.return %0 : i32
+  }
+}

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -6,6 +6,9 @@ config.name = 'Reussir'
 config.test_format = lit.formats.ShTest(True)
 
 config.suffixes = ['.mlir', '.rr', '.repl']
+# `Inputs/` directories hold companion files (transform scripts, C drivers)
+# referenced by tests via %S; they are not tests themselves.
+config.excludes = ['Inputs']
 
 config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = os.path.join(config.test_output_root, 'test')


### PR DESCRIPTION
Stacked on #350 (base: `pm/13-transform-interpreter`) — the driver half of the Phase 1 split: expose the pipeline anchors on `rrc` so the integrated flow works end to end, reading `.rr`/`.mlir` and emitting scheduled LLVM IR or objects through the ordinary pipeline:

```bash
rrc kernel.mlir --emit llvm-ir --transform-script schedule.mlir@kernel -o kernel.ll
```

## What this adds

- `rrc --transform-script <file.mlir>[@entry|@kernel]` — repeatable; anchor defaults to `kernel`; parsed into `LoweringOptions::transform_scripts`. The anchor is whatever follows the last `@`, so paths containing `@` still work with an explicit anchor.
- Lit coverage (companion scripts under `Inputs/`, newly excluded from lit discovery):
  - `dot_file_script_e2e.mlir` — `rrc` reads MLIR with a file-based schedule, FileChecks the unrolled LLVM-dialect output (4× `llvm.mul` vs 1 unscheduled), then links and **executes** the scheduled binary (dot(0..15, 1..16) = 1360).
  - `transform_script_errors.mlir` — unknown anchor name, script missing the anchor entry point, and missing script file are all clean compile errors naming the problem.

## Known pitfall (documented in the e2e test)

With optimization enabled the inliner runs long before the `kernel` anchor and can inline + erase a private kernel function; an attribute-scoped schedule then fails its match — loudly (`transform.structured.match` requires exactly one target), never a silent no-op. The tests pin `-O none`; the principled fix is the Phase 2 `#[kernel]` attribute pinning scheduled functions across the optimization prologue.

## Testing

- `ninja check` 293/293 (with this stacked on 1/2); `cargo test -p reussir-compiler` green; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JE66sf9LGX3Px8A7LRLEod

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786057573&installation_id=144622820&pr_number=351&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F351&signature=ed62e6af7966bda81dec74cce55928ded82349c2b6d3fd818ae23e69aaf69a30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->