### PR TITLE
[backend] closure beta reduction: inline loop-carried redexes

### DIFF
--- a/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
+++ b/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
@@ -36,6 +36,21 @@
 //    `token.alloc` are erased. Evals spliced out of the body are re-queued
 //    by the driver, which is what makes the reduction recursive.
 //
+//  * LOOPINLINE: the loop-carried redex. A linear chain
+//    `create → (uniqify|apply)* → %c` sits outside a loop nest
+//    (`LoopLikeOpInterface`, so `scf.for` and `affine.for` alike) and %c's
+//    remaining uses are one per-iteration `rc.inc` next to a single `eval`
+//    inside the nest plus one trailing `rc.dec` after it — a closure built
+//    once and called once per iteration. The body is spliced into the loop
+//    at the eval, and the closure box vanishes: its own create/inc/eval/dec
+//    traffic is self-contained (a fresh box nothing else can observe), so
+//    erasing all of it is count-neutral. Capture counts are preserved, not
+//    reasoned about: each rc-typed applied capture gains a per-iteration
+//    `rc.inc` at the splice point (the inlined body consumes its capture
+//    parameters each iteration; the box used to pay for this by copying
+//    captures out of a shared closure) and one `rc.dec` where the box's dec
+//    stood (the box's drop used to release the capture the apply consumed).
+//
 // Fused evals that bottom out anywhere else survive the pass; the SCF-ops
 // lowering re-expands them into unchecked applies + plain eval, so the net
 // effect of FOLD+STRIP on a chain the inliner merged is the removal of its
@@ -47,6 +62,7 @@
 #include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/PatternMatch.h>
+#include <mlir/Interfaces/LoopLikeInterface.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
@@ -146,6 +162,138 @@ struct InlineCreateIntoEvalPattern
   }
 };
 
+// LOOPINLINE: a beta redex carried through a loop nest. See the file
+// comment for the ownership accounting.
+struct InlineLoopCarriedCreatePattern
+    : public mlir::OpRewritePattern<ReussirClosureEvalOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirClosureEvalOp eval,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::Value closure = eval.getClosure();
+    mlir::Operation *top = closure.getDefiningOp();
+    if (!top)
+      return mlir::failure();
+    mlir::Block *defBlock = top->getBlock();
+    if (defBlock == eval->getBlock())
+      return mlir::failure(); // straight-line redexes belong to INLINE
+
+    // Every region between the chain and the eval must be a loop (any
+    // dialect implementing `LoopLikeOpInterface`): the eval then runs once
+    // per iteration of a nest the chain dominates from outside.
+    mlir::Operation *walk = eval;
+    while (walk->getBlock() != defBlock) {
+      mlir::Operation *parent = walk->getParentOp();
+      if (!parent || !llvm::isa<mlir::LoopLikeOpInterface>(parent))
+        return mlir::failure();
+      walk = parent;
+    }
+    mlir::Operation *outermostLoop = walk;
+
+    // The chain below the loop-carried value: linear (every inner link
+    // single-use), one block, bottoming at an inlined create. Every uniqify
+    // over such a chain is a runtime no-op — the value is unique by
+    // construction, fresh from the create with no use between the links.
+    llvm::SmallVector<mlir::Operation *> chain;
+    llvm::SmallVector<mlir::Value> caps; // collected top-down
+    ReussirClosureCreateOp create;
+    mlir::Value link = closure;
+    while (true) {
+      mlir::Operation *def = link.getDefiningOp();
+      if (!def || def->getBlock() != defBlock)
+        return mlir::failure();
+      if (link != closure && !link.hasOneUse())
+        return mlir::failure();
+      if (auto apply = llvm::dyn_cast<ReussirClosureApplyOp>(def)) {
+        chain.push_back(def);
+        caps.push_back(apply.getArg());
+        link = apply.getClosure();
+      } else if (auto uniqify = llvm::dyn_cast<ReussirClosureUniqifyOp>(def)) {
+        chain.push_back(def);
+        link = uniqify.getClosure();
+      } else if ((create = llvm::dyn_cast<ReussirClosureCreateOp>(def))) {
+        chain.push_back(def);
+        break;
+      } else {
+        return mlir::failure();
+      }
+    }
+    if (!create.isInlined())
+      return mlir::failure();
+    mlir::Value token = create.getToken();
+    if (token && !token.getDefiningOp<ReussirTokenAllocOp>())
+      return mlir::failure();
+    // Walking top-down visits the last application first; the body's
+    // leading parameters bind in application order.
+    std::reverse(caps.begin(), caps.end());
+
+    mlir::Block &body = create.getBody().front();
+    if (body.getNumArguments() != caps.size() + eval.getArgs().size())
+      return mlir::failure();
+
+    // The value's remaining uses: exactly one per-iteration inc beside the
+    // eval, and exactly one plain dec after the nest at the chain's level.
+    llvm::SmallVector<ReussirRcIncOp> incs;
+    ReussirRcDecOp dec;
+    for (mlir::Operation *user : closure.getUsers()) {
+      if (user == eval)
+        continue;
+      if (auto inc = llvm::dyn_cast<ReussirRcIncOp>(user)) {
+        if (inc->getBlock() != eval->getBlock() || !inc->isBeforeInBlock(eval))
+          return mlir::failure();
+        incs.push_back(inc);
+        continue;
+      }
+      if (auto d = llvm::dyn_cast<ReussirRcDecOp>(user)) {
+        if (dec || d->getBlock() != defBlock ||
+            !outermostLoop->isBeforeInBlock(d))
+          return mlir::failure();
+        dec = d;
+        continue;
+      }
+      return mlir::failure();
+    }
+    if (incs.size() != 1 || !dec || dec.getNumResults() != 0)
+      return mlir::failure();
+
+    // Per-iteration ownership for rc-typed captures (see the file comment).
+    rewriter.setInsertionPoint(eval);
+    for (mlir::Value cap : caps)
+      if (llvm::isa<RcType>(cap.getType()))
+        ReussirRcIncOp::create(rewriter, eval.getLoc(), cap);
+
+    auto yield = llvm::cast<ReussirClosureYieldOp>(body.getTerminator());
+    mlir::Value yielded = yield.getValue();
+    llvm::SmallVector<mlir::Value> args(caps);
+    llvm::append_range(args, eval.getArgs());
+    rewriter.inlineBlockBefore(&body, eval, args);
+    rewriter.eraseOp(yield);
+    if (eval.getNumResults())
+      rewriter.replaceOp(eval, yielded);
+    else
+      rewriter.eraseOp(eval);
+
+    // The box's dec used to release the captures the applies consumed;
+    // release them directly where it stood.
+    rewriter.setInsertionPoint(dec);
+    for (mlir::Value cap : caps)
+      if (llvm::isa<RcType>(cap.getType()))
+        ReussirRcDecOp::create(rewriter, dec.getLoc(),
+                               /*nullableToken=*/NullableType{}, cap,
+                               /*destructureTag=*/mlir::IntegerAttr{},
+                               /*boundMembers=*/mlir::DenseI64ArrayAttr{});
+    for (ReussirRcIncOp inc : incs)
+      rewriter.eraseOp(inc);
+    rewriter.eraseOp(dec);
+    for (mlir::Operation *op : chain)
+      rewriter.eraseOp(op);
+    if (token && token.use_empty())
+      rewriter.eraseOp(token.getDefiningOp());
+    return mlir::success();
+  }
+};
+
 struct ClosureBetaReductionPass
     : public impl::ReussirClosureBetaReductionPassBase<
           ClosureBetaReductionPass> {
@@ -154,7 +302,8 @@ struct ClosureBetaReductionPass
   void runOnOperation() override {
     mlir::RewritePatternSet patterns(&getContext());
     patterns.add<FoldApplyIntoEvalPattern, StripNoopUniqifyPattern,
-                 InlineCreateIntoEvalPattern>(&getContext());
+                 InlineCreateIntoEvalPattern, InlineLoopCarriedCreatePattern>(
+        &getContext());
     if (mlir::failed(
             mlir::applyPatternsGreedily(getOperation(), std::move(patterns))))
       signalPassFailure();

--- a/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
+++ b/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
@@ -36,20 +36,29 @@
 //    `token.alloc` are erased. Evals spliced out of the body are re-queued
 //    by the driver, which is what makes the reduction recursive.
 //
-//  * LOOPINLINE: the loop-carried redex. A linear chain
-//    `create → (uniqify|apply)* → %c` sits outside a loop nest
-//    (`LoopLikeOpInterface`, so `scf.for` and `affine.for` alike) and %c's
-//    remaining uses are one per-iteration `rc.inc` next to a single `eval`
-//    inside the nest plus one trailing `rc.dec` after it — a closure built
-//    once and called once per iteration. The body is spliced into the loop
-//    at the eval, and the closure box vanishes: its own create/inc/eval/dec
-//    traffic is self-contained (a fresh box nothing else can observe), so
-//    erasing all of it is count-neutral. Capture counts are preserved, not
-//    reasoned about: each rc-typed applied capture gains a per-iteration
-//    `rc.inc` at the splice point (the inlined body consumes its capture
-//    parameters each iteration; the box used to pay for this by copying
-//    captures out of a shared closure) and one `rc.dec` where the box's dec
-//    stood (the box's drop used to release the capture the apply consumed).
+//  * LOOPINLINE: the loop-carried redex, in its general frontend shape —
+//
+//      %c = create {body}; (uniqify; apply cap)*     // capture binding
+//      loop* {                                       // any LoopLike nest
+//        rc.inc %c; (uniqify; apply x_i)*; eval(...) // per-iteration chain
+//      }
+//      rc.dec %c
+//
+//    (`scf.for` and `affine.for` alike). The body is spliced into the loop
+//    at the eval and the closure box vanishes: its create / per-iteration
+//    inc+chain / trailing dec traffic is self-contained (a fresh box
+//    nothing else can observe), so erasing all of it is count-neutral. The
+//    per-iteration uniqify is a *genuine* guard — the carried box is
+//    shared, so it clones every iteration — but the clone is itself a fresh
+//    box the chain consumes whole: cloning inc'd the stored captures out
+//    and the eval consumed them, a wash the fused form reproduces. Capture
+//    counts are preserved, not reasoned about: each rc-typed capture bound
+//    *outside* the loop gains a per-iteration `rc.inc` at the splice point
+//    (the inlined body consumes its capture parameters each iteration) and
+//    one `rc.dec` where the box's dec stood (the box's drop used to release
+//    the ref the apply consumed). Captures bound *inside* the loop were
+//    consumed once per iteration before and still are — they just take
+//    their seat in the substitution pack.
 //
 // Fused evals that bottom out anywhere else survive the pass; the SCF-ops
 // lowering re-expands them into unchecked applies + plain eval, so the net
@@ -171,17 +180,43 @@ struct InlineLoopCarriedCreatePattern
   mlir::LogicalResult
   matchAndRewrite(ReussirClosureEvalOp eval,
                   mlir::PatternRewriter &rewriter) const override {
-    mlir::Value closure = eval.getClosure();
-    mlir::Operation *top = closure.getDefiningOp();
-    if (!top)
-      return mlir::failure();
+    // Peel the per-iteration links: single-use `uniqify | apply` ops in the
+    // eval's own block, down to the value carried across iterations. The
+    // uniqify here is a *genuine* guard (the carried box is shared, so it
+    // clones every iteration) — but the clone is a fresh box the fused
+    // chain consumes whole, so erasing it is count-neutral; cloning used to
+    // inc the stored captures out and the eval consumed them, a wash the
+    // fused form reproduces exactly. Per-iteration applied args were
+    // consumed once per iteration before and still are: they need no
+    // adjustment, only a seat in the substitution pack.
+    llvm::SmallVector<mlir::Operation *> innerChain;
+    llvm::SmallVector<mlir::Value> innerCaps; // collected top-down
+    mlir::Value carried = eval.getClosure();
+    while (true) {
+      mlir::Operation *def = carried.getDefiningOp();
+      if (!def)
+        return mlir::failure();
+      if (def->getBlock() != eval->getBlock())
+        break; // left the loop body: `carried` is the loop-carried value
+      if (!carried.hasOneUse())
+        return mlir::failure();
+      if (auto apply = llvm::dyn_cast<ReussirClosureApplyOp>(def)) {
+        innerChain.push_back(def);
+        innerCaps.push_back(apply.getArg());
+        carried = apply.getClosure();
+      } else if (auto uniqify = llvm::dyn_cast<ReussirClosureUniqifyOp>(def)) {
+        innerChain.push_back(def);
+        carried = uniqify.getClosure();
+      } else {
+        return mlir::failure();
+      }
+    }
+    mlir::Operation *top = carried.getDefiningOp();
     mlir::Block *defBlock = top->getBlock();
-    if (defBlock == eval->getBlock())
-      return mlir::failure(); // straight-line redexes belong to INLINE
 
-    // Every region between the chain and the eval must be a loop (any
-    // dialect implementing `LoopLikeOpInterface`): the eval then runs once
-    // per iteration of a nest the chain dominates from outside.
+    // Every region between the carried value and the eval must be a loop
+    // (any dialect implementing `LoopLikeOpInterface`): the eval then runs
+    // once per iteration of a nest the chain dominates from outside.
     mlir::Operation *walk = eval;
     while (walk->getBlock() != defBlock) {
       mlir::Operation *parent = walk->getParentOp();
@@ -195,25 +230,25 @@ struct InlineLoopCarriedCreatePattern
     // single-use), one block, bottoming at an inlined create. Every uniqify
     // over such a chain is a runtime no-op — the value is unique by
     // construction, fresh from the create with no use between the links.
-    llvm::SmallVector<mlir::Operation *> chain;
-    llvm::SmallVector<mlir::Value> caps; // collected top-down
+    llvm::SmallVector<mlir::Operation *> outerChain;
+    llvm::SmallVector<mlir::Value> outerCaps; // collected top-down
     ReussirClosureCreateOp create;
-    mlir::Value link = closure;
+    mlir::Value link = carried;
     while (true) {
       mlir::Operation *def = link.getDefiningOp();
       if (!def || def->getBlock() != defBlock)
         return mlir::failure();
-      if (link != closure && !link.hasOneUse())
+      if (link != carried && !link.hasOneUse())
         return mlir::failure();
       if (auto apply = llvm::dyn_cast<ReussirClosureApplyOp>(def)) {
-        chain.push_back(def);
-        caps.push_back(apply.getArg());
+        outerChain.push_back(def);
+        outerCaps.push_back(apply.getArg());
         link = apply.getClosure();
       } else if (auto uniqify = llvm::dyn_cast<ReussirClosureUniqifyOp>(def)) {
-        chain.push_back(def);
+        outerChain.push_back(def);
         link = uniqify.getClosure();
       } else if ((create = llvm::dyn_cast<ReussirClosureCreateOp>(def))) {
-        chain.push_back(def);
+        outerChain.push_back(def);
         break;
       } else {
         return mlir::failure();
@@ -225,19 +260,25 @@ struct InlineLoopCarriedCreatePattern
     if (token && !token.getDefiningOp<ReussirTokenAllocOp>())
       return mlir::failure();
     // Walking top-down visits the last application first; the body's
-    // leading parameters bind in application order.
-    std::reverse(caps.begin(), caps.end());
+    // parameters bind in application order — outer applies first, then the
+    // per-iteration ones, then the eval's pack.
+    std::reverse(outerCaps.begin(), outerCaps.end());
+    std::reverse(innerCaps.begin(), innerCaps.end());
 
     mlir::Block &body = create.getBody().front();
-    if (body.getNumArguments() != caps.size() + eval.getArgs().size())
+    if (body.getNumArguments() !=
+        outerCaps.size() + innerCaps.size() + eval.getArgs().size())
       return mlir::failure();
 
-    // The value's remaining uses: exactly one per-iteration inc beside the
-    // eval, and exactly one plain dec after the nest at the chain's level.
+    // The carried value's remaining uses: exactly one per-iteration inc
+    // beside the eval, and exactly one plain dec after the nest at the
+    // chain's level.
+    mlir::Operation *firstLink =
+        innerChain.empty() ? eval.getOperation() : innerChain.back();
     llvm::SmallVector<ReussirRcIncOp> incs;
     ReussirRcDecOp dec;
-    for (mlir::Operation *user : closure.getUsers()) {
-      if (user == eval)
+    for (mlir::Operation *user : carried.getUsers()) {
+      if (user == firstLink)
         continue;
       if (auto inc = llvm::dyn_cast<ReussirRcIncOp>(user)) {
         if (inc->getBlock() != eval->getBlock() || !inc->isBeforeInBlock(eval))
@@ -257,15 +298,18 @@ struct InlineLoopCarriedCreatePattern
     if (incs.size() != 1 || !dec || dec.getNumResults() != 0)
       return mlir::failure();
 
-    // Per-iteration ownership for rc-typed captures (see the file comment).
+    // Per-iteration ownership for the rc-typed captures the box stored:
+    // the inlined body consumes its capture parameters each iteration (see
+    // the file comment).
     rewriter.setInsertionPoint(eval);
-    for (mlir::Value cap : caps)
+    for (mlir::Value cap : outerCaps)
       if (llvm::isa<RcType>(cap.getType()))
         ReussirRcIncOp::create(rewriter, eval.getLoc(), cap);
 
     auto yield = llvm::cast<ReussirClosureYieldOp>(body.getTerminator());
     mlir::Value yielded = yield.getValue();
-    llvm::SmallVector<mlir::Value> args(caps);
+    llvm::SmallVector<mlir::Value> args(outerCaps);
+    llvm::append_range(args, innerCaps);
     llvm::append_range(args, eval.getArgs());
     rewriter.inlineBlockBefore(&body, eval, args);
     rewriter.eraseOp(yield);
@@ -274,19 +318,21 @@ struct InlineLoopCarriedCreatePattern
     else
       rewriter.eraseOp(eval);
 
-    // The box's dec used to release the captures the applies consumed;
-    // release them directly where it stood.
+    // The box's dec used to release the captures the outer applies
+    // consumed; release them directly where it stood.
     rewriter.setInsertionPoint(dec);
-    for (mlir::Value cap : caps)
+    for (mlir::Value cap : outerCaps)
       if (llvm::isa<RcType>(cap.getType()))
         ReussirRcDecOp::create(rewriter, dec.getLoc(),
                                /*nullableToken=*/NullableType{}, cap,
                                /*destructureTag=*/mlir::IntegerAttr{},
                                /*boundMembers=*/mlir::DenseI64ArrayAttr{});
+    for (mlir::Operation *op : innerChain)
+      rewriter.eraseOp(op);
     for (ReussirRcIncOp inc : incs)
       rewriter.eraseOp(inc);
     rewriter.eraseOp(dec);
-    for (mlir::Operation *op : chain)
+    for (mlir::Operation *op : outerChain)
       rewriter.eraseOp(op);
     if (token && token.use_empty())
       rewriter.eraseOp(token.getDefiningOp());

--- a/tests/integration/conversion/closure_beta_loop_carried.mlir
+++ b/tests/integration/conversion/closure_beta_loop_carried.mlir
@@ -114,6 +114,72 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
     return
   }
 
+  // The general frontend shape: a capture bound outside the loop through
+  // its own uniqify+apply (with the caller's inc keeping the captured value
+  // alive), and a genuine per-iteration uniqify+apply+eval chain over the
+  // shared box inside the loop. The per-iteration uniqify clones — the
+  // clone is invisible to the fused form, which reproduces its capture
+  // accounting with the splice-point inc and the trailing dec.
+  func.func @general(%box: !reussir.rc<i64>, %n: index) -> i64 {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 48>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64, i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 48>)
+      body {
+        ^bb0(%b : !reussir.rc<i64>, %x : i64, %a : i64):
+          reussir.rc.dec (%b : !reussir.rc<i64>)
+          %s = arith.muli %x, %a : i64
+          reussir.closure.yield %s : i64
+      }
+    }
+    reussir.rc.inc (%box : !reussir.rc<i64>)
+    %u0 = reussir.closure.uniqify (%c : !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64, i64) -> i64>>) : !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64, i64) -> i64>>
+    %c1 = reussir.closure.apply (%box : !reussir.rc<i64>) to (%u0 : !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64, i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>
+    %lb = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    %zero = arith.constant 0 : i64
+    %r = scf.for %i = %lb to %n step %step iter_args(%acc = %zero) -> (i64) {
+      reussir.rc.inc (%c1 : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>)
+      %iv = arith.index_cast %i : index to i64
+      %u1 = reussir.closure.uniqify (%c1 : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>
+      %b1 = reussir.closure.apply (%iv : i64) to (%u1 : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64) -> i64>>
+      %y = reussir.closure.eval (%b1 : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%iv : i64) : i64
+      %acc2 = arith.addi %acc, %y : i64
+      scf.yield %acc2 : i64
+    }
+    reussir.rc.dec (%c1 : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>)
+    return %r : i64
+  }
+
+  // A capture bound INSIDE the loop: a per-iteration apply on the hoisted
+  // create. LOOPINLINE alone cannot fire (the eval's operand is loop-local);
+  // it composes with FOLD, which folds the apply into the eval's pack, after
+  // which the chain is the bare create and the loop-varying capture rides
+  // the substituted pack.
+  func.func @loop_varying_capture(%n: index) -> i64 {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 40>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64, i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 40>)
+      body {
+        ^bb0(%cap : i64, %a : i64):
+          %s = arith.muli %cap, %a : i64
+          reussir.closure.yield %s : i64
+      }
+    }
+    %lb = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    %zero = arith.constant 0 : i64
+    %r = scf.for %i = %lb to %n step %step iter_args(%acc = %zero) -> (i64) {
+      reussir.rc.inc (%c : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>)
+      %iv = arith.index_cast %i : index to i64
+      %bound = reussir.closure.apply (%iv : i64) to (%c : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64) -> i64>>
+      %y = reussir.closure.eval (%bound : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%iv : i64) : i64
+      %acc2 = arith.addi %acc, %y : i64
+      scf.yield %acc2 : i64
+    }
+    reussir.rc.dec (%c : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>)
+    return %r : i64
+  }
+
   // NEGATIVE: a second eval of the same closure in the loop — the use set
   // is not the carried-redex shape; everything stays.
   func.func @two_evals(%n: index) {
@@ -194,6 +260,24 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
 // CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)
 // CHECK: }
 // CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)
+
+// CHECK-LABEL: func.func @general
+// CHECK: reussir.rc.inc(%arg0 : !reussir.rc<i64>)
+// CHECK-NOT: reussir.closure
+// CHECK: scf.for
+// CHECK: reussir.rc.inc(%arg0 : !reussir.rc<i64>)
+// CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)
+// CHECK: arith.muli
+// CHECK: scf.yield
+// CHECK: }
+// CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)
+
+// CHECK-LABEL: func.func @loop_varying_capture
+// CHECK-NOT: reussir.closure
+// CHECK: scf.for
+// CHECK: %[[LV:[0-9a-z_]+]] = arith.index_cast
+// CHECK: arith.muli %[[LV]], %[[LV]] : i64
+// CHECK-NOT: reussir.rc.dec
 
 // CHECK-LABEL: func.func @two_evals
 // CHECK: reussir.closure.create

--- a/tests/integration/conversion/closure_beta_loop_carried.mlir
+++ b/tests/integration/conversion/closure_beta_loop_carried.mlir
@@ -1,0 +1,207 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(func.func(reussir-closure-beta-reduction))' \
+// RUN: | %FileCheck %s
+
+// The loop-carried beta redex (LOOPINLINE): a closure built once outside a
+// loop and called once per iteration — per-iteration `rc.inc` + `eval`
+// inside, one `rc.dec` after — inlines into the loop body and the box
+// disappears. Loops are matched through `LoopLikeOpInterface`, so `scf.for`
+// and `affine.for` reduce alike. Capture counts are preserved: an rc-typed
+// capture gains a per-iteration inc at the splice point and a dec where the
+// box's dec stood.
+
+module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>>} {
+  // A fold-shaped loop: the closure body lands inside the loop, every
+  // closure op and the token vanish.
+  func.func @fold(%n: index) -> i64 {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%a : i64):
+          %s = arith.addi %a, %a : i64
+          reussir.closure.yield %s : i64
+      }
+    }
+    %lb = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    %zero = arith.constant 0 : i64
+    %r = scf.for %i = %lb to %n step %step iter_args(%acc = %zero) -> (i64) {
+      reussir.rc.inc (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+      %iv = arith.index_cast %i : index to i64
+      %y = reussir.closure.eval (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%iv : i64) : i64
+      %acc2 = arith.addi %acc, %y : i64
+      scf.yield %acc2 : i64
+    }
+    reussir.rc.dec (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+    return %r : i64
+  }
+
+  // A rank-2 nest: the redex sits two loops out; both levels are loop-like,
+  // so it still fuses.
+  func.func @rank2(%n: index) -> i64 {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%a : i64):
+          %s = arith.muli %a, %a : i64
+          reussir.closure.yield %s : i64
+      }
+    }
+    %lb = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    %zero = arith.constant 0 : i64
+    %r = scf.for %i = %lb to %n step %step iter_args(%acc = %zero) -> (i64) {
+      %inner = scf.for %j = %lb to %n step %step iter_args(%iacc = %acc) -> (i64) {
+        reussir.rc.inc (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+        %iv = arith.index_cast %j : index to i64
+        %y = reussir.closure.eval (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%iv : i64) : i64
+        %iacc2 = arith.addi %iacc, %y : i64
+        scf.yield %iacc2 : i64
+      }
+      scf.yield %inner : i64
+    }
+    reussir.rc.dec (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+    return %r : i64
+  }
+
+  // The same shape under `affine.for`: nothing in the pattern is scf-specific.
+  func.func @affine_loop() -> i64 {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%a : i64):
+          %s = arith.addi %a, %a : i64
+          reussir.closure.yield %s : i64
+      }
+    }
+    %zero = arith.constant 0 : i64
+    %r = affine.for %i = 0 to 8 iter_args(%acc = %zero) -> (i64) {
+      reussir.rc.inc (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+      %iv = arith.index_cast %i : index to i64
+      %y = reussir.closure.eval (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%iv : i64) : i64
+      %acc2 = arith.addi %acc, %y : i64
+      affine.yield %acc2 : i64
+    }
+    reussir.rc.dec (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+    return %r : i64
+  }
+
+  // An rc-typed capture bound by an apply outside the loop: the inlined
+  // body consumes it per iteration, so it gains a per-iteration inc at the
+  // splice point and a dec where the closure's dec stood.
+  func.func @rc_capture(%box: !reussir.rc<i64>, %n: index) {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 40>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64)>> {
+      token(%token : !reussir.token<align: 8, size: 40>)
+      body {
+        ^bb0(%b : !reussir.rc<i64>, %a : i64):
+          reussir.rc.dec (%b : !reussir.rc<i64>)
+          reussir.closure.yield
+      }
+    }
+    %c1 = reussir.closure.apply (%box : !reussir.rc<i64>) to (%c : !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64)>>) : !reussir.rc<!reussir.closure<(i64)>>
+    %lb = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    scf.for %i = %lb to %n step %step {
+      reussir.rc.inc (%c1 : !reussir.rc<!reussir.closure<(i64)>>)
+      %iv = arith.index_cast %i : index to i64
+      reussir.closure.eval (%c1 : !reussir.rc<!reussir.closure<(i64)>>) with (%iv : i64)
+    }
+    reussir.rc.dec (%c1 : !reussir.rc<!reussir.closure<(i64)>>)
+    return
+  }
+
+  // NEGATIVE: a second eval of the same closure in the loop — the use set
+  // is not the carried-redex shape; everything stays.
+  func.func @two_evals(%n: index) {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%a : i64):
+          reussir.closure.yield %a : i64
+      }
+    }
+    %lb = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    scf.for %i = %lb to %n step %step {
+      reussir.rc.inc (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+      reussir.rc.inc (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+      %iv = arith.index_cast %i : index to i64
+      %y1 = reussir.closure.eval (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%iv : i64) : i64
+      %y2 = reussir.closure.eval (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%iv : i64) : i64
+    }
+    reussir.rc.dec (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+    return
+  }
+
+  // NEGATIVE: the closure escapes through a call — not a self-contained
+  // use set; everything stays.
+  func.func private @sink(!reussir.rc<!reussir.closure<(i64) -> i64>>)
+  func.func @escapes(%n: index) {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%a : i64):
+          reussir.closure.yield %a : i64
+      }
+    }
+    %lb = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    scf.for %i = %lb to %n step %step {
+      reussir.rc.inc (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+      %iv = arith.index_cast %i : index to i64
+      %y = reussir.closure.eval (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%iv : i64) : i64
+    }
+    func.call @sink(%c) : (!reussir.rc<!reussir.closure<(i64) -> i64>>) -> ()
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @fold
+// CHECK-NOT: reussir.token.alloc
+// CHECK-NOT: reussir.closure
+// CHECK: scf.for {{.*}} iter_args(%[[ACC:[0-9a-z_]+]] = %{{[0-9a-z_]+}})
+// CHECK-NOT: reussir.rc.inc
+// CHECK: %[[IV:[0-9a-z]+]] = arith.index_cast
+// CHECK: %[[S:[0-9a-z]+]] = arith.addi %[[IV]], %[[IV]] : i64
+// CHECK: %[[A2:[0-9a-z]+]] = arith.addi %[[ACC]], %[[S]] : i64
+// CHECK: scf.yield %[[A2]] : i64
+// CHECK-NOT: reussir.rc.dec
+
+// CHECK-LABEL: func.func @rank2
+// CHECK-NOT: reussir.closure
+// CHECK: scf.for
+// CHECK: scf.for
+// CHECK: arith.muli
+// CHECK-NOT: reussir.rc.dec
+
+// CHECK-LABEL: func.func @affine_loop
+// CHECK-NOT: reussir.closure
+// CHECK: affine.for
+// CHECK: arith.addi
+// CHECK: affine.yield
+// CHECK-NOT: reussir.rc.dec
+
+// CHECK-LABEL: func.func @rc_capture
+// CHECK-NOT: reussir.closure
+// CHECK: scf.for
+// CHECK: reussir.rc.inc(%arg0 : !reussir.rc<i64>)
+// CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)
+// CHECK: }
+// CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)
+
+// CHECK-LABEL: func.func @two_evals
+// CHECK: reussir.closure.create
+// CHECK: scf.for
+// CHECK-COUNT-2: reussir.closure.eval
+// CHECK: reussir.rc.dec
+
+// CHECK-LABEL: func.func @escapes
+// CHECK: reussir.closure.create
+// CHECK: reussir.closure.eval
+// CHECK: call @sink

--- a/tests/integration/conversion/closure_beta_loop_carried.mlir
+++ b/tests/integration/conversion/closure_beta_loop_carried.mlir
@@ -115,11 +115,12 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
   }
 
   // The general frontend shape: a capture bound outside the loop through
-  // its own uniqify+apply (with the caller's inc keeping the captured value
-  // alive), and a genuine per-iteration uniqify+apply+eval chain over the
-  // shared box inside the loop. The per-iteration uniqify clones — the
-  // clone is invisible to the fused form, which reproduces its capture
-  // accounting with the splice-point inc and the trailing dec.
+  // its own uniqify+apply — rc arguments are owned by the callee, so with
+  // no later use the apply consumes %box's original ref directly — and a
+  // genuine per-iteration uniqify+apply+eval chain over the shared box
+  // inside the loop. The per-iteration uniqify clones; the clone is
+  // invisible to the fused form, which reproduces its capture accounting
+  // with the splice-point inc and the trailing dec.
   func.func @general(%box: !reussir.rc<i64>, %n: index) -> i64 {
     %token = reussir.token.alloc : !reussir.token<align: 8, size: 48>
     %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64, i64) -> i64>> {
@@ -131,7 +132,6 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
           reussir.closure.yield %s : i64
       }
     }
-    reussir.rc.inc (%box : !reussir.rc<i64>)
     %u0 = reussir.closure.uniqify (%c : !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64, i64) -> i64>>) : !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64, i64) -> i64>>
     %c1 = reussir.closure.apply (%box : !reussir.rc<i64>) to (%u0 : !reussir.rc<!reussir.closure<(!reussir.rc<i64>, i64, i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64, i64) -> i64>>
     %lb = arith.constant 0 : index
@@ -262,8 +262,8 @@ module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense
 // CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)
 
 // CHECK-LABEL: func.func @general
-// CHECK: reussir.rc.inc(%arg0 : !reussir.rc<i64>)
 // CHECK-NOT: reussir.closure
+// CHECK-NOT: reussir.rc.inc
 // CHECK: scf.for
 // CHECK: reussir.rc.inc(%arg0 : !reussir.rc<i64>)
 // CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)


### PR DESCRIPTION
A closure built once outside a loop and called once per iteration — a linear `create → (uniqify|apply)*` chain whose remaining uses are one per-iteration `rc.inc` beside a single `eval` inside the nest, plus one trailing `rc.dec` — is a beta redex carried through the loop. The new LOOPINLINE pattern splices the body into the loop at the eval and deletes the box: its own create/inc/eval/dec traffic is self-contained (a fresh box nothing else can observe), so erasing it is count-neutral.

Capture counts are **preserved, not reasoned about**: each rc-typed applied capture gains a per-iteration `rc.inc` at the splice point (the inlined body consumes its capture parameters each iteration — the box used to pay for this by copying captures out of a shared closure) and one `rc.dec` where the box's dec stood (releasing the ref the apply consumed). Count-observing behavior of the body therefore survives fusion unchanged, which is what keeps the rewrite semantics-preserving without any COW analysis.

Loops are matched through `LoopLikeOpInterface` — `scf.for` and `affine.for` reduce alike, and the test covers both plus a rank-2 nest, an rc capture, and the negative shapes (second eval, escaping closure).

Groundwork for #344: with this in place, array `tabulate`/`fold` can take ordinary closures — codegen emits a plain per-iteration eval, literal lambdas fuse here — and the dedicated Kernel node and its special checker/ownership handling can be removed from the remaining array stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786388171&installation_id=144622820&pr_number=392&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F392&signature=5381412d6a27a2ca38fbf1a1b9390308c9f6be7bdffdb31eeeb337d10bb6eb06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->