### PR TITLE
[frontend] array tabulate/fold: kernels are ordinary closures

### DIFF
--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -261,28 +261,16 @@ pub enum ExprKind<'tcx> {
         args: &'tcx [Expr<'tcx>],
     },
     /// A built-in operation on a statically shaped array, mirroring
-    /// [`crate::semi::hir::ExprKind::ArrayOp`]: the resolved op, its value
-    /// operands, and — for `Tabulate`/`Fold` — an inline kernel. The kernel is
-    /// not a closure: its body references enclosing bindings directly
-    /// (read-only borrows for the op's duration) and codegen inlines it into
-    /// the element loop nest.
+    /// [`crate::semi::hir::ExprKind::ArrayOp`]: the resolved op and its value
+    /// operands. `Tabulate`/`Fold` carry their kernel as an ordinary
+    /// closure-typed operand (the last one).
     ArrayOp {
         op: crate::intrinsic::ArrayFn,
         args: &'tcx [Expr<'tcx>],
-        kernel: Option<&'tcx Kernel<'tcx>>,
     },
     Match(&'tcx Expr<'tcx>, DecisionTree<'tcx>),
     /// Error-recovery placeholder.
     Poison,
-}
-
-/// The inline kernel of an [`ArrayOp`](ExprKind::ArrayOp); see
-/// [`crate::semi::hir::Kernel`]. The type checker guarantees the body is
-/// rc-free (plain-typed throughout, except `get` reads of enclosing arrays).
-#[derive(Clone, Copy, Debug)]
-pub struct Kernel<'tcx> {
-    pub params: &'tcx [(VarId, Ty<'tcx>)],
-    pub body: &'tcx Expr<'tcx>,
 }
 
 /// A pattern binding: a local variable bound to a scrutinee [`Path`].

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -450,23 +450,8 @@ impl Render<'_> {
                     + self.value(c.body)
                     + text(" }")
             }
-            ArrayOp { op, args, kernel } => {
-                let mut d =
-                    text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")");
-                if let Some(k) = kernel {
-                    let params: Vec<Doc<'static>> = k
-                        .params
-                        .iter()
-                        .map(|(v, t)| var(*v) + text(": ") + self.ty(*t))
-                        .collect();
-                    d = d
-                        + text(" kernel(")
-                        + comma_sep(params)
-                        + text(") { ")
-                        + self.value(k.body)
-                        + text(" }");
-                }
-                d
+            ArrayOp { op, args } => {
+                text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")")
             }
             Let { .. } | Seq(_) | If(..) | Match(..) => {
                 unreachable!("structural forms are rendered by `value`")

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -744,14 +744,9 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 args: self.lower_slice(args, subst),
             },
             ExprKind::Closure(c) => M::Closure(self.lower_closure(c, subst)),
-            ExprKind::ArrayOp { op, args, kernel } => M::ArrayOp {
+            ExprKind::ArrayOp { op, args } => M::ArrayOp {
                 op: *op,
                 args: self.lower_slice(args, subst),
-                kernel: kernel.as_ref().map(|k| {
-                    let params = self.lower_var_tys(&k.params, subst);
-                    let body = self.lower_ref(&k.body, subst);
-                    &*self.tcx.alloc(mir::Kernel { params, body })
-                }),
             },
             ExprKind::Match(scrut, tree) => {
                 M::Match(self.lower_ref(scrut, subst), self.lower_tree(tree, subst))
@@ -1240,7 +1235,7 @@ mod tests {
     fn children<'tcx>(e: &mir::Expr<'tcx>) -> Vec<&'tcx mir::Expr<'tcx>> {
         use mir::ExprKind::*;
         match e.kind {
-            ArrayOp { args, kernel, .. } => args.iter().chain(kernel.map(|k| k.body)).collect(),
+            ArrayOp { args, .. } => args.iter().collect(),
             GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
             | Poison => vec![],
             Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -515,29 +515,14 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                     s.union_with(&self.free(arg));
                 }
             }
-            // An array op uses its value operands, plus every enclosing var the
-            // inline kernel body reads (the kernel's own params are binders).
-            ExprKind::ArrayOp { args, kernel, .. } => {
+            // An array op uses its value operands (a Tabulate/Fold kernel is
+            // an ordinary closure-typed operand among them).
+            ExprKind::ArrayOp { args, .. } => {
                 for arg in args {
                     s.union_with(&self.free(arg));
                 }
-                if let Some(k) = kernel {
-                    s.union_with(&self.kernel_free(k));
-                }
             }
         }
-        s
-    }
-
-    /// The free RR variables of an [`ArrayOp`](ExprKind::ArrayOp) kernel body,
-    /// minus the kernel's own parameters.
-    fn kernel_free(&mut self, k: &mir::Kernel<'tcx>) -> VarSet {
-        let mut s = self.free(k.body);
-        let mut params = VarSet::default();
-        for &(p, _) in k.params {
-            params.insert(p);
-        }
-        s.subtract(&params);
         s
     }
 
@@ -643,23 +628,20 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             ExprKind::ClosureCall { target, args } => {
                 self.place_closure_call(target, args, live_after)
             }
-            ExprKind::ArrayOp { op, args, kernel } => {
-                self.place_array_op(e, op, args, kernel, live_after)
-            }
+            ExprKind::ArrayOp { op, args } => self.place_array_op(e, op, args, live_after),
         }
     }
 
-    /// Place an [`ArrayOp`](ExprKind::ArrayOp)'s operands and kernel.
+    /// Place an [`ArrayOp`](ExprKind::ArrayOp)'s operands.
     ///
     /// Ownership contract per op (see [`ArrayFn`](crate::intrinsic::ArrayFn)):
     /// `Set` and `Splat` treat their operands like call arguments (the `Set`
     /// base is consumed — the op returns the updated array); `Get` and `Fold`
-    /// only *borrow* their array operand; and a kernel body's free vars are
-    /// read-only borrows for the whole op (the type checker restricts kernel
-    /// bodies to be rc-free, so RR vars appear there only as `get` bases).
+    /// only *borrow* their array operand. A `Tabulate`/`Fold` kernel is an
+    /// ordinary closure-typed operand, consumed like a call argument.
     ///
-    /// Borrowed vars take no rc op at their use; instead, like a `Proj` base,
-    /// any of them that is dead downstream is dropped right after the op. A
+    /// A borrowed `Var` base takes no rc op at its use; instead, like a
+    /// `Proj` base, it is dropped right after the op if dead downstream. A
     /// non-`Var` borrowed base is a temporary: placed as a value and its
     /// result dropped after the op ([`RcOp::DropValue`]).
     fn place_array_op(
@@ -667,18 +649,12 @@ impl<'tcx> Analyzer<'_, 'tcx> {
         e: &Expr<'tcx>,
         op: crate::intrinsic::ArrayFn,
         args: &'tcx [Expr<'tcx>],
-        kernel: Option<&'tcx mir::Kernel<'tcx>>,
         live_after: &VarSet,
     ) {
         use crate::intrinsic::ArrayFn;
         let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold);
 
-        // Everything the op borrows rather than consumes: kernel-read vars,
-        // plus a `Var` base of a borrowing op.
         let mut borrowed = VarSet::default();
-        if let Some(k) = kernel {
-            borrowed.union_with(&self.kernel_free(k));
-        }
         let mut base_is_borrowed_var = false;
         if borrows_base
             && self.rr.is_rr(args[0].ty)
@@ -689,7 +665,8 @@ impl<'tcx> Analyzer<'_, 'tcx> {
         }
 
         // Value operands, left-to-right with standard liveness threading, all
-        // under `live_after ∪ borrowed` so nothing borrowed is treated as dead.
+        // under `live_after ∪ borrowed` so the borrowed base is not treated
+        // as dead at its use.
         let mut live = live_after.clone();
         live.union_with(&borrowed);
         let n = args.len();
@@ -708,13 +685,7 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             }
         }
 
-        // The kernel body: every free var is in `live`, so its placement adds
-        // no consuming ops (its RR uses are `get` bases, which borrow).
-        if let Some(k) = kernel {
-            self.place(k.body, &live);
-        }
-
-        // Borrowed vars whose last use is this op die here.
+        // A borrowed var whose last use is this op dies here.
         for v in borrowed.iter() {
             if !live_after.contains(v) {
                 self.add_after(e.id, RcOp::Drop(v));

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -807,11 +807,10 @@ fn interp<'tcx>(
                 interp(a, ot, rr, rc);
             }
         }
-        // An array op consumes its operands like call args, except a
-        // borrowing op's (`get`/`fold`) array base, which follows the `Proj`
-        // borrow rule. A kernel body only reads enclosing vars — interpreting
-        // it must leave ownership untouched.
-        ExprKind::ArrayOp { op, args, kernel } => {
+        // An array op consumes its operands like call args (a Tabulate/Fold
+        // kernel closure among them), except a borrowing op's (`get`/`fold`)
+        // array base, which follows the `Proj` borrow rule.
+        ExprKind::ArrayOp { op, args } => {
             use crate::intrinsic::ArrayFn;
             let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold);
             for (i, a) in args.iter().enumerate() {
@@ -820,11 +819,6 @@ fn interp<'tcx>(
                 } else {
                     interp(a, ot, rr, rc);
                 }
-            }
-            if let Some(k) = kernel {
-                let before = rc.clone();
-                interp(k.body, ot, rr, rc);
-                assert_eq!(before, *rc, "kernel body must not change ownership");
             }
         }
         ExprKind::GlobalStr(_)
@@ -942,7 +936,7 @@ fn uses_var(e: &Expr<'_>, y: VarId) -> bool {
 fn children<'tcx>(e: &Expr<'tcx>) -> Vec<&'tcx Expr<'tcx>> {
     use ExprKind::*;
     match e.kind {
-        ArrayOp { args, kernel, .. } => args.iter().chain(kernel.map(|k| k.body)).collect(),
+        ArrayOp { args, .. } => args.iter().collect(),
         GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
         | Poison => vec![],
         Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -161,6 +161,18 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// The **checking** judgment `Γ ⊢ e ⇐ T ⇒ h`: synthesize `e`, then [`Self::expect`]
     /// its type against `T` (the CHECK rule). Always produces a node.
     pub(super) fn check_expr(&mut self, e: &surface::Expr, expected: Ty<'tcx>) -> Expr<'tcx> {
+        // (LAM⇐) a literal lambda checks against an expected closure type:
+        // unannotated parameters take the expected parameter types and the
+        // body checks against the expected result, so lambdas in argument
+        // position need no annotations.
+        if let surface::ExprKind::Lambda(lam) = e.kind()
+            && let TyKind::Closure { params, ret } = *self.infer.shallow_resolve(expected).kind()
+            && params.len() == lam.args.len()
+        {
+            let h = self.lambda(&lam, Some((params, ret)), Some(e.span()));
+            self.expect(h.ty, expected, h.span);
+            return h;
+        }
         let h = self.infer_expr(e);
         self.expect(h.ty, expected, h.span);
         h
@@ -693,21 +705,47 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// minus the params. Capturing or returning a flex value is a diagnostic (a flex
     /// value cannot escape its region).
     fn infer_lambda(&mut self, lam: &surface::Lambda, span: Option<Span>) -> Expr<'tcx> {
+        self.lambda(lam, None, span)
+    }
+
+    /// The shared lambda rule: synthesis when `expected` is `None`, checking
+    /// against an expected `(params) -> ret` otherwise (unannotated
+    /// parameters take the expected types; annotations must agree with them).
+    fn lambda(
+        &mut self,
+        lam: &surface::Lambda,
+        expected: Option<(&'tcx [Ty<'tcx>], Ty<'tcx>)>,
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
         let mark = self.vars.mark();
         let mut params = Vec::new();
-        for (name, ty) in &lam.args {
+        for (i, (name, ty)) in lam.args.iter().enumerate() {
+            let exp_p = expected.map(|(ps, _)| ps[i]);
             let pty = match ty {
-                Some(t) => self.eval_type(t),
-                None => self.infer.new_hole_ty(),
+                Some(t) => {
+                    let t = self.eval_type(t);
+                    if let Some(exp_p) = exp_p {
+                        self.expect(t, exp_p, span);
+                    }
+                    t
+                }
+                None => exp_p.unwrap_or_else(|| self.infer.new_hole_ty()),
             };
             let var = self.vars.fresh(*name, pty, None);
             params.push((var, pty));
         }
-        let body = match &lam.ret_ty {
+        let ret = match &lam.ret_ty {
             Some(rt) => {
-                let expected = self.eval_type(rt);
-                self.check_expr(&lam.body, expected)
+                let rt = self.eval_type(rt);
+                if let Some((_, exp_r)) = expected {
+                    self.expect(rt, exp_r, span);
+                }
+                Some(rt)
             }
+            None => expected.map(|(_, r)| r),
+        };
+        let body = match ret {
+            Some(expected) => self.check_expr(&lam.body, expected),
             None => self.infer_expr(&lam.body),
         };
         self.vars.restore(mark);
@@ -1093,8 +1131,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     }
 
     /// The constructing array intrinsics: `splat` checks its one argument
-    /// against the element type, `tabulate` checks a literal kernel lambda of
-    /// one `i64` parameter per dimension against it.
+    /// against the element type, `tabulate` checks its kernel — an ordinary
+    /// closure taking one `i64` index per dimension — against
+    /// `(i64, …) -> elem`. Any closure-typed expression works (a literal
+    /// lambda fuses into the loop nest under optimization; anything else is
+    /// called per element).
     fn infer_array_ctor(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
         use crate::intrinsic::ArrayFn;
         let method = self.sym(fc.name.basename).to_string();
@@ -1133,23 +1174,21 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match op {
             ArrayFn::Splat => {
                 let v = self.check_expr(&fc.args[0], elem);
+                self.mk_expr(ExprKind::ArrayOp { op, args: vec![v] }, arr, span)
+            }
+            ArrayFn::Tabulate => {
+                let i64_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Signed(64));
+                let params = vec![i64_ty; dims.len()];
+                let kernel_ty = self.tcx.mk_closure(&params, elem);
+                let kernel = self.check_expr(&fc.args[0], kernel_ty);
                 self.mk_expr(
                     ExprKind::ArrayOp {
                         op,
-                        args: vec![v],
-                        kernel: None,
+                        args: vec![kernel],
                     },
                     arr,
                     span,
                 )
-            }
-            ArrayFn::Tabulate => {
-                let _ = dims;
-                self.error(
-                    span,
-                    "`core::intrinsic::array::tabulate` is not available yet",
-                );
-                self.poison(span)
             }
             _ => unreachable!("filtered above"),
         }
@@ -1195,7 +1234,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     ExprKind::ArrayOp {
                         op: ArrayFn::Get,
                         args: hargs,
-                        kernel: None,
                     },
                     elem,
                     span,
@@ -1222,15 +1260,31 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     ExprKind::ArrayOp {
                         op: ArrayFn::Set,
                         args: hargs,
-                        kernel: None,
                     },
                     bty,
                     span,
                 )
             }
             "fold" => {
-                self.error(span, "`core::intrinsic::array::fold` is not available yet");
-                self.poison(span)
+                if args.len() != 2 {
+                    self.error(
+                        span,
+                        "`fold` expects an initial accumulator and a kernel closure",
+                    );
+                    return self.poison(span);
+                }
+                let init = self.infer_expr(&args[0]);
+                let acc_ty = init.ty;
+                let kernel_ty = self.tcx.mk_closure(&[acc_ty, elem], acc_ty);
+                let kernel = self.check_expr(&args[1], kernel_ty);
+                self.mk_expr(
+                    ExprKind::ArrayOp {
+                        op: ArrayFn::Fold,
+                        args: vec![base, init, kernel],
+                    },
+                    acc_ty,
+                    span,
+                )
             }
             _ => unreachable!("routed here only for get/set/fold"),
         }
@@ -1786,21 +1840,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 body: zb(self, c.body),
             }),
             Match(scrut, tree) => Match(zb(self, scrut), self.zonk_tree(tree)),
-            ArrayOp { op, args, kernel } => {
-                let args = args.into_iter().map(|e| self.zonk_expr(e)).collect();
-                let kernel = kernel.map(|k| {
-                    let k = super::hir::Kernel {
-                        params: k
-                            .params
-                            .into_iter()
-                            .map(|(v, t)| (v, self.zonk_ty(t, span)))
-                            .collect(),
-                        body: zb(self, k.body),
-                    };
-                    Box::new(k)
-                });
-                ArrayOp { op, args, kernel }
-            }
+            ArrayOp { op, args } => ArrayOp {
+                op,
+                args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
+            },
             other => other,
         }
     }
@@ -1875,19 +1918,7 @@ fn free_vars<'tcx>(e: &Expr<'tcx>, out: &mut Vec<VarId>) {
             args.iter().for_each(|e| free_vars(e, out));
         }
         Closure(c) => free_vars(&c.body, out),
-        ArrayOp { args, kernel, .. } => {
-            args.iter().for_each(|e| free_vars(e, out));
-            if let Some(k) = kernel {
-                // Kernel params are binders, not free uses.
-                let mut body = Vec::new();
-                free_vars(&k.body, &mut body);
-                for v in body {
-                    if !k.params.iter().any(|&(p, _)| p == v) {
-                        push(out, v);
-                    }
-                }
-            }
-        }
+        ArrayOp { args, .. } => args.iter().for_each(|e| free_vars(e, out)),
         Match(scrut, _) => free_vars(scrut, out),
         GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Poison => {}
     }

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -152,32 +152,16 @@ pub enum ExprKind<'tcx> {
         args: Vec<Expr<'tcx>>,
     },
     /// A built-in operation on a statically shaped array (issue #344): the
-    /// resolved op, its value operands (see [`crate::intrinsic::ArrayFn`] for
-    /// each op's operand list), and — for `Tabulate`/`Fold` — an inline kernel.
-    ///
-    /// The kernel is *not* a closure: its body is checked in the enclosing
-    /// scope with only the kernel params added, so free variables reference
-    /// enclosing bindings directly (read-only for the op's duration) and no
-    /// capture list exists. Codegen inlines the body into the loop nest.
+    /// resolved op and its value operands (see [`crate::intrinsic::ArrayFn`]
+    /// for each op's operand list). `Tabulate`/`Fold` take their kernel as an
+    /// ordinary closure-typed operand (the last one); the optimizer inlines a
+    /// literal lambda into the loop nest (loop-carried beta reduction).
     ArrayOp {
         op: crate::intrinsic::ArrayFn,
         args: Vec<Expr<'tcx>>,
-        kernel: Option<Box<Kernel<'tcx>>>,
     },
     /// Error-recovery placeholder.
     Poison,
-}
-
-/// The inline kernel of an [`ArrayOp`](ExprKind::ArrayOp): parameters bound
-/// per element/iteration (`Tabulate`: one `i64` per dimension; `Fold`:
-/// `(acc, elem)`) and the body producing the element / next accumulator.
-/// The type checker restricts the body to be rc-free — every subexpression is
-/// of plain (unmanaged) type except array reads (`get`) of enclosing arrays —
-/// so inlining it into a loop introduces no per-iteration ownership work.
-#[derive(Clone, Debug)]
-pub struct Kernel<'tcx> {
-    pub params: Vec<(VarId, Ty<'tcx>)>,
-    pub body: Box<Expr<'tcx>>,
 }
 
 // ===== decision trees (compiled pattern matches) =====

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -508,23 +508,8 @@ impl<'a> Printer<'a> {
                     + self.value(&c.body)
                     + text(" }")
             }
-            ExprKind::ArrayOp { op, args, kernel } => {
-                let mut d =
-                    text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")");
-                if let Some(k) = kernel {
-                    let params: Vec<Doc<'static>> = k
-                        .params
-                        .iter()
-                        .map(|(v, t)| var(*v) + text(": ") + self.ty(*t))
-                        .collect();
-                    d = d
-                        + text(" kernel(")
-                        + comma_sep(params)
-                        + text(") { ")
-                        + self.value(&k.body)
-                        + text(" }");
-                }
-                d
+            ExprKind::ArrayOp { op, args } => {
+                text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")")
             }
             ExprKind::Let { .. } | ExprKind::Seq(_) | ExprKind::If(..) | ExprKind::Match(..) => {
                 unreachable!("structural forms are rendered by `value`")

--- a/tests/integration/frontend/array.rr
+++ b/tests/integration/frontend/array.rr
@@ -27,3 +27,34 @@ pub fn bump(a : [f64; 8], i : i64, v : f64) -> [f64; 8] {
 pub fn cell(m : [i32; 4, 4], i : i64, j : i64) -> i32 {
     core::intrinsic::array::get(m, i, j)
 }
+
+// CHECK: pub fn #make() -> [f64; 8]
+// CHECK: array#tabulate(closure[](v{{[0-9]+}}: i64) {
+pub fn make() -> [f64; 8] {
+    core::intrinsic::array::tabulate<[f64; 8]>(|i| i as f64)
+}
+
+// CHECK: pub fn #sum(v0 (a): [f64; 8]) -> f64
+// CHECK: array#fold(v0 : [f64; 8]{{.*}}, 0.0 : f64{{.*}}, closure[](v{{[0-9]+}}: f64, v{{[0-9]+}}: f64) {
+pub fn sum(a : [f64; 8]) -> f64 {
+    core::intrinsic::array::fold(a, 0.0, |acc, x| acc + x)
+}
+
+// The kernel is an ordinary closure: a stencil reading the enclosing array
+// captures it like any lambda would.
+// CHECK: pub fn #blur(v0 (x): [f64; 8]) -> [f64; 8]
+// CHECK: array#tabulate(closure[v0: [f64; 8]](v{{[0-9]+}}: i64) {
+// CHECK: array#get(v0
+pub fn blur(x : [f64; 8]) -> [f64; 8] {
+    core::intrinsic::array::tabulate<[f64; 8]>(|i|
+        if i == 0 { core::intrinsic::array::get(x, i) }
+        else { (core::intrinsic::array::get(x, i - 1) + core::intrinsic::array::get(x, i)) / 2.0 })
+}
+
+// A named closure works too — the kernel operand is any closure-typed
+// expression, not only a literal lambda.
+// CHECK: pub fn #apply_named(v0 (f): (f64, f64) -> f64, v1 (a): [f64; 8]) -> f64
+// CHECK: array#fold(v1 : [f64; 8]{{.*}}, 1.0 : f64{{.*}}, v0 : (f64, f64) -> f64
+pub fn apply_named(f : (f64, f64) -> f64, a : [f64; 8]) -> f64 {
+    core::intrinsic::array::fold(a, 1.0, f)
+}

--- a/tests/integration/frontend/array_errors.rr
+++ b/tests/integration/frontend/array_errors.rr
@@ -35,3 +35,15 @@ fn rank_mismatch(m : [f64; 4, 4]) -> f64 { core::intrinsic::array::get(m, 0) }
 
 // CHECK: `core::intrinsic::array::get` expects an array as its first argument, found `i64`
 fn not_an_array(x : i64) -> i64 { core::intrinsic::array::get(x, 0) }
+
+// A tabulate kernel is checked as an ordinary closure: one i64 parameter
+// per dimension.
+// CHECK: type mismatch: expected `(i64, i64) -> f64`
+fn wrong_rank(m : [f64; 4, 4]) -> [f64; 4, 4] {
+    core::intrinsic::array::tabulate<[f64; 4, 4]>(|i| 0.0)
+}
+
+// CHECK: type mismatch: expected `(f64, f64) -> f64`
+fn wrong_kernel(a : [f64; 4]) -> f64 {
+    core::intrinsic::array::fold(a, 0.0, |acc: f64, x: i64| acc)
+}


### PR DESCRIPTION
The kernel-carrying array ops land on plain closures instead of the dedicated Kernel node (per the design discussion on #344 / #392 groundwork): `tabulate<[T; e…]>(f)` checks `f` against `(i64, …) -> T` and `fold(a, init, f)` against `(A, T) -> A`. Any closure-typed expression works — named or literal; a literal lambda fuses into the loop nest under `-Oaggressive` (loop-carried beta reduction, #392), anything else is called per element. A stencil reading its enclosing array captures it like any lambda would; the capture's rc semantics (COW observability) are carried by the ordinary ownership placement.

The `Kernel` node and its special handling leave HIR/MIR, monomorphization, and ownership retroactively — the kernel is just a consumed closure operand now, and the borrow contract that remains in `place_array_op` is purely about the `get`/`fold` array base.

This also adds the checking-mode lambda rule (`LAM⇐`) to `check_expr`: a literal lambda checked against an expected closure type seeds its unannotated parameters from the expected parameter types and checks the body against the expected result — so kernels (and closure arguments generally) need no annotations.

Supersedes #381 (the Kernel-based checker), which never merged. Codegen still reports array ops as not lowered; the loop emission lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786390056&installation_id=144622820&pr_number=393&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F393&signature=f98722c6783ad2305ecba81477ee8ef3bd1cc6284ff79630e24a8d0d181b2ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->