### PR TITLE
[backend] token uniformity: only count token-producing arms (fixes 2x rbtree regression)

### DIFF
--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -647,18 +647,36 @@ def ReussirRcCreateVariantOp : ReussirRcOp<"create_variant", [
 }
 
 def ReussirRcTaggedOp : ReussirRcOp<"tagged", [Pure]> {
-  let summary = "Materialize a nullary variant as a tagged pointer immediate";
+  let summary = "Materialize a nullary variant as a pointer immediate";
   let description = [{
     `reussir.rc.tagged` produces an rc pointer encoding a *nullary* variant
-    (an arm whose payload is an empty compound) as an unboxed immediate: the
-    pointer's top byte is `tag + 1` and its low bits hold the address of a
-    per-tag dummy box `{refcount = 2, tag}`. No allocation takes place, and
-    no observable reference counting: because the target's TBI ignores the
-    top byte on data accesses, refcount/uniqueness/tag reads through the
-    value land in the dummy box and observe a well-formed shared header,
-    so the hot lowerings need no immediate-checks at all. Only introduced
-    when the special-pointer-tag scheme is enabled (aarch64 targets, whose
-    TBI the encoding hard-depends on).
+    (an arm whose payload is an empty compound) as an unboxed immediate. No
+    allocation takes place — no token is ever attached — and no observable
+    reference counting happens: the value points at a per-tag dummy box (a
+    static global shaped like a real box header `{refcount, tag}`), so
+    refcount/uniqueness/tag reads through it land in well-formed memory and
+    observe a never-unique shared header — the hot lowerings need no
+    immediate-checks at all; only the few guarded refcount *stores* must
+    avoid writing the dummy box.
+
+    The op itself is encoding-agnostic; the module's
+    `reussir.special_ptr_tag` attribute selects how the immediate is
+    encoded at LLVM lowering:
+      * `immortal` (any target): the immediate is the dummy box address,
+        plain; guards recognize immediates by the dummy refcount's
+        immortal magnitude.
+      * `tbi` (aarch64, 64-bit): additionally ORs `(tag + 1) << 56` into
+        the pointer's top byte (hardware top-byte-ignore masks it on data
+        accesses), so the tag also decodes from the pointer without a
+        memory access; guards test the top byte.
+
+    Under both encodings the op reserves one byte for the tag, `0` meaning
+    "untagged, a real box pointer" — the verifier bounds `tag + 1 <= 0xFF`
+    so the same IR stays valid under either encoding. That range is a
+    *type-level* eligibility concern (`RcType::mayCarrySpecialPointerTag`
+    refuses types whose nullary arms exceed the slot); per arm, "nullary on
+    a taggable type" alone decides immediate-vs-boxed, and hence
+    token-vs-no-token.
     ```mlir
     %leaf = reussir.rc.tagged tag(1) : !reussir.rc<!reussir.record<...>>
     ```

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -671,8 +671,12 @@ def ReussirRcTaggedOp : ReussirRcOp<"tagged", [Pure]> {
         memory access; guards test the top byte.
 
     Under both encodings the op reserves one byte for the tag, `0` meaning
-    "untagged, a real box pointer" — the verifier bounds `tag + 1 <= 0xFF`
-    so the same IR stays valid under either encoding. That range is a
+    "untagged, a real box pointer". The bound exists for the *guards*: under
+    `tbi` a zero top byte is the classifier for "real box, stores may
+    proceed", so every immediate must carry a nonzero top byte — an
+    unencodable arm must stay a real box (see the scheme invariant at
+    `kSpecialPtrTagAttr`). The verifier enforces `tag + 1 <= 0xFF` under
+    both encodings so the same IR stays valid under either. The range is a
     *type-level* eligibility concern (`RcType::mayCarrySpecialPointerTag`
     refuses types whose nullary arms exceed the slot); per arm, "nullary on
     a taggable type" alone decides immediate-vs-boxed, and hence

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -164,6 +164,15 @@ def ReussirRecordType
       // fused-header variants.
       llvm::TypeSize getVariantArmAllocSize(const mlir::DataLayout &dataLayout,
                                             size_t tag) const;
+      // Whether arm `tag` is *nullary*: an empty compound. On a taggable box
+      // type (`RcType::mayCarrySpecialPointerTag`, which also guarantees at
+      // the type level that every nullary arm fits `rc.tagged`'s tag slot),
+      // constructions of exactly these arms are rewritten to unboxed
+      // immediates that never allocate — so under the special-pointer-tag
+      // scheme "nullary arm of a taggable type" means "never produces a
+      // token". Single source of truth shared by the rewrite pattern and
+      // the token-type computation.
+      bool isNullaryArm(size_t tag) const;
       // A shared/regional variant record carries a fused 8-byte box header:
       // `{4-byte count slot, i32 tag, payload}`. When rc-boxed, the box IS
       // the record — the refcount overlays the leading slot, so the rc

--- a/include/Reussir/Transformation/SpecialPointerTag.h
+++ b/include/Reussir/Transformation/SpecialPointerTag.h
@@ -18,6 +18,25 @@ namespace reussir {
 /// unboxed immediates pointing at per-tag dummy boxes. Its value selects
 /// the encoding (`kSpecialPtrTagTBI` or `kSpecialPtrTagImmortal`); the LLVM
 /// lowering patterns read it to pick the guard strategy on taggable types.
+///
+/// THE SCHEME'S CORE INVARIANT (the one non-obvious rule everything else
+/// follows from): guards classify a value as immediate-vs-box WITHOUT a
+/// per-value fallback path, so the classifier's "this is a real box" answer
+/// must never be wrong for an immediate. Under `tbi` the classifier is the
+/// pointer's top byte alone (a register-only test — no load): ZERO MEANS
+/// "REAL BOX, STORES MAY PROCEED". That is sound only if EVERY immediate
+/// carries a nonzero top byte, i.e. `tag + 1` fits one byte. Hence an arm
+/// whose tag cannot be encoded must never become an immediate — it stays a
+/// real, allocated, token-producing box — and eligibility is enforced
+/// all-or-nothing at the type level (`RcType::mayCarrySpecialPointerTag`:
+/// every nullary arm must fit) rather than per arm, so downstream logic
+/// (the rewrite pattern, token typing) can reason simply "nullary arm of a
+/// taggable type = immediate = never a token" with no tag arithmetic.
+/// A hybrid "immortal fallback inside a tbi module" (zero-top-byte
+/// immediates recognized by refcount magnitude) would decouple eligibility
+/// from the tag range, but every guard would then need to LOAD the refcount
+/// — surrendering tbi's load-free `rc.set` guard, which is the encoding's
+/// point.
 constexpr llvm::StringLiteral kSpecialPtrTagAttr = "reussir.special_ptr_tag";
 
 /// TBI encoding (aarch64): the immediate's top byte is `tag + 1` and its low

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 #include <array>
+#include <optional>
+
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallSet.h>
@@ -39,6 +41,7 @@
 #include "Reussir/IR/ReussirEnumAttrs.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
+#include "Reussir/Transformation/SpecialPointerTag.h"
 #include "mlir/IR/PatternMatch.h"
 
 #include <llvm/ADT/DenseSet.h>
@@ -452,21 +455,52 @@ TokenType ReussirRcDecOp::getTokenType() {
           dataLayout, getDestructureTagAttr().getInt());
       return TokenType::get(getContext(), alignment, armSize.getFixedValue());
     }
-    // A variant whose arms are all the same size stays a *static* token even
-    // when unpinned: the max-arm size is exact for every arm, so it reuses
-    // and frees normally. Only a genuinely non-uniform variant needs the
-    // dynamic (runtime-carried) size.
-    uint64_t armSize0 =
-        recordType.getVariantArmAllocSize(dataLayout, 0).getFixedValue();
+    // A variant whose *token-producing* arms are all the same size stays a
+    // *static* token even when unpinned: that size is exact for every box
+    // the dec can ever free, so it reuses and frees normally. Only a
+    // genuinely non-uniform variant needs the dynamic (runtime-carried)
+    // size. Crucially, an arm only counts if a box of it can exist: under
+    // the special-pointer-tag scheme (module layout info stamped by the
+    // pass, which runs before token instantiation) a nullary arm of a
+    // taggable type is constructed as an unboxed immediate — it never
+    // allocates and its decrement never yields a token — so its phantom
+    // size must not force the dynamic path. E.g. `Tree { Branch(...), Leaf }`
+    // has exactly one real arm and keeps a static token, preserving in-place
+    // reuse instead of a runtime realloc per node (the 2x rbtree regression
+    // this rule fixes).
+    mlir::ModuleOp module = (*this)->getParentOfType<mlir::ModuleOp>();
+    bool nullaryImmediates = module && module->hasAttr(kSpecialPtrTagAttr) &&
+                             rcType.mayCarrySpecialPointerTag();
+    // Mirrors NullaryVariantPattern's per-arm eligibility (SpecialPointerTag):
+    // an empty compound arm with an encodable tag never boxes.
+    auto producesToken = [&](size_t tag) {
+      if (!nullaryImmediates || tag + 1 > 0xFF)
+        return true;
+      auto arm = llvm::dyn_cast<RecordType>(recordType.getMembers()[tag]);
+      return !(arm && arm.isCompound() && arm.getMembers().empty());
+    };
+    std::optional<uint64_t> tokenArmSize;
     bool uniform = true;
-    for (size_t tag = 1, n = recordType.getMembers().size(); tag < n; ++tag)
-      if (recordType.getVariantArmAllocSize(dataLayout, tag).getFixedValue() !=
-          armSize0) {
+    for (size_t tag = 0, n = recordType.getMembers().size(); tag < n; ++tag) {
+      if (!producesToken(tag))
+        continue;
+      uint64_t armSize =
+          recordType.getVariantArmAllocSize(dataLayout, tag).getFixedValue();
+      if (!tokenArmSize) {
+        tokenArmSize = armSize;
+      } else if (*tokenArmSize != armSize) {
         uniform = false;
         break;
       }
-    if (uniform)
-      return TokenType::get(getContext(), alignment, armSize0);
+    }
+    if (uniform && tokenArmSize)
+      return TokenType::get(getContext(), alignment, *tokenArmSize);
+    if (!tokenArmSize) {
+      // Every arm is an immediate: no token is ever produced at runtime; the
+      // declared type is moot — keep the uniform box size (always static).
+      auto boxSize = dataLayout.getTypeSize(rcBoxType);
+      return TokenType::get(getContext(), alignment, boxSize.getFixedValue());
+    }
     return TokenType::getDynamic(getContext(), alignment);
   }
   auto size = dataLayout.getTypeSize(rcBoxType);

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -471,20 +471,15 @@ TokenType ReussirRcDecOp::getTokenType() {
     mlir::ModuleOp module = (*this)->getParentOfType<mlir::ModuleOp>();
     bool nullaryImmediates = module && module->hasAttr(kSpecialPtrTagAttr) &&
                              rcType.mayCarrySpecialPointerTag();
-    // Mirrors NullaryVariantPattern's per-arm eligibility (SpecialPointerTag):
-    // an empty compound arm with an encodable tag never boxes. "Encodable"
-    // means the tag fits the immediate's one-byte tag slot: the TBI encoding
-    // stores `tag + 1` in the pointer's top byte (the +1 reserves 0 to mean
-    // "untagged, a real box pointer"), so only tags 0..254 have a
-    // representation — see `ReussirRcTaggedOp::verify` and the same bound in
-    // `RcType::mayCarrySpecialPointerTag`. A nullary arm with a larger tag is
-    // NOT rewritten by the pass, still allocates a real box, and therefore
-    // must keep counting toward the token type.
+    // An arm cannot produce a token exactly when the scheme is enabled and
+    // its constructions are rewritten to immediates — which for a taggable
+    // type (`mayCarrySpecialPointerTag`, folded into `nullaryImmediates`
+    // above and guaranteeing the tag-slot range at the type level) is
+    // simply every *nullary* arm. Same predicate as the rewrite pattern, so
+    // the two can never drift apart; encoding-agnostic (the arch/encoding
+    // choice was resolved when the pass stamped the module attribute).
     auto producesToken = [&](size_t tag) {
-      if (!nullaryImmediates || tag + 1 > 0xFF)
-        return true;
-      auto arm = llvm::dyn_cast<RecordType>(recordType.getMembers()[tag]);
-      return !(arm && arm.isCompound() && arm.getMembers().empty());
+      return !(nullaryImmediates && recordType.isNullaryArm(tag));
     };
     std::optional<uint64_t> tokenArmSize;
     bool uniform = true;

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -472,7 +472,14 @@ TokenType ReussirRcDecOp::getTokenType() {
     bool nullaryImmediates = module && module->hasAttr(kSpecialPtrTagAttr) &&
                              rcType.mayCarrySpecialPointerTag();
     // Mirrors NullaryVariantPattern's per-arm eligibility (SpecialPointerTag):
-    // an empty compound arm with an encodable tag never boxes.
+    // an empty compound arm with an encodable tag never boxes. "Encodable"
+    // means the tag fits the immediate's one-byte tag slot: the TBI encoding
+    // stores `tag + 1` in the pointer's top byte (the +1 reserves 0 to mean
+    // "untagged, a real box pointer"), so only tags 0..254 have a
+    // representation — see `ReussirRcTaggedOp::verify` and the same bound in
+    // `RcType::mayCarrySpecialPointerTag`. A nullary arm with a larger tag is
+    // NOT rewritten by the pass, still allocates a real box, and therefore
+    // must keep counting toward the token type.
     auto producesToken = [&](size_t tag) {
       if (!nullaryImmediates || tag + 1 > 0xFF)
         return true;

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -926,13 +926,16 @@ bool RcType::mayCarrySpecialPointerTag() const {
     return false;
   // The type participates in the scheme iff it has a nullary arm to encode
   // AND every nullary arm fits `rc.tagged`'s one-byte tag slot (`tag + 1`,
-  // 0 reserved for "untagged real pointer" — the op verifier's bound, shared
-  // by both encodings). All-or-nothing on purpose: with the range handled
-  // here at the type level, downstream logic (the rewrite pattern, the
-  // token-type computation) may reason per-arm as simply "nullary arm of a
-  // taggable type = immediate = never a token", with no tag arithmetic. A
-  // variant whose nullary arm sits beyond the slot (a > 255-arm enum) just
-  // keeps boxing everything.
+  // 0 reserved for "untagged real pointer"). The range requirement exists
+  // for the guards, not the tags: under `tbi` a zero top byte means "real
+  // box, stores may proceed", so every immediate must carry a nonzero top
+  // byte — see the scheme invariant at `kSpecialPtrTagAttr`
+  // (Transformation/SpecialPointerTag.h). All-or-nothing on purpose: with
+  // the range handled here at the type level, downstream logic (the rewrite
+  // pattern, the token-type computation) may reason per-arm as simply
+  // "nullary arm of a taggable type = immediate = never a token", with no
+  // tag arithmetic. A variant whose nullary arm sits beyond the slot (a
+  // > 255-arm enum) just keeps boxing everything.
   bool hasNullaryArm = false;
   for (size_t idx = 0, n = variantType.getMembers().size(); idx < n; ++idx) {
     if (!variantType.isNullaryArm(idx))

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -602,6 +602,13 @@ bool RecordType::hasFusedHeader() const {
   return isVariant() && getDefaultCapability() != Capability::value;
 }
 
+bool RecordType::isNullaryArm(size_t tag) const {
+  if (tag >= getMembers().size())
+    return false;
+  auto arm = llvm::dyn_cast<RecordType>(getMembers()[tag]);
+  return arm && arm.isCompound() && arm.getMembers().empty();
+}
+
 mlir::IntegerType RecordType::getTagType() const {
   if (hasFusedHeader())
     return mlir::IntegerType::get(getContext(), 32);
@@ -917,14 +924,24 @@ bool RcType::mayCarrySpecialPointerTag() const {
   auto variantType = llvm::dyn_cast<RecordType>(getElementType());
   if (!variantType || !variantType.isVariant() || !variantType.getComplete())
     return false;
-  for (auto [idx, member] : llvm::enumerate(variantType.getMembers())) {
+  // The type participates in the scheme iff it has a nullary arm to encode
+  // AND every nullary arm fits `rc.tagged`'s one-byte tag slot (`tag + 1`,
+  // 0 reserved for "untagged real pointer" — the op verifier's bound, shared
+  // by both encodings). All-or-nothing on purpose: with the range handled
+  // here at the type level, downstream logic (the rewrite pattern, the
+  // token-type computation) may reason per-arm as simply "nullary arm of a
+  // taggable type = immediate = never a token", with no tag arithmetic. A
+  // variant whose nullary arm sits beyond the slot (a > 255-arm enum) just
+  // keeps boxing everything.
+  bool hasNullaryArm = false;
+  for (size_t idx = 0, n = variantType.getMembers().size(); idx < n; ++idx) {
+    if (!variantType.isNullaryArm(idx))
+      continue;
     if (idx + 1 > 0xFF)
-      break;
-    auto arm = llvm::dyn_cast<RecordType>(member);
-    if (arm && arm.isCompound() && arm.getMembers().empty())
-      return true;
+      return false;
+    hasNullaryArm = true;
   }
-  return false;
+  return hasNullaryArm;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
+++ b/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
@@ -65,14 +65,14 @@ struct NullaryVariantPattern
     if (!payloadTy || !payloadTy.isCompound() ||
         !payloadTy.getMembers().empty())
       return mlir::failure();
+    // Arm-side eligibility is simply "nullary" — the shared predicate the
+    // token-type computation also consults, so "rewritten here" and
+    // "produces no token there" can never drift apart. The tag-slot range
+    // is a type-level property: `mayCarrySpecialPointerTag` (checked above)
+    // already guaranteed every nullary arm of this type is encodable.
     size_t tag = variant.getTag().getZExtValue();
-    if (tag + 1 > 0xFF)
-      return mlir::failure();
     auto variantType = llvm::dyn_cast<RecordType>(rcType.getElementType());
-    if (tag >= variantType.getMembers().size())
-      return mlir::failure();
-    auto arm = llvm::dyn_cast<RecordType>(variantType.getMembers()[tag]);
-    if (!arm || !arm.isCompound() || !arm.getMembers().empty())
+    if (!variantType || !variantType.isNullaryArm(tag))
       return mlir::failure();
     rewriter.replaceOpWithNewOp<ReussirRcTaggedOp>(op, rcType,
                                                    variant.getTagAttr());

--- a/tests/integration/conversion/nullary_immediate_token_uniformity.mlir
+++ b/tests/integration/conversion/nullary_immediate_token_uniformity.mlir
@@ -1,0 +1,42 @@
+// RUN: %reussir-opt %s --split-input-file --reussir-token-instantiation | %FileCheck %s
+
+// Only *token-producing* arms count toward a dec's token type. Under the
+// special-pointer-tag scheme (module stamped `reussir.special_ptr_tag`, as
+// the pass that runs before token instantiation does), a nullary arm of a
+// taggable variant is an unboxed immediate: it never allocates and its
+// decrement never yields a token. So `Tree { Branch(32B), Leaf(nullary) }`
+// has exactly one real arm and an unpinned dec keeps a STATIC 32-byte token
+// — preserving in-place reuse (`token.ensure`) instead of a runtime realloc
+// per node (the 2x rbtree regression this pins against). Without the module
+// attribute (boxed nullary encoding) the Leaf boxes are real 8-byte cells,
+// the arms are genuinely non-uniform, and the dec is dynamic `token<?>`.
+
+!tree = !reussir.record<variant "Tree" {!reussir.record<compound "Tree.Branch" [value] {i64, !reussir.record<variant "Tree">, !reussir.record<variant "Tree">}>, !reussir.record<compound "Tree.Leaf" [value] {}>}>
+!rctree = !reussir.rc<!tree>
+
+// Tagged module: nullary Leaf is an immediate -> static token (8 header + 24
+// payload = 32; both value/borrow paths must agree).
+// CHECK-LABEL: @tagged
+module @tagged attributes { reussir.special_ptr_tag = "immortal", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+  // CHECK: reussir.rc.dec{{.*}}: !reussir.nullable<!reussir.token<align : 8, size : 32>>
+  func.func @dec(%0: !rctree) {
+    reussir.rc.dec (%0 : !rctree)
+    return
+  }
+}
+
+// -----
+
+!tree = !reussir.record<variant "Tree" {!reussir.record<compound "Tree.Branch" [value] {i64, !reussir.record<variant "Tree">, !reussir.record<variant "Tree">}>, !reussir.record<compound "Tree.Leaf" [value] {}>}>
+!rctree = !reussir.rc<!tree>
+
+// Boxed module (no attribute): Leaf boxes exist (8B) -> arms non-uniform ->
+// dynamic token.
+// CHECK-LABEL: @boxed
+module @boxed attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+  // CHECK: reussir.rc.dec{{.*}}: !reussir.nullable<!reussir.token<align : 8, size : ?>>
+  func.func @dec(%0: !rctree) {
+    reussir.rc.dec (%0 : !rctree)
+    return
+  }
+}


### PR DESCRIPTION
## The regression

Since #365 made per-constructor sizing the default, **rbtree doubled (359→728 ms) and rbtree-zipper nearly tripled (295→798 ms vs Koka)**. An allocator/LTO ablation (mimalloc v2/v3 × align 8/16 × thin/full LTO × ±rac, all ~730-830 ms) exonerated the runtime — it was compiler-side.

## Root cause

An unpinned variant dec's token type is static iff all arms share one size. The check counted **every** arm — including nullary arms that, under the special-pointer-tag scheme, are unboxed immediates: they never allocate and their decrements never yield a token. Their phantom size made single-real-arm variants like `Tree { Branch(32B), Leaf }` look non-uniform → dynamic `token<?>` → every node reuse became a runtime `__reussir_realloc_unsized` call (43 sites in rbtree's IR, **zero** plain allocates) instead of a static in-place `token.ensure`.

## Fix

`RcDecOp::getTokenType` now reads the module layout info the pass already stamps (`reussir.special_ptr_tag`, set before token instantiation) and skips arms that cannot produce a token, mirroring `NullaryVariantPattern`'s eligibility exactly (taggable rc type, empty compound arm, encodable tag). Uniformity is computed over the remaining real arms; if none remain, the dec can never yield a token and keeps the uniform static size. Under the boxed nullary encoding (no module attribute) nullary boxes are real 8-byte cells and behavior is unchanged (dynamic, as today).

## Measured (x64 9950X, ThinLTO, koka 3.2.3, suite driver)

| bench | before | after | koka |
|---|---|---|---|
| rbtree | 728 ms | **370 ms** | 379 ms |
| rbtree-zipper | 798 ms | **274 ms** | 295 ms |
| nbe-closure | 134 ms / 154 MB | unchanged | 136 ms / 155 MB |

Reussir now matches-or-beats Koka on 4 of the 5 suite benchmarks (nbe-hoas 1.13× remains — that's #358's territory).

New lit test pins both sides (tagged module → static token; boxed → dynamic). Full conversion+frontend lit suite 175/175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786246074&installation_id=144622820&pr_number=369&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F369&signature=6fad588db583fe5e4545d8a8780ee18a2493f3e042a0b1ff0321c3656caa453a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->