### PR TITLE
[backend] materialize stack slots in the entry block

### DIFF
--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -278,6 +278,46 @@ void addLifetimeOrInvariantOp(
   Op::create(rewriter, loc, value);
 }
 
+// Materializes a stack slot in the enclosing function's entry block. A
+// fixed-size alloca outside the entry block is not a static alloca: it is
+// lowered as a dynamic stack adjustment — growing the frame on every
+// execution of the site once a loop encloses it — and its mere presence
+// makes TailCallElimination refuse to fold the function's self tail
+// recursion into a loop (`canTRE` requires every alloca to be static).
+// Only the slot is hoisted; the stores that fill it stay at the use site.
+mlir::Value createEntryBlockAlloca(mlir::ConversionPatternRewriter &rewriter,
+                                   mlir::Location loc, mlir::Type elemType,
+                                   unsigned alignment, mlir::Operation *op) {
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+  mlir::OpBuilder::InsertionGuard guard(rewriter);
+  if (auto func = op->getParentOfType<mlir::FunctionOpInterface>();
+      func && !func.getFunctionBody().empty())
+    rewriter.setInsertionPointToStart(&func.getFunctionBody().front());
+  mlir::Value one = mlir::LLVM::ConstantOp::create(
+      rewriter, loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(1));
+  return mlir::LLVM::AllocaOp::create(rewriter, loc, ptrType, elemType, one,
+                                      alignment);
+}
+
+// Whether `op`'s enclosing function contains a direct self call. A stack
+// slot in such a function can end up inside a loop TailCallElimination
+// later builds around the recursion, so a fill-once claim about the slot
+// (invariant.start) would be violated by the next iteration's store.
+bool enclosingFunctionIsSelfRecursive(mlir::Operation *op) {
+  auto func = op->getParentOfType<mlir::FunctionOpInterface>();
+  if (!func)
+    return true;
+  llvm::StringRef name = mlir::SymbolTable::getSymbolName(func).getValue();
+  bool found = false;
+  func.walk([&](mlir::CallOpInterface call) {
+    auto callee = llvm::dyn_cast_if_present<mlir::SymbolRefAttr>(
+        call.getCallableForCallee());
+    if (callee && callee.getLeafReference().getValue() == name)
+      found = true;
+  });
+  return found;
+}
+
 struct ReussirPanicConversionPattern
     : public mlir::OpConversionPattern<ReussirPanicOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -743,20 +783,22 @@ struct ReussirRefSpilledConversionPattern
     auto dataLayout = getDataLayout(*converter, op.getOperation());
 
     auto valueType = converter->convertType(op.getValue().getType());
-    auto llvmPtrType = converter->convertType(op.getSpilled().getType());
     auto alignment = dataLayout.getTypePreferredAlignment(valueType);
 
     // Allocate stack space using llvm.alloca
-    auto convertedIndexType = converter->getIndexType();
-    auto constantArraySize = mlir::arith::ConstantOp::create(
-        rewriter, loc, rewriter.getIntegerAttr(convertedIndexType, 1));
-    auto allocaOp = mlir::LLVM::AllocaOp::create(
-        rewriter, loc, llvmPtrType, valueType, constantArraySize, alignment);
+    mlir::Value allocaOp =
+        createEntryBlockAlloca(rewriter, loc, valueType, alignment, op);
 
-    // Store the value to the allocated space
+    // Store the value to the allocated space. The spilled aggregate never
+    // changes after this store, but claiming so with invariant.start is only
+    // sound when the fill executes once: in a self recursive function
+    // TailCallElimination may fold the recursion into a loop around this
+    // very site, and the next iteration's refill of the (entry-block,
+    // per-frame) slot would violate the invariant.
     mlir::LLVM::StoreOp::create(rewriter, loc, value, allocaOp);
-    mlir::LLVM::InvariantStartOp::create(
-        rewriter, loc, dataLayout.getTypeABIAlignment(valueType), allocaOp);
+    if (!enclosingFunctionIsSelfRecursive(op))
+      mlir::LLVM::InvariantStartOp::create(
+          rewriter, loc, dataLayout.getTypeABIAlignment(valueType), allocaOp);
     rewriter.replaceOp(op, allocaOp);
 
     return mlir::success();
@@ -849,13 +891,11 @@ struct ReussirRecordExtractConversionPattern
     // Create an opaque pointer type for memory operations
     auto ptrType = mlir::LLVM::LLVMPointerType::get(ctx);
 
-    // Constant '1' for the alloca array size
-    mlir::Value one = mlir::LLVM::ConstantOp::create(
-        rewriter, loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(1));
-
     // 1. Spill: Allocate memory for the struct on the stack
-    mlir::Value alloca = mlir::LLVM::AllocaOp::create(rewriter, loc, ptrType,
-                                                      llvmStructType, one);
+    auto dataLayout = getDataLayout(*converter, op.getOperation());
+    mlir::Value alloca = createEntryBlockAlloca(
+        rewriter, loc, llvmStructType,
+        dataLayout.getTypePreferredAlignment(llvmStructType), op);
 
     addLifetimeOrInvariantOp<mlir::LLVM::LifetimeStartOp>(
         rewriter, loc, llvmStructType, alloca, *converter, op.getOperation());
@@ -907,7 +947,6 @@ struct ReussirRecordVariantConversionPattern
 
     if (!llvmStructType)
       return op.emitOpError("failed to convert record type to LLVM type");
-    auto indexType = converter->getIndexType();
     // Get the tag (at the record's minimal tag width) and value (already
     // converted by the type converter)
     mlir::Value tag = mlir::arith::ConstantOp::create(
@@ -920,11 +959,9 @@ struct ReussirRecordVariantConversionPattern
     auto dataLayout = getDataLayout(*converter, op.getOperation());
     auto alignment = dataLayout.getTypePreferredAlignment(llvmStructType);
     auto ptrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
-    auto one = mlir::arith::ConstantOp::create(
-        rewriter, loc, mlir::IntegerAttr::get(indexType, 1));
     // Allocate stack space for the struct
-    auto allocaOp = mlir::LLVM::AllocaOp::create(
-        rewriter, loc, ptrType, llvmStructType, one, alignment);
+    mlir::Value allocaOp =
+        createEntryBlockAlloca(rewriter, loc, llvmStructType, alignment, op);
     addLifetimeOrInvariantOp<mlir::LLVM::LifetimeStartOp>(
         rewriter, loc, llvmStructType, allocaOp, *converter, op.getOperation());
     // Store the tag (past the count slot for fused-header variants).
@@ -2139,15 +2176,15 @@ struct ReussirRegionCreateOpConversionPattern
     auto ptrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
     auto converter =
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
-    auto one = mlir::arith::ConstantOp::create(
-        rewriter, op.getLoc(),
-        mlir::IntegerAttr::get(converter->getIndexType(), 1));
-    auto alloca = rewriter.replaceOpWithNewOp<mlir::LLVM::AllocaOp>(
-        op, ptrType, ptrType, one);
+    auto dataLayout = getDataLayout(*converter, op.getOperation());
+    mlir::Value alloca = createEntryBlockAlloca(
+        rewriter, op.getLoc(), ptrType,
+        dataLayout.getTypePreferredAlignment(ptrType), op);
     addLifetimeOrInvariantOp<mlir::LLVM::LifetimeStartOp>(
         rewriter, op.getLoc(), ptrType, alloca, *converter, op.getOperation());
     auto nullValue = mlir::LLVM::ZeroOp::create(rewriter, op.getLoc(), ptrType);
     mlir::LLVM::StoreOp::create(rewriter, op.getLoc(), nullValue, alloca);
+    rewriter.replaceOp(op, alloca);
     return mlir::success();
   }
 };

--- a/tests/integration/conversion/record_ops.mlir
+++ b/tests/integration/conversion/record_ops.mlir
@@ -39,17 +39,19 @@ module {
 // Members are packed by descending alignment (the tail pointer precedes the
 // i32 head); a shared variant carries the fused 8-byte box header
 // {i32 count slot, i32 tag} and the box IS the record.
-// CHECK: %"List::Cons" = type { ptr, i32, [4 x i8] }
-// CHECK: %List = type { i32, i32, %"List::Cons" }
+// CHECK-DAG: %"List::Cons" = type { ptr, i32, [4 x i8] }
+// CHECK-DAG: %List = type { i32, i32, %"List::Cons" }
 
 // CHECK-LABEL: define ptr @cons(i32 %0, ptr %1)
+// Stack slots are hoisted to the entry block (static allocas); the fills
+// stay at the use sites.
+// CHECK: %[[alloca:[0-9]+]] = alloca %List, i64 1, align 8
 // CHECK: %[[cons_alloca:[0-9]+]] = alloca %"List::Cons", align 8
 // CHECK: %[[cons_ptr0:[0-9]+]] = getelementptr %"List::Cons", ptr %[[cons_alloca]], i32 0, i32 1
 // CHECK: store i32 %0, ptr %[[cons_ptr0]], align 4
 // CHECK: %[[cons_ptr1:[0-9]+]] = getelementptr %"List::Cons", ptr %[[cons_alloca]], i32 0, i32 0
 // CHECK: store ptr %1, ptr %[[cons_ptr1]], align 8
 // CHECK: %[[cons_loaded:[0-9]+]] = load %"List::Cons", ptr %[[cons_alloca]], align 8
-// CHECK: %[[alloca:[0-9]+]] = alloca %List, i64 1, align 8
 // CHECK: call void @llvm.lifetime.start.p0({{.*}}ptr %[[alloca]])
 // CHECK: %[[tag_ptr:[0-9]+]] = getelementptr %List, ptr %[[alloca]], i32 0, i32 1
 // CHECK: store i32 0, ptr %[[tag_ptr]], align 4

--- a/tests/integration/frontend/deep_value_tail_recursion.c
+++ b/tests/integration/frontend/deep_value_tail_recursion.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t deep_test_ffi(int64_t n);
+
+int main(void) {
+  // sum(1..1000000) mod 1000000007 — one million recursion frames unless the
+  // self tail call runs in constant stack.
+  int64_t result = deep_test_ffi(1000000);
+  if (result != 496500) {
+    fprintf(stderr, "FAIL: expected 496500, got %lld\n", (long long)result);
+    abort();
+  }
+  return 0;
+}

--- a/tests/integration/frontend/deep_value_tail_recursion.rr
+++ b/tests/integration/frontend/deep_value_tail_recursion.rr
@@ -1,0 +1,38 @@
+// Deep self tail recursion returning a `[value]` enum — the shape TRMC
+// skips (no rc-boxed result), so the loop conversion is LLVM
+// TailCallElimination's job. TCE refuses to touch a function whose stack
+// slots are not static allocas, and the record/spill lowering used to
+// materialize them at the use site (functional-queue's `churn` kept a
+// frame per round and overflowed the default stack). With every slot
+// hoisted to the entry block, a million-deep recursion must complete
+// within the default stack rlimit at every optimizing level.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.o %S/deep_value_tail_recursion.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.default.o --relocation-mode pic
+// RUN: %cc %t.default.o %S/deep_value_tail_recursion.c -o %t.default.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.default.exe
+
+// Three words of payload so the return is too large for registers: the
+// sret-demoted aggregate is the case every IR-level tail-call rewrite
+// historically failed on.
+enum [value] Out {
+    Done(i64, i64, i64)
+}
+
+fn spin(n : i64, acc : i64) -> Out {
+    if n == 0 {
+        Out::Done{acc, acc, acc}
+    } else {
+        spin(n - 1, (acc + n) % 1000000007)
+    }
+}
+
+fn deep_test(n : i64) -> i64 {
+    match spin(n, 0) {
+        Out::Done(a, _, _) => a
+    }
+}
+
+extern "C" trampoline "deep_test_ffi" = deep_test;


### PR DESCRIPTION
## Problem

\`benchmark/functional-queue\` segfaults at the default stack rlimit: \`churn\` (1M-round self tail recursion returning the \`[value]\` enum \`Pop\`) keeps a real frame per round (~250MB of stack). TRMC only covers rc-boxed returns, so the loop conversion is LLVM TailCallElimination's job — and TCE refuses to touch a function whose stack slots are not static allocas (\`canTRE\` requires every alloca to be static, i.e. fixed-size **and in the entry block**). Reussir's record/spill/region lowerings materialized slots at the use site, disqualifying every function that spills a value record. Non-entry allocas are also lowered as dynamic stack adjustments by instruction selection, which is its own footgun once any loop encloses such a site.

## Fix

- Hoist every stack slot (\`ref.spilled\`, record compound/variant materialization, region context) to the function entry block; the fills stay at the use site.
- Stop emitting \`invariant.start\` on spill slots inside self-recursive functions: TCE can now legitimately build a loop around the fill, and the next iteration's store would violate a fill-once claim. Non-recursive spills keep the CSE-enabling invariant.

## Results (x64 9950X, functional-queue 65536 × 1M rounds)

| | before | after |
|---|---|---|
| default stack | **segfault** | 108ms, checksum correct |
| unlimited stack | 420ms (0.27 user + 0.15 sys, 126k page faults) | 108ms (sys ~0) |
| vs koka (73ms) | 5.8× | **1.48×** |

\`churn\`/\`drain\` now TCE-loop and inline away entirely. rbtree / nbe-closure / derive unchanged (within noise). New e2e test: million-deep self tail recursion returning a 32-byte \`[value]\` enum at the default rlimit, at \`-Odefault\` and \`-Oaggressive\`.

Sibling PRs stack on this to compare TCO-guarantee mechanisms (musttail marking vs MLIR-level loop conversion) — this patch alone already unlocks stock TCE for the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786484253&installation_id=144622820&pr_number=401&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F401&signature=667e1453ac3c820d82a8280560f55c0db58e648927ff6f0f50a3a773ee9a4ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->