### PR TITLE
[codegen] array constructors and fold: inlined scf.for loop nests

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -2659,12 +2659,25 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
 
     /// Lower an [`ArrayOp`](ExprKind::ArrayOp). The shapes:
     ///
-    /// * `get` — borrow + view + bounds-checked `memref.load`;
-    /// * `set` — bounds checks, then `array.with_unique_view` storing the
-    ///   element (the empty-yield implicit result is the updated array).
+    /// * `get` — borrow + view + a bounds-guarded `memref.load`;
+    /// * `set` — a bounds-guarded `array.with_unique_view` storing the
+    ///   element (the empty-yield implicit result is the updated array);
+    /// * `splat` — a fresh `rc.create` over a poison payload (uniquely owned
+    ///   by construction, so a plain borrow + view is a mutable view), filled
+    ///   by a check-free `scf.for` nest (the loops iterate exactly the
+    ///   extents);
+    /// * `tabulate` — the same fresh box, each element computed by calling
+    ///   the kernel closure;
+    /// * `fold` — borrow + view and an `scf.for` nest threading the
+    ///   accumulator through `iter_args`, the kernel closure called per
+    ///   element.
     ///
-    /// The constructors and `fold` — the loop nests calling the kernel
-    /// closure per element — land separately.
+    /// The kernel closure is called through the frontend's standard
+    /// per-call chain — a per-iteration `rc.inc` pre-paying the consume,
+    /// then `uniqify → apply… → eval` — which is exactly the loop-carried
+    /// redex the closure beta reduction inlines at `-Oaggressive`: a literal
+    /// lambda kernel fuses into the nest, leaving check-free loops with no
+    /// closure calls and no per-iteration rc traffic.
     fn lower_array_op<'b>(
         &self,
         block: &'b Block<'c>,
@@ -2676,9 +2689,9 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         match op {
             ArrayFn::Get => self.array_get(block, env, e, args).map(Some),
             ArrayFn::Set => self.array_set(block, env, args).map(Some),
-            ArrayFn::Splat | ArrayFn::Tabulate | ArrayFn::Fold => {
-                err("array constructors and fold are not lowered yet")
-            }
+            ArrayFn::Splat => self.array_splat(block, env, e, args).map(Some),
+            ArrayFn::Tabulate => self.array_tabulate(block, env, e, args).map(Some),
+            ArrayFn::Fold => self.array_fold(block, env, e, args).map(Some),
         }
     }
 
@@ -2863,5 +2876,257 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             then.append_operation(scf::r#yield(&[updated], loc));
             Ok(())
         })
+    }
+    /// A fresh, uniquely-owned rc array over an uninitialized (poison)
+    /// payload; the caller fills every element before the value escapes.
+    fn fresh_array<'b>(&self, block: &'b Block<'c>, arr_ty: Ty<'tcx>) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let inner = self.tys.array_inner_of(arr_ty)?;
+        let rc_ty = self.tys.mlir_ty(arr_ty)?;
+        let poison = self.append(block, builders::poison(self.context, inner, loc));
+        Ok(self.append(block, builders::rc_create(self.context, poison, rc_ty, loc)))
+    }
+
+    /// Call an already-lowered kernel closure value with the given argument
+    /// values: the frontend's standard chain — `uniqify → apply… → eval` —
+    /// minus the pre-paying `rc.inc`, which the caller emits (per iteration
+    /// for a loop). Returns the result value (`None` for a unit result).
+    fn call_kernel<'b>(
+        &self,
+        block: &'b Block<'c>,
+        closure: Value<'c, 'b>,
+        kernel_ty: Ty<'tcx>,
+        args: &[Value<'c, 'b>],
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let loc = self.loc();
+        let (params, ret) = match kernel_ty.kind() {
+            TyKind::Closure { params, ret } => (*params, *ret),
+            _ => return err("array kernel is not a closure"),
+        };
+        let target_ty = self.tys.mlir_ty(kernel_ty)?;
+        let mut chain = self.append(block, builders::closure_uniqify(closure, target_ty, loc));
+        for (i, &arg) in args.iter().enumerate() {
+            let applied_ty = self.tys.closure_type(&params[i + 1..], ret)?;
+            chain = self.append(block, builders::closure_apply(arg, chain, applied_ty, loc));
+        }
+        let result_ty = if is_unit(ret) {
+            None
+        } else {
+            Some(self.tys.mlir_ty(ret)?)
+        };
+        let op = block.append_operation(builders::closure_eval(chain, result_ty, loc));
+        Ok(result_ty.map(|_| op.result(0).expect("eval result").into()))
+    }
+
+    fn array_splat<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        e: &Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    ) -> Result<Value<'c, 'b>> {
+        let value = self
+            .expr(block, env, &args[0])?
+            .ok_or_else(|| LoweringError("array element is unit".into()))?;
+        let rc_val = self.fresh_array(block, e.ty)?;
+        let view = self.array_view_of(block, rc_val, e.ty)?;
+        let dims = Self::array_dims(e.ty)?;
+        self.splat_nest(block, view, value, dims, Vec::new())?;
+        Ok(rc_val)
+    }
+
+    /// The `scf.for` nest of `splat`: store `value` at every index tuple.
+    fn splat_nest<'b>(
+        &self,
+        block: &'b Block<'c>,
+        view: Value<'c, 'b>,
+        value: Value<'c, 'b>,
+        dims: &[u64],
+        ivs: Vec<Value<'c, 'b>>,
+    ) -> Result<()> {
+        let loc = self.loc();
+        if dims.is_empty() {
+            block.append_operation(memref::store(value, view, &ivs, loc));
+            return Ok(());
+        }
+        let lb = self.index_const(block, 0);
+        let ub = self.index_const(block, dims[0] as i64);
+        let step = self.index_const(block, 1);
+        let inner = Block::new(&[(Type::index(self.context), loc)]);
+        {
+            let iv = inner.argument(0).expect("loop induction variable").into();
+            let mut ivs2: Vec<Value<'c, '_>> = ivs.iter().copied().collect();
+            ivs2.push(iv);
+            self.splat_nest(&inner, view, value, &dims[1..], ivs2)?;
+            inner.append_operation(scf::r#yield(&[], loc));
+        }
+        let region = Region::new();
+        region.append_block(inner);
+        block.append_operation(scf::r#for(lb, ub, step, region, loc));
+        Ok(())
+    }
+
+    fn array_tabulate<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        e: &Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let kernel = &args[0];
+        let closure = self
+            .expr(block, env, kernel)?
+            .ok_or_else(|| LoweringError("array kernel is unit".into()))?;
+        let rc_val = self.fresh_array(block, e.ty)?;
+        let view = self.array_view_of(block, rc_val, e.ty)?;
+        let dims = Self::array_dims(e.ty)?;
+        self.tabulate_nest(block, view, closure, kernel.ty, dims, Vec::new())?;
+        // The op consumed the kernel operand; the per-iteration incs paid
+        // for the evals, so one release remains.
+        block.append_operation(dialect::rc_dec(self.context, closure, loc).into());
+        Ok(rc_val)
+    }
+
+    /// The `scf.for` nest of `tabulate`: at each index tuple, call the
+    /// kernel on the (i64-cast) indices and store the element.
+    fn tabulate_nest<'b>(
+        &self,
+        block: &'b Block<'c>,
+        view: Value<'c, 'b>,
+        closure: Value<'c, 'b>,
+        kernel_ty: Ty<'tcx>,
+        dims: &[u64],
+        ivs: Vec<Value<'c, 'b>>,
+    ) -> Result<()> {
+        let loc = self.loc();
+        if dims.is_empty() {
+            block.append_operation(dialect::rc_inc(self.context, closure, loc).into());
+            let i64_ty = IntegerType::new(self.context, 64).into();
+            let idxs: Vec<Value<'c, 'b>> = ivs
+                .iter()
+                .map(|&iv| self.append(block, arith::index_cast(iv, i64_ty, loc)))
+                .collect();
+            let elem = self
+                .call_kernel(block, closure, kernel_ty, &idxs)?
+                .ok_or_else(|| LoweringError("array kernel yields unit".into()))?;
+            block.append_operation(memref::store(elem, view, &ivs, loc));
+            return Ok(());
+        }
+        let lb = self.index_const(block, 0);
+        let ub = self.index_const(block, dims[0] as i64);
+        let step = self.index_const(block, 1);
+        let inner = Block::new(&[(Type::index(self.context), loc)]);
+        {
+            let iv = inner.argument(0).expect("loop induction variable").into();
+            let mut ivs2: Vec<Value<'c, '_>> = ivs.iter().copied().collect();
+            ivs2.push(iv);
+            self.tabulate_nest(&inner, view, closure, kernel_ty, &dims[1..], ivs2)?;
+            inner.append_operation(scf::r#yield(&[], loc));
+        }
+        let region = Region::new();
+        region.append_block(inner);
+        block.append_operation(scf::r#for(lb, ub, step, region, loc));
+        Ok(())
+    }
+
+    fn array_fold<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        e: &Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        let base = &args[0];
+        let dims = Self::array_dims(base.ty)?;
+        let rc_val = self
+            .expr(block, env, base)?
+            .ok_or_else(|| LoweringError("array base is unit".into()))?;
+        // A temporary base is released after the op by a value-keyed drop.
+        self.remember_temp(env, base, rc_val);
+        let view = self.array_view_of(block, rc_val, base.ty)?;
+        let init = self
+            .expr(block, env, &args[1])?
+            .ok_or_else(|| LoweringError("fold accumulator is unit".into()))?;
+        let kernel = &args[2];
+        let closure = self
+            .expr(block, env, kernel)?
+            .ok_or_else(|| LoweringError("array kernel is unit".into()))?;
+        let acc_ty = self.tys.mlir_ty(e.ty)?;
+        let result = self.fold_nest(
+            block,
+            view,
+            closure,
+            kernel.ty,
+            acc_ty,
+            dims,
+            Vec::new(),
+            init,
+        )?;
+        block.append_operation(dialect::rc_dec(self.context, closure, loc).into());
+        Ok(result)
+    }
+
+    /// The `scf.for` nest of `fold`: the accumulator threads through
+    /// `iter_args` at every level; innermost, the kernel is called on
+    /// `(acc, element)`.
+    #[allow(clippy::too_many_arguments)]
+    fn fold_nest<'b>(
+        &self,
+        block: &'b Block<'c>,
+        view: Value<'c, 'b>,
+        closure: Value<'c, 'b>,
+        kernel_ty: Ty<'tcx>,
+        acc_ty: Type<'c>,
+        dims: &[u64],
+        ivs: Vec<Value<'c, 'b>>,
+        acc: Value<'c, 'b>,
+    ) -> Result<Value<'c, 'b>> {
+        let loc = self.loc();
+        if dims.is_empty() {
+            block.append_operation(dialect::rc_inc(self.context, closure, loc).into());
+            let x = self.append(block, memref::load(view, &ivs, loc));
+            return self
+                .call_kernel(block, closure, kernel_ty, &[acc, x])?
+                .ok_or_else(|| LoweringError("fold kernel yields unit".into()));
+        }
+        let lb = self.index_const(block, 0);
+        let ub = self.index_const(block, dims[0] as i64);
+        let step = self.index_const(block, 1);
+        let inner = Block::new(&[(Type::index(self.context), loc), (acc_ty, loc)]);
+        {
+            let iv = inner.argument(0).expect("loop induction variable").into();
+            let carried = inner.argument(1).expect("loop-carried accumulator").into();
+            let mut ivs2: Vec<Value<'c, '_>> = ivs.iter().copied().collect();
+            ivs2.push(iv);
+            let next = self.fold_nest(
+                &inner,
+                view,
+                closure,
+                kernel_ty,
+                acc_ty,
+                &dims[1..],
+                ivs2,
+                carried,
+            )?;
+            inner.append_operation(scf::r#yield(&[next], loc));
+        }
+        let region = Region::new();
+        region.append_block(inner);
+        let op = block.append_operation(
+            reussir_backend::melior::dialect::ods::scf::r#for(
+                self.context,
+                &[acc_ty],
+                lb,
+                ub,
+                step,
+                &[acc],
+                region,
+                loc,
+            )
+            .into(),
+        );
+        Ok(op.result(0).expect("loop-carried result").into())
     }
 }

--- a/tests/integration/frontend/array_codegen.rr
+++ b/tests/integration/frontend/array_codegen.rr
@@ -1,4 +1,4 @@
-// Codegen for the array access ops (issue #344): `get` borrows the rc box,
+// Codegen for the array ops (issue #344). Access: `get` borrows the rc box,
 // materializes a memref view, and sinks the load into a bounds guard; `set`
 // sinks the `array.with_unique_view` store the same way, its implicit
 // result being the (cloned-if-shared) updated array. Each index gets one
@@ -6,13 +6,34 @@
 // huge value, so `ult` covers both sides), and-reduced per op into a single
 // verdict; the access is the guard's then-branch, and the failure branch
 // panics then yields a poison of the result type. Constant indices fold
-// away at canonicalization.
+// away at canonicalization. Constructors and fold are check-free loop
+// nests calling the kernel closure per element; at -Oaggressive the
+// loop-carried beta reduction inlines literal lambdas (FUSED lines).
 //
 // Functions appear in the module sorted by mangled name; the CHECK blocks
 // follow that order.
 
 // RUN: %rrc %s --emit mlir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s --emit llvm-ir -o %t.ll
+// RUN: %rrc %s --emit mlir-llvm --no-source-locations -Oaggressive -o - | %FileCheck %s --check-prefix=FUSED
+
+// A fold: borrow + view, the accumulator threaded through iter_args, and
+// the kernel closure called on (acc, element); no bounds checks anywhere in
+// the nest (the loop iterates exactly the extents).
+// CHECK-LABEL: func.func @_RC3sum
+// CHECK: %[[FVIEW:.+]] = reussir.array.view
+// CHECK: reussir.closure.create
+// CHECK: %[[RES:.+]] = scf.for %[[FIV:.+]] = %{{.+}} iter_args(%[[ACC:.+]] = %{{.+}}) -> (f64) {
+// CHECK: reussir.rc.inc
+// CHECK: %[[X:.+]] = memref.load %[[FVIEW]][%[[FIV]]]
+// CHECK: reussir.closure.apply(%[[ACC]] : f64)
+// CHECK: reussir.closure.apply(%[[X]] : f64)
+// CHECK: %[[NEXT:.+]] = reussir.closure.eval
+// CHECK: scf.yield %[[NEXT]] : f64
+// CHECK: reussir.rc.dec
+pub fn sum(a : [f64; 8]) -> f64 {
+    core::intrinsic::array::fold(a, 0.0, |acc, x| acc + x)
+}
 
 // Rank-2 access: one bounds compare per dimension, and-reduced into one guard.
 // CHECK-LABEL: func.func @_RC4cell
@@ -23,6 +44,42 @@
 // CHECK: memref.load %{{.+}}[%{{.+}}, %{{.+}}] : memref<4x4xi32>
 pub fn cell(m : [i32; 4, 4], i : i64, j : i64) -> i32 {
     core::intrinsic::array::get(m, i, j)
+}
+
+// A tabulate constructor: a fresh rc.create over a poison payload (uniquely
+// owned by construction, so the plain borrowed view is mutable), filled by a
+// check-free loop calling the kernel closure per element through the
+// standard per-call chain — a per-iteration rc.inc pre-paying the consume,
+// then uniqify → apply… → eval. That is exactly the loop-carried redex the
+// closure beta reduction inlines at -Oaggressive (see the FUSED lines).
+// CHECK-LABEL: func.func @_RC4iota
+// CHECK: reussir.closure.create
+// CHECK: %[[POISON:.+]] = ub.poison : !reussir.array<8 x f64>
+// CHECK: %[[ARR:.+]] = reussir.rc.create value(%[[POISON]]
+// CHECK: %[[TVIEW:.+]] = reussir.array.view
+// CHECK: scf.for %[[IV:.+]] = %{{.+}} to %{{.+}} step %{{.+}} {
+// CHECK: reussir.rc.inc
+// CHECK: %[[I64:.+]] = arith.index_cast %[[IV]] : index to i64
+// CHECK: reussir.closure.uniqify
+// CHECK: reussir.closure.apply(%[[I64]] : i64)
+// CHECK: %[[ELT:.+]] = reussir.closure.eval
+// CHECK: memref.store %[[ELT]], %[[TVIEW]][%[[IV]]]
+// CHECK: reussir.rc.dec
+// CHECK: return %[[ARR]]
+pub fn iota() -> [f64; 8] {
+    core::intrinsic::array::tabulate<[f64; 8]>(|i| i as f64)
+}
+
+// A splat constructor: the same fresh box, one value stored everywhere — no
+// kernel, no closure ops anywhere.
+// CHECK-LABEL: func.func @_RC4ones
+// CHECK-NOT: reussir.closure
+// CHECK: ub.poison
+// CHECK: reussir.rc.create
+// CHECK: scf.for
+// CHECK: memref.store
+pub fn ones() -> [f64; 8] {
+    core::intrinsic::array::splat<[f64; 8]>(1.0)
 }
 
 // CHECK-LABEL: func.func @_RC4read
@@ -58,3 +115,14 @@ pub fn read(a : [f64; 8], i : i64) -> f64 {
 pub fn write(a : [f64; 8], i : i64, v : f64) -> [f64; 8] {
     core::intrinsic::array::set(a, i, v)
 }
+
+// At -Oaggressive the loop-carried beta reduction inlines the literal
+// lambda kernels: no closure machinery survives anywhere in the module.
+// FUSED-NOT: closure
+// FUSED-LABEL: llvm.func @_RC3sum
+// FUSED-NOT: closure
+// FUSED: llvm.fadd
+// FUSED-LABEL: llvm.func @_RC4iota
+// FUSED-NOT: closure
+// FUSED-LABEL: llvm.func @_RC4ones
+// FUSED-NOT: closure


### PR DESCRIPTION
splat/tabulate create a fresh rc box over a poison payload — uniquely owned by construction, so the plain borrowed view is mutable — and fill it with a rank-deep `scf.for` nest; fold borrows a view and threads its accumulator through `iter_args` (built raw: melior's scf.for builder cannot express loop-carried values). Kernel bodies are inlined into the nests, so the loops are bounds-check-free by construction and carry zero per-iteration rc traffic. Completes the Phase A op set.

Part 9 of the arrays stack; contains parts 1–8 — review the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786382430&installation_id=144622820&pr_number=384&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F384&signature=4b1d673fbb4b92cb3ea91a9e6f70dafd55923786dcaa55b3febcd765087083e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->