### PR TITLE
[backend] inc/dec cancellation: count-observing ops are barriers

### DIFF
--- a/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
@@ -264,6 +264,26 @@ llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
         break;
       if (llvm::isa<ReussirRegionCleanupOp>(next))
         break;
+      // Count-*observing* ops: `array.with_unique_view`, `closure.uniqify`
+      // and a standalone `rc.is_unique` read `count == 1` to decide between
+      // in-place mutation and a defensive clone. The inc/dec pair around them
+      // is not redundant — it is exactly what makes the count observation see
+      // the value as shared — so cancelling across them would turn a
+      // copy-on-write into an in-place mutation of a live shared value.
+      if (auto viewOp = llvm::dyn_cast<ReussirArrayWithUniqueViewOp>(next);
+          viewOp && aliasAnalysis.alias(op.getRcPtr(), viewOp.getArray()) !=
+                        mlir::AliasResult::NoAlias)
+        break;
+      if (auto uniqifyOp = llvm::dyn_cast<ReussirClosureUniqifyOp>(next);
+          uniqifyOp &&
+          aliasAnalysis.alias(op.getRcPtr(), uniqifyOp.getClosure()) !=
+              mlir::AliasResult::NoAlias)
+        break;
+      if (auto isUniqueOp = llvm::dyn_cast<ReussirRcIsUniqueOp>(next);
+          isUniqueOp &&
+          aliasAnalysis.alias(op.getRcPtr(), isUniqueOp.getRcPtr()) !=
+              mlir::AliasResult::NoAlias)
+        break;
       // `closure.apply`/`closure.eval` consume/mutate only their own closure
       // operand, so they are risky only when that operand may alias the
       // incremented pointer; an application of an unrelated closure is harmless

--- a/tests/integration/conversion/inc_dec_cancellation_count_observing.mlir
+++ b/tests/integration/conversion/inc_dec_cancellation_count_observing.mlir
@@ -1,0 +1,68 @@
+// RUN: %reussir-opt %s --reussir-inc-dec-cancellation | %FileCheck %s
+
+// Regression for a copy-on-write miscompile (issue #344): an inc/dec pair
+// around a count-*observing* op — `reussir.array.with_unique_view`,
+// `reussir.closure.uniqify`, or a standalone `reussir.rc.is_unique` — is not
+// redundant: the extra count is exactly what makes the observation see the
+// value as shared and take the defensive-clone path. Cancelling across it
+// turned `let b = a.set(…)` with `a` still live into an in-place mutation of
+// `a`. The pass must keep the pair when the observing op's operand may alias
+// the incremented pointer, and may still cancel across observations of
+// *unrelated* values.
+
+!arr = !reussir.array<4 x f64>
+!rc_arr = !reussir.rc<!arr>
+!clo = !reussir.closure<(f64) -> f64>
+!rc_clo = !reussir.rc<!clo>
+
+module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+  // CHECK-LABEL: @cow_set
+  // CHECK: reussir.rc.inc
+  // CHECK: reussir.array.with_unique_view
+  // CHECK: reussir.rc.dec
+  func.func @cow_set(%a: !rc_arr) -> !rc_arr {
+    reussir.rc.inc (%a : !rc_arr)
+    %b = reussir.array.with_unique_view (%a : !rc_arr) -> !rc_arr {
+      ^bb0(%view: memref<4xf64>):
+        %c0 = arith.constant 0 : index
+        %v = arith.constant 9.9e+01 : f64
+        memref.store %v, %view[%c0] : memref<4xf64>
+        reussir.scf.yield
+    }
+    %tk = reussir.rc.dec (%a : !rc_arr) : !reussir.nullable<!reussir.token<align: 8, size: 40>>
+    return %b : !rc_arr
+  }
+
+  // CHECK-LABEL: @observed_unique
+  // CHECK: reussir.rc.inc
+  // CHECK: reussir.rc.is_unique
+  // CHECK: reussir.rc.dec
+  func.func @observed_unique(%a: !rc_arr) -> i1 {
+    reussir.rc.inc (%a : !rc_arr)
+    %u = reussir.rc.is_unique (%a : !rc_arr) : i1
+    %tk = reussir.rc.dec (%a : !rc_arr) : !reussir.nullable<!reussir.token<align: 8, size: 40>>
+    return %u : i1
+  }
+
+  // CHECK-LABEL: @uniqify_blocks
+  // CHECK: reussir.rc.inc
+  // CHECK: reussir.closure.uniqify
+  // CHECK: reussir.rc.dec
+  func.func @uniqify_blocks(%f: !rc_clo) -> !rc_clo {
+    reussir.rc.inc (%f : !rc_clo)
+    %u = reussir.closure.uniqify (%f : !rc_clo) : !rc_clo
+    reussir.rc.dec (%f : !rc_clo)
+    return %u : !rc_clo
+  }
+
+  // An adjacent inc/dec pair with nothing observing in between still cancels
+  // (the barrier is the observing op, not the array type).
+  // CHECK-LABEL: @plain_pair_still_cancels
+  // CHECK-NOT: reussir.rc.inc
+  // CHECK-NOT: reussir.rc.dec
+  func.func @plain_pair_still_cancels(%a: !rc_arr) {
+    reussir.rc.inc (%a : !rc_arr)
+    %tk = reussir.rc.dec (%a : !rc_arr) : !reussir.nullable<!reussir.token<align: 8, size: 40>>
+    return
+  }
+}


### PR DESCRIPTION
IncDecCancellation cancelled inc/dec pairs across **count-observing** ops. `array.with_unique_view`, `closure.uniqify`, and standalone `rc.is_unique` read `count == 1` to pick in-place vs clone — the pair is what makes a shared value look shared, so cancelling it turned copy-on-write into in-place mutation of a live original. Such ops now block cancellation when their operand may alias the incremented pointer; the regression test pins all three plus the still-cancels case.

Part 1 of the statically-shaped-arrays stack (#344); supersedes #345. Each PR in the stack targets main with a cumulative branch, so this one's diff is self-contained and later PRs shrink as earlier ones merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786382351&installation_id=144622820&pr_number=376&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F376&signature=df874c48857baf63faf6ebec8a5bcfd9a8ce6ef2ba66d4c5ac3e8ee2eef76aec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->