### PR TITLE
[backend] make per-constructor variant box sizing the default (#325, 3/N)

### DIFF
--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -80,10 +80,10 @@ enum VariantEncoding {
 /// CLI surface for the variant box-sizing contract.
 #[derive(Clone, Copy, PartialEq, Eq, palc::ValueEnum)]
 enum BoxSizing {
-    /// Every boxed variant cell is the max-arm width (the shipped layout
-    /// contract; any arm's block reuses for any other).
+    /// Opt-out: every boxed variant cell is the max-arm width (any arm's
+    /// block reuses for any other, at the cost of trailing padding).
     Uniform,
-    /// EXPERIMENTAL: each cell is sized for its constructed arm
+    /// Default: each cell is sized for its constructed arm
     /// (`header + arm[k]`); offsets unchanged, trailing padding dropped.
     PerConstructor,
 }
@@ -231,18 +231,19 @@ struct Cli {
           default_value_t = VariantEncoding::ArchDependent)]
     nullary_variant_encoding: VariantEncoding,
 
-    /// How boxed enum variants size their heap cells. `uniform` (default,
-    /// the shipped layout contract) sizes every cell at the max-arm width,
-    /// so any arm's block can be reused for any other. `per-constructor`
-    ///(EXPERIMENTAL — allocation-side only for now; requires the
-    /// bundled mimalloc runtime, whose free ignores the stated size) sizes
-    /// each cell for the constructed arm: `header + arm[k]`. Field offsets
-    /// are identical either way — per-constructor only drops the trailing
-    /// padding up to the max arm, shrinking leaf-heavy workloads' cache
-    /// footprint (nbe-closure: the 16-byte leaf arms double to 32 under
-    /// `uniform`, which measured as ~the whole gap vs Koka).
+    /// How boxed enum variants size their heap cells. `per-constructor`
+    /// (default) sizes each cell for its constructed arm (`header + arm[k]`):
+    /// an unpinned decrement of a non-uniform variant frees the exact runtime
+    /// size (via a dynamic `token<align, ?>`), so this is sound on any
+    /// allocator, not just the bundled mimalloc. `uniform` (opt-out) sizes
+    /// every cell at the max-arm width, so any arm's block reuses for any
+    /// other, at the cost of trailing padding. Field offsets are identical
+    /// either way — per-constructor only drops the trailing padding up to the
+    /// max arm, shrinking leaf-heavy workloads' cache footprint (nbe-closure:
+    /// the 16-byte leaf arms double to 32 under `uniform`, which measured as
+    /// ~the whole gap vs Koka).
     #[arg(long = "variant-box-sizing", value_enum,
-          default_value_t = BoxSizing::Uniform)]
+          default_value_t = BoxSizing::PerConstructor)]
     variant_box_sizing: BoxSizing,
 
     /// Split codegen into this many units. Each function's body is emitted in

--- a/docs/design/per-constructor-box-sizing.md
+++ b/docs/design/per-constructor-box-sizing.md
@@ -81,8 +81,17 @@ Landed: the switch (`reussir.per_constructor_box_sizing` module attr,
 `token<?>` fallback reuse. Sound (requested alloc/free sizes round-trip;
 executing gate `per_ctor_box_sizing_mixed_arms.rr` under both sizings).
 
-Remaining: regional `rc.create*` bump path; confirm TRMC constructor contexts
-(they already ride `rc.create_variant`, so per-arm); the 8-granular mimalloc
-bin to capture the 24-byte arms; measure the full suite + flip the default;
-generated FFI marshalling (the layout was never a plain cast, so non-uniform
-sizing doesn't move that goalpost).
+**Now the default** (`rrc --variant-box-sizing per-constructor`; `uniform`
+is the opt-out). Every construction path was already per-arm-correct through
+the `getTokenType()` / `getVariantArmAllocSize()` single source of truth —
+the heap path (#360/#361), the **regional** bump `rc.create` (token-driven:
+the cell size is the token's, never `getTypeSize(rcBoxType)`; the region is a
+linked bump, so per-arm just shortens each cell), and **TRMC** holes (the
+constructor's token is threaded through unchanged). Flipping the flag needed
+no lowering change; the full integration suite is green under it.
+
+Remaining: the 8-granular mimalloc bin to capture the 24-byte arms (a runtime
+knob, orthogonal — `AllocatorBinModel.h` is only a *pairing hint*, so its
+geometry never gates correctness); benchmark the full suite to quantify the
+win at the new default; generated FFI marshalling (the layout was never a
+plain cast, so non-uniform sizing doesn't move that goalpost).

--- a/include/Reussir/Support/AllocatorBinModel.h
+++ b/include/Reussir/Support/AllocatorBinModel.h
@@ -16,21 +16,25 @@
 
 namespace reussir {
 
-// Size-class (bin) map of the default reussir-rt allocator: mimalloc v3
-// behind the natural-bin GlobalAlloc. Verified against
+// Approximate size-class (bin) map of the default reussir-rt allocator
+// (mimalloc behind the natural-bin GlobalAlloc), as observed via
 // mi_usable_size(mi_malloc(n)) for n in [1, 1024]:
 //   <= 16      : 8-byte bins  {8, 16}
-//   17 .. 128  : 16-byte bins {32, 48, ..., 128}   (note: no 24-byte bin)
+//   17 .. 128  : 16-byte bins {32, 48, ..., 128}
 //   > 128      : each power-of-two octave splits into four bins
 //                (129..256 step 32, 257..512 step 64, 513..1024 step 128, …)
+// The exact geometry varies by mimalloc major (e.g. whether 24 gets its own
+// bin), which is fine — see below.
 //
-// This is a contract with the *linked* allocator, not a heuristic: TokenReuse
-// emits `token.realloc` pairings only for sizes that share a bin here, and
-// the same-bin lowering reuses the block in place without consulting the
-// runtime. If the rt default allocator (or its bin geometry) changes, this
-// map must change with it — a mismatch silently turns "in-place" pairings
-// into moving reallocs (see #325: the previous SnMalloc-derived model paired
-// across mimalloc bins, each such realloc copying dead token bytes).
+// This is only a *hint*, not a correctness contract. TokenReuse consults it to
+// choose which donor to prefer: a fixed-size donor sharing a bin with its
+// acceptor scores above a cross-bin one, since reusing it avoids a moving
+// realloc. It gates nothing in lowering — `token.realloc` always calls
+// `__reussir_reallocate` (which copies if the allocator moves the block), so a
+// stale or imprecise map only costs a suboptimal pairing (an avoidable copy),
+// never a miscompile. Keep it roughly in step with the linked allocator to keep
+// the heuristic sharp (see #325: the previous SnMalloc-derived model paired
+// across mimalloc bins, so its "in-bin" reallocs copied anyway).
 constexpr std::size_t allocatorBinSize(std::size_t size) {
   if (size <= 16)
     return (size + 7) & ~std::size_t{7};


### PR DESCRIPTION
Capstone of the per-constructor box sizing stack (#360 create-side per-arm tokens, #361 dynamic-token free + `token<?>` reuse). Flips `rrc --variant-box-sizing` default from `uniform` → `per-constructor`; `uniform` stays as the opt-out.

## No lowering change needed
Every variant construction path already sizes through the `getTokenType()` / `getVariantArmAllocSize()` single source of truth, so flipping the default just turns the module attr on by default. The two paths the design doc flagged as "remaining" turned out already per-arm-correct:

- **Regional bump `rc.create`** — token-driven (`BasicOpsLowering.cpp:1476–1508`): GEPs off the instantiated token and chains the cell into the region list; never computes size from `getTypeSize(rcBoxType)`. The region is a linked bump (runtime `region/mod.rs` frees whole regions, not cells), so per-arm just shortens each cell.
- **TRMC holes** — thread the constructor's token through unchanged, inheriting #360's per-arm token.

## Doc/comment corrections
- CLI/enum doc comments: per-constructor is the default; dropped the stale "EXPERIMENTAL / mimalloc-only" caveat (#361's dynamic token frees the exact size on any allocator).
- `AllocatorBinModel.h`: its header claimed to be "a contract with the linked allocator, not a heuristic" and described an in-place same-bin realloc that #361 **removed**. Corrected to state the truth — it's only a pairing **hint** (single use: TokenReuse donor scoring), gates nothing in lowering, so its bin geometry never affects correctness (a mispredicted pairing still lowers to a real `__reussir_reallocate` that copies if the block moves).

## Verification
- Default now emits per-arm allocate sizes (16/24) where `uniform` emits the max (32).
- Full integration suite green under the flipped default: **277 passed, 0 failed**; 19 sanitizer tests unsupported in this build config (exercised in CI; #361 already ran the per-constructor free path under ASan).

Follow-ups (out of scope): 8-granular mimalloc bin to capture the 24-byte arms; benchmark at the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786198213&installation_id=144622820&pr_number=365&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F365&signature=33ddaedebc78957e2dbb6eee7131d80d8f2cd2b441b9d7c85b1d0f8882016084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->