### PR TITLE
[frontend] TyKind::Array: the [T; extents…] type through the type system

### DIFF
--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -27,8 +27,8 @@ use std::cell::RefCell;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use reussir_backend::dialect::ty::{
-    ReussirAtomicKind, ReussirCapability, ReussirLifeScope, ReussirRecordKind, closure, nullable,
-    rc, record_complete_in_place, record_incomplete, record_is_complete, r#ref, region,
+    ReussirAtomicKind, ReussirCapability, ReussirLifeScope, ReussirRecordKind, array, closure,
+    nullable, rc, record_complete_in_place, record_incomplete, record_is_complete, r#ref, region,
     str as str_type,
 };
 use reussir_backend::melior::Context;
@@ -113,7 +113,10 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
     /// This is the complement, among reference-counted values, of an inline
     /// `[value]` record — which is acquired/dropped through a reference instead.
     pub(super) fn is_managed_rc(&self, ty: Ty<'tcx>) -> bool {
-        self.is_shared_record(ty) || self.is_regional_record(ty) || is_closure(ty)
+        self.is_shared_record(ty)
+            || self.is_regional_record(ty)
+            || is_closure(ty)
+            || matches!(ty.kind(), TyKind::Array { .. })
     }
 
     /// Lower a ground type to MLIR: records resolve through the layout table, a
@@ -139,6 +142,9 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             // A closure value is a shared `rc<closure<params -> ret>>`; captures
             // have already been supplied (see [`closure_type`](Self::closure_type)).
             TyKind::Closure { params, ret } => self.closure_type(params, ret),
+            // A statically shaped array is one shared `rc` box holding the whole
+            // payload (`!reussir.rc<!reussir.array<dims x elem>>`); see #344.
+            TyKind::Array { .. } => Ok(self.rc_type(self.array_inner_of(ty)?)),
             _ => scalar_ty(self.context, ty),
         }
     }
@@ -369,6 +375,17 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         Ok(closure(self.context, &input_tys, output))
     }
 
+    /// The `!reussir.array<dims x elem>` payload type of an array-typed `ty`
+    /// (the type inside its `rc` box, and the element type of its views).
+    pub(super) fn array_inner_of(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
+        let TyKind::Array { elem, dims } = *ty.kind() else {
+            return err("array payload requested for a non-array type");
+        };
+        let elem = scalar_ty(self.context, elem)?;
+        let shape: Vec<i64> = dims.iter().map(|&d| d as i64).collect();
+        Ok(array(&shape, elem))
+    }
+
     /// `!reussir.rc<inner, shared>` — the pointer type for a heap-allocated,
     /// reference-counted value with the default (non-atomic) box layout.
     pub(super) fn rc_type(&self, inner: Type<'c>) -> Type<'c> {
@@ -483,6 +500,7 @@ fn scalar_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
         TyKind::Unit => err("unit has no MLIR value type"),
         TyKind::Str => Ok(str_type(context, ReussirLifeScope::Global)),
         TyKind::Record { .. } => err("record type reached scalar lowering without a layout"),
+        TyKind::Array { .. } => err("array type reached scalar lowering without its rc wrapper"),
         TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),
         // Intercepted by [`TypeCtx::mlir_ty`]; reaching here is a bug.
         TyKind::Closure { .. } => err("closure type reached scalar lowering without an rc wrapper"),

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -145,6 +145,18 @@ impl<'a> Mangler<'a> {
                 // to its inner type.
                 self.path_with_args_segs(out, &["Nullable"], &[inner]);
             }
+            TyKind::Array { elem, dims } => {
+                // An array mangles as a synthetic record whose identifier
+                // carries the extents (`Array512x512`), applied to the element.
+                let mut name = String::from("Array");
+                for (i, d) in dims.iter().enumerate() {
+                    if i > 0 {
+                        name.push('x');
+                    }
+                    name.push_str(&d.to_string());
+                }
+                self.path_with_args_segs(out, &[&name], &[elem]);
+            }
             TyKind::Record { def, args, .. } => {
                 // The per-use capability (`flex`) is irrelevant to the ABI.
                 self.path_with_args(out, def, args);

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -257,6 +257,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let ret = self.ty(ret);
                 self.tcx.mk_closure(&params, ret)
             }
+            raw::Ty::Array { elem, dims } => {
+                let elem = self.ty(elem);
+                self.tcx.mk_array(elem, dims)
+            }
         }
     }
 
@@ -645,6 +649,16 @@ mod tests {
             "pub fn fib(n: u64) -> u64 { \
              let m = n + 1; \
              if n <= 1 { m } else { fib(n - 1) + fib(n - 2) } }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_array_types() {
+        // The `[elem; extents…]` type in parameter and return position;
+        // rank-1 and rank-2. The array *ops* have their own round-trip test.
+        roundtrip(
+            "pub fn id(a: [f64; 8]) -> [f64; 8] { a } \
+             pub fn fst(m: [i32; 4, 4], n: [i32; 4, 4]) -> [i32; 4, 4] { m }",
         );
     }
 

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -105,6 +105,8 @@ Ty: raw::Ty = {
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
     <cap:Cap> <path:TyPathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
+    "[" <elem:Ty> ";" <dims:CommaPlus<"int">> "]"
+        => raw::Ty::Array { elem: Box::new(elem), dims: dims.iter().map(raw::small_u64).collect() },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -176,7 +176,12 @@ impl Render<'_> {
                 } else {
                     Doc::Null
                 };
-                text("enum ") + fixed + self.ty(rec.ty) + text(" { ") + comma_sep(parts) + text(" }")
+                text("enum ")
+                    + fixed
+                    + self.ty(rec.ty)
+                    + text(" { ")
+                    + comma_sep(parts)
+                    + text(" }")
             }
         };
         head + body + text(";")
@@ -232,6 +237,14 @@ impl Render<'_> {
             TyKind::Unit => text("()"),
             TyKind::Bottom => text("!"),
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
+            TyKind::Array { elem, dims } => {
+                let mut d = text("[") + self.ty(elem) + text(";");
+                for (i, extent) in dims.iter().enumerate() {
+                    let sep = if i > 0 { "," } else { "" };
+                    d = d + text(format!("{sep} {extent}"));
+                }
+                d + text("]")
+            }
             TyKind::Record { def, args, flex } => {
                 let mut d = match flex {
                     Flexivity::Flex | Flexivity::Rigid | Flexivity::Regional => {

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -205,6 +205,11 @@ pub enum Ty {
         params: Vec<Ty>,
         ret: Box<Ty>,
     },
+    /// `[elem; extents…]` — a statically shaped array.
+    Array {
+        elem: Box<Ty>,
+        dims: Vec<u64>,
+    },
 }
 
 /// The per-use capability prefix printed before a record type (absent = value).

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -231,7 +231,10 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         };
         // `#[repr(fixed)]` is carried straight from the collected record; a
         // missing definition (elaboration failure) is treated as non-fixed.
-        let repr_fixed = input.records.get(&def).is_some_and(|record| record.repr_fixed);
+        let repr_fixed = input
+            .records
+            .get(&def)
+            .is_some_and(|record| record.repr_fixed);
         records.push(mir::RecordInstance {
             symbol,
             ty,
@@ -346,6 +349,7 @@ const RECURSION_LIMIT: usize = 128;
 fn ty_depth(ty: Ty<'_>) -> usize {
     match *ty.kind() {
         TyKind::Nullable(inner) => 1 + ty_depth(inner),
+        TyKind::Array { elem, .. } => 1 + ty_depth(elem),
         TyKind::Record { args, .. } => 1 + args.iter().map(|&a| ty_depth(a)).max().unwrap_or(0),
         TyKind::Closure { params, ret } => {
             1 + params
@@ -478,6 +482,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 self.note_records(ret);
             }
             TyKind::Nullable(inner) => self.note_records(inner),
+            TyKind::Array { elem, .. } => self.note_records(elem),
             _ => {}
         }
     }
@@ -511,6 +516,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 self.discover_records(ret, worklist);
             }
             TyKind::Nullable(inner) => self.discover_records(inner, worklist),
+            TyKind::Array { elem, .. } => self.discover_records(elem, worklist),
             _ => {}
         }
     }
@@ -1216,6 +1222,7 @@ mod tests {
                 params.iter().all(|&p| is_ground(p)) && is_ground(ret)
             }
             TyKind::Nullable(inner) => is_ground(inner),
+            TyKind::Array { elem, .. } => is_ground(elem),
             _ => true,
         }
     }

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -307,6 +307,9 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
         // Overwritten with the real answer below.
         self.memo.borrow_mut().insert(ty, false);
         let b = match *ty.kind() {
+            // An array is one rc-managed box regardless of its (Plain)
+            // element type.
+            TyKind::Array { .. } => true,
             // The management class is the record table's call (keyed by the
             // canonical, flexivity-erased type); the per-use flexivity then refines
             // the one case where it matters — a regional record.

--- a/crates/reussir-core/src/full/subst.rs
+++ b/crates/reussir-core/src/full/subst.rs
@@ -35,6 +35,7 @@ pub fn subst_ty<'tcx>(tcx: &TyCtxt<'tcx>, ty: Ty<'tcx>, subst: &Subst<'tcx>) -> 
             tcx.mk_closure(&params, subst_ty(tcx, ret, subst))
         }
         TyKind::Nullable(inner) => tcx.mk_nullable(subst_ty(tcx, inner, subst)),
+        TyKind::Array { elem, dims } => tcx.mk_array(subst_ty(tcx, elem, subst), dims),
         TyKind::Int(_)
         | TyKind::Fp(_)
         | TyKind::Bool

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -433,6 +433,16 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.push_ty_display(out, inner);
                 out.push('>');
             }
+            TyKind::Array { elem, dims } => {
+                out.push('[');
+                self.push_ty_display(out, elem);
+                out.push(';');
+                for (i, extent) in dims.iter().enumerate() {
+                    let sep = if i > 0 { "," } else { "" };
+                    let _ = write!(out, "{sep} {extent}");
+                }
+                out.push(']');
+            }
             TyKind::Record { def, args, flex } => {
                 match flex {
                     Flexivity::Flex => out.push_str("[flex] "),
@@ -947,6 +957,18 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .collect()
     }
 
+    /// Phase A of the array design (issue #344) supports arrays as locals,
+    /// parameters, and returns only — a record member of array type has no
+    /// dialect-level member representation yet.
+    fn reject_array_member(&mut self, fty: Ty<'tcx>, span: Option<Span>) {
+        if matches!(fty.kind(), crate::semi::ty::TyKind::Array { .. }) {
+            self.error(
+                span,
+                "an array cannot be a record member in this version (see issue #344)",
+            );
+        }
+    }
+
     fn populate_record(&mut self, rec: &surface::Record, def: DefId) {
         let Some(record) = self.records.get(&def) else {
             return;
@@ -969,6 +991,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (name, ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
+                        self.reject_array_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -981,6 +1004,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
+                        self.reject_array_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -994,7 +1018,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         let (name, tys) = &v.value;
                         Variant {
                             name: *name,
-                            fields: tys.iter().map(|t| self.eval_type(t)).collect(),
+                            fields: tys
+                                .iter()
+                                .map(|t| {
+                                    let fty = self.eval_type(t);
+                                    self.reject_array_member(fty, span);
+                                    fty
+                                })
+                                .collect(),
                         }
                     })
                     .collect(),

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -270,6 +270,7 @@ pub(super) fn ty_has_hole(ty: crate::semi::ty::Ty<'_>) -> bool {
             params.iter().any(|p| ty_has_hole(*p)) || ty_has_hole(*ret)
         }
         TyKind::Nullable(inner) => ty_has_hole(*inner),
+        TyKind::Array { elem, .. } => ty_has_hole(*elem),
         _ => false,
     }
 }
@@ -287,6 +288,7 @@ pub(super) fn collect_holes(ty: crate::semi::ty::Ty<'_>, out: &mut Vec<HoleId>) 
             collect_holes(*ret, out);
         }
         TyKind::Nullable(inner) => collect_holes(*inner, out),
+        TyKind::Array { elem, .. } => collect_holes(*elem, out),
         _ => {}
     }
 }

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -301,6 +301,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let ret = self.ty(ret);
                 self.tcx.mk_closure(&params, ret)
             }
+            raw::Ty::Array { elem, dims } => {
+                let elem = self.ty(elem);
+                self.tcx.mk_array(elem, dims)
+            }
         }
     }
 
@@ -710,6 +714,16 @@ mod tests {
         roundtrip_with_locations(
             "enum Opt { None, Some(i64) }\n\
              pub fn g(o: Opt) -> i64 { match o { Opt::None => 0, Opt::Some(x) => { let y = x; y } } }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_array_types() {
+        // The `[elem; extents…]` type in parameter and return position;
+        // rank-1 and rank-2. The array *ops* have their own round-trip test.
+        roundtrip(
+            "pub fn id(a: [f64; 8]) -> [f64; 8] { a } \
+             pub fn fst(m: [i32; 4, 4], n: [i32; 4, 4]) -> [i32; 4, 4] { m }",
         );
     }
 

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -164,6 +164,8 @@ Ty: raw::Ty = {
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
     <cap:Cap> "#" <path:PathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
+    "[" <elem:Ty> ";" <dims:CommaPlus<"int">> "]"
+        => raw::Ty::Array { elem: Box::new(elem), dims: dims.iter().map(raw::small_u64).collect() },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -283,6 +283,14 @@ impl<'a> Printer<'a> {
             TyKind::Generic(g) => text(format!("${}", g.0)),
             TyKind::Hole(_) => unreachable!("a fully elaborated HIR carries no inference holes"),
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
+            TyKind::Array { elem, dims } => {
+                let mut d = text("[") + self.ty(elem) + text(";");
+                for (i, extent) in dims.iter().enumerate() {
+                    let sep = if i > 0 { "," } else { "" };
+                    d = d + text(format!("{sep} {extent}"));
+                }
+                d + text("]")
+            }
             TyKind::Record { def, args, flex } => {
                 let mut d = match flex {
                     Flexivity::Flex | Flexivity::Rigid | Flexivity::Regional => {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -172,6 +172,11 @@ pub enum Ty {
         params: Vec<Ty>,
         ret: Box<Ty>,
     },
+    /// `[elem; extents…]` — a statically shaped array.
+    Array {
+        elem: Box<Ty>,
+        dims: Vec<u64>,
+    },
 }
 
 /// The four raw words of an interned `StringToken`.

--- a/crates/reussir-core/src/semi/infer.rs
+++ b/crates/reussir-core/src/semi/infer.rs
@@ -209,6 +209,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let inner = self.resolve(*inner);
                 self.tcx.mk_nullable(inner)
             }
+            TyKind::Array { elem, dims } => {
+                let elem = self.resolve(*elem);
+                self.tcx.mk_array(elem, dims)
+            }
             _ => ty,
         }
     }
@@ -295,6 +299,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.unify(*r1, *r2)
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify(*x, *y),
+            (TyKind::Array { elem: e1, dims: d1 }, TyKind::Array { elem: e2, dims: d2 })
+                if d1 == d2 =>
+            {
+                self.unify(*e1, *e2)
+            }
 
             (TyKind::Int(x), TyKind::Int(y)) if x == y => Ok(()),
             (TyKind::Fp(x), TyKind::Fp(y)) if x == y => Ok(()),
@@ -343,6 +352,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.occurs(h, *ret)
             }
             TyKind::Nullable(inner) => self.occurs(h, *inner),
+            TyKind::Array { elem, .. } => self.occurs(h, *elem),
             _ => false,
         }
     }
@@ -493,6 +503,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.unify_instantiated(*r1, inst, *r2)
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify_instantiated(*x, inst, *y),
+            (TyKind::Array { elem: e1, dims: d1 }, TyKind::Array { elem: e2, dims: d2 })
+                if d1 == d2 =>
+            {
+                self.unify_instantiated(*e1, inst, *e2)
+            }
 
             (TyKind::Int(x), TyKind::Int(y)) if x == y => Ok(()),
             (TyKind::Fp(x), TyKind::Fp(y)) if x == y => Ok(()),
@@ -545,6 +560,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             TyKind::Nullable(inner) => {
                 let inner = self.materialize(*inner, inst);
                 self.tcx.mk_nullable(inner)
+            }
+            TyKind::Array { elem, dims } => {
+                let elem = self.materialize(*elem, inst);
+                self.tcx.mk_array(elem, dims)
             }
             _ => template,
         }

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -139,6 +139,13 @@ pub enum TyKind<'tcx> {
         params: &'tcx [Ty<'tcx>],
         ret: Ty<'tcx>,
     },
+    /// A statically shaped multidimensional array of `Plain` elements,
+    /// reference counted as a whole; the extents are part of the type
+    /// (`[f64; 512, 512]`). See issue #344.
+    Array {
+        elem: Ty<'tcx>,
+        dims: &'tcx [u64],
+    },
     Nullable(Ty<'tcx>),
     /// A rigid type parameter in scope.
     Generic(GenericId),
@@ -253,6 +260,11 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn mk_hole(&self, hole: HoleId) -> Ty<'tcx> {
         self.mk(TyKind::Hole(hole))
+    }
+
+    pub fn mk_array(&self, elem: Ty<'tcx>, dims: &[u64]) -> Ty<'tcx> {
+        let dims = self.alloc_slice(dims);
+        self.mk(TyKind::Array { elem, dims })
     }
 
     pub fn mk_nullable(&self, inner: Ty<'tcx>) -> Ty<'tcx> {

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -69,6 +69,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.tcx.mk_closure(&args, ret)
             }
             TypeKind::TypeExpr(path, args) => self.eval_type_expr(path, args, ty.span()),
+            TypeKind::TypeArray(elem, extents) => self.eval_array_type(elem, extents, ty.span()),
         }
     }
 
@@ -125,6 +126,76 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
         // A user record, resolved to its def — bare in the current module, or
         // module-qualified (`utils::math::Cell`, `root::…`, `super::…`).
+        return self.eval_record_type_expr(path, args, span, key);
+    }
+
+    /// Evaluate a statically shaped array type (`[f64; 512]`,
+    /// `[f64; 5, 16, 8]`) into a [`TyKind::Array`].
+    pub(crate) fn eval_array_type(
+        &mut self,
+        elem: &surface::Type,
+        extents: &[surface::Expr],
+        span: surface::Span,
+    ) -> Ty<'tcx> {
+        if extents.is_empty() {
+            // Only reachable through parser recovery (`[T; ]` is a syntax
+            // error); avoid constructing a rank-0 array on top of it.
+            return self.tcx.mk(TyKind::Bottom);
+        }
+        let elem = self.eval_type(elem);
+        // Phase A restricts elements to plain scalars: views over the
+        // payload must be free of reference-count traffic.
+        if !is_plain_scalar_or_deferred(elem) {
+            self.error(
+                Some(span),
+                format!(
+                    "non-scalar array element types are not supported yet; found `{}`",
+                    self.ty_display(elem)
+                ),
+            );
+        }
+        let mut dims = Vec::with_capacity(extents.len());
+        let mut product: u128 = 1;
+        for e in extents {
+            let extent = self.eval_extent(e);
+            if extent == 0 {
+                self.error(Some(e.span()), "array extents must be positive");
+            }
+            product = product.saturating_mul(u128::from(extent.max(1)));
+            dims.push(extent.max(1));
+        }
+        if product > (1u128 << 32) {
+            self.error(Some(span), "array is too large (more than 2^32 elements)");
+        }
+        self.tcx.mk_array(elem, &dims)
+    }
+
+    /// Evaluate one array extent expression. The grammar admits any
+    /// expression; for now only an integer literal evaluates — everything
+    /// else reports and recovers with extent 1. An out-of-range literal
+    /// clamps; the product check reports it as too large.
+    fn eval_extent(&mut self, e: &surface::Expr) -> u64 {
+        match e.kind() {
+            surface::ExprKind::ConstExpr(crate::surface::Const::ConstInt(n)) => {
+                u64::try_from(&n).unwrap_or(u64::MAX)
+            }
+            _ => {
+                self.error(
+                    Some(e.span()),
+                    "this kind of array extent cannot be evaluated yet (only integer literals are supported)",
+                );
+                1
+            }
+        }
+    }
+
+    fn eval_record_type_expr(
+        &mut self,
+        path: &surface::Path,
+        args: &[surface::Type],
+        span: surface::Span,
+        key: reussir_syntax::kind::TokenKey,
+    ) -> Ty<'tcx> {
         let Some(def) = self.resolve_record_ref(path) else {
             let hint = if path.segments.is_empty() {
                 self.record_suggestion(key)
@@ -214,6 +285,21 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 /// rejected; `Record`/`Closure` are valid inners, and `Generic`/`Hole`/`Bottom`
 /// are deferred (resolved/checked later) so this never reports a false positive
 /// on a not-yet-ground type.
+/// Whether `t` qualifies as a Phase-A array element: a plain scalar, or a
+/// generic/hole deferred to the monomorphization-time groundness check.
+pub(crate) fn is_plain_scalar_or_deferred(t: Ty<'_>) -> bool {
+    matches!(
+        t.kind(),
+        TyKind::Int(_)
+            | TyKind::Fp(_)
+            | TyKind::Bool
+            | TyKind::Char
+            | TyKind::Generic(_)
+            | TyKind::Hole(_)
+            | TyKind::Bottom
+    )
+}
+
 fn is_concretely_non_pointer(t: Ty<'_>) -> bool {
     matches!(
         t.kind(),

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -217,7 +217,10 @@ fn is_expr_kind(kind: SyntaxKind) -> bool {
 }
 
 fn is_type_kind(kind: SyntaxKind) -> bool {
-    matches!(kind, PrimType | PathType | ArrowType | ParenTypeList)
+    matches!(
+        kind,
+        PrimType | PathType | ArrowType | ParenTypeList | SyntaxKind::ArrayType
+    )
 }
 
 fn expr_children(node: &ResolvedNode) -> impl Iterator<Item = &ResolvedNode> {
@@ -382,6 +385,10 @@ pub enum TypeKind {
     TypeExpr(Path, SmallVec<[Type; 2]>),
     /// A closure type: argument types and a result.
     TypeArrow(SmallVec<[Type; 2]>, Type),
+    /// A statically shaped array: an element type and one extent expression
+    /// per dimension (`[f64; 512]`, `[f64; 5, 16, 8]`). The extents are kept
+    /// as expressions; the elaborator decides which forms it can evaluate.
+    TypeArray(Type, SmallVec<[Expr; 2]>),
 }
 
 /// A type expression (a view over a `PrimType` / `PathType` / `ArrowType` node).
@@ -412,6 +419,13 @@ impl Type {
         let node = &self.node;
         match node.kind() {
             PrimType => prim_type(tokens(node).next().expect("prim type token").text()),
+            SyntaxKind::ArrayType => {
+                let elem = nodes(node)
+                    .find(|n| is_type_kind(n.kind()))
+                    .expect("array element type");
+                let extents = expr_children(node).map(Expr::new).collect();
+                TypeKind::TypeArray(Type::new(elem), extents)
+            }
             PathType => {
                 let path = child_node(node, PathKind).expect("type path");
                 let args = child_node(node, TypeArgList)

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -622,6 +622,14 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             TyKind::Nullable(inner) => {
                 format!("Nullable<{}>", Self::render_ty_with(elab, inner))
             }
+            TyKind::Array { elem, dims } => {
+                let dims: Vec<String> = dims.iter().map(|d| d.to_string()).collect();
+                format!(
+                    "[{}; {}]",
+                    Self::render_ty_with(elab, elem),
+                    dims.join(", ")
+                )
+            }
             TyKind::Record { def, args, .. } => {
                 let mut out = elab.defs.path(def).display(elab.resolver);
                 if !args.is_empty() {

--- a/tests/integration/frontend/array.rr
+++ b/tests/integration/frontend/array.rr
@@ -1,0 +1,18 @@
+// Statically shaped arrays (issue #344, Phase A): the `[elem; extents…]`
+// type, end to end through elaboration, monomorphization, and codegen. The
+// `core::intrinsic::array` operations have their own tests.
+
+// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+
+// CHECK: pub fn #id(v0 (a): [f64; 8]) -> [f64; 8]
+pub fn id(a : [f64; 8]) -> [f64; 8] {
+    a
+}
+
+// An array is one reference-counted box: passing it around is rc traffic
+// only, and the extents are part of the type.
+// CHECK: pub fn #fst(v0 (m): [i32; 4, 4], v1 (n): [i32; 4, 4]) -> [i32; 4, 4]
+pub fn fst(m : [i32; 4, 4], n : [i32; 4, 4]) -> [i32; 4, 4] {
+    m
+}

--- a/tests/integration/frontend/array_errors.rr
+++ b/tests/integration/frontend/array_errors.rr
@@ -1,0 +1,21 @@
+// Diagnostics for the Phase A array type restrictions (issue #344). All are
+// declaration (type/record) errors that surface during scanning, so the
+// CHECKs are unordered `CHECK-DAG`s.
+
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+// CHECK-DAG: non-scalar array element types are not supported yet
+struct S { x: i32 }
+fn bad_elem(a : [S; 4]) -> i64 { 0 }
+
+// CHECK-DAG: an array cannot be a record member in this version
+struct Holder { data: [f64; 4] }
+
+// CHECK-DAG: array extents must be positive
+fn zero_extent(a : [f64; 0]) -> i64 { 0 }
+
+// CHECK-DAG: this kind of array extent cannot be evaluated yet
+fn expr_extent(a : [f64; 2 + 2]) -> i64 { 0 }
+
+// CHECK-DAG: this kind of array extent cannot be evaluated yet
+fn name_extent(a : [f64; n]) -> i64 { 0 }


### PR DESCRIPTION
The statically shaped array type (#344) from surface to codegen'd type: elaboration (`[elem; e1, e2, …]` with positive literal extents, product capped at 2^32, Phase-A plain-scalar elements, no record members), unification/holes/occurs, substitution and monomorphization groundness, mangling, the textual HIR/MIR round trip of the type, and MLIR type lowering to a reference-counted `!reussir.array` box (`rc.inc`/`rc.dec`, no drop glue). Array *operations* come separately.

Part 3 of the arrays stack; contains parts 1–2 — review the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786382373&installation_id=144622820&pr_number=378&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F378&signature=0e3b66a797af870395f7e3ab5998d5ae7d6f003b018e37020f7aebaf23e0656c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->