### PR TITLE
[frontend][backend] arrays as record members: one shared rc box, like closures

### DIFF
--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -153,14 +153,16 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
     /// by its bare element type, never an `rc` pointer: the dialect boxes a member
     /// whose element capability is `shared`/`regional` to a pointer on its own (a
     /// `!reussir.rc<…>` member is rejected — "use capability instead"). This holds
-    /// for a `shared`/`regional` record member (its inner record type) and for a
+    /// for a `shared`/`regional` record member (its inner record type), for a
     /// closure member (its bare `closure` type — a closure is a shared `rc` value
-    /// just like a shared record). A scalar or `[value]` record member is the same
-    /// as [`mlir_ty`](Self::mlir_ty).
+    /// just like a shared record), and for an array member (its bare `array`
+    /// payload type — an array is one shared `rc` box too). A scalar or `[value]`
+    /// record member is the same as [`mlir_ty`](Self::mlir_ty).
     fn member_ty(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
         match *ty.kind() {
             TyKind::Record { .. } => self.record_inner_of(ty),
             TyKind::Closure { params, ret } => self.closure_inner(params, ret),
+            TyKind::Array { .. } => self.array_inner_of(ty),
             _ => self.mlir_ty(ty),
         }
     }

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -957,18 +957,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .collect()
     }
 
-    /// Phase A of the array design (issue #344) supports arrays as locals,
-    /// parameters, and returns only — a record member of array type has no
-    /// dialect-level member representation yet.
-    fn reject_array_member(&mut self, fty: Ty<'tcx>, span: Option<Span>) {
-        if matches!(fty.kind(), crate::semi::ty::TyKind::Array { .. }) {
-            self.error(
-                span,
-                "an array cannot be a record member in this version (see issue #344)",
-            );
-        }
-    }
-
     fn populate_record(&mut self, rec: &surface::Record, def: DefId) {
         let Some(record) = self.records.get(&def) else {
             return;
@@ -991,7 +979,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (name, ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
-                        self.reject_array_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -1004,7 +991,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
-                        self.reject_array_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -1020,11 +1006,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                             name: *name,
                             fields: tys
                                 .iter()
-                                .map(|t| {
-                                    let fty = self.eval_type(t);
-                                    self.reject_array_member(fty, span);
-                                    fty
-                                })
+                                .map(|t| self.eval_type(t))
                                 .collect(),
                         }
                     })
@@ -1146,6 +1128,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 flex: Flexivity::Irrelevant,
                 ..
             } => self.error(span, "a `[field]` link element must be a regional record"),
+            // An array is pointer-like (one shared rc box), so the `Nullable`
+            // check below would let it through — but a `[field]` link stores a
+            // regional record, never a shared box.
+            TyKind::Array { .. } => {
+                self.error(span, "a `[field]` link element must be a regional record")
+            }
             // Regional records are fine; non-record elements are already rejected
             // by the `Nullable` pointer-like check.
             _ => {}

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -242,8 +242,12 @@ bool isTriviallyCopyable(mlir::Type type) {
 // 1. it is a mutable field (isField == true)
 // 2. it is a referential record (either shared or regional)
 // 3. it is a closure
+// 4. it is an array — one shared rc box, like a closure
 // unless this layout is derived for memory box internal layout, which forces
-// the structure to expand in place.
+// the structure to expand in place. That exemption covers the array case (an
+// array box's payload IS the bare array, laid out inline) but not the closure
+// case (a closure box is a ClosureBoxType — a raw ClosureType is always the
+// pointer to one).
 mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
                              bool isField, bool memBoxInternal) {
   auto ptrTy = mlir::LLVM::LLVMPointerType::get(context);
@@ -253,7 +257,8 @@ mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
       (isField ||
        (recordTy &&
         (recordTy.getDefaultCapability() == Capability::shared ||
-         recordTy.getDefaultCapability() == Capability::regional))))
+         recordTy.getDefaultCapability() == Capability::regional)) ||
+       llvm::isa<ArrayType>(rawMember)))
     member = ptrTy;
   if (llvm::isa<ClosureType>(member))
     member = ptrTy;
@@ -1295,8 +1300,9 @@ mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap) {
               return Capability::field;
             return type.getDefaultCapability();
           })
-          .Case<ClosureType>(
-              [](ClosureType) -> Capability { return Capability::shared; })
+          // A closure or an array member is one shared rc box.
+          .Case<ClosureType, ArrayType>(
+              [](mlir::Type) -> Capability { return Capability::shared; })
           .Default([](mlir::Type) { return Capability::unspecified; });
   if (targetCap == Capability::field) {
     // Target capability is rigid unless the reference capability is flex

--- a/tests/integration/frontend/array_errors.rr
+++ b/tests/integration/frontend/array_errors.rr
@@ -9,8 +9,10 @@
 struct S { x: i32 }
 fn bad_elem(a : [S; 4]) -> i64 { 0 }
 
-// CHECK-DAG: an array cannot be a record member in this version
-struct Holder { data: [f64; 4] }
+// An array member is fine (one shared rc box, like a closure member), but a
+// mutable `[field]` link stores a regional record — an array cannot back one.
+// CHECK-DAG: a `[field]` link element must be a regional record
+struct [regional] MutHolder { data: [field] [f64; 4] }
 
 // CHECK-DAG: array extents must be positive
 fn zero_extent(a : [f64; 0]) -> i64 { 0 }

--- a/tests/integration/frontend/array_struct_materialize.c
+++ b/tests/integration/frontend/array_struct_materialize.c
@@ -1,0 +1,59 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Float results cross the C-ABI trampoline via an out-parameter (only
+   void/integer/pointer returns are direct). */
+extern void test_shared_ffi(double *);
+extern int64_t test_value_ffi(void);
+extern void test_enum_blob_ffi(double *);
+extern void test_enum_empty_ffi(double *);
+extern void test_cow_field_ffi(double *);
+extern void test_multi_ffi(double *);
+extern int64_t test_generic_ffi(void);
+extern int64_t test_nested_ffi(void);
+extern int64_t test_rank2_field_ffi(void);
+
+static int check_f64(const char *name, void (*fn)(double *), double want) {
+  double got = 0.0;
+  fn(&got);
+  if (got != want) {
+    fprintf(stderr, "%s: got %f, want %f\n", name, got, want);
+    return 1;
+  }
+  return 0;
+}
+
+static int check_i64(const char *name, int64_t got, int64_t want) {
+  if (got != want) {
+    fprintf(stderr, "%s: got %lld, want %lld\n", name, (long long)got,
+            (long long)want);
+    return 1;
+  }
+  return 0;
+}
+
+int main(void) {
+  int failed = 0;
+  /* shared: get(splat(2.5), 3) * 4.0 = 10.0 */
+  failed |= check_f64("shared", test_shared_ffi, 10.0);
+  /* value: i*i at 3 and 7 through two copies = 9 + 49 = 58 */
+  failed |= check_i64("value", test_value_ffi(), 58);
+  /* enum blob: fold(splat(7.0)) = 28.0; empty arm = -1.0 */
+  failed |= check_f64("enum_blob", test_enum_blob_ffi, 28.0);
+  failed |= check_f64("enum_empty", test_enum_empty_ffi, -1.0);
+  /* cow through field: original 1.0 + updated 99.0 = 100.0 */
+  failed |= check_f64("cow_field", test_cow_field_ffi, 100.0);
+  /* multi: (0+1+2+3) twice + 2.0 = 14.0 */
+  failed |= check_f64("multi", test_multi_ffi, 14.0);
+  /* generic Pair<[i64;4]>: fst[2] = 3, snd[3] = 6 → 9 */
+  failed |= check_i64("generic", test_generic_ffi(), 9);
+  /* nested: (i+1) tabulate at 5 = 6 */
+  failed |= check_i64("nested", test_nested_ffi(), 6);
+  /* rank-2: cells[1][2] = 12, fold = 36 → 48 */
+  failed |= check_i64("rank2_field", test_rank2_field_ffi(), 48);
+  if (failed)
+    abort();
+  puts("all ok");
+  return 0;
+}

--- a/tests/integration/frontend/array_struct_materialize.rr
+++ b/tests/integration/frontend/array_struct_materialize.rr
@@ -1,0 +1,130 @@
+// RUN: %rrc %s --emit mlir -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/array_struct_materialize.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -O aggressive
+// RUN: %cc %t.opt.o %S/array_struct_materialize.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+// Test: arrays materialized as fields inside value and shared records and as
+// enum variant payloads. An array is one shared rc box (like a closure), so a
+// record member of array type is the bare `!reussir.array` payload type — the
+// dialect boxes the member to a pointer on its own — and every projection
+// yields the `rc<array>` handle. The runs exercise construction, projection
+// with multiplicity (acquire/drop of the shared box), copy-on-write through a
+// projected field, generic instantiation with an array argument, nested
+// value-in-shared placement, and rank-2 members.
+
+// The record members are the bare array payload types, never `rc`.
+// CHECK-DAG: !reussir.record<compound "_RC7SHolder" {!reussir.array<4 x f64>, f64}>
+// CHECK-DAG: !reussir.record<compound "_RC7VHolder" [value] {!reussir.array<8 x i64>}>
+
+struct [shared] SHolder {
+    data: [f64; 4],
+    scale: f64
+}
+
+struct [value] VHolder {
+    data: [i64; 8]
+}
+
+struct [shared] Outer {
+    inner: VHolder
+}
+
+struct [shared] Grid {
+    cells: [i64; 2, 3]
+}
+
+struct Pair<T> {
+    fst: T,
+    snd: T
+}
+
+enum Payload {
+    Empty,
+    Blob([f64; 4])
+}
+
+// --- Test 1: array in shared struct — construct, project, read ---
+pub fn test_shared() -> f64 {
+    let a = core::intrinsic::array::splat<[f64; 4]>(2.5);
+    let h = SHolder { data: a, scale: 4.0 };
+    core::intrinsic::array::get(h.data, 3) * h.scale
+}
+extern "C" trampoline "test_shared_ffi" = test_shared;
+
+// --- Test 2: array in value struct, copied (two owners of one box) ---
+pub fn test_value() -> i64 {
+    let h = VHolder { data: core::intrinsic::array::tabulate<[i64; 8]>(|i| i * i) };
+    let g = h;
+    core::intrinsic::array::get(h.data, 3) + core::intrinsic::array::get(g.data, 7)
+}
+extern "C" trampoline "test_value_ffi" = test_value;
+
+// --- Test 3: enum variant carrying an array, matched back out ---
+pub fn test_enum_blob() -> f64 {
+    let p = Payload::Blob{core::intrinsic::array::splat<[f64; 4]>(7.0)};
+    match p {
+        Payload::Blob(data) => core::intrinsic::array::fold(data, 0.0, |acc, x| acc + x),
+        Payload::Empty => -1.0
+    }
+}
+extern "C" trampoline "test_enum_blob_ffi" = test_enum_blob;
+
+pub fn test_enum_empty() -> f64 {
+    let p = Payload::Empty{};
+    match p {
+        Payload::Blob(data) => core::intrinsic::array::fold(data, 0.0, |acc, x| acc + x),
+        Payload::Empty => -1.0
+    }
+}
+extern "C" trampoline "test_enum_empty_ffi" = test_enum_empty;
+
+// --- Test 4: copy-on-write through a projected field — the struct is still
+// live across the `set`, so the update clones and the original observes its
+// old value. 1.0 + 99.0 = 100.0 ---
+pub fn test_cow_field() -> f64 {
+    let h = SHolder { data: core::intrinsic::array::splat<[f64; 4]>(1.0), scale: 0.0 };
+    let updated = core::intrinsic::array::set(h.data, 0, 99.0);
+    core::intrinsic::array::get(h.data, 0) + core::intrinsic::array::get(updated, 0)
+}
+extern "C" trampoline "test_cow_field_ffi" = test_cow_field;
+
+// --- Test 5: projection multiplicity across call boundaries ---
+fn sum4(a : [f64; 4]) -> f64 {
+    core::intrinsic::array::fold(a, 0.0, |acc, x| acc + x)
+}
+pub fn test_multi() -> f64 {
+    let h = SHolder { data: core::intrinsic::array::tabulate<[f64; 4]>(|i| i as f64), scale: 2.0 };
+    sum4(h.data) + sum4(h.data) + h.scale
+}
+extern "C" trampoline "test_multi_ffi" = test_multi;
+
+// --- Test 6: generic record instantiated at an array type ---
+// (The tabulate kernels here are deliberately non-identity: `|i| i` trips a
+// pre-existing beta-reduction crash at `-O aggressive`, unrelated to record
+// members.)
+pub fn test_generic() -> i64 {
+    let p = Pair {
+        fst: core::intrinsic::array::splat<[i64; 4]>(3),
+        snd: core::intrinsic::array::tabulate<[i64; 4]>(|i| i * 2)
+    };
+    core::intrinsic::array::get(p.fst, 2) + core::intrinsic::array::get(p.snd, 3)
+}
+extern "C" trampoline "test_generic_ffi" = test_generic;
+
+// --- Test 7: array inside a value struct inside a shared struct ---
+pub fn test_nested() -> i64 {
+    let o = Outer { inner: VHolder { data: core::intrinsic::array::tabulate<[i64; 8]>(|i| i + 1) } };
+    core::intrinsic::array::get(o.inner.data, 5)
+}
+extern "C" trampoline "test_nested_ffi" = test_nested;
+
+// --- Test 8: rank-2 array member ---
+pub fn test_rank2_field() -> i64 {
+    let g = Grid { cells: core::intrinsic::array::tabulate<[i64; 2, 3]>(|i, j| i * 10 + j) };
+    core::intrinsic::array::get(g.cells, 1, 2)
+        + core::intrinsic::array::fold(g.cells, 0, |acc, x| acc + x)
+}
+extern "C" trampoline "test_rank2_field_ffi" = test_rank2_field;


### PR DESCRIPTION
Lifts the Phase A restriction (issue #344) that rejected arrays as record members. An array value is already one shared rc box (`rc<array<dims x elem>>`), so a member of array type needs no new representation — it stores the pointer to its box, exactly like a closure member.

## What changed

**Dialect (`lib/IR/ReussirTypes.cpp`)** — the two functions every member-handling path routes through:
- `memberStorageType`: an array member is stored as a pointer. The `memBoxInternal` exemption keeps the array **inline** when it is the rc box's own payload (this is what sizes `rc.create` allocations); closures stay unconditional since a raw `ClosureType` is always the pointer to a `ClosureBoxType`.
- `getProjectedType`: an array member projects as `rc<array, shared>`, same rule as closures.

Record layout/packing, the construction/projection verifiers (`record.compound`, `record.variant`, `ref.project`), acquire/drop glue, destructuring decrements, triviality classification, and the LLVM struct conversion all consult these two functions, so no other dialect changes were needed.

**Codegen (`crates/reussir-codegen/src/lower/ty.rs`)** — `member_ty` lowers an array member to its bare `!reussir.array` payload type; the dialect boxes it to a pointer on its own (mirrors the closure arm). Projection and construction already line up: `mlir_ty` of an array is the `rc<array>` handle the verifier expects on both sides.

**Semi (`crates/reussir-core/src/semi/ctxt.rs`)** — `reject_array_member` deleted. One new guard: a mutable `[field]` link still cannot hold an array (links store regional records), and an array is pointer-like enough to slip past the `Nullable` check, so `note_link_element` rejects it explicitly.

Ownership analysis needed nothing: `is_rr` already classifies arrays as rc-managed, and member dup/drop placement is type-driven.

## Tests

- `array_struct_materialize.{rr,c}` (modeled on `closure_struct_materialize`): arrays in `[shared]`/`[value]` structs and enum variant payloads, end to end at `-O default` and `-O aggressive` — construction, projection with multiplicity across call boundaries, copy-on-write through a projected field (original observes its old value), generic `Pair<T>` instantiated at an array type, an array inside a value struct inside a shared struct, and a rank-2 member. Plus a FileCheck leg pinning the record types carrying bare `!reussir.array` members.
- `array_errors.rr`: the member rejection is replaced by the `[field]`-link rejection.
- Full suites green: 307 lit passed / 20 unsupported, ctest 17/17.

## Note: pre-existing crash, unrelated to this PR

While writing the tests I hit an rrc segfault at `-O aggressive` on `core::intrinsic::array::tabulate<[i64; 8]>(|i| i)` — an **identity** tabulate kernel, no records involved. It reproduces on pristine `main` (crash in `InlineLoopCarriedCreatePattern::matchAndRewrite` → `RewriterBase::replaceOp`, ClosureBetaReduction pass). The new test deliberately uses non-identity kernels to stay clear of it; happy to file/fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k

---
_Generated by [Claude Code](https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786463731&installation_id=144622820&pr_number=395&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F395&signature=cee581d30a58585ad77b81071163d0c1fb6fb9b1b74d2a73580a5e5d5bb9a2ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->