### PR TITLE
[frontend] array intrinsics: tabulate and fold, with inline kernels

### DIFF
--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1144,12 +1144,20 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 )
             }
             ArrayFn::Tabulate => {
-                let _ = dims;
-                self.error(
+                let i64_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Signed(64));
+                let param_tys = vec![i64_ty; dims.len()];
+                let Some(kernel) = self.check_kernel(&fc.args[0], &param_tys, elem, &method) else {
+                    return self.poison(span);
+                };
+                self.mk_expr(
+                    ExprKind::ArrayOp {
+                        op,
+                        args: Vec::new(),
+                        kernel: Some(Box::new(kernel)),
+                    },
+                    arr,
                     span,
-                    "`core::intrinsic::array::tabulate` is not available yet",
-                );
-                self.poison(span)
+                )
             }
             _ => unreachable!("filtered above"),
         }
@@ -1229,10 +1237,211 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 )
             }
             "fold" => {
-                self.error(span, "`core::intrinsic::array::fold` is not available yet");
-                self.poison(span)
+                if args.len() != 2 {
+                    self.error(
+                        span,
+                        "`fold` expects an initial accumulator and a kernel lambda",
+                    );
+                    return self.poison(span);
+                }
+                let init = self.infer_expr(&args[0]);
+                let acc_ty = init.ty;
+                let Some(kernel) = self.check_kernel(&args[1], &[acc_ty, elem], acc_ty, "fold")
+                else {
+                    return self.poison(span);
+                };
+                self.mk_expr(
+                    ExprKind::ArrayOp {
+                        op: ArrayFn::Fold,
+                        args: vec![base, init],
+                        kernel: Some(Box::new(kernel)),
+                    },
+                    acc_ty,
+                    span,
+                )
             }
             _ => unreachable!("routed here only for get/set/fold"),
+        }
+    }
+
+    /// Check an [`ArrayOp`](ExprKind::ArrayOp) kernel: a *literal* lambda whose
+    /// parameters take the given types and whose body checks against `ret`.
+    /// The body is checked in the enclosing scope with only the params added —
+    /// free variables reference enclosing bindings directly (no captures) —
+    /// and the rc-free body restriction is enforced after zonking, once types
+    /// are resolved (see `enforce_kernel_expr`).
+    fn check_kernel(
+        &mut self,
+        arg: &surface::Expr,
+        param_tys: &[Ty<'tcx>],
+        ret: Ty<'tcx>,
+        what: &str,
+    ) -> Option<super::hir::Kernel<'tcx>> {
+        let span = Some(arg.span());
+        let surface::ExprKind::Lambda(lam) = arg.kind() else {
+            self.error(
+                span,
+                format!("`{what}` requires a literal lambda kernel (e.g. `|i| …`)"),
+            );
+            return None;
+        };
+        if lam.args.len() != param_tys.len() {
+            self.error(
+                span,
+                format!(
+                    "`{what}` kernel takes {} parameter(s), got {}",
+                    param_tys.len(),
+                    lam.args.len()
+                ),
+            );
+            return None;
+        }
+        let mark = self.vars.mark();
+        let mut params = Vec::new();
+        for ((name, ann), &pty) in lam.args.iter().zip(param_tys) {
+            if let Some(t) = ann {
+                let t = self.eval_type(t);
+                self.expect(t, pty, span);
+            }
+            let var = self.vars.fresh(*name, pty, None);
+            params.push((var, pty));
+        }
+        if let Some(rt) = &lam.ret_ty {
+            let rt = self.eval_type(rt);
+            self.expect(rt, ret, span);
+        }
+        let body = self.check_expr(&lam.body, ret);
+        self.vars.restore(mark);
+        Some(super::hir::Kernel {
+            params,
+            body: Box::new(body),
+        })
+    }
+
+    /// Whether a type may appear in an array-kernel body: a plain scalar (or a
+    /// deferred generic, matching the element-type rule), plus `Unit` for
+    /// statement positions. Managed values would need per-iteration rc ops in
+    /// the inlined loop body, defeating the point of the kernel form.
+    fn kernel_ty_allowed(&mut self, ty: Ty<'tcx>) -> bool {
+        let ty = self.infer.resolve(ty);
+        matches!(ty.kind(), TyKind::Unit) || crate::semi::ty_eval::is_plain_scalar_or_deferred(ty)
+    }
+
+    /// Enforce the kernel-body restriction on a zonked kernel body: every
+    /// subexpression computes a plain scalar; the only managed values are
+    /// enclosing arrays read through nested `get`s on plain variables. This is
+    /// what lets ownership treat kernel free vars as read-only borrows and
+    /// codegen inline the body into a loop with no rc traffic.
+    fn enforce_kernel_expr(&mut self, e: &Expr<'tcx>) {
+        use crate::intrinsic::ArrayFn;
+        match &e.kind {
+            ExprKind::ArrayOp {
+                op: ArrayFn::Get,
+                args,
+                ..
+            } => {
+                if !matches!(args[0].kind, ExprKind::Var(_)) {
+                    self.error(
+                        args[0].span,
+                        "an array read inside a kernel must be on an array variable",
+                    );
+                }
+                for a in &args[1..] {
+                    self.enforce_kernel_expr(a);
+                }
+                return;
+            }
+            ExprKind::ArrayOp { op, .. } => {
+                self.error(
+                    e.span,
+                    format!(
+                        "`{}` is not allowed inside an array kernel (only `get` reads are)",
+                        op.as_str()
+                    ),
+                );
+                return;
+            }
+            _ => {}
+        }
+        if !self.kernel_ty_allowed(e.ty) {
+            let shown = self.infer.resolve(e.ty);
+            self.error(
+                e.span,
+                format!(
+                    "array kernel bodies are restricted to plain scalar computation; \
+                     a value of type `{}` is not allowed here",
+                    self.ty_display(shown)
+                ),
+            );
+            return; // don't cascade into children of an already-rejected node
+        }
+        match &e.kind {
+            ExprKind::Negate(x) | ExprKind::Not(x) | ExprKind::Cast(x, _) => {
+                self.enforce_kernel_expr(x)
+            }
+            ExprKind::Arith(l, _, r) | ExprKind::Cmp(l, _, r) => {
+                self.enforce_kernel_expr(l);
+                self.enforce_kernel_expr(r);
+            }
+            ExprKind::If(c, t, f) => {
+                self.enforce_kernel_expr(c);
+                self.enforce_kernel_expr(t);
+                self.enforce_kernel_expr(f);
+            }
+            ExprKind::Let { value, .. } => self.enforce_kernel_expr(value),
+            ExprKind::Seq(es) => es.iter().for_each(|e| self.enforce_kernel_expr(e)),
+            ExprKind::FuncCall { args, .. } | ExprKind::Intrinsic { args, .. } => {
+                args.iter().for_each(|e| self.enforce_kernel_expr(e))
+            }
+            ExprKind::Proj(base, _) => self.enforce_kernel_expr(base),
+            ExprKind::Match(scrut, tree) => {
+                self.enforce_kernel_expr(scrut);
+                self.enforce_kernel_tree(tree);
+            }
+            // Leaves, or forms whose own (already-allowed) type makes their
+            // children irrelevant here.
+            _ => {}
+        }
+    }
+
+    fn enforce_kernel_tree(&mut self, tree: &super::hir::DecisionTree<'tcx>) {
+        use super::hir::{DecisionTree, SwitchCases};
+        match tree {
+            DecisionTree::Uncovered | DecisionTree::Unreachable => {}
+            DecisionTree::Leaf { body, .. } => self.enforce_kernel_expr(body),
+            DecisionTree::Guard {
+                guard,
+                success,
+                failure,
+                ..
+            } => {
+                self.enforce_kernel_expr(guard);
+                self.enforce_kernel_tree(success);
+                self.enforce_kernel_tree(failure);
+            }
+            DecisionTree::Switch { cases, .. } => match cases {
+                SwitchCases::Int { cases, default } => {
+                    cases.iter().for_each(|(_, t)| self.enforce_kernel_tree(t));
+                    self.enforce_kernel_tree(default);
+                }
+                SwitchCases::Bool { if_true, if_false } => {
+                    self.enforce_kernel_tree(if_true);
+                    self.enforce_kernel_tree(if_false);
+                }
+                SwitchCases::Char { cases, default } => {
+                    cases.iter().for_each(|(_, t)| self.enforce_kernel_tree(t));
+                    self.enforce_kernel_tree(default);
+                }
+                SwitchCases::Ctor(subs) => subs.iter().for_each(|t| self.enforce_kernel_tree(t)),
+                SwitchCases::String { cases, default } => {
+                    cases.iter().for_each(|(_, t)| self.enforce_kernel_tree(t));
+                    self.enforce_kernel_tree(default);
+                }
+                SwitchCases::Nullable { non_null, null } => {
+                    self.enforce_kernel_tree(non_null);
+                    self.enforce_kernel_tree(null);
+                }
+            },
         }
     }
 
@@ -1797,6 +2006,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                             .collect(),
                         body: zb(self, k.body),
                     };
+                    // Types are resolved now — enforce the rc-free body rule.
+                    self.enforce_kernel_expr(&k.body);
                     Box::new(k)
                 });
                 ArrayOp { op, args, kernel }

--- a/tests/integration/frontend/array.rr
+++ b/tests/integration/frontend/array.rr
@@ -27,3 +27,26 @@ pub fn bump(a : [f64; 8], i : i64, v : f64) -> [f64; 8] {
 pub fn cell(m : [i32; 4, 4], i : i64, j : i64) -> i32 {
     core::intrinsic::array::get(m, i, j)
 }
+
+// CHECK: pub fn #make() -> [f64; 8]
+// CHECK: array#tabulate() kernel(v{{[0-9]+}}: i64) {
+pub fn make() -> [f64; 8] {
+    core::intrinsic::array::tabulate<[f64; 8]>(|i| i as f64)
+}
+
+// CHECK: pub fn #sum(v0 (a): [f64; 8]) -> f64
+// CHECK: array#fold(v0 : [f64; 8] {{.*}}, 0.0 : f64 {{.*}}) kernel(v{{[0-9]+}}: f64, v{{[0-9]+}}: f64) {
+pub fn sum(a : [f64; 8]) -> f64 {
+    core::intrinsic::array::fold(a, 0.0, |acc, x| acc + x)
+}
+
+// Kernels may read enclosing arrays (a stencil): the reads reference the
+// enclosing binding directly — no closure, no captures.
+// CHECK: pub fn #blur(v0 (x): [f64; 8]) -> [f64; 8]
+// CHECK: array#tabulate() kernel(v{{[0-9]+}}: i64) {
+// CHECK: array#get(v0
+pub fn blur(x : [f64; 8]) -> [f64; 8] {
+    core::intrinsic::array::tabulate<[f64; 8]>(|i|
+        if i == 0 { core::intrinsic::array::get(x, i) }
+        else { (core::intrinsic::array::get(x, i - 1) + core::intrinsic::array::get(x, i)) / 2.0 })
+}

--- a/tests/integration/frontend/array_errors.rr
+++ b/tests/integration/frontend/array_errors.rr
@@ -35,3 +35,35 @@ fn rank_mismatch(m : [f64; 4, 4]) -> f64 { core::intrinsic::array::get(m, 0) }
 
 // CHECK: `core::intrinsic::array::get` expects an array as its first argument, found `i64`
 fn not_an_array(x : i64) -> i64 { core::intrinsic::array::get(x, 0) }
+
+// CHECK: `tabulate` requires a literal lambda kernel
+fn make_it(f : i64 -> f64) -> [f64; 4] { core::intrinsic::array::tabulate<[f64; 4]>(f) }
+
+// CHECK: `fold` kernel takes 2 parameter(s), got 1
+fn short_kernel(a : [f64; 4]) -> f64 { core::intrinsic::array::fold(a, 0.0, |acc| acc) }
+
+// A kernel body may not create managed values (here: a boxed list).
+enum List { Cons(i64), Nil() }
+// CHECK: array kernel bodies are restricted to plain scalar computation
+fn managed_kernel(a : [i64; 4]) -> i64 {
+    core::intrinsic::array::fold(a, 0, |acc, x| {
+        let v = List::Cons{x};
+        match v { List::Cons(h) => acc + h, List::Nil() => acc }
+    })
+}
+
+// Only `get` is allowed inside a kernel.
+// CHECK: `set` is not allowed inside an array kernel
+fn set_in_kernel(a : [f64; 4], b : [f64; 4]) -> f64 {
+    core::intrinsic::array::fold(a, 0.0, |acc, x| {
+        let c = core::intrinsic::array::set(b, 0, x);
+        acc
+    })
+}
+
+// A nested kernel read must be directly on an array variable.
+// CHECK: an array read inside a kernel must be on an array variable
+fn temp_get_in_kernel(a : [f64; 4]) -> f64 {
+    core::intrinsic::array::fold(a, 0.0, |acc, x|
+        core::intrinsic::array::get(core::intrinsic::array::splat<[f64; 4]>(x), 0) + acc)
+}


### PR DESCRIPTION
The kernel-carrying ops: `tabulate<[T; e…]>(|i…| e)` takes one `i64` index parameter per dimension; `fold(a, init, |acc, x| e)` reduces row-major. Kernels must be literal lambdas and are checked in the enclosing scope with only their params bound — free vars reference enclosing bindings directly. After zonking, bodies are restricted (recursively, through match trees) to plain-scalar computation; the only managed reads are nested `get`s on array variables. That is what lets ownership treat kernel free vars as read-only borrows and codegen inline the body into a loop nest with zero per-iteration rc traffic.

Part 6 of the arrays stack; contains parts 1–5 — review the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786382405&installation_id=144622820&pr_number=381&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F381&signature=e07367aced76012e58902c71be77711f3176e41829305320f6060b86988fbb9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->