### PR TITLE
[syntax] parse opaque transform module items

### DIFF
--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -128,6 +128,7 @@ impl Emitter<'_> {
             EnumStmt => self.record_stmt(node, "EnumKind"),
             ModStmt => self.mod_stmt(node),
             ExternTrampolineStmt => self.extern_stmt(node),
+            TransformStmt => self.transform_stmt(node),
             k => unreachable!("unexpected statement node {k:?}"),
         };
         tagged("SpannedStmt", self.with_node_span(node, inner))
@@ -311,6 +312,13 @@ impl Emitter<'_> {
             "etsFunc": self.path(func),
             "etsFuncTyArgs": ty_args,
         })
+    }
+
+    fn transform_stmt(&self, node: &ResolvedNode) -> Value {
+        let body = tokens(node)
+            .find(|token| token.kind() == RawMlirLiteral)
+            .expect("transform body");
+        tagged("TransformStmt", Value::String(body.text().into()))
     }
 
     // ===== paths and types =====

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -21,6 +21,8 @@ pub enum SyntaxKind {
     FloatLit,
     StringLit,
     CharLit,
+    /// An opaque MLIR literal block: `[{ ... }]`.
+    RawMlirLiteral,
 
     // ===== Tokens: hard keywords =====
     FnKw,
@@ -120,6 +122,8 @@ pub enum SyntaxKind {
     EnumStmt,
     ModStmt,
     ExternTrampolineStmt,
+    /// A module-level `transform [{ ... }];` item.
+    TransformStmt,
     GenericParamList,
     GenericParam,
     ParamList,
@@ -250,6 +254,7 @@ impl SyntaxKind {
             FloatLit => "a floating-point literal",
             StringLit => "a string literal",
             CharLit => "a character literal",
+            RawMlirLiteral => "an MLIR literal block",
             FnKw => "`fn`",
             StructKw => "`struct`",
             EnumKw => "`enum`",

--- a/crates/reussir-syntax/src/lexer.rs
+++ b/crates/reussir-syntax/src/lexer.rs
@@ -41,6 +41,8 @@ pub enum LexErrorKind {
     UnterminatedChar,
     InvalidChar,
     UnterminatedBlockComment,
+    UnterminatedRawMlirLiteral,
+    InvalidRawMlirLiteralTerminator,
 }
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,6 +79,8 @@ pub enum RawToken {
     String,
     #[token("'", lex_char)]
     Char,
+    #[token("[{", lex_raw_mlir_literal)]
+    RawMlirLiteral,
 
     #[token("::")]
     PathSep,
@@ -202,6 +206,64 @@ fn lex_block_comment(lex: &mut logos::Lexer<RawToken>) -> Result<(), LexErrorKin
     }
 }
 
+/// Scan an opaque `[{ ... }]` block. Braces inside strings and comments do
+/// not affect the nesting depth; every other byte is deliberately left to
+/// MLIR's parser.
+fn lex_raw_mlir_literal(lex: &mut logos::Lexer<RawToken>) -> Result<(), LexErrorKind> {
+    let bytes = lex.remainder().as_bytes();
+    let mut depth = 1usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    match bytes[i] {
+                        b'\\' => i = (i + 2).min(bytes.len()),
+                        b'"' => {
+                            i += 1;
+                            break;
+                        }
+                        _ => i += 1,
+                    }
+                }
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && &bytes[i..i + 2] != b"*/" {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+            }
+            b'{' => {
+                depth += 1;
+                i += 1;
+            }
+            b'}' => {
+                depth -= 1;
+                i += 1;
+                if depth == 0 {
+                    if bytes.get(i) == Some(&b']') {
+                        lex.bump(i + 1);
+                        return Ok(());
+                    }
+                    lex.bump(i);
+                    return Err(LexErrorKind::InvalidRawMlirLiteralTerminator);
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    lex.bump(bytes.len());
+    Err(LexErrorKind::UnterminatedRawMlirLiteral)
+}
+
 /// Scan a string literal after the opening quote (it may span newlines) and
 /// validate the whole token against Rust's string escape grammar.
 fn lex_string(lex: &mut logos::Lexer<RawToken>) -> Result<(), LexErrorKind> {
@@ -288,6 +350,7 @@ impl RawToken {
             RawToken::Float => SyntaxKind::FloatLit,
             RawToken::String => SyntaxKind::StringLit,
             RawToken::Char => SyntaxKind::CharLit,
+            RawToken::RawMlirLiteral => SyntaxKind::RawMlirLiteral,
             RawToken::PathSep => SyntaxKind::PathSep,
             RawToken::Arrow => SyntaxKind::Arrow,
             RawToken::FatArrow => SyntaxKind::FatArrow,
@@ -361,6 +424,10 @@ pub fn tokenize(source: &str) -> (Vec<Token>, Vec<LexError>) {
                     LexErrorKind::UnterminatedChar => "unterminated character literal",
                     LexErrorKind::InvalidChar => "invalid character literal",
                     LexErrorKind::UnterminatedBlockComment => "unterminated block comment",
+                    LexErrorKind::UnterminatedRawMlirLiteral => "unterminated MLIR literal block",
+                    LexErrorKind::InvalidRawMlirLiteralTerminator => {
+                        "MLIR literal block must end with `}]`"
+                    }
                     LexErrorKind::Unrecognized => {
                         if lexer.slice().starts_with(|c: char| c.is_ascii_digit()) {
                             // e.g. a radix prefix with no digits (`0x`, `0b_`).
@@ -405,6 +472,28 @@ mod tests {
         assert_eq!(kinds("if lettuce"), vec![K::IfKw, K::Ident]);
         // Contextual keywords stay identifiers.
         assert_eq!(kinds("shared trampoline i32 bool"), vec![K::Ident; 4]);
+    }
+
+    #[test]
+    fn raw_mlir_literal_is_one_opaque_token() {
+        let source = r#"[{
+            %x = transform.structured.match ops{["scf.for"]} in %target
+            transform.include @tail failures(propagate) (%x)
+            // braces in comments do not count: {
+            transform.test "string with }]" ^bb0 $opaque
+        }]"#;
+        assert_eq!(kinds(source), vec![K::RawMlirLiteral]);
+    }
+
+    #[test]
+    fn malformed_raw_mlir_literal_is_reported() {
+        let (_, errors) = tokenize("[{ transform.yield }");
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("must end"));
+
+        let (_, errors) = tokenize("[{ transform.yield");
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("unterminated"));
     }
 
     #[test]

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -155,6 +155,7 @@ fn repl_route(p: &parser::Parser) -> ReplInputKind {
         RegionalKw => p.nth(1) == FnKw,
         // An outer attribute `#[...]` only ever heads an item.
         Pound => true,
+        Ident if p.current_text() == "transform" && p.nth(1) == RawMlirLiteral => true,
         _ => false,
     };
     if starts_item {
@@ -383,6 +384,39 @@ mod tests {
     fn parses_trampoline_and_mod() {
         json_of(
             "pub mod utils;\nfn fib<T>(n: T) -> T { n }\nextern \"C\" trampoline \"fib_ffi\" = fib<u64>;",
+        );
+    }
+
+    #[test]
+    fn parses_opaque_transform_item() {
+        let source = r#"transform [{
+    %loops = transform.structured.match ops{["scf.for"]} in %target
+        : (!transform.op<"func.func">) -> !transform.any_op
+    transform.loop.unroll %loops { factor = 4 } : !transform.any_op
+    transform.yield
+}];"#;
+        let json = json_of(source);
+        let item = unwrap_span(&json[0]);
+        assert_eq!(item["tag"], "TransformStmt");
+        assert_eq!(
+            item["contents"],
+            &source["transform ".len()..source.len() - 1]
+        );
+    }
+
+    #[test]
+    fn transform_remains_a_contextual_word() {
+        json_of("fn transform(transform: i32) -> i32 { transform }");
+    }
+
+    #[test]
+    fn transform_item_requires_a_semicolon() {
+        let parse = parse("transform [{ transform.yield }]");
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|error| error.message.contains("`;`"))
         );
     }
 

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -4,7 +4,9 @@
 //!
 //! ```text
 //! source-file ::= stmt*
-//! stmt        ::= 'pub'? (fn-stmt | struct-stmt | enum-stmt | mod-stmt | extern-stmt)
+//! stmt        ::= 'pub'? (fn-stmt | struct-stmt | enum-stmt | mod-stmt
+//!                           | extern-stmt | transform-stmt)
+//! transform-stmt ::= 'transform' RAW-MLIR-LITERAL ';'
 //! fn-stmt     ::= 'regional'? 'fn' name generics? '(' params ')' ('->' '[flex]'? type)? (block | ';')
 //! struct-stmt ::= 'struct' capability? name generics? (named-fields | unnamed-fields)
 //! enum-stmt   ::= 'enum' capability? name generics? '{' variant,* '}'
@@ -34,7 +36,7 @@ impl Parser<'_> {
     pub(crate) fn source_file(&mut self) {
         let m = self.start();
         while !self.at_eof() {
-            if self.current().starts_stmt() {
+            if self.current().starts_stmt() || self.at_transform_stmt() {
                 self.stmt();
             } else {
                 // Statement-level recovery: collect the unexpected tokens
@@ -42,10 +44,10 @@ impl Parser<'_> {
                 // again.
                 let e = self.start();
                 self.error(format!(
-                    "expected a top-level item (fn, struct, enum, mod, or extern), found {}",
+                    "expected a top-level item (fn, struct, enum, mod, extern, or transform), found {}",
                     self.current().describe()
                 ));
-                while !self.at_eof() && !self.current().starts_stmt() {
+                while !self.at_eof() && !self.current().starts_stmt() && !self.at_transform_stmt() {
                     self.bump();
                 }
                 e.complete(self, ErrorNode);
@@ -67,15 +69,28 @@ impl Parser<'_> {
             EnumKw => self.enum_stmt(m),
             ModKw => self.mod_stmt(m),
             ExternKw => self.extern_trampoline_stmt(m),
+            Ident if self.at_transform_stmt() => self.transform_stmt(m),
             _ => {
                 self.error(format!(
-                    "expected `fn`, `struct`, `enum`, `mod`, or `extern` after visibility, found {}",
+                    "expected `fn`, `struct`, `enum`, `mod`, `extern`, or `transform` after visibility, found {}",
                     self.current().describe()
                 ));
                 // Consume nothing further; the outer loop recovers.
                 m.complete(self, ErrorNode);
             }
         }
+    }
+
+    fn at_transform_stmt(&self) -> bool {
+        self.at_ctx_kw("transform") && self.nth(1) == RawMlirLiteral
+    }
+
+    /// `transform [{ opaque MLIR }];`.
+    fn transform_stmt(&mut self, m: Marker) {
+        self.bump();
+        self.expect(RawMlirLiteral);
+        self.expect(Semicolon);
+        m.complete(self, TransformStmt);
     }
 
     fn fn_stmt(&mut self, m: Marker) {


### PR DESCRIPTION
[syntax] parse opaque transform module items

Introduces contextual `transform [{...}];` module items and an opaque balanced raw-MLIR literal token. Strings and comments inside a block stay opaque, malformed delimiters produce syntax diagnostics, and parser JSON retains the block.

Cumulative stack layer 1/6. Base: `main`.

Tests:
- `cargo test --locked -p reussir-syntax`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786387708&installation_id=144622820&pr_number=386&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F386&signature=6f81bce2d56c4e3e90f3cbc72c44a0188c264baa7ed2108c895ac987b673212a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->