### PR TITLE
[backend] TokenReuse: flush carried tokens before tail-positioned calls (#325 P8)

### DIFF
--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -71,6 +71,11 @@ namespace reussir {
 //    Remove the selected token from the pool. Currently, we just iterate all
 //    the tokens to find the most suitable one.
 // 5. At `CallOpInterface` or `LoopLikeOpInterface`, we free all pending tokens.
+//    With `reuse-across-call`, non-tail calls stop flushing so tokens can feed
+//    acceptors after the call — but tail-positioned calls always flush: no
+//    acceptor can follow them, and a post-call free would break the tail call
+//    (stack overflow on deep recursion) and defer the release of every carried
+//    block until the whole callee subtree returns (#325 P8).
 //    (TODO: Exceptional/Early-Exit Regions do not exist in MLIR yet but
 //    maintainers are actively working on it. We need to monitor the progress.)
 // 6. At `RegionBranchInterface`, we continue on each nested branch and
@@ -228,6 +233,41 @@ getDfsOrder(const mlir::DenseMap<mlir::Operation *, unsigned> &dfsOrder,
   return 0;
 }
 
+// A call sits in tail position when nothing observable runs after it on any
+// path to the function return: it immediately precedes its block terminator,
+// its results feed nothing but that terminator, and every enclosing region op
+// sits in tail position itself (loops never qualify — a call ending a loop
+// body resumes iteration, not the return). Tokens carried across such a call
+// can never be consumed afterwards — the only thing that could follow is
+// their `token.free`, which both keeps the frame alive (deep nbe-shaped
+// recursion overflows the default stack) and defers the release of every
+// carried block until after the whole callee subtree (peak live memory ~
+// doubles on allocation-dense evaluators). So the matcher must treat a
+// tail-positioned call as a flush point even with reuse-across-call enabled.
+bool isTailPositioned(mlir::Operation *op) {
+  while (true) {
+    mlir::Block *block = op->getBlock();
+    if (!block)
+      return false;
+    mlir::Operation *terminator = block->getTerminator();
+    if (op->getNextNode() != terminator)
+      return false;
+    for (mlir::OpResult res : op->getResults())
+      for (mlir::Operation *user : res.getUsers())
+        if (user != terminator)
+          return false;
+    mlir::Operation *parent = block->getParentOp();
+    if (!parent)
+      return false;
+    if (isa<mlir::FunctionOpInterface>(parent))
+      return terminator->hasTrait<mlir::OpTrait::ReturnLike>();
+    if (isa<mlir::LoopLikeOpInterface>(parent) ||
+        !isa<mlir::RegionBranchOpInterface>(parent))
+      return false;
+    op = parent;
+  }
+}
+
 // A member decrement expands *inside* its owner's expanded decrement: the
 // owner's unique branch releases its fields, so a pattern-destructured child
 // box dies — and yields its reuse token — two regions deep. That token's SSA
@@ -376,7 +416,8 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
 
     for (auto &op : region.front()) {
       if (isa<mlir::LoopLikeOpInterface>(op) ||
-          (!reuseAcrossCall && isa<mlir::CallOpInterface>(op))) {
+          (isa<mlir::CallOpInterface>(op) &&
+           (!reuseAcrossCall || isTailPositioned(&op)))) {
         mlir::func::CallOp funcCall = llvm::dyn_cast<mlir::func::CallOp>(op);
         // skip intrinsic calls
         if (!funcCall ||

--- a/tests/integration/frontend/reuse_across_call_tail_stack.c
+++ b/tests/integration/frontend/reuse_across_call_tail_stack.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t tail_spin_ffi(int64_t depth);
+
+int main(void) {
+  /* Far more frames than the default 8 MiB stack can hold: only a
+     preserved tail call survives this depth. */
+  int64_t r = tail_spin_ffi(50000000);
+  if (r != 0) {
+    fprintf(stderr, "FAIL: expected 0, got %lld\n", (long long)r);
+    abort();
+  }
+  return 0;
+}

--- a/tests/integration/frontend/reuse_across_call_tail_stack.rr
+++ b/tests/integration/frontend/reuse_across_call_tail_stack.rr
@@ -1,0 +1,45 @@
+// RUN: %rrc %s -o %t.o --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %t.o %S/reuse_across_call_tail_stack.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// Deep tail recursion where the dead box's token is consumed by a create on
+// one sibling path but left pending on the other, which ends in a tail call.
+// The sibling consumption keeps the token's SSA value used, so the free
+// cannot be sunk into the decrement's unique branch (the P1 rescue); with
+// --reuse-across-call the matcher used to leave that free *after* the tail
+// call, breaking the tail-call shape — tens of millions of frames overflow
+// the default stack (#325 P8). Tail-positioned calls must flush pending
+// tokens before the call so the recursion lowers to a loop. This test
+// intentionally runs at the default stack size — do not raise RLIMIT_STACK.
+
+enum Node {
+    Big(i64, i64, i64),
+    Nil
+}
+
+fn spin(n: Node, depth: i64) -> i64 {
+    match n {
+        Node::Big(a, _, _) =>
+            if a % 2 == 0 {
+                // Consumes the dead `Big` token: same-typed create right
+                // before the call.
+                spin(Node::Big{a - 1, 0, 0}, depth)
+            } else {
+                // No acceptor on this path: the token is pending across a
+                // tail-positioned call (`Nil` is a tagged immediate).
+                spin(Node::Nil, depth)
+            },
+        Node::Nil =>
+            if depth <= 0 {
+                0
+            } else {
+                spin(Node::Big{depth * 2, 0, 0}, depth - 1)
+            }
+    }
+}
+
+fn tail_spin(depth: i64) -> i64 {
+    spin(Node::Nil, depth)
+}
+
+extern "C" trampoline "tail_spin_ffi" = tail_spin;


### PR DESCRIPTION
## Summary

Fixes **P8** from #325 — the gate for defaulting `--reuse-across-call`.

With rac enabled, calls stop being flush points, so a token with no acceptor is freed at a region terminator — *after* the call. For a **tail-positioned** call that is pure loss twice over:

1. the post-call `token.free` breaks the tail-call shape → nbe-hoas segfaults at the default 8 MiB stack;
2. the free is deferred until the whole callee subtree returns → allocation-dense recursive evaluators hold every carried block alive at peak (**~2× live memory** on the nbe pair; minor page faults scale exactly with it, and the cost is invisible to cachegrind — it's paging/TLB, not LL misses).

Nothing after a tail-positioned call can ever consume a token — the only possible successor is its own free — so carrying past one is never profitable. This PR makes tail-positioned calls flush points even in rac mode. `isTailPositioned` walks up from the call, requiring it (and each enclosing region op) to immediately precede its block terminator with results feeding nothing but that terminator, rejecting loop parents, until it reaches a ReturnLike function terminator.

## Measured (x64 Ryzen 9950X, xLTO + static mimalloc, koka 3.2.3 same-session; details in #325)

| bench (+rac) | before | after |
|---|---|---|
| nbe-hoas @8MiB stack | **segfault** | exit 0 |
| nbe-hoas | 449 ms / 429 MB | **334 ms / 246 MB** (−25% / −43%) |
| nbe-closure | 358 ms / 430 MB | **231 ms / 246 MB** (−35% / −43%) |
| rbtree (i32 port) | 358 ms / 133 MB | 358 ms / 129 MB (unchanged) |
| rbtree-zipper | 299 ms / 194 MB | 293 ms / 194 MB (unchanged) |

nbe-closure+rac now **beats** −rac (247 ms); nbe-hoas+rac is within 4% of −rac (from 39% behind). The reuse-critical carrying on rbtree/zipper is untouched — a call feeding a create is not tail-positioned.

Orthogonal to the phantom-realloc issue (counts unchanged: 8.9 M calls on nbe-hoas) — that is a separate fix targeting `possiblyInplaceReallocable`'s stale size-class model.

## Test plan
- [x] New executing lit test at **default stack size**: sibling-path consumption keeps the token's SSA value used (defeats the P1 free-sinking rescue), the other path tail-calls with the token pending; 50 M frames. Verified it **segfaults on main** and passes with this fix.
- [x] Full lit suite: 273 passed / 19 unsupported / 0 failed
- [x] ctest: 17/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786076222&installation_id=144622820&pr_number=354&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F354&signature=8902c9f2c2e8ba5b1ef6d41ed0029c2eb556bd9daff272851439a8a6fb3e161f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->