### PR TITLE
[backend] closure WPD 3/3: run WholeProgramDevirt in the backend pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Notes for Claude
+
+## Git workflow
+
+- **PR stacking: every patch is based on `main`.** When splitting work into a
+  PR stack, rebase each branch onto `main` as soon as its predecessor merges
+  and retarget the PR's base to `main`. Never chain PR bases
+  (`part-2 -> part-1`, `part-3 -> part-2`): predecessors are squash-merged, so
+  chained bases duplicate already-merged history and show stale diffs.

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -122,7 +122,7 @@ unsafe extern "C" {
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;
     pub fn reussirCreateCompilePolymorphicFFIPass(optimized: bool) -> MlirPass;
     pub fn reussirCreateInvariantGroupAnalysisPass() -> MlirPass;
-    pub fn reussirCreateBasicOpsLoweringPass() -> MlirPass;
+    pub fn reussirCreateBasicOpsLoweringPass(closure_wpd: bool) -> MlirPass;
     pub fn reussirCreateDebugInfoConversionPass() -> MlirPass;
     pub fn reussirCreateAcquireDropExpansionPass(
         expand_decrement: bool,
@@ -176,7 +176,6 @@ unsafe extern "C" {
     /// into a real DWARF `DW_TAG_variant_part`, so a debugger shows only the
     /// active case. Operates in place; a no-op when `module` has no debug info.
     pub fn reussirFixupVariantDebugInfo(module: LLVMModuleRef);
-
     /// Reports whether TPDE support was compiled into the backend.
     pub fn reussirHasTPDE() -> c_int;
 

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -142,6 +142,14 @@ pub struct LoweringOptions {
     /// zero overhead: no transform pass is added and the pipeline is exactly
     /// the fixed pass list. `rrc` exposes this as `--transform-script`.
     pub transform_scripts: Vec<(Anchor, PathBuf)>,
+    /// Emit whole-program devirtualization artifacts for closures (vtable
+    /// type ids + call-site type tests). Sound only on a CLOSED WORLD: a
+    /// single module that contains every closure vtable its call sites can
+    /// observe — whole-program AOT with one codegen unit and no closure type
+    /// in any exported signature. Off by default so embedders whose modules
+    /// exchange closures (REPL/JIT increments) never opt in accidentally;
+    /// `rrc` enables it under `--closure-wpd` when the conditions hold.
+    pub closure_wpd: bool,
 }
 
 impl Default for LoweringOptions {
@@ -160,6 +168,9 @@ impl Default for LoweringOptions {
             // layout contract; only an explicit driver flag turns it off.
             pack_record_members: true,
             transform_scripts: Vec::new(),
+            // Off by default: only `rrc` can see that the closed-world
+            // conditions hold (whole-program AOT, one codegen unit).
+            closure_wpd: false,
         }
     }
 }
@@ -362,7 +373,7 @@ pub fn run_lowering_pipeline(
         module: sys::reussirCreateCanonicalizerPass();
         module: sys::reussirCreateControlFlowSinkPass();
         module: sys::reussirCreateSCFToControlFlowPass();
-        module: sys::reussirCreateBasicOpsLoweringPass();
+        module: sys::reussirCreateBasicOpsLoweringPass(options.closure_wpd);
         module: sys::reussirCreateConvertToLLVMPass();
         module: sys::reussirCreateReconcileUnrealizedCastsPass();
         // Convert fused Reussir debug-info attributes to LLVM DI now that

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -190,6 +190,16 @@ struct Cli {
     #[arg(long = "reuse-across-call")]
     reuse_across_call: bool,
 
+    /// Disable whole-program devirtualization of closures. WPD tags every
+    /// closure vtable with its type-id tiers and asserts them at the indirect
+    /// eval/clone/drop call sites, letting LLVM replace single-implementation
+    /// dispatches with direct calls. It is enabled by default at `-O
+    /// aggressive` and `-O size` whenever the closed-world conditions hold (a
+    /// whole-program AOT build with a single codegen unit) and silently
+    /// disabled otherwise.
+    #[arg(long = "no-closure-wpd")]
+    no_closure_wpd: bool,
+
     /// Lay out compound record members in declaration order instead of the
     /// default packed order (members sorted by descending storage alignment,
     /// eliminating inter-member padding). Packing is the shipped default and
@@ -587,11 +597,25 @@ fn backend_module(
     // `#[repr(fixed)]` (uniform max-arm) or defaults to per-constructor
     // sizing, threaded into the dialect variant record type's `fixed` flag —
     // no module-wide switch.
+    // Closure WPD is sound only on a closed world: this module must contain
+    // every closure vtable its type tests can observe. A whole-program AOT
+    // build with one codegen unit satisfies that (vtables are internal and
+    // closures never cross the C ABI); a partitioned build does not — a
+    // closure created in one unit flows into another whose type tests have
+    // never seen its vtable. It is reserved for the opt levels that ask for
+    // whole-program effort — `aggressive`, and `size`, where devirtualized
+    // vtables become dead and their outlined functions collectible — and the
+    // type-test intrinsics only lower inside the optimizing backend pipeline
+    // anyway.
+    let closure_wpd = !cli.no_closure_wpd
+        && cli.codegen_units == 1
+        && matches!(opt, OptLevel::Aggressive | OptLevel::Size);
     let options = LoweringOptions {
         opt,
         reuse_token_across_call: cli.reuse_across_call,
         nullary_variant_encoding: cli.nullary_variant_encoding.resolve(machine.triple()),
         pack_record_members: !cli.no_pack_record_members,
+        closure_wpd,
         ..LoweringOptions::default()
     };
     let optimize_ffi = !matches!(opt, OptLevel::None);

--- a/docs/design/closure-wpd.md
+++ b/docs/design/closure-wpd.md
@@ -112,6 +112,29 @@ call site's (both are `invariant.group` loads of the same slot), runs
 `WholeProgramDevirt` before the per-module pipeline (so devirtualized calls
 inline), and lowers away the remaining type tests.
 
+## Measured results (x86-64, LLVM 22)
+
+- An **exported** higher-order function evaluating a single-implementation
+  family goes from a genuine indirect dispatch to the closure body inlined
+  outright (`closure_wpd_devirt.rr`). Locally created and consumed closures
+  already devirtualized before this work via the constant vtable store +
+  `invariant.group` loads; WPD's contribution is exactly the cases local
+  reasoning cannot see (exported functions, merges, data structures).
+- **nbe-hoas** (HOAS normalizer, one closure family in the whole program):
+  all 8 remaining indirect calls (evaluate/clone/drop in the recursive
+  evaluator) fold to direct calls and inline at `-O aggressive`.
+  Wall-clock is neutral-to-slightly-negative (~0–3%
+  slower on a small container): dispatch was never the bottleneck there —
+  the indirect branches were perfectly predictable — and inlining the large
+  evaluator body into its callers costs some code size. The expected wins
+  are small-closure HOF code (map/filter-style), where devirtualization
+  lets the body fold into the loop.
+- **Branch funnels are disabled** (`wholeprogramdevirt-branch-funnel-threshold=0`):
+  `llvm.icall.branch.funnel` only survives instruction selection when the
+  CFI-mode LowerTypeTests has rebuilt the vtables into one combined global,
+  and we run the drop-mode lowering instead. Multi-implementation families
+  simply stay indirect.
+
 ## Invariant canary
 
 Everything above rests on the `evaluate` ABI reading all arguments from the

--- a/docs/design/closure-wpd.md
+++ b/docs/design/closure-wpd.md
@@ -61,11 +61,16 @@ vtable/slot load is `invariant.group`-tagged).
 **family root** id — whose candidate set is every closure in the program
 returning `c`. The hierarchy only pays off by strengthening: since
 apply/uniqify/clone preserve the vtable, any id valid before an apply is
-valid after it. At lowering time the eval walks its operand's SSA chain back
-through those ops (and through block arguments, meeting over predecessors)
-to the fullest statically visible suffix, and tests *that* id — e.g. a
-parameter typed `(a, b) -> c` applied twice locally lets the eval test
-`closure<(a,b)->c>` instead of `closure<()->c>`.
+valid after it. The basic-ops pass prologue runs a sparse forward dataflow
+analysis (`SparseForwardDataFlowAnalysis`) whose lattice per SSA closure
+value is the fullest statically known suffix of its backing vtable's
+original signature: apply/uniqify/clone forward their operand's view
+unchanged, every other producer contributes the static type, and merge
+points (block arguments, over live predecessors only) join by longest
+common suffix — loop-carried closures reach the fixpoint instead of being
+given up on. Each indirect call site then asserts its operand's resolved
+view — e.g. a parameter typed `(a, b) -> c` applied twice locally lets the
+eval test `closure<(a,b)->c>` instead of `closure<()->c>`.
 
 ## Closed-world soundness
 
@@ -94,16 +99,18 @@ what makes devirtualization legal without LTO summaries.
 
 `rrc` (on by default at `-O aggressive`/`-O size`; `--no-closure-wpd` opts
 out) → `LoweringOptions::closure_wpd` → the basic-ops lowering records
-`reussir.wpd.vtables` (vtable symbol → id tiers) on the module; the
-conversion patterns carry each vtable's tiers onto its global
-(`reussir.wpd.type_ids`) and assert the strengthened id at each indirect
-slot call site with `reussir.closure.wpd_test` → at
-`translateModuleToLLVMIR`, the dialect's LLVM translation interface — the
-LLVM dialect can express neither `!type` metadata nor `llvm.type.test`'s
-metadata-string operand — stamps the metadata and lowers each `wpd_test`
-into `llvm.type.test` + `llvm.assume` → the backend LLVM pipeline runs
+`reussir.wpd.vtables` (vtable symbol → id tiers) on the module and inserts
+a `reussir.closure.wpd_test` with the strengthened id in front of each
+indirect slot call site → the conversion patterns carry each vtable's tiers
+onto its global (`reussir.wpd.type_ids`) and rewrite each `wpd_test` onto
+its loaded vtable pointer → at `translateModuleToLLVMIR`, the dialect's
+LLVM translation interface — the LLVM dialect can express neither `!type`
+metadata nor `llvm.type.test`'s metadata-string operand — stamps the
+metadata and lowers each `wpd_test` into `llvm.type.test` + `llvm.assume`
+→ the backend LLVM pipeline folds the assertion's vtable load into the
+call site's (both are `invariant.group` loads of the same slot), runs
 `WholeProgramDevirt` before the per-module pipeline (so devirtualized calls
-inline) and lowers away the remaining type tests.
+inline), and lowers away the remaining type tests.
 
 ## Invariant canary
 

--- a/docs/design/closure-wpd.md
+++ b/docs/design/closure-wpd.md
@@ -1,0 +1,114 @@
+# Whole-program devirtualization for closures
+
+## The vtable hierarchy
+
+A closure box is `{refcnt, vtable, cursor, payload…}` behind an rc pointer;
+its vtable is three slots, `{drop, clone, evaluate}`. The slot ABIs depend on
+nothing beyond the closure's **return type**:
+
+- `evaluate` is `fn(rc<box>) -> c` — `closure.eval` is verified fully-applied
+  and the outlined function reads **every** argument from the payload;
+- `drop` is `fn(rc) -> void` and `clone` is `fn(rc) -> rc` — signature-free.
+
+`closure.apply`/`closure.uniqify`/`closure.clone` never change the vtable —
+only the static type (one fewer leading parameter) and the cursor. So the
+vtable created for a signature `(a, b) -> c` may back a value of static type
+`(b) -> c` or `() -> c`: in C++ terms, **`apply` is an upcast** — the static
+type moves toward the base, the vtable pointer is unchanged. That induces a
+suffix hierarchy per return type:
+
+```
+closure.uid  >  closure<(a, b) -> c>  >  closure<(b) -> c>  >  closure<() -> c>
+(one vtable)     (exact signature)        (a applied)          (family root)
+```
+
+The set of vtables that can back a static type grows as leading parameters
+are dropped: `vtables((a,b)->c) ⊆ vtables((b)->c) ⊆ vtables(()->c)`. Edges
+require exact structural equality of the suffix — there is no variance. It is
+a DAG keyed by suffixes, not a tree (`(b)->c` is the parent of `(x,b)->c` for
+every `x`). There is no type-erased `closure` root: the type system has no
+such type, so no call site could ever test it.
+
+Captures fold into the same hierarchy for free: the frontend materializes a
+capture as a pre-applied leading parameter (`|x: i32| x + k` outlines as
+`(i32, i32) -> i32` with `k` applied at creation), so a capturing closure
+shares its suffix tiers with every capture-free closure of the same visible
+type — precisely the set a call site can actually observe.
+
+This maps 1:1 onto LLVM's WPD model: each vtable global carries one `!type`
+id per suffix of its original signature (all at offset 0 — a single address
+point), and each indirect slot call tests the id of its operand's **static**
+type with `llvm.type.test` + `llvm.assume`. WPD devirtualizes per
+(type id, slot byte offset), so drop (0), clone (8) and evaluate (16)
+devirtualize independently.
+
+Type ids are structural and follow the project's v0 mangling scheme
+(`ClosureWpd.h`, mirroring the subset in
+`crates/reussir-core/src/full/mangle.rs`): a suffix `(tᵢ, …, tₙ) -> c`
+mangles through the v0 closure-type production as
+`_RFK17ReussirClosureWpd {C<digest(tⱼ)>}* E (C<digest(c)> | u)`, where each
+type appears as a crate-root nominal holding the base-62 BLAKE3 digest of
+its canonical textual form (the `Blake3Symbol.h` convention) — identical
+signatures produce identical ids in any module. The most-derived tier is the
+path `<vtable>::wpd` (`_RNv<vtable path>3wpd`), unique per vtable and useful
+for exact-match reasoning, though locally created closures already
+devirtualize without it (`closure.create` stores a constant vtable and every
+vtable/slot load is `invariant.group`-tagged).
+
+## Call-site strengthening
+
+`closure.eval` requires `closure<() -> c>`, so a naive eval test uses the
+**family root** id — whose candidate set is every closure in the program
+returning `c`. The hierarchy only pays off by strengthening: since
+apply/uniqify/clone preserve the vtable, any id valid before an apply is
+valid after it. At lowering time the eval walks its operand's SSA chain back
+through those ops (and through block arguments, meeting over predecessors)
+to the fullest statically visible suffix, and tests *that* id — e.g. a
+parameter typed `(a, b) -> c` applied twice locally lets the eval test
+`closure<(a,b)->c>` instead of `closure<()->c>`.
+
+## Closed-world soundness
+
+`llvm.type.test` + `assume` is UB the moment a vtable **without** the
+metadata reaches a tested call site. The artifacts are therefore only emitted
+when one module provably contains every closure vtable its call sites can
+observe:
+
+- whole-program AOT (`rrc`) with a **single codegen unit** — a partitioned
+  build hands closures created in one unit to tests in another;
+- `-O aggressive` or `-O size` — the opt levels that ask for whole-program
+  effort (and the type tests only lower inside the optimizing backend
+  pipeline; `llvm.type.test` cannot reach instruction selection);
+- closures never cross the C ABI today (trampolines are scalar-only, the
+  polymorphic FFI has no closure lowering, the runtime has no closure entry
+  points) and every vtable is `internal`. If an exported signature ever
+  carries a closure type, emission must be disabled for that module.
+
+The REPL/JIT exchange closures between incremental modules and therefore
+never opt in (`LoweringOptions::default()` keeps `closure_wpd` off).
+
+Each vtable is stamped with translation-unit `!vcall_visibility`, which is
+what makes devirtualization legal without LTO summaries.
+
+## Pipeline
+
+`rrc` (on by default at `-O aggressive`/`-O size`; `--no-closure-wpd` opts
+out) → `LoweringOptions::closure_wpd` → the basic-ops lowering records
+`reussir.wpd.vtables` (vtable symbol → id tiers) on the module; the
+conversion patterns carry each vtable's tiers onto its global
+(`reussir.wpd.type_ids`) and assert the strengthened id at each indirect
+slot call site with `reussir.closure.wpd_test` → at
+`translateModuleToLLVMIR`, the dialect's LLVM translation interface — the
+LLVM dialect can express neither `!type` metadata nor `llvm.type.test`'s
+metadata-string operand — stamps the metadata and lowers each `wpd_test`
+into `llvm.type.test` + `llvm.assume` → the backend LLVM pipeline runs
+`WholeProgramDevirt` before the per-module pipeline (so devirtualized calls
+inline) and lowers away the remaining type tests.
+
+## Invariant canary
+
+Everything above rests on the `evaluate` ABI reading all arguments from the
+payload. `tests/integration/conversion/closure_wpd_ids.mlir` pins both that
+signature and the id tiers; if evaluation ever passes remaining arguments in
+registers, the suffix hierarchy collapses to exact-signature families and the
+tiered ids must be regenerated accordingly.

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -52,7 +52,7 @@ MlirPass reussirCreateRcCreateFusionPass(void);
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void);
 MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized);
 MlirPass reussirCreateInvariantGroupAnalysisPass(void);
-MlirPass reussirCreateBasicOpsLoweringPass(void);
+MlirPass reussirCreateBasicOpsLoweringPass(bool closureWpd);
 MlirPass reussirCreateDebugInfoConversionPass(void);
 
 // Acquire/drop expansion has two phases controlled by these options; the

--- a/include/Reussir/Conversion/BasicOpsLowering.h
+++ b/include/Reussir/Conversion/BasicOpsLowering.h
@@ -21,12 +21,12 @@
 #include <mlir/IR/BuiltinOps.h>
 
 #include "Reussir/Conversion/TypeConverter.h"
+// Pass declarations (including the options structs) come from the blanket
+// `GEN_PASS_DECL` expansion in Passes.h; re-expanding the per-pass sections
+// here would redefine `ReussirBasicOpsLoweringPassOptions`.
+#include "Reussir/Conversion/Passes.h"
 
 namespace reussir {
-
-#define GEN_PASS_DECL_REUSSIRBASICOPSLOWERINGPASS
-#define GEN_PASS_DECL_REUSSIRDEBUGINFOCONVERSIONPASS
-#include "Reussir/Conversion/Passes.h.inc"
 
 void populateBasicOpsLoweringToLLVMConversionPatterns(
     mlir::LLVMTypeConverter &converter, mlir::RewritePatternSet &patterns);

--- a/include/Reussir/Conversion/ClosureWpd.h
+++ b/include/Reussir/Conversion/ClosureWpd.h
@@ -1,0 +1,142 @@
+//===-- ClosureWpd.h - closure whole-program devirt type ids ---*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// Type identifiers for whole-program devirtualization (WPD) of closures.
+//
+// Closure vtables form a suffix hierarchy: `closure.apply` never changes the
+// vtable — only the static type (one fewer leading parameter) and the cursor —
+// so a vtable created for signature `(a, b) -> c` may back a value of static
+// type `(b) -> c` or `() -> c`. Every slot's ABI depends on nothing beyond the
+// return type (`evaluate` is `fn(rc<box>) -> c` reading all args from the
+// payload; `drop`/`clone` are signature-independent), which is what makes the
+// substitution sound. In C++/WPD terms, `apply` is an upcast: the vtable of a
+// closure is tagged with one type id per *suffix* of its original signature,
+// and an indirect call site tests the id of its operand's static type.
+//
+// Ids follow the project's v0 mangling scheme (the subset documented in
+// `crates/reussir-core/src/full/mangle.rs`), using its closure-type
+// production with one content-addressed segment per type. The id of a suffix
+// `(tᵢ, …, tₙ) -> c` is
+//
+//   _R F K 17ReussirClosureWpd {C<digest(tⱼ)>}* E (C<digest(c)> | u)
+//
+// where `<digest(t)>` is the length-prefixed v0 identifier holding
+// `b62(blake3(print(t)))` — the `Blake3Symbol.h` convention, shared with the
+// Rust frontend — and a closure returning nothing uses the v0 unit code `u`.
+// Ids are built from the types' canonical textual forms, so identical
+// signatures produce identical ids in any module. The most-derived tier is
+// unique per vtable: the path `<vtable>::wpd`, i.e. `_RNv<vtable path>3wpd`,
+// nested under the vtable's own v0 symbol.
+//
+// See docs/design/closure-wpd.md for the full design, including the
+// closed-world conditions under which the type tests are sound.
+//
+//===----------------------------------------------------------------------===//
+#ifndef REUSSIR_CONVERSION_CLOSUREWPD_H
+#define REUSSIR_CONVERSION_CLOSUREWPD_H
+
+#include <string>
+
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringExtras.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include "Reussir/Conversion/Blake3Symbol.h"
+#include "Reussir/IR/ReussirTypes.h"
+
+namespace reussir {
+
+/// The module-level attribute carrying `vtable symbol -> [type ids]`, set by
+/// the basic-ops lowering when `closure-wpd` is enabled. Its presence is the
+/// switch the conversion patterns key their WPD emission off.
+inline constexpr llvm::StringRef kClosureWpdVtableMapAttr =
+    "reussir.wpd.vtables";
+
+/// The per-global attribute (an array of id strings) the vtable conversion
+/// pattern stamps onto each closure vtable `llvm.mlir.global`. The dialect's
+/// LLVM translation interface turns it into `!type` metadata (offset 0 — the
+/// vtable has a single address point) plus translation-unit
+/// `!vcall_visibility` on the translated global.
+inline constexpr llvm::StringRef kClosureWpdTypeIdsAttr =
+    "reussir.wpd.type_ids";
+
+/// Appends `body` as a v0 identifier: `<length> [_] <body>`, with the `_`
+/// separator exactly when the body leads with a digit or `_` (mirroring
+/// `mangle.rs`; the length excludes the separator).
+inline void appendClosureWpdV0Ident(std::string &out, llvm::StringRef body) {
+  out += std::to_string(body.size());
+  if (!body.empty() && (llvm::isDigit(body.front()) || body.front() == '_'))
+    out += '_';
+  out += body;
+}
+
+/// Appends the id segment of one type: a crate-root nominal (`C<ident>`)
+/// whose identifier is the base-62 BLAKE3 digest of the type's canonical
+/// textual form.
+inline void appendClosureWpdTypeSegment(std::string &out, mlir::Type type) {
+  std::string text;
+  llvm::raw_string_ostream os(text);
+  type.print(os);
+  llvm::BLAKE3 hasher;
+  hasher.update(text);
+  out += 'C';
+  appendClosureWpdV0Ident(out, base62Digits(blake3Words(hasher)));
+}
+
+/// The type id of `closureType`'s exact static signature — the id an indirect
+/// call site tests for an operand of this static type.
+inline std::string closureWpdTypeId(ClosureType closureType) {
+  std::string id = "_RFK";
+  appendClosureWpdV0Ident(id, "ReussirClosureWpd");
+  for (mlir::Type input : closureType.getInputTypes())
+    appendClosureWpdTypeSegment(id, input);
+  id += 'E';
+  if (mlir::Type output = closureType.getOutputType())
+    appendClosureWpdTypeSegment(id, output);
+  else
+    id += 'u';
+  return id;
+}
+
+/// The most-derived, per-vtable tier: the path `<vtable>::wpd` nested under
+/// the vtable's own v0 symbol.
+inline std::string closureWpdUidTypeId(llvm::StringRef vtableSymbol) {
+  std::string id = "_RNv";
+  if (vtableSymbol.consume_front("_R")) {
+    id += vtableSymbol;
+  } else {
+    // Not a v0 symbol (hand-written IR): treat it as a crate-root segment.
+    id += 'C';
+    appendClosureWpdV0Ident(id, vtableSymbol);
+  }
+  id += "3wpd";
+  return id;
+}
+
+/// All type ids a vtable for `closureType` (the closure's ORIGINAL, unapplied
+/// signature) carries: one per signature suffix, from the family root
+/// `() -> c` up to the full signature, plus the per-vtable uid tier.
+inline llvm::SmallVector<std::string>
+closureWpdVtableTypeIds(ClosureType closureType, llvm::StringRef vtableSymbol) {
+  llvm::SmallVector<std::string> ids;
+  auto inputs = closureType.getInputTypes();
+  mlir::Type output = closureType.getOutputType();
+  // Suffixes from empty (family root) to the full signature.
+  for (size_t kept = 0; kept <= inputs.size(); ++kept) {
+    ClosureType suffix = ClosureType::get(closureType.getContext(),
+                                          inputs.take_back(kept), output);
+    ids.push_back(closureWpdTypeId(suffix));
+  }
+  ids.push_back(closureWpdUidTypeId(vtableSymbol));
+  return ids;
+}
+
+} // namespace reussir
+
+#endif // REUSSIR_CONVERSION_CLOSUREWPD_H

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -29,7 +29,23 @@ def ReussirBasicOpsLoweringPass
     materializing the Reussir runtime declarations and normalizing fused debug
     information. The actual lowering of Reussir basic operations is provided by
     the registered LLVM lowering interface and is driven by `convert-to-llvm`.
+
+    With `closure-wpd` enabled, the pass also records the whole-program
+    devirtualization type ids of every outlined closure vtable on the module
+    (`reussir.wpd.vtables`); the vtable conversion pattern carries them onto
+    the vtable globals (`reussir.wpd.type_ids`) and the conversion patterns
+    assert them at the indirect vtable call sites (eval/clone/drop) with
+    `reussir.closure.wpd_test`. The dialect's LLVM translation interface
+    turns both into the real artifacts — `!type` / `!vcall_visibility`
+    metadata and `llvm.type.test` + `llvm.assume` — during
+    `translateModuleToLLVMIR`. Only enable this on a closed world: one module
+    carrying every closure vtable the tested call sites can observe (see
+    docs/design/closure-wpd.md).
   }];
+  let options = [
+    Option<"closureWpd", "closure-wpd", "bool", /*default=*/"false",
+        "emit whole-program devirtualization artifacts for closure vtables">,
+  ];
   let dependentDialects = ["::mlir::arith::ArithDialect",
                            "::mlir::memref::MemRefDialect",
                            "::mlir::scf::SCFDialect",

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1611,6 +1611,31 @@ def ReussirClosureCloneOp : ReussirClosureOp<"clone", []> {
   let hasVerifier = 1;
 }
 
+def ReussirClosureWpdTestOp : ReussirClosureOp<"wpd_test", []> {
+  let summary = "Assert a whole-program-devirtualization type id of a vtable";
+  let description = [{
+    `reussir.closure.wpd_test` asserts that `vtable` (a lowered pointer to a
+    closure vtable global) carries the whole-program-devirtualization type id
+    `id` — see `ClosureWpd.h` and docs/design/closure-wpd.md for the id
+    scheme and the closed-world conditions that make the assertion sound.
+
+    The op is emitted by the closure conversion patterns (when the basic-ops
+    lowering runs with `closure-wpd`) next to each indirect vtable slot load,
+    and survives conversion untouched: the LLVM dialect can express neither
+    `!type` metadata nor the metadata-string operand of `llvm.type.test`, so
+    the Reussir dialect's LLVM translation interface lowers this op directly
+    to `llvm.type.test(%vtable, !"id")` + `llvm.assume` during
+    `translateModuleToLLVMIR`.
+  }];
+  let arguments = (ins
+    Arg<AnyType, "lowered pointer to the vtable">:$vtable,
+    StrAttr:$id
+  );
+  let assemblyFormat = [{
+    `(` $vtable `:` type($vtable) `)` `id` `(` $id `)` attr-dict
+  }];
+}
+
 def ReussirClosureInspectPayloadOp : ReussirClosureOp<"inspect_payload", []> {
   let summary = "Inspect closure payload";
   let description = [{

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1614,21 +1614,24 @@ def ReussirClosureCloneOp : ReussirClosureOp<"clone", []> {
 def ReussirClosureWpdTestOp : ReussirClosureOp<"wpd_test", []> {
   let summary = "Assert a whole-program-devirtualization type id of a vtable";
   let description = [{
-    `reussir.closure.wpd_test` asserts that `vtable` (a lowered pointer to a
-    closure vtable global) carries the whole-program-devirtualization type id
-    `id` — see `ClosureWpd.h` and docs/design/closure-wpd.md for the id
-    scheme and the closed-world conditions that make the assertion sound.
+    `reussir.closure.wpd_test` asserts that the vtable backing `vtable`
+    carries the whole-program-devirtualization type id `id` — see
+    `ClosureWpd.h` and docs/design/closure-wpd.md for the id scheme and the
+    closed-world conditions that make the assertion sound.
 
-    The op is emitted by the closure conversion patterns (when the basic-ops
-    lowering runs with `closure-wpd`) next to each indirect vtable slot load,
-    and survives conversion untouched: the LLVM dialect can express neither
-    `!type` metadata nor the metadata-string operand of `llvm.type.test`, so
-    the Reussir dialect's LLVM translation interface lowers this op directly
-    to `llvm.type.test(%vtable, !"id")` + `llvm.assume` during
-    `translateModuleToLLVMIR`.
+    The op has two forms over its lifetime. The basic-ops lowering prologue
+    (under `closure-wpd`) inserts it with an **rc'd closure** operand in
+    front of each indirect vtable call site, carrying the strengthened id
+    the sparse strengthening analysis computed for that operand. Its
+    conversion pattern then loads the box's vtable slot (`invariant.group`)
+    and re-emits the op on the **loaded vtable pointer**; that form survives
+    to `translateModuleToLLVMIR`, where the dialect's LLVM translation
+    interface lowers it to `llvm.type.test(%vtable, !"id")` + `llvm.assume`
+    — the LLVM dialect can express neither `!type` metadata nor the
+    intrinsic's metadata-string operand.
   }];
   let arguments = (ins
-    Arg<AnyType, "lowered pointer to the vtable">:$vtable,
+    Arg<AnyType, "rc'd closure (pre-conversion) or vtable pointer">:$vtable,
     StrAttr:$id
   );
   let assemblyFormat = [{

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -20,6 +20,8 @@
 #include "Reussir/LLVMPass/AllocationSimplication.h"
 #include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"
 
+#include <llvm/Transforms/IPO/LowerTypeTests.h>
+
 #ifdef REUSSIR_HAS_TPDE
 #include <cstdint>
 #include <vector>
@@ -60,6 +62,14 @@ void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt)
 
   llvm::ModulePassManager mpm;
   mpm.addPass(reussir::llvmpass::RuntimeFunctionAttributorPass());
+  // Consume the closure-WPD artifacts (`llvm.type.test` + `assume` at the
+  // indirect vtable call sites) before the module pipeline: drop the assumes
+  // and fold the tests away so no `llvm.type.test` ever reaches instruction
+  // selection. A no-op for modules lowered without `closure-wpd` (REPL/JIT
+  // increments among them — this entry point serves both backends).
+  mpm.addPass(llvm::LowerTypeTestsPass(
+      /*ExportSummary=*/nullptr, /*ImportSummary=*/nullptr,
+      llvm::lowertypetests::DropTestKind::Assume));
   mpm.addPass(pb.buildPerModuleDefaultPipeline(level));
   mpm.addPass(reussir::llvmpass::AllocationSimplicationPass());
   mpm.run(m, mam);

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -20,7 +20,12 @@
 #include "Reussir/LLVMPass/AllocationSimplication.h"
 #include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"
 
+#include <llvm/Support/CommandLine.h>
 #include <llvm/Transforms/IPO/LowerTypeTests.h>
+#include <llvm/Transforms/Scalar/GVN.h>
+#include <llvm/Transforms/IPO/WholeProgramDevirt.h>
+
+#include <mutex>
 
 #ifdef REUSSIR_HAS_TPDE
 #include <cstdint>
@@ -62,11 +67,45 @@ void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt)
 
   llvm::ModulePassManager mpm;
   mpm.addPass(reussir::llvmpass::RuntimeFunctionAttributorPass());
-  // Consume the closure-WPD artifacts (`llvm.type.test` + `assume` at the
-  // indirect vtable call sites) before the module pipeline: drop the assumes
-  // and fold the tests away so no `llvm.type.test` ever reaches instruction
-  // selection. A no-op for modules lowered without `closure-wpd` (REPL/JIT
-  // increments among them — this entry point serves both backends).
+  // Whole-program devirtualization of closures, ahead of the module pipeline
+  // so devirtualized slot calls can inline. The lowering tagged each closure
+  // vtable with its suffix type-id tiers (translation-unit vcall visibility —
+  // legal without LTO summaries) and asserted the strengthened id at every
+  // indirect eval/clone/drop site; when a tested id has a single
+  // implementation in the module, WPD folds the slot call direct.
+  // Branch-funnel devirtualization is OFF: `llvm.icall.branch.funnel`'s
+  // instruction selection requires every vtable operand to derive from one
+  // combined GlobalValue — the layout only the CFI-mode LowerTypeTests
+  // builds. We run the drop-mode lowering instead, so a funnel emitted for a
+  // multi-implementation family would abort at object emission ("all
+  // llvm.icall.branch.funnel operands must refer to the same GlobalValue").
+  // The threshold is a cl::opt with no pass-constructor equivalent.
+  static std::once_flag disableBranchFunnels;
+  std::call_once(disableBranchFunnels, [] {
+    auto &options = llvm::cl::getRegisteredOptions();
+    auto it = options.find("wholeprogramdevirt-branch-funnel-threshold");
+    if (it != options.end())
+      static_cast<llvm::cl::opt<unsigned> *>(it->second)->setValue(0);
+  });
+  // The lowering's type-test assertion loads the vtable slot separately from
+  // the call site it guards, and WPD only devirtualizes calls hanging off
+  // the type-tested pointer itself. Both are `invariant.group` loads of the
+  // same slot, so one GVN run — which folds redundant invariant-group loads
+  // even across the refcount store — funnels the call onto the tested value.
+  // GVN is not free, so it (and WPD) only run when the module actually
+  // carries type tests; modules lowered without `closure-wpd` (REPL/JIT
+  // increments among them) keep their pipeline unchanged.
+  if (llvm::Intrinsic::getDeclarationIfExists(&m,
+                                              llvm::Intrinsic::type_test)) {
+    mpm.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::GVNPass()));
+    mpm.addPass(llvm::WholeProgramDevirtPass(
+        /*ExportSummary=*/nullptr, /*ImportSummary=*/nullptr));
+  }
+  // Then consume the artifacts (`llvm.type.test` + `assume`): drop the
+  // assumes and fold the dead tests away so no `llvm.type.test` ever reaches
+  // instruction selection. Both passes are no-ops for modules lowered
+  // without `closure-wpd` (REPL/JIT increments among them — this entry point
+  // serves both backends).
   mpm.addPass(llvm::LowerTypeTestsPass(
       /*ExportSummary=*/nullptr, /*ImportSummary=*/nullptr,
       llvm::lowertypetests::DropTestKind::Assume));

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -113,8 +113,10 @@ MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized) {
 MlirPass reussirCreateInvariantGroupAnalysisPass(void) {
   return wrapOwned(reussir::createReussirInvariantGroupAnalysisPass());
 }
-MlirPass reussirCreateBasicOpsLoweringPass(void) {
-  return wrapOwned(reussir::createReussirBasicOpsLoweringPass());
+MlirPass reussirCreateBasicOpsLoweringPass(bool closureWpd) {
+  reussir::ReussirBasicOpsLoweringPassOptions options;
+  options.closureWpd = closureWpd;
+  return wrapOwned(reussir::createReussirBasicOpsLoweringPass(options));
 }
 MlirPass reussirCreateDebugInfoConversionPass(void) {
   return wrapOwned(reussir::createReussirDebugInfoConversionPass());

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -8,6 +8,7 @@
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringSet.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/DebugInfo/DWARF/DWARFAttribute.h>
 #include <llvm/Support/Casting.h>
@@ -53,6 +54,7 @@
 #include "Reussir/Conversion/BasicOpsLowering.h"
 #include "Reussir/Conversion/Blake3Symbol.h"
 #include "Reussir/Conversion/CABISignatureConversion.h"
+#include "Reussir/Conversion/ClosureWpd.h"
 #include "Reussir/Conversion/TypeConverter.h"
 #include "Reussir/IR/ReussirAttrs.h"
 #include "Reussir/IR/ReussirDialect.h"
@@ -1812,6 +1814,16 @@ struct ReussirClosureVtableOpConversionPattern
         rewriter, op.getLoc(), vtableType, /*isConstant=*/true,
         mlir::LLVM::Linkage::Internal, op.getSymName(), nullptr);
 
+    // With `closure-wpd` on, the basic-ops pass prologue recorded this
+    // vtable's type-id tiers on the module; carry them on the global so the
+    // dialect's LLVM translation interface can stamp the `!type` /
+    // `!vcall_visibility` metadata the LLVM dialect cannot express.
+    if (auto map =
+            op->getParentOfType<mlir::ModuleOp>()->getAttrOfType<
+                mlir::DictionaryAttr>(kClosureWpdVtableMapAttr))
+      if (mlir::Attribute ids = map.get(op.getSymName()))
+        vtableOp->setAttr(kClosureWpdTypeIdsAttr, ids);
+
     // Create initializer block
     mlir::Block *initBlock =
         rewriter.createBlock(&vtableOp.getInitializerRegion());
@@ -3266,11 +3278,45 @@ struct ReussirConvertToLLVMPatternInterface
 struct BasicOpsLoweringPass
     : public impl::ReussirBasicOpsLoweringPassBase<BasicOpsLoweringPass> {
   using Base::Base;
+
+  // Record every outlined closure's WPD type-id tiers on the module, keyed by
+  // vtable symbol: `apply` never changes a closure's vtable, so a vtable
+  // carries one id per *suffix* of its original signature (plus its own uid
+  // tier) — see ClosureWpd.h. The map's presence is also the switch the
+  // conversion patterns key their WPD emission off: the vtable pattern copies
+  // its entry onto the vtable global (as `reussir.wpd.type_ids`, which the
+  // dialect's LLVM translation interface turns into `!type` /
+  // `!vcall_visibility` metadata).
+  void buildClosureWpdVtableMap(mlir::ModuleOp moduleOp) {
+    llvm::SmallVector<mlir::NamedAttribute> entries;
+    llvm::StringSet<> seen;
+    mlir::MLIRContext *ctx = moduleOp.getContext();
+    moduleOp.walk([&](ReussirClosureCreateOp op) {
+      if (!op.isOutlined())
+        return;
+      llvm::StringRef vtableSym = op.getVtableAttr().getValue();
+      if (!seen.insert(vtableSym).second)
+        return;
+      auto closureType =
+          llvm::cast<ClosureType>(op.getClosure().getType().getElementType());
+      llvm::SmallVector<mlir::Attribute> ids;
+      for (const std::string &id :
+           closureWpdVtableTypeIds(closureType, vtableSym))
+        ids.push_back(mlir::StringAttr::get(ctx, id));
+      entries.emplace_back(mlir::StringAttr::get(ctx, vtableSym),
+                           mlir::ArrayAttr::get(ctx, ids));
+    });
+    moduleOp->setAttr(kClosureWpdVtableMapAttr,
+                      mlir::DictionaryAttr::get(ctx, entries));
+  }
+
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
     mlir::LLVMTypeConverter converter(moduleOp.getContext(),
                                       getReussirToLLVMOptions(moduleOp));
     ensureRuntimeFunctions(moduleOp, converter);
+    if (closureWpd)
+      buildClosureWpdVtableMap(moduleOp);
     // Fused debug-info attributes are converted to LLVM DI by the separate
     // `reussir-lowering-debug-info` pass, which runs after `convert-to-llvm`
     // so the functions are already `llvm.func` (a function's DI only survives

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -47,6 +47,10 @@
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h>
+#include <mlir/Analysis/DataFlow/DeadCodeAnalysis.h>
+#include <mlir/Analysis/DataFlow/SparseAnalysis.h>
+#include <mlir/Analysis/DataFlowFramework.h>
 #include <mlir/Interfaces/DataLayoutInterfaces.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/DialectConversion.h>
@@ -1912,6 +1916,40 @@ struct ReussirClosureCreateOpConversionPattern
   }
 };
 
+// Lowers a prologue-inserted `reussir.closure.wpd_test` from its rc'd-closure
+// form onto the vtable pointer: loads the vtable slot (`invariant.group`, like
+// every other vtable load) and re-emits the op on the loaded pointer, the form
+// the dialect's LLVM translation interface turns into `llvm.type.test` +
+// `llvm.assume`. The load duplicates the one the adjacent call site emits;
+// both are `invariant.group` loads of the same slot, folded to one by the
+// backend pipeline before WholeProgramDevirt consumes the test.
+struct ReussirClosureWpdTestOpConversionPattern
+    : public mlir::OpConversionPattern<ReussirClosureWpdTestOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirClosureWpdTestOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto rcType = llvm::dyn_cast<RcType>(op.getVtable().getType());
+    if (!rcType)
+      return mlir::failure(); // Already the lowered vtable-pointer form.
+    auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    auto converter =
+        static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
+    auto structType = converter->convertType(rcType.getInnerBoxType());
+    auto vtablePtr = mlir::LLVM::GEPOp::create(
+        rewriter, op.getLoc(), llvmPtrType, structType, adaptor.getVtable(),
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1, ClosureBoxType::VTABLE_INDEX});
+    auto vtable = mlir::LLVM::LoadOp::create(rewriter, op.getLoc(), llvmPtrType,
+                                             vtablePtr);
+    vtable.setInvariantGroup(true);
+    ReussirClosureWpdTestOp::create(rewriter, op.getLoc(), vtable,
+                                    op.getIdAttr());
+    rewriter.eraseOp(op);
+    return mlir::success();
+  }
+};
+
 struct ReussirRcDecOpConversionPattern
     : public mlir::OpConversionPattern<ReussirRcDecOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -3250,6 +3288,15 @@ struct ReussirConvertToLLVMPatternInterface
     populateLLVMInterfaceForDialect<mlir::ub::UBDialect>(
         patterns.getContext(), target, typeConverter, patterns);
     populateBasicOpsLoweringToLLVMConversionPatterns(typeConverter, patterns);
+    // `reussir.closure.wpd_test` converts from its rc'd-closure form onto the
+    // loaded vtable pointer, and THAT form stays in the LLVM-dialect module
+    // until `translateModuleToLLVMIR`, where the dialect's LLVM translation
+    // interface lowers it to `llvm.type.test` + `llvm.assume` — neither of
+    // which the LLVM dialect can express.
+    target.addDynamicallyLegalOp<ReussirClosureWpdTestOp>(
+        [](ReussirClosureWpdTestOp op) {
+          return !llvm::isa<RcType>(op.getVtable().getType());
+        });
     target.addIllegalOp<
         ReussirPanicOp, ReussirExpectOp, ReussirCctxEmptyOp, ReussirCctxExtendOp,
         ReussirCctxApplyOp, ReussirTokenAllocOp, ReussirTokenFreeOp,
@@ -3274,6 +3321,139 @@ struct ReussirConvertToLLVMPatternInterface
         ReussirStrSliceOp, ReussirTrampolineOp, ReussirTokenLaunderOp>();
   }
 };
+
+//===----------------------------------------------------------------------===//
+// Closure WPD: suffix strengthening as a sparse forward dataflow analysis
+//===----------------------------------------------------------------------===//
+
+// The strengthened view of one SSA closure value: the fullest suffix of its
+// backing vtable's ORIGINAL signature statically known to be valid for it —
+// the strongest type id an indirect call site on the value may assert.
+// apply/uniqify/clone never change a closure's vtable, so the knowledge
+// survives them unchanged; where control flow merges, the sound view is the
+// longest common suffix of the incoming views (the meet in the suffix
+// hierarchy). This is what makes the tiered ids pay off: an eval operand is
+// always typed `() -> c` (the family root, backed by every closure returning
+// c), but a parameter typed `(a, b) -> c` applied twice locally lets the
+// eval test the far smaller `(a, b) -> c` set.
+class ClosureStrength {
+public:
+  // The uninitialized (bottom) state: nothing propagated here yet.
+  ClosureStrength() = default;
+  explicit ClosureStrength(ClosureType type)
+      : initialized(true), type(type) {}
+
+  // The pessimistic view of a value: its static type for rc'd closures, "no
+  // information" (a null type) for everything else.
+  static ClosureStrength pessimistic(mlir::Value value) {
+    if (auto rcType = llvm::dyn_cast<RcType>(value.getType()))
+      if (auto closure = llvm::dyn_cast<ClosureType>(rcType.getElementType()))
+        return ClosureStrength(closure);
+    return ClosureStrength(ClosureType());
+  }
+
+  bool isUninitialized() const { return !initialized; }
+  ClosureType getType() const { return type; }
+
+  bool operator==(const ClosureStrength &rhs) const {
+    return initialized == rhs.initialized && type == rhs.type;
+  }
+
+  // The longest common suffix — the strongest view sound for a value merging
+  // from both sides. Outputs agree whenever suffix-related views of the same
+  // static type meet; anything else (including a null "no information" side)
+  // collapses to no information.
+  static ClosureStrength join(const ClosureStrength &lhs,
+                              const ClosureStrength &rhs) {
+    if (lhs.isUninitialized())
+      return rhs;
+    if (rhs.isUninitialized())
+      return lhs;
+    if (lhs.type == rhs.type)
+      return lhs;
+    if (!lhs.type || !rhs.type ||
+        lhs.type.getOutputType() != rhs.type.getOutputType())
+      return ClosureStrength(ClosureType());
+    auto lhsIn = lhs.type.getInputTypes();
+    auto rhsIn = rhs.type.getInputTypes();
+    size_t common = 0;
+    while (common < lhsIn.size() && common < rhsIn.size() &&
+           lhsIn[lhsIn.size() - 1 - common] == rhsIn[rhsIn.size() - 1 - common])
+      ++common;
+    return ClosureStrength(ClosureType::get(
+        lhs.type.getContext(), lhsIn.take_back(common), lhs.type.getOutputType()));
+  }
+
+  void print(llvm::raw_ostream &os) const {
+    if (!initialized)
+      os << "<uninitialized>";
+    else if (!type)
+      os << "<no info>";
+    else
+      os << type;
+  }
+
+private:
+  bool initialized = false;
+  ClosureType type = nullptr;
+};
+
+using ClosureStrengthLattice = mlir::dataflow::Lattice<ClosureStrength>;
+
+// Forward propagation of ClosureStrength over the SSA graph. The framework
+// handles the control-flow plumbing — block arguments join over their
+// (live) predecessors, loop-carried closures reach a fixpoint instead of
+// being given up on — so the transfer function only encodes the one domain
+// fact: apply/uniqify/clone are vtable-preserving.
+class ClosureStrengthAnalysis
+    : public mlir::dataflow::SparseForwardDataFlowAnalysis<
+          ClosureStrengthLattice> {
+public:
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+
+  mlir::LogicalResult
+  visitOperation(mlir::Operation *op,
+                 llvm::ArrayRef<const ClosureStrengthLattice *> operands,
+                 llvm::ArrayRef<ClosureStrengthLattice *> results) override {
+    unsigned chased;
+    if (llvm::isa<ReussirClosureUniqifyOp, ReussirClosureCloneOp>(op))
+      chased = 0;
+    else if (llvm::isa<ReussirClosureApplyOp>(op))
+      chased = 1; // (arg, closure)
+    else {
+      // Any other op contributes only static knowledge to its results.
+      setAllToEntryStates(results);
+      return mlir::success();
+    }
+    const ClosureStrength &in = operands[chased]->getValue();
+    if (in.isUninitialized())
+      return mlir::success(); // Revisited once the operand resolves.
+    propagateIfChanged(results[0], results[0]->join(in));
+    return mlir::success();
+  }
+
+  // Values the analysis cannot see past (entry arguments, external calls,
+  // unhandled producers) carry exactly their static type.
+  void setToEntryState(ClosureStrengthLattice *lattice) override {
+    propagateIfChanged(
+        lattice, lattice->join(ClosureStrength::pessimistic(lattice->getAnchor())));
+  }
+};
+
+// The strengthened type of a closure value after the solver ran: the lattice
+// view when one was computed, the static type otherwise.
+static ClosureType strengthenedClosureType(mlir::DataFlowSolver &solver,
+                                           mlir::Value closure) {
+  auto staticType = llvm::cast<ClosureType>(
+      llvm::cast<RcType>(closure.getType()).getElementType());
+  auto *lattice = solver.lookupState<ClosureStrengthLattice>(closure);
+  if (!lattice)
+    return staticType;
+  const ClosureStrength &strength = lattice->getValue();
+  if (strength.isUninitialized() || !strength.getType())
+    return staticType;
+  return strength.getType();
+}
 
 struct BasicOpsLoweringPass
     : public impl::ReussirBasicOpsLoweringPassBase<BasicOpsLoweringPass> {
@@ -3310,13 +3490,54 @@ struct BasicOpsLoweringPass
                       mlir::DictionaryAttr::get(ctx, entries));
   }
 
+  // Run the strengthening analysis, then insert a `reussir.closure.wpd_test`
+  // asserting the strengthened id in front of every indirect vtable call
+  // site — eval (evaluate slot), closure.clone (clone slot), rc.dec of a
+  // closure (drop slot). The op is inserted here, on clean pre-conversion
+  // IR; its own conversion pattern later rewrites it onto the loaded vtable
+  // pointer, and the dialect's LLVM translation interface lowers that to
+  // `llvm.type.test` + `llvm.assume`.
+  mlir::LogicalResult insertClosureWpdTypeTests(mlir::ModuleOp moduleOp) {
+    mlir::DataFlowSolver solver;
+    // Dead-code + constant-propagation feed the sparse framework's
+    // reachability (dead predecessors do not weaken a merge).
+    solver.load<mlir::dataflow::DeadCodeAnalysis>();
+    solver.load<mlir::dataflow::SparseConstantPropagation>();
+    solver.load<ClosureStrengthAnalysis>();
+    if (mlir::failed(solver.initializeAndRun(moduleOp)))
+      return mlir::failure();
+    mlir::OpBuilder builder(moduleOp.getContext());
+    auto testBefore = [&](mlir::Operation *op, mlir::Value closure) {
+      builder.setInsertionPoint(op);
+      std::string id =
+          closureWpdTypeId(strengthenedClosureType(solver, closure));
+      ReussirClosureWpdTestOp::create(builder, op->getLoc(), closure,
+                                      builder.getStringAttr(id));
+    };
+    moduleOp.walk([&](mlir::Operation *op) {
+      if (auto eval = llvm::dyn_cast<ReussirClosureEvalOp>(op))
+        return testBefore(op, eval.getClosure());
+      if (auto clone = llvm::dyn_cast<ReussirClosureCloneOp>(op))
+        return testBefore(op, clone.getClosure());
+      if (auto dec = llvm::dyn_cast<ReussirRcDecOp>(op)) {
+        auto rcType = llvm::dyn_cast<RcType>(dec.getRcPtr().getType());
+        if (rcType && llvm::isa<ClosureType>(rcType.getElementType()))
+          testBefore(op, dec.getRcPtr());
+      }
+    });
+    return mlir::success();
+  }
+
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
     mlir::LLVMTypeConverter converter(moduleOp.getContext(),
                                       getReussirToLLVMOptions(moduleOp));
     ensureRuntimeFunctions(moduleOp, converter);
-    if (closureWpd)
+    if (closureWpd) {
       buildClosureWpdVtableMap(moduleOp);
+      if (mlir::failed(insertClosureWpdTypeTests(moduleOp)))
+        return signalPassFailure();
+    }
     // Fused debug-info attributes are converted to LLVM DI by the separate
     // `reussir-lowering-debug-info` pass, which runs after `convert-to-llvm`
     // so the functions are already `llvm.func` (a function's DI only survives
@@ -3410,6 +3631,7 @@ void populateBasicOpsLoweringToLLVMConversionPatterns(
       ReussirClosureApplyOpConversionPattern,
       ReussirClosureCloneOpConversionPattern,
       ReussirClosureEvalOpConversionPattern,
+      ReussirClosureWpdTestOpConversionPattern,
       ReussirClosureInspectPayloadOpConversionPattern,
       ReussirClosureCursorOpConversionPattern,
       ReussirClosureTransferOpConversionPattern,

--- a/lib/IR/CMakeLists.txt
+++ b/lib/IR/CMakeLists.txt
@@ -10,4 +10,7 @@ add_mlir_dialect_library(MLIRReussir
     Core
   LINK_LIBS PUBLIC
     ${dialect_libs}
+    # The dialect's LLVMTranslationDialectInterface (ReussirInterfaces.cpp)
+    # emits LLVM IR for the ops/attributes the LLVM dialect cannot express.
+    MLIRTargetLLVMIRExport
 )

--- a/lib/IR/ReussirInterfaces.cpp
+++ b/lib/IR/ReussirInterfaces.cpp
@@ -11,13 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirInterfaces.h"
+#include "Reussir/Conversion/ClosureWpd.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
 
-#include <llvm/Bitcode/BitcodeReader.h>
-#include <llvm/Linker/Linker.h>
-#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Metadata.h>
+#include <llvm/IR/Module.h>
 #include <mlir/Target/LLVMIR/LLVMTranslationInterface.h>
 #include <mlir/Target/LLVMIR/ModuleTranslation.h>
 #include <mlir/Transforms/InliningUtils.h>
@@ -25,46 +27,71 @@
 #include "Reussir/IR/ReussirInterfaces.cpp.inc"
 
 namespace reussir {
-// namespace {
-// using namespace mlir;
-// struct ReussirLLVMTranslation : public mlir::LLVMTranslationDialectInterface
-// {
-//   using LLVMTranslationDialectInterface::LLVMTranslationDialectInterface;
-
-//   LogicalResult
-//   convertOperation(Operation *op, llvm::IRBuilderBase &builder,
-//                    LLVM::ModuleTranslation &state) const override {
-//     if (auto polyffi = dyn_cast<ReussirPolyFFIOp>(op)) {
-//       if (!polyffi.getCompiledModule())
-//         return op->emitError("PolyFFI operation has no compiled module");
-//       auto denseI8array =
-//           dyn_cast<DenseElementsAttr>(*polyffi.getCompiledModule());
-//       if (!denseI8array)
-//         return op->emitError("compiledModule is not a DenseElementsAttr");
-//       llvm::ArrayRef<char> bitcodeData = denseI8array.getRawData();
-//       std::unique_ptr<llvm::MemoryBuffer> memBuffer =
-//           llvm::MemoryBuffer::getMemBuffer(
-//               llvm::StringRef(bitcodeData.data(), bitcodeData.size()));
-//       llvm::Expected<std::unique_ptr<llvm::Module>> moduleOrErr =
-//           llvm::parseBitcodeFile(memBuffer->getMemBufferRef(),
-//                                  state.getLLVMContext());
-//       if (!moduleOrErr)
-//         return op->emitError("PolyFFI operation has invalid bitcode");
-//       std::unique_ptr<llvm::Module> innerModule = std::move(*moduleOrErr);
-//       auto layout = state.getLLVMModule()->getDataLayout();
-//       innerModule->setDataLayout(layout);
-//       bool flag = llvm::Linker::linkModules(*state.getLLVMModule(),
-//                                             std::move(innerModule));
-//       if (flag)
-//         return op->emitError("PolyFFI operation cannot be linked");
-//       return success();
-//     }
-//     return failure();
-//   }
-// };
-// } // namespace
-
 namespace {
+// Translation of the Reussir ops and attributes that survive the conversion
+// pipeline into the LLVM dialect module because the LLVM dialect cannot
+// express their artifacts (`!type` metadata and `llvm.type.test`'s
+// metadata-string operand):
+//
+//  * `reussir.closure.wpd_test` becomes `llvm.type.test(%vtable, !"id")`
+//    feeding `llvm.assume`;
+//  * the `reussir.wpd.type_ids` attribute on a closure vtable
+//    `llvm.mlir.global` becomes `!type {i64 0, !"id"}` entries (the vtable
+//    has a single address point) plus translation-unit `!vcall_visibility`
+//    on the translated global. The visibility is what makes
+//    devirtualization legal without LTO: the lowering only emits WPD
+//    artifacts on a closed world (see docs/design/closure-wpd.md), so every
+//    possible callee of a tested call site is inside this module.
+struct ReussirLLVMTranslation : public mlir::LLVMTranslationDialectInterface {
+  using LLVMTranslationDialectInterface::LLVMTranslationDialectInterface;
+
+  mlir::LogicalResult
+  convertOperation(mlir::Operation *op, llvm::IRBuilderBase &builder,
+                   mlir::LLVM::ModuleTranslation &state) const override {
+    auto test = llvm::dyn_cast<ReussirClosureWpdTestOp>(op);
+    if (!test)
+      return op->emitError("cannot translate operation to LLVM IR");
+    llvm::LLVMContext &ctx = builder.getContext();
+    llvm::Value *vtable = state.lookupValue(test.getVtable());
+    if (!vtable || !vtable->getType()->isPointerTy())
+      return test.emitError("expected the vtable to lower to a pointer");
+    llvm::Value *id = llvm::MetadataAsValue::get(
+        ctx, llvm::MDString::get(ctx, test.getId()));
+    llvm::CallInst *hit = builder.CreateIntrinsic(llvm::Intrinsic::type_test,
+                                                  {}, {vtable, id});
+    builder.CreateAssumption(hit);
+    return mlir::success();
+  }
+
+  mlir::LogicalResult
+  amendOperation(mlir::Operation *op,
+                 llvm::ArrayRef<llvm::Instruction *> instructions,
+                 mlir::NamedAttribute attribute,
+                 mlir::LLVM::ModuleTranslation &state) const override {
+    if (attribute.getName() != kClosureWpdTypeIdsAttr)
+      return mlir::success(); // Not ours to amend (e.g. the module-level
+                              // vtable map, kept for introspection).
+    auto global = llvm::dyn_cast<mlir::LLVM::GlobalOp>(op);
+    auto ids = llvm::dyn_cast<mlir::ArrayAttr>(attribute.getValue());
+    if (!global || !ids)
+      return op->emitError("expected '")
+             << kClosureWpdTypeIdsAttr
+             << "' to be an array of strings on an llvm.mlir.global";
+    auto *vtable =
+        llvm::dyn_cast_or_null<llvm::GlobalObject>(state.lookupGlobal(global));
+    if (!vtable)
+      return op->emitError("vtable global was not translated");
+    llvm::LLVMContext &ctx = vtable->getContext();
+    for (mlir::Attribute id : ids)
+      vtable->addTypeMetadata(
+          0, llvm::MDString::get(
+                 ctx, llvm::cast<mlir::StringAttr>(id).getValue()));
+    vtable->setVCallVisibilityMetadata(
+        llvm::GlobalObject::VCallVisibilityTranslationUnit);
+    return mlir::success();
+  }
+};
+
 struct ReussirInlinerInterface : public mlir::DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
   bool isLegalToInline(mlir::Operation *, mlir::Region *, bool,
@@ -75,13 +102,7 @@ struct ReussirInlinerInterface : public mlir::DialectInlinerInterface {
 } // namespace
 
 void ReussirDialect::registerInterfaces() {
-  // addInterfaces<ReussirLLVMTranslation>();
   addInterfaces<ReussirInlinerInterface>();
+  addInterfaces<ReussirLLVMTranslation>();
 }
-// void registerReussirDialectTranslation(DialectRegistry &registry) {
-//   registry.insert<ReussirDialect>();
-//   registry.addExtension(+[](MLIRContext *ctx, ReussirDialect *dialect) {
-//     dialect->addInterfaces<ReussirLLVMTranslation>();
-//   });
-// }
 } // namespace reussir

--- a/tests/integration/conversion/closure_wpd_call_sites.mlir
+++ b/tests/integration/conversion/closure_wpd_call_sites.mlir
@@ -1,0 +1,50 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-lowering-scf-ops,convert-scf-to-cf,reussir-lowering-basic-ops{closure-wpd=1},reussir-convert-to-llvm,reconcile-unrealized-casts)' \
+// RUN: | %FileCheck %s
+
+// Closure WPD call-site type tests (docs/design/closure-wpd.md). Every
+// indirect vtable call site — eval (evaluate slot), the uniqify expansion's
+// closure.clone (clone slot), rc.dec of a closure (drop slot) — asserts the
+// type id of its operand's STATIC type with a `reussir.closure.wpd_test`,
+// which the dialect's LLVM translation interface lowers to `llvm.type.test`
+// + `llvm.assume`.
+//
+// The ids are STRENGTHENED: apply/uniqify/clone never change the vtable, so
+// the walk chases the operand back through them — and through the uniqify
+// expansion's control-flow diamond, meeting over both predecessors — to the
+// fullest statically visible suffix. In @chain every site therefore tests
+// the full two-argument id even though the eval's operand is typed
+// `() -> i32`: parameter (i32,i32) -> apply -> uniqify diamond -> apply ->
+// eval. In @root no stronger fact is visible and the eval tests the family
+// root (no parameter segment between the binder and `E`).
+
+module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>>} {
+  func.func @root(%g : !reussir.rc<!reussir.closure<() -> i32>>) -> i32 {
+    %r = reussir.closure.eval (%g : !reussir.rc<!reussir.closure<() -> i32>>) : i32
+    return %r : i32
+  }
+
+  func.func @chain(%f : !reussir.rc<!reussir.closure<(i32, i32) -> i32>>) -> i32 {
+    %a = arith.constant 1 : i32
+    %b = arith.constant 2 : i32
+    %f1 = reussir.closure.apply (%a : i32) to (%f : !reussir.rc<!reussir.closure<(i32, i32) -> i32>>) : !reussir.rc<!reussir.closure<(i32) -> i32>>
+    %u = reussir.closure.uniqify (%f1 : !reussir.rc<!reussir.closure<(i32) -> i32>>) : !reussir.rc<!reussir.closure<(i32) -> i32>>
+    %f2 = reussir.closure.apply (%b : i32) to (%u : !reussir.rc<!reussir.closure<(i32) -> i32>>) : !reussir.rc<!reussir.closure<() -> i32>>
+    %r = reussir.closure.eval (%f2 : !reussir.rc<!reussir.closure<() -> i32>>) : i32
+    return %r : i32
+  }
+}
+
+// @root — nothing to strengthen: the eval tests the family root, and its
+// return segment ([[RET]]) roots the whole family.
+// CHECK-LABEL: llvm.func @root
+// CHECK: reussir.closure.wpd_test(%{{[0-9]+}} : !llvm.ptr) id("_RFK17ReussirClosureWpdE[[RET:C[^"]+]]")
+
+// @chain — the uniqify expansion's clone (clone slot), the shared-path
+// rc.dec (drop slot), and the eval (evaluate slot) all strengthened to the
+// full signature: parameter segments ([[ARGS]]) before the `E`, same family
+// root after it.
+// CHECK-LABEL: llvm.func @chain
+// CHECK: reussir.closure.wpd_test(%{{[0-9]+}} : !llvm.ptr) id("_RFK17ReussirClosureWpd[[ARGS:C[^"]+]]E[[RET]]")
+// CHECK: reussir.closure.wpd_test(%{{[0-9]+}} : !llvm.ptr) id("_RFK17ReussirClosureWpd[[ARGS]]E[[RET]]")
+// CHECK: reussir.closure.wpd_test(%{{[0-9]+}} : !llvm.ptr) id("_RFK17ReussirClosureWpd[[ARGS]]E[[RET]]")

--- a/tests/integration/conversion/closure_wpd_ids.mlir
+++ b/tests/integration/conversion/closure_wpd_ids.mlir
@@ -1,0 +1,52 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-closure-outlining,convert-scf-to-cf,reussir-lowering-basic-ops{closure-wpd=1})' \
+// RUN: | %FileCheck %s
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-closure-outlining,convert-scf-to-cf,reussir-lowering-basic-ops)' \
+// RUN: | %FileCheck %s --check-prefix=CHECK-OFF
+
+// Closure WPD type-id tiers (docs/design/closure-wpd.md). A vtable for a
+// closure of original signature (i32, i32) -> i32 carries one id per suffix
+// of that signature — family root `() -> i32`, `(i32) -> i32`, the full
+// signature — plus its own uid tier. Ids follow the project's v0 mangling
+// scheme: the closure-type production `FK…E…` over one content-addressed
+// `C<digest>` nominal per type, so the ids are structural — both parameters
+// are i32 and the same segment appears in every tier ([[ARG]]), and the
+// return segment ([[RET]]) roots the family. The uid tier is the path
+// `<vtable>::wpd` nested under the vtable's own v0 symbol. Without the
+// `closure-wpd` option nothing is recorded.
+//
+// This test is also the ABI canary for the hierarchy itself: the outlined
+// `evaluate` must take exactly ONE argument (the rc'd box) and read every
+// closure argument from the payload. If evaluation ever passes remaining
+// arguments in registers, a vtable can no longer stand in for its suffix
+// types and the tiered ids above become UNSOUND — regenerate the scheme
+// before appeasing this test.
+
+module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>>} {
+  func.func @make() -> !reussir.rc<!reussir.closure<(i32, i32) -> i32>> {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 40>
+    %closure = reussir.closure.create -> !reussir.rc<!reussir.closure<(i32, i32) -> i32>> {
+      token(%token : !reussir.token<align: 8, size: 40>)
+      body {
+        ^bb0(%a : i32, %b : i32):
+          %add = arith.addi %a, %b : i32
+          reussir.closure.yield %add : i32
+      }
+    }
+    return %closure : !reussir.rc<!reussir.closure<(i32, i32) -> i32>>
+  }
+}
+
+// CHECK: module @test attributes
+// CHECK-SAME: reussir.wpd.vtables = {
+// CHECK-SAME: {{"?}}_R[[VTPATH:[0-9a-zA-Z$_]+]]{{"?}} = [
+// CHECK-SAME: "_RFK17ReussirClosureWpdE[[RET:C[0-9a-zA-Z_]+]]",
+// CHECK-SAME: "_RFK17ReussirClosureWpd[[ARG:C[0-9a-zA-Z_]+]]E[[RET]]",
+// CHECK-SAME: "_RFK17ReussirClosureWpd[[ARG]][[ARG]]E[[RET]]",
+// CHECK-SAME: "_RNv[[VTPATH]]3wpd"]
+
+// The ABI canary: exactly one parameter — the rc'd closure box, no comma.
+// CHECK: func.func private @[[EVAL:[^(]*8evaluate]](%{{[a-z0-9]+}}: !reussir.rc<!reussir.closure_box<i32, i32> unspecified> {{{[^}]*}}}) -> i32
+
+// CHECK-OFF-NOT: reussir.wpd.vtables

--- a/tests/integration/conversion/closure_wpd_translate.mlir
+++ b/tests/integration/conversion/closure_wpd_translate.mlir
@@ -1,0 +1,35 @@
+// RUN: %reussir-translate %s --reussir-to-llvmir | %FileCheck %s
+
+// The Reussir dialect's LLVM translation interface materializes the closure
+// WPD artifacts the LLVM dialect cannot express (docs/design/closure-wpd.md):
+//
+//  * `reussir.wpd.type_ids` on a vtable global becomes one
+//    `!type {i64 0, !"<id>"}` entry per id tier plus translation-unit
+//    `!vcall_visibility` (`!{i64 2}`) — exactly what LLVM's
+//    WholeProgramDevirt consumes;
+//  * `reussir.closure.wpd_test` becomes `llvm.type.test(%vtable, !"<id>")`
+//    feeding `llvm.assume`.
+
+module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>>} {
+  llvm.mlir.global internal constant @vtable() {reussir.wpd.type_ids = ["_RFK17ReussirClosureWpdECroot", "_RNvCvtable3wpd"]} : !llvm.struct<(ptr, ptr, ptr)> {
+    %0 = llvm.mlir.zero : !llvm.struct<(ptr, ptr, ptr)>
+    llvm.return %0 : !llvm.struct<(ptr, ptr, ptr)>
+  }
+
+  llvm.func @use(%box : !llvm.ptr) -> !llvm.ptr {
+    %vtable = llvm.load %box : !llvm.ptr -> !llvm.ptr
+    reussir.closure.wpd_test (%vtable : !llvm.ptr) id ("_RFK17ReussirClosureWpdECroot")
+    llvm.return %vtable : !llvm.ptr
+  }
+}
+
+// CHECK: @vtable = internal constant { ptr, ptr, ptr } zeroinitializer, !type ![[T0:[0-9]+]], !type ![[T1:[0-9]+]], !vcall_visibility ![[VIS:[0-9]+]]
+
+// CHECK-LABEL: define ptr @use(
+// CHECK: %[[VT:[0-9a-z]+]] = load ptr, ptr %{{[0-9a-z]+}}
+// CHECK-NEXT: %[[HIT:[0-9a-z]+]] = call i1 @llvm.type.test(ptr %[[VT]], metadata !"_RFK17ReussirClosureWpdECroot")
+// CHECK-NEXT: call void @llvm.assume(i1 %[[HIT]])
+
+// CHECK-DAG: ![[T0]] = !{i64 0, !"_RFK17ReussirClosureWpdECroot"}
+// CHECK-DAG: ![[T1]] = !{i64 0, !"_RNvCvtable3wpd"}
+// CHECK-DAG: ![[VIS]] = !{i64 2}

--- a/tests/integration/frontend/closure_wpd_devirt.c
+++ b/tests/integration/frontend/closure_wpd_devirt.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t wpd_single_ffi(int64_t n);
+extern int32_t wpd_multi_ffi(int32_t n);
+
+int main(void) {
+  /* Single-impl family: devirtualized (or plainly indirect without WPD). */
+  if (wpd_single_ffi(21) != 42) {
+    fprintf(stderr, "FAIL: single\n");
+    abort();
+  }
+  /* Two-impl family: exercises the branch-funnel / residual-indirect path. */
+  if (wpd_multi_ffi(10) != 50) {
+    fprintf(stderr, "FAIL: multi\n");
+    abort();
+  }
+  return 0;
+}

--- a/tests/integration/frontend/closure_wpd_devirt.rr
+++ b/tests/integration/frontend/closure_wpd_devirt.rr
@@ -1,0 +1,57 @@
+// RUN: %rrc %s --emit llvm-ir -O aggressive -o %t.ll && %FileCheck %s < %t.ll
+// RUN: %rrc %s --emit llvm-ir -O aggressive --no-closure-wpd -o %t.off.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.off.ll
+// RUN: %rrc %s -o %t.o --relocation-mode pic -O aggressive
+// RUN: %cc %t.o %S/closure_wpd_devirt.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.off.o --relocation-mode pic -O aggressive --no-closure-wpd
+// RUN: %cc %t.off.o %S/closure_wpd_devirt.c -o %t.off.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.off.exe
+
+// Whole-program devirtualization of closures, end to end. `apply_single` is
+// EXPORTED, so nothing local pins which closure flows in — without WPD its
+// eval is a genuine indirect call (the `invariant.group` folding that
+// devirtualizes locally created closures cannot reach it). With WPD the
+// `(i64) -> i64` family has a single implementation in the whole module, so
+// the eval (and the drop on the consumed reference) fold to direct calls —
+// LLVM then inlines the closure body outright.
+//
+// The `(i32) -> i32` family has TWO implementations: single-impl devirt
+// cannot fire there, and WPD may leave indirect calls or lower them through
+// `llvm.icall.branch.funnel` comparison ladders — either way the executions
+// below pin the behavior for both families in both modes.
+
+pub fn apply_single(f: (i64) -> i64, x: i64) -> i64 {
+    f(x)
+}
+
+pub fn run_single(n: i64) -> i64 {
+    let double = |x: i64| x * 2;
+    apply_single(double, n)
+}
+
+pub fn apply_multi(f: (i32) -> i32, x: i32) -> i32 {
+    f(x)
+}
+
+pub fn run_multi(n: i32) -> i32 {
+    let double = |x: i32| x * 2;
+    let triple = |x: i32| x * 3;
+    apply_multi(double, n) + apply_multi(triple, n)
+}
+
+extern "C" trampoline "wpd_single_ffi" = run_single;
+extern "C" trampoline "wpd_multi_ffi" = run_multi;
+
+// With WPD the single-implementation evaluate is folded direct and inlined:
+// the closure body (`x * 2`, canonicalized to a shift) appears right inside
+// the exported function, with no call in between.
+// (apply_multi lowers first in the module; anchoring both labels keeps the
+// body check scoped to apply_single.)
+// CHECK-LABEL: define{{.*}}@_RC11apply_multi
+// CHECK-LABEL: define{{.*}}@_RC12apply_single
+// CHECK: shl i64
+
+// Without WPD the exported function must dispatch through the vtable: an
+// indirect call (register callee), and no trace of the closure body.
+// CHECK-OFF-LABEL: define{{.*}}@_RC12apply_single
+// CHECK-OFF: call {{.*}}%{{[0-9]+}}(

--- a/tests/integration/frontend/closure_wpd_metadata.rr
+++ b/tests/integration/frontend/closure_wpd_metadata.rr
@@ -2,6 +2,8 @@
 // RUN: %rrc %s --emit llvm-ir -O aggressive --no-closure-wpd -o %t.off.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.off.ll
 // RUN: %rrc %s --emit llvm-ir -O default -o %t.off.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.off.ll
 // RUN: %rrc %s --emit llvm-ir -O aggressive --codegen-units 2 -o %t.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.0.ll
+// RUN: %rrc %s --emit mlir-llvm -O aggressive -o %t.mlir && %FileCheck %s --check-prefix=CHECK-SITES < %t.mlir
+// RUN: %rrc %s -O aggressive -o %t.o
 
 // Closure WPD vtable metadata, end to end through rrc: every closure vtable
 // global carries its `!type` id tiers (offset 0) and translation-unit
@@ -28,14 +30,26 @@ pub fn use_adder(n: i32) -> i32 {
 // returns), the full signature, and the uid. A capturing closure therefore
 // shares its suffix tiers with any capture-free closure of the same type —
 // captures are just arguments that were applied at creation.
-// CHECK: {{.*\$closure.*}} = internal constant { ptr, ptr, ptr } { {{.*}} }, !type ![[T0:[0-9]+]], !type ![[T1:[0-9]+]], !type ![[T2:[0-9]+]], !type ![[T3:[0-9]+]], !vcall_visibility ![[VIS:[0-9]+]]
+// (`!vcall_visibility` is also stamped, but the backend pipeline's
+// LowerTypeTests consumes it together with the type tests, so the final IR
+// only retains the `!type` tiers; devirtualization firing — which requires
+// the translation-unit visibility — pins it end to end.)
+// CHECK: {{.*\$closure.*}} = internal constant { ptr, ptr, ptr } { {{.*}} }, !type ![[T0:[0-9]+]], !type ![[T1:[0-9]+]], !type ![[T2:[0-9]+]], !type ![[T3:[0-9]+]]
 
 // CHECK-DAG: ![[T0]] = !{i64 0, !"_RFK17ReussirClosureWpdE[[RET:C[0-9a-zA-Z_]+]]"}
 // CHECK-DAG: ![[T1]] = !{i64 0, !"_RFK17ReussirClosureWpd[[ARG:C[0-9a-zA-Z_]+]]E[[RET]]"}
 // CHECK-DAG: ![[T2]] = !{i64 0, !"_RFK17ReussirClosureWpd[[ARG]][[ARG]]E[[RET]]"}
 // CHECK-DAG: ![[T3]] = !{i64 0, !"_RNv{{.*}}3wpd"}
-// Translation-unit visibility: what makes devirtualization legal without LTO.
-// CHECK-DAG: ![[VIS]] = !{i64 2}
+
+// The lowered-MLIR dump (before translation) asserts the ids at the indirect
+// slot call sites; they are strengthened past the family root — at least one
+// `C` parameter segment before the `E`.
+// CHECK-SITES: reussir.closure.wpd_test{{.*}} id{{ ?}}("_RFK17ReussirClosureWpdC{{[0-9a-zA-Z_]+}}E
+
+// After the backend pipeline no type test survives (LowerTypeTests consumes
+// them), so nothing can leak into instruction selection — pinned by the
+// object-emission RUN line above.
+// CHECK-NOT: llvm.type.test
 
 // CHECK-OFF-NOT: !type
 // CHECK-OFF-NOT: !vcall_visibility

--- a/tests/integration/frontend/closure_wpd_metadata.rr
+++ b/tests/integration/frontend/closure_wpd_metadata.rr
@@ -1,0 +1,41 @@
+// RUN: %rrc %s --emit llvm-ir -O aggressive -o %t.ll && %FileCheck %s < %t.ll
+// RUN: %rrc %s --emit llvm-ir -O aggressive --no-closure-wpd -o %t.off.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.off.ll
+// RUN: %rrc %s --emit llvm-ir -O default -o %t.off.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.off.ll
+// RUN: %rrc %s --emit llvm-ir -O aggressive --codegen-units 2 -o %t.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.0.ll
+
+// Closure WPD vtable metadata, end to end through rrc: every closure vtable
+// global carries its `!type` id tiers (offset 0) and translation-unit
+// `!vcall_visibility`, the artifacts LLVM's whole-program devirtualization
+// consumes. `make_adder` is exported so the vtable provably survives
+// optimization. WPD is reserved for the whole-program opt levels
+// (`aggressive`/`size`): the artifacts vanish at `-O default`, under
+// `--no-closure-wpd`, and in partitioned builds (`--codegen-units 2`),
+// where the closed-world precondition does not hold.
+
+pub fn make_adder(k: i32) -> (i32) -> i32 {
+    |x: i32| x + k
+}
+
+pub fn use_adder(n: i32) -> i32 {
+    let f = make_adder(n);
+    f(3)
+}
+
+// The vtable global, stamped with the id tiers. The frontend materializes
+// the capture `k` as a pre-applied leading parameter, so the outlined
+// signature is `(i32, i32) -> i32` and the vtable carries FOUR tiers: the
+// family root `() -> i32`, `(i32) -> i32` (the static type `make_adder`
+// returns), the full signature, and the uid. A capturing closure therefore
+// shares its suffix tiers with any capture-free closure of the same type —
+// captures are just arguments that were applied at creation.
+// CHECK: {{.*\$closure.*}} = internal constant { ptr, ptr, ptr } { {{.*}} }, !type ![[T0:[0-9]+]], !type ![[T1:[0-9]+]], !type ![[T2:[0-9]+]], !type ![[T3:[0-9]+]], !vcall_visibility ![[VIS:[0-9]+]]
+
+// CHECK-DAG: ![[T0]] = !{i64 0, !"_RFK17ReussirClosureWpdE[[RET:C[0-9a-zA-Z_]+]]"}
+// CHECK-DAG: ![[T1]] = !{i64 0, !"_RFK17ReussirClosureWpd[[ARG:C[0-9a-zA-Z_]+]]E[[RET]]"}
+// CHECK-DAG: ![[T2]] = !{i64 0, !"_RFK17ReussirClosureWpd[[ARG]][[ARG]]E[[RET]]"}
+// CHECK-DAG: ![[T3]] = !{i64 0, !"_RNv{{.*}}3wpd"}
+// Translation-unit visibility: what makes devirtualization legal without LTO.
+// CHECK-DAG: ![[VIS]] = !{i64 2}
+
+// CHECK-OFF-NOT: !type
+// CHECK-OFF-NOT: !vcall_visibility

--- a/tests/integration/frontend/closure_wpd_metadata.rr
+++ b/tests/integration/frontend/closure_wpd_metadata.rr
@@ -46,9 +46,9 @@ pub fn use_adder(n: i32) -> i32 {
 // `C` parameter segment before the `E`.
 // CHECK-SITES: reussir.closure.wpd_test{{.*}} id{{ ?}}("_RFK17ReussirClosureWpdC{{[0-9a-zA-Z_]+}}E
 
-// After the backend pipeline no type test survives (LowerTypeTests consumes
-// them), so nothing can leak into instruction selection — pinned by the
-// object-emission RUN line above.
+// After the backend pipeline no type test survives (WholeProgramDevirt and
+// LowerTypeTests consume them), so nothing can leak into instruction
+// selection — pinned by the object-emission RUN line above.
 // CHECK-NOT: llvm.type.test
 
 // CHECK-OFF-NOT: !type

--- a/tool/reussir-translate/main.cpp
+++ b/tool/reussir-translate/main.cpp
@@ -43,9 +43,11 @@ int main(int argc, char **argv) {
         return mlir::success();
       },
       [](mlir::DialectRegistry &registry) {
+        // The Reussir dialect carries its own LLVM translation interface
+        // (registered by the dialect itself), so inserting it suffices for
+        // the ops/attributes that survive conversion into the LLVM module.
         registry.insert<mlir::DLTIDialect, mlir::func::FuncDialect,
                         reussir::ReussirDialect>();
-        // reussir::registerReussirDialectTranslation(registry);
         mlir::registerAllToLLVMIRTranslations(registry);
       });
   return failed(


### PR DESCRIPTION
Stack 3/3, on top of #372 and #373 (both merged; based directly on `main`).

Inserts `WholeProgramDevirt` (module mode, null summaries — legal because every closure vtable carries translation-unit vcall visibility) ahead of the per-module pipeline, so devirtualized slot calls inline, with 2/3's type-test lowering consuming the artifacts right after.

A GVN run precedes it: the lowering's type-test assertion loads the vtable slot separately from the call site it guards, and WPD only devirtualizes calls hanging off the type-tested pointer itself. Both are `invariant.group` loads of the same slot, which GVN folds even across the refcount store, funneling the call onto the tested value. GVN and WPD only run when the module actually carries `llvm.type.test`; modules lowered without `closure-wpd` (REPL/JIT increments among them) keep their pipeline unchanged.

**Branch funnels are disabled** (the threshold cl::opt has no pass-constructor equivalent): `llvm.icall.branch.funnel` only survives instruction selection once the CFI-mode LowerTypeTests has rebuilt the vtables into one combined global, and we run the drop-mode lowering instead — a funnel emitted for a two-implementation family aborts codegen with "all llvm.icall.branch.funnel operands must refer to the same GlobalValue" (caught by `closure_wpd_devirt.rr`'s multi-impl execution leg). Multi-implementation families simply stay indirect.

Also adds a repo `CLAUDE.md` noting the PR-stacking workflow (every patch based on `main`).

## Measured (see `docs/design/closure-wpd.md`)

- An **exported** higher-order function evaluating a single-implementation family goes from a genuine indirect dispatch to the closure body inlined outright — the case the existing constant-vtable + `invariant.group` folding cannot see (locally created and consumed closures already devirtualized before this work).
- **nbe-hoas** (one closure family): all 8 remaining indirect calls in the recursive evaluator — evaluate, clone, drop — fold to direct calls and inline at `-O aggressive`. Wall-clock is neutral to ~3% slower there: the indirect branches were perfectly predictable (dispatch was never the bottleneck) and inlining the large evaluator body costs code size. The follow-up that should actually move nbe-hoas — a variadic `closure.eval` (direct application + evaluation, skipping the cursor round-trip and the defensive clone) plus a greedy def-use beta-reduction pass — is designed and queued separately.

## Testing

- `closure_wpd_devirt.rr` pins both directions: with WPD the exported `apply_single` contains the inlined closure body and no indirect call; without it the vtable dispatch remains. Single- and two-implementation families execute correctly in both modes.
- Full `check` suite green (292 pass / 19 unsupported), ctest 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k