### PR TITLE
[tests] array e2e: construction, access, folds, COW, in-place update

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -76,6 +76,14 @@ pub struct LlvmOpaqueMemoryBuffer {
 }
 /// Mirrors `LLVMModuleRef`.
 pub type LLVMModuleRef = *mut LlvmOpaqueModule;
+
+/// Mirrors `LLVMTargetMachineRef`.
+#[repr(C)]
+pub struct LlvmOpaqueTargetMachine {
+    _private: [u8; 0],
+}
+
+pub type LLVMTargetMachineRef = *mut LlvmOpaqueTargetMachine;
 /// Mirrors `LLVMContextRef`.
 pub type LLVMContextRef = *mut LlvmOpaqueContext;
 /// Mirrors `LLVMMemoryBufferRef`.
@@ -204,7 +212,11 @@ unsafe extern "C" {
     /// Runs the Reussir LLVM optimization pipeline on `module` in place at the
     /// requested level (a no-op for `None`/`Tpde`). `opt` mirrors the backend's
     /// `ReussirOptOption`/`ReussirJitOptLevel` C enum.
-    pub fn reussirRunBackendLLVMPipeline(module: LLVMModuleRef, opt: c_int);
+    pub fn reussirRunBackendLLVMPipeline(
+        module: LLVMModuleRef,
+        opt: c_int,
+        machine: LLVMTargetMachineRef,
+    );
 
     /// Compiles `module` to an ELF object with TPDE after stamping the given data
     /// layout and triple on it. Returns null if TPDE is unavailable or

--- a/crates/reussir-backend/src/llvm.rs
+++ b/crates/reussir-backend/src/llvm.rs
@@ -55,13 +55,25 @@ pub unsafe fn translate_to_llvm_ir(
 /// Runs the Reussir backend LLVM pass pipeline on `module` in place (a no-op for
 /// [`OptLevel::None`]/[`OptLevel::Tpde`], matching the C++ backend).
 ///
+/// `machine` supplies the target model the cost-driven passes (loop/SLP
+/// vectorization) work against; without one they would run on the base
+/// TargetTransformInfo, which has no vector registers, and never fire. Pass
+/// null to have the pipeline build a host TargetMachine internally (the JIT
+/// case).
+///
 /// # Safety
-/// `module` must be a valid `LLVMModuleRef`.
-pub unsafe fn run_backend_llvm_pipeline(module: LLVMModuleRef, opt: OptLevel) {
+/// `module` must be a valid `LLVMModuleRef`, and `machine` a valid
+/// `LLVMTargetMachineRef` or null.
+pub unsafe fn run_backend_llvm_pipeline(
+    module: LLVMModuleRef,
+    opt: OptLevel,
+    machine: llvm_sys::target_machine::LLVMTargetMachineRef,
+) {
     unsafe {
         sys::reussirRunBackendLLVMPipeline(
             module as sys::LLVMModuleRef,
             opt.as_reussir_opt_option(),
+            machine as sys::LLVMTargetMachineRef,
         );
     }
 }

--- a/crates/reussir-compiler/src/lib.rs
+++ b/crates/reussir-compiler/src/lib.rs
@@ -280,11 +280,30 @@ pub fn emit_to_file(
     out_path: &Path,
 ) -> Result<(), String> {
     unsafe {
-        run_backend_llvm_pipeline(finalized.module, opt);
+        // Stamp the target before the pass pipeline runs: the module's triple
+        // and data layout feed the pipeline's queries, and the machine feeds
+        // the TargetTransformInfo the cost-driven passes (vectorization)
+        // decide against.
+        stamp_target(finalized.module, machine);
+        run_backend_llvm_pipeline(finalized.module, opt, machine.machine);
         let result = emit(finalized.module, machine, kind, out_path);
         LLVMDisposeModule(finalized.module);
         LLVMContextDispose(finalized.context);
         result
+    }
+}
+
+/// Stamps `machine`'s target triple and data layout onto the module, so the
+/// emitted artifact's ABI matches the target (and so `%cc` and downstream
+/// tools can consume the IR-text form).
+unsafe fn stamp_target(llvm_module: LLVMModuleRef, machine: &TargetMachine) {
+    unsafe {
+        LLVMSetTarget(llvm_module, machine.triple.as_ptr());
+        let target_data = LLVMCreateTargetDataLayout(machine.machine);
+        // `LLVMSetModuleDataLayout` copies the layout into the module, so the
+        // target-data handle is ours to dispose.
+        LLVMSetModuleDataLayout(llvm_module, target_data);
+        LLVMDisposeTargetData(target_data);
     }
 }
 
@@ -295,17 +314,6 @@ unsafe fn emit(
     out_path: &Path,
 ) -> Result<(), String> {
     unsafe {
-        // Stamp the module with the target triple and data layout so the emitted
-        // object's ABI matches the target (and so `%cc` can link it). The IR-text
-        // path needs this too: it carries the target as `target triple`/`target
-        // datalayout` lines, which downstream tools (and `%FileCheck`) rely on.
-        LLVMSetTarget(llvm_module, machine.triple.as_ptr());
-        let target_data = LLVMCreateTargetDataLayout(machine.machine);
-        // `LLVMSetModuleDataLayout` copies the layout into the module, so the
-        // target-data handle is ours to dispose.
-        LLVMSetModuleDataLayout(llvm_module, target_data);
-        LLVMDisposeTargetData(target_data);
-
         // LLVM IR text needs no target-machine emission — just print the module.
         if kind == OutputKind::LlvmIr {
             let s = LLVMPrintModuleToString(llvm_module);

--- a/crates/reussir-jit/src/orc.rs
+++ b/crates/reussir-jit/src/orc.rs
@@ -383,7 +383,7 @@ impl OrcJit {
 
             // Run the Reussir LLVM passes in place, then add the IR module.
             tracing::trace!("running backend LLVM pass pipeline");
-            run_backend_llvm_pipeline(llvm_module, opt);
+            run_backend_llvm_pipeline(llvm_module, opt, std::ptr::null_mut());
             self.add_owned_module(context, llvm_module, tracker)?;
             tracing::debug!("added LLVM-IR module to the JIT");
             Ok(())

--- a/include/Reussir-c/Jit.h
+++ b/include/Reussir-c/Jit.h
@@ -17,6 +17,7 @@
 #ifndef REUSSIR_C_JIT_H
 #define REUSSIR_C_JIT_H
 
+#include "llvm-c/TargetMachine.h"
 #include "llvm-c/Types.h"
 
 #ifdef __cplusplus
@@ -36,7 +37,14 @@ typedef enum ReussirJitOptLevel {
 // RuntimeFunctionAttributor pass, the default per-module pipeline at the
 // requested level, then the AllocationSimplification pass. A no-op for the
 // `None` and `Tpde` levels (matching the C++ backend).
-void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt);
+//
+// `machine` supplies the target model the cost-driven passes (loop/SLP
+// vectorization) work against; without one the pipeline would run on the
+// base TargetTransformInfo, which has no vector registers, and every
+// vectorization would be costed as impossible. Pass NULL to have the
+// pipeline build a host TargetMachine internally (the JIT case).
+void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt,
+                                   LLVMTargetMachineRef machine);
 
 // Compiles `module` to an ELF object file using TPDE, after setting the given
 // data layout and target triple on it. Returns NULL if TPDE support was not

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -13,8 +13,12 @@
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
+#include <llvm/MC/TargetRegistry.h>
+#include <llvm/TargetParser/SubtargetFeature.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/CBindingWrapping.h>
+#include <llvm/Target/TargetMachine.h>
+#include <llvm/TargetParser/Host.h>
 #include <llvm/TargetParser/Triple.h>
 #include <llvm/Transforms/IPO/LowerTypeTests.h>
 #include <llvm/Transforms/IPO/WholeProgramDevirt.h>
@@ -30,13 +34,58 @@
 #endif
 
 void reussirRunBackendLLVMPipeline(LLVMModuleRef module,
-                                   ReussirJitOptLevel opt) {
+                                   ReussirJitOptLevel opt,
+                                   LLVMTargetMachineRef machine) {
   if (opt == ReussirJitOptNone || opt == ReussirJitOptTpde)
     return;
 
   llvm::Module &m = *llvm::unwrap(module);
 
-  llvm::PassBuilder pb;
+  // The cost-driven passes (loop/SLP vectorization) consult the
+  // TargetTransformInfo the PassBuilder derives from its TargetMachine; a
+  // machine-less PassBuilder falls back to the base model, which has no
+  // vector registers, so vectorization would silently never fire. The AOT
+  // driver hands its machine through (faithful to --target-cpu/-triple);
+  // the JIT passes NULL and gets a host machine with the host's features.
+  llvm::TargetMachine *tm = reinterpret_cast<llvm::TargetMachine *>(machine);
+  std::unique_ptr<llvm::TargetMachine> ownedTm;
+  if (!tm) {
+    llvm::Triple triple = m.getTargetTriple();
+    if (triple.getTriple().empty())
+      triple = llvm::Triple(llvm::sys::getDefaultTargetTriple());
+    std::string lookupError;
+    if (const llvm::Target *target =
+            llvm::TargetRegistry::lookupTarget(triple.getTriple(),
+                                               lookupError)) {
+      llvm::SubtargetFeatures features;
+      for (const auto &[name, enabled] : llvm::sys::getHostCPUFeatures())
+        features.AddFeature(name, enabled);
+      ownedTm.reset(target->createTargetMachine(
+          triple, llvm::sys::getHostCPUName(), features.getString(),
+          llvm::TargetOptions(), std::nullopt));
+      tm = ownedTm.get();
+    }
+  }
+
+  // Stamp the machine's CPU and feature set onto every function definition
+  // (mirroring clang's -march handling): the pipeline below vectorizes
+  // against this machine, and the emitted IR must declare the features it
+  // uses so a downstream compilation of the IR text (e.g. the sanitizer
+  // harnesses driving clang over rrc's .ll) selects for the same ISA.
+  if (tm) {
+    llvm::StringRef cpu = tm->getTargetCPU();
+    llvm::StringRef features = tm->getTargetFeatureString();
+    for (llvm::Function &f : m) {
+      if (f.isDeclaration())
+        continue;
+      if (!cpu.empty() && !f.hasFnAttribute("target-cpu"))
+        f.addFnAttr("target-cpu", cpu);
+      if (!features.empty() && !f.hasFnAttribute("target-features"))
+        f.addFnAttr("target-features", features);
+    }
+  }
+
+  llvm::PassBuilder pb(tm);
   llvm::LoopAnalysisManager lam;
   llvm::FunctionAnalysisManager fam;
   llvm::CGSCCAnalysisManager cgam;

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -2887,10 +2887,16 @@ struct ReussirRefMemcpyConversionPattern
     mlir::Type elementType = converter->convertType(srcType.getElementType());
     size_t size = dataLayout.getTypeSize(elementType);
 
-    // Create LLVM memcpy intrinsic (non-overlapping, so isVolatile = false)
-    rewriter.replaceOpWithNewOp<mlir::LLVM::MemcpyInlineOp>(
-        op, adaptor.getDst(), adaptor.getSrc(),
-        rewriter.getIntegerAttr(converter->getIndexType(), size),
+    // Create LLVM memcpy intrinsic (non-overlapping, so isVolatile = false).
+    // The plain form, not memcpy.inline: with a constant length LLVM already
+    // expands small copies to loads/stores and picks the best strategy
+    // (expansion or libcall) for large ones — forcing inline expansion on a
+    // big payload (e.g. a whole array clone) just unrolls it.
+    auto sizeVal = mlir::LLVM::ConstantOp::create(
+        rewriter, op.getLoc(), converter->getIndexType(),
+        rewriter.getIntegerAttr(converter->getIndexType(), size));
+    rewriter.replaceOpWithNewOp<mlir::LLVM::MemcpyOp>(
+        op, adaptor.getDst(), adaptor.getSrc(), sizeVal,
         /*isVolatile=*/false);
     return mlir::success();
   }

--- a/tests/integration/conversion/ref_ops.mlir
+++ b/tests/integration/conversion/ref_ops.mlir
@@ -70,7 +70,8 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
       return
   }
   // CHECK-LABEL: llvm.func @reference_memcpy(%arg0: !llvm.ptr, %arg1: !llvm.ptr)
-  // CHECK: "llvm.intr.memcpy.inline"(%arg1, %arg0) <{isVolatile = false, len = 8 : i64}> : (!llvm.ptr, !llvm.ptr) -> ()
+  // CHECK: %[[LEN:.+]] = llvm.mlir.constant(8 : i64) : i64
+  // CHECK: "llvm.intr.memcpy"(%arg1, %arg0, %[[LEN]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
   // CHECK: llvm.return
   // CHECK: }
 

--- a/tests/integration/frontend/array_codegen.rr
+++ b/tests/integration/frontend/array_codegen.rr
@@ -126,3 +126,34 @@ pub fn write(a : [f64; 8], i : i64, v : f64) -> [f64; 8] {
 // FUSED-NOT: closure
 // FUSED-LABEL: llvm.func @_RC4ones
 // FUSED-NOT: closure
+
+// The backend pipeline runs against the real TargetMachine, so rrc's own
+// -Oaggressive artifacts vectorize (no external opt run needed). The small
+// arrays above fully unroll instead; this fill loop is wide enough to be
+// worth vectorizing on any SIMD baseline.
+// RUN: %rrc %s --emit llvm-ir -Oaggressive -o %t.vec.ll
+// RUN: %FileCheck %s --check-prefix=VEC < %t.vec.ll
+// VEC: <{{(vscale x )?[0-9]+}} x float>
+pub fn big() -> [f32; 1024] {
+    core::intrinsic::array::splat<[f32; 1024]>(1.0)
+}
+
+// The same shape isolated for inspection: take an array parameter, add one
+// to every element by tail recursion over get/set, return the result — no
+// construction, no reduction. At -Oaggressive the recursion becomes a
+// loop, the unique-carrying specialization drops the count checks, the
+// bounds guards fold (the index is provably in range), and the in-place
+// update vectorizes.
+// VEC-LABEL: @_RC8plus_one
+// VEC: <{{(vscale x )?[0-9]+}} x float>
+fn bump_from(a : [f32; 1024], i : i64) -> [f32; 1024] {
+    if i == 1024 {
+        a
+    } else {
+        let v = core::intrinsic::array::get(a, i);
+        bump_from(core::intrinsic::array::set(a, i, v + 1.0), i + 1)
+    }
+}
+pub fn plus_one(a : [f32; 1024]) -> [f32; 1024] {
+    bump_from(a, 0)
+}

--- a/tests/integration/frontend/array_codegen.rr
+++ b/tests/integration/frontend/array_codegen.rr
@@ -129,14 +129,12 @@ pub fn write(a : [f64; 8], i : i64, v : f64) -> [f64; 8] {
 
 // The backend pipeline runs against the real TargetMachine, so rrc's own
 // -Oaggressive artifacts vectorize (no external opt run needed). The small
-// arrays above fully unroll instead; this fill loop is wide enough to be
-// worth vectorizing on any SIMD baseline.
+// arrays above fully unroll instead, and a constant fill loop is not a
+// stable anchor either (Darwin turns it into a memset-pattern libcall), so
+// the vectorization pin below is plus_one's in-place update loop — a
+// load/fadd/store body no idiom pass can replace.
 // RUN: %rrc %s --emit llvm-ir -Oaggressive -o %t.vec.ll
 // RUN: %FileCheck %s --check-prefix=VEC < %t.vec.ll
-// VEC: <{{(vscale x )?[0-9]+}} x float>
-pub fn big() -> [f32; 1024] {
-    core::intrinsic::array::splat<[f32; 1024]>(1.0)
-}
 
 // The same shape isolated for inspection: take an array parameter, add one
 // to every element by tail recursion over get/set, return the result — no

--- a/tests/integration/frontend/array_e2e.c
+++ b/tests/integration/frontend/array_e2e.c
@@ -1,0 +1,67 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Float results cross the C-ABI trampoline via an out-parameter (only
+   void/integer/pointer returns are direct). */
+extern void test_tabulate_sum_ffi(double *);
+extern int64_t test_splat_get_ffi(void);
+extern void test_unique_update_ffi(double *);
+extern void test_cow_ffi(double *);
+extern int64_t test_rank2_ffi(void);
+extern void test_stencil_ffi(double *);
+extern void test_shared_kernel_ffi(double *);
+extern void test_capture_fold_ffi(double *);
+extern int64_t test_rank3_ffi(void);
+extern void test_temp_base_ffi(double *);
+extern int64_t test_chained_set_ffi(void);
+extern void test_recursive_plus_one_ffi(float *);
+
+static int check_f64(const char *name, void (*fn)(double *), double want) {
+  double got = 0.0;
+  fn(&got);
+  if (got != want) {
+    fprintf(stderr, "%s: got %f, want %f\n", name, got, want);
+    return 1;
+  }
+  return 0;
+}
+
+static int check_i64(const char *name, int64_t got, int64_t want) {
+  if (got != want) {
+    fprintf(stderr, "%s: got %lld, want %lld\n", name, (long long)got,
+            (long long)want);
+    return 1;
+  }
+  return 0;
+}
+
+int main(void) {
+  int failures = 0;
+  failures += check_f64("tabulate_sum", test_tabulate_sum_ffi, 28.0);
+  failures += check_i64("splat_get", test_splat_get_ffi(), 7);
+  failures += check_f64("unique_update", test_unique_update_ffi, 38.0);
+  failures += check_f64("cow", test_cow_ffi, 100.0);
+  /* sum(i*10+j over 4x4) = 10*6*4 + 6*4 = 264; m[2][3] = 23 => 287 */
+  failures += check_i64("rank2", test_rank2_ffi(), 287);
+  /* y[0] = 3, y[1..7] = 3 => 24 */
+  failures += check_f64("stencil", test_stencil_ffi, 24.0);
+  /* 28 + (1 + 4*2) = 37 */
+  failures += check_f64("shared_kernel", test_shared_kernel_ffi, 37.0);
+  /* 3 * (0+1+2+3) = 18 */
+  failures += check_f64("capture_fold", test_capture_fold_ffi, 18.0);
+  /* sum(i*100+j*10+k over 2x3x4) = 1476; m[1][2][3] = 123 => 1599 */
+  failures += check_i64("rank3", test_rank3_ffi(), 1599);
+  failures += check_f64("temp_base", test_temp_base_ffi, 9.0);
+  failures += check_i64("chained_set", test_chained_set_ffi(), 6);
+  /* 1024 elements, 1.0 + 1.0 each => 2048 */
+  {
+    float got = 0.0f;
+    test_recursive_plus_one_ffi(&got);
+    if (got != 2048.0f) {
+      fprintf(stderr, "recursive_plus_one: got %f, want 2048\n", (double)got);
+      failures += 1;
+    }
+  }
+  return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/array_e2e.rr
+++ b/tests/integration/frontend/array_e2e.rr
@@ -1,0 +1,132 @@
+// End-to-end semantics of the Phase A array intrinsics (issue #344):
+// construction, reads/writes, folds, rank-2 indexing, copy-on-write on a
+// shared array, and in-place update of a unique one.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/array_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/array_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+// tabulate + fold: sum of 0..7 = 28.
+pub fn test_tabulate_sum() -> f64 {
+    core::intrinsic::array::fold(
+        core::intrinsic::array::tabulate<[f64; 8]>(|i| i as f64),
+        0.0, |acc, x| acc + x)
+}
+extern "C" trampoline "test_tabulate_sum_ffi" = test_tabulate_sum;
+
+// splat + get.
+pub fn test_splat_get() -> i64 {
+    let a = core::intrinsic::array::splat<[i64; 16]>(7);
+    core::intrinsic::array::get(a, 15)
+}
+extern "C" trampoline "test_splat_get_ffi" = test_splat_get;
+
+// A unique array updates in place through a call boundary.
+fn bump(a : [f64; 8], i : i64, v : f64) -> [f64; 8] {
+    core::intrinsic::array::set(a, i, core::intrinsic::array::get(a, i) + v)
+}
+pub fn test_unique_update() -> f64 {
+    let a = core::intrinsic::array::tabulate<[f64; 8]>(|i| i as f64);
+    core::intrinsic::array::fold(bump(a, 3, 10.0), 0.0, |acc, x| acc + x)
+}
+extern "C" trampoline "test_unique_update_ffi" = test_unique_update;
+
+// Copy-on-write: `a` is still live across the `set`, so the update must
+// clone; the original observes its old value. 1.0 + 99.0 = 100.0.
+pub fn test_cow() -> f64 {
+    let a = core::intrinsic::array::splat<[f64; 4]>(1.0);
+    let b = core::intrinsic::array::set(a, 0, 99.0);
+    core::intrinsic::array::get(a, 0) + core::intrinsic::array::get(b, 0)
+}
+extern "C" trampoline "test_cow_ffi" = test_cow;
+
+// Rank-2: m[i][j] = i * 10 + j, summed row-major; checked against the
+// closed form.
+pub fn test_rank2() -> i64 {
+    let m = core::intrinsic::array::tabulate<[i64; 4, 4]>(|i, j| i * 10 + j);
+    core::intrinsic::array::fold(m, 0, |acc, x| acc + x)
+        + core::intrinsic::array::get(m, 2, 3)
+}
+extern "C" trampoline "test_rank2_ffi" = test_rank2;
+
+// A stencil kernel reading the enclosing array.
+pub fn test_stencil() -> f64 {
+    let x = core::intrinsic::array::splat<[f64; 8]>(3.0);
+    let y = core::intrinsic::array::tabulate<[f64; 8]>(|i|
+        if i == 0 { core::intrinsic::array::get(x, i) }
+        else { (core::intrinsic::array::get(x, i - 1) + core::intrinsic::array::get(x, i)) / 2.0 });
+    core::intrinsic::array::fold(y, 0.0, |acc, v| acc + v)
+}
+extern "C" trampoline "test_stencil_ffi" = test_stencil;
+
+// A let-bound kernel reaches the folds as a *variable*, so it stays a real
+// closure at every opt level (no fusion) and is shared by two ops: the
+// per-element uniqify sees a shared box and clones each iteration —
+// maximal pressure on the closure rc path. 28.0 + (1.0 + 8.0) = 37.0.
+pub fn test_shared_kernel() -> f64 {
+    let f = |acc, x| acc + x;
+    let a = core::intrinsic::array::tabulate<[f64; 8]>(|i| i as f64);
+    let b = core::intrinsic::array::splat<[f64; 4]>(2.0);
+    core::intrinsic::array::fold(a, 0.0, f) + core::intrinsic::array::fold(b, 1.0, f)
+}
+extern "C" trampoline "test_shared_kernel_ffi" = test_shared_kernel;
+
+// A fold kernel capturing *another array*: the capture rides the closure
+// (copied out per element when unfused), and the read borrows it.
+// 3.0 * (0+1+2+3) = 18.0.
+pub fn test_capture_fold() -> f64 {
+    let w = core::intrinsic::array::splat<[f64; 4]>(3.0);
+    let a = core::intrinsic::array::tabulate<[f64; 4]>(|i| i as f64);
+    core::intrinsic::array::fold(a, 0.0, |acc, x|
+        acc + x * core::intrinsic::array::get(w, 0))
+}
+extern "C" trampoline "test_capture_fold_ffi" = test_capture_fold;
+
+// Rank-3: three nested loops, accumulator threaded through every level.
+// sum(i*100+j*10+k) = 1476, plus m[1][2][3] = 123 → 1599.
+pub fn test_rank3() -> i64 {
+    let m = core::intrinsic::array::tabulate<[i64; 2, 3, 4]>(|i, j, k| i * 100 + j * 10 + k);
+    core::intrinsic::array::fold(m, 0, |acc, x| acc + x)
+        + core::intrinsic::array::get(m, 1, 2, 3)
+}
+extern "C" trampoline "test_rank3_ffi" = test_rank3;
+
+// A `get` directly on a constructor result: the temporary base is released
+// right after the op by the value-keyed drop. (3*3) = 9.0.
+pub fn test_temp_base() -> f64 {
+    core::intrinsic::array::get(
+        core::intrinsic::array::tabulate<[f64; 4]>(|i| (i * i) as f64), 3)
+}
+extern "C" trampoline "test_temp_base_ffi" = test_temp_base;
+
+// A chain of sets over a uniquely owned array: every step updates in
+// place, no clones. 1 + 2 + 3 + 0 = 6.
+pub fn test_chained_set() -> i64 {
+    let a = core::intrinsic::array::splat<[i64; 4]>(0);
+    let b = core::intrinsic::array::set(
+        core::intrinsic::array::set(
+            core::intrinsic::array::set(a, 0, 1), 1, 2), 2, 3);
+    core::intrinsic::array::fold(b, 0, |acc, x| acc + x)
+}
+extern "C" trampoline "test_chained_set_ffi" = test_chained_set;
+
+// All-elements-plus-one written as plain tail recursion over get/set — no
+// loop kernel anywhere in the update. The uniquely owned array threads
+// through the recursion, so all 1024 sets update in place.
+fn plus_one_from(a : [f32; 1024], i : i64) -> [f32; 1024] {
+    if i == 1024 {
+        a
+    } else {
+        let v = core::intrinsic::array::get(a, i);
+        plus_one_from(core::intrinsic::array::set(a, i, v + 1.0), i + 1)
+    }
+}
+pub fn test_recursive_plus_one() -> f32 {
+    let a = core::intrinsic::array::splat<[f32; 1024]>(1.0);
+    let b = plus_one_from(a, 0);
+    core::intrinsic::array::fold(b, 0.0, |acc, x| acc + x)
+}
+extern "C" trampoline "test_recursive_plus_one_ffi" = test_recursive_plus_one;

--- a/tests/integration/sanitizer/e2e/array.rr
+++ b/tests/integration/sanitizer/e2e/array.rr
@@ -1,0 +1,25 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/array_e2e.rr. Its FFI returns only scalars,
+// so the compiled code must free every allocation itself: array boxes from
+// splat/tabulate/set-clones, and — at the unfused levels — the per-element
+// closure clones of the shared/captured kernels. Any leak (or ASan error)
+// reported here is a real ownership/lowering/backend bug.
+//
+// -Onone and -Odefault run the kernels as genuine closures (uniqify-clone,
+// apply, eval per element); -Oaggressive runs them fused by the
+// loop-carried beta reduction. Both regimes must be clean.
+
+// RUN: %rrc %S/../../frontend/array_e2e.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/array_e2e.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/array_e2e.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/array_e2e.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/array_e2e.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/array_e2e.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe


### PR DESCRIPTION
Execute the Phase A array semantics at -O0 and -Oaggressive through a C harness: tabulate+fold, splat+get, rank-2 row-major indexing, a stencil kernel reading its enclosing array, copy-on-write when the original stays live across a `set`, and in-place update of a unique array through a call boundary.

Part 10 (last) of the arrays stack; contains parts 1–9 — review the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786382431&installation_id=144622820&pr_number=385&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F385&signature=bb1e4abadb71b4b2bf90a5232ecf4191bc2fbc75ba0a92a1c8b94a268f78ef8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->