### PR TITLE
[backend] unsized dynamic token<?> + 8-granular mimalloc bins (#325)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,14 +1,17 @@
-# snmalloc-sys vendors a copy of snmalloc whose CMake build compiles with
-# `/WX` (warnings-as-errors) under MSVC. Recent MSVC toolchains (VS 2022 17.x /
-# VS 18, 14.5x) emit C4864 ("expected 'template' keyword before dependent
-# template name") inside snmalloc's `corealloc.h`, which `/WX` promotes to a
-# hard error and breaks the Windows (MSVC) build of `reussir-rt`.
+# reussir-rt uses mimalloc as the language-heap allocator. libmimalloc-sys has
+# no feature to set mimalloc's small-bin granularity, so inject the compile
+# define here: `MI_MAX_ALIGN_SIZE=8` makes mimalloc guarantee only 8-byte
+# alignment and step its small size-classes by 8, giving 8-granular bins
+# {8,16,24,32,40,48,56,64} instead of the default 16-granular {8,16,32,48,…}.
+# That lets a per-constructor variant box of 24/40/… bytes occupy its exact
+# size instead of rounding up (e.g. a 24-byte `App` node stays 24, not 32),
+# which is what closes the nbe-closure footprint gap vs Koka (Koka sets the
+# same define in kklib). Reussir boxes are <=8-aligned and `alloc.rs`'s
+# natural-alignment dispatch routes any over-aligned request through
+# `mi_*_aligned`, so weakening malloc's implicit alignment to 8 is sound. The
+# define is inert for the other C build-scripts (backtrace, psm, stacker),
+# which do not use the macro.
 #
-# Disable just that warning for the MSVC target. `/wd<n>` removes the warning
-# entirely, so `/WX` cannot promote it regardless of flag order. The cc/cmake
-# build crates fold these target-prefixed vars into `CMAKE_CXX_FLAGS`, and the
-# target suffix scopes them to MSVC only — the gnu/gnullvm (clang) Windows
-# builds and all other platforms are unaffected.
+# The `alloc.rs` `MI_MAX_ALIGN_SIZE` constant must stay equal to this value.
 [env]
-CFLAGS_x86_64_pc_windows_msvc = "/wd4864"
-CXXFLAGS_x86_64_pc_windows_msvc = "/wd4864"
+CFLAGS = "-DMI_MAX_ALIGN_SIZE=8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,15 +321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,10 +2089,10 @@ version = "0.1.0"
 dependencies = [
  "backtrace",
  "hashbrown 0.16.1",
+ "libc",
  "libmimalloc-sys",
  "num_enum",
  "smallvec",
- "snmalloc-rs",
  "stacker",
 ]
 
@@ -2339,24 +2330,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "snmalloc-rs"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530a04ae687609072d0edd38866406fbbcd23d2f716791437e312ec4d64a355a"
-dependencies = [
- "snmalloc-sys",
-]
-
-[[package]]
-name = "snmalloc-sys"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96cbeb16d6bcc5979f80ec907582a886b7fb3b9a707678b63dd93a10d8ee858"
-dependencies = [
- "cmake",
-]
 
 [[package]]
 name = "stable_deref_trait"

--- a/crates/reussir-rt/Cargo.toml
+++ b/crates/reussir-rt/Cargo.toml
@@ -7,22 +7,27 @@ license.workspace = true
 [dependencies]
 backtrace = { version = "0.3.75" }
 hashbrown = { version = "0.16.0" }
+# Fallback allocator when the mimalloc backend is unavailable: the sanitizer
+# runtime variants (built `--no-default-features`), miri, and lean embeddings
+# like reussir-jit. libc `malloc`/`free`/`realloc` recover the block size from
+# the pointer (so the unsized `token<?>` ABI works), the sanitizers *interpose*
+# them (so ASan/LSan/MSan actually see the runtime's allocations — mimalloc's
+# and dlmalloc's private heaps are invisible to them), and miri shims them.
+libc = "0.2"
 libmimalloc-sys = { version = "0.1.44", optional = true }
-snmalloc-rs = { version = "0.7", optional = true }
 num_enum = "0.7.4"
 smallvec = "1.15.1"
 stacker.workspace = true
 
 [features]
 default = ["mimalloc-v2"]
-snmalloc = ["snmalloc-rs"]
-# `mimalloc` is the version-neutral gate the code checks; select the bundled
-# mimalloc major through one of the versioned features (with
-# --no-default-features). v2 (default) is the stable line; v3 has the
-# reworked page management and lower fragmentation. Both share the bin geometry
-# that include/Reussir/Support/AllocatorBinModel.h models (verified by
-# probing mi_usable_size on both), so the compiler-side size-class contract
-# holds for either.
+# The language heap requires a size-recovering allocator (`token<?>` frees
+# without a size); mimalloc is that allocator today (dlmalloc later). `mimalloc`
+# is the version-neutral gate the code checks; select the bundled major through
+# one of the versioned features (with --no-default-features). v3 has the
+# reworked page management and lower fragmentation; v2 (default) is the stable
+# line. Both share the bin geometry that
+# include/Reussir/Support/AllocatorBinModel.h models (only a pairing hint).
 mimalloc = ["dep:libmimalloc-sys"]
 mimalloc-v3 = ["mimalloc", "libmimalloc-sys/v3"]
 mimalloc-v2 = ["mimalloc"]

--- a/crates/reussir-rt/src/alloc.rs
+++ b/crates/reussir-rt/src/alloc.rs
@@ -1,122 +1,215 @@
-use std::alloc::Layout;
+//! Direct allocator entry points for the Reussir language heap.
+//!
+//! The runtime no longer routes the language heap through Rust's `GlobalAlloc`.
+//! `GlobalAlloc::dealloc`/`realloc` require the block's `Layout`, but an
+//! unpinned decrement of a non-uniform per-constructor variant frees a
+//! `token<?>` whose size is not known at the call site. Instead the heap talks
+//! to a *size-recovering* allocator directly (mimalloc: `mi_free`/`mi_realloc`
+//! recover the block from the pointer; dlmalloc later). That lets a `token<?>`
+//! be a bare pointer with no carried size — no fat `{ptr,size}` value and no
+//! per-arm size computation at the free site. The linked allocator is always
+//! size-recovering; there is no `Layout`-tracking fallback.
+//!
+//! Two ABIs coexist: the *sized* `__reussir_deallocate`/`__reussir_reallocate`
+//! (static tokens still pass their known size, ignored by the backend) and the
+//! *unsized* `__reussir_dealloc_unsized`/`__reussir_realloc_unsized` (dynamic
+//! `token<?>`), which pass only the pointer (and, for realloc, the new
+//! alignment + size).
 
-/// A `GlobalAlloc` over mimalloc's raw entry points.
-///
-/// The `mimalloc` crate routes every allocation through `mi_malloc_aligned`,
-/// and mimalloc v3 serves an aligned request from its natural size bins only
-/// when the rounded block size is a power of two; everything else takes the
-/// over-allocating aligned path, so e.g. a 48-byte rc box occupies a 64-byte
-/// block — growing every heap line the program touches — and pays the generic
-/// path's extra instructions on each call. Dispatch on the layout instead: a
-/// natural bin already satisfies `align` whenever `align <= 16`
-/// (`MI_MAX_ALIGN_SIZE`: bin sizes are multiples of 8 and, above 16, of 16,
-/// and a page's first block is 16-aligned) and `size` is a multiple of
-/// `align`, so such requests — every rc box among them — take the plain fast
-/// path.
+/// mimalloc backend (production). Its free/realloc recover the block size from
+/// the pointer, so no size is needed to free or grow.
 #[cfg(all(feature = "mimalloc", not(miri)))]
-pub mod mimalloc {
-    use std::alloc::{GlobalAlloc, Layout};
-
+mod backend {
     use libmimalloc_sys as ffi;
 
     /// `MI_MAX_ALIGN_SIZE`: the alignment mimalloc's plain entry points
-    /// guarantee for naturally aligned sizes.
-    const MI_MAX_ALIGN_SIZE: usize = 16;
+    /// guarantee for naturally aligned sizes. Must match the value mimalloc is
+    /// built with (`.cargo/config.toml` sets `-DMI_MAX_ALIGN_SIZE=8`): the 8
+    /// unlocks 8-granular size-classes so a 24-byte variant box stays 24
+    /// bytes. A natural bin already satisfies `align` whenever
+    /// `align <= 8` and `size` is a multiple of `align`, so such requests
+    /// (every rc box among them — Reussir boxes are <=8-aligned) take the
+    /// plain fast path; anything over-aligned goes through the aligned path.
+    const MI_MAX_ALIGN_SIZE: usize = 8;
 
     #[inline]
     const fn naturally_aligned(size: usize, align: usize) -> bool {
         align <= MI_MAX_ALIGN_SIZE && size % align == 0
     }
 
-    pub struct MiMalloc;
-
-    unsafe impl GlobalAlloc for MiMalloc {
-        #[inline]
-        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-            unsafe {
-                if naturally_aligned(layout.size(), layout.align()) {
-                    ffi::mi_malloc(layout.size()).cast()
-                } else {
-                    ffi::mi_malloc_aligned(layout.size(), layout.align()).cast()
-                }
+    #[inline]
+    pub unsafe fn alloc(align: usize, size: usize) -> *mut u8 {
+        unsafe {
+            if naturally_aligned(size, align) {
+                ffi::mi_malloc(size).cast()
+            } else {
+                ffi::mi_malloc_aligned(size, align).cast()
             }
         }
+    }
 
-        #[inline]
-        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-            unsafe {
-                if naturally_aligned(layout.size(), layout.align()) {
-                    ffi::mi_zalloc(layout.size()).cast()
-                } else {
-                    ffi::mi_zalloc_aligned(layout.size(), layout.align()).cast()
-                }
+    #[inline]
+    pub unsafe fn free(ptr: *mut u8) {
+        unsafe { ffi::mi_free(ptr.cast()) }
+    }
+
+    #[inline]
+    pub unsafe fn realloc(ptr: *mut u8, new_align: usize, new_size: usize) -> *mut u8 {
+        // The result only has to satisfy the (new) alignment; mi_realloc accepts
+        // blocks from either path and recovers the old size itself.
+        unsafe {
+            if naturally_aligned(new_size, new_align) {
+                ffi::mi_realloc(ptr.cast(), new_size).cast()
+            } else {
+                ffi::mi_realloc_aligned(ptr.cast(), new_size, new_align).cast()
             }
         }
+    }
+}
 
-        #[inline]
-        unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-            unsafe { ffi::mi_free(ptr.cast()) }
-        }
+/// Fallback backend for builds without the mimalloc backend: the sanitizer
+/// runtime variants (built `--no-default-features`), `miri` (mimalloc's C can't
+/// run in the interpreter), and lean embeddings like reussir-jit. It calls libc
+/// `malloc`/`free`/`realloc` directly — size-recovering (so the unsized
+/// `token<?>` ABI works), *interposed by the sanitizers* (so ASan/LSan/MSan see
+/// the runtime's allocations, which they cannot through mimalloc's or
+/// dlmalloc's private heaps), and shimmed by miri. Never used in production.
+#[cfg(any(not(feature = "mimalloc"), miri))]
+mod backend {
+    use core::ffi::c_void;
 
-        #[inline]
-        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-            // The result only has to satisfy the (unchanged) alignment, so
-            // dispatch on the new size; mi_realloc accepts blocks from either
-            // path.
-            unsafe {
-                if naturally_aligned(new_size, layout.align()) {
-                    ffi::mi_realloc(ptr.cast(), new_size).cast()
-                } else {
-                    ffi::mi_realloc_aligned(ptr.cast(), new_size, layout.align()).cast()
-                }
+    /// libc `malloc` guarantees `max_align_t` (16-byte) alignment; anything
+    /// larger goes through `posix_memalign`.
+    const MALLOC_ALIGN: usize = 16;
+
+    #[inline]
+    pub unsafe fn alloc(align: usize, size: usize) -> *mut u8 {
+        // Both the language heap (`__reussir_*`) and the global allocator route
+        // here. `malloc` already returns `max_align_t` (16-byte) aligned, so it
+        // covers every request up to 16. Larger alignments go through
+        // `posix_memalign`; those are always powers of two >= 32, hence valid
+        // multiples of `sizeof(void*)`.
+        if align <= MALLOC_ALIGN {
+            unsafe { libc::malloc(size) as *mut u8 }
+        } else {
+            let mut ptr: *mut c_void = core::ptr::null_mut();
+            if unsafe { libc::posix_memalign(&mut ptr, align, size) } != 0 {
+                return core::ptr::null_mut();
             }
+            ptr as *mut u8
         }
+    }
+
+    #[inline]
+    pub unsafe fn free(ptr: *mut u8) {
+        unsafe { libc::free(ptr as *mut c_void) }
+    }
+
+    #[inline]
+    pub unsafe fn realloc(ptr: *mut u8, new_align: usize, new_size: usize) -> *mut u8 {
+        // `realloc` preserves malloc's `max_align_t` alignment, which covers
+        // every Reussir box (all <=8-aligned); reussir never grows to a larger
+        // alignment.
+        let _ = new_align;
+        unsafe { libc::realloc(ptr as *mut c_void, new_size) as *mut u8 }
+    }
+}
+
+/// The runtime's `#[global_allocator]`: forwards Rust's own allocations
+/// (`Vec`/`Box`, the region headers freed through `std::alloc`, hashbrown, …)
+/// to the *same* backend the language heap uses. This is essential, not
+/// cosmetic: runtime-internal allocations and `__reussir_*` blocks cross — a
+/// region cell is allocated by generated code via `__reussir_allocate` yet its
+/// memory is released through `std::alloc::dealloc` — so both sides must be one
+/// allocator.
+///
+/// It uses the same allocator but *not* the language heap's 8-byte-natural
+/// convention: the process global allocator must honor `max_align_t`
+/// (16-byte) alignment even for small requests, because platform code that
+/// shares this heap assumes it (notably macOS system frameworks and parts of
+/// Rust's std). So every allocation is forced to at least 16-byte alignment
+/// via the backend's aligned path. `__reussir_*` keep the 8-byte convention
+/// (reussir boxes request their own alignment and never escape to that code),
+/// preserving the 8-granular per-constructor win; they also call the backend
+/// *directly*, so the unsized `token<?>` ABI needs no `Layout`.
+pub struct ReussirGlobalAlloc;
+
+/// `max_align_t` — the alignment a C/Rust global allocator is expected to
+/// provide for any allocation.
+const GLOBAL_MAX_ALIGN: usize = 16;
+
+unsafe impl std::alloc::GlobalAlloc for ReussirGlobalAlloc {
+    #[inline]
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        unsafe { backend::alloc(layout.align().max(GLOBAL_MAX_ALIGN), layout.size()) }
+    }
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: std::alloc::Layout) {
+        unsafe { backend::free(ptr) }
+    }
+    #[inline]
+    unsafe fn realloc(
+        &self,
+        ptr: *mut u8,
+        layout: std::alloc::Layout,
+        new_size: usize,
+    ) -> *mut u8 {
+        unsafe { backend::realloc(ptr, layout.align().max(GLOBAL_MAX_ALIGN), new_size) }
     }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __reussir_allocate(align: usize, size: usize) -> *mut u8 {
-    unsafe {
-        // The language makes sure the alignment is valid. This will still be checked
-        // in debug mode even though it is 'unchecked' API.
-        let layout = Layout::from_size_align(size, align).unwrap_unchecked();
-        let ptr = std::alloc::alloc(layout);
-        if ptr.is_null() {
-            crate::panic!("allocation failed");
-        }
-        ptr
+    let ptr = unsafe { backend::alloc(align, size) };
+    if ptr.is_null() {
+        unsafe { crate::panic!("allocation failed") };
     }
+    ptr
 }
 
+/// Free a statically sized token. The size/align are the caller's record of the
+/// block; a size-recovering backend ignores them.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __reussir_deallocate(ptr: *mut u8, align: usize, size: usize) {
+pub unsafe extern "C" fn __reussir_deallocate(ptr: *mut u8, _align: usize, _size: usize) {
     if !ptr.is_null() {
-        let layout = unsafe { Layout::from_size_align(size, align).unwrap_unchecked() };
-        unsafe { std::alloc::dealloc(ptr, layout) };
+        unsafe { backend::free(ptr) };
     }
 }
 
-// TODO: maybe this can be optimized further since we do not need copy the data.
+/// Free a dynamic `token<?>`: only the pointer is known — the backend recovers
+/// the block size.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __reussir_dealloc_unsized(ptr: *mut u8) {
+    if !ptr.is_null() {
+        unsafe { backend::free(ptr) };
+    }
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __reussir_reallocate(
     ptr: *mut u8,
-    old_align: usize,
-    old_size: usize,
+    _old_align: usize,
+    _old_size: usize,
     new_align: usize,
     new_size: usize,
 ) -> *mut u8 {
-    unsafe {
-        if ptr.is_null() || old_align != new_align {
-            if !ptr.is_null() {
-                __reussir_deallocate(ptr, old_align, old_size);
-            }
-            return __reussir_allocate(new_align, new_size);
-        }
-        let layout = Layout::from_size_align(old_size, old_align).unwrap_unchecked();
-        let ptr = std::alloc::realloc(ptr, layout, new_size);
-        if ptr.is_null() {
-            crate::panic!("reallocation failed");
-        }
-        ptr
+    unsafe { __reussir_realloc_unsized(ptr, new_align, new_size) }
+}
+
+/// Resize a dynamic `token<?>` to `new_size`/`new_align`: the old size is not
+/// supplied — the backend recovers it.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __reussir_realloc_unsized(
+    ptr: *mut u8,
+    new_align: usize,
+    new_size: usize,
+) -> *mut u8 {
+    if ptr.is_null() {
+        return unsafe { __reussir_allocate(new_align, new_size) };
     }
+    let ptr = unsafe { backend::realloc(ptr, new_align, new_size) };
+    if ptr.is_null() {
+        unsafe { crate::panic!("reallocation failed") };
+    }
+    ptr
 }

--- a/crates/reussir-rt/src/lib.rs
+++ b/crates/reussir-rt/src/lib.rs
@@ -1,14 +1,15 @@
 #![allow(clippy::missing_safety_doc)]
 
-#[cfg(all(feature = "mimalloc", not(miri)))]
+// The language heap talks to a size-recovering allocator directly through the
+// `__reussir_*` entry points in `alloc` (so a `token<?>` frees without a
+// `Layout`). Rust's own allocations go through `ReussirGlobalAlloc`, which
+// forwards to that *same* backend — runtime-internal memory and `__reussir_*`
+// blocks cross (region headers are allocated by `__reussir_allocate` and freed
+// through `std::alloc`), so they must be one allocator. Skipped under miri,
+// where the backend cannot service the interpreter's own allocations.
+#[cfg(not(miri))]
 #[global_allocator]
-static GLOBAL: alloc::mimalloc::MiMalloc = alloc::mimalloc::MiMalloc;
-
-// mimalloc is in the default feature set, so an additive `--features snmalloc`
-// would otherwise enable both and declare two global allocators.
-#[cfg(all(feature = "snmalloc", not(feature = "mimalloc"), not(miri)))]
-#[global_allocator]
-static GLOBAL: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+static GLOBAL: alloc::ReussirGlobalAlloc = alloc::ReussirGlobalAlloc;
 
 pub mod alloc;
 pub mod collections;

--- a/crates/reussir-rt/src/symbols.rs
+++ b/crates/reussir-rt/src/symbols.rs
@@ -10,7 +10,10 @@
 
 use core::ffi::c_void;
 
-use crate::alloc::{__reussir_allocate, __reussir_deallocate, __reussir_reallocate};
+use crate::alloc::{
+    __reussir_allocate, __reussir_dealloc_unsized, __reussir_deallocate, __reussir_realloc_unsized,
+    __reussir_reallocate,
+};
 use crate::panic::__reussir_panic;
 use crate::region::{
     __reussir_acquire_rigid_object, __reussir_cleanup_region, __reussir_freeze_flex_object,
@@ -48,7 +51,9 @@ pub fn exported_symbols() -> &'static [RuntimeSymbol] {
     symbols![
         __reussir_allocate,
         __reussir_deallocate,
+        __reussir_dealloc_unsized,
         __reussir_reallocate,
+        __reussir_realloc_unsized,
         __reussir_panic,
         __reussir_freeze_flex_object,
         __reussir_cleanup_region,

--- a/include/Reussir/Support/AllocatorBinModel.h
+++ b/include/Reussir/Support/AllocatorBinModel.h
@@ -16,30 +16,28 @@
 
 namespace reussir {
 
-// Approximate size-class (bin) map of the default reussir-rt allocator
-// (mimalloc behind the natural-bin GlobalAlloc), as observed via
-// mi_usable_size(mi_malloc(n)) for n in [1, 1024]:
-//   <= 16      : 8-byte bins  {8, 16}
-//   17 .. 128  : 16-byte bins {32, 48, ..., 128}
-//   > 128      : each power-of-two octave splits into four bins
-//                (129..256 step 32, 257..512 step 64, 513..1024 step 128, …)
-// The exact geometry varies by mimalloc major (e.g. whether 24 gets its own
-// bin), which is fine — see below.
+// Size-class (bin) map of the default reussir-rt allocator: mimalloc behind
+// the natural-bin path, built with `MI_MAX_ALIGN_SIZE=8` (so it guarantees
+// only 8-byte alignment and its small size-classes step by 8, not 16 — see
+// crates/reussir-rt). Verified against mi_usable_size(mi_malloc(n)) for
+// n in [1, 1024]:
+//   <= 64      : 8-byte bins  {8, 16, 24, 32, 40, 48, 56, 64}
+//   > 64       : each power-of-two octave splits into four bins
+//                (65..128 step 16, 129..256 step 32, 257..512 step 64, …)
+// The 8-granular small range is what lets a per-constructor 24-byte variant
+// box occupy a real 24-byte block instead of rounding to 32 (the default
+// `MI_MAX_ALIGN_SIZE=16` gives 16-granular bins {8,16,32,48,…} with no 24).
 //
-// This is only a *hint*, not a correctness contract. TokenReuse consults it to
-// choose which donor to prefer: a fixed-size donor sharing a bin with its
-// acceptor scores above a cross-bin one, since reusing it avoids a moving
-// realloc. It gates nothing in lowering — `token.realloc` always calls
-// `__reussir_reallocate` (which copies if the allocator moves the block), so a
-// stale or imprecise map only costs a suboptimal pairing (an avoidable copy),
-// never a miscompile. Keep it roughly in step with the linked allocator to keep
-// the heuristic sharp (see #325: the previous SnMalloc-derived model paired
-// across mimalloc bins, so its "in-bin" reallocs copied anyway).
+// This is only a *hint*, not a correctness contract: TokenReuse consults it to
+// prefer a donor that shares a bin with its acceptor (so reuse avoids a moving
+// realloc). It gates nothing in lowering — `token.realloc` always calls the
+// runtime, which copies if the block moves — so a stale or imprecise map only
+// costs a suboptimal pairing, never a miscompile. Keep it roughly in step with
+// the linked allocator to keep the heuristic sharp (see #325: the previous
+// SnMalloc-derived model paired across mimalloc bins, so its reallocs copied).
 constexpr std::size_t allocatorBinSize(std::size_t size) {
-  if (size <= 16)
+  if (size <= 64)
     return (size + 7) & ~std::size_t{7};
-  if (size <= 128)
-    return (size + 15) & ~std::size_t{15};
   const std::size_t octave = std::bit_ceil(size);
   const std::size_t step = octave / 8;
   return (size + step - 1) & ~(step - 1);

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -113,16 +113,6 @@ namespace {
 // The only other guard is `rc.assume_unique`, which must neutralize its
 // assumption for immediates (an `assume(false)` would be unsound).
 
-// Whether `ty` is `nullable<token<align, ?>>` — a nullable dynamic token,
-// which lowers to a fat `{ptr, size}` struct rather than a bare
-// pointer, so nullable check/create must operate on the pointer field.
-inline bool isDynamicTokenNullable(mlir::Type ty) {
-  auto nullable = llvm::dyn_cast<NullableType>(ty);
-  if (!nullable)
-    return false;
-  auto token = llvm::dyn_cast<TokenType>(nullable.getPtrTy());
-  return token && token.isDynamicSize();
-}
 
 enum class TagEncoding { None, TBI, Immortal };
 
@@ -382,9 +372,9 @@ struct ReussirTokenFreeConversionPattern
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
     ensureRuntimeFunctions(op->getParentOfType<mlir::ModuleOp>(), *converter);
 
-    // Get the token operand (already converted: a bare pointer for a static
-    // token, a fat `{ptr, size}` for a dynamic one).
-    mlir::Value tokenVal = adaptor.getToken();
+    // The token is a bare pointer either way (a dynamic `token<?>` carries no
+    // size; the allocator recovers the block from the pointer).
+    mlir::Value tokenPtr = adaptor.getToken();
 
     // Get the token type and extract alignment and size
     TokenType tokenType = llvm::dyn_cast<TokenType>(op.getToken().getType());
@@ -397,28 +387,24 @@ struct ReussirTokenFreeConversionPattern
       return op.emitOpError(
           "token operand must be of TokenType or NullableTokenType");
 
+    auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
+
+    if (tokenType.isDynamicSize()) {
+      // Unsized free: hand the allocator only the pointer; it recovers the
+      // block size (mimalloc `mi_free`, dlmalloc later).
+      auto deallocFunc = moduleOp.lookupSymbol<mlir::LLVM::LLVMFuncOp>(
+          "__reussir_dealloc_unsized");
+      rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
+          op, deallocFunc, mlir::ValueRange{tokenPtr});
+      return mlir::success();
+    }
+
+    // Statically sized token: pass the known (align, size).
     auto indexType = converter->getIndexType();
     auto alignConst = mlir::arith::ConstantOp::create(
         rewriter, loc, mlir::IntegerAttr::get(indexType, tokenType.getAlign()));
-
-    // The pointer and the (static or runtime) size to hand `deallocate`.
-    mlir::Value tokenPtr;
-    mlir::Value sizeVal;
-    if (tokenType.isDynamicSize()) {
-      // Fat token: pointer is field 0, the runtime size field 1.
-      tokenPtr = mlir::LLVM::ExtractValueOp::create(
-          rewriter, loc, tokenVal, llvm::ArrayRef<int64_t>{0});
-      sizeVal = mlir::LLVM::ExtractValueOp::create(
-          rewriter, loc, tokenVal, llvm::ArrayRef<int64_t>{1});
-    } else {
-      tokenPtr = tokenVal;
-      sizeVal = mlir::arith::ConstantOp::create(
-          rewriter, loc,
-          mlir::IntegerAttr::get(indexType, tokenType.getSize()));
-    }
-
-    // Replace the original operation with the runtime function call
-    auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
+    auto sizeVal = mlir::arith::ConstantOp::create(
+        rewriter, loc, mlir::IntegerAttr::get(indexType, tokenType.getSize()));
     auto deallocFunc =
         moduleOp.lookupSymbol<mlir::LLVM::LLVMFuncOp>("__reussir_deallocate");
     rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
@@ -449,59 +435,11 @@ struct ReussirRcReinterpretConversionPattern
   mlir::LogicalResult
   matchAndRewrite(ReussirRcReinterpretOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    // A static token is the box pointer verbatim. A *dynamic* token
-    // (`token<align, ?>`, from an unpinned variant dec under per-constructor
-    // sizing) is a fat `{ptr, size}`: recover the exact size from the box's
-    // still-live fused tag (per-constructor box) so the later free /
-    // realloc pass an exact size on any allocator.
-    auto tokenType = llvm::dyn_cast<TokenType>(op.getReinterpreted().getType());
-    if (!tokenType || !tokenType.isDynamicSize()) {
-      rewriter.replaceOp(op, adaptor.getRcPtr());
-      return mlir::success();
-    }
-    auto converter =
-        static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
-    mlir::Location loc = op.getLoc();
-    auto recordType =
-        llvm::cast<RecordType>(op.getRcPtr().getType().getElementType());
-    auto dataLayout = getDataLayout(*converter, op);
-    auto indexTy = converter->getIndexType();
-    auto i32Ty = rewriter.getI32Type();
-    auto ptrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
-    mlir::Value box = adaptor.getRcPtr();
-    // Fused header `{i32 count, i32 tag}`: the tag is the second i32 word.
-    auto hdrTy = mlir::LLVM::LLVMArrayType::get(i32Ty, 2);
-    mlir::Value tagPtr = mlir::LLVM::GEPOp::create(
-        rewriter, loc, ptrTy, hdrTy, box,
-        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1});
-    mlir::Value tag =
-        mlir::LLVM::LoadOp::create(rewriter, loc, i32Ty, tagPtr);
-    mlir::Value tagIdx = mlir::LLVM::ZExtOp::create(rewriter, loc, indexTy, tag);
-    // size = select over the arms; the fallback is unreachable (the tag is
-    // always in range) but keeps the chain total.
-    auto armConst = [&](size_t k) {
-      return mlir::LLVM::ConstantOp::create(
-          rewriter, loc, indexTy,
-          rewriter.getIntegerAttr(
-              indexTy, recordType.getVariantArmAllocSize(dataLayout, k)
-                           .getFixedValue()));
-    };
-    mlir::Value size = armConst(0);
-    for (size_t k = 1; k < recordType.getMembers().size(); ++k) {
-      mlir::Value isK = mlir::LLVM::ICmpOp::create(
-          rewriter, loc, mlir::LLVM::ICmpPredicate::eq, tagIdx,
-          mlir::LLVM::ConstantOp::create(rewriter, loc, indexTy,
-                                         rewriter.getIntegerAttr(indexTy, k)));
-      size = mlir::LLVM::SelectOp::create(rewriter, loc, isK, armConst(k), size);
-    }
-    // Assemble the fat `{ptr, size}` token.
-    mlir::Type fatTy = converter->convertType(tokenType);
-    mlir::Value fat = mlir::LLVM::UndefOp::create(rewriter, loc, fatTy);
-    fat = mlir::LLVM::InsertValueOp::create(rewriter, loc, fat, box,
-                                            llvm::ArrayRef<int64_t>{0});
-    fat = mlir::LLVM::InsertValueOp::create(rewriter, loc, fat, size,
-                                            llvm::ArrayRef<int64_t>{1});
-    rewriter.replaceOp(op, fat);
+    // The token is the box pointer verbatim — static and dynamic tokens alike.
+    // A dynamic `token<align, ?>` (from an unpinned variant dec under
+    // per-constructor sizing) carries no size: the free/realloc runtime
+    // recovers the block from this pointer, so no per-arm size is computed here.
+    rewriter.replaceOp(op, adaptor.getRcPtr());
     return mlir::success();
   }
 };
@@ -613,26 +551,9 @@ struct ReussirTokenReallocConversionPattern
     TokenType outputTokenType = op.getRealloced().getType();
     auto indexType = converter->getIndexType();
     auto loc = op.getLoc();
-    // The old pointer and size: a dynamic token (`token<align, ?>`) is a fat
-    // `{ptr, size}` carrying its size at runtime; a static token is a bare
-    // pointer with a compile-time size.
-    mlir::Value tokenVal = adaptor.getToken();
-    mlir::Value oldPtr;
-    mlir::Value oldSizeVal;
-    if (inputTokenType.isDynamicSize()) {
-      oldPtr = mlir::LLVM::ExtractValueOp::create(
-          rewriter, loc, tokenVal, llvm::ArrayRef<int64_t>{0});
-      oldSizeVal = mlir::LLVM::ExtractValueOp::create(
-          rewriter, loc, tokenVal, llvm::ArrayRef<int64_t>{1});
-    } else {
-      oldPtr = tokenVal;
-      oldSizeVal = mlir::arith::ConstantOp::create(
-          rewriter, loc,
-          mlir::IntegerAttr::get(indexType, inputTokenType.getSize()));
-    }
-    mlir::Value oldAlignVal = mlir::arith::ConstantOp::create(
-        rewriter, loc,
-        mlir::IntegerAttr::get(indexType, inputTokenType.getAlign()));
+    // The token is a bare pointer either way. `token.realloc` always yields a
+    // statically sized token, so the new (align, size) are constants.
+    mlir::Value oldPtr = adaptor.getToken();
     mlir::Value newAlignVal = mlir::arith::ConstantOp::create(
         rewriter, loc,
         mlir::IntegerAttr::get(indexType, outputTokenType.getAlign()));
@@ -640,14 +561,31 @@ struct ReussirTokenReallocConversionPattern
         rewriter, loc,
         mlir::IntegerAttr::get(indexType, outputTokenType.getSize()));
     auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
-    auto reallocFunc =
-        moduleOp.lookupSymbol<mlir::LLVM::LLVMFuncOp>("__reussir_reallocate");
-    mlir::Value reallocated =
-        mlir::LLVM::CallOp::create(
-            rewriter, loc, reallocFunc,
-            mlir::ValueRange{oldPtr, oldAlignVal, oldSizeVal, newAlignVal,
-                             newSizeVal})
-            .getResult();
+    mlir::Value reallocated;
+    if (inputTokenType.isDynamicSize()) {
+      // Unsized resize: the allocator recovers the old block from the pointer.
+      auto reallocFunc = moduleOp.lookupSymbol<mlir::LLVM::LLVMFuncOp>(
+          "__reussir_realloc_unsized");
+      reallocated = mlir::LLVM::CallOp::create(
+                        rewriter, loc, reallocFunc,
+                        mlir::ValueRange{oldPtr, newAlignVal, newSizeVal})
+                        .getResult();
+    } else {
+      // Statically sized input: pass the known old (align, size).
+      mlir::Value oldAlignVal = mlir::arith::ConstantOp::create(
+          rewriter, loc,
+          mlir::IntegerAttr::get(indexType, inputTokenType.getAlign()));
+      mlir::Value oldSizeVal = mlir::arith::ConstantOp::create(
+          rewriter, loc,
+          mlir::IntegerAttr::get(indexType, inputTokenType.getSize()));
+      auto reallocFunc =
+          moduleOp.lookupSymbol<mlir::LLVM::LLVMFuncOp>("__reussir_reallocate");
+      reallocated = mlir::LLVM::CallOp::create(
+                        rewriter, loc, reallocFunc,
+                        mlir::ValueRange{oldPtr, oldAlignVal, oldSizeVal,
+                                         newAlignVal, newSizeVal})
+                        .getResult();
+    }
     // Launder the result. The reallocated block holds a freshly constructed
     // object; an LTO'd allocator fast path may return the identical pointer,
     // so its stale invariant-group metadata must be stripped. The ptr-eq
@@ -1270,12 +1208,9 @@ struct ReussirNullableCheckConversionPattern
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Type llvmPtrType =
         mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    // Every token (static or dynamic `token<?>`) is a bare pointer; presence
+    // is the pointer being non-null.
     mlir::Value nullable = adaptor.getNullable();
-    // A nullable dynamic token (`token<align, ?>`,) lowers to a fat
-    // `{ptr, size}`; presence is the pointer field being non-null.
-    if (isDynamicTokenNullable(op.getNullable().getType()))
-      nullable = mlir::LLVM::ExtractValueOp::create(
-          rewriter, op.getLoc(), nullable, llvm::ArrayRef<int64_t>{0});
     mlir::Value nullConstant =
         mlir::LLVM::ZeroOp::create(rewriter, op.getLoc(), llvmPtrType);
     rewriter.replaceOpWithNewOp<mlir::LLVM::ICmpOp>(
@@ -1291,15 +1226,10 @@ struct ReussirNullableCreateConversionPattern
   mlir::LogicalResult
   matchAndRewrite(ReussirNullableCreateOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    // Check if the operation has input. If so, replace it directly with
-    // adaptor value. Otherwise, create a new null value. A nullable dynamic
-    // token is a fat `{ptr, size}` struct; its null is a zero struct
-    // (a null pointer field), not a bare null pointer.
+    // Present: forward the pointer. Absent: a null pointer (every token,
+    // including a dynamic `token<?>`, is a bare pointer).
     if (op.getPtr())
       rewriter.replaceOp(op, adaptor.getPtr());
-    else if (isDynamicTokenNullable(op.getResult().getType()))
-      rewriter.replaceOpWithNewOp<mlir::LLVM::ZeroOp>(
-          op, getTypeConverter()->convertType(op.getResult().getType()));
     else
       rewriter.replaceOpWithNewOp<mlir::LLVM::ZeroOp>(
           op, mlir::LLVM::LLVMPointerType::get(rewriter.getContext()));
@@ -3203,6 +3133,28 @@ void ensureRuntimeFunctions(mlir::ModuleOp module,
   reallocFunc.setArgAttr(2, "llvm.noundef", builder.getUnitAttr());
   reallocFunc.setArgAttr(3, "llvm.noundef", builder.getUnitAttr());
   reallocFunc.setArgAttr(4, "llvm.noundef", builder.getUnitAttr());
+
+  // Unsized ABI for dynamic `token<?>`: the allocator recovers the block size
+  // from the pointer, so free takes only the pointer and realloc takes only
+  // the new (align, size).
+  auto deallocUnsizedFunc =
+      addRuntimeFunction(body, "__reussir_dealloc_unsized", {llvmPtrType}, {});
+  deallocUnsizedFunc->setAttr("passthrough", passthroughDealloc);
+  deallocUnsizedFunc.setArgAttr(0, "llvm.nocapture", builder.getUnitAttr());
+  deallocUnsizedFunc.setArgAttr(0, "llvm.allocptr", builder.getUnitAttr());
+  deallocUnsizedFunc.setArgAttr(0, "llvm.noundef", builder.getUnitAttr());
+
+  auto reallocUnsizedFunc = addRuntimeFunction(
+      body, "__reussir_realloc_unsized",
+      {llvmPtrType, indexType, indexType}, {llvmPtrType});
+  reallocUnsizedFunc->setAttr("passthrough", passthroughRealloc);
+  reallocUnsizedFunc.setArgAttr(0, "llvm.allocptr", builder.getUnitAttr());
+  reallocUnsizedFunc.setArgAttr(1, "llvm.allocalign", builder.getUnitAttr());
+  reallocUnsizedFunc.setResultAttr(0, "llvm.noundef", builder.getUnitAttr());
+  reallocUnsizedFunc.setArgAttr(0, "llvm.noundef", builder.getUnitAttr());
+  reallocUnsizedFunc.setArgAttr(1, "llvm.noundef", builder.getUnitAttr());
+  reallocUnsizedFunc.setArgAttr(2, "llvm.noundef", builder.getUnitAttr());
+
   // currently this will abort execution after printing the message and
   // stacktrace. No unwinding is attempted yet.
   addRuntimeFunction(body, "__reussir_panic", {llvmPtrType, indexType}, {});

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -207,16 +207,12 @@ void populateReussirToLLVMTypeConversions(mlir::LLVMTypeConverter &converter) {
   converter.addConversion([](ViewType type) {
     return mlir::LLVM::LLVMPointerType::get(type.getContext());
   });
-  converter.addConversion([&converter](TokenType type) -> mlir::Type {
-    auto ptrTy = mlir::LLVM::LLVMPointerType::get(type.getContext());
-    // A static token is a bare pointer. A dynamic token (`size: ?`, from an
-    // unpinned variant decrement under per-constructor sizing) carries its
-    // runtime size alongside the pointer as a fat `{ptr, size}` pair, so its
-    // free/realloc can pass the exact size on any allocator.
-    if (!type.isDynamicSize())
-      return ptrTy;
-    return mlir::LLVM::LLVMStructType::getLiteral(
-        type.getContext(), {ptrTy, converter.getIndexType()});
+  converter.addConversion([](TokenType type) -> mlir::Type {
+    // Every token is a bare pointer. A dynamic token (`size: ?`, from an
+    // unpinned variant decrement under per-constructor sizing) carries no
+    // size: its free/realloc go through the unsized runtime ABI, which
+    // recovers the block from the pointer (a size-recovering allocator).
+    return mlir::LLVM::LLVMPointerType::get(type.getContext());
   });
   converter.addConversion([](RawPtrType type) {
     return mlir::LLVM::LLVMPointerType::get(type.getContext());

--- a/tests/integration/conversion/straight_line_reuse.mlir
+++ b/tests/integration/conversion/straight_line_reuse.mlir
@@ -3,6 +3,11 @@
 !rc64 = !reussir.rc<i64>
 !rc64x2 = !reussir.rc<!reussir.record<compound "test" {i64, i64}>>
 !rc64x3 = !reussir.rc<!reussir.record<compound "test3" {i64, i64, i64}>>
+// 8 i64 fields + 8-byte header = 72 B; 9 fields = 80 B. Both round to the same
+// 80-byte allocator bin (bins step by 16 above 64), so a dead 72-byte token
+// feeds an 80-byte create in place.
+!rc64x8 = !reussir.rc<!reussir.record<compound "test8" {i64, i64, i64, i64, i64, i64, i64, i64}>>
+!rc64x9 = !reussir.rc<!reussir.record<compound "test9" {i64, i64, i64, i64, i64, i64, i64, i64, i64}>>
 
 module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"} {
     func.func @reuse(%0: !rc64) -> !rc64 {
@@ -17,9 +22,10 @@ module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<
         return %5 : !rc64
     }
 
-    // A 16-byte token cannot feed a 24-byte create: mimalloc serves 16 and
-    // 24 from different bins (16 vs 32), so such a realloc would move. The
-    // matcher must leave the fresh alloc alone and free the dead token.
+    // A 16-byte token cannot feed a 24-byte create: with 8-granular bins
+    // (MI_MAX_ALIGN_SIZE=8) 16 and 24 are distinct bins, so such a realloc
+    // would move. The matcher must leave the fresh alloc alone and free the
+    // dead token.
     // CHECK-LABEL: @no_cross_bin_realloc
     func.func @no_cross_bin_realloc(%0: !rc64) -> !rc64x2 {
         %1 = reussir.rc.borrow (%0 : !rc64) : !reussir.ref<i64>
@@ -36,18 +42,18 @@ module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<
         return %6 : !rc64x2
     }
 
-    // 24 and 32 share a mimalloc bin (both served from the 32-byte bin), so
-    // the dead 24-byte token feeds the 32-byte create via token.realloc.
+    // 72 and 80 share a mimalloc bin (both served from the 80-byte bin), so
+    // the dead 72-byte token feeds the 80-byte create via token.realloc.
     // CHECK-LABEL: @same_bin_realloc
-    func.func @same_bin_realloc(%0: !rc64x2) -> !rc64x3 {
-        %1 = reussir.rc.borrow (%0 : !rc64x2) : !reussir.ref<!reussir.record<compound "test" {i64, i64}>>
-        %3 = reussir.rc.dec (%0 : !rc64x2) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
+    func.func @same_bin_realloc(%0: !rc64x8) -> !rc64x9 {
+        %1 = reussir.rc.borrow (%0 : !rc64x8) : !reussir.ref<!reussir.record<compound "test8" {i64, i64, i64, i64, i64, i64, i64, i64}>>
+        %3 = reussir.rc.dec (%0 : !rc64x8) : !reussir.nullable<!reussir.token<align: 8, size: 72>>
         %4 = arith.constant 0 : i64
-        %5 = reussir.record.compound (%4, %4, %4 : i64, i64, i64) : !reussir.record<compound "test3" {i64, i64, i64}>
-        // CHECK:      %[[a:[a-z0-9]+]] = reussir.token.realloc(%{{[a-z0-9]+}} : !reussir.nullable<!reussir.token<align : 8, size : 24>>) : <align : 8, size : 32>
-        // CHECK-NEXT: %{{[a-z0-9]+}} = reussir.rc.create value(%{{[a-z0-9]+}} : !reussir.record<compound "test3" {i64, i64, i64}>) token(%[[a]] : !reussir.token<align : 8, size : 32>) : !reussir.rc<!reussir.record<compound "test3" {i64, i64, i64}>>
-        %tk = reussir.token.alloc : !reussir.token<align: 8, size: 32>
-        %6 = reussir.rc.create value(%5 : !reussir.record<compound "test3" {i64, i64, i64}>) token(%tk : !reussir.token<align: 8, size: 32>) : !rc64x3
-        return %6 : !rc64x3
+        %5 = reussir.record.compound (%4, %4, %4, %4, %4, %4, %4, %4, %4 : i64, i64, i64, i64, i64, i64, i64, i64, i64) : !reussir.record<compound "test9" {i64, i64, i64, i64, i64, i64, i64, i64, i64}>
+        // CHECK:      %[[a:[a-z0-9]+]] = reussir.token.realloc(%{{[a-z0-9]+}} : !reussir.nullable<!reussir.token<align : 8, size : 72>>) : <align : 8, size : 80>
+        // CHECK-NEXT: %{{[a-z0-9]+}} = reussir.rc.create value(%{{[a-z0-9]+}} : !reussir.record<compound "test9" {i64, i64, i64, i64, i64, i64, i64, i64, i64}>) token(%[[a]] : !reussir.token<align : 8, size : 80>) : !reussir.rc<!reussir.record<compound "test9" {i64, i64, i64, i64, i64, i64, i64, i64, i64}>>
+        %tk = reussir.token.alloc : !reussir.token<align: 8, size: 80>
+        %6 = reussir.rc.create value(%5 : !reussir.record<compound "test9" {i64, i64, i64, i64, i64, i64, i64, i64, i64}>) token(%tk : !reussir.token<align: 8, size: 80>) : !rc64x9
+        return %6 : !rc64x9
     }
 }


### PR DESCRIPTION
Two changes that together make per-constructor variant sizing pay off on nbe-closure — measured to match Koka's footprint and beat its time.

## 1. Dynamic `token<?>` → bare pointer + unsized runtime ABI
#361 lowered `token<align, ?>` to a fat `{ptr, size}` and recovered the size at the **free site** by switching on the box's fused tag — codegen emitted that as `lea`+`cmov` on every drop. On mimalloc (whose free ignores the size) it's dead work, and the cmov is a data dependency that serialized the rc hot path, making per-constructor *slower* than uniform (260 vs 244 ms at n=4M).

Now `token<?>` converts to a plain pointer and free/realloc use an unsized ABI:
- `__reussir_dealloc_unsized(ptr)`
- `__reussir_realloc_unsized(ptr, align, size)`

The allocator recovers the block (mimalloc `mi_free`/`mi_realloc`; dlmalloc later). Removed: the per-arm size-select chain (the cmov source), the fat-struct handling in reinterpret / `token.free` / `token.realloc` / nullable check+create, and the size-carrying type conversion. Per-ctor `eval` drops **27 → 7 cmov** (equal to uniform).

The runtime no longer routes the language heap through `GlobalAlloc` (its `dealloc` needs a `Layout` we don't have for `token<?>`) — `__reussir_*` call the allocator directly. **snmalloc is dropped for now**; the heap requires a size-recovering allocator (mimalloc today, dlmalloc later).

## 2. `MI_MAX_ALIGN_SIZE=8` (8-granular bins)
Wired via `.cargo/config.toml` (libmimalloc-sys has no feature for it). Default mimalloc guarantees 16-byte alignment → small classes step by 16 (`{8,16,32,48,…}`) → a 24-byte `App`/`Lam` box rounds to 32. `=8` gives 8-granular classes (`{8,16,24,32,40,48,56,64}`) so those nodes occupy 24 bytes — exactly what Koka does (`kklib/CMakeLists.txt:98`). Reussir boxes are ≤8-aligned and the natural-alignment dispatch routes over-aligned requests through `mi_*_aligned`, so weakening implicit malloc alignment to 8 is sound. `AllocatorBinModel.h` updated to the 8-granular geometry and reframed as the pairing **hint** it is (gates nothing in lowering).

## Result — ablation on nbe-closure (n=4M, ThinLTO)
Baseline uniform+align16 = 197 ms / 246 MB:

| lever | Δ time | Δ RSS |
|---|---|---|
| variable-size alone | −10% | −25% (only 16B leaves shrink) |
| align8 alone | −6% | 0% (uniform is all 32B) |
| **both** | **91 ms** | **155 MB** |
| *Koka* | *120 ms* | *155 MB* |

Super-additive — matches Koka's RSS and beats its time. Full lit suite green (277). `straight_line_reuse.mlir` updated: 24 and 32 are distinct bins now, so the same-bin realloc case uses 72→80 (both in the 80-byte bin).

Follow-up (next patch): replace the `--variant-box-sizing` flag with a per-enum `#[variable-sized]` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786205438&installation_id=144622820&pr_number=366&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F366&signature=d0ed8fe3cfcb017f0a2433b379d9b6cc187fdc2aa182cc76eb9a01665323f0bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->