### PR TITLE
[runtime] feature flags to select bundled mimalloc major (v3 default, v2 optional)

### DIFF
--- a/crates/reussir-rt/Cargo.toml
+++ b/crates/reussir-rt/Cargo.toml
@@ -7,16 +7,25 @@ license.workspace = true
 [dependencies]
 backtrace = { version = "0.3.75" }
 hashbrown = { version = "0.16.0" }
-libmimalloc-sys = { version = "0.1.44", features = ["v3"], optional = true }
+libmimalloc-sys = { version = "0.1.44", optional = true }
 snmalloc-rs = { version = "0.7", optional = true }
 num_enum = "0.7.4"
 smallvec = "1.15.1"
 stacker.workspace = true
 
 [features]
-default = ["mimalloc"]
+default = ["mimalloc-v3"]
 snmalloc = ["snmalloc-rs"]
+# `mimalloc` is the version-neutral gate the code checks; select the bundled
+# mimalloc major through one of the versioned features (with
+# --no-default-features). v3 (default) has the reworked page management and
+# lower fragmentation; v2 is the stable line. Both share the bin geometry
+# that include/Reussir/Support/AllocatorBinModel.h models (verified by
+# probing mi_usable_size on both), so the compiler-side size-class contract
+# holds for either.
 mimalloc = ["dep:libmimalloc-sys"]
+mimalloc-v3 = ["mimalloc", "libmimalloc-sys/v3"]
+mimalloc-v2 = ["mimalloc"]
 
 [lib]
 crate-type = ["dylib", "lib", "staticlib"]


### PR DESCRIPTION
Moves the mimalloc major-version choice off the hardwired `libmimalloc-sys` feature and into `reussir-rt` features:

- `mimalloc-v3` (default) — the current behavior, v3's reworked page management / lower fragmentation
- `mimalloc-v2` — the stable line, via `--no-default-features --features mimalloc-v2`
- `mimalloc` stays as the version-neutral gate the code `cfg`-checks; both versioned features imply it

Verified both select the intended allocator (`mi_version()` = 315 / 224) and — relevant for the size-class contract from #355 — **both majors have byte-identical bin geometry** (probed `mi_usable_size(mi_malloc(n))` for n ∈ [1,1024] on each; both round small bins to double words via `MI_ALIGN2W`), so `AllocatorBinModel.h` holds for either selection with no compiler-side change.

## Test plan
- [x] default build → `mi_version() == 315`
- [x] `--no-default-features --features mimalloc-v2` → `mi_version() == 224`
- [x] bin-geometry probe identical on both
- [x] `cargo build --locked` for both (no lockfile change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786078783&installation_id=144622820&pr_number=356&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F356&signature=4ca977f43db5e161068e036bdce54932ca7e15b59b06f09b153d3da820f14805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->