### PR TITLE
[backend] closure beta reduction: preserve identity yields

### DIFF
--- a/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
+++ b/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
@@ -157,8 +157,10 @@ struct InlineCreateIntoEvalPattern
     assert(body.getNumArguments() == eval.getArgs().size() &&
            "eval pack must cover the create's full signature");
     auto yield = llvm::cast<ReussirClosureYieldOp>(body.getTerminator());
-    mlir::Value yielded = yield.getValue();
     rewriter.inlineBlockBefore(&body, eval, eval.getArgs());
+    // Read the operand after inlining, once block arguments have been replaced
+    // with the eval pack and before the moved terminator is erased.
+    mlir::Value yielded = yield.getValue();
     rewriter.eraseOp(yield);
     if (eval.getNumResults())
       rewriter.replaceOp(eval, yielded);
@@ -307,11 +309,13 @@ struct InlineLoopCarriedCreatePattern
         ReussirRcIncOp::create(rewriter, eval.getLoc(), cap);
 
     auto yield = llvm::cast<ReussirClosureYieldOp>(body.getTerminator());
-    mlir::Value yielded = yield.getValue();
     llvm::SmallVector<mlir::Value> args(outerCaps);
     llvm::append_range(args, innerCaps);
     llvm::append_range(args, eval.getArgs());
     rewriter.inlineBlockBefore(&body, eval, args);
+    // The yield may refer directly to a body argument; fetch it only after
+    // inlining has replaced that argument with its value from `args`.
+    mlir::Value yielded = yield.getValue();
     rewriter.eraseOp(yield);
     if (eval.getNumResults())
       rewriter.replaceOp(eval, yielded);

--- a/tests/integration/conversion/closure_beta_identity.mlir
+++ b/tests/integration/conversion/closure_beta_identity.mlir
@@ -1,0 +1,57 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(func.func(reussir-closure-beta-reduction))' \
+// RUN: | %FileCheck %s
+
+// Regression test for issue #396. An identity closure yields one of its block
+// arguments directly. `inlineBlockBefore` replaces that argument and destroys
+// the source block, so both the direct and loop-carried beta reductions must
+// use the substituted value rather than retain the old block argument.
+
+module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>>} {
+  func.func @direct_identity(%x: i64) -> i64 {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%a : i64):
+          reussir.closure.yield %a : i64
+      }
+    }
+    %r = reussir.closure.eval (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%x : i64) : i64
+    return %r : i64
+  }
+
+  func.func @loop_identity(%n: index) -> i64 {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %c = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%a : i64):
+          reussir.closure.yield %a : i64
+      }
+    }
+    %lb = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    %zero = arith.constant 0 : i64
+    %r = scf.for %i = %lb to %n step %step iter_args(%acc = %zero) -> (i64) {
+      reussir.rc.inc (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+      %iv = arith.index_cast %i : index to i64
+      %next = reussir.closure.eval (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>) with (%iv : i64) : i64
+      scf.yield %next : i64
+    }
+    reussir.rc.dec (%c : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+    return %r : i64
+  }
+}
+
+// CHECK-LABEL: func.func @direct_identity
+// CHECK-NOT: reussir
+// CHECK: return %arg0 : i64
+
+// CHECK-LABEL: func.func @loop_identity
+// CHECK-NOT: reussir
+// CHECK: %[[RESULT:[0-9a-z_]+]] = scf.for
+// CHECK: %[[IV:[0-9a-z_]+]] = arith.index_cast
+// CHECK-NEXT: scf.yield %[[IV]] : i64
+// CHECK-NOT: reussir
+// CHECK: return %[[RESULT]] : i64

--- a/tests/integration/frontend/issue_396_identity_closure.rr
+++ b/tests/integration/frontend/issue_396_identity_closure.rr
@@ -1,0 +1,18 @@
+// RUN: %rrc %s -O aggressive -o %t.o
+
+// Issue #396: beta reduction cached an identity closure's yielded block
+// argument before inlining destroyed that block. Exercise the loop-carried
+// array kernels from the report and the same stale-value bug in direct inlining.
+
+pub fn no_get() -> [i64; 8] {
+    core::intrinsic::array::tabulate<[i64; 8]>(|i| i)
+}
+
+pub fn fold_id(a: [i64; 8]) -> i64 {
+    core::intrinsic::array::fold(a, 0, |acc, x| acc)
+}
+
+pub fn direct_id(x: i64) -> i64 {
+    let f = |y: i64| y;
+    f(x)
+}


### PR DESCRIPTION
## Summary

- read closure yield operands after inlineBlockBefore substitutes block arguments
- fix both direct and loop-carried closure beta reduction
- add pass-level and end-to-end regressions for identity kernels

Closes #396

## Testing

- focused closure beta lit tests: 5 passed
- C++ unit tests: 17 passed
- Rust backend and compiler unit tests passed
- full lit suite: 304 passed, 24 unsupported

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786467460&installation_id=144622820&pr_number=397&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F397&signature=7afd3ab842902cc0ce1eaa47cae9b635c222f933031ea8cc948df926c3fbc53b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->