### PR TITLE
[runtime] default the bundled mimalloc to the stable v2 line

### DIFF
--- a/crates/reussir-rt/Cargo.toml
+++ b/crates/reussir-rt/Cargo.toml
@@ -14,12 +14,12 @@ smallvec = "1.15.1"
 stacker.workspace = true
 
 [features]
-default = ["mimalloc-v3"]
+default = ["mimalloc-v2"]
 snmalloc = ["snmalloc-rs"]
 # `mimalloc` is the version-neutral gate the code checks; select the bundled
 # mimalloc major through one of the versioned features (with
-# --no-default-features). v3 (default) has the reworked page management and
-# lower fragmentation; v2 is the stable line. Both share the bin geometry
+# --no-default-features). v2 (default) is the stable line; v3 has the
+# reworked page management and lower fragmentation. Both share the bin geometry
 # that include/Reussir/Support/AllocatorBinModel.h models (verified by
 # probing mi_usable_size on both), so the compiler-side size-class contract
 # holds for either.


### PR DESCRIPTION
Flips `reussir-rt`'s default feature from `mimalloc-v3` to `mimalloc-v2`.

- v3's reworked page management / lower fragmentation stays available via `--no-default-features --features mimalloc-v3`.
- Both majors share the bin geometry modeled by `include/Reussir/Support/AllocatorBinModel.h` (same size classes, verified via `mi_usable_size`), so the compiler-side size-class contract — and per-constructor box sizing's reuse pairing — is unaffected.

One-line default flip plus a comment fix (the note still labelled v3 as the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786174963&installation_id=144622820&pr_number=363&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F363&signature=595b28a4a990b66b15363bcbcb5a820f2135cdb66267e8fa42f49d9314c9e3fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->