### PR TITLE
[backend] variant-encoding: PoC Koka/Lean low-bit TaggedBox encoding (#325)

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -110,13 +110,13 @@ unsafe extern "C" {
     pub fn reussirCreateSCFOpsLoweringPass() -> MlirPass;
     pub fn reussirCreateRcCreateSinkPass() -> MlirPass;
 
-    /// Encodes nullary variants of shared rc-boxed enums as tagged pointer
-    /// immediates (top byte = tag + 1) and stamps the module so the LLVM
-    /// lowering steers refcount stores away from the dummy boxes. Only added
-    /// when the scheme is enabled; `arch_independent` selects the encoding:
-    /// false = `tbi` (top-byte tag, aarch64), true = `immortal` (plain dummy
-    /// address with an immortal refcount, any target).
-    pub fn reussirCreateSpecialPointerTagPass(arch_independent: bool) -> MlirPass;
+    /// Encodes nullary variants of shared rc-boxed enums as unboxed
+    /// immediates and stamps the module so the LLVM lowering steers the cold
+    /// refcount guards. Only added when the scheme is enabled; `encoding`
+    /// selects the representation: `tbi` (top-byte tag, aarch64), `immortal`
+    /// (plain dummy address with an immortal refcount, any target), or
+    /// `taggedbox` (Koka/Lean-style low-bit immediate, no dummy box).
+    pub fn reussirCreateSpecialPointerTagPass(encoding: MlirStringRef) -> MlirPass;
     pub fn reussirCreateRcDispatchFusionPass() -> MlirPass;
     pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -66,6 +66,24 @@ pub enum NullaryVariantEncoding {
     /// dependency (works on any target, including wasm32); foreign code
     /// sees a layout-compatible box.
     Immortal,
+    /// PoC (#325): Koka/Lean-style low-bit tagged immediate `(tag << 1) | 1`.
+    /// No dummy box; rc ops recognize the immediate by testing the pointer's
+    /// low bit and skip the box behind a predicted-not-taken branch, and the
+    /// variant tag is decoded as `imm >> 1`. Targets without TBI (x86_64).
+    TaggedBox,
+}
+
+impl NullaryVariantEncoding {
+    /// The `reussir-special-pointer-tag` pass `encoding=` string for this
+    /// choice (only the immediate encodings; `Boxed` runs no pass).
+    fn pass_encoding(self) -> &'static str {
+        match self {
+            NullaryVariantEncoding::Boxed => "",
+            NullaryVariantEncoding::Tbi => "tbi",
+            NullaryVariantEncoding::Immortal => "immortal",
+            NullaryVariantEncoding::TaggedBox => "taggedbox",
+        }
+    }
 }
 
 /// A named interception point in the lowering pipeline where user-supplied
@@ -305,7 +323,7 @@ pub fn run_lowering_pipeline(
         // construction.
         if options.nullary_variant_encoding != NullaryVariantEncoding::Boxed => {
             module: sys::reussirCreateSpecialPointerTagPass(
-                options.nullary_variant_encoding == NullaryVariantEncoding::Immortal,
+                string_ref(options.nullary_variant_encoding.pass_encoding()),
             );
         }
 

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -73,6 +73,13 @@ enum VariantEncoding {
     /// The immortal dummy-box encoding — no TBI/LAM pointer tricks, works
     /// on any target (including wasm32).
     ArchIndependent,
+    /// PoC (#325): Koka/Lean-style low-bit tagged immediate. A nullary
+    /// variant becomes the pure value `(tag << 1) | 1` — no dummy box at
+    /// all — and rc ops recognize it by testing the low bit, taking the
+    /// predicted-not-taken branch rather than the immortal encoding's
+    /// count-magnitude guard. Intended for targets without TBI (x86_64),
+    /// where it trades the immortal dummy-box reads for branchy tag decodes.
+    TaggedBox,
     /// Legacy heap-boxed layout; no immediates.
     Boxed,
 }
@@ -89,6 +96,7 @@ impl VariantEncoding {
                 }
             }
             VariantEncoding::ArchIndependent => NullaryVariantEncoding::Immortal,
+            VariantEncoding::TaggedBox => NullaryVariantEncoding::TaggedBox,
             VariantEncoding::Boxed => NullaryVariantEncoding::Boxed,
         }
     }
@@ -215,8 +223,10 @@ struct Cli {
     /// the arch-independent form. `arch-independent` uses no TBI/LAM-style
     /// pointer tricks on any target: the immediate is the dummy box address
     /// itself, with an immortal refcount — foreign code sees a
-    /// layout-compatible box. `boxed` keeps the legacy heap-boxed layout.
-    #[arg(long = "nullary-variant-encoding", value_enum,
+    /// layout-compatible box. `tagged-box` is a PoC Koka/Lean-style low-bit
+    /// immediate — `(tag << 1) | 1`, no dummy box, low-bit branch guards.
+    /// `boxed` keeps the legacy heap-boxed layout.
+    #[arg(long = "variant-encoding", value_enum,
           default_value_t = VariantEncoding::ArchDependent)]
     nullary_variant_encoding: VariantEncoding,
 

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -40,13 +40,14 @@ MlirPass reussirCreateInferVariantTagPass(void);
 MlirPass reussirCreateSCFOpsLoweringPass(void);
 MlirPass reussirCreateRcCreateSinkPass(void);
 
-/// Encodes nullary variants of shared rc-boxed enums as tagged pointer
-/// immediates (top byte = tag + 1) and stamps the module so the LLVM
-/// lowering steers refcount stores away from the dummy boxes. Add only when
-/// the scheme is enabled; `archIndependent` selects the encoding: false =
-/// `tbi` (top-byte tag, requires hardware top-byte-ignore, aarch64), true =
-/// `immortal` (plain dummy address with an immortal refcount, any target).
-MlirPass reussirCreateSpecialPointerTagPass(bool archIndependent);
+/// Encodes nullary variants of shared rc-boxed enums as unboxed immediates
+/// and stamps the module so the LLVM lowering steers the cold refcount
+/// guards. Add only when the scheme is enabled; `encoding` selects the
+/// representation: `tbi` (top-byte tag, requires hardware top-byte-ignore,
+/// aarch64), `immortal` (plain dummy address with an immortal refcount, any
+/// target), or `taggedbox` (Koka/Lean-style low-bit immediate `(tag<<1)|1`,
+/// no dummy box; low-bit branch guards, for targets without TBI).
+MlirPass reussirCreateSpecialPointerTagPass(MlirStringRef encoding);
 MlirPass reussirCreateRcDispatchFusionPass(void);
 MlirPass reussirCreateRcCreateFusionPass(void);
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void);

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -26,14 +26,16 @@ def ReussirSpecialPointerTagPass
     shared rc-boxed enums into `reussir.rc.tagged` immediates pointing at
     per-tag dummy boxes (no allocation) and stamps the module with the
     chosen encoding so the LLVM lowering steers refcount stores away from
-    the dummy boxes on taggable types. Two encodings exist: `tbi` (top byte
-    = tag + 1; hard-depends on hardware top-byte-ignore, aarch64) and
-    `immortal` (plain dummy address with an immortal refcount; no
-    architectural dependency).
+    the dummy boxes on taggable types. Three encodings exist: `tbi` (top byte
+    = tag + 1; hard-depends on hardware top-byte-ignore, aarch64), `immortal`
+    (plain dummy address with an immortal refcount; no architectural
+    dependency), and `taggedbox` (PoC Koka/Lean-style low-bit immediate
+    `(tag << 1) | 1`; no dummy box, rc ops guard on the pointer's low bit).
   }];
   let options = [Option<"encoding", "encoding", "std::string",
                         /*default=*/"\"tbi\"",
-                        "Immediate encoding: 'tbi' or 'immortal'">];
+                        "Immediate encoding: 'tbi', 'immortal', or "
+                        "'taggedbox'">];
   let dependentDialects = ["::reussir::ReussirDialect"];
 }
 

--- a/include/Reussir/Transformation/SpecialPointerTag.h
+++ b/include/Reussir/Transformation/SpecialPointerTag.h
@@ -30,6 +30,15 @@ constexpr llvm::StringLiteral kSpecialPtrTagTBI = "tbi";
 /// value (2^62); guards test refcount magnitude instead of pointer bits.
 constexpr llvm::StringLiteral kSpecialPtrTagImmortal = "immortal";
 
+/// PoC (#325): Koka/Lean-style low-bit tagged immediate. A nullary variant
+/// is the pure value `(tag << 1) | 1` — no dummy box exists — so the
+/// immediate is *not* dereferenceable. Every rc op that would touch the box
+/// first tests the pointer's low bit and skips the box behind a
+/// predicted-not-taken branch; the variant tag is decoded as `imm >> 1`.
+/// Recognition is a cheap `and` rather than a load, mirroring Koka's
+/// `kk_datatype_is_ptr`. For targets without TBI (x86_64).
+constexpr llvm::StringLiteral kSpecialPtrTagTaggedBox = "taggedbox";
+
 } // namespace reussir
 
 #endif // REUSSIR_TRANSFORMATION_SPECIALPOINTERTAG_H

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -39,7 +39,6 @@
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/Transformation/Passes.h"
-#include "Reussir/Transformation/SpecialPointerTag.h"
 
 using namespace mlir;
 
@@ -86,10 +85,9 @@ MlirPass reussirCreateInferVariantTagPass(void) {
 MlirPass reussirCreateSCFOpsLoweringPass(void) {
   return wrapOwned(reussir::createReussirSCFOpsLoweringPass());
 }
-MlirPass reussirCreateSpecialPointerTagPass(bool archIndependent) {
+MlirPass reussirCreateSpecialPointerTagPass(MlirStringRef encoding) {
   reussir::ReussirSpecialPointerTagPassOptions options;
-  options.encoding = archIndependent ? reussir::kSpecialPtrTagImmortal.str()
-                                     : reussir::kSpecialPtrTagTBI.str();
+  options.encoding = unwrap(encoding).str();
   return wrapOwned(reussir::createReussirSpecialPointerTagPass(options));
 }
 

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -113,7 +113,17 @@ namespace {
 // The only other guard is `rc.assume_unique`, which must neutralize its
 // assumption for immediates (an `assume(false)` would be unsound).
 
-enum class TagEncoding { None, TBI, Immortal };
+// TaggedBox (PoC, #325): the Koka/Lean low-bit convention. Unlike TBI and
+// Immortal, the immediate is *not* a dummy-box pointer — it is the pure
+// value `(tag << 1) | 1`, so it cannot be dereferenced. Every rc access
+// that would touch the box (fetch, set, inc, the variant-tag read,
+// uniqueness) first tests the pointer's low bit and, when set, skips the box
+// behind a predicted-not-taken branch (tag reads decode `imm >> 1`). This
+// trades the dummy-box's guard-free hot reads for a branch on every access,
+// but recognizes immediates with a cheap `and` instead of the immortal
+// encoding's count-magnitude load — the point of the experiment on targets
+// without TBI.
+enum class TagEncoding { None, TBI, Immortal, TaggedBox };
 
 // The immortal encoding's dummy refcount initializer and recognition
 // threshold for a `width`-bit refcount word.
@@ -131,8 +141,37 @@ TagEncoding specialPtrTagEncoding(mlir::Operation *op) {
   auto attr = module->getAttrOfType<mlir::StringAttr>(kSpecialPtrTagAttr);
   if (!attr)
     return TagEncoding::None;
-  return attr.getValue() == kSpecialPtrTagImmortal ? TagEncoding::Immortal
-                                                   : TagEncoding::TBI;
+  if (attr.getValue() == kSpecialPtrTagImmortal)
+    return TagEncoding::Immortal;
+  if (attr.getValue() == kSpecialPtrTagTaggedBox)
+    return TagEncoding::TaggedBox;
+  return TagEncoding::TBI;
+}
+
+// Whether `recordType` is a complete variant with at least one nullary arm
+// (an empty compound) — the shape whose constructions the special-pointer-tag
+// pass turns into immediates. A `record.tag` scrutinee of such a type may be
+// a low-bit tagged immediate under the TaggedBox encoding, so its tag read
+// must decode instead of loading. Mirrors RcType::mayCarrySpecialPointerTag's
+// arm scan (kept local: that predicate needs the RcType wrapper this site
+// does not have).
+bool variantMayBeTaggedImmediate(RecordType recordType) {
+  if (!recordType || !recordType.isVariant() || !recordType.getComplete())
+    return false;
+  // The low-bit decode reads the tag straight from the pointer, which only
+  // equals the raw immediate when the box IS its element (fused header, so
+  // rc.borrow is an offset-0 GEP). Non-fused taggable variants do not exist
+  // in the current scheme, but gate on it so the decode stays exact.
+  if (!recordType.hasFusedHeader())
+    return false;
+  for (auto [idx, member] : llvm::enumerate(recordType.getMembers())) {
+    if (idx + 1 > 0xFF)
+      break;
+    auto arm = llvm::dyn_cast<RecordType>(member);
+    if (arm && arm.isCompound() && arm.getMembers().empty())
+      return true;
+  }
+  return false;
 }
 
 // The per-tag dummy box a tagged immediate points at: `{refcount, tag}`,
@@ -215,6 +254,22 @@ mlir::Value isTaggedImmediate(mlir::Value topByte, mlir::Location loc,
                                     topByte, zero);
 }
 
+// `(ptr & 1) != 0` — the value is a TaggedBox low-bit immediate. Koka's
+// `kk_datatype_is_ptr` inverted: a real heap box is 8-byte aligned, so its
+// low bit is clear; a nullary immediate `(tag << 1) | 1` has it set.
+mlir::Value isLowBitTagged(mlir::Value ptr, mlir::Location loc,
+                           mlir::OpBuilder &builder) {
+  auto i64Ty = builder.getI64Type();
+  auto raw = mlir::LLVM::PtrToIntOp::create(builder, loc, i64Ty, ptr);
+  auto one = mlir::LLVM::ConstantOp::create(builder, loc, i64Ty,
+                                            builder.getI64IntegerAttr(1));
+  auto zero = mlir::LLVM::ConstantOp::create(builder, loc, i64Ty,
+                                             builder.getI64IntegerAttr(0));
+  auto masked = mlir::LLVM::AndOp::create(builder, loc, raw, one);
+  return mlir::LLVM::ICmpOp::create(builder, loc, mlir::LLVM::ICmpPredicate::ne,
+                                    masked, zero);
+}
+
 // Steer `addr` to the scratch word when `isTagged` holds.
 mlir::Value guardedAddr(mlir::Operation *op, mlir::Value isTagged,
                         mlir::Value addr, mlir::Location loc,
@@ -248,6 +303,34 @@ void emitGuardedStore(mlir::ConversionPatternRewriter &rewriter,
                                              contBlock, storeBlock);
   condBr->setAttr("branch_weights", rewriter.getDenseI32ArrayAttr({1, 2000}));
   rewriter.setInsertionPointToStart(contBlock);
+}
+
+// The read-side dual of `emitGuardedStore` for the TaggedBox encoding: yield
+// `sentinel` for a recognized low-bit immediate (whose pointer cannot be
+// dereferenced) and the loaded value otherwise, through a predicted-not-taken
+// branch rather than an address select. Used where the count would otherwise
+// be read off the (nonexistent) dummy box; `sentinel` must route the caller
+// to the shared/non-unique branch. Returns the merged value.
+mlir::Value emitGuardedLoad(mlir::ConversionPatternRewriter &rewriter,
+                            mlir::Location loc, mlir::Type resultTy,
+                            mlir::Value addr, mlir::Value skipCond,
+                            mlir::Value sentinel) {
+  mlir::Block *condBlock = rewriter.getInsertionBlock();
+  mlir::Block *contBlock =
+      rewriter.splitBlock(condBlock, rewriter.getInsertionPoint());
+  mlir::Value merged = contBlock->addArgument(resultTy, loc);
+  mlir::Block *loadBlock = rewriter.createBlock(
+      contBlock->getParent(), mlir::Region::iterator(contBlock));
+  rewriter.setInsertionPointToEnd(loadBlock);
+  mlir::Value loaded = mlir::LLVM::LoadOp::create(rewriter, loc, resultTy, addr);
+  mlir::LLVM::BrOp::create(rewriter, loc, loaded, contBlock);
+  rewriter.setInsertionPointToEnd(condBlock);
+  auto condBr = mlir::LLVM::CondBrOp::create(rewriter, loc, skipCond, contBlock,
+                                             mlir::ValueRange{sentinel},
+                                             loadBlock, mlir::ValueRange{});
+  condBr->setAttr("branch_weights", rewriter.getDenseI32ArrayAttr({1, 2000}));
+  rewriter.setInsertionPointToStart(contBlock);
+  return merged;
 }
 
 void ensureRuntimeFunctions(mlir::ModuleOp module,
@@ -471,12 +554,26 @@ struct ReussirRcFetchConversionPattern
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter())
             ->getIndexType();
     mlir::Location loc = op.getLoc();
-    // No guard for tagged immediates: TBI masks the top byte, so the load
-    // hits the dummy box's refcount, which is pinned >= 2 — exactly what
-    // routes the expanded decrement to its shared branch and answers
-    // `is_unique` with false (see the special-pointer-tag notes above).
-    mlir::Value loaded = mlir::LLVM::LoadOp::create(
-        rewriter, loc, rewriter.getI32Type(), adaptor.getRcPtr());
+    // No guard for the dummy-box encodings: TBI masks the top byte and the
+    // immortal address is real, so the load hits the dummy box's refcount,
+    // pinned >= 2 — exactly what routes the expanded decrement to its shared
+    // branch and answers `is_unique` with false. The TaggedBox immediate has
+    // no box, so its pointer cannot be loaded: guard the load and yield a
+    // sentinel `2` (>= 2, so the same shared-branch routing holds).
+    TagEncoding encoding = specialPtrTagEncoding(op);
+    mlir::Value loaded;
+    if (encoding == TagEncoding::TaggedBox &&
+        op.getRcPtr().getType().mayCarrySpecialPointerTag()) {
+      mlir::Value tagged = isLowBitTagged(adaptor.getRcPtr(), loc, rewriter);
+      mlir::Value sentinel = mlir::LLVM::ConstantOp::create(
+          rewriter, loc, rewriter.getI32Type(),
+          rewriter.getI32IntegerAttr(2));
+      loaded = emitGuardedLoad(rewriter, loc, rewriter.getI32Type(),
+                               adaptor.getRcPtr(), tagged, sentinel);
+    } else {
+      loaded = mlir::LLVM::LoadOp::create(rewriter, loc, rewriter.getI32Type(),
+                                          adaptor.getRcPtr());
+    }
     mlir::Value widened =
         llvm::cast<mlir::IntegerType>(indexTy).getWidth() > 32
             ? mlir::LLVM::ZExtOp::create(rewriter, loc, indexTy, loaded)
@@ -520,6 +617,10 @@ struct ReussirRcSetConversionPattern
       if (encoding == TagEncoding::TBI) {
         mlir::Value top = topByteOf(addr, op.getLoc(), rewriter);
         tagged = isTaggedImmediate(top, op.getLoc(), rewriter);
+      } else if (encoding == TagEncoding::TaggedBox) {
+        // The immediate carries no box; recognize it by the low bit and skip
+        // the store (the address is not writable).
+        tagged = isLowBitTagged(addr, op.getLoc(), rewriter);
       } else {
         tagged = isImmortalCount(narrowCount, op.getLoc(), rewriter);
       }
@@ -1164,13 +1265,34 @@ struct ReussirRecordTagConversionPattern
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, tagField});
 
     // Load the tag value at the record's minimal tag width and widen it to
-    // the op's index result. Under the special-pointer-tag scheme a tagged
+    // the op's index result. Under the TBI/immortal schemes a tagged
     // immediate scrutinee needs no decode: the load lands in its per-tag
     // dummy box (TBI masks the top byte) and reads the real tag — so the
-    // match hot path is identical with and without the scheme.
+    // match hot path is identical with and without the scheme. Under
+    // TaggedBox there is no dummy box, so a low-bit immediate is decoded as
+    // `imm >> 1` behind a branch and only a real box is loaded.
     mlir::IntegerType tagType = recordType.getTagType();
-    mlir::Value narrowTag =
-        mlir::LLVM::LoadOp::create(rewriter, loc, tagType, tagPtr);
+    mlir::Value narrowTag;
+    if (specialPtrTagEncoding(op) == TagEncoding::TaggedBox &&
+        variantMayBeTaggedImmediate(recordType)) {
+      auto i64Ty = rewriter.getI64Type();
+      mlir::Value raw = mlir::LLVM::PtrToIntOp::create(rewriter, loc, i64Ty,
+                                                       refPtr);
+      auto oneI64 = mlir::LLVM::ConstantOp::create(
+          rewriter, loc, i64Ty, rewriter.getI64IntegerAttr(1));
+      mlir::Value shifted = mlir::LLVM::LShrOp::create(rewriter, loc, raw,
+                                                       oneI64);
+      mlir::Value decoded =
+          tagType.getWidth() < 64
+              ? mlir::LLVM::TruncOp::create(rewriter, loc, tagType, shifted)
+                    .getResult()
+              : shifted;
+      mlir::Value tagged = isLowBitTagged(refPtr, loc, rewriter);
+      narrowTag =
+          emitGuardedLoad(rewriter, loc, tagType, tagPtr, tagged, decoded);
+    } else {
+      narrowTag = mlir::LLVM::LoadOp::create(rewriter, loc, tagType, tagPtr);
+    }
     mlir::Value tagValue =
         tagType.getWidth() <
                 llvm::cast<mlir::IntegerType>(indexType).getWidth()
@@ -1267,6 +1389,44 @@ struct ReussirRcIncConversionPattern
           rewriter, op.getLoc(), llvmPtrType, convertedBoxType,
           adaptor.getRcPtr(), llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
     }
+    auto countType = rewriter.getI32Type();
+    TagEncoding encoding = specialPtrTagEncoding(op);
+    // TaggedBox: the immediate has no box, so neither the count load nor its
+    // store may touch it. Skip the entire increment (load + add + store)
+    // behind a predicted-not-taken low-bit branch — Koka's `if (is_ptr) dup`.
+    // (mayCarrySpecialPointerTag implies a non-atomic normal box, so the
+    // atomic path below is never an immediate.)
+    if (encoding == TagEncoding::TaggedBox &&
+        rcPtrTy.mayCarrySpecialPointerTag() &&
+        rcPtrTy.getAtomicKind() == AtomicKind::normal) {
+      mlir::Value tagged =
+          isLowBitTagged(adaptor.getRcPtr(), op.getLoc(), rewriter);
+      mlir::Block *condBlock = rewriter.getInsertionBlock();
+      mlir::Block *contBlock =
+          rewriter.splitBlock(condBlock, rewriter.getInsertionPoint());
+      mlir::Block *incBlock = rewriter.createBlock(
+          contBlock->getParent(), mlir::Region::iterator(contBlock));
+      rewriter.setInsertionPointToEnd(incBlock);
+      auto one = mlir::arith::ConstantOp::create(
+          rewriter, op.getLoc(), mlir::IntegerAttr::get(countType, 1));
+      mlir::Value oldRefCnt = mlir::LLVM::LoadOp::create(
+          rewriter, op.getLoc(), countType, refcntPtr);
+      auto newRefCnt = mlir::arith::AddIOp::create(rewriter, op.getLoc(),
+                                                   countType, oldRefCnt, one);
+      mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), newRefCnt, refcntPtr);
+      mlir::Value geOne = mlir::LLVM::ICmpOp::create(
+          rewriter, op.getLoc(), mlir::LLVM::ICmpPredicate::uge, oldRefCnt, one);
+      mlir::LLVM::AssumeOp::create(rewriter, op.getLoc(), geOne);
+      mlir::LLVM::BrOp::create(rewriter, op.getLoc(), contBlock);
+      rewriter.setInsertionPointToEnd(condBlock);
+      auto condBr = mlir::LLVM::CondBrOp::create(rewriter, op.getLoc(), tagged,
+                                                 contBlock, incBlock);
+      condBr->setAttr("branch_weights",
+                      rewriter.getDenseI32ArrayAttr({1, 2000}));
+      rewriter.setInsertionPointToStart(contBlock);
+      rewriter.eraseOp(op);
+      return mlir::success();
+    }
     // Usually no guard for tagged immediates: the increment lands on the
     // dummy box's refcount — a benign write that only ever grows it (rc.set,
     // the sole decrementing store, is steered away). The exception is the
@@ -1274,8 +1434,6 @@ struct ReussirRcIncConversionPattern
     // dummy could actually be grown past wrap-around within a program's
     // lifetime: there the increment's store is steered to the scratch word
     // instead (the load stays plain, so nothing on the read path changes).
-    auto countType = rewriter.getI32Type();
-    TagEncoding encoding = specialPtrTagEncoding(op);
     bool steerNarrowImmortal = encoding == TagEncoding::Immortal &&
                                rcPtrTy.mayCarrySpecialPointerTag();
     auto one = mlir::arith::ConstantOp::create(
@@ -1489,6 +1647,17 @@ struct ReussirRcTaggedConversionPattern
             ->getIndexType());
     mlir::Type ptrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
     TagEncoding encoding = specialPtrTagEncoding(op);
+    // TaggedBox: no dummy box at all — the immediate is the pure value
+    // `(tag << 1) | 1` (Koka/Lean low-bit convention). All accesses through
+    // it are guarded by the low bit at their lowering sites.
+    if (encoding == TagEncoding::TaggedBox) {
+      uint64_t imm = (op.getTag().getZExtValue() << 1) | 1;
+      mlir::Value immVal = mlir::LLVM::ConstantOp::create(
+          rewriter, loc, indexTy,
+          rewriter.getIntegerAttr(indexTy, static_cast<int64_t>(imm)));
+      rewriter.replaceOpWithNewOp<mlir::LLVM::IntToPtrOp>(op, ptrTy, immVal);
+      return mlir::success();
+    }
     auto dummy =
         tagDummyBox(op->getParentOfType<mlir::ModuleOp>(), loc,
                     op.getTag().getZExtValue(), encoding, rewriter);
@@ -1981,6 +2150,7 @@ struct ReussirRcIsUniqueOpConversionPattern
                            mlir::Value rcPtr,
                            const mlir::TypeConverter *typeConverter,
                            mlir::ConversionPatternRewriter &rewriter,
+                           TagEncoding encoding = TagEncoding::None,
                            mlir::Value *outCount = nullptr) {
     RcBoxType rcBoxType = rcPtrTy.getInnerBoxType();
     auto convertedBoxType = typeConverter->convertType(rcBoxType);
@@ -1989,12 +2159,22 @@ struct ReussirRcIsUniqueOpConversionPattern
     auto refcntPtr = mlir::LLVM::GEPOp::create(
         rewriter, loc, llvmPtrType, convertedBoxType, rcPtr,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 0});
-    // No guard for tagged immediates: the load reads the dummy box's
-    // refcount, pinned above the unique/shared decision point, so
-    // uniqueness is naturally false there.
+    // No guard for the dummy-box encodings: the load reads the dummy box's
+    // refcount, pinned above the unique/shared decision point, so uniqueness
+    // is naturally false there. TaggedBox has no box, so guard the load and
+    // yield a sentinel `2` (!= 1, so not unique) for a low-bit immediate.
     auto countType = rewriter.getI32Type();
-    auto refcnt =
-        mlir::LLVM::LoadOp::create(rewriter, loc, countType, refcntPtr);
+    mlir::Value refcnt;
+    if (encoding == TagEncoding::TaggedBox &&
+        rcPtrTy.mayCarrySpecialPointerTag()) {
+      mlir::Value tagged = isLowBitTagged(rcPtr, loc, rewriter);
+      mlir::Value sentinel = mlir::LLVM::ConstantOp::create(
+          rewriter, loc, countType, rewriter.getI32IntegerAttr(2));
+      refcnt =
+          emitGuardedLoad(rewriter, loc, countType, refcntPtr, tagged, sentinel);
+    } else {
+      refcnt = mlir::LLVM::LoadOp::create(rewriter, loc, countType, refcntPtr);
+    }
     if (outCount)
       *outCount = refcnt;
     auto one = mlir::arith::ConstantOp::create(
@@ -2009,7 +2189,8 @@ struct ReussirRcIsUniqueOpConversionPattern
                   mlir::ConversionPatternRewriter &rewriter) const override {
     RcType rcPtrTy = op.getRcPtr().getType();
     auto isUnique = buildUniquenessCondition(
-        op.getLoc(), rcPtrTy, adaptor.getRcPtr(), getTypeConverter(), rewriter);
+        op.getLoc(), rcPtrTy, adaptor.getRcPtr(), getTypeConverter(), rewriter,
+        specialPtrTagEncoding(op));
     rewriter.replaceOp(op, isUnique);
     return mlir::success();
   }
@@ -2022,23 +2203,25 @@ struct ReussirRcAssumeUniqueOpConversionPattern
   mlir::LogicalResult
   matchAndRewrite(ReussirRcAssumeUniqueOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    // NOTE: for a tagged immediate the condition reads the dummy box's
-    // refcount and is `false`; asserting `assume(false)` would be unsound,
-    // so neutralize the assumption on that path. TBI recognizes immediates
-    // by the pointer's top byte, the immortal encoding by the loaded
-    // count's magnitude.
+    // NOTE: for a tagged immediate the condition is `false` (or its load is
+    // skipped); asserting `assume(false)` would be unsound, so neutralize the
+    // assumption on that path. TBI recognizes immediates by the pointer's top
+    // byte, the immortal encoding by the loaded count's magnitude, TaggedBox
+    // by the pointer's low bit.
     RcType rcPtrTy = op.getRcPtr().getType();
     mlir::Value count;
+    TagEncoding encoding = specialPtrTagEncoding(op);
     mlir::Value isUnique =
         ReussirRcIsUniqueOpConversionPattern::buildUniquenessCondition(
             op.getLoc(), rcPtrTy, adaptor.getRcPtr(), getTypeConverter(),
-            rewriter, &count);
-    TagEncoding encoding = specialPtrTagEncoding(op);
+            rewriter, encoding, &count);
     if (encoding != TagEncoding::None && rcPtrTy.mayCarrySpecialPointerTag()) {
       mlir::Value tagged;
       if (encoding == TagEncoding::TBI) {
         mlir::Value top = topByteOf(adaptor.getRcPtr(), op.getLoc(), rewriter);
         tagged = isTaggedImmediate(top, op.getLoc(), rewriter);
+      } else if (encoding == TagEncoding::TaggedBox) {
+        tagged = isLowBitTagged(adaptor.getRcPtr(), op.getLoc(), rewriter);
       } else {
         tagged = isImmortalCount(count, op.getLoc(), rewriter);
       }

--- a/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
+++ b/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
@@ -85,7 +85,8 @@ struct SpecialPointerTagPass
   using Base::Base;
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
-    if (encoding != kSpecialPtrTagTBI && encoding != kSpecialPtrTagImmortal) {
+    if (encoding != kSpecialPtrTagTBI && encoding != kSpecialPtrTagImmortal &&
+        encoding != kSpecialPtrTagTaggedBox) {
       module.emitError("unknown special-pointer-tag encoding: ") << encoding;
       return signalPassFailure();
     }

--- a/tests/integration/conversion/special_pointer_tag_lowering_taggedbox.mlir
+++ b/tests/integration/conversion/special_pointer_tag_lowering_taggedbox.mlir
@@ -1,0 +1,91 @@
+// RUN: %reussir-opt %s --convert-to-llvm | \
+// RUN: %reussir-translate --mlir-to-llvmir | %FileCheck %s
+
+// LLVM lowering under the *taggedbox* special-pointer-tag encoding (module
+// stamped `reussir.special_ptr_tag = "taggedbox"`). This is the Koka/Lean
+// low-bit convention: a nullary variant becomes the pure value
+// `(tag << 1) | 1` — there is no dummy box, so the immediate is not
+// dereferenceable. Every rc access first tests the pointer's low bit and,
+// when set, skips the box behind a predicted-not-taken branch (`!prof`
+// weights 1:2000). The variant tag is decoded as `imm >> 1` rather than
+// loaded. Recognition is a cheap `and`, not the immortal encoding's
+// count-magnitude load.
+
+!list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Nil" [value] {}>}>
+!rclist = !reussir.rc<!list>
+
+module @test attributes { reussir.special_ptr_tag = "taggedbox", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+
+  // Immediate materialization: the pure value (tag << 1) | 1 = 3 for tag 1.
+  // No dummy box global, no `or`, just an inttoptr of the constant.
+  // CHECK-LABEL: define ptr @make_nil()
+  // CHECK-NOT: @_RNvC17REUSSIR_TAG_DUMMY
+  // CHECK: ret ptr inttoptr (i64 3 to ptr)
+  func.func @make_nil() -> !rclist {
+    %0 = reussir.rc.tagged tag(1) : !rclist
+    return %0 : !rclist
+  }
+
+  // Fetch: the immediate has no box, so the count load is guarded by the low
+  // bit and yields a sentinel `2` (!= 1 -> routes to the shared branch).
+  // CHECK-LABEL: define i64 @fetch(ptr %0)
+  // CHECK: %[[RAW:.+]] = ptrtoint ptr %0 to i64
+  // CHECK: %[[BIT:.+]] = and i64 %[[RAW]], 1
+  // CHECK: %[[TAGGED:.+]] = icmp ne i64 %[[BIT]], 0
+  // CHECK: br i1 %[[TAGGED]], label %[[CONT:.+]], label %[[LOAD:.+]], !prof
+  // CHECK: [[LOAD]]:
+  // CHECK: %[[CNT:.+]] = load i32, ptr %0
+  // CHECK: [[CONT]]:
+  // CHECK: %[[PHI:.+]] = phi i32 [ %[[CNT]], %[[LOAD]] ], [ 2, %1 ]
+  func.func @fetch(%rc: !rclist) -> index {
+    %cnt = reussir.rc.fetch (%rc : !rclist) : index
+    return %cnt : index
+  }
+
+  // Tag read: a low-bit immediate decodes `imm >> 1`; only a real box loads.
+  // CHECK-LABEL: define i64 @tag(ptr %0)
+  // CHECK: %[[R:.+]] = ptrtoint ptr %0 to i64
+  // CHECK: %[[SH:.+]] = lshr i64 %[[R]], 1
+  // CHECK: %[[DEC:.+]] = trunc i64 %[[SH]] to i32
+  // CHECK: br i1 %{{.+}}, label %[[TCONT:.+]], label %[[TLOAD:.+]], !prof
+  // CHECK: [[TLOAD]]:
+  // CHECK: %[[LT:.+]] = load i32, ptr
+  // CHECK: [[TCONT]]:
+  // CHECK: phi i32 [ %[[LT]], %[[TLOAD]] ], [ %[[DEC]], %1 ]
+  func.func @tag(%ref: !reussir.ref<!list shared>) -> index {
+    %tag = reussir.record.tag(%ref : !reussir.ref<!list shared>) : index
+    return %tag : index
+  }
+
+  // The decrementing store: recognize an immediate by the low bit and skip
+  // the store behind an unlikely branch (the immediate is not writable).
+  // CHECK-LABEL: define void @set(ptr %0, i64 %1)
+  // CHECK: %[[SR:.+]] = ptrtoint ptr %0 to i64
+  // CHECK: %[[SB:.+]] = and i64 %[[SR]], 1
+  // CHECK: %[[ST:.+]] = icmp ne i64 %[[SB]], 0
+  // CHECK: br i1 %[[ST]], label %[[SCONT:.+]], label %[[SSTORE:.+]], !prof
+  // CHECK: [[SSTORE]]:
+  // CHECK: store i32 %{{.+}}, ptr %0
+  // CHECK: br label %[[SCONT]]
+  func.func @set(%rc: !rclist, %v: index) {
+    reussir.rc.set(%rc : !rclist, %v : index)
+    return
+  }
+
+  // Increment: the whole load+add+store is skipped for an immediate (no box
+  // to grow), behind the same predicted-not-taken low-bit branch.
+  // CHECK-LABEL: define void @inc(ptr %0)
+  // CHECK: %[[IR:.+]] = ptrtoint ptr %0 to i64
+  // CHECK: %[[IB:.+]] = and i64 %[[IR]], 1
+  // CHECK: %[[IT:.+]] = icmp ne i64 %[[IB]], 0
+  // CHECK: br i1 %[[IT]], label %[[ICONT:.+]], label %[[IINC:.+]], !prof
+  // CHECK: [[IINC]]:
+  // CHECK: %[[OLD:.+]] = load i32
+  // CHECK: %[[NEW:.+]] = add i32 %[[OLD]], 1
+  // CHECK: store i32 %[[NEW]]
+  // CHECK: br label %[[ICONT]]
+  func.func @inc(%rc: !rclist) {
+    reussir.rc.inc(%rc : !rclist)
+    return
+  }
+}


### PR DESCRIPTION
## What

Renames the driver flag `--nullary-variant-encoding` → **`--variant-encoding`** and adds a PoC third nullary-variant representation, **`tagged-box`**, alongside `arch-dependent` / `arch-independent` / `boxed`.

`tagged-box` is the **Koka/Lean low-bit convention**: a nullary variant becomes the pure value `(tag << 1) | 1` — there is *no* per-tag dummy box, so the immediate is not dereferenceable. Every rc access that would touch the box first tests the pointer's low bit and, when set, skips the box behind a predicted-not-taken branch (`!prof` 1:2000); the variant tag is decoded as `imm >> 1`. Recognition is a cheap `and`, not the immortal encoding's count-magnitude load.

This is the encoding floated in #325 for targets without TBI (x86_64), to test whether replacing the immortal dummy-box machinery with Koka-style branches closes the x64 nbe gap.

## Plumbing

- **CLI** (`reussir-compiler`): flag rename + `VariantEncoding::TaggedBox`; **backend** (`pipeline.rs`): `NullaryVariantEncoding::TaggedBox` with a `pass_encoding()` string map.
- **CAPI**: `reussirCreateSpecialPointerTagPass` now takes the encoding as `MlirStringRef` instead of a `bool`, so all three immediate encodings flow through; `kSpecialPtrTagTaggedBox = "taggedbox"`.
- **BasicOpsLowering** (`TagEncoding::TaggedBox`): low-bit guards at `rc.tagged` (`inttoptr((tag<<1)|1)`, no dummy box), `rc.fetch`/`is_unique` (guarded load, sentinel `2`), `rc.set` (skip store), `rc.inc` (skip load+add+store), `record.tag` (decode `imm>>1`), `assume_unique` (neutralize). New helpers `isLowBitTagged`, `emitGuardedLoad`, `variantMayBeTaggedImmediate` (fused-header gated — the decode assumes `rc.borrow` is an offset-0 GEP).
- Lit test `special_pointer_tag_lowering_taggedbox.mlir` pins the lowering.

## Result — a negative one

x86_64 (Ryzen 9950X), mimalloc-v3 rt held constant, `-Oaggressive --reuse-across-call`, clang `-O3 -flto -march=native`, hyperfine 5 warmup / 10 runs:

| benchmark   | koka   | immortal | tagged-box | tb/imm | tb vs koka |
|-------------|-------:|---------:|-----------:|:------:|:----------:|
| rbtree      | 346.3  | 350.7    | 348.2      | 0.993  | 1.01×      |
| nbe-hoas    | 179.6  | 283.0    | 282.0      | 0.997  | 1.57×      |
| nbe-closure | 127.0  | 223.2    | 221.3      | 0.991  | 1.74×      |
| derive      | 528.8  | 587.3    | 584.6      | 0.995  | 1.11×      |

(ms, mean; σ ≈ 3–12 ms. A confirmation run flips the nbe sign, so this is a tie.)

**TaggedBox is a statistical tie with immortal on x64, and the nbe gap vs Koka (1.57×/1.74×) is unchanged.** So the immortal encoding's dummy-box reads / count-magnitude guards were *not* the x64 nbe bottleneck — swapping them for Koka-style low-bit branches buys nothing. This redirects the remaining gap back at the borrowed-traversal rc traffic / memory-level-parallelism already identified by the perf-counter analysis in #325, not the immediate encoding.

The encoding stays in as an opt-in `--variant-encoding tagged-box` so the experiment is reproducible and the mechanism is available if a future case (e.g. FFI-free hot paths where the dummy-box loads *do* dominate) benefits.

## Caveats

- PoC only. Unlike TBI/immortal, a TaggedBox immediate is not a layout-compatible box, so it does **not** support the dereference-free FFI tag decode. Opt-in only; not wired into `arch-dependent`.
- Stacks on #358 (reuses `emitGuardedStore`); base branch is `fix/gated-tag-stores`. Rebase onto `main` once #358 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1uVYwR1HudwbuuxfdxEr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786113971&installation_id=144622820&pr_number=359&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F359&signature=624111440caa3fab1cd01bb78506ad2c714614cd0c5368e7c8012c0b2bd31233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->