### PR TITLE
[test] pin straight-line reuse of a dynamic token<?> donor

### DIFF
--- a/tests/integration/conversion/straight_line_dynamic_reuse.mlir
+++ b/tests/integration/conversion/straight_line_dynamic_reuse.mlir
@@ -1,0 +1,43 @@
+// RUN: %reussir-opt %s -reussir-token-reuse | %FileCheck %s
+
+// Straight-line reuse of a *dynamic* token (`token<align, ?>`, #361). An
+// unpinned decrement of a non-uniform variant yields a dynamic donor whose
+// size is only known at runtime. Unlike a statically-sized donor — which
+// only pairs within its mimalloc bin (see straight_line_reuse.mlir) — a
+// dynamic token is a *universal fallback* donor: TokenReuse pairs it with any
+// acceptor via `token.realloc`, which resizes to the acceptor's exact size at
+// runtime. Binning is only a heuristic for *which* donor to prefer; it never
+// gates this pairing.
+
+!list = !reussir.record<variant "List" {!reussir.record<compound "List.Cons" [value] {i64, !reussir.record<variant "List">}>, !reussir.record<compound "List.Var" [value] {i64}>, !reussir.record<compound "List.Nil" [value] {}>}>
+!rclist = !reussir.rc<!list>
+
+module @test attributes { reussir.per_constructor_box_sizing, dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+    // The dead dynamic donor feeds a 16-byte `Var` construction. The fresh
+    // 16-byte alloc is dropped; the donor is realloc'd to size 16 in place of it.
+    // CHECK-LABEL: @dyn_reuse_leaf
+    func.func @dyn_reuse_leaf(%0: !rclist, %x: i64) -> !rclist {
+        %tok = reussir.rc.dec (%0 : !rclist) : !reussir.nullable<!reussir.token<align: 8, size: ?>>
+        // CHECK-NOT:  reussir.token.alloc
+        // CHECK:      %[[t:[a-z0-9]+]] = reussir.token.realloc(%{{[a-z0-9]+}} : !reussir.nullable<!reussir.token<align : 8, size : ?>>) : <align : 8, size : 16>
+        // CHECK-NEXT: reussir.rc.create_variant"(%{{[a-z0-9]+}}, %[[t]]){{.*}}tag = 1
+        %tk = reussir.token.alloc : !reussir.token<align: 8, size: 16>
+        %r = "reussir.rc.create_variant"(%x, %tk) <{operandSegmentSizes = array<i32: 0, 1, 1, 0>, tag = 1 : index}> : (i64, !reussir.token<align: 8, size: 16>) -> !rclist
+        return %r : !rclist
+    }
+
+    // Same dynamic donor, but the acceptor is a 24-byte `Cons`. A statically
+    // 16-byte donor could never reach this (16 and 24 are different bins), but
+    // the dynamic donor reallocs to 24 all the same — the universal-fallback
+    // property that `token<?>` exists to provide.
+    // CHECK-LABEL: @dyn_reuse_any_size
+    func.func @dyn_reuse_any_size(%0: !rclist, %x: i64, %tail: !rclist) -> !rclist {
+        %tok = reussir.rc.dec (%0 : !rclist) : !reussir.nullable<!reussir.token<align: 8, size: ?>>
+        // CHECK-NOT:  reussir.token.alloc
+        // CHECK:      %[[t:[a-z0-9]+]] = reussir.token.realloc(%{{[a-z0-9]+}} : !reussir.nullable<!reussir.token<align : 8, size : ?>>) : <align : 8, size : 24>
+        // CHECK-NEXT: reussir.rc.create_variant"(%{{[a-z0-9]+}}, %{{[a-z0-9]+}}, %[[t]]){{.*}}tag = 0
+        %tk = reussir.token.alloc : !reussir.token<align: 8, size: 24>
+        %r = "reussir.rc.create_variant"(%x, %tail, %tk) <{operandSegmentSizes = array<i32: 0, 2, 1, 0>, tag = 0 : index}> : (i64, !rclist, !reussir.token<align: 8, size: 24>) -> !rclist
+        return %r : !rclist
+    }
+}


### PR DESCRIPTION
#361 landed the dynamic `token<align, ?>` fallback donor but the only dialect coverage was a round-trip (`token_dynamic_size.mlir`); the straight-line reuse pairing itself was untested. This adds it.

`straight_line_dynamic_reuse.mlir` (`-reussir-token-reuse`) pins:
- **`@dyn_reuse_leaf`** — unpinned dec of a non-uniform `List` variant → dynamic donor → `token.realloc` into a 16-byte `Var` construction; the fresh alloc is dropped.
- **`@dyn_reuse_any_size`** — same donor reused into a 24-byte `Cons`. A statically-16-byte donor could never reach this (16 and 24 are different mimalloc bins), but the dynamic donor reallocs to 24 — pinning that `token<?>` is a **universal fallback** donor and binning stays a pairing heuristic that never gates reuse.

Test-only; verified against the built `reussir-opt` + FileCheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786175210&installation_id=144622820&pr_number=364&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F364&signature=74fbf1112439edf42e15fb51a35d1b56bd96ae797e25e09553baf238db228428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->