### PR TITLE
[frontend] collect transform anchors and scripts

### DIFF
--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -31,8 +31,8 @@ pub mod resolve;
 pub mod ty_eval;
 
 pub use ctxt::{
-    Checkpoint, DefaultCap, Elaborator, PackageFile, Report, Severity, render_reports,
-    render_reports_to,
+    Checkpoint, DefaultCap, Elaborator, PackageFile, Report, Severity, TransformScript,
+    render_reports, render_reports_to,
 };
 
 use reussir_syntax::kind::{Resolver, TokenKey};
@@ -138,6 +138,49 @@ mod tests {
             let elab = elaborate_package(tcx, &pkg_files, &interner);
             f(&elab, tcx);
         });
+    }
+
+    #[test]
+    fn collects_transform_anchors_and_scripts() {
+        check(
+            "#[transform_anchor]\nfn selected() {}\nfn plain() {}\n\
+             transform [{\n  transform.yield\n}];",
+            |elab, _| {
+                assert_eq!(elab.transform_anchors.len(), 1);
+                let proto = elab
+                    .functions
+                    .get(&elab.transform_anchors[0])
+                    .expect("anchored function");
+                assert_eq!(elab.sym(proto.name), "selected");
+                assert_eq!(elab.transform_scripts.len(), 1);
+                assert_eq!(elab.transform_scripts[0].body, "{\n  transform.yield\n}");
+            },
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_transform_anchors() {
+        let reports = reports_of(
+            "#[transform_anchor(argument)] fn with_arg() {}\n\
+             #[transform_anchor] struct S {}\n\
+             #[transform_anchor] fn declaration();\n\
+             #[transform_anchor] #[transform_anchor] fn duplicate() {}",
+        );
+        let messages: Vec<&str> = reports
+            .iter()
+            .map(|report| report.message.as_str())
+            .collect();
+        for expected in [
+            "does not accept arguments",
+            "only be attached to a function",
+            "requires a function body",
+            "only be specified once",
+        ] {
+            assert!(
+                messages.iter().any(|message| message.contains(expected)),
+                "missing {expected:?}: {messages:#?}"
+            );
+        }
     }
 
     #[test]
@@ -392,7 +435,9 @@ mod tests {
             // Input 2: a batch containing a duplicate is rejected wholesale —
             // including its error-free items.
             let p2 = parse(
-                "fn triple(x: i32) -> i32 { 3 * x }\n\
+                "#[transform_anchor]\n\
+                 fn triple(x: i32) -> i32 { 3 * x }\n\
+                 transform [{ transform.yield }];\n\
                  fn double(x: i32) -> i32 { x }",
             );
             let errs = elab
@@ -404,6 +449,8 @@ mod tests {
                 "{errs:#?}"
             );
             assert_eq!(elab.elaborated.len(), 1, "batch rolled back");
+            assert!(elab.transform_anchors.is_empty(), "anchors rolled back");
+            assert!(elab.transform_scripts.is_empty(), "scripts rolled back");
             assert!(!elab.has_errors(), "rejected reports don't persist");
 
             // Input 3: `triple` was rolled back, so its name is free again,

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -44,6 +44,14 @@ pub struct Report {
     pub file: FileId,
 }
 
+/// A module-level transform script collected from source.
+#[derive(Clone, Debug)]
+pub struct TransformScript {
+    pub body: String,
+    pub span: Span,
+    pub file: FileId,
+}
+
 /// Render `reports` to stderr with source-caret context and return whether any
 /// was an error (warnings alone do not fail a compile). A report the middle-end
 /// could not trace back to a span — an internal/whole-program error — prints as
@@ -273,6 +281,10 @@ pub struct Elaborator<'a, 'tcx> {
     pub functions: FxHashMap<DefId, FuncProto<'tcx>>,
     /// Resolved extern-trampoline roots (mono seeds). See [`TrampolineRoot`].
     pub trampolines: Vec<TrampolineRoot<'tcx>>,
+    /// Functions explicitly marked with `#[transform_anchor]`, in source order.
+    pub transform_anchors: Vec<DefId>,
+    /// Inline transform scripts, in source order.
+    pub transform_scripts: Vec<TransformScript>,
     pub generics: Vec<GenericInfo>,
     pub strings: StringUniqifier,
     pub elaborated: Vec<Function<'tcx>>,
@@ -308,6 +320,8 @@ pub struct Checkpoint {
     pub(super) defs: usize,
     pub(super) generics: usize,
     pub(super) trampolines: usize,
+    pub(super) transform_anchors: usize,
+    pub(super) transform_scripts: usize,
     pub(super) elaborated: usize,
     pub(super) reports: usize,
 }
@@ -335,6 +349,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             builtins,
             trait_names,
             trampolines: Vec::new(),
+            transform_anchors: Vec::new(),
+            transform_scripts: Vec::new(),
             records: FxHashMap::default(),
             functions: FxHashMap::default(),
             generics: Vec::new(),
@@ -697,6 +713,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             defs: self.defs.len(),
             generics: self.generics.len(),
             trampolines: self.trampolines.len(),
+            transform_anchors: self.transform_anchors.len(),
+            transform_scripts: self.transform_scripts.len(),
             elaborated: self.elaborated.len(),
             reports: self.reports.len(),
         }
@@ -714,6 +732,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.functions.retain(|def, _| def.0 < live);
         self.generics.truncate(cp.generics);
         self.trampolines.truncate(cp.trampolines);
+        self.transform_anchors.truncate(cp.transform_anchors);
+        self.transform_scripts.truncate(cp.transform_scripts);
         self.elaborated.truncate(cp.elaborated);
         self.reports.truncate(cp.reports);
     }
@@ -771,6 +791,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // Project each item once — `kind()` re-walks the node and is not
         // memoized — then run the passes over the typed collections, each item
         // tagged with its file/module scope.
+        #[derive(Clone, Copy)]
         struct Scope<'p> {
             file: FileId,
             module: &'p [TokenKey],
@@ -785,14 +806,36 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     module,
                 };
                 let span = span_of(stmt);
+                let attrs = stmt.attributes();
+                self.set_current_file(*file);
                 match stmt.kind() {
-                    surface::StmtKind::Record(rec) => records.push((rec, span, scope)),
-                    surface::StmtKind::Function(func) => functions.push((func, span, scope)),
-                    surface::StmtKind::ExternTrampoline(t) => trampolines.push((t, span, scope)),
+                    surface::StmtKind::Record(rec) => {
+                        self.validate_transform_anchor(&attrs, None);
+                        records.push((rec, span, scope));
+                    }
+                    surface::StmtKind::Function(func) => {
+                        let anchor =
+                            self.validate_transform_anchor(&attrs, Some(func.body.is_some()));
+                        functions.push((func, span, scope, anchor));
+                    }
+                    surface::StmtKind::ExternTrampoline(t) => {
+                        self.validate_transform_anchor(&attrs, None);
+                        trampolines.push((t, span, scope));
+                    }
                     // `mod` declarations drive package *discovery* (the driver
                     // maps them to files before elaboration); here they carry
                     // no items.
-                    surface::StmtKind::Mod(..) => {}
+                    surface::StmtKind::Mod(..) => {
+                        self.validate_transform_anchor(&attrs, None);
+                    }
+                    surface::StmtKind::Transform(script) => {
+                        self.validate_transform_anchor(&attrs, None);
+                        self.transform_scripts.push(TransformScript {
+                            body: script.body,
+                            span: script.body_span,
+                            file: *file,
+                        });
+                    }
                 }
             }
         }
@@ -810,12 +853,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .collect();
         let function_defs: Vec<Option<DefId>> = functions
             .iter()
-            .map(|(func, span, scope)| {
+            .map(|(func, span, scope, _)| {
                 self.set_current_file(scope.file);
                 self.defs.set_module(scope.module.to_vec());
                 self.scan_function(func, *span)
             })
             .collect();
+        functions
+            .iter()
+            .zip(&function_defs)
+            .filter_map(|((_, _, _, anchor), def)| if *anchor { *def } else { None })
+            .for_each(|def| self.transform_anchors.push(def));
         records
             .iter()
             .zip(record_defs)
@@ -826,7 +874,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         functions
             .iter()
             .zip(function_defs)
-            .filter_map(|((func, span, _), def)| Some((func, *span, def?)))
+            .filter_map(|((func, span, _, _), def)| Some((func, *span, def?)))
             .for_each(|(func, span, def)| {
                 self.check_function(func, def, span);
             });
@@ -835,6 +883,47 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             self.defs.set_module(scope.module.to_vec());
             self.collect_trampoline(tramp, *span);
         });
+    }
+
+    fn validate_transform_anchor(
+        &mut self,
+        attrs: &[surface::Attribute],
+        function_has_body: Option<bool>,
+    ) -> bool {
+        let mut seen = false;
+        let mut valid = true;
+        let mut span = None;
+        for attr in attrs {
+            if self.sym(attr.name) != "transform_anchor" {
+                continue;
+            }
+            span = Some(attr.span);
+            if function_has_body.is_none() {
+                self.error(
+                    span,
+                    "`#[transform_anchor]` may only be attached to a function",
+                );
+                valid = false;
+                continue;
+            }
+            if seen {
+                self.error(
+                    span,
+                    "`#[transform_anchor]` may only be specified once per function",
+                );
+                valid = false;
+            }
+            seen = true;
+            if !attr.args.is_empty() {
+                self.error(span, "`#[transform_anchor]` does not accept arguments");
+                valid = false;
+            }
+        }
+        if seen && function_has_body == Some(false) {
+            self.error(span, "`#[transform_anchor]` requires a function body");
+            valid = false;
+        }
+        seen && valid
     }
 
     fn scan_record(&mut self, rec: &surface::Record, span: Option<Span>) -> Option<DefId> {

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -841,6 +841,14 @@ fn let_name(node: &ResolvedNode) -> Option<&ResolvedToken> {
 
 // ===== statements =====
 
+/// An outer item attribute such as `#[transform_anchor]`.
+#[derive(Clone, Debug)]
+pub struct Attribute {
+    pub name: TokenKey,
+    pub args: Vec<TokenKey>,
+    pub span: Span,
+}
+
 /// A function definition. `params`/`return` carry the `[flex]` flag as a bool.
 #[derive(Clone, Debug)]
 pub struct Function {
@@ -884,6 +892,13 @@ pub struct ExternTrampoline {
     pub ty_args: SmallVec<[Type; 2]>,
 }
 
+/// An opaque MLIR transform script. `body` includes its surrounding braces.
+#[derive(Clone, Debug)]
+pub struct TransformScript {
+    pub body: String,
+    pub body_span: Span,
+}
+
 #[derive(Clone, Debug)]
 pub enum StmtKind {
     Function(Function),
@@ -891,6 +906,7 @@ pub enum StmtKind {
     /// `mod` declaration: `(visibility, name)`.
     Mod(Visibility, TokenKey),
     ExternTrampoline(ExternTrampoline),
+    Transform(TransformScript),
 }
 
 /// A statement (a view over a top-level item node).
@@ -908,6 +924,13 @@ impl Stmt {
         node_span(&self.node)
     }
 
+    pub fn attributes(&self) -> Vec<Attribute> {
+        nodes(&self.node)
+            .filter(|node| node.kind() == AttrList)
+            .map(attribute_of)
+            .collect()
+    }
+
     pub fn kind(&self) -> StmtKind {
         let node = &self.node;
         match node.kind() {
@@ -916,8 +939,18 @@ impl Stmt {
             EnumStmt => StmtKind::Record(record_of(node, RecordKind::EnumKind)),
             ModStmt => StmtKind::Mod(visibility_of(node), key(name_after(node, ModKw))),
             ExternTrampolineStmt => StmtKind::ExternTrampoline(extern_of(node)),
+            TransformStmt => StmtKind::Transform(transform_of(node)),
             k => unreachable!("unexpected statement node {k:?}"),
         }
+    }
+}
+
+fn attribute_of(node: &ResolvedNode) -> Attribute {
+    let mut names = tokens(node).filter(|token| token.kind().is_ident_like());
+    Attribute {
+        name: key(names.next().expect("attribute name")),
+        args: names.map(key).collect(),
+        span: node_span(node),
     }
 }
 
@@ -1072,6 +1105,21 @@ fn extern_of(node: &ResolvedNode) -> ExternTrampoline {
     }
 }
 
+fn transform_of(node: &ResolvedNode) -> TransformScript {
+    let token = tokens(node)
+        .find(|token| token.kind() == RawMlirLiteral)
+        .expect("transform literal");
+    let text = token.text();
+    let span = token_span(token);
+    TransformScript {
+        body: text[1..text.len() - 1].to_owned(),
+        body_span: Span {
+            start: span.start + 1,
+            end: span.end - 1,
+        },
+    }
+}
+
 // ===== program =====
 
 /// A whole parsed source file: the top-level statement views.
@@ -1151,5 +1199,26 @@ mod tests {
         assert!(f.is_regional);
         // The `[flex]` flag on the first parameter is preserved.
         assert!(f.params[0].2);
+    }
+
+    #[test]
+    fn views_attributes_and_transform_scripts() {
+        let source = "#[transform_anchor]\nfn f() {}\ntransform [{\n  transform.yield\n}];";
+        let parse = parse(source);
+        let prog = program(&parse.root);
+
+        let attrs = prog[0].attributes();
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(parse.resolver().resolve(attrs[0].name), "transform_anchor");
+        assert!(attrs[0].args.is_empty());
+
+        let StmtKind::Transform(script) = prog[1].kind() else {
+            panic!("expected a transform script");
+        };
+        assert_eq!(script.body, "{\n  transform.yield\n}");
+        assert_eq!(
+            &source[script.body_span.start as usize..script.body_span.end as usize],
+            script.body
+        );
     }
 }


### PR DESCRIPTION
[frontend] collect transform anchors and scripts

Adds structured surface attributes, validates no-argument `#[transform_anchor]` on individual body-bearing functions, and collects deterministic anchored `DefId` values plus source-spanned module transform scripts.

Cumulative stack layer 2/6; includes the syntax layer. Base: `main`.

Tests:
- `cargo test --locked -p reussir-syntax -p reussir-core`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786387729&installation_id=144622820&pr_number=387&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F387&signature=738c47d96bb99ab9f6a6bf2f4d4c5851f10325785efde1ba135b993a53205b36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->