### PR TITLE
[llvm] guarantee TCO for direct self tail recursion (musttail marking)

### DIFF
--- a/include/Reussir/LLVMPass/MustTailMarking.h
+++ b/include/Reussir/LLVMPass/MustTailMarking.h
@@ -1,0 +1,27 @@
+//===- MustTailMarking.h - Reussir self-tail-call marking pass -*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass guarantees constant stack usage for direct self tail recursion by
+// duplicating the return into the recursive call's block and marking the call
+// `musttail`.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <llvm/IR/PassManager.h>
+
+namespace reussir::llvmpass {
+
+class MustTailMarkingPass : public llvm::PassInfoMixin<MustTailMarkingPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module,
+                              llvm::ModuleAnalysisManager &);
+};
+
+} // namespace reussir::llvmpass

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -22,8 +22,10 @@
 #include <llvm/TargetParser/Triple.h>
 #include <llvm/Transforms/IPO/LowerTypeTests.h>
 #include <llvm/Transforms/IPO/WholeProgramDevirt.h>
+#include <llvm/Transforms/Scalar/TailRecursionElimination.h>
 
 #include "Reussir/LLVMPass/AllocationSimplication.h"
+#include "Reussir/LLVMPass/MustTailMarking.h"
 #include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"
 
 #ifdef REUSSIR_HAS_TPDE
@@ -137,6 +139,18 @@ void reussirRunBackendLLVMPipeline(LLVMModuleRef module,
   mpm.addPass(llvm::LowerTypeTestsPass(
       /*ExportSummary=*/nullptr, /*ImportSummary=*/nullptr,
       llvm::lowertypetests::DropTestKind::Assume));
+  // Guarantee constant stack usage for direct self tail recursion before the
+  // module pipeline reshapes the single-exit CFG: the freshly translated IR
+  // still has the plain `call @self; br ... ret` shape this marking
+  // recognizes. Register-trivial returns get `musttail` (instruction
+  // selection must emit a real tail call); aggregate returns get the
+  // duplicated `ret` plus the plain `tail` marker, which is exactly the
+  // shape the TailCallElimination run right behind folds into a loop —
+  // before DeadArgumentElimination's aggregate-return shrinking can wrap
+  // the call in the extract/insert chains that used to hide it.
+  mpm.addPass(reussir::llvmpass::MustTailMarkingPass());
+  mpm.addPass(
+      llvm::createModuleToFunctionPassAdaptor(llvm::TailCallElimPass()));
   mpm.addPass(pb.buildPerModuleDefaultPipeline(level));
   mpm.addPass(reussir::llvmpass::AllocationSimplicationPass());
   mpm.run(m, mam);

--- a/lib/LLVMPass/AllocationSimplication/CMakeLists.txt
+++ b/lib/LLVMPass/AllocationSimplication/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(ReussirLLVMAllocationSimplicationPass STATIC
   AllocationSimplication.cpp
+  MustTailMarking.cpp
   RuntimeFunctionAttributor.cpp
 )
 

--- a/lib/LLVMPass/AllocationSimplication/MustTailMarking.cpp
+++ b/lib/LLVMPass/AllocationSimplication/MustTailMarking.cpp
@@ -1,0 +1,148 @@
+//===- MustTailMarking.cpp - Reussir self-tail-call marking pass ---------===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// Reussir lowers each function as a single-exit CFG: every return-position
+// value branches (possibly through several forwarding blocks and phis) into
+// one common return block. A direct self recursive call in tail position
+// therefore never sits directly in front of a `ret`, and once
+// DeadArgumentElimination shrinks an aggregate return the forwarding chain
+// gains extractvalue/insertvalue wrappers that neither TailCallElimination
+// nor CodeGenPrepare's dup-ret recognize — the recursion keeps real stack
+// frames and deep workloads overflow the stack (functional-queue's `churn`).
+//
+// This pass runs before the module optimization pipeline, while the
+// translated IR still has the plain shape `%r = call @self(...); br ...phi...
+// ret`. For every direct self call whose result only flows through empty
+// forwarding blocks into the function's return, it duplicates the return
+// into the call's block and marks the call `musttail`: from that point on
+// TailCallElimination usually rewrites the recursion into a loop, and even
+// if no IR pass does, instruction selection must emit a real tail call — the
+// stack no longer grows with recursion depth. Marking is skipped whenever a
+// call argument is derived from a caller alloca (`musttail` forbids the
+// callee to access the caller's frame).
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/LLVMPass/MustTailMarking.h"
+
+#include <llvm/Analysis/ValueTracking.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/CFG.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+namespace reussir::llvmpass {
+namespace {
+
+// Whether any call argument may point into the caller's own frame. A
+// `musttail` callee must not access the caller's allocas; the caller's frame
+// is gone when the callee runs.
+bool anyArgumentDerivedFromAlloca(llvm::CallInst *call) {
+  for (llvm::Value *arg : call->args())
+    if (arg->getType()->isPointerTy() &&
+        llvm::isa<llvm::AllocaInst>(llvm::getUnderlyingObject(arg)))
+      return true;
+  return false;
+}
+
+// Follows the self call's result from its block through unconditional
+// branches into the common return block. Every hop must be an "empty"
+// forwarding block — phis plus an unconditional branch, or phis plus the
+// `ret` — and the tracked value must remain the returned value (either
+// rebound through a phi or passed through by dominance). Returns true iff
+// the walk ends at `ret <tracked value>` (or `ret void` for a void self
+// call).
+bool returnsCallResult(llvm::CallInst *call) {
+  llvm::Value *tracked = call;
+  llvm::BasicBlock *block = call->getParent();
+  llvm::Instruction *terminator = block->getTerminator();
+  // A bound well past any realistic forwarding chain; guards degenerate CFGs.
+  constexpr unsigned kMaxHops = 32;
+  for (unsigned hop = 0; hop < kMaxHops; ++hop) {
+    if (auto *ret = llvm::dyn_cast<llvm::ReturnInst>(terminator))
+      return call->getType()->isVoidTy() ? ret->getNumOperands() == 0
+                                         : ret->getReturnValue() == tracked;
+    auto *branch = llvm::dyn_cast<llvm::BranchInst>(terminator);
+    if (!branch || branch->isConditional())
+      return false;
+    llvm::BasicBlock *successor = branch->getSuccessor(0);
+    // The successor must compute nothing of its own: phis, then the
+    // terminator. Rebind the tracked value through the phi that receives it;
+    // a phi that merges an unrelated value is fine as long as the eventual
+    // `ret` still returns the tracked value.
+    for (llvm::PHINode &phi : successor->phis())
+      if (phi.getIncomingValueForBlock(block) == tracked)
+        tracked = &phi;
+    if (&*successor->getFirstNonPHIOrDbg() != successor->getTerminator())
+      return false;
+    block = successor;
+    terminator = successor->getTerminator();
+  }
+  return false;
+}
+
+// Rewrites `call; br` into `call; ret` (removing the call's block from its
+// former successor's phis) and marks the call. Void, scalar, and pointer
+// returns take `musttail` — the instruction-selection guarantee. An
+// aggregate return only gets the plain `tail` marker: `musttail` on a
+// return the target demotes to sret is a hard instruction-selection error
+// ("failed to perform tail call elimination on a call site marked
+// musttail"), and how many scalars still fit return registers is a
+// target-specific limit an IR pass must not encode. The duplicated `ret`
+// puts the call in the exact `call; ret` shape TailCallElimination (run
+// right after this pass) folds into a loop for any first-class type.
+void markSelfTailCall(llvm::CallInst *call) {
+  llvm::BasicBlock *block = call->getParent();
+  llvm::Instruction *terminator = block->getTerminator();
+  if (auto *branch = llvm::dyn_cast<llvm::BranchInst>(terminator)) {
+    branch->getSuccessor(0)->removePredecessor(block);
+    terminator->eraseFromParent();
+    llvm::Value *result = call->getType()->isVoidTy() ? nullptr : call;
+    llvm::ReturnInst::Create(call->getContext(), result, block);
+  }
+  llvm::Type *type = call->getType();
+  bool registerTrivial = type->isVoidTy() || type->isIntegerTy() ||
+                         type->isPointerTy() || type->isFloatingPointTy();
+  call->setTailCallKind(registerTrivial ? llvm::CallInst::TCK_MustTail
+                                        : llvm::CallInst::TCK_Tail);
+}
+
+bool processFunction(llvm::Function &function) {
+  if (function.isDeclaration() || function.isVarArg())
+    return false;
+  llvm::SmallVector<llvm::CallInst *> selfTailCalls;
+  for (llvm::BasicBlock &block : function) {
+    auto *call = llvm::dyn_cast_if_present<llvm::CallInst>(
+        block.getTerminator()->getPrevNode());
+    // `musttail` requires the call to immediately precede the return, the
+    // matching self signature is given by construction, and the calling
+    // conventions coincide on a self call.
+    if (!call || call->getCalledFunction() != &function ||
+        call->getCallingConv() != function.getCallingConv() ||
+        anyArgumentDerivedFromAlloca(call) || !returnsCallResult(call))
+      continue;
+    selfTailCalls.push_back(call);
+  }
+  for (llvm::CallInst *call : selfTailCalls)
+    markSelfTailCall(call);
+  return !selfTailCalls.empty();
+}
+
+} // namespace
+
+llvm::PreservedAnalyses
+MustTailMarkingPass::run(llvm::Module &module, llvm::ModuleAnalysisManager &) {
+  bool changed = false;
+  for (llvm::Function &function : module)
+    changed |= processFunction(function);
+  return changed ? llvm::PreservedAnalyses::none()
+                 : llvm::PreservedAnalyses::all();
+}
+
+} // namespace reussir::llvmpass


### PR DESCRIPTION
Stacks on #401. One of two candidate mechanisms (the other: MLIR-level loop conversion) for turning "stock TCE happens to fire" into a guarantee — compare and pick.

## What it does

\`MustTailMarkingPass\` (LLVM IR, runs before the module pipeline on freshly translated IR, where the single-exit CFG still has the plain \`call @self; br …phi… ret\` shape):

- walks each direct self call whose result flows only through empty forwarding blocks into the common return;
- duplicates the \`ret\` into the call block (dup-ret canonicalization);
- marks the call \`musttail\` when the return type is register-trivial (void/int/ptr/float) — the hard instruction-selection guarantee; aggregate returns keep plain \`tail\` (\`musttail\` on an sret-demoted return is a **fatal ISel error** — "failed to perform tail call elimination on a call site marked musttail" — and the register limit is target-specific, e.g. 24-byte structs fit x86-64's RAX/RDX/RCX but 32-byte don't);
- a scheduled \`TailCallElimination\` right behind folds the canonicalized \`call; ret\` into a loop for any first-class type — before DeadArgumentElimination can wrap the call in the extract/insert chains that used to hide it.

Skips calls with alloca-derived arguments (\`musttail\`/\`tail\` forbid touching the caller's frame) and vararg functions.

## Results

- functional-queue 65536×1M: **statistical tie with #401 alone** (141.6 ± 2.6 vs 142.4 ± 3.9 ms) — on today's benchmarks stock TCE already fires once #401 makes the allocas static, and the early TCE run converts every marked call (zero \`musttail\` survives to the final IR).
- Value = insurance: recursion TCE declines for its own heuristic reasons still cannot silently keep frames when the return is register-trivial; the dup-ret runs pre-DAE, which is the pass that used to defeat both TCE and CodeGenPrepare's dup-ret.
- All 333 lit tests + unit tests pass.

Caveat vs the loop-conversion sibling: only active at optimizing levels (the LLVM leg is skipped at \`-Onone\`), and the aggregate-return arm remains "TCE reliably fires on the canonical shape" rather than a structural guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786484388&installation_id=144622820&pr_number=402&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F402&signature=67ebce6358b7bf2cf696acf8255019bdda6bbe6a7fa40fceb6189d330fcbacf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->