### PR TITLE
[hir] preserve inline transform metadata

### DIFF
--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -723,7 +723,8 @@ fn frontend_package<'c, 'tcx>(
             hir::print::Printer::new(&elab.defs, elab.resolver)
         } else {
             hir::print::Printer::with_sources(&elab.defs, elab.resolver, &pkg.cache)
-        };
+        }
+        .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts);
         let strings = elab.strings.entries();
         let text = printer.program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
         return Ok(Produced::Text(text));
@@ -784,7 +785,8 @@ fn frontend<'c, 'tcx>(
                     hir::print::Printer::new(&elab.defs, elab.resolver)
                 } else {
                     hir::print::Printer::with_sources(&elab.defs, elab.resolver, sources)
-                };
+                }
+                .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts);
                 let strings = elab.strings.entries();
                 let text =
                     printer.program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
@@ -820,7 +822,8 @@ fn frontend<'c, 'tcx>(
                         hir::print::Printer::with_sources(&parsed.defs, &parsed.names, cache)
                     }
                     _ => hir::print::Printer::new(&parsed.defs, &parsed.names),
-                };
+                }
+                .with_transform_metadata(&parsed.transform_anchors, &parsed.transform_scripts);
                 let text = printer.program(
                     &parsed.funcs,
                     &parsed.strings,

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -40,6 +40,10 @@ pub enum Token<'a> {
     Extern,
     #[token("trampoline")]
     Trampoline,
+    #[token("transform")]
+    Transform,
+    #[token("transform_anchor")]
+    TransformAnchor,
     #[token("let")]
     Let,
     #[token("in")]

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -48,7 +48,7 @@ pub struct Report {
 #[derive(Clone, Debug)]
 pub struct TransformScript {
     pub body: String,
-    pub span: Span,
+    pub span: Option<Span>,
     pub file: FileId,
 }
 
@@ -832,7 +832,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         self.validate_transform_anchor(&attrs, None);
                         self.transform_scripts.push(TransformScript {
                             body: script.body,
-                            span: script.body_span,
+                            span: Some(script.body_span),
                             file: *file,
                         });
                     }

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -16,7 +16,9 @@ use reussir_syntax::source::FileId;
 use rustc_hash::FxHashMap;
 
 use crate::ir_lex::lex;
-use crate::semi::ctxt::{DefaultCap, Record, RecordFields, TrampolineRoot, Variant};
+use crate::semi::ctxt::{
+    DefaultCap, Record, RecordFields, TrampolineRoot, TransformScript, Variant,
+};
 use crate::semi::hir::grammar as hir_ir;
 use crate::semi::hir::raw;
 use crate::semi::hir::{
@@ -34,6 +36,8 @@ use crate::utils::string::StringToken;
 /// [`crate::full::mono::monomorphize`] via a `MonoInput`.
 pub struct Parsed<'tcx> {
     pub funcs: Vec<Function<'tcx>>,
+    pub transform_anchors: Vec<DefId>,
+    pub transform_scripts: Vec<TransformScript>,
     pub strings: Vec<(StringToken, String)>,
     pub records: FxHashMap<DefId, Record<'tcx>>,
     pub trampolines: Vec<TrampolineRoot<'tcx>>,
@@ -99,6 +103,11 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
             return Err(id);
         }
     }
+    for t in &raw.transforms {
+        if let Some(id) = file_ref_check(&files, t.file) {
+            return Err(id);
+        }
+    }
     let strings = raw::string_entries(&raw.strings)?;
     let mut b = Builder {
         tcx,
@@ -108,10 +117,27 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
     };
     // Records first so their `DefId`s exist before function bodies reference them.
     let records: FxHashMap<DefId, Record<'tcx>> = raw.records.iter().map(|r| b.record(r)).collect();
-    let funcs = raw.funcs.iter().map(|f| b.func(f)).collect();
+    let funcs: Vec<Function<'tcx>> = raw.funcs.iter().map(|f| b.func(f)).collect();
+    let transform_anchors = raw
+        .funcs
+        .iter()
+        .zip(&funcs)
+        .filter_map(|(raw, func)| raw.transform_anchor.then_some(func.def))
+        .collect();
+    let transform_scripts = raw
+        .transforms
+        .iter()
+        .map(|script| TransformScript {
+            body: script.body.clone(),
+            span: span_of(script.span),
+            file: file_of(script.file),
+        })
+        .collect();
     let trampolines = raw.trampolines.iter().map(|t| b.trampoline(t)).collect();
     Ok(Parsed {
         funcs,
+        transform_anchors,
+        transform_scripts,
         strings,
         records,
         trampolines,
@@ -609,19 +635,30 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
             let strings = elab.strings.entries();
-            let text = Printer::new(&elab.defs, elab.resolver).program(
-                &elab.elaborated,
-                &strings,
-                &elab.records,
-                &elab.trampolines,
-            );
+            let text = Printer::new(&elab.defs, elab.resolver)
+                .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             let parsed = parse_program(tcx, &text).expect("re-parse");
-            let text2 = Printer::new(&parsed.defs, &parsed.names).program(
-                &parsed.funcs,
-                &parsed.strings,
-                &parsed.records,
-                &parsed.trampolines,
+            assert_eq!(parsed.transform_anchors.len(), elab.transform_anchors.len());
+            assert_eq!(
+                parsed
+                    .transform_scripts
+                    .iter()
+                    .map(|script| &script.body)
+                    .collect::<Vec<_>>(),
+                elab.transform_scripts
+                    .iter()
+                    .map(|script| &script.body)
+                    .collect::<Vec<_>>()
             );
+            let text2 = Printer::new(&parsed.defs, &parsed.names)
+                .with_transform_metadata(&parsed.transform_anchors, &parsed.transform_scripts)
+                .program(
+                    &parsed.funcs,
+                    &parsed.strings,
+                    &parsed.records,
+                    &parsed.trampolines,
+                );
             assert_eq!(
                 text, text2,
                 "round-trip mismatch\n=== printed ===\n{text}\n=== reparsed ===\n{text2}"
@@ -644,12 +681,9 @@ mod tests {
 
             let cache = SourceCache::single("<test>", source);
             let strings = elab.strings.entries();
-            let text = Printer::with_sources(&elab.defs, elab.resolver, &cache).program(
-                &elab.elaborated,
-                &strings,
-                &elab.records,
-                &elab.trampolines,
-            );
+            let text = Printer::with_sources(&elab.defs, elab.resolver, &cache)
+                .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             assert!(
                 text.contains("0 = \"<test>\";"),
                 "file table missing:\n{text}"
@@ -657,17 +691,31 @@ mod tests {
             assert!(text.contains(" in 0"), "item location missing:\n{text}");
             let parsed = parse_program(tcx, &text).expect("re-parse");
             assert_eq!(parsed.files, vec!["<test>".to_string()]);
+            assert_eq!(parsed.transform_anchors.len(), elab.transform_anchors.len());
+            assert_eq!(
+                parsed
+                    .transform_scripts
+                    .iter()
+                    .map(|script| (&script.body, script.file, script.span))
+                    .collect::<Vec<_>>(),
+                elab.transform_scripts
+                    .iter()
+                    .map(|script| (&script.body, script.file, script.span))
+                    .collect::<Vec<_>>()
+            );
             // Rebuild the render cache exactly as a driver would from the table.
             let mut cache2 = SourceCache::new();
             for name in &parsed.files {
                 cache2.add_unavailable(name);
             }
-            let text2 = Printer::with_sources(&parsed.defs, &parsed.names, &cache2).program(
-                &parsed.funcs,
-                &parsed.strings,
-                &parsed.records,
-                &parsed.trampolines,
-            );
+            let text2 = Printer::with_sources(&parsed.defs, &parsed.names, &cache2)
+                .with_transform_metadata(&parsed.transform_anchors, &parsed.transform_scripts)
+                .program(
+                    &parsed.funcs,
+                    &parsed.strings,
+                    &parsed.records,
+                    &parsed.trampolines,
+                );
             assert_eq!(
                 text, text2,
                 "lossless round-trip mismatch\n=== printed ===\n{text}\n=== reparsed ===\n{text2}"
@@ -757,6 +805,15 @@ mod tests {
         );
         roundtrip_with_locations(
             "pub fn g(x: f64) -> f64 { core::intrinsic::math::fpowi(x, 3, 1) }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_transform_metadata() {
+        roundtrip_with_locations(
+            "#[transform_anchor]\n\
+             pub fn transform(transform_anchor: i32) -> i32 { transform_anchor }\n\
+             transform [{\n  transform.yield\n}];",
         );
     }
 

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -20,6 +20,7 @@ Item: raw::Item = {
     <s:StringDecl> => raw::Item::String(s),
     <r:RecordDecl> => raw::Item::Record(r),
     <t:TrampDecl> => raw::Item::Tramp(t),
+    <t:TransformDecl> => raw::Item::Transform(t),
     <f:Func> => raw::Item::Func(f),
 };
 
@@ -79,7 +80,7 @@ Member: raw::Member = <n:(<"quoted"> ":")?> <f:"field"?> <t:Ty>
 
 /// An enum variant: its source name and ordered field types.
 Variant: raw::Variant =
-    <name:"ident"> "(" <fs:Comma<Ty>> ")" => raw::Variant { name: name.into(), fields: fs };
+    <name:Name> "(" <fs:Comma<Ty>> ")" => raw::Variant { name: name.into(), fields: fs };
 
 TrampDecl: raw::Tramp =
     "extern" <abi:"quoted"> "trampoline" <name:"quoted"> "=" "#" <target:PathArgs> ";"
@@ -90,10 +91,20 @@ TrampDecl: raw::Tramp =
         ty_args: target.1,
     };
 
+TransformDecl: raw::Transform =
+    "transform" <body:"quoted"> <loc:ItemLoc?> ";"
+    => raw::Transform {
+        body: unescape_debug_str(body).into_owned(),
+        file: loc.map(|l| l.0),
+        span: loc.and_then(|l| l.1),
+    };
+
 Func: raw::Func =
-    <p:"pub"?> <r:"regional"?> "fn" "#" <path:QPath> <generics:Generics?>
+    <a:("#" "[" "transform_anchor" "]")?> <p:"pub"?> <r:"regional"?>
+    "fn" "#" <path:QPath> <generics:Generics?>
     "(" <params:Comma<Param>> ")" "->" <ret:Ty> <loc:ItemLoc?> <body:Body>
     => raw::Func {
+        transform_anchor: a.is_some(),
         is_pub: p.is_some(),
         regional: r.is_some(),
         path,
@@ -109,7 +120,7 @@ Generics: Vec<raw::Generic> = "<" <CommaPlus<Generic>> ">";
 
 /// A fully-qualified item path: `a::b::Name`. Serialized with its segments
 /// joined; the rebuild pass splits them back into module + item name.
-QPath: String = <first:"ident"> <rest:("::" <"ident">)*> => {
+QPath: String = <first:Name> <rest:("::" <Name>)*> => {
     let mut s = first.to_string();
     for seg in rest {
         s.push_str("::");
@@ -122,14 +133,14 @@ QPath: String = <first:"ident"> <rest:("::" <"ident">)*> => {
 /// into one recursive production: after each `::` the next token — an
 /// identifier vs `<` — decides between another path segment and the
 /// type-argument list, which keeps the grammar LR(1).
-PathArgs: (String, Vec<raw::Ty>) = <first:"ident"> <tail:PathArgsTail> => {
+PathArgs: (String, Vec<raw::Ty>) = <first:Name> <tail:PathArgsTail> => {
     let (rest, args) = tail;
     (format!("{first}{rest}"), args)
 };
 
 PathArgsTail: (String, Vec<raw::Ty>) = {
     => (String::new(), Vec::new()),
-    "::" <seg:"ident"> <tail:PathArgsTail> => {
+    "::" <seg:Name> <tail:PathArgsTail> => {
         let (rest, args) = tail;
         (format!("::{seg}{rest}"), args)
     },
@@ -139,12 +150,19 @@ PathArgsTail: (String, Vec<raw::Ty>) = {
 Generic: raw::Generic = <r:"regional"?> <g:"generic">
     => raw::Generic { id: g, regional: r.is_some() };
 
+/// Source identifiers remain legal when they spell a transform directive.
+Name: &'input str = {
+    <name:"ident"> => name,
+    "transform" => "transform",
+    "transform_anchor" => "transform_anchor",
+};
+
 Body: Option<raw::Expr> = {
     "{" <b:Block> "}" => Some(b),
     ";" => None,
 };
 
-Param: raw::Param = <var:"var"> "(" <name:"ident"> ")" ":" <ty:Ty>
+Param: raw::Param = <var:"var"> "(" <name:Name> ")" ":" <ty:Ty>
     => raw::Param { var, name: name.into(), ty };
 
 // ----- types -----
@@ -198,7 +216,7 @@ Block: raw::Expr = <sp:Span?> <first:Expr> <rest:(";" <Expr>)*> => {
 /// block (a `Seq`) are the structural exceptions whose type is not printed.
 Expr: raw::Expr = {
     <a:Atom> ":" <t:Ty> <sp:Span?> => raw::Expr::new(a, t).with_span(sp),
-    "let" <sp:Span?> <var:"var"> "(" <name:"ident"> <nsp:Span?> ")" "=" <value:Expr>
+    "let" <sp:Span?> <var:"var"> "(" <name:Name> <nsp:Span?> ")" "=" <value:Expr>
         => raw::Expr::new(
             raw::Kind::Let { var, name: name.into(), name_span: nsp, value },
             raw::Ty::Unit,
@@ -231,7 +249,7 @@ Atom: raw::Kind = {
         => raw::Kind::CompoundCall { path: path.0, ty_args: path.1, args },
     "#" <path:PathArgs> "#" <v:"int"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::VariantCall { path: path.0, ty_args: path.1, variant: raw::small_usize(&v), args },
-    "intrinsic" "#" <family:"ident"> "#" <name:"ident"> "#" <imm:"int"> "(" <args:Comma<Expr>> ")"
+    "intrinsic" "#" <family:Name> "#" <name:Name> "#" <imm:"int"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::Intrinsic { family: family.to_string(), name: name.to_string(), imm: raw::small_u32(&imm), args },
     "array" "#" <op:"ident"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::ArrayOp { op: op.to_string(), args },
@@ -343,6 +361,8 @@ extern {
         "fixed" => Token::Fixed,
         "extern" => Token::Extern,
         "trampoline" => Token::Trampoline,
+        "transform" => Token::Transform,
+        "transform_anchor" => Token::TransformAnchor,
         "quoted" => Token::Quoted(<Cow<'input, str>>),
         "let" => Token::Let,
         "if" => Token::If,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -16,7 +16,7 @@ use pprint::{Doc, Printer as PpPrinter, hardline, indent, pprint};
 use reussir_syntax::kind::{Resolver, TokenKey};
 use reussir_syntax::source::SourceCache;
 
-use crate::semi::ctxt::{DefaultCap, Record, RecordFields, TrampolineRoot};
+use crate::semi::ctxt::{DefaultCap, Record, RecordFields, TrampolineRoot, TransformScript};
 use crate::semi::hir::{
     ArithOp, CmpOp, DecisionTree, Expr, ExprKind, Function, PatVarRef, SwitchCases, VarId,
 };
@@ -41,6 +41,8 @@ pub struct Printer<'a> {
     /// Without it the dump is the bare program (human display, e.g. the
     /// REPL's `:dump context`).
     sources: Option<&'a SourceCache>,
+    transform_anchors: &'a [DefId],
+    transform_scripts: &'a [TransformScript],
 }
 
 impl<'a> Printer<'a> {
@@ -49,6 +51,8 @@ impl<'a> Printer<'a> {
             defs,
             resolver,
             sources: None,
+            transform_anchors: &[],
+            transform_scripts: &[],
         }
     }
 
@@ -62,7 +66,20 @@ impl<'a> Printer<'a> {
             defs,
             resolver,
             sources: Some(sources),
+            transform_anchors: &[],
+            transform_scripts: &[],
         }
+    }
+
+    /// Attach module transform metadata to the next program rendering.
+    pub fn with_transform_metadata(
+        mut self,
+        anchors: &'a [DefId],
+        scripts: &'a [TransformScript],
+    ) -> Self {
+        self.transform_anchors = anchors;
+        self.transform_scripts = scripts;
+        self
     }
 
     /// Render the resumable Semi output: record declarations, trampoline roots,
@@ -77,26 +94,33 @@ impl<'a> Printer<'a> {
     ) -> String {
         let mut items: Vec<Doc<'static>> = Vec::new();
         if let Some(cache) = self.sources {
-            for id in cache.ids() {
-                items.push(text(format!("{} = {:?};", id.index(), cache.name(id))));
-            }
+            items.extend(
+                cache
+                    .ids()
+                    .map(|id| text(format!("{} = {:?};", id.index(), cache.name(id)))),
+            );
         }
-        for (token, payload) in strings {
-            items.push(string_decl(*token, payload));
-        }
+        items.extend(
+            strings
+                .iter()
+                .map(|(token, payload)| string_decl(*token, payload)),
+        );
         let mut recs: Vec<&Record<'_>> = records.values().collect();
         // Sort by qualified path (phase-canonical: identical across the original
         // elaboration and a reparse, unlike the session-local `DefId`).
         recs.sort_by_key(|r| self.path(r.def));
-        for r in recs {
-            items.push(self.record(r));
-        }
-        for t in trampolines {
-            items.push(self.trampoline(t));
-        }
-        for f in funcs {
-            items.push(self.function(f));
-        }
+        items.extend(recs.into_iter().map(|record| self.record(record)));
+        items.extend(
+            trampolines
+                .iter()
+                .map(|trampoline| self.trampoline(trampoline)),
+        );
+        items.extend(
+            self.transform_scripts
+                .iter()
+                .map(|script| self.transform(script)),
+        );
+        items.extend(funcs.iter().map(|function| self.function(function)));
 
         let mut doc = Doc::Null;
         for (i, item) in items.into_iter().enumerate() {
@@ -212,8 +236,17 @@ impl<'a> Printer<'a> {
             + text(";")
     }
 
+    fn transform(&self, script: &TransformScript) -> Doc<'static> {
+        text(format!("transform {:?}", script.body))
+            + self.item_loc(script.file, script.span)
+            + text(";")
+    }
+
     fn function(&self, f: &Function<'_>) -> Doc<'static> {
         let mut head = String::new();
+        if self.transform_anchors.contains(&f.def) {
+            head.push_str("#[transform_anchor] ");
+        }
         if f.visibility == Visibility::Public {
             head.push_str("pub ");
         }

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -19,6 +19,7 @@ pub struct Program {
     pub strings: Vec<StringEntry>,
     pub records: Vec<Record>,
     pub trampolines: Vec<Tramp>,
+    pub transforms: Vec<Transform>,
     pub funcs: Vec<Func>,
 }
 
@@ -29,6 +30,7 @@ pub enum Item {
     String(StringEntry),
     Record(Record),
     Tramp(Tramp),
+    Transform(Transform),
     Func(Func),
 }
 
@@ -39,6 +41,7 @@ impl Program {
             strings: Vec::new(),
             records: Vec::new(),
             trampolines: Vec::new(),
+            transforms: Vec::new(),
             funcs: Vec::new(),
         };
         for item in items {
@@ -47,6 +50,7 @@ impl Program {
                 Item::String(s) => p.strings.push(s),
                 Item::Record(r) => p.records.push(r),
                 Item::Tramp(t) => p.trampolines.push(t),
+                Item::Transform(t) => p.transforms.push(t),
                 Item::Func(f) => p.funcs.push(f),
             }
         }
@@ -121,7 +125,15 @@ pub struct Tramp {
 }
 
 #[derive(Clone, Debug)]
+pub struct Transform {
+    pub body: String,
+    pub file: Option<u32>,
+    pub span: Option<Span>,
+}
+
+#[derive(Clone, Debug)]
 pub struct Func {
+    pub transform_anchor: bool,
     pub is_pub: bool,
     pub regional: bool,
     pub path: String,

--- a/crates/reussir-repl/src/commands.rs
+++ b/crates/reussir-repl/src/commands.rs
@@ -64,12 +64,9 @@ pub fn dispatch(session: &mut ReplSession<'_, '_>, command: &str) -> Outcome {
                     .map(|(k, v)| (*k, v.clone()))
                     .collect();
                 let strings = elab.strings.entries();
-                let text = Printer::new(&elab.defs, elab.resolver).program(
-                    &funcs,
-                    &strings,
-                    &records,
-                    &elab.trampolines,
-                );
+                let text = Printer::new(&elab.defs, elab.resolver)
+                    .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
+                    .program(&funcs, &strings, &records, &elab.trampolines);
                 Outcome::Text(text)
             }
             Some("compiled") => {


### PR DESCRIPTION
[hir] preserve inline transform metadata

Carries function anchors and module transform scripts through textual HIR, including optional source spans, and preserves them through compiler and REPL HIR emission and re-entry.

Cumulative stack layer 3/6; includes syntax and frontend layers. Base: `main`.

Tests:
- `cargo test --locked -p reussir-core`
- `cmake --build build --target rrc-test rrepl-test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786387734&installation_id=144622820&pr_number=388&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F388&signature=b8ab3236d2880ad6319436fd2bd10eee71bd196c94518e228e6428f9d431606d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->