### PR TITLE
[ci][draft] disk-usage probe for ubuntu-24.04 rrc-test ENOSPC

### DIFF
--- a/.github/workflows/mlir-cpp-test.yml
+++ b/.github/workflows/mlir-cpp-test.yml
@@ -15,7 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         llvm-version: [22]
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        # DISK-USAGE PROBE: scoped to the x86 runner that hit
+        # "No space left on device" during the rrc cargo test.
+        os: [ubuntu-24.04]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -43,16 +45,16 @@ jobs:
         run: |
           # Add LLVM apt repository GPG key
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          
+
           # Get Ubuntu codename
           CODENAME=$(lsb_release -cs)
-          
+
           # Add LLVM apt repository with consistent suffix pattern
           echo "deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${{ matrix.llvm-version }} main" | sudo tee /etc/apt/sources.list.d/llvm.list
-          
+
           # Update apt cache
           sudo apt-get update
-          
+
           # Install LLVM/Clang toolchain. libpolly-*-dev provides the static
           # Polly archives that llvm-config --link-static references (needed by
           # mlir-sys / tblgen / llvm-sys); libclang-*-dev provides libclang for
@@ -68,9 +70,21 @@ jobs:
             llvm-${{ matrix.llvm-version }}-dev \
             llvm-${{ matrix.llvm-version }}-tools \
             libpolly-${{ matrix.llvm-version }}-dev
-          
+
           echo "LD_LIBRARY_PATH=/usr/lib/llvm-${{ matrix.llvm-version }}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           echo "LLVM_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-${{ matrix.llvm-version }}" >> $GITHUB_ENV
+
+      # ------------------------------------------------------------------ probe
+      - name: "DISK 📊 baseline (after deps + LLVM, before build)"
+        if: always()
+        run: |
+          echo "===================== DISK: baseline ====================="
+          df -h /
+          echo "--- runner top-level (one filesystem, depth 1) ---"
+          sudo du -xh -d1 / 2>/dev/null | sort -rh | head -15 || true
+          echo "--- LLVM apt install size ---"
+          du -sh /usr/lib/llvm-${{ matrix.llvm-version }} 2>/dev/null || true
+      # ------------------------------------------------------------------------
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -96,24 +110,68 @@ jobs:
           -DMLIR_DIR=/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/mlir
 
       - name: Build
-        run: cmake --build build --parallel
+        run: |
+          cmake --build build --parallel
+          echo "== DISK after C++ Build =="; df -h /
 
       - name: Run Unit Tests
         run: |
           cmake --build build --target reussir-ut
           ctest --test-dir build --output-on-failure
+          echo "== DISK after Unit Tests =="; df -h /
 
       - name: Run Integration Tests
-        run: cmake --build build --target check
+        run: |
+          cmake --build build --target check
+          echo "== DISK after Integration Tests =="; df -h /
 
       - name: Run Sanitizer Integration Tests
-        run: cmake --build build --target check-sanitizer
+        run: |
+          cmake --build build --target check-sanitizer
+          echo "== DISK after Sanitizer Tests (4 rt variants built) =="; df -h /
 
       - name: Build and Test reussir-backend
-        run: cmake --build build --target reussir-backend-test
+        run: |
+          cmake --build build --target reussir-backend-test
+          echo "== DISK after reussir-backend-test =="; df -h /
 
       - name: Build and Test reussir-codegen
-        run: cmake --build build --target reussir-codegen-test
+        run: |
+          cmake --build build --target reussir-codegen-test
+          echo "== DISK after reussir-codegen-test (right before rrc) =="; df -h /
 
       - name: Build and Test rrc
-        run: cmake --build build --target rrc-test
+        run: |
+          cmake --build build --target rrc-test
+          echo "== DISK after rrc-test =="; df -h /
+
+      # ------------------------------------------------------------ deep dive
+      - name: "DISK 📊 deep dive (final, runs even on failure)"
+        if: always()
+        run: |
+          echo "===================== DISK: final ====================="
+          df -h /
+          echo
+          echo "--- runner top-level (one filesystem, depth 1, top 15) ---"
+          sudo du -xh -d1 / 2>/dev/null | sort -rh | head -15 || true
+          echo
+          echo "--- known suspects (sorted) ---"
+          du -sh \
+            "$GITHUB_WORKSPACE/build" \
+            "$GITHUB_WORKSPACE/build/target" \
+            "$GITHUB_WORKSPACE/build/lib" \
+            "$GITHUB_WORKSPACE/build/.rustup" \
+            "$HOME/.cargo" \
+            "$HOME/.rustup" \
+            /usr/lib/llvm-${{ matrix.llvm-version }} \
+            2>/dev/null | sort -rh || true
+          echo
+          echo "--- build/ breakdown (depth 2, top 25) ---"
+          du -xh -d2 "$GITHUB_WORKSPACE/build" 2>/dev/null | sort -rh | head -25 || true
+          echo
+          echo "--- cargo target/release/deps: biggest 25 artifacts ---"
+          du -ah "$GITHUB_WORKSPACE/build/target/release/deps" 2>/dev/null | sort -rh | head -25 || true
+          echo
+          echo "--- sccache cache size ---"
+          du -sh "$HOME/.cache/sccache" 2>/dev/null || true
+      # ------------------------------------------------------------------------


### PR DESCRIPTION
**Draft / diagnostic only — do not merge.**

Adds `df`/`du` instrumentation to the x86 `ubuntu-24.04` build job to diagnose the intermittent `No space left on device` seen while building `libmlir_sys.rlib` during the `rrc` cargo test (observed on PR #367, cleared on re-run — so disk headroom is marginal).

What it captures:
- Matrix scoped to `ubuntu-24.04` (the runner that flaked).
- `df -h /` after each heavy step (C++ build, sanitizer variants, each cargo test) to show the fill curve.
- Two `if: always()` `du` deep-dives (baseline + final) breaking down `build/`, the cargo target dir, `build/lib`, rustup toolchains, LLVM, and sccache — so the biggest consumers are visible even if a step ENOSPCs.

I'll read the run logs and report the numbers back, then delete this branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786219185&installation_id=144622820&pr_number=368&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F368&signature=ca5467bfc996ea0aa40f50dec67f60584b3773a8a30729f09c727a4911790e32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->