### PR TITLE
[backend] ensure lowering: reuse the dec condition only for its own token

### DIFF
--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -360,24 +360,45 @@ namespace {
 struct ReussirNullableDispatchOpRewritePattern
     : public mlir::OpConversionPattern<ReussirNullableDispatchOp> {
   using OpConversionPattern::OpConversionPattern;
+
+  // Whether `result` of an expanded decrement's scf.if is non-null exactly
+  // when the if's condition holds — i.e. it is the decrement's *own* token
+  // (then yields `nullable.create` of a pointer, else yields a null
+  // `nullable.create`). Token reuse widens these ifs with extra results that
+  // carry *inner* member-decrement tokens out (see `escapeTrappedTokensOnce`);
+  // such a result is yielded from a nested if and its nullness depends on the
+  // inner decrement's count, not this condition, so it must not match.
+  static bool tokenMatchesCondition(mlir::scf::IfOp ifOp,
+                                    mlir::OpResult result) {
+    unsigned idx = result.getResultNumber();
+    auto thenCreate =
+        ifOp.thenYield().getOperand(idx).getDefiningOp<ReussirNullableCreateOp>();
+    auto elseCreate =
+        ifOp.elseYield().getOperand(idx).getDefiningOp<ReussirNullableCreateOp>();
+    return thenCreate && elseCreate && thenCreate.getPtr() &&
+           !elseCreate.getPtr();
+  }
+
   mlir::LogicalResult
   matchAndRewrite(ReussirNullableDispatchOp op,
                   OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     // First, create a check operation to get the null flag from the input.
-    mlir::Value flag = reussir::ReussirNullableCheckOp::create(rewriter, 
+    mlir::Value flag = reussir::ReussirNullableCheckOp::create(rewriter,
         op.getLoc(), op.getNullable());
     // mark expect not null
     if (op->hasAttr(REUSSIR_EXPANDED_ENSURE_ATTR))
       flag = reussir::ReussirExpectOp::create(rewriter, op.getLoc(), flag, true);
 
-    auto scfIfOp = mlir::scf::IfOp::create(rewriter, 
+    auto scfIfOp = mlir::scf::IfOp::create(rewriter,
         op.getLoc(), op->getResultTypes(), flag, /*addThenRegion=*/true,
         /*addElseRegion=*/true);
     if (op->hasAttr(REUSSIR_EXPANDED_ENSURE_ATTR))
       if (auto producerIf = mlir::dyn_cast_if_present<mlir::scf::IfOp>(
               op.getNullable().getDefiningOp()))
-        if (producerIf->hasAttr(kExpandedDecrementAttr))
+        if (producerIf->hasAttr(kExpandedDecrementAttr) &&
+            tokenMatchesCondition(producerIf,
+                                  llvm::cast<mlir::OpResult>(op.getNullable())))
           scfIfOp.getConditionMutable().assign(producerIf.getCondition());
     // first, do the easy part, for else region, we can just inline the
     // operation

--- a/tests/integration/conversion/escaped_token_ensure_lowering.mlir
+++ b/tests/integration/conversion/escaped_token_ensure_lowering.mlir
@@ -24,14 +24,16 @@ module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<
     // The widened decrement: condition %[[UNIQ]], own token + escaped token.
     // CHECK: %[[UNIQ:.+]] = reussir.expect
     // CHECK: %[[TOKS:.+]]:2 = scf.if %[[UNIQ]]
-    // The escaped token (%[[TOKS]]#1): its ensure keeps a real null check.
-    // CHECK: %[[CHK:.+]] = reussir.nullable.check(%[[TOKS]]#1
-    // CHECK: %[[CHKEXP:.+]] = reussir.expect(%[[CHK]]
-    // CHECK: scf.if %[[CHKEXP]]
-    // The own token (%[[TOKS]]#0): its ensure reuses the decrement's
-    // condition directly.
-    // CHECK: reussir.nullable.check(%[[TOKS]]#0
-    // CHECK: scf.if %[[UNIQ]]
+    // The two ensures lower in pattern-application order, which is not
+    // deterministic across platforms — match them as a DAG. The escaped
+    // token (%[[TOKS]]#1) keeps a real null check; the own token
+    // (%[[TOKS]]#0) reuses the decrement's condition directly (its if
+    // yields a bare token, unlike the widened if's nullables, so the
+    // `scf.if %[[UNIQ]] -> (!reussir.token` line is unambiguous).
+    // CHECK-DAG: %[[CHK:.+]] = reussir.nullable.check(%[[TOKS]]#1
+    // CHECK-DAG: %[[CHKEXP:.+]] = reussir.expect(%[[CHK]]
+    // CHECK-DAG: scf.if %[[CHKEXP]]
+    // CHECK-DAG: scf.if %[[UNIQ]] -> (!reussir.token
     func.func @escape(%o: !rcOuter, %va: !inner, %vb: !inner) -> (!rcInner, !rcInner) {
         %prev = reussir.rc.fetch (%o : !rcOuter) : index
         %c1 = arith.constant 1 : index

--- a/tests/integration/conversion/escaped_token_ensure_lowering.mlir
+++ b/tests/integration/conversion/escaped_token_ensure_lowering.mlir
@@ -1,0 +1,72 @@
+// RUN: %reussir-opt %s -reussir-token-reuse --reussir-lowering-scf-ops | %FileCheck %s
+
+// The ensure lowering may replace its null check with the producing expanded
+// decrement's own condition — but only for the decrement's *own* token
+// (result 0: then yields a nonnull `nullable.create`, else yields null),
+// where "condition holds" and "token is nonnull" coincide. Token reuse also
+// widens these ifs with *escaped* results carrying inner member-decrement
+// tokens out; such a result's nullness follows the inner decrement's count,
+// not the outer condition, so its ensure must keep a genuine
+// `nullable.check`. Substituting the outer condition there hands a null
+// token to the reuse path of `rc.create` (issue #398: a unique owner whose
+// dead member is a tagged-immediate nullary — the immediate never takes the
+// unique path, its escaped token is always null, and the in-place
+// initialization writes through null).
+
+!inner = !reussir.record<compound "pair" {i64, i64}>
+!rcInner = !reussir.rc<!inner>
+!outer = !reussir.record<compound "node" {!inner, i64}>
+!rcOuter = !reussir.rc<!outer>
+!tk = !reussir.token<align: 8, size: 24>
+
+module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-i64:64-n8:16:32:64-S128"} {
+    // CHECK-LABEL: func.func @escape
+    // The widened decrement: condition %[[UNIQ]], own token + escaped token.
+    // CHECK: %[[UNIQ:.+]] = reussir.expect
+    // CHECK: %[[TOKS:.+]]:2 = scf.if %[[UNIQ]]
+    // The escaped token (%[[TOKS]]#1): its ensure keeps a real null check.
+    // CHECK: %[[CHK:.+]] = reussir.nullable.check(%[[TOKS]]#1
+    // CHECK: %[[CHKEXP:.+]] = reussir.expect(%[[CHK]]
+    // CHECK: scf.if %[[CHKEXP]]
+    // The own token (%[[TOKS]]#0): its ensure reuses the decrement's
+    // condition directly.
+    // CHECK: reussir.nullable.check(%[[TOKS]]#0
+    // CHECK: scf.if %[[UNIQ]]
+    func.func @escape(%o: !rcOuter, %va: !inner, %vb: !inner) -> (!rcInner, !rcInner) {
+        %prev = reussir.rc.fetch (%o : !rcOuter) : index
+        %c1 = arith.constant 1 : index
+        %isOne = arith.cmpi eq, %prev, %c1 : index
+        %unique = reussir.expect (%isOne : i1, true) : i1
+        %t = scf.if %unique -> (!reussir.nullable<!tk>) {
+            %ref = reussir.rc.borrow (%o : !rcOuter) : !reussir.ref<!outer>
+            %slot = reussir.ref.project (%ref : !reussir.ref<!outer>) [0] : !reussir.ref<!rcInner>
+            %m = reussir.ref.load (%slot : !reussir.ref<!rcInner>) : !rcInner
+            %mprev = reussir.rc.fetch (%m : !rcInner) : index
+            %misOne = arith.cmpi eq, %mprev, %c1 : index
+            %munique = reussir.expect (%misOne : i1, true) : i1
+            %mt = scf.if %munique -> (!reussir.nullable<!tk>) {
+                %mtok = reussir.rc.reinterpret (%m : !rcInner) : !tk
+                %mnn = reussir.nullable.create (%mtok : !tk) : !reussir.nullable<!tk>
+                scf.yield %mnn : !reussir.nullable<!tk>
+            } else {
+                %mdec = arith.subi %mprev, %c1 : index
+                reussir.rc.set (%m : !rcInner, %mdec : index)
+                %mnull = reussir.nullable.create : !reussir.nullable<!tk>
+                scf.yield %mnull : !reussir.nullable<!tk>
+            } {reussir.expanded_decrement}
+            %tok = reussir.rc.reinterpret (%o : !rcOuter) : !tk
+            %nn = reussir.nullable.create (%tok : !tk) : !reussir.nullable<!tk>
+            scf.yield %nn : !reussir.nullable<!tk>
+        } else {
+            %dec = arith.subi %prev, %c1 : index
+            reussir.rc.set (%o : !rcOuter, %dec : index)
+            %null = reussir.nullable.create : !reussir.nullable<!tk>
+            scf.yield %null : !reussir.nullable<!tk>
+        } {reussir.expanded_decrement}
+        %tka = reussir.token.alloc : !tk
+        %a = reussir.rc.create value(%va : !inner) token(%tka : !tk) : !rcInner
+        %tkb = reussir.token.alloc : !tk
+        %b = reussir.rc.create value(%vb : !inner) token(%tkb : !tk) : !rcInner
+        return %a, %b : !rcInner, !rcInner
+    }
+}

--- a/tests/integration/frontend/example_hm_queue.c
+++ b/tests/integration/frontend/example_hm_queue.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t queue_test_ffi(void);
+
+/* 64 interleaved rounds enqueue 0..127 and everything is dequeued; the sum
+   0+1+...+127 = 8128. */
+int main(void) {
+  int64_t got = queue_test_ffi();
+  if (got != 8128) {
+    fprintf(stderr, "hm_queue: got %lld, want 8128\n", (long long)got);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/example_hm_queue.rr
+++ b/tests/integration/frontend/example_hm_queue.rr
@@ -1,0 +1,155 @@
+// The Hood-Melville real-time queue from issue #398: a shared `Queue`
+// record whose `[value]` rotation state embeds shared `QList` members.
+// Regression coverage for the ensure-lowering condition-reuse bug: the
+// queue's expanded decrement is widened with escaped member-dec tokens
+// (a dead `QList` inside the unique branch), and the ensure of such an
+// escaped token must null-check it rather than reuse the outer condition —
+// a `Nil` tagged immediate never takes the unique path, so its escaped
+// token is always null even when the queue box itself is unique.
+// Exercised under both nullary-variant encodings.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/example_hm_queue.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %t.opt.o %S/example_hm_queue.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+// RUN: %rrc %s -o %t.boxed.o --relocation-mode pic -Oaggressive --nullary-variant-encoding boxed
+// RUN: %cc %t.boxed.o %S/example_hm_queue.c -o %t.boxed.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.boxed.exe
+
+enum QList {
+    Nil,
+    Cons(i64, QList)
+}
+
+enum [value] Rotation {
+    Idle,
+    Reversing(i64, QList, QList, QList, QList),
+    Appending(i64, QList, QList),
+    Done(QList)
+}
+
+struct Queue {
+    lenf : i64,
+    front : QList,
+    state : Rotation,
+    lenr : i64,
+    rear : QList
+}
+
+enum [value] Pop {
+    Pop(i64, Queue),
+    Empty
+}
+
+fn exec(state : Rotation) -> Rotation {
+    match state {
+        Rotation::Reversing(ok, QList::Cons(x, f), f1, QList::Cons(y, r), r1) =>
+            Rotation::Reversing{ok + 1, f, QList::Cons{x, f1}, r, QList::Cons{y, r1}},
+        Rotation::Reversing(ok, QList::Nil, f1, QList::Cons(y, QList::Nil), r1) =>
+            Rotation::Appending{ok, f1, QList::Cons{y, r1}},
+        Rotation::Appending(0, _, r1) => Rotation::Done{r1},
+        Rotation::Appending(ok, QList::Cons(x, f1), r1) =>
+            Rotation::Appending{ok - 1, f1, QList::Cons{x, r1}},
+        other => other
+    }
+}
+
+fn invalidate(state : Rotation) -> Rotation {
+    match state {
+        Rotation::Reversing(ok, f, f1, r, r1) => Rotation::Reversing{ok - 1, f, f1, r, r1},
+        Rotation::Appending(0, _, QList::Cons(_, r1)) => Rotation::Done{r1},
+        Rotation::Appending(ok, f1, r1) => Rotation::Appending{ok - 1, f1, r1},
+        other => other
+    }
+}
+
+fn exec2(q : Queue) -> Queue {
+    match exec(exec(q.state)) {
+        Rotation::Done(front1) => Queue {
+            lenf: q.lenf, front: front1, state: Rotation::Idle,
+            lenr: q.lenr, rear: q.rear
+        },
+        state1 => Queue {
+            lenf: q.lenf, front: q.front, state: state1,
+            lenr: q.lenr, rear: q.rear
+        }
+    }
+}
+
+fn check(q : Queue) -> Queue {
+    if q.lenr <= q.lenf {
+        exec2(q)
+    } else {
+        exec2(Queue {
+            lenf: q.lenf + q.lenr,
+            front: q.front,
+            state: Rotation::Reversing{0, q.front, QList::Nil, q.rear, QList::Nil},
+            lenr: 0,
+            rear: QList::Nil
+        })
+    }
+}
+
+fn snoc(q : Queue, value : i64) -> Queue {
+    check(Queue {
+        lenf: q.lenf,
+        front: q.front,
+        state: q.state,
+        lenr: q.lenr + 1,
+        rear: QList::Cons{value, q.rear}
+    })
+}
+
+fn uncons(q : Queue) -> Pop {
+    match q.front {
+        QList::Cons(value, front) => Pop::Pop{value, check(Queue {
+            lenf: q.lenf - 1,
+            front,
+            state: invalidate(q.state),
+            lenr: q.lenr,
+            rear: q.rear
+        })},
+        QList::Nil => Pop::Empty
+    }
+}
+
+fn drain(n : i64, q : Queue, acc : i64) -> i64 {
+    if n == 0 {
+        acc
+    } else {
+        match uncons(q) {
+            Pop::Pop(x, rest) => drain(n - 1, rest, acc + x),
+            Pop::Empty => 0 - 1
+        }
+    }
+}
+
+
+
+// Interleave enqueues and dequeues so rotations start, execute, and finish
+// while both encodings' Nil immediates flow through every state field.
+fn pump(i : i64, n : i64, q : Queue, acc : i64) -> i64 {
+    if i == n {
+        drain(n, q, acc)
+    } else {
+        match uncons(snoc(snoc(q, i * 2), i * 2 + 1)) {
+            Pop::Pop(x, rest) => pump(i + 1, n, rest, acc + x),
+            Pop::Empty => 0 - 1
+        }
+    }
+}
+
+fn queue_test() -> i64 {
+    let empty = Queue {
+        lenf: 0, front: QList::Nil, state: Rotation::Idle,
+        lenr: 0, rear: QList::Nil
+    };
+    // 64 rounds each enqueue {2i, 2i+1} and dequeue one, leaving a 64-deep
+    // backlog that drain empties. Sum of all values 0..127 = 8128, verified
+    // by the driver.
+    pump(0, 64, empty, 0)
+}
+
+extern "C" trampoline "queue_test_ffi" = queue_test;


### PR DESCRIPTION
## Root cause (#398)

Two passes compose unsoundly:

1. **TokenReuse** (`escapeTrappedTokensOnce`) widens an expanded decrement's `scf.if` with extra results that carry **inner member-decrement tokens** out of the unique branch, so a dead member's box can be reused by a downstream create. Those escaped results are null whenever the *inner* decrement took its shared path — independent of the outer condition. TokenReuse itself models this (`expandedDecProducerRc` special-cases result 0).
2. **SCFOpsLowering**'s `token.ensure` lowering has a fast path: when the ensured nullable is produced by an expanded-decrement `scf.if`, it replaces the null check with that if's own condition (count == 1). It never checked **which result** it was ensuring — sound for the decrement's own token (result 0), unsound for every escaped result.

In the reproducer: `snoc` consumes a unique `Queue` whose expanded decrement is widened with the dead rear `QList`'s token. Under the default special-pointer-tag encoding, a `Nil` rear is a tagged immediate whose dummy-box count never reaches 1, so the escaped token is **always null** — yet the ensure branched on the *queue's* uniqueness and sent the null token into `rc.create`'s in-place-reuse path: the reported write to address `0x4` (tag store at `null + 4`). Reproduces at every opt level, even `-Onone` with clang `-O0`.

`--nullary-variant-encoding boxed` only masks the bug: a freshly built `Nil` box is unique, so the escaped token happened to be nonnull. A *shared* inner member could reproduce the same crash under any encoding.

## Fix

Guard the condition-reuse: substitute only when the ensured result's then-yield is a nonnull `nullable.create` and its else-yield a null one — i.e. exactly "nonnull ⟺ condition", which is the decrement's own token. Escaped results keep a genuine `nullable.check`; the fast path for the common `dec → create` pairing is unchanged (verified in the lowered IR: own token still branches on the dec condition).

## Tests

- `conversion/escaped_token_ensure_lowering.mlir` — the widened two-result shape through `-reussir-token-reuse --reussir-lowering-scf-ops`: the escaped token's ensure keeps `nullable.check`, the own token's ensure reuses the condition.
- `frontend/example_hm_queue.rr` + driver — the issue's Hood–Melville queue as an e2e test, extended to 64 interleaved snoc/uncons rounds (checksum 8128), run at `-Onone`, `-Oaggressive --reuse-across-call`, and `--nullary-variant-encoding boxed`.

Local gate: 331/331. The original reproducer prints `3` at `-Onone`/`-Odefault`/`-Oaggressive`/`-Oaggressive --reuse-across-call`.

Fixes #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786472460&installation_id=144622820&pr_number=399&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F399&signature=f9bf4c439e6bec2566c2f4821c7fc5f7f06c61b6ccd50dc8d9df312b8eec0e6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->