### PR TITLE
[backend] per-constructor variant box sizing: switch + arm-size helper + create-side + verifier (#325, 1/N)

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -117,6 +117,11 @@ unsafe extern "C" {
     /// false = `tbi` (top-byte tag, aarch64), true = `immortal` (plain dummy
     /// address with an immortal refcount, any target).
     pub fn reussirCreateSpecialPointerTagPass(arch_independent: bool) -> MlirPass;
+    /// Stamps (or removes) the module unit attribute opting the compilation
+    /// into per-constructor variant box sizing (#325). Experimental until
+    /// the full landing plan completes (allocation/free/reuse must agree on
+    /// the per-arm size); off by default.
+    pub fn reussirModuleSetPerConstructorBoxSizing(module: MlirModule, enable: bool);
     pub fn reussirCreateRcDispatchFusionPass() -> MlirPass;
     pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -171,6 +171,20 @@ impl Default for LoweringOptions {
 /// ABI alignment 4), so every size and alignment the pipeline computes —
 /// allocation sizes, spill alignments, load/store alignment annotations —
 /// understates the target.
+/// Stamps the module attribute opting the compilation into per-constructor
+/// variant box sizing (#325): boxed variant heap cells sized for the
+/// constructed arm (`header + arm[k]`) instead of the uniform max-arm
+/// width; field offsets are unchanged. Experimental until the landing plan
+/// (docs/design/per-constructor-box-sizing.md) completes — with only the
+/// allocation side landed, non-mimalloc allocators (wasm/talc) would see
+/// wrong-size frees. `rrc` exposes this as `--variant-box-sizing`; call
+/// before the lowering pipeline runs, like [`attach_target_spec`].
+pub fn set_per_constructor_box_sizing(module: &Module, enable: bool) {
+    // SAFETY: `module` is live for the call; the CAPI only sets/removes a
+    // module attribute.
+    unsafe { sys::reussirModuleSetPerConstructorBoxSizing(module.to_raw(), enable) }
+}
+
 pub fn attach_target_spec(module: &Module, data_layout: &str, triple: &str) -> Result<(), String> {
     let data_layout = std::ffi::CString::new(data_layout)
         .map_err(|_| "data layout contains a NUL byte".to_string())?;

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -77,6 +77,17 @@ enum VariantEncoding {
     Boxed,
 }
 
+/// CLI surface for the variant box-sizing contract (#325).
+#[derive(Clone, Copy, PartialEq, Eq, palc::ValueEnum)]
+enum BoxSizing {
+    /// Every boxed variant cell is the max-arm width (the shipped layout
+    /// contract; any arm's block reuses for any other).
+    Uniform,
+    /// EXPERIMENTAL: each cell is sized for its constructed arm
+    /// (`header + arm[k]`); offsets unchanged, trailing padding dropped.
+    PerConstructor,
+}
+
 impl VariantEncoding {
     /// Resolves the CLI choice against the target `triple`.
     fn resolve(self, triple: &str) -> NullaryVariantEncoding {
@@ -219,6 +230,20 @@ struct Cli {
     #[arg(long = "nullary-variant-encoding", value_enum,
           default_value_t = VariantEncoding::ArchDependent)]
     nullary_variant_encoding: VariantEncoding,
+
+    /// How boxed enum variants size their heap cells. `uniform` (default,
+    /// the shipped layout contract) sizes every cell at the max-arm width,
+    /// so any arm's block can be reused for any other. `per-constructor`
+    /// (#325, EXPERIMENTAL — allocation-side only for now; requires the
+    /// bundled mimalloc runtime, whose free ignores the stated size) sizes
+    /// each cell for the constructed arm: `header + arm[k]`. Field offsets
+    /// are identical either way — per-constructor only drops the trailing
+    /// padding up to the max arm, shrinking leaf-heavy workloads' cache
+    /// footprint (nbe-closure: the 16-byte leaf arms double to 32 under
+    /// `uniform`, which measured as ~the whole gap vs Koka).
+    #[arg(long = "variant-box-sizing", value_enum,
+          default_value_t = BoxSizing::Uniform)]
+    variant_box_sizing: BoxSizing,
 
     /// Split codegen into this many units. Each function's body is emitted in
     /// exactly one unit (a stable hash of its mangled symbol picks which);
@@ -583,6 +608,10 @@ fn backend_module(
     // real target sizes and alignments.
     let machine = TargetMachine::new(spec, opt, reloc)?;
     pipeline::attach_target_spec(&module, machine.data_layout(), machine.triple())?;
+    pipeline::set_per_constructor_box_sizing(
+        &module,
+        cli.variant_box_sizing == BoxSizing::PerConstructor,
+    );
     let options = LoweringOptions {
         opt,
         reuse_token_across_call: cli.reuse_across_call,

--- a/docs/design/per-constructor-box-sizing.md
+++ b/docs/design/per-constructor-box-sizing.md
@@ -1,0 +1,98 @@
+# Per-constructor variant box sizing (#325)
+
+## Motivation (measured, 2026-07-08, x86_64 Ryzen 9950X)
+
+`nbe-closure` runs 1.74× slower than Koka at **fewer** executed instructions
+(0.67×) — the gap is memory stalls: 13× the LLC misses, IPC 2.3 vs 5.9.
+Padding Koka's constructors to Reussir's uniform 32-byte cells reproduced
+Reussir's misses (0.22M → 2.51M vs our 2.42M) and runtime (125 → 238ms vs
+our 224ms) almost exactly, so node size is causally ~the whole gap. Koka
+sizes each constructor individually (`Var`/`VVar` = 16B); Reussir boxes
+every variant at its max-arm width (32B), doubling the numerous leaf nodes.
+Ruled out by experiment: borrow inference (Koka has none — `^` is
+annotation-only and it dups `env` at fan-outs exactly like us), the
+immediate encoding (PR #359: TaggedBox tied immortal), reuse pairing (both
+compilers do size-keyed Perceus reuse), and allocation volume (+39% allocs
+= +5% time).
+
+## Design
+
+A boxed **fused-header** variant cell is sized `header + arm[k]` (its own
+immutable tag `k`) instead of `header + max(arms)`.
+
+* **Offsets never move.** The payload offset is a function of the
+  variant-wide alignment, which per-arm sizing keeps; only the trailing
+  padding up to the max arm is dropped. Every projection/load/store/tag
+  read is byte-identical, so record access lowering is untouched.
+* **Value (inline) variants stay uniform.** They embed in other layouts
+  (`ref.spilled`, `ref.memcpy`, array strides) and are never a heap cell.
+* **No unsized free / no `token<?>`.** Every free is downstream of a tag
+  discriminator: a tag-known dec (post-match, `reussir-infer-variant-tag`)
+  frees with the static per-arm size; a tag-unknown dec is pushed to the
+  outlined dtor whose per-arm switch (it must read the tag anyway to drop
+  fields) frees with that arm's constant — placed *after* the
+  special-pointer-tag immediate check. Works on caller-supplies-layout
+  allocators (wasm/talc), not just mimalloc.
+* **Reuse is untouched structurally.** `TokenReuse` pairs via
+  `sameAllocatorBin(old, new)`; per-arm sizes flow in as values and
+  cross-size pairings (16 ↮ 32) are refused automatically. NB: mimalloc has
+  no 24-byte bin (24 → 32), so the practical win is precisely the 16-byte
+  bin for one-word arms — the leaves the padding experiment indicted.
+
+**Invariant** (what the verifier + ASan gates enforce): for any boxed
+variant, `allocated size == token<> size == freed size == header + arm[k]`.
+
+## Switch
+
+Module unit attribute `reussir.per_constructor_box_sizing`
+(`include/Reussir/Support/VariantBoxSizing.h`), stamped by
+`rrc --variant-box-sizing=per-constructor` via
+`reussirModuleSetPerConstructorBoxSizing` /
+`pipeline::set_per_constructor_box_sizing`. Default `uniform`. An attribute
+(not dialect state) so lit tests opt in by writing it on the module.
+
+## Landing plan — stacked PRs, each ~300–400 LOC, each targeting main
+
+1. **[this PR] Switch + arm-size helper + create-side + verifier.**
+   `RecordType::getVariantArmAllocSize(dataLayout, tag)` (variant-wide
+   alignment, arm-k payload); `ReussirRcCreateVariantOp::getTokenType()`
+   returns the per-arm token under the attribute (fused-header, complete,
+   non-regional only); `verifyRcCreateLikeOp` now checks the provided token
+   against the op's own `TokenAcceptor::getTokenType()` — the single source
+   of truth — so a wrong-size pairing is a *compile* error, not a heap
+   overflow. EXPERIMENTAL until step 2: allocation is per-arm but
+   tag-unknown frees still claim max-arm; safe only on mimalloc (free
+   ignores the stated size).
+2. **Free side.** (a) Tag-known decs: when `reussir-infer-variant-tag` (or
+   dispatch fusion) pinned the arm, `ReussirRcDecOp::getTokenType()`
+   returns the per-arm token so the unique-path
+   `rc.reinterpret → token.free` carries the right size. (b) Tag-unknown
+   decs: `AcquireDropExpansion`'s outlined dtor emits the per-arm constant
+   free in each switch arm, after the tagged-immediate guard. Gate: an
+   ASan-executing mixed-arm lit test driving both paths; wasm/talc
+   correctness run. **This is the highest-risk step; do not stack further
+   until ASan is green.**
+3. **Reuse + lowering audit.** Confirm `SCFOpsLowering`'s same-bin
+   `token.realloc` fast path keys on concrete arm sizes; lit-pin that a
+   16→32 pairing no longer fires while 32→32 still does; poison-reuse
+   guard uses the token size (already per-arm by construction).
+4. **Indirect producers.** Regional `rc.create*` (bump path in
+   `crates/reussir-rt/src/region/mod.rs` + `initializeRcCreateStorage`)
+   and TRMC constructor contexts (`cctx.extend/apply` hole allocation in
+   `TRMCRecursionAnalysis`) take the concrete arm size. `quote` is
+   TRMC-heavy and hot — measure before/after.
+5. **Validate + flip default.** Targets from the padding control:
+   nbe-closure LLC ~2.4M → ~0.2M, ~224 → ~130ms, RSS ~246 → ~155MB.
+   Measure the lost 16↔32 reuse pairings on the tree benches; full suite +
+   aarch64 + wasm; then flip `--variant-box-sizing` default and keep the
+   flag one release as escape hatch.
+6. **FFI marshalling** (separate): non-uniform + fused-header + tagged
+   layouts already rule out plain-cast FFI; generated marshalling is the
+   answer regardless.
+
+## Verified so far (PR 1)
+
+Token instantiation on the mixed-arm probe:
+`Cons{i64, rc}` → `token<align 8, size 24>`, `Var{i64}` →
+`token<align 8, size 16>` with the attribute; both 24 without. Full lit
+suite green with the verifier now routed through `getTokenType()`.

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -127,6 +127,14 @@ int reussirHasTPDE(void);
 bool reussirModuleAttachTargetSpec(MlirModule module, const char *dataLayout,
                                    const char *triple);
 
+// Stamps (or removes) the module unit attribute opting the compilation into
+// per-constructor variant box sizing (#325): boxed variant heap cells sized
+// for the constructed arm instead of the uniform max-arm width. Experimental
+// until the full landing plan (docs/design/per-constructor-box-sizing.md)
+// completes: with only the allocation side landed, a non-mimalloc allocator
+// (wasm/talc) would see wrong-size frees. Off by default.
+void reussirModuleSetPerConstructorBoxSizing(MlirModule module, bool enable);
+
 // Sets whether compound record members are laid out in packed physical order
 // (descending storage alignment) rather than declaration order. On by default.
 // This is a whole-compilation layout contract held on the context-loaded

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -143,6 +143,17 @@ def ReussirRecordType
         mlir::Type memberWithLargestAlignment;
       };
       LayoutInfo getElementRegionLayoutInfo(const mlir::DataLayout &dataLayout) const;
+      // Per-constructor box sizing (#325): the byte size a fused-header
+      // variant box needs when it is known to hold arm `tag` — the fused
+      // header plus that arm's storage, in place of the uniform max-arm
+      // size `getTypeSizeInBits/8` reports. The payload offset (and thus
+      // every field offset) is derived from the *variant-wide* alignment,
+      // identical to the uniform layout: per-arm sizing only drops the
+      // trailing padding up to the max arm. Callers gate on
+      // `kPerConstructorBoxSizingAttr` (Support/VariantBoxSizing.h); only
+      // valid on complete fused-header variants.
+      llvm::TypeSize getVariantArmAllocSize(const mlir::DataLayout &dataLayout,
+                                            size_t tag) const;
       // A shared/regional variant record carries a fused 8-byte box header:
       // `{4-byte count slot, i32 tag, payload}`. When rc-boxed, the box IS
       // the record — the refcount overlays the leading slot, so the rc

--- a/include/Reussir/Support/VariantBoxSizing.h
+++ b/include/Reussir/Support/VariantBoxSizing.h
@@ -1,0 +1,48 @@
+//===-- VariantBoxSizing.h - per-constructor variant box sizing -*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 With LLVM Exceptions OR MIT
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#ifndef REUSSIR_SUPPORT_VARIANTBOXSIZING_H
+#define REUSSIR_SUPPORT_VARIANTBOXSIZING_H
+
+#include "llvm/ADT/StringRef.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+
+namespace reussir {
+
+/// Module unit attribute opting the compilation into *per-constructor* box
+/// sizing (#325): a boxed variant's heap cell is sized for the constructed
+/// arm (`header + arm[k]`) instead of the uniform max-arm width. Field
+/// offsets never move — the payload offset is derived from the variant-wide
+/// alignment, so per-arm sizing only drops the trailing padding up to the
+/// max arm. The measured motivation is nbe-closure, where the numerous
+/// leaf arms (Var/VVar-shaped: header + one word = 16 bytes) doubled to the
+/// 32-byte max-arm bin dominate the cache footprint (padding Koka to
+/// uniform 32B reproduced our LLC misses and runtime almost exactly).
+///
+/// The invariant every consumer must preserve: for any boxed variant,
+///   allocated size == token<> size == freed size == header + arm[k]
+/// where k is the box's own (immutable) tag. Producers/consumers of the
+/// size are staged behind this attribute (see
+/// docs/design/per-constructor-box-sizing.md for the landing plan); until
+/// the full stack lands the attribute is experimental and must not be
+/// stamped by default.
+constexpr llvm::StringLiteral kPerConstructorBoxSizingAttr =
+    "reussir.per_constructor_box_sizing";
+
+/// Whether the module enclosing `op` opted into per-constructor box sizing.
+inline bool perConstructorBoxSizing(mlir::Operation *op) {
+  auto module = op->getParentOfType<mlir::ModuleOp>();
+  return module && module->hasAttr(kPerConstructorBoxSizingAttr);
+}
+
+} // namespace reussir
+
+#endif // REUSSIR_SUPPORT_VARIANTBOXSIZING_H

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -38,6 +38,7 @@
 #include "Reussir/Conversion/SCFOpsLowering.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
+#include "Reussir/Support/VariantBoxSizing.h"
 #include "Reussir/Transformation/Passes.h"
 #include "Reussir/Transformation/SpecialPointerTag.h"
 
@@ -236,4 +237,13 @@ bool reussirModuleAttachTargetSpec(MlirModule module, const char *dataLayout,
 void reussirContextSetPackRecordMembers(MlirContext context, bool enable) {
   mlir::MLIRContext *ctx = unwrap(context);
   ctx->getOrLoadDialect<reussir::ReussirDialect>()->setPackRecordMembers(enable);
+}
+
+void reussirModuleSetPerConstructorBoxSizing(MlirModule module, bool enable) {
+  mlir::ModuleOp moduleOp = unwrap(module);
+  if (enable)
+    moduleOp->setAttr(reussir::kPerConstructorBoxSizingAttr,
+                      mlir::UnitAttr::get(moduleOp.getContext()));
+  else
+    moduleOp->removeAttr(reussir::kPerConstructorBoxSizingAttr);
 }

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -39,6 +39,7 @@
 #include "Reussir/IR/ReussirEnumAttrs.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
+#include "Reussir/Support/VariantBoxSizing.h"
 #include "mlir/IR/PatternMatch.h"
 
 #include <llvm/ADT/DenseSet.h>
@@ -115,22 +116,22 @@ mlir::LogicalResult verifyRcCreateLikeOp(mlir::Operation *op, RcType rcType,
   if (!token)
     return mlir::success();
 
+  // The op's own `TokenAcceptor::getTokenType()` is the single source of
+  // truth for the box's layout — under per-constructor box sizing (#325) a
+  // variant construction expects `header + arm[tag]`, not the uniform
+  // max-arm width, and this check is what holds the
+  // allocated == token == freed size invariant together.
+  auto acceptor = llvm::cast<TokenAcceptor>(op);
+  TokenType expected = acceptor.getTokenType();
   TokenType tokenType = llvm::cast<TokenType>(token.getType());
-  auto rcBoxType =
-      RcBoxType::get(op->getContext(), valueType, region != nullptr);
-  auto dataLayout = mlir::DataLayout::closest(op);
-  auto alignment = dataLayout.getTypeABIAlignment(rcBoxType);
-  auto size = dataLayout.getTypeSize(rcBoxType);
-  if (!size.isFixed())
-    return op->emitOpError("RC type must have a fixed size");
-  if (tokenType.getAlign() != alignment)
+  if (tokenType.getAlign() != expected.getAlign())
     return op->emitOpError("token alignment must match RC type alignment, ")
            << "token alignment: " << tokenType.getAlign()
-           << ", RC type alignment: " << alignment;
-  if (tokenType.getSize() != size)
+           << ", RC type alignment: " << expected.getAlign();
+  if (tokenType.getSize() != expected.getSize())
     return op->emitOpError("token size must match RC type size, ")
            << "token size: " << tokenType.getSize()
-           << ", RC type size: " << size.getFixedValue();
+           << ", RC type size: " << expected.getSize();
   return mlir::success();
 }
 
@@ -591,11 +592,25 @@ mlir::LogicalResult ReussirRcCreateVariantOp::verify() {
 // RcCreateVariantOp TokenAcceptor Interface
 //===----------------------------------------------------------------------===//
 TokenType ReussirRcCreateVariantOp::getTokenType() {
+  mlir::Type elementType = getRcPtr().getType().getElementType();
   auto rcBoxType =
-      RcBoxType::get(getContext(), getRcPtr().getType().getElementType(),
-                     getRegion() != nullptr);
+      RcBoxType::get(getContext(), elementType, getRegion() != nullptr);
   auto dataLayout = mlir::DataLayout::closest(getOperation());
   auto alignment = dataLayout.getTypeABIAlignment(rcBoxType);
+  // Per-constructor box sizing (module opt-in, #325): a fused-header
+  // variant box IS its record, and this op constructs a statically known
+  // arm — size the token for `header + arm[tag]` instead of the max-arm
+  // width. Alignment (hence the payload offset and every field offset) is
+  // unchanged. Regional boxes keep the uniform size: their bump-allocation
+  // header/lifecycle is handled separately (phase 4 of the landing plan).
+  if (auto recordType = llvm::dyn_cast<RecordType>(elementType);
+      recordType && recordType.isVariant() && recordType.getComplete() &&
+      rcBoxType.isHeaderFused() && !getRegion() &&
+      perConstructorBoxSizing(getOperation())) {
+    llvm::TypeSize armSize =
+        recordType.getVariantArmAllocSize(dataLayout, getTag().getZExtValue());
+    return TokenType::get(getContext(), alignment, armSize.getFixedValue());
+  }
   auto size = dataLayout.getTypeSize(rcBoxType);
   return TokenType::get(getContext(), alignment, size.getFixedValue());
 }

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -660,6 +660,30 @@ RecordType::LayoutInfo RecordType::getElementRegionLayoutInfo(
   return {size, largestAlignment, memberWithLargestAlignment};
 }
 
+llvm::TypeSize
+RecordType::getVariantArmAllocSize(const mlir::DataLayout &dataLayout,
+                                   size_t tag) const {
+  assert(isVariant() && "arm alloc size is a variant-box query");
+  assert(hasFusedHeader() && "per-arm sizing requires the fused-header "
+                             "layout (box pointer == record pointer)");
+  assert(tag < getMembers().size() && "tag out of range");
+  // The payload offset is a function of the *variant-wide* alignment — keep
+  // it, so every arm's fields sit at exactly the offsets of the uniform
+  // layout and only the trailing padding up to the max arm is dropped.
+  // Mirrors the fused-header branch of getTypeSizeInBits with the max-arm
+  // payload size replaced by arm `tag`'s.
+  auto [maxSize, align, _] = getElementRegionLayoutInfo(dataLayout);
+  (void)maxSize;
+  mlir::Type member = getProjectedType(getMembers()[tag],
+                                       getMemberIsField()[tag],
+                                       Capability::value);
+  llvm::TypeSize armSize = dataLayout.getTypeSize(member);
+  llvm::Align finalAlign = std::max(align, llvm::Align(8));
+  llvm::TypeSize headerSize =
+      llvm::alignTo(llvm::TypeSize::getFixed(8), align.value());
+  return llvm::alignTo(armSize + headerSize, finalAlign.value());
+}
+
 //===----------------------------------------------------------------------===//
 // RecordType DataLayoutInterface
 //===----------------------------------------------------------------------===//

--- a/tests/integration/conversion/per_constructor_token_size.mlir
+++ b/tests/integration/conversion/per_constructor_token_size.mlir
@@ -1,0 +1,30 @@
+// RUN: %reussir-opt %s --reussir-token-instantiation | %FileCheck %s
+
+// Per-constructor box sizing (#325): with the module opted in via
+// `reussir.per_constructor_box_sizing`, a fused-header variant construction
+// sizes its allocation token for the *constructed arm* (`header + arm[k]`)
+// instead of the uniform max-arm width. Field offsets are unchanged — the
+// payload offset comes from the variant-wide alignment — so only the
+// trailing padding up to the max arm is dropped. Without the attribute
+// every existing test pins the uniform behavior.
+//
+// List: Cons {i64, rc} => 8 (header) + 16 = 24; Var {i64} => 8 + 8 = 16;
+// under the uniform contract both would be 24.
+
+!list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Var" [value] {i64}>, !reussir.record<compound "List.Nil" [value] {}>}>
+!rclist = !reussir.rc<!list>
+
+module @test attributes { reussir.per_constructor_box_sizing, dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+  // CHECK-LABEL: @cons
+  // CHECK: reussir.token.alloc : <align : 8, size : 24>
+  func.func @cons(%x: i64, %t: !rclist) -> !rclist {
+    %0 = "reussir.rc.create_variant"(%x, %t) <{operandSegmentSizes = array<i32: 0, 2, 0, 0>, tag = 0 : index}> : (i64, !rclist) -> !rclist
+    return %0 : !rclist
+  }
+  // CHECK-LABEL: @leaf
+  // CHECK: reussir.token.alloc : <align : 8, size : 16>
+  func.func @leaf(%x: i64) -> !rclist {
+    %0 = "reussir.rc.create_variant"(%x) <{operandSegmentSizes = array<i32: 0, 1, 0, 0>, tag = 1 : index}> : (i64) -> !rclist
+    return %0 : !rclist
+  }
+}


### PR DESCRIPTION
Opens the per-constructor variant box sizing stack for #325 — plan in `docs/design/per-constructor-box-sizing.md` (in this PR).

## Why

nbe-closure's 1.74× gap vs Koka is **causally node size**: Reussir boxes every variant at max-arm width (32 B), Koka sizes per constructor (`Var`/`VVar` = 16 B). Padding Koka to uniform 32 B reproduced our LLC misses (0.22 M → 2.51 M vs our 2.42 M) and runtime (125 → 238 ms vs our 224 ms) almost exactly. Borrow inference (Koka has none — `^` is annotation-only), the immediate encoding (#359), reuse pairing, and allocation volume were each ruled out by experiment.

## Design invariant

For any boxed variant: `allocated size == token<> size == freed size == header + arm[k]`, `k` the box's own tag. **Offsets never move** — the payload offset comes from the variant-wide alignment, so per-arm sizing only drops trailing padding; all record access lowering is untouched. Value variants stay uniform. No unsized free: every free is downstream of a tag discriminator (tag-known decs statically; tag-unknown via the outlined dtor's per-arm switch — step 2), so wasm/talc keep working.

## This PR (1/N)

- Module unit attr `reussir.per_constructor_box_sizing` (`Support/VariantBoxSizing.h`), stamped by `rrc --variant-box-sizing=per-constructor` (default `uniform`); attribute rather than dialect state so lit tests opt in on the module.
- `RecordType::getVariantArmAllocSize(dataLayout, tag)` — fused-header size with arm k's payload, variant-wide alignment preserved.
- `ReussirRcCreateVariantOp::getTokenType()` → per-arm token under the attr (complete fused-header variants, non-regional).
- `verifyRcCreateLikeOp` now validates the provided token against the op's own `TokenAcceptor::getTokenType()` — single source of truth; a wrong-size token is a **compile error**, not a heap overflow.

Verified: `Cons{i64,rc}` → `token<8,24>`, `Var{i64}` → `token<8,16>` with the attr; both 24 without. Full lit suite green (294).

## Status / stack

**EXPERIMENTAL until 2/N (free side: tag-known dec tokens + outlined-dtor per-arm frees, ASan-gated).** With only this PR, per-arm allocation + max-arm frees is safe only on the bundled mimalloc (free ignores the stated size). Remaining steps in the design doc: 2 free side → 3 reuse/lowering audit → 4 regional + TRMC cctx → 5 measure & flip default → 6 FFI marshalling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1uVYwR1HudwbuuxfdxEr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786158860&installation_id=144622820&pr_number=360&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F360&signature=20e943ef9156e2e7799f3d10cad16e5facfb4b2c2d136c70cf79c622b867a203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->