### PR TITLE
[frontend] ArrayOp: the built-in array operation node in HIR and MIR

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -688,6 +688,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             NullableCall(inner) => self.nullable_call(block, env, e, *inner).map(Some),
             Closure(c) => self.closure(block, env, c).map(Some),
             ClosureCall { target, args } => self.closure_call(block, env, target, args),
+            ArrayOp { .. } => err("array operations are not lowered yet"),
             GlobalStr(token) => self.global_str(block, e, *token).map(Some),
             Poison => err("poison expression reached lowering"),
         }

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -260,9 +260,29 @@ pub enum ExprKind<'tcx> {
         target: &'tcx Expr<'tcx>,
         args: &'tcx [Expr<'tcx>],
     },
+    /// A built-in operation on a statically shaped array, mirroring
+    /// [`crate::semi::hir::ExprKind::ArrayOp`]: the resolved op, its value
+    /// operands, and — for `Tabulate`/`Fold` — an inline kernel. The kernel is
+    /// not a closure: its body references enclosing bindings directly
+    /// (read-only borrows for the op's duration) and codegen inlines it into
+    /// the element loop nest.
+    ArrayOp {
+        op: crate::intrinsic::ArrayFn,
+        args: &'tcx [Expr<'tcx>],
+        kernel: Option<&'tcx Kernel<'tcx>>,
+    },
     Match(&'tcx Expr<'tcx>, DecisionTree<'tcx>),
     /// Error-recovery placeholder.
     Poison,
+}
+
+/// The inline kernel of an [`ArrayOp`](ExprKind::ArrayOp); see
+/// [`crate::semi::hir::Kernel`]. The type checker guarantees the body is
+/// rc-free (plain-typed throughout, except `get` reads of enclosing arrays).
+#[derive(Clone, Copy, Debug)]
+pub struct Kernel<'tcx> {
+    pub params: &'tcx [(VarId, Ty<'tcx>)],
+    pub body: &'tcx Expr<'tcx>,
 }
 
 /// A pattern binding: a local variable bound to a scrutinee [`Path`].

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -450,6 +450,24 @@ impl Render<'_> {
                     + self.value(c.body)
                     + text(" }")
             }
+            ArrayOp { op, args, kernel } => {
+                let mut d =
+                    text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")");
+                if let Some(k) = kernel {
+                    let params: Vec<Doc<'static>> = k
+                        .params
+                        .iter()
+                        .map(|(v, t)| var(*v) + text(": ") + self.ty(*t))
+                        .collect();
+                    d = d
+                        + text(" kernel(")
+                        + comma_sep(params)
+                        + text(") { ")
+                        + self.value(k.body)
+                        + text(" }");
+                }
+                d
+            }
             Let { .. } | Seq(_) | If(..) | Match(..) => {
                 unreachable!("structural forms are rendered by `value`")
             }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -744,6 +744,15 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 args: self.lower_slice(args, subst),
             },
             ExprKind::Closure(c) => M::Closure(self.lower_closure(c, subst)),
+            ExprKind::ArrayOp { op, args, kernel } => M::ArrayOp {
+                op: *op,
+                args: self.lower_slice(args, subst),
+                kernel: kernel.as_ref().map(|k| {
+                    let params = self.lower_var_tys(&k.params, subst);
+                    let body = self.lower_ref(&k.body, subst);
+                    &*self.tcx.alloc(mir::Kernel { params, body })
+                }),
+            },
             ExprKind::Match(scrut, tree) => {
                 M::Match(self.lower_ref(scrut, subst), self.lower_tree(tree, subst))
             }
@@ -1231,6 +1240,7 @@ mod tests {
     fn children<'tcx>(e: &mir::Expr<'tcx>) -> Vec<&'tcx mir::Expr<'tcx>> {
         use mir::ExprKind::*;
         match e.kind {
+            ArrayOp { args, kernel, .. } => args.iter().chain(kernel.map(|k| k.body)).collect(),
             GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
             | Poison => vec![],
             Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -515,7 +515,29 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                     s.union_with(&self.free(arg));
                 }
             }
+            // An array op uses its value operands, plus every enclosing var the
+            // inline kernel body reads (the kernel's own params are binders).
+            ExprKind::ArrayOp { args, kernel, .. } => {
+                for arg in args {
+                    s.union_with(&self.free(arg));
+                }
+                if let Some(k) = kernel {
+                    s.union_with(&self.kernel_free(k));
+                }
+            }
         }
+        s
+    }
+
+    /// The free RR variables of an [`ArrayOp`](ExprKind::ArrayOp) kernel body,
+    /// minus the kernel's own parameters.
+    fn kernel_free(&mut self, k: &mir::Kernel<'tcx>) -> VarSet {
+        let mut s = self.free(k.body);
+        let mut params = VarSet::default();
+        for &(p, _) in k.params {
+            params.insert(p);
+        }
+        s.subtract(&params);
         s
     }
 
@@ -620,6 +642,82 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             ExprKind::Closure(c) => self.place_closure(e.id, &c, live_after),
             ExprKind::ClosureCall { target, args } => {
                 self.place_closure_call(target, args, live_after)
+            }
+            ExprKind::ArrayOp { op, args, kernel } => {
+                self.place_array_op(e, op, args, kernel, live_after)
+            }
+        }
+    }
+
+    /// Place an [`ArrayOp`](ExprKind::ArrayOp)'s operands and kernel.
+    ///
+    /// Ownership contract per op (see [`ArrayFn`](crate::intrinsic::ArrayFn)):
+    /// `Set` and `Splat` treat their operands like call arguments (the `Set`
+    /// base is consumed — the op returns the updated array); `Get` and `Fold`
+    /// only *borrow* their array operand; and a kernel body's free vars are
+    /// read-only borrows for the whole op (the type checker restricts kernel
+    /// bodies to be rc-free, so RR vars appear there only as `get` bases).
+    ///
+    /// Borrowed vars take no rc op at their use; instead, like a `Proj` base,
+    /// any of them that is dead downstream is dropped right after the op. A
+    /// non-`Var` borrowed base is a temporary: placed as a value and its
+    /// result dropped after the op ([`RcOp::DropValue`]).
+    fn place_array_op(
+        &mut self,
+        e: &Expr<'tcx>,
+        op: crate::intrinsic::ArrayFn,
+        args: &'tcx [Expr<'tcx>],
+        kernel: Option<&'tcx mir::Kernel<'tcx>>,
+        live_after: &VarSet,
+    ) {
+        use crate::intrinsic::ArrayFn;
+        let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold);
+
+        // Everything the op borrows rather than consumes: kernel-read vars,
+        // plus a `Var` base of a borrowing op.
+        let mut borrowed = VarSet::default();
+        if let Some(k) = kernel {
+            borrowed.union_with(&self.kernel_free(k));
+        }
+        let mut base_is_borrowed_var = false;
+        if borrows_base
+            && self.rr.is_rr(args[0].ty)
+            && let ExprKind::Var(x) = args[0].kind
+        {
+            borrowed.insert(x);
+            base_is_borrowed_var = true;
+        }
+
+        // Value operands, left-to-right with standard liveness threading, all
+        // under `live_after ∪ borrowed` so nothing borrowed is treated as dead.
+        let mut live = live_after.clone();
+        live.union_with(&borrowed);
+        let n = args.len();
+        for i in 0..n {
+            if i == 0 && base_is_borrowed_var {
+                continue; // a borrowed base takes no rc op at its use
+            }
+            let mut la = live.clone();
+            for later in &args[i + 1..] {
+                la.union_with(&self.free(later));
+            }
+            self.place(&args[i], &la);
+            if i == 0 && borrows_base && self.rr.is_rr(args[0].ty) {
+                // A temporary base is borrowed for the op, then released.
+                self.add_after(e.id, RcOp::DropValue(args[0].id));
+            }
+        }
+
+        // The kernel body: every free var is in `live`, so its placement adds
+        // no consuming ops (its RR uses are `get` bases, which borrow).
+        if let Some(k) = kernel {
+            self.place(k.body, &live);
+        }
+
+        // Borrowed vars whose last use is this op die here.
+        for v in borrowed.iter() {
+            if !live_after.contains(v) {
+                self.add_after(e.id, RcOp::Drop(v));
             }
         }
     }

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -415,6 +415,7 @@ fn kind_name(kind: &ExprKind<'_>) -> &'static str {
         ExprKind::NullableCall(_) => "NullableCall",
         ExprKind::Closure(_) => "Closure",
         ExprKind::ClosureCall { .. } => "ClosureCall",
+        ExprKind::ArrayOp { .. } => "ArrayOp",
         ExprKind::Match(..) => "Match",
         ExprKind::Poison => "Poison",
     }
@@ -806,6 +807,26 @@ fn interp<'tcx>(
                 interp(a, ot, rr, rc);
             }
         }
+        // An array op consumes its operands like call args, except a
+        // borrowing op's (`get`/`fold`) array base, which follows the `Proj`
+        // borrow rule. A kernel body only reads enclosing vars — interpreting
+        // it must leave ownership untouched.
+        ExprKind::ArrayOp { op, args, kernel } => {
+            use crate::intrinsic::ArrayFn;
+            let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold);
+            for (i, a) in args.iter().enumerate() {
+                if i == 0 && borrows_base {
+                    interp_borrow(a, ot, rr, rc);
+                } else {
+                    interp(a, ot, rr, rc);
+                }
+            }
+            if let Some(k) = kernel {
+                let before = rc.clone();
+                interp(k.body, ot, rr, rc);
+                assert_eq!(before, *rc, "kernel body must not change ownership");
+            }
+        }
         ExprKind::GlobalStr(_)
         | ExprKind::ConstChar(_)
         | ExprKind::ConstInt(_)
@@ -921,6 +942,7 @@ fn uses_var(e: &Expr<'_>, y: VarId) -> bool {
 fn children<'tcx>(e: &Expr<'tcx>) -> Vec<&'tcx Expr<'tcx>> {
     use ExprKind::*;
     match e.kind {
+        ArrayOp { args, kernel, .. } => args.iter().chain(kernel.map(|k| k.body)).collect(),
         GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
         | Poison => vec![],
         Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -151,6 +151,60 @@ impl FastMath {
     }
 }
 
+/// A built-in operation on a statically shaped array (`TyKind::Array`, issue
+/// #344), spelled `core::intrinsic::array::<fn>`. Unlike [`IntrinsicOp`],
+/// these carry their own HIR/MIR node (`ExprKind::ArrayOp`) because
+/// `Tabulate`/`Fold` hold an inline kernel body, which the generic
+/// `Intrinsic` node cannot.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ArrayFn {
+    /// `splat<[T; e…]>(v)`: every element is `v`. Value operands: `[v]`.
+    Splat,
+    /// `tabulate<[T; e…]>(|i, …| e)`: element at each index tuple is the
+    /// kernel applied to the (row-major) indices. No value operands.
+    Tabulate,
+    /// `get(a, i, …)`: checked element read. Value operands: `[a, i…]`; `a`
+    /// is borrowed, not consumed.
+    Get,
+    /// `set(a, i, …, v)`: checked element write, consuming `a` and returning
+    /// the updated array (copy-on-write when shared). Value operands:
+    /// `[a, i…, v]`.
+    Set,
+    /// `fold(a, init, |acc, x| e)`: row-major reduction. Value operands:
+    /// `[a, init]`; `a` is borrowed, not consumed.
+    Fold,
+}
+
+impl ArrayFn {
+    /// Parse a surface / textual-IR name.
+    pub fn parse(name: &str) -> Option<ArrayFn> {
+        match name {
+            "splat" => Some(ArrayFn::Splat),
+            "tabulate" => Some(ArrayFn::Tabulate),
+            "get" => Some(ArrayFn::Get),
+            "set" => Some(ArrayFn::Set),
+            "fold" => Some(ArrayFn::Fold),
+            _ => None,
+        }
+    }
+
+    /// The surface name, also used by the textual IR (`array#<name>`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ArrayFn::Splat => "splat",
+            ArrayFn::Tabulate => "tabulate",
+            ArrayFn::Get => "get",
+            ArrayFn::Set => "set",
+            ArrayFn::Fold => "fold",
+        }
+    }
+
+    /// Whether the op takes an inline kernel body.
+    pub fn has_kernel(self) -> bool {
+        matches!(self, ArrayFn::Tabulate | ArrayFn::Fold)
+    }
+}
+
 /// A resolved intrinsic operation: which family, which op within it, and the
 /// family's compile-time immediates. One generic `Intrinsic` IR node carries
 /// this through HIR/MIR, so the node itself — and its traversal, ownership, and

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1653,6 +1653,19 @@ fn free_vars<'tcx>(e: &Expr<'tcx>, out: &mut Vec<VarId>) {
             args.iter().for_each(|e| free_vars(e, out));
         }
         Closure(c) => free_vars(&c.body, out),
+        ArrayOp { args, kernel, .. } => {
+            args.iter().for_each(|e| free_vars(e, out));
+            if let Some(k) = kernel {
+                // Kernel params are binders, not free uses.
+                let mut body = Vec::new();
+                free_vars(&k.body, &mut body);
+                for v in body {
+                    if !k.params.iter().any(|&(p, _)| p == v) {
+                        push(out, v);
+                    }
+                }
+            }
+        }
         Match(scrut, _) => free_vars(scrut, out),
         GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Poison => {}
     }

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -151,8 +151,33 @@ pub enum ExprKind<'tcx> {
         target: Box<Expr<'tcx>>,
         args: Vec<Expr<'tcx>>,
     },
+    /// A built-in operation on a statically shaped array (issue #344): the
+    /// resolved op, its value operands (see [`crate::intrinsic::ArrayFn`] for
+    /// each op's operand list), and — for `Tabulate`/`Fold` — an inline kernel.
+    ///
+    /// The kernel is *not* a closure: its body is checked in the enclosing
+    /// scope with only the kernel params added, so free variables reference
+    /// enclosing bindings directly (read-only for the op's duration) and no
+    /// capture list exists. Codegen inlines the body into the loop nest.
+    ArrayOp {
+        op: crate::intrinsic::ArrayFn,
+        args: Vec<Expr<'tcx>>,
+        kernel: Option<Box<Kernel<'tcx>>>,
+    },
     /// Error-recovery placeholder.
     Poison,
+}
+
+/// The inline kernel of an [`ArrayOp`](ExprKind::ArrayOp): parameters bound
+/// per element/iteration (`Tabulate`: one `i64` per dimension; `Fold`:
+/// `(acc, elem)`) and the body producing the element / next accumulator.
+/// The type checker restricts the body to be rc-free — every subexpression is
+/// of plain (unmanaged) type except array reads (`get`) of enclosing arrays —
+/// so inlining it into a loop introduces no per-iteration ownership work.
+#[derive(Clone, Debug)]
+pub struct Kernel<'tcx> {
+    pub params: Vec<(VarId, Ty<'tcx>)>,
+    pub body: Box<Expr<'tcx>>,
 }
 
 // ===== decision trees (compiled pattern matches) =====

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -508,6 +508,24 @@ impl<'a> Printer<'a> {
                     + self.value(&c.body)
                     + text(" }")
             }
+            ExprKind::ArrayOp { op, args, kernel } => {
+                let mut d =
+                    text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")");
+                if let Some(k) = kernel {
+                    let params: Vec<Doc<'static>> = k
+                        .params
+                        .iter()
+                        .map(|(v, t)| var(*v) + text(": ") + self.ty(*t))
+                        .collect();
+                    d = d
+                        + text(" kernel(")
+                        + comma_sep(params)
+                        + text(") { ")
+                        + self.value(&k.body)
+                        + text(" }");
+                }
+                d
+            }
             ExprKind::Let { .. } | ExprKind::Seq(_) | ExprKind::If(..) | ExprKind::Match(..) => {
                 unreachable!("structural forms are rendered by `value`")
             }


### PR DESCRIPTION
The `ArrayFn` family (splat/tabulate/get/set/fold) and its dedicated `ExprKind::ArrayOp` node — needed because tabulate/fold carry an inline kernel body, which the generic `Intrinsic` node cannot. Kernels are not closures: bodies reference enclosing bindings directly, and those free vars are read-only borrows for the op's duration. Ownership placement implements the contract (get/fold borrow their array base Proj-style; set consumes it, so dup-if-live keeps copy-on-write observable), and monomorphization maps the node through to MIR. Nothing constructs the node from surface syntax yet.

Part 4 of the arrays stack; contains parts 1–3 — review the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786382401&installation_id=144622820&pr_number=379&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F379&signature=fe63d867a954cf83db68d1283d7676076b88a090d4efe6e56e8e3223f23c2027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->