### PR TITLE
[runtime] no-copy language realloc: in-place when the block fits, else free+alloc (#362)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
+ "cty",
  "libc",
 ]
 

--- a/crates/reussir-rt/Cargo.toml
+++ b/crates/reussir-rt/Cargo.toml
@@ -14,7 +14,9 @@ hashbrown = { version = "0.16.0" }
 # them (so ASan/LSan/MSan actually see the runtime's allocations — mimalloc's
 # and dlmalloc's private heaps are invisible to them), and miri shims them.
 libc = "0.2"
-libmimalloc-sys = { version = "0.1.44", optional = true }
+# `extended` only adds extern declarations (mi_usable_size for the no-copy
+# language realloc); the linked C library is the same either way.
+libmimalloc-sys = { version = "0.1.44", optional = true, features = ["extended"] }
 num_enum = "0.7.4"
 smallvec = "1.15.1"
 stacker.workspace = true

--- a/crates/reussir-rt/src/alloc.rs
+++ b/crates/reussir-rt/src/alloc.rs
@@ -15,6 +15,15 @@
 //! *unsized* `__reussir_dealloc_unsized`/`__reussir_realloc_unsized` (dynamic
 //! `token<?>`), which pass only the pointer (and, for realloc, the new
 //! alignment + size).
+//!
+//! The language reallocs do NOT preserve the block's contents (#362): every
+//! `token.realloc` resizes a *dead* donor whose storage the acceptor is about
+//! to overwrite with a freshly constructed object — the compiler already
+//! declares the entry points `allockind("realloc,uninitialized,...")`. So the
+//! backend resizes in place when the existing block satisfies the new layout
+//! and otherwise does a plain free + alloc, never a copying `realloc`. Only
+//! `ReussirGlobalAlloc::realloc` keeps the copying path — Rust's
+//! `GlobalAlloc::realloc` contract requires it.
 
 /// mimalloc backend (production). Its free/realloc recover the block size from
 /// the pointer, so no size is needed to free or grow.
@@ -63,6 +72,25 @@ mod backend {
             } else {
                 ffi::mi_realloc_aligned(ptr.cast(), new_size, new_align).cast()
             }
+        }
+    }
+
+    /// Resize a block whose contents are dead — the language-heap realloc.
+    /// Keeps the block when it already satisfies the new layout (mimalloc
+    /// recovers the usable size from the pointer, so a same-bin resize — the
+    /// pairing TokenReuse prefers — is pointer-identity); otherwise free +
+    /// alloc, skipping mi_realloc's copy of the dead contents. The
+    /// `usable / 2` floor mirrors mi_realloc's shrink policy: a much smaller
+    /// object moves to a right-sized block instead of squatting on a big one.
+    #[inline]
+    pub unsafe fn realloc_dead(ptr: *mut u8, new_align: usize, new_size: usize) -> *mut u8 {
+        unsafe {
+            let usable = ffi::mi_usable_size(ptr.cast());
+            if ptr as usize % new_align == 0 && new_size <= usable && new_size >= usable / 2 {
+                return ptr;
+            }
+            ffi::mi_free(ptr.cast());
+            alloc(new_align, new_size)
         }
     }
 }
@@ -194,6 +222,21 @@ mod backend {
     }
 
     pub use imp::{alloc, free, realloc};
+
+    /// Resize a block whose contents are dead — the language-heap realloc.
+    /// The platform allocators expose no portable usable-size query, so this
+    /// is always free + alloc. That is not just simple but *diagnostic*: the
+    /// result is always a fresh block, so generated code that wrongly reads
+    /// the donor's contents after a `token.realloc` fails loudly under the
+    /// sanitizers/miri instead of being masked by an in-place resize. It also
+    /// honors any alignment, unlike the copying realloc above.
+    #[inline]
+    pub unsafe fn realloc_dead(ptr: *mut u8, new_align: usize, new_size: usize) -> *mut u8 {
+        unsafe {
+            imp::free(ptr);
+            imp::alloc(new_align, new_size)
+        }
+    }
 }
 
 /// The runtime's `#[global_allocator]`: forwards Rust's own allocations
@@ -278,7 +321,9 @@ pub unsafe extern "C" fn __reussir_reallocate(
 }
 
 /// Resize a dynamic `token<?>` to `new_size`/`new_align`: the old size is not
-/// supplied — the backend recovers it.
+/// supplied — the backend recovers it. The block's contents are NOT preserved
+/// (see the module docs): the donor is dead, so a cross-bin resize is a plain
+/// free + alloc instead of a copying realloc.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __reussir_realloc_unsized(
     ptr: *mut u8,
@@ -288,7 +333,7 @@ pub unsafe extern "C" fn __reussir_realloc_unsized(
     if ptr.is_null() {
         return unsafe { __reussir_allocate(new_align, new_size) };
     }
-    let ptr = unsafe { backend::realloc(ptr, new_align, new_size) };
+    let ptr = unsafe { backend::realloc_dead(ptr, new_align, new_size) };
     if ptr.is_null() {
         unsafe { crate::panic!("reallocation failed") };
     }
@@ -301,8 +346,8 @@ mod tests {
     /// Asserts only what the ABI promises: non-null, requested alignment, and
     /// that the result is a writable block freeable by the pointer-only free.
     /// Deliberately NO content-preservation check — the language-heap realloc
-    /// resizes a *dead* donor's storage, and a future no-copy grow (#362) may
-    /// not carry contents. Cfg-agnostic on purpose: under the default feature
+    /// resizes a *dead* donor's storage and does not copy (#362).
+    /// Cfg-agnostic on purpose: under the default feature
     /// this exercises the mimalloc backend, under `--no-default-features` the
     /// platform fallback (Unix `malloc`/`posix_memalign`, Windows
     /// `_aligned_*`), and under miri the shimmed fallback — the same paths the
@@ -338,6 +383,39 @@ mod tests {
             assert!(!p.is_null());
             assert_eq!(p as usize % 64, 0);
             super::backend::free(p);
+        }
+    }
+
+    /// The dead-contents resize behind the language reallocs. Asserts the ABI
+    /// (non-null, aligned, writable, pointer-only-freeable) across a within-bin
+    /// grow, a cross-bin grow, and a large shrink; contents are dead by
+    /// contract so none are checked.
+    #[test]
+    fn backend_realloc_dead() {
+        unsafe {
+            let p = super::backend::alloc(8, 24);
+            assert!(!p.is_null());
+            // A resize the block already fits (same bin): mimalloc keeps it,
+            // so this must be pointer-identity there. The fallback always
+            // moves — no identity assert for it.
+            let q = super::backend::realloc_dead(p, 8, 24);
+            assert!(!q.is_null());
+            #[cfg(all(feature = "mimalloc", not(miri)))]
+            assert_eq!(q, p, "a fitting resize stays in place under mimalloc");
+            // Cross-bin grow: relocates without copying the dead contents.
+            let r = super::backend::realloc_dead(q, 8, 4096);
+            assert!(!r.is_null());
+            assert_eq!(r as usize % 8, 0);
+            for i in 0..4096 {
+                r.add(i).write(i as u8);
+            }
+            // Large shrink: moves to a right-sized block (mi_realloc's shrink
+            // policy) rather than squatting on the big one.
+            let s = super::backend::realloc_dead(r, 8, 16);
+            assert!(!s.is_null());
+            assert_eq!(s as usize % 8, 0);
+            s.cast::<u64>().write(42);
+            super::backend::free(s);
         }
     }
 

--- a/docs/design/per-constructor-box-sizing.md
+++ b/docs/design/per-constructor-box-sizing.md
@@ -71,8 +71,14 @@ identical pointer, whose stale invariant-group metadata must be stripped; the
 ptr-eq assume keeps value propagation across the barrier. (`token.realloc`'s
 result is always a static token, so the launder applies to a bare pointer.)
 
-Follow-up: the reuse `realloc` copies the dead donor's contents when it
-relocates — wasted work. A no-copy resize is tracked in #362.
+The reuse `realloc` is **no-copy** (#362): the donor's contents are dead (the
+acceptor overwrites the block with a freshly constructed object, and the entry
+points are declared `allockind("realloc,uninitialized,...")`), so the runtime
+keeps the block when it already satisfies the new layout (mimalloc recovers
+the usable size from the pointer; a same-bin resize is pointer-identity) and
+otherwise does a plain free + alloc — never a copying `mi_realloc`. Only the
+runtime's Rust `GlobalAlloc` keeps a copying realloc, as its contract
+requires.
 
 ## Status / follow-ups
 

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -237,6 +237,11 @@ def ReussirTokenReallocOp : ReussirTokenOp<"realloc", []> {
     layout and the new layout are different, the memory will be reallocated, such reallocation
     may happen in place depending on the allocator and the new size.
 
+    The block's contents are NOT preserved across the resize: the operand token is dead
+    storage about to be overwritten (token reuse), so the runtime relocates with a plain
+    free + alloc instead of a copying realloc — the runtime entry points are declared
+    `allockind("realloc,uninitialized,...")` accordingly.
+
     ```mlir
     %realloced = reussir.token.realloc
       (%token : !reussir.token<align: 8, size: 8>) 

--- a/include/Reussir/Support/AllocatorBinModel.h
+++ b/include/Reussir/Support/AllocatorBinModel.h
@@ -31,8 +31,10 @@ namespace reussir {
 // This is only a *hint*, not a correctness contract: TokenReuse consults it to
 // prefer a donor that shares a bin with its acceptor (so reuse avoids a moving
 // realloc). It gates nothing in lowering — `token.realloc` always calls the
-// runtime, which copies if the block moves — so a stale or imprecise map only
-// costs a suboptimal pairing, never a miscompile. Keep it roughly in step with
+// runtime, which relocates if the block does not fit (a plain free + alloc;
+// the donor's contents are dead, so nothing is copied — #362) — so a stale or
+// imprecise map only costs a suboptimal pairing, never a miscompile. Keep it
+// roughly in step with
 // the linked allocator to keep the heuristic sharp (see #325: the previous
 // SnMalloc-derived model paired across mimalloc bins, so its reallocs copied).
 constexpr std::size_t allocatorBinSize(std::size_t size) {


### PR DESCRIPTION
token.realloc always resizes a dead donor whose storage the acceptor
overwrites with a freshly constructed object, and the entry points are
already declared allockind("realloc,uninitialized,aligned") — yet the
runtime forwarded them to mi_realloc, which memcpys min(old,new) bytes
whenever the resize crosses a mimalloc bin and the block relocates.

Split the language-heap resize from the copying realloc:

- backend::realloc_dead (mimalloc): keep the block when the pointer
  satisfies the new alignment and mi_usable_size covers the new size
  (a same-bin resize — TokenReuse's preferred pairing — is pointer
  identity), with mi_realloc's usable/2 shrink floor so a much smaller
  object moves to a right-sized block; otherwise mi_free + alloc, no
  copy. Needs libmimalloc-sys's 'extended' feature (declarations only;
  same linked C library).
- fallback backend: always free + alloc — no portable usable-size
  query, and a guaranteed-fresh block makes generated code that wrongly
  reads donor contents fail loudly under ASan/miri. This also lifts the
  over-16-alignment realloc limitation for the language heap.
- __reussir_reallocate/__reussir_realloc_unsized now route through
  realloc_dead; ReussirGlobalAlloc::realloc keeps the copying
  backend::realloc, as the Rust GlobalAlloc contract requires.

Document the contents-not-preserved contract on the op, the bin-model
header, and the design doc; cover fit/cross-bin/shrink in a backend
test.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786288388&installation_id=144622820&pr_number=370&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F370&signature=39fa758db0b0a30b61826fd1caf6c5892a0f5c068df47f1a79ff7a57c777ea3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->