### PR TITLE
[mir] preserve inline transform metadata

### DIFF
--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -839,6 +839,8 @@ fn frontend<'c, 'tcx>(
                 elaborated: &parsed.funcs,
                 records: &parsed.records,
                 trampolines: &parsed.trampolines,
+                transform_anchors: &parsed.transform_anchors,
+                transform_scripts: &parsed.transform_scripts,
                 strings: parsed.strings.clone(),
             };
             let (full, reports) = monomorphize(&input);

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -20,7 +20,7 @@ use reussir_syntax::kind::TokenKey;
 use reussir_syntax::source::FileId;
 
 use crate::literal::{FloatLit, Integer};
-use crate::semi::ctxt::DefaultCap;
+use crate::semi::ctxt::{DefaultCap, TransformScript};
 use crate::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use crate::semi::ty::Ty;
 use crate::surface::{Span, Visibility};
@@ -58,6 +58,7 @@ pub struct Program<'tcx> {
     pub records: Vec<RecordInstance<'tcx>>,
     pub trampolines: Vec<Trampoline>,
     pub string_literals: Vec<(StringToken, String)>,
+    pub transform_scripts: Vec<TransformScript>,
     /// Interner backing every [`Symbol`] in this program.
     pub symbols: Rodeo,
 }
@@ -73,6 +74,7 @@ impl<'tcx> Program<'tcx> {
 #[derive(Clone, Debug)]
 pub struct Function<'tcx> {
     pub symbol: Symbol,
+    pub transform_anchor: bool,
     pub visibility: Visibility,
     pub is_regional: bool,
     pub params: Vec<Param<'tcx>>,

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -16,7 +16,7 @@ use rustc_hash::FxHashMap;
 
 use crate::full::mir::{self, grammar as ir, raw};
 use crate::ir_lex::lex;
-use crate::semi::ctxt::DefaultCap;
+use crate::semi::ctxt::{DefaultCap, TransformScript};
 use crate::semi::hir::{ArithOp, CmpOp, VarId};
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{Flexivity, FpTy, IntTy, Ty, TyCtxt, TyKind};
@@ -80,6 +80,11 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
     }
     for f in &raw.funcs {
         if let Some(id) = file_ref_check(&files, f.file) {
+            return Err(id);
+        }
+    }
+    for t in &raw.transforms {
+        if let Some(id) = file_ref_check(&files, t.file) {
             return Err(id);
         }
     }
@@ -185,6 +190,21 @@ impl<'tcx> Builder<'_, 'tcx> {
             })
             .collect();
         let functions: Vec<mir::Function<'tcx>> = raw.funcs.iter().map(|f| self.func(f)).collect();
+        let transform_scripts = raw
+            .transforms
+            .into_iter()
+            .map(|script| TransformScript {
+                body: script.body,
+                span: script
+                    .span
+                    .map(|(start, end)| crate::surface::Span { start, end }),
+                file: script
+                    .file
+                    .map_or(reussir_syntax::source::FileId::ROOT, |index| {
+                        reussir_syntax::source::FileId::from_index(index)
+                    }),
+            })
+            .collect();
 
         // Move the freshly-built symbol interner into the program.
         let symbols = std::mem::take(&mut self.symbols);
@@ -193,6 +213,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             records,
             trampolines,
             string_literals,
+            transform_scripts,
             symbols,
         }
     }
@@ -215,6 +236,7 @@ impl<'tcx> Builder<'_, 'tcx> {
         let body = f.body.as_ref().map(|b| self.expr_ref(b));
         mir::Function {
             symbol,
+            transform_anchor: f.transform_anchor,
             visibility: if f.is_pub {
                 crate::surface::Visibility::Public
             } else {
@@ -547,7 +569,7 @@ fn cmp(op: raw::CmpOp) -> CmpOp {
 fn file_ref_check(files: &[String], file: Option<u32>) -> Option<String> {
     match file {
         Some(id) if id as usize >= files.len() => Some(format!(
-            "function references file {id}, but the source-file table has {} entr(y/ies)",
+            "item references file {id}, but the source-file table has {} entr(y/ies)",
             files.len()
         )),
         _ => None,
@@ -577,6 +599,30 @@ mod tests {
 
             let text = Printer::new(&elab.defs, elab.resolver).program(&full);
             let parsed = parse_program(tcx, &text).expect("re-parse");
+            assert_eq!(
+                parsed
+                    .program
+                    .functions
+                    .iter()
+                    .filter(|function| function.transform_anchor)
+                    .count(),
+                full.functions
+                    .iter()
+                    .filter(|function| function.transform_anchor)
+                    .count()
+            );
+            assert_eq!(
+                parsed
+                    .program
+                    .transform_scripts
+                    .iter()
+                    .map(|script| &script.body)
+                    .collect::<Vec<_>>(),
+                full.transform_scripts
+                    .iter()
+                    .map(|script| &script.body)
+                    .collect::<Vec<_>>()
+            );
             let text2 = Printer::new(&parsed.defs, &parsed.names).program(&parsed.program);
             assert_eq!(
                 text, text2,
@@ -608,6 +654,18 @@ mod tests {
             assert!(text.contains(" in 0"), "fn file reference missing:\n{text}");
             let parsed = parse_program(tcx, &text).expect("re-parse");
             assert_eq!(parsed.files, vec!["<test>".to_string()]);
+            assert_eq!(
+                parsed
+                    .program
+                    .transform_scripts
+                    .iter()
+                    .map(|script| (&script.body, script.file, script.span))
+                    .collect::<Vec<_>>(),
+                full.transform_scripts
+                    .iter()
+                    .map(|script| (&script.body, script.file, script.span))
+                    .collect::<Vec<_>>()
+            );
             let mut cache2 = SourceCache::new();
             for name in &parsed.files {
                 cache2.add_unavailable(name);
@@ -681,6 +739,15 @@ mod tests {
                 core::intrinsic::array::set(a, i, core::intrinsic::array::get(a, i) + v)
             }
             "#,
+        );
+    }
+
+    #[test]
+    fn roundtrips_transform_metadata() {
+        roundtrip_with_locations(
+            "#[transform_anchor]\n\
+             pub fn transform(transform_anchor: i32) -> i32 { transform_anchor }\n\
+             transform [{\n  transform.yield\n}];",
         );
     }
 

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -22,6 +22,7 @@ Item: raw::Item = {
     <f:Func> => raw::Item::Func(f),
     "extern" <abi:"quoted"> "trampoline" <export:"quoted"> "=" "@" <target:Sym> ";"
         => raw::Item::Tramp(raw::Tramp { abi: abi.into(), export: export.into(), target }),
+    <t:TransformDecl> => raw::Item::Transform(t),
 };
 
 /// One source-file table entry: `0 = "src/lib.rr";`. Spans are byte offsets
@@ -33,8 +34,19 @@ FileDecl: raw::FileEntry = <id:"int"> "=" <name:"quoted"> ";"
 StringDecl: raw::StringEntry = <token:StrWords> "=" <payload:"quoted"> ";"
     => raw::StringEntry { token, payload: unescape_debug_str(payload).into_owned() };
 
+TransformDecl: raw::Transform =
+    "transform" <body:"quoted"> <loc:ItemLoc?> ";"
+    => raw::Transform {
+        body: unescape_debug_str(body).into_owned(),
+        file: loc.map(|l| l.0),
+        span: loc.and_then(|l| l.1),
+    };
+
 /// A source span: `[start..end]`, byte offsets into the owning item's file.
 Span: raw::Span = "[" <s:"int"> ".." <e:"int"> "]" => (raw::small_u32(&s), raw::small_u32(&e));
+
+ItemLoc: (u32, Option<raw::Span>) =
+    "in" <f:"int"> <sp:Span?> => (raw::small_u32(&f), sp);
 
 /// The capability a record declares by default.
 DefCap: raw::DefCap = {
@@ -61,16 +73,24 @@ Member: raw::Member = <n:(<"quoted"> ":")?> <f:"field"?> <t:Ty>
 /// An enum variant: its mangled payload symbol, source name, and ordered field
 /// types.
 Variant: raw::Variant =
-    "@" <symbol:Sym> <name:"ident"> "(" <fs:Comma<Ty>> ")"
+    "@" <symbol:Sym> <name:Name> "(" <fs:Comma<Ty>> ")"
         => raw::Variant { symbol, name: name.into(), fields: fs };
 
 /// A symbol body (after `@`).
 Sym: String = <s:"ident"> => s.into();
 
+Name: &'input str = {
+    <name:"ident"> => name,
+    "transform" => "transform",
+    "transform_anchor" => "transform_anchor",
+};
+
 Func: raw::Func =
-    <p:"pub"?> <r:"regional"?> "fn" "@" <symbol:Sym>
+    <a:("#" "[" "transform_anchor" "]")?> <p:"pub"?> <r:"regional"?>
+    "fn" "@" <symbol:Sym>
     "(" <params:Comma<Param>> ")" "->" <ret:Ty> <file:("in" <"int">)?> <body:Body>
     => raw::Func {
+        transform_anchor: a.is_some(),
         is_pub: p.is_some(),
         regional: r.is_some(),
         symbol,
@@ -86,7 +106,7 @@ Body: Option<raw::Expr> = {
 };
 
 Param: raw::Param =
-    <var:"var"> "(" <name:"ident"> ")" ":" <ty:Ty>
+    <var:"var"> "(" <name:Name> ")" ":" <ty:Ty>
     => raw::Param { var, name: name.into(), ty };
 
 // ----- types -----
@@ -115,14 +135,14 @@ Ty: raw::Ty = {
 /// (`pkg::m::Cell::<u64>`), factored into one recursive production so the
 /// grammar stays LR(1): after each `::` the next token — an identifier vs
 /// `<` — decides between another path segment and the type-argument list.
-TyPathArgs: (String, Vec<raw::Ty>) = <first:"ident"> <tail:TyPathArgsTail> => {
+TyPathArgs: (String, Vec<raw::Ty>) = <first:Name> <tail:TyPathArgsTail> => {
     let (rest, args) = tail;
     (format!("{first}{rest}"), args)
 };
 
 TyPathArgsTail: (String, Vec<raw::Ty>) = {
     => (String::new(), Vec::new()),
-    "::" <seg:"ident"> <tail:TyPathArgsTail> => {
+    "::" <seg:Name> <tail:TyPathArgsTail> => {
         let (rest, args) = tail;
         (format!("::{seg}{rest}"), args)
     },
@@ -161,7 +181,7 @@ Block: raw::Expr = <sp:Span?> <first:Expr> <rest:(";" <Expr>)*> => {
 /// block (a `Seq`) are the two structural exceptions.
 Expr: raw::Expr = {
     <a:Atom> ":" <t:Ty> <sp:Span?> => raw::Expr::new(a, t).with_span(sp),
-    "let" <sp:Span?> <var:"var"> "(" <name:"ident"> ")" "=" <value:Expr>
+    "let" <sp:Span?> <var:"var"> "(" <name:Name> ")" "=" <value:Expr>
         => raw::Expr::new(raw::Kind::Let { var, name: name.into(), value }, raw::Ty::Unit)
             .with_span(sp),
     "{" <b:Block> "}" => b,
@@ -191,7 +211,7 @@ Atom: raw::Kind = {
     "@" <symbol:Sym> "{" <args:Comma<Expr>> "}" => raw::Kind::Ctor { symbol, args },
     "@" <symbol:Sym> "::" "#" <v:"int"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::Variant { symbol, variant: raw::small_usize(&v), args },
-    "intrinsic" "#" <family:"ident"> "#" <name:"ident"> "#" <imm:"int"> "(" <args:Comma<Expr>> ")"
+    "intrinsic" "#" <family:Name> "#" <name:Name> "#" <imm:"int"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::Intrinsic { family: family.to_string(), name: name.to_string(), imm: raw::small_u32(&imm), args },
     "array" "#" <op:"ident"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::ArrayOp { op: op.to_string(), args },
@@ -308,6 +328,8 @@ extern {
         "fixed" => Token::Fixed,
         "extern" => Token::Extern,
         "trampoline" => Token::Trampoline,
+        "transform" => Token::Transform,
+        "transform_anchor" => Token::TransformAnchor,
         "let" => Token::Let,
         "if" => Token::If,
         "then" => Token::Then,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -78,27 +78,39 @@ impl<'a> Printer<'a> {
 
         let mut items: Vec<Doc<'static>> = Vec::new();
         if let Some(cache) = self.sources {
-            for id in cache.ids() {
-                items.push(text(format!("{} = {:?};", id.index(), cache.name(id))));
-            }
+            items.extend(
+                cache
+                    .ids()
+                    .map(|id| text(format!("{} = {:?};", id.index(), cache.name(id)))),
+            );
         }
-        for (token, payload) in &program.string_literals {
-            items.push(string_decl(*token, payload));
-        }
-        for rec in &program.records {
-            items.push(r.record(rec));
-        }
-        for func in &program.functions {
-            items.push(r.function(func));
-        }
-        for t in &program.trampolines {
-            items.push(text(format!(
+        items.extend(
+            program
+                .string_literals
+                .iter()
+                .map(|(token, payload)| string_decl(*token, payload)),
+        );
+        items.extend(program.records.iter().map(|record| r.record(record)));
+        items.extend(
+            program
+                .transform_scripts
+                .iter()
+                .map(|script| r.transform(script)),
+        );
+        items.extend(
+            program
+                .functions
+                .iter()
+                .map(|function| r.function(function)),
+        );
+        items.extend(program.trampolines.iter().map(|trampoline| {
+            text(format!(
                 "extern \"{}\" trampoline \"{}\" = @{};",
-                t.abi,
-                r.sym(t.export),
-                r.sym(t.target),
-            )));
-        }
+                trampoline.abi,
+                r.sym(trampoline.export),
+                r.sym(trampoline.target),
+            ))
+        }));
 
         // One blank line between top-level items.
         let mut doc = Doc::Null;
@@ -189,6 +201,9 @@ impl Render<'_> {
 
     fn function(&self, func: &mir::Function<'_>) -> Doc<'static> {
         let mut head = String::new();
+        if func.transform_anchor {
+            head.push_str("#[transform_anchor] ");
+        }
         if func.visibility == Visibility::Public {
             head.push_str("pub ");
         }
@@ -220,6 +235,18 @@ impl Render<'_> {
             }
             None => sig + text(";"),
         }
+    }
+
+    fn transform(&self, script: &crate::semi::ctxt::TransformScript) -> Doc<'static> {
+        let loc = if self.sources.is_some() {
+            let span = script.span.map_or_else(String::new, |span| {
+                format!(" [{}..{}]", span.start, span.end)
+            });
+            format!(" in {}{span}", script.file.index())
+        } else {
+            String::new()
+        };
+        text(format!("transform {:?}{loc};", script.body))
     }
 
     // ----- types -----

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -68,6 +68,7 @@ pub struct Program {
     pub records: Vec<RecordDecl>,
     pub funcs: Vec<Func>,
     pub trampolines: Vec<Tramp>,
+    pub transforms: Vec<Transform>,
 }
 
 /// One top-level item, as the grammar yields them before partitioning.
@@ -78,6 +79,7 @@ pub enum Item {
     Record(RecordDecl),
     Func(Func),
     Tramp(Tramp),
+    Transform(Transform),
 }
 
 /// A ground record declaration: its v0 symbol, the capability it declares by
@@ -141,6 +143,7 @@ impl Program {
             records: Vec::new(),
             funcs: Vec::new(),
             trampolines: Vec::new(),
+            transforms: Vec::new(),
         };
         for item in items {
             match item {
@@ -149,6 +152,7 @@ impl Program {
                 Item::Record(r) => p.records.push(r),
                 Item::Func(f) => p.funcs.push(f),
                 Item::Tramp(t) => p.trampolines.push(t),
+                Item::Transform(t) => p.transforms.push(t),
             }
         }
         p
@@ -157,6 +161,7 @@ impl Program {
 
 #[derive(Clone, Debug)]
 pub struct Func {
+    pub transform_anchor: bool,
     pub is_pub: bool,
     pub regional: bool,
     pub symbol: String,
@@ -180,6 +185,13 @@ pub struct Tramp {
     pub abi: String,
     pub export: String,
     pub target: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct Transform {
+    pub body: String,
+    pub file: Option<u32>,
+    pub span: Option<Span>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -52,7 +52,7 @@ use crate::full::mir;
 use crate::full::subst::{Subst, subst_ty};
 use crate::literal;
 use crate::semi::ctxt::{
-    DefaultCap, Elaborator, Record, RecordFields, Report, Severity, TrampolineRoot,
+    DefaultCap, Elaborator, Record, RecordFields, Report, Severity, TrampolineRoot, TransformScript,
 };
 use crate::semi::hir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::resolve::DefTable;
@@ -72,6 +72,8 @@ pub struct MonoInput<'a, 'tcx> {
     pub elaborated: &'a [Function<'tcx>],
     pub records: &'a FxHashMap<DefId, Record<'tcx>>,
     pub trampolines: &'a [TrampolineRoot<'tcx>],
+    pub transform_anchors: &'a [DefId],
+    pub transform_scripts: &'a [TransformScript],
     pub strings: Vec<(StringToken, String)>,
 }
 
@@ -85,6 +87,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             elaborated: &self.elaborated,
             records: &self.records,
             trampolines: &self.trampolines,
+            transform_anchors: &self.transform_anchors,
+            transform_scripts: &self.transform_scripts,
             strings: self.strings.entries(),
         }
     }
@@ -172,6 +176,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         let symbol = driver.symbol_of(inst.def, inst.ty_args);
         functions.push(mir::Function {
             symbol,
+            transform_anchor: input.transform_anchors.contains(&func.def),
             visibility: func.visibility,
             is_regional: func.is_regional,
             params,
@@ -267,6 +272,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             records,
             trampolines,
             string_literals: input.strings.clone(),
+            transform_scripts: input.transform_scripts.to_vec(),
             symbols,
         },
         reports,
@@ -1058,12 +1064,9 @@ mod tests {
 
             // Serialize the HIR, parse it back, and monomorphize *that*.
             let strings = elab.strings.entries();
-            let hir_text = HirPrinter::new(&elab.defs, elab.resolver).program(
-                &elab.elaborated,
-                &strings,
-                &elab.records,
-                &elab.trampolines,
-            );
+            let hir_text = HirPrinter::new(&elab.defs, elab.resolver)
+                .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             let parsed = parse_program(tcx, &hir_text).expect("re-parse HIR");
             let input = MonoInput {
                 tcx,
@@ -1072,6 +1075,8 @@ mod tests {
                 elaborated: &parsed.funcs,
                 records: &parsed.records,
                 trampolines: &parsed.trampolines,
+                transform_anchors: &parsed.transform_anchors,
+                transform_scripts: &parsed.transform_scripts,
                 strings: parsed.strings.clone(),
             };
             let (mir1, r1) = monomorphize(&input);
@@ -1153,19 +1158,13 @@ mod tests {
 
             // ----- print HIR + round-trip it through the parser -----
             let strings = elab.strings.entries();
-            let hir_text = HirPrinter::new(&elab.defs, elab.resolver).program(
-                &elab.elaborated,
-                &strings,
-                &elab.records,
-                &elab.trampolines,
-            );
+            let hir_text = HirPrinter::new(&elab.defs, elab.resolver)
+                .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             let hir = parse_hir(tcx, &hir_text).expect("re-parse HIR");
-            let hir_text2 = HirPrinter::new(&hir.defs, &hir.names).program(
-                &hir.funcs,
-                &hir.strings,
-                &hir.records,
-                &hir.trampolines,
-            );
+            let hir_text2 = HirPrinter::new(&hir.defs, &hir.names)
+                .with_transform_metadata(&hir.transform_anchors, &hir.transform_scripts)
+                .program(&hir.funcs, &hir.strings, &hir.records, &hir.trampolines);
             assert_eq!(
                 hir_text, hir_text2,
                 "HIR round-trip mismatch\n=== printed ===\n{hir_text}\n=== reparsed ===\n{hir_text2}"
@@ -1179,6 +1178,8 @@ mod tests {
                 elaborated: &hir.funcs,
                 records: &hir.records,
                 trampolines: &hir.trampolines,
+                transform_anchors: &hir.transform_anchors,
+                transform_scripts: &hir.transform_scripts,
                 strings: hir.strings.clone(),
             };
             let (mir_resumed, r_resumed) = monomorphize(&resumed_input);
@@ -1292,6 +1293,28 @@ mod tests {
             let mut sorted = syms.clone();
             sorted.dedup();
             assert_eq!(sorted.len(), syms.len(), "duplicate instances: {syms:?}");
+        });
+    }
+
+    #[test]
+    fn transform_anchor_marks_each_generic_instance() {
+        let src = r#"
+            #[transform_anchor]
+            fn id<T>(x: T) -> T { x }
+            pub fn use_i32(n: i32) -> i32 { id(n) }
+            pub fn use_bool(b: bool) -> bool { id(b) }
+            transform [{ transform.yield }];
+        "#;
+        with_full(src, |full| {
+            assert_eq!(
+                full.functions
+                    .iter()
+                    .filter(|function| function.transform_anchor)
+                    .count(),
+                2
+            );
+            assert_eq!(full.transform_scripts.len(), 1);
+            assert_eq!(full.transform_scripts[0].body, "{ transform.yield }");
         });
     }
 

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -361,6 +361,7 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
         let body = self.tcx.alloc(body);
         Function {
             symbol,
+            transform_anchor: false,
             visibility: Visibility::Private,
             is_regional: false,
             params,

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -610,7 +610,7 @@ fn file_of(f: Option<u32>) -> FileId {
 fn file_ref_check(files: &[String], file: Option<u32>) -> Option<String> {
     match file {
         Some(id) if id as usize >= files.len() => Some(format!(
-            "function references file {id}, but the source-file table has {} entr(y/ies)",
+            "item references file {id}, but the source-file table has {} entr(y/ies)",
             files.len()
         )),
         _ => None,


### PR DESCRIPTION
[mir] preserve inline transform metadata

Propagates anchor markers through monomorphization to every emitted generic instance, carries scripts into MIR, and round-trips both forms through textual MIR and HIR-to-MIR compiler re-entry.

Cumulative stack layer 4/6; includes syntax, frontend, and HIR layers. Base: `main`.

Tests:
- `cargo test --locked -p reussir-core`
- `cmake --build build --target rrc-test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786387741&installation_id=144622820&pr_number=389&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F389&signature=8a4f7aec99fac9042e88304c252f5179d5d8eeefb772caf2ed63337d18b3bea1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->