### PR TITLE
[mlir] loop direct self tail recursion at the structured level

### DIFF
--- a/crates/reussir-backend-sys/build.rs
+++ b/crates/reussir-backend-sys/build.rs
@@ -43,6 +43,7 @@ const REUSSIR_ARCHIVES: &[&str] = &[
     "MLIRReussirInvariantGroupAnalysis",
     "MLIRReussirUniqueCarryingRecursionAnalysis",
     "MLIRReussirTRMCRecursionAnalysis",
+    "MLIRReussirSelfTailCallElimination",
     // The custom LLVM passes run by the JIT codegen helper (Jit.cpp).
     "ReussirLLVMAllocationSimplicationPass",
 ];

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -129,6 +129,7 @@ unsafe extern "C" {
     pub fn reussirCreateRcDispatchFusionPass() -> MlirPass;
     pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;
+    pub fn reussirCreateSelfTailCallEliminationPass() -> MlirPass;
     pub fn reussirCreateCompilePolymorphicFFIPass(optimized: bool) -> MlirPass;
     pub fn reussirCreateInvariantGroupAnalysisPass() -> MlirPass;
     pub fn reussirCreateBasicOpsLoweringPass(closure_wpd: bool) -> MlirPass;

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -376,6 +376,11 @@ pub fn run_lowering_pipeline(
         func:   sys::reussirCreateRcCreateSinkPass();
         func:   sys::reussirCreateRcCreateFusionPass();
         module: sys::reussirCreateTRMCRecursionAnalysisPass();
+        // Loop the remaining plain self tail calls (any return type,
+        // including the .trmc helpers TRMC just introduced) while control
+        // flow is still structured — the stack guarantee must not depend on
+        // LLVM TailCallElimination's eligibility heuristics.
+        func:   sys::reussirCreateSelfTailCallEliminationPass();
         module: sys::reussirCreateCompilePolymorphicFFIPass(false);
 
         // `kernel` anchor: the Reussir-level work is done (both

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -54,6 +54,7 @@ MlirPass reussirCreateSpecialPointerTagPass(bool archIndependent);
 MlirPass reussirCreateRcDispatchFusionPass(void);
 MlirPass reussirCreateRcCreateFusionPass(void);
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void);
+MlirPass reussirCreateSelfTailCallEliminationPass(void);
 MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized);
 MlirPass reussirCreateInvariantGroupAnalysisPass(void);
 MlirPass reussirCreateBasicOpsLoweringPass(bool closureWpd);

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -225,4 +225,26 @@ def ReussirTRMCRecursionAnalysisPass
                            "::mlir::LLVM::LLVMDialect"];
 }
 
+def ReussirSelfTailCallEliminationPass
+    : Pass<"reussir-self-tail-call-elimination", "::mlir::func::FuncOp"> {
+  let summary = "rewrite direct self tail recursion into scf.while loops";
+  let description = [{
+    `reussir-self-tail-call-elimination` rewrites a function whose
+    return-position spine (`scf.if`/`scf.index_switch` chains) contains
+    direct self tail calls into an `scf.while` loop carrying the function
+    arguments, independent of the return type. TRMC covers recursion that
+    builds an rc-boxed result; this pass covers the rest — notably `[value]`
+    returns, where relying on LLVM's TailCallElimination is heuristic (it
+    bails on non-static allocas and DeadArgumentElimination's
+    aggregate-return shrinking hides the ret from it), so deep recursion
+    could keep a frame per call and overflow the stack. Runs after TRMC so
+    the `.trmc` helpers' plain self tail calls loop as well.
+  }];
+  let dependentDialects = ["::reussir::ReussirDialect",
+                           "::mlir::arith::ArithDialect",
+                           "::mlir::func::FuncDialect",
+                           "::mlir::scf::SCFDialect",
+                           "::mlir::ub::UBDialect"];
+}
+
 #endif // REUSSIR_TRANSFORMATION_PASSES_TD

--- a/lib/Bridge/Bridge.cppm
+++ b/lib/Bridge/Bridge.cppm
@@ -185,6 +185,8 @@ void createLoweringPipeline(mlir::PassManager &pm,
   pm.addNestedPass<mlir::func::FuncOp>(
       reussir::createReussirRcCreateFusionPass());
   pm.addPass(reussir::createReussirTRMCRecursionAnalysisPass());
+  pm.addNestedPass<mlir::func::FuncOp>(
+      reussir::createReussirSelfTailCallEliminationPass());
   pm.addPass(reussir::createReussirCompilePolymorphicFFIPass());
 
   if (enableInvariantAnalysis) {

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -48,7 +48,8 @@ set(REUSSIR_BACKEND_ARCHIVES
   MLIRReussirTokenReuse
   MLIRReussirInvariantGroupAnalysis
   MLIRReussirUniqueCarryingRecursionAnalysis
-  MLIRReussirTRMCRecursionAnalysis)
+  MLIRReussirTRMCRecursionAnalysis
+  MLIRReussirSelfTailCallElimination)
 add_dependencies(ReussirCAPI ${REUSSIR_BACKEND_ARCHIVES})
 
 # Aggregate target the Rust crates depend on.

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -106,6 +106,9 @@ MlirPass reussirCreateRcDispatchFusionPass(void) {
 MlirPass reussirCreateRcCreateFusionPass(void) {
   return wrapOwned(reussir::createReussirRcCreateFusionPass());
 }
+MlirPass reussirCreateSelfTailCallEliminationPass(void) {
+  return wrapOwned(reussir::createReussirSelfTailCallEliminationPass());
+}
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void) {
   return wrapOwned(reussir::createReussirTRMCRecursionAnalysisPass());
 }

--- a/lib/Transformation/CMakeLists.txt
+++ b/lib/Transformation/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(SpecialPointerTag)
 add_subdirectory(InvariantGroupAnalysis)
 add_subdirectory(UniqueCarryingRecursionAnalysis)
 add_subdirectory(TRMCRecursionAnalysis)
+add_subdirectory(SelfTailCallElimination)
 
 set(REUSSIR_TRANSFORMATION_AGGREGATE_LIBS
   MLIRReussirClosureBetaReduction
@@ -22,6 +23,7 @@ set(REUSSIR_TRANSFORMATION_AGGREGATE_LIBS
   MLIRReussirInvariantGroupAnalysis
   MLIRReussirUniqueCarryingRecursionAnalysis
   MLIRReussirTRMCRecursionAnalysis
+  MLIRReussirSelfTailCallElimination
 )
 
 add_library(MLIRReussirTransformation INTERFACE)

--- a/lib/Transformation/SelfTailCallElimination/CMakeLists.txt
+++ b/lib/Transformation/SelfTailCallElimination/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_mlir_library(MLIRReussirSelfTailCallElimination
+  SelfTailCallElimination.cpp
+
+  DEPENDS
+  MLIRReussirTransformationPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRReussir
+  MLIRArithDialect
+  MLIRFuncDialect
+  MLIRSCFDialect
+  MLIRUBDialect
+  MLIRPass
+)

--- a/lib/Transformation/SelfTailCallElimination/SelfTailCallElimination.cpp
+++ b/lib/Transformation/SelfTailCallElimination/SelfTailCallElimination.cpp
@@ -1,0 +1,240 @@
+//===-- SelfTailCallElimination.cpp - self tail calls to loops --*- C++ -*-===//
+//
+// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+//
+// Rewrites direct self tail recursion into an `scf.while` loop while the IR
+// is still structured, independent of the return type.
+//
+// TRMC covers self recursion that builds an rc-boxed result; everything else
+// — notably a `[value]` enum return like functional-queue's `churn` — used
+// to lean on LLVM's TailCallElimination, whose eligibility is heuristic (it
+// bails on non-static allocas, and DeadArgumentElimination's
+// aggregate-return shrinking can hide the `ret` from it). This pass makes
+// the loop structural instead: the function body becomes the before-region
+// of an `scf.while` whose carried values are the function arguments, every
+// return-position spine op (`scf.if`/`scf.index_switch`) is widened to also
+// yield a continue flag and the next iteration's arguments, and each leaf
+// yields either "continue with the self call's operands" or "stop with this
+// value". Stack slots stay outside the loop: the slot lowering materializes
+// them in the entry block (see BasicOpsLowering), so an iteration reuses its
+// frame instead of growing it — the reason a naive per-iteration alloca
+// would defeat the very stack guarantee this pass exists to give.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/Transformation/Passes.h"
+#include "Reussir/IR/ReussirDialect.h"
+
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/UB/IR/UBOps.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/Interfaces/SideEffectInterfaces.h>
+#include <mlir/Pass/Pass.h>
+
+namespace reussir {
+
+#define GEN_PASS_DEF_REUSSIRSELFTAILCALLELIMINATIONPASS
+#include "Reussir/Transformation/Passes.h.inc"
+
+namespace {
+
+// Whether every op between `op` (exclusive) and its block's terminator is
+// side-effect free. Only then does jumping back to the loop header instead
+// of returning through the spine preserve behavior.
+bool pureUntilTerminator(mlir::Operation *op) {
+  for (mlir::Operation *cursor = op->getNextNode();
+       cursor != op->getBlock()->getTerminator();
+       cursor = cursor->getNextNode())
+    if (!mlir::isMemoryEffectFree(cursor))
+      return false;
+  return true;
+}
+
+// A direct self tail call: calls `func`, single-result, its only use is the
+// enclosing terminator, and nothing effectful runs between call and
+// terminator.
+mlir::func::CallOp asSelfTailCall(mlir::Value value, mlir::func::FuncOp func) {
+  auto call =
+      llvm::dyn_cast_if_present<mlir::func::CallOp>(value.getDefiningOp());
+  if (!call || call.getCallee() != func.getName() ||
+      call.getNumResults() != 1 || !value.hasOneUse() ||
+      !pureUntilTerminator(call))
+    return nullptr;
+  return call;
+}
+
+// A spine op the widening can rebuild: a single-result `scf.if` or
+// `scf.index_switch` whose only use is the enclosing terminator, with
+// single-block regions each yielding one value, and nothing effectful
+// between it and the terminator.
+bool isSpineOp(mlir::Value value) {
+  mlir::Operation *def = value.getDefiningOp();
+  if (!def || !llvm::isa<mlir::scf::IfOp, mlir::scf::IndexSwitchOp>(def) ||
+      def->getNumResults() != 1 || !value.hasOneUse() ||
+      !pureUntilTerminator(def))
+    return false;
+  return llvm::all_of(def->getRegions(), [](mlir::Region &region) {
+    if (!region.hasOneBlock())
+      return false;
+    auto yield =
+        llvm::dyn_cast<mlir::scf::YieldOp>(region.front().getTerminator());
+    return yield && yield.getNumOperands() == 1;
+  });
+}
+
+// Whether the return-position spine below `value` contains at least one
+// rewritable self tail call.
+bool spineHasSelfTailCall(mlir::Value value, mlir::func::FuncOp func) {
+  if (asSelfTailCall(value, func))
+    return true;
+  if (!isSpineOp(value))
+    return false;
+  return llvm::any_of(value.getDefiningOp()->getRegions(),
+                      [&](mlir::Region &region) {
+                        auto yield = llvm::cast<mlir::scf::YieldOp>(
+                            region.front().getTerminator());
+                        return spineHasSelfTailCall(yield.getOperand(0), func);
+                      });
+}
+
+// Rewrites the spine below `value` into widened form and returns the SSA
+// values (continue, nextArgs..., result) available right before
+// `terminator`. Consumed spine ops and self calls are queued on `toErase`;
+// they lose their last use when the caller replaces `terminator`.
+llvm::SmallVector<mlir::Value>
+widenSpine(mlir::OpBuilder &builder, mlir::Operation *terminator,
+           mlir::Value value, mlir::func::FuncOp func,
+           llvm::SmallVectorImpl<mlir::Operation *> &toErase) {
+  mlir::Location loc = terminator->getLoc();
+  mlir::Type resultType = func.getResultTypes().front();
+
+  if (mlir::func::CallOp call = asSelfTailCall(value, func)) {
+    builder.setInsertionPoint(terminator);
+    llvm::SmallVector<mlir::Value> widened;
+    widened.push_back(mlir::arith::ConstantOp::create(
+        builder, loc, builder.getBoolAttr(true)));
+    llvm::append_range(widened, call.getOperands());
+    widened.push_back(mlir::ub::PoisonOp::create(builder, loc, resultType));
+    toErase.push_back(call);
+    return widened;
+  }
+
+  if (isSpineOp(value) && spineHasSelfTailCall(value, func)) {
+    mlir::Operation *def = value.getDefiningOp();
+    // Rewrite each region's yield to the widened form first, then rebuild
+    // the op with the widened result list and steal its regions.
+    for (mlir::Region &region : def->getRegions()) {
+      auto yield =
+          llvm::cast<mlir::scf::YieldOp>(region.front().getTerminator());
+      llvm::SmallVector<mlir::Value> widened =
+          widenSpine(builder, yield, yield.getOperand(0), func, toErase);
+      builder.setInsertionPoint(yield);
+      mlir::scf::YieldOp::create(builder, yield.getLoc(), widened);
+      yield.erase();
+    }
+    llvm::SmallVector<mlir::Type> widenedTypes{builder.getI1Type()};
+    llvm::append_range(widenedTypes, func.getArgumentTypes());
+    widenedTypes.push_back(resultType);
+    mlir::OperationState state(def->getLoc(), def->getName().getStringRef());
+    state.addOperands(def->getOperands());
+    state.addTypes(widenedTypes);
+    state.addAttributes(def->getAttrs());
+    for (unsigned i = 0, e = def->getNumRegions(); i < e; ++i)
+      state.addRegion();
+    builder.setInsertionPoint(def);
+    mlir::Operation *widenedOp = builder.create(state);
+    for (auto [target, source] :
+         llvm::zip(widenedOp->getRegions(), def->getRegions()))
+      target.takeBody(source);
+    toErase.push_back(def);
+    return llvm::SmallVector<mlir::Value>(widenedOp->getResults());
+  }
+
+  // A finished value: stop the loop with it.
+  builder.setInsertionPoint(terminator);
+  llvm::SmallVector<mlir::Value> widened;
+  widened.push_back(mlir::arith::ConstantOp::create(
+      builder, loc, builder.getBoolAttr(false)));
+  for (mlir::Type argType : func.getArgumentTypes())
+    widened.push_back(mlir::ub::PoisonOp::create(builder, loc, argType));
+  widened.push_back(value);
+  return widened;
+}
+
+void convertToLoop(mlir::func::FuncOp func) {
+  mlir::Region &body = func.getBody();
+  mlir::Block *oldEntry = &body.front();
+  auto returnOp = llvm::cast<mlir::func::ReturnOp>(oldEntry->getTerminator());
+  mlir::OpBuilder builder(func.getContext());
+  mlir::Location loc = func.getLoc();
+
+  // The loop carries the function arguments and forwards them plus the
+  // finished result out of the before-region; the after-region only feeds
+  // the carried arguments back.
+  llvm::SmallVector<mlir::Type> carriedTypes(func.getArgumentTypes());
+  llvm::SmallVector<mlir::Type> forwardedTypes(carriedTypes);
+  forwardedTypes.push_back(func.getResultTypes().front());
+
+  llvm::SmallVector<mlir::Location> argLocs(carriedTypes.size(), loc);
+  mlir::Block *newEntry =
+      builder.createBlock(&body, body.begin(), carriedTypes, argLocs);
+  builder.setInsertionPointToEnd(newEntry);
+  auto whileOp = mlir::scf::WhileOp::create(builder, loc, forwardedTypes,
+                                            newEntry->getArguments());
+  mlir::func::ReturnOp::create(builder, loc,
+                               whileOp.getResults().take_back(1));
+
+  // The original body becomes the before-region; its block arguments (the
+  // old function arguments) become the loop-carried values.
+  whileOp.getBefore().getBlocks().splice(whileOp.getBefore().end(),
+                                         body.getBlocks(),
+                                         oldEntry->getIterator());
+
+  // The after-region feeds the carried arguments back to the next iteration.
+  mlir::Block *afterBlock = builder.createBlock(
+      &whileOp.getAfter(), whileOp.getAfter().end(), forwardedTypes,
+      llvm::SmallVector<mlir::Location>(forwardedTypes.size(), loc));
+  builder.setInsertionPointToEnd(afterBlock);
+  mlir::scf::YieldOp::create(
+      builder, loc, afterBlock->getArguments().take_front(carriedTypes.size()));
+
+  // Widen the return spine and terminate the before-region with the
+  // condition.
+  llvm::SmallVector<mlir::Operation *> toErase;
+  llvm::SmallVector<mlir::Value> widened =
+      widenSpine(builder, returnOp, returnOp.getOperand(0), func, toErase);
+  builder.setInsertionPoint(returnOp);
+  mlir::scf::ConditionOp::create(builder, loc, widened.front(),
+                                 llvm::ArrayRef(widened).drop_front());
+  returnOp.erase();
+  for (mlir::Operation *op : toErase)
+    op->erase();
+}
+
+struct SelfTailCallEliminationPass
+    : public impl::ReussirSelfTailCallEliminationPassBase<
+          SelfTailCallEliminationPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    mlir::func::FuncOp func = getOperation();
+    if (func.isDeclaration() || func.getNumResults() != 1 ||
+        !func.getBody().hasOneBlock())
+      return;
+    auto returnOp = llvm::dyn_cast<mlir::func::ReturnOp>(
+        func.getBody().front().getTerminator());
+    if (!returnOp || returnOp.getNumOperands() != 1)
+      return;
+    if (!spineHasSelfTailCall(returnOp.getOperand(0), func))
+      return;
+    convertToLoop(func);
+  }
+};
+
+} // namespace
+} // namespace reussir

--- a/tests/integration/conversion/self_tail_call_elimination.mlir
+++ b/tests/integration/conversion/self_tail_call_elimination.mlir
@@ -1,0 +1,66 @@
+// RUN: %reussir-opt %s --reussir-self-tail-call-elimination | %FileCheck %s
+
+// A direct self tail call returning a [value] record — the shape TRMC skips
+// (no rc-boxed result). The function body becomes the before-region of an
+// scf.while carrying the arguments; the recursive arm yields
+// (true, next args, poison) and the finished arm (false, poisons, result).
+
+!out = !reussir.record<compound "Out" [value] {i64, i64}>
+
+// CHECK-LABEL: func.func @spin(
+// CHECK-SAME:    %[[N:[a-z0-9]+]]: i64, %[[ACC:[a-z0-9]+]]: i64
+// CHECK:  %[[RES:.+]]:3 = scf.while (%[[CN:.+]] = %[[N]], %[[CACC:.+]] = %[[ACC]])
+// CHECK:    %[[COND:.+]] = arith.cmpi eq, %[[CN]]
+// CHECK:    %[[W:.+]]:4 = scf.if %[[COND]] -> (i1, i64, i64, !reussir.record
+// CHECK:      %[[DONE:.+]] = reussir.record.compound
+// CHECK:      %[[FALSE:.+]] = arith.constant false
+// CHECK:      %[[PN:.+]] = ub.poison : i64
+// CHECK:      %[[PACC:.+]] = ub.poison : i64
+// CHECK:      scf.yield %[[FALSE]], %[[PN]], %[[PACC]], %[[DONE]]
+// CHECK:    } else {
+// CHECK:      %[[TRUE:.+]] = arith.constant true
+// CHECK:      %[[PR:.+]] = ub.poison : !reussir.record
+// CHECK:      scf.yield %[[TRUE]], %{{.+}}, %{{.+}}, %[[PR]]
+// CHECK:    }
+// CHECK-NOT: func.call @spin
+// CHECK:    scf.condition(%[[W]]#0) %[[W]]#1, %[[W]]#2, %[[W]]#3
+// CHECK:  } do {
+// CHECK:  ^bb0(%[[AN:.+]]: i64, %[[AACC:.+]]: i64, %{{.+}}: !reussir.record
+// CHECK:    scf.yield %[[AN]], %[[AACC]]
+// CHECK:  }
+// CHECK:  return %[[RES]]#2
+func.func @spin(%n: i64, %acc: i64) -> !out {
+  %zero = arith.constant 0 : i64
+  %one = arith.constant 1 : i64
+  %cond = arith.cmpi eq, %n, %zero : i64
+  %result = scf.if %cond -> (!out) {
+    %done = reussir.record.compound(%acc, %acc : i64, i64) : !out
+    scf.yield %done : !out
+  } else {
+    %n1 = arith.subi %n, %one : i64
+    %acc1 = arith.addi %acc, %n : i64
+    %next = func.call @spin(%n1, %acc1) : (i64, i64) -> !out
+    scf.yield %next : !out
+  }
+  return %result : !out
+}
+
+// A function whose recursion is not in tail position must be left alone.
+// CHECK-LABEL: func.func @not_tail(
+// CHECK-NOT: scf.while
+// CHECK: %[[R:.+]] = func.call @not_tail
+// CHECK: arith.addi %[[R]],
+func.func @not_tail(%n: i64) -> i64 {
+  %zero = arith.constant 0 : i64
+  %one = arith.constant 1 : i64
+  %cond = arith.cmpi eq, %n, %zero : i64
+  %result = scf.if %cond -> (i64) {
+    scf.yield %zero : i64
+  } else {
+    %n1 = arith.subi %n, %one : i64
+    %r = func.call @not_tail(%n1) : (i64) -> i64
+    %sum = arith.addi %r, %one : i64
+    scf.yield %sum : i64
+  }
+  return %result : i64
+}

--- a/tool/reussir-opt/main.cpp
+++ b/tool/reussir-opt/main.cpp
@@ -90,6 +90,9 @@ int main(int argc, char **argv) {
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return reussir::createReussirTRMCRecursionAnalysisPass();
   });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return reussir::createReussirSelfTailCallEliminationPass();
+  });
   return failed(mlir::MlirOptMain(
       argc, argv, "Reussir analysis and optimization driver\n", registry));
 }


### PR DESCRIPTION
Stacks on #401. The other candidate mechanism (sibling: #402 musttail marking) for turning "stock TCE happens to fire" into a guarantee — compare and pick one.

## What it does

New \`reussir-self-tail-call-elimination\` func pass, scheduled right after TRMC (so the \`.trmc\` helpers' plain self tail calls loop as well):

- a function whose return-position spine (\`scf.if\`/\`scf.index_switch\` chains) contains direct self tail calls is rewritten into an \`scf.while\` carrying the function arguments;
- spine ops widen to also yield \`(continue: i1, next args…)\`; recursive leaves yield \`(true, call operands, poison result)\`, finished leaves \`(false, poison args, value)\`;
- eligibility degrades per-leaf: a self call with effectful ops between it and the yield simply stays a call (sound fallback), mirroring TRMC's per-site philosophy;
- stack slots stay per-frame — the entry-block materialization from #401 means an iteration reuses its slots instead of growing the stack (the "value context is stack allocated" trap).

## Comparison vs #402 (musttail marking)

| | this PR (structural loop) | #402 (musttail + early TCE) |
|---|---|---|
| functional-queue 65536×1M | 147.1 ± 3.4 ms | 141.6 ± 2.8 ms |
| \`-Onone\` deep recursion | **passes** (structural, no LLVM leg needed) | stack overflow (LLVM leg skipped) |
| guarantee | structural at MLIR level, any return type, any target | \`musttail\` ISel guarantee for register-trivial returns; aggregates rely on TCE firing on the canonicalized \`call; ret\` shape |
| blast radius | new pass + registration (~230 LOC) | ~130 LOC LLVM pass |

Both are perf-ties with #401 alone on the current suite (base already unlocks stock TCE); the choice is about which guarantee shape the project wants. rbtree / nbe-closure / derive unchanged. All 335 lit tests + unit tests pass (new pass-level lit test included: value-enum-returning recursion loops, non-tail recursion left alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786484965&installation_id=144622820&pr_number=403&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F403&signature=dfe64d566f39a855f0a3ba86b8171f84a6a18c239f06f1d8d377f10fa5604425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->