### PR TITLE
[backend] gate guarded rc stores behind unlikely branches instead of cmov steering (#325)

### DIFF
--- a/include/Reussir/Transformation/SpecialPointerTag.h
+++ b/include/Reussir/Transformation/SpecialPointerTag.h
@@ -34,9 +34,13 @@ namespace reussir {
 /// taggable type = immediate = never a token" with no tag arithmetic.
 /// A hybrid "immortal fallback inside a tbi module" (zero-top-byte
 /// immediates recognized by refcount magnitude) would decouple eligibility
-/// from the tag range, but every guard would then need to LOAD the refcount
-/// — surrendering tbi's load-free `rc.set` guard, which is the encoding's
-/// point.
+/// from the tag range. It was rejected not for guard cost (at the guarded
+/// sites the count is already in a register: `rc.set` tests its own operand,
+/// `rc.inc` just loaded it) but for what it erodes: two classifiers to keep
+/// sound instead of one, immediates whose tags are no longer decodable from
+/// the pointer (the tbi encoding's FFI point), and allocation/token
+/// behavior that would differ between encodings for the same source —
+/// all to serve variants with more than 255 arms.
 constexpr llvm::StringLiteral kSpecialPtrTagAttr = "reussir.special_ptr_tag";
 
 /// TBI encoding (aarch64): the immediate's top byte is `tag + 1` and its low

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -216,15 +216,6 @@ mlir::Value isTaggedImmediate(mlir::Value topByte, mlir::Location loc,
                                     topByte, zero);
 }
 
-// Steer `addr` to the scratch word when `isTagged` holds.
-mlir::Value guardedAddr(mlir::Operation *op, mlir::Value isTagged,
-                        mlir::Value addr, mlir::Location loc,
-                        mlir::OpBuilder &builder) {
-  auto scratch =
-      tagScratchAddr(op->getParentOfType<mlir::ModuleOp>(), loc, builder);
-  return mlir::LLVM::SelectOp::create(builder, loc, isTagged, scratch, addr);
-}
-
 // Skip a guarded refcount store entirely behind an unlikely branch. The
 // select-steered form makes the store *address* data-depend on the freshly
 // loaded count, so the store — and everything queued behind it — serializes

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -225,6 +225,32 @@ mlir::Value guardedAddr(mlir::Operation *op, mlir::Value isTagged,
   return mlir::LLVM::SelectOp::create(builder, loc, isTagged, scratch, addr);
 }
 
+// Skip a guarded refcount store entirely behind an unlikely branch. The
+// select-steered form makes the store *address* data-depend on the freshly
+// loaded count, so the store — and everything queued behind it — serializes
+// against the load on every rc op (measured: IPC halves on nbe-shaped
+// traversals, #325). A predicted-not-taken branch turns that data dependency
+// into a control dependency the core speculates past, and skipping the store
+// outright also means the dummy box is never written: no scratch word, no
+// wrap-around accounting on this path.
+void emitGuardedStore(mlir::ConversionPatternRewriter &rewriter,
+                      mlir::Location loc, mlir::Value value, mlir::Value addr,
+                      mlir::Value skipCond) {
+  mlir::Block *condBlock = rewriter.getInsertionBlock();
+  mlir::Block *contBlock =
+      rewriter.splitBlock(condBlock, rewriter.getInsertionPoint());
+  mlir::Block *storeBlock = rewriter.createBlock(
+      contBlock->getParent(), mlir::Region::iterator(contBlock));
+  rewriter.setInsertionPointToEnd(storeBlock);
+  mlir::LLVM::StoreOp::create(rewriter, loc, value, addr);
+  mlir::LLVM::BrOp::create(rewriter, loc, contBlock);
+  rewriter.setInsertionPointToEnd(condBlock);
+  auto condBr = mlir::LLVM::CondBrOp::create(rewriter, loc, skipCond,
+                                             contBlock, storeBlock);
+  condBr->setAttr("branch_weights", rewriter.getDenseI32ArrayAttr({1, 2000}));
+  rewriter.setInsertionPointToStart(contBlock);
+}
+
 void ensureRuntimeFunctions(mlir::ModuleOp module,
                             const mlir::LLVMTypeConverter &converter);
 
@@ -488,13 +514,15 @@ struct ReussirRcSetConversionPattern
             : adaptor.getRefCount();
     // `rc.set` is the one store that can lower a refcount, so it must not
     // reach the dummy box (its count would eventually decay to 1 and send an
-    // immediate down the unique branch). Steer a recognized-immediate access
-    // to the scratch word instead; the address select is off any result's
-    // critical path. TBI recognizes immediates by the pointer's top byte,
-    // the immortal encoding by the magnitude of the count being stored (the
-    // dummy's decremented count still clears the threshold: it starts at
-    // 3 * 2^(w-2) and never actually decreases, since this very steering
-    // keeps every decrementing store away from it).
+    // immediate down the unique branch). Skip a recognized-immediate store
+    // behind an unlikely branch: the dummy's count is then never written at
+    // all, and the store issues speculatively on the (overwhelmingly common)
+    // real-box path instead of address-depending on the loaded count. TBI
+    // recognizes immediates by the pointer's top byte, the immortal encoding
+    // by the magnitude of the count being stored (the dummy's decremented
+    // count still clears the threshold: it starts at 3 * 2^(w-2) and never
+    // actually decreases, since this very gating keeps every decrementing
+    // store away from it).
     TagEncoding encoding = specialPtrTagEncoding(op);
     if (encoding != TagEncoding::None &&
         op.getRcPtr().getType().mayCarrySpecialPointerTag()) {
@@ -505,7 +533,9 @@ struct ReussirRcSetConversionPattern
       } else {
         tagged = isImmortalCount(narrowCount, op.getLoc(), rewriter);
       }
-      addr = guardedAddr(op, tagged, addr, op.getLoc(), rewriter);
+      emitGuardedStore(rewriter, op.getLoc(), narrowCount, addr, tagged);
+      rewriter.eraseOp(op);
+      return mlir::success();
     }
     rewriter.replaceOpWithNewOp<mlir::LLVM::StoreOp>(op, narrowCount, addr);
     return mlir::success();
@@ -1296,13 +1326,18 @@ struct ReussirRcIncConversionPattern
                                              refcntPtr);
       auto newRefCnt = mlir::arith::AddIOp::create(rewriter, op.getLoc(),
                                                    countType, oldRefCnt, one);
-      mlir::Value storeAddr = refcntPtr;
       if (steerNarrowImmortal) {
+        // Same rationale as `rc.set`: skip the dummy's store behind an
+        // unlikely branch rather than address-selecting it into the scratch
+        // word, so the store doesn't data-depend on the loaded count.
         mlir::Value immortal =
             isImmortalCount(oldRefCnt, op.getLoc(), rewriter);
-        storeAddr = guardedAddr(op, immortal, refcntPtr, op.getLoc(), rewriter);
+        emitGuardedStore(rewriter, op.getLoc(), newRefCnt, refcntPtr,
+                         immortal);
+      } else {
+        mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), newRefCnt,
+                                    refcntPtr);
       }
-      mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), newRefCnt, storeAddr);
     } else {
       oldRefCnt = mlir::LLVM::AtomicRMWOp::create(
           rewriter, op.getLoc(), mlir::LLVM::AtomicBinOp::add, refcntPtr, one,

--- a/tests/integration/conversion/special_pointer_tag_lowering.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering.mlir
@@ -7,13 +7,13 @@
 // `{refcount = 2, tag}`. TBI makes loads through the tagged value land in
 // the dummy box, so the hot reads (rc.fetch, rc.is_unique, record.tag)
 // lower to plain loads with no immediate-check; only `rc.set` — the one
-// store that could decay the dummy's refcount to 1 — steers a tagged
-// access to the scratch word.
+// store that could decay the dummy's refcount to 1 — skips a tagged
+// access behind an unlikely branch (a select-steered store address would
+// data-depend on the count and serialize every rc op against its load).
 
 !list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Nil" [value] {}>}>
 !rclist = !reussir.rc<!list>
 
-// CHECK-DAG: @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2 = internal global i64 0
 // CHECK-DAG: @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX = internal global [2 x i32] [i32 2, i32 1]
 module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
 
@@ -53,15 +53,18 @@ module @test attributes { reussir.special_ptr_tag = "tbi", dlti.dl_spec = #dlti.
     return %tag : index
   }
 
-  // The decrementing store: a tagged access is steered to the scratch word
-  // so the dummy refcount can never decay below 2.
+  // The decrementing store: a tagged access skips the store entirely via an
+  // unlikely branch, so the dummy refcount is never written and can never
+  // decay below 2.
   // CHECK-LABEL: define void @set(ptr %0, i64 %1)
   // CHECK: %[[NARROW:.+]] = trunc i64 %1 to i32
   // CHECK: %[[INT:.+]] = ptrtoint ptr %0 to i64
   // CHECK: %[[TOP:.+]] = lshr i64 %[[INT]], 56
   // CHECK: %[[ISTAG:.+]] = icmp ne i64 %[[TOP]], 0
-  // CHECK: %[[ADDR:.+]] = select i1 %[[ISTAG]], ptr @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2, ptr %0
-  // CHECK: store i32 %[[NARROW]], ptr %[[ADDR]]
+  // CHECK: br i1 %[[ISTAG]], label %[[CONT:.+]], label %[[STORE:.+]], !prof
+  // CHECK: [[STORE]]:
+  // CHECK: store i32 %[[NARROW]], ptr %0
+  // CHECK: br label %[[CONT]]
   func.func @set(%rc: !rclist, %v: index) {
     reussir.rc.set(%rc : !rclist, %v : index)
     return

--- a/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering_immortal.mlir
@@ -8,12 +8,11 @@
 // 3 * 2^62 = 0xC000000000000000 for a 64-bit refcount word. Hot reads
 // (rc.fetch, rc.is_unique, record.tag) are plain loads; `rc.set` recognizes
 // a dummy by the magnitude of the stored count (>= 2^63; a real refcount
-// can never get there) and steers it to the scratch word.
+// can never get there) and skips it behind an unlikely branch.
 
 !list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Nil" [value] {}>}>
 !rclist = !reussir.rc<!list>
 
-// CHECK-DAG: @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2 = internal global i64 0
 // CHECK-DAG: @_RNvC17REUSSIR_TAG_DUMMY43JTSaUNTZpqgb8a0JnRra5ebq8TvOJDFg1m5Smu4IYVX = internal global [2 x i32] [i32 -1073741824, i32 1]
 module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
 
@@ -54,13 +53,16 @@ module @test attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #
 
   // The decrementing store: a count at or above 2^63 identifies a dummy
   // (its stored value is `immortal - 1`, still over the threshold), and the
-  // store is steered to the scratch word so the dummy never decays.
+  // store is skipped behind an unlikely branch so the dummy never decays —
+  // and the store no longer address-depends on the loaded count.
   // CHECK-LABEL: define void @set(ptr %0, i64 %1)
   // CHECK-NOT: lshr
   // CHECK: %[[NARROW:.+]] = trunc i64 %1 to i32
   // CHECK: %[[ISDUMMY:.+]] = icmp uge i32 %[[NARROW]], -2147483648
-  // CHECK: %[[ADDR:.+]] = select i1 %[[ISDUMMY]], ptr @_RNvC19REUSSIR_TAG_SCRATCH43DvQR3LzfbDLEt0P0zamCLh5N8ob8mGkcKPkikTHzGH2, ptr %0
-  // CHECK: store i32 %[[NARROW]], ptr %[[ADDR]]
+  // CHECK: br i1 %[[ISDUMMY]], label %[[CONT:.+]], label %[[STORE:.+]], !prof
+  // CHECK: [[STORE]]:
+  // CHECK: store i32 %[[NARROW]], ptr %0
+  // CHECK: br label %[[CONT]]
   func.func @set(%rc: !rclist, %v: index) {
     reussir.rc.set(%rc : !rclist, %v : index)
     return


### PR DESCRIPTION
## The finding (perf-counter session, full data in #325)

With footprint and miss counts fully controlled (the padded-Koka experiment), the residual nbe gap is pure IPC: **2.0 vs Koka's 4.06** at equal L1d/dTLB/branch-miss counts. The special-pointer-tag scheme's scratch-word steering lowers guarded rc stores as an address `select` → `cmov`, so the store address data-depends on the just-loaded refcount and every rc op serializes against its header load. Census: our hot `eval` carried **23 cmov + 12 memory-RMW** rc ops; Koka's eval has **0 and 0**.

## The fix

Lower the guard as a **predicted-not-taken branch that skips the store outright** (`branch_weights` 1:2000) at both guarded sites (`rc.set`, immortal 32-bit `rc.inc`). Control dependency → speculation. Bonus soundness simplification: the dummy box is *never written* on these paths — the scratch-word steering disappears from the rc guards along with its wrap-around accounting. (`tagScratchAddr` remains for the cctx hole-plug store, deliberately: its `hole == null` condition is not rare-biased, so `cmov` stays the right tool there.)

## Revision 2026-07-10

Rebased onto main (now carrying per-constructor box sizing #360–#367 and the nullary-token-uniformity fix #369); removed the orphaned `guardedAddr` helper (`-Werror`-clean); refined the scheme-invariant notes in `SpecialPointerTag.h`.

## Measured on the rebase (x64 9950X, ThinLTO, koka 3.2.3, suite driver, same-session koka lane)

| bench (+rac) | before (main) | gated | koka |
|---|---|---|---|
| nbe-hoas | 225.6 ms | **184.1 ms (−18%)** | 190.2 ms — **the last loss flips to a win** |
| nbe-closure | 126.7 ms | **114.5 ms (−10%)** | 131.2 ms |
| rbtree | 352.7 ms | 355.6 ms | 375.6 ms — the designed-adversarial case holds |

With this PR on top of #369, **Reussir beats Koka on all 5 suite benchmarks**.

## Test plan
- [x] `special_pointer_tag_lowering{,_immortal}.mlir` updated to the branch shape; scratch-global CHECK removed from the guarded sites
- [x] Full conversion+frontend lit 175/175 on the rebase
- [x] Benchmark sweep above (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)