### PR TITLE
[pipeline] run inline transform schedules

### DIFF
--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -9,7 +9,8 @@
 use std::path::PathBuf;
 
 use melior::Context;
-use melior::ir::Module;
+use melior::ir::operation::{OperationLike, OperationMutLike};
+use melior::ir::{BlockLike, Identifier, Module, Operation};
 use melior::pass::{Pass, PassManager};
 
 use reussir_backend_sys as sys;
@@ -266,6 +267,12 @@ pub fn run_lowering_pipeline(
     module: &mut Module,
     options: &LoweringOptions,
 ) -> Result<(), melior::Error> {
+    let inline_transform = module.as_operation().has_attribute(INLINE_TRANSFORM_ATTR);
+    if inline_transform {
+        let _ = module
+            .as_operation_mut()
+            .remove_attribute(INLINE_TRANSFORM_ATTR);
+    }
     let _span = tracing::debug_span!(
         "reussir_lowering",
         opt = ?options.opt,
@@ -273,6 +280,7 @@ pub fn run_lowering_pipeline(
         enable_invariant_analysis = options.enable_invariant_analysis,
         nullary_variant_encoding = ?options.nullary_variant_encoding,
         pack_record_members = options.pack_record_members,
+        inline_transform,
     )
     .entered();
 
@@ -375,6 +383,11 @@ pub fn run_lowering_pipeline(
         // begun — array kernels are plain memref/scf/arith loop nests, the
         // transform dialect's home turf. Runs before the invariant analysis
         // so that pass sees the scheduled IR.
+        if inline_transform => {
+            module: sys::reussirCreateTransformInterpreterPass(
+                string_ref(INLINE_TRANSFORM_ENTRY_POINT),
+            );
+        }
         if at_anchor(Anchor::Kernel) => {
             module: sys::reussirCreateTransformInterpreterPass(
                 string_ref(Anchor::Kernel.entry_point()),
@@ -402,11 +415,33 @@ pub fn run_lowering_pipeline(
 
     tracing::trace!("running Reussir lowering pipeline");
     let result = manager.run(module);
+    if result.is_ok() && inline_transform {
+        erase_inline_transform_schedule(context, module);
+    }
     match &result {
         Ok(()) => tracing::debug!("lowered module to the LLVM dialect"),
         Err(error) => tracing::error!(?error, "lowering pipeline failed"),
     }
     result
+}
+
+fn erase_inline_transform_schedule(context: &Context, module: &mut Module) {
+    let sequence = Identifier::new(context, "transform.named_sequence");
+    let body = module.body();
+    let mut operation = body.first_operation_mut();
+    while let Some(mut current) = operation {
+        operation = current.next_in_block_mut();
+        if current.name() == sequence {
+            let raw = current.to_raw();
+            current.remove_from_parent();
+            // SAFETY: detaching leaves this live operation without an owner;
+            // wrapping it transfers ownership so dropping destroys it.
+            drop(unsafe { Operation::from_raw(raw) });
+        }
+    }
+    let _ = module
+        .as_operation_mut()
+        .remove_attribute("transform.with_named_sequence");
 }
 
 #[cfg(test)]
@@ -435,6 +470,47 @@ mod tests {
         // After lowering, the function is an llvm.func rather than a func.func.
         let rendered = module.as_operation().to_string();
         assert!(rendered.contains("llvm.func @answer"), "got:\n{rendered}");
+    }
+
+    #[test]
+    fn runs_and_erases_inline_transform_schedule() {
+        let context = crate::context();
+        let source = r#"
+            module attributes {
+                reussir.inline_transform,
+                transform.with_named_sequence
+            } {
+              func.func @answer() -> i32 attributes {reussir.transform_anchor} {
+                %0 = arith.constant 42 : i32
+                func.return %0 : i32
+              }
+              transform.named_sequence @__reussir_inline_0(
+                  %target: !transform.any_op {transform.readonly}) {
+                transform.annotate %target "reussir.inline_ran" : !transform.any_op
+                transform.yield
+              }
+              transform.named_sequence @__reussir_inline_transform(
+                  %module: !transform.any_op {transform.readonly}) {
+                %target = transform.structured.match ops{["func.func"]}
+                    attributes{reussir.transform_anchor} in %module
+                    : (!transform.any_op) -> !transform.any_op
+                transform.include @__reussir_inline_0 failures(propagate) (%target)
+                    : (!transform.any_op) -> ()
+                transform.yield
+              }
+            }
+        "#;
+        let mut module = Module::parse(&context, source).expect("module should parse");
+        run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
+            .expect("pipeline should succeed");
+        let rendered = module.as_operation().to_string();
+        assert!(rendered.contains("reussir.inline_ran"), "{rendered}");
+        assert!(!rendered.contains("transform.named_sequence"), "{rendered}");
+        assert!(
+            !rendered.contains("transform.with_named_sequence"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains(INLINE_TRANSFORM_ATTR), "{rendered}");
     }
 
     // A loop-nest kernel of the shape the `kernel` anchor guarantees: by the

--- a/tests/integration/frontend/inline_transform.rr
+++ b/tests/integration/frontend/inline_transform.rr
@@ -1,0 +1,49 @@
+// Inline schedules survive HIR/MIR reload and run at the kernel anchor. The
+// rank-2 array splat supplies a predictable perfect loop nest. Navigating from
+// its store to the outer loop and unrolling-and-jamming it proves that the
+// schedule rewrites payload IR rather than merely being parsed.
+//
+// RUN: %rrc %s --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=EMBED
+// RUN: %rrc %s --emit hir --no-source-locations -o %t.hir
+// RUN: %rrc %t.hir --from hir --emit mir --no-source-locations -o %t.mir
+// RUN: %rrc %t.mir --from mir --emit mlir-llvm --no-source-locations -O none -o - \
+// RUN:   | %FileCheck %s --check-prefix=LOWER
+// RUN: %rrc %t.mir --from mir --emit llvm-ir -O none -o %t.ll
+
+#[transform_anchor]
+pub fn target() -> [i64; 4, 16] {
+    core::intrinsic::array::splat<[i64; 4, 16]>(7)
+}
+
+transform [{
+    transform.annotate %target "reussir.inline_ran" : !transform.any_op
+    %stores = transform.structured.match ops{["memref.store"]} in %target
+        : (!transform.any_op) -> !transform.op<"memref.store">
+    %outer = transform.get_parent_op %stores {
+        op_name = "scf.for", nth_parent = 2 : i64, deduplicate
+    } : (!transform.op<"memref.store">) -> !transform.op<"scf.for">
+    transform.loop.unroll_and_jam %outer { factor = 2 }
+        : !transform.op<"scf.for">
+    transform.yield
+}];
+
+// EMBED: module attributes {reussir.inline_transform, transform.with_named_sequence}
+// EMBED: func.func @_RC6target
+// EMBED-SAME: attributes {no_inline, reussir.transform_anchor}
+// EMBED: transform.named_sequence @__reussir_inline_0
+// EMBED: transform.annotate
+// EMBED: transform.structured.match ops{["memref.store"]}
+// EMBED: transform.get_parent_op
+// EMBED: transform.loop.unroll_and_jam
+// EMBED: transform.named_sequence @__reussir_inline_transform
+
+// LOWER-NOT: transform.named_sequence
+// LOWER-LABEL: llvm.func @_RC6target
+// LOWER-SAME: attributes {reussir.inline_ran, reussir.transform_anchor}
+// LOWER-DAG: %[[OUTER_STEP:.+]] = llvm.mlir.constant(2 : index) : i64
+// LOWER-COUNT-2: llvm.store %{{.+}}, %{{.+}} : i64, !llvm.ptr
+// LOWER-NOT: llvm.store %{{.+}}, %{{.+}} : i64, !llvm.ptr
+// LOWER: llvm.add %{{.+}}, %[[OUTER_STEP]] : i64
+// LOWER-NOT: llvm.store %{{.+}}, %{{.+}} : i64, !llvm.ptr
+// LOWER: llvm.return
+// LOWER-NOT: transform.named_sequence


### PR DESCRIPTION
[pipeline] run inline transform schedules

Runs the compiler-generated inline transform dispatcher at the existing kernel pipeline anchor before any optional external kernel script. After successful lowering, it erases the embedded named sequences and their module markers so LLVM translation sees only payload IR.

The end-to-end lit test now exercises a real array schedule instead of annotation alone: a rank-2 `array::splat` loop nest is located through `transform.get_parent_op`, rewritten with `transform.loop.unroll_and_jam`, round-tripped through HIR and MIR, lowered to two jammed stores with an outer step of two, and translated to LLVM IR.

Rebased onto current `main`; this PR now contains only the final pipeline layer.

Tests:

- `ninja -C build reussir-backend-test` (10 passed; 1 environment-gated test ignored)
- `./reussir-ut` from `build/bin` (17/17 passed)
- focused lit: `frontend/inline_transform.rr` (1/1 passed)
- `cargo fmt --check -p reussir-backend`
