### PR TITLE
[frontend] closure captures: free variables, not variable occurrences

### DIFF
--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1875,52 +1875,126 @@ fn cmp_op(op: BinOp) -> CmpOp {
     }
 }
 
-/// Collect the free variables referenced in an expression tree.
+/// Collect the free variables of an expression tree: every `Var` occurrence
+/// minus every variable the tree itself binds (`let`s, pattern bindings,
+/// nested closure parameters). Variable ids are fresh per binder within a
+/// function body, so a single flat bound set is enough — no scoping needed.
 fn free_vars<'tcx>(e: &Expr<'tcx>, out: &mut Vec<VarId>) {
-    use ExprKind::*;
-    let push = |out: &mut Vec<VarId>, v: VarId| {
-        if !out.contains(&v) {
+    let mut used = Vec::new();
+    let mut bound = Vec::new();
+    var_occurrences(e, &mut used, &mut bound);
+    for v in used {
+        if !bound.contains(&v) && !out.contains(&v) {
             out.push(v);
         }
-    };
+    }
+}
+
+fn var_occurrences<'tcx>(e: &Expr<'tcx>, used: &mut Vec<VarId>, bound: &mut Vec<VarId>) {
+    use ExprKind::*;
     match &e.kind {
-        Var(v) => push(out, *v),
+        Var(v) => used.push(*v),
         Intrinsic { args, .. } => {
             for a in args {
-                free_vars(a, out);
+                var_occurrences(a, used, bound);
             }
         }
-        Negate(e) | Not(e) | Cast(e, _) | RegionRun(e) | Proj(e, _) => free_vars(e, out),
+        Negate(e) | Not(e) | Cast(e, _) | RegionRun(e) | Proj(e, _) => {
+            var_occurrences(e, used, bound)
+        }
         Arith(l, _, r) | Cmp(l, _, r) | Assign(l, _, r) => {
-            free_vars(l, out);
-            free_vars(r, out);
+            var_occurrences(l, used, bound);
+            var_occurrences(r, used, bound);
         }
         If(c, t, f) => {
-            free_vars(c, out);
-            free_vars(t, out);
-            free_vars(f, out);
+            var_occurrences(c, used, bound);
+            var_occurrences(t, used, bound);
+            var_occurrences(f, used, bound);
         }
         Let { var, value, .. } => {
-            free_vars(value, out);
-            push(out, *var);
+            var_occurrences(value, used, bound);
+            bound.push(*var);
         }
-        Seq(es) => es.iter().for_each(|e| free_vars(e, out)),
+        Seq(es) => es.iter().for_each(|e| var_occurrences(e, used, bound)),
         FuncCall { args, .. } | CompoundCall { args, .. } | VariantCall { args, .. } => {
-            args.iter().for_each(|e| free_vars(e, out))
+            args.iter().for_each(|e| var_occurrences(e, used, bound))
         }
         NullableCall(e) => {
             if let Some(e) = e {
-                free_vars(e, out)
+                var_occurrences(e, used, bound)
             }
         }
         ClosureCall { target, args } => {
-            free_vars(target, out);
-            args.iter().for_each(|e| free_vars(e, out));
+            var_occurrences(target, used, bound);
+            args.iter().for_each(|e| var_occurrences(e, used, bound));
         }
-        Closure(c) => free_vars(&c.body, out),
-        ArrayOp { args, .. } => args.iter().for_each(|e| free_vars(e, out)),
-        Match(scrut, _) => free_vars(scrut, out),
+        Closure(c) => {
+            bound.extend(c.params.iter().map(|&(v, _)| v));
+            var_occurrences(&c.body, used, bound);
+        }
+        ArrayOp { args, .. } => args.iter().for_each(|e| var_occurrences(e, used, bound)),
+        Match(scrut, tree) => {
+            var_occurrences(scrut, used, bound);
+            tree_occurrences(tree, used, bound);
+        }
         GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Poison => {}
+    }
+}
+
+fn tree_occurrences<'tcx>(
+    t: &crate::semi::hir::DecisionTree<'tcx>,
+    used: &mut Vec<VarId>,
+    bound: &mut Vec<VarId>,
+) {
+    use crate::semi::hir::{DecisionTree, SwitchCases};
+    match t {
+        DecisionTree::Uncovered | DecisionTree::Unreachable => {}
+        DecisionTree::Leaf { body, bindings } => {
+            bound.extend(bindings.iter().map(|&(v, _)| v));
+            var_occurrences(body, used, bound);
+        }
+        DecisionTree::Guard {
+            bindings,
+            guard,
+            success,
+            failure,
+        } => {
+            bound.extend(bindings.iter().map(|&(v, _)| v));
+            var_occurrences(guard, used, bound);
+            tree_occurrences(success, used, bound);
+            tree_occurrences(failure, used, bound);
+        }
+        DecisionTree::Switch { cases, .. } => match cases {
+            SwitchCases::Int { cases, default } => {
+                cases
+                    .iter()
+                    .for_each(|(_, t)| tree_occurrences(t, used, bound));
+                tree_occurrences(default, used, bound);
+            }
+            SwitchCases::Bool { if_true, if_false } => {
+                tree_occurrences(if_true, used, bound);
+                tree_occurrences(if_false, used, bound);
+            }
+            SwitchCases::Char { cases, default } => {
+                cases
+                    .iter()
+                    .for_each(|(_, t)| tree_occurrences(t, used, bound));
+                tree_occurrences(default, used, bound);
+            }
+            SwitchCases::Ctor(subtrees) => subtrees
+                .iter()
+                .for_each(|t| tree_occurrences(t, used, bound)),
+            SwitchCases::String { cases, default } => {
+                cases
+                    .iter()
+                    .for_each(|(_, t)| tree_occurrences(t, used, bound));
+                tree_occurrences(default, used, bound);
+            }
+            SwitchCases::Nullable { non_null, null } => {
+                tree_occurrences(non_null, used, bound);
+                tree_occurrences(null, used, bound);
+            }
+        },
     }
 }
 

--- a/tests/integration/frontend/closure_captures.rr
+++ b/tests/integration/frontend/closure_captures.rr
@@ -1,0 +1,37 @@
+// Closure capture computation: captures are the body's free variables —
+// `Var` occurrences minus everything the body itself binds. Regression
+// coverage for three binder kinds the old occurrence walk got wrong: a
+// `let`-bound local leaked into the capture list (unbound at the creation
+// site), match arms were skipped entirely (so a variable used only inside
+// an arm was never captured), and a nested lambda's parameters were not
+// subtracted.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+
+enum E { A(i64), B }
+
+fn apply1(f : i64 -> i64, x : i64) -> i64 { f(x) }
+fn apply_e(f : E -> i64, e : E) -> i64 { f(e) }
+
+// A `let`-bound local is not a capture; only `k` crosses the boundary.
+// CHECK: fn #let_in_lambda(v0 (k): i64, v1 (x): i64) -> i64 {
+// CHECK: closure[v0: i64](v2: i64) { { let v3 (t)
+fn let_in_lambda(k : i64, x : i64) -> i64 {
+    apply1(|y| { let t = y + 1; t * k }, x)
+}
+
+// A variable used only inside match arms is still a capture, and the
+// pattern binding `v` is not.
+// CHECK: fn #match_in_lambda(v0 (k): i64, v1 (e): #E) -> i64 {
+// CHECK: closure[v0: i64](v2: #E) { match v2 : #E {
+fn match_in_lambda(k : i64, e : E) -> i64 {
+    apply_e(|x : E| match x { E::A(v) => v + k, E::B => k }, e)
+}
+
+// An inner lambda's parameter is bound, not free: both closures capture
+// exactly `k`.
+// CHECK: fn #nested_lambda(v0 (k): i64, v1 (x): i64) -> i64 {
+// CHECK: closure[v0: i64](v2: i64) { #apply1(closure[v0: i64](v3: i64)
+fn nested_lambda(k : i64, x : i64) -> i64 {
+    apply1(|y| apply1(|z| z + k, y), x)
+}

--- a/tests/integration/frontend/example_life.c
+++ b/tests/integration/frontend/example_life.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t life_test_ffi(int64_t);
+
+/* Population after 100 generations of the hash-seeded soup; the reference
+   value comes from an independent simulation of the same rule and seed. */
+int main(void) {
+  int64_t got = life_test_ffi(100);
+  if (got != 520) {
+    fprintf(stderr, "life(100): got %lld, want 520\n", (long long)got);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/example_life.rr
+++ b/tests/integration/frontend/example_life.rr
@@ -1,0 +1,66 @@
+// Conway's Game of Life on a toroidal 64x64 grid — a sophisticated array
+// workload: each generation is a rank-2 tabulate whose kernel captures the
+// previous grid, `let`-binds its wrapped neighbor indices (a body-local
+// binder inside a capturing lambda), and reads nine cells; the run loop
+// threads the grid through tail recursion and the final population count is
+// a fold. At -Oaggressive the loop-carried beta reduction fuses the kernels
+// and the masked indices let the bounds guards fold.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/example_life.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %t.opt.o %S/example_life.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+fn wrap(x : i64) -> i64 {
+    (x + 64) % 64
+}
+
+fn step(g : [i32; 64, 64]) -> [i32; 64, 64] {
+    core::intrinsic::array::tabulate<[i32; 64, 64]>(|i, j| {
+        let im = wrap(i - 1);
+        let ip = wrap(i + 1);
+        let jm = wrap(j - 1);
+        let jp = wrap(j + 1);
+        let n = core::intrinsic::array::get(g, im, jm)
+              + core::intrinsic::array::get(g, im, j)
+              + core::intrinsic::array::get(g, im, jp)
+              + core::intrinsic::array::get(g, i, jm)
+              + core::intrinsic::array::get(g, i, jp)
+              + core::intrinsic::array::get(g, ip, jm)
+              + core::intrinsic::array::get(g, ip, j)
+              + core::intrinsic::array::get(g, ip, jp);
+        let alive = core::intrinsic::array::get(g, i, j);
+        if alive == 1 {
+            if n == 2 { 1 } else { if n == 3 { 1 } else { 0 } }
+        } else {
+            if n == 3 { 1 } else { 0 }
+        }
+    })
+}
+
+fn run(g : [i32; 64, 64], n : i64) -> [i32; 64, 64] {
+    if n == 0 { g } else { run(step(g), n - 1) }
+}
+
+// Deterministic ~34% soup from a per-cell hash; no PRNG state to thread.
+fn seed() -> [i32; 64, 64] {
+    core::intrinsic::array::tabulate<[i32; 64, 64]>(|i, j| {
+        if (i * 2654435761 + j * 40503 + i * j * 2246822519) % 97 < 33 {
+            1
+        } else {
+            0
+        }
+    })
+}
+
+fn population(g : [i32; 64, 64]) -> i64 {
+    core::intrinsic::array::fold(g, 0, |acc : i64, c : i32| acc + (c as i64))
+}
+
+fn life_test(gens : i64) -> i64 {
+    population(run(seed(), gens))
+}
+
+extern "C" trampoline "life_test_ffi" = life_test;

--- a/tests/integration/frontend/example_qsort.c
+++ b/tests/integration/frontend/example_qsort.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t qsort_test_ffi(int64_t);
+
+/* Checksum of two sort rounds (seeds 43 and 44); the reference value comes
+   from an independent sort of the same MINSTD sequences. A -1 means the
+   result was not sorted. */
+int main(void) {
+  int64_t got = qsort_test_ffi(2);
+  if (got != 738424691) {
+    fprintf(stderr, "qsort(2): got %lld, want 738424691\n", (long long)got);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/example_qsort.rr
+++ b/tests/integration/frontend/example_qsort.rr
@@ -1,0 +1,89 @@
+// Functional in-place quicksort over [i64; 65536] — a sophisticated array
+// workload built from plain get/set only, no tabulate/fold kernels in the
+// hot path. The array is threaded linearly through mutual recursion, so
+// uniqueness makes every set an in-place store; the partition base case
+// performs the recursive sort calls directly, avoiding the need to return
+// an (array, pivot-index) pair (records cannot hold arrays yet).
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/example_qsort.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %t.opt.o %S/example_qsort.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+fn lcg(x : i64) -> i64 {
+    (x * 48271) % 2147483647
+}
+
+fn fill(a : [i64; 65536], i : i64, x : i64) -> [i64; 65536] {
+    if i == 65536 {
+        a
+    } else {
+        let x1 = lcg(x);
+        fill(core::intrinsic::array::set(a, i, x1), i + 1, x1)
+    }
+}
+
+fn swap(a : [i64; 65536], i : i64, j : i64) -> [i64; 65536] {
+    let x = core::intrinsic::array::get(a, i);
+    let y = core::intrinsic::array::get(a, j);
+    core::intrinsic::array::set(core::intrinsic::array::set(a, i, y), j, x)
+}
+
+fn qsort_go(a : [i64; 65536], lo : i64, hi : i64) -> [i64; 65536] {
+    if lo >= hi {
+        a
+    } else {
+        let p = core::intrinsic::array::get(a, hi);
+        partition(a, lo, hi, p, lo, lo)
+    }
+}
+
+// Lomuto partition with pivot at hi; invariant: [lo, i) < p, [i, j) >= p.
+fn partition(a : [i64; 65536], lo : i64, hi : i64, p : i64, i : i64, j : i64) -> [i64; 65536] {
+    if j == hi {
+        let a1 = swap(a, i, hi);
+        qsort_go(qsort_go(a1, lo, i - 1), i + 1, hi)
+    } else {
+        if core::intrinsic::array::get(a, j) < p {
+            partition(swap(a, i, j), lo, hi, p, i + 1, j + 1)
+        } else {
+            partition(a, lo, hi, p, i, j + 1)
+        }
+    }
+}
+
+// Sortedness check plus checksum; returns -1 on an ordering violation.
+fn check(a : [i64; 65536], i : i64, prev : i64, acc : i64) -> i64 {
+    if i == 65536 {
+        acc
+    } else {
+        let v = core::intrinsic::array::get(a, i);
+        if prev > v {
+            0 - 1
+        } else {
+            check(a, i + 1, v, (acc + v) % 1000000007)
+        }
+    }
+}
+
+fn round(seed : i64) -> i64 {
+    let a = fill(core::intrinsic::array::splat<[i64; 65536]>(0), 0, seed);
+    let s = qsort_go(a, 0, 65535);
+    check(s, 0, 0 - 1, 0)
+}
+
+fn rounds(r : i64, acc : i64) -> i64 {
+    if r == 0 {
+        acc
+    } else {
+        rounds(r - 1, (acc + round(42 + r)) % 1000000007)
+    }
+}
+
+fn qsort_test(r : i64) -> i64 {
+    rounds(r, 0)
+}
+
+extern "C" trampoline "qsort_test_ffi" = qsort_test;


### PR DESCRIPTION
## Bug

`free_vars` in the lambda rule was an occurrence walk, not a free-variable computation:

- `Let { var, .. }` **pushed the bound variable into the free set**, so any `let` inside a lambda body became a phantom capture the creation site could not supply — `lowering error: unbound captured variable VarId(N)`.
- `Match(scrut, _)` **ignored the decision tree entirely**, so a variable used only inside a match arm was never captured — `lowering error: unbound variable VarId(N)`.
- Nested `Closure(c)` did not subtract the inner lambda's parameters.

None of the existing tests put a `let` or `match` inside a kernel lambda, so this never surfaced until drafting array benchmark programs (a Game of Life kernel that `let`-binds its wrapped neighbor indices).

## Fix

Collect `Var` occurrences and subtract everything the body binds: `let`s, pattern bindings in decision-tree leaves and guards, and nested closure parameters. Variable ids are fresh per binder within a function body, so a single flat bound set suffices — no scoping structure needed.

## Tests

- `closure_captures.rr`: HIR-level checks that the capture list is exactly the outer variable for all three shapes (let-in-lambda, match-in-lambda, nested lambda).
- `example_life.rr` / `example_qsort.rr` (+ C drivers): two sophisticated end-to-end array workloads, verified against independent reference simulations at `-Onone` and `-Oaggressive --reuse-across-call`:
  - toroidal 64×64 Game of Life — rank-2 tabulate kernels capturing the previous grid (needs this fix), fold population count; kernels fuse, masked-index guards fold;
  - functional in-place quicksort over `[i64; 65536]` — plain get/set through mutual recursion, uniqueness makes every set an in-place store.

Local gate: 326/326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786401508&installation_id=144622820&pr_number=394&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F394&signature=36a4a6ef838719a9752d2708d258c884545ef14259e216d797135d16617313a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->