### PR TITLE
[rt][backend] size-specialized allocation entry __reussir_allocate_small

### DIFF
--- a/crates/reussir-rt/src/alloc.rs
+++ b/crates/reussir-rt/src/alloc.rs
@@ -57,6 +57,19 @@ mod backend {
         }
     }
 
+    /// Allocate a *small, naturally aligned* block: the compiler only emits
+    /// calls with a constant `size <= MI_SMALL_SIZE_MAX` (1024) whose
+    /// requested alignment is natural (`align <= 8` and dividing `size`), so
+    /// the generic wrapper's alignment/divisibility checks and mimalloc's
+    /// own size classification are all discharged statically. `mi_malloc_small`
+    /// indexes the heap's direct small-page table without a bounds check in
+    /// release builds — the size precondition is load-bearing.
+    #[inline]
+    pub unsafe fn alloc_small(size: usize) -> *mut u8 {
+        debug_assert!(size <= ffi::MI_SMALL_SIZE_MAX);
+        unsafe { ffi::mi_malloc_small(size).cast() }
+    }
+
     #[inline]
     pub unsafe fn free(ptr: *mut u8) {
         unsafe { ffi::mi_free(ptr.cast()) }
@@ -223,6 +236,16 @@ mod backend {
 
     pub use imp::{alloc, free, realloc};
 
+    /// The small-block entry under the fallback backend: the platform
+    /// allocators have no small fast path, so this is the plain (sanitizer-
+    /// interposable) allocation at natural alignment. The compiler-side
+    /// contract (size <= 1024, natural alignment) still holds; it is simply
+    /// not needed here.
+    #[inline]
+    pub unsafe fn alloc_small(size: usize) -> *mut u8 {
+        unsafe { imp::alloc(8, size) }
+    }
+
     /// Resize a block whose contents are dead — the language-heap realloc.
     /// The platform allocators expose no portable usable-size query, so this
     /// is always free + alloc. That is not just simple but *diagnostic*: the
@@ -285,6 +308,21 @@ unsafe impl std::alloc::GlobalAlloc for ReussirGlobalAlloc {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __reussir_allocate(align: usize, size: usize) -> *mut u8 {
     let ptr = unsafe { backend::alloc(align, size) };
+    if ptr.is_null() {
+        unsafe { crate::panic!("allocation failed") };
+    }
+    ptr
+}
+
+/// Allocate a block whose layout the compiler proved *small and naturally
+/// aligned*: constant `size <= 1024` (mimalloc's `MI_SMALL_SIZE_MAX` — the
+/// shared contract in `include/Reussir/Support/AllocatorBinModel.h`) with
+/// `align <= 8` dividing it. This is the sized fast path of
+/// `__reussir_allocate` with every runtime check discharged at compile time;
+/// the OOM contract is identical.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __reussir_allocate_small(size: usize) -> *mut u8 {
+    let ptr = unsafe { backend::alloc_small(size) };
     if ptr.is_null() {
         unsafe { crate::panic!("allocation failed") };
     }

--- a/crates/reussir-rt/src/symbols.rs
+++ b/crates/reussir-rt/src/symbols.rs
@@ -11,8 +11,8 @@
 use core::ffi::c_void;
 
 use crate::alloc::{
-    __reussir_allocate, __reussir_dealloc_unsized, __reussir_deallocate, __reussir_realloc_unsized,
-    __reussir_reallocate,
+    __reussir_allocate, __reussir_allocate_small, __reussir_dealloc_unsized, __reussir_deallocate,
+    __reussir_realloc_unsized, __reussir_reallocate,
 };
 use crate::panic::__reussir_panic;
 use crate::region::{
@@ -50,6 +50,7 @@ pub fn exported_symbols() -> &'static [RuntimeSymbol] {
     }
     symbols![
         __reussir_allocate,
+        __reussir_allocate_small,
         __reussir_deallocate,
         __reussir_dealloc_unsized,
         __reussir_reallocate,

--- a/include/Reussir/Support/AllocatorBinModel.h
+++ b/include/Reussir/Support/AllocatorBinModel.h
@@ -49,6 +49,14 @@ constexpr std::size_t allocatorBinSize(std::size_t size) {
 // huge segments where the bin model (and in-place reuse) no longer applies.
 inline constexpr std::size_t kAllocatorBinModelMax = 64 * 1024;
 
+// The `__reussir_allocate_small` contract, shared with the runtime
+// (crates/reussir-rt/src/alloc.rs): mimalloc's MI_SMALL_SIZE_MAX
+// (128 * sizeof(void*)). `mi_malloc_small` indexes the heap's direct
+// small-page table without a bounds check in release builds, so the compiler
+// must only emit the small entry point for constant layouts within this
+// bound (and at natural alignment: align <= 8 dividing size).
+inline constexpr std::size_t kSmallAllocationLimit = 1024;
+
 // Whether two (align, size) layouts are served from the same allocator bin,
 // i.e. a block allocated for one satisfies the other in place. Restricted to
 // the natural-alignment path (align <= 16): over-aligned allocations go

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -57,6 +57,7 @@
 #include "Reussir/Conversion/TypeConverter.h"
 #include "Reussir/IR/ReussirAttrs.h"
 #include "Reussir/IR/ReussirDialect.h"
+#include "Reussir/Support/AllocatorBinModel.h"
 #include "Reussir/IR/ReussirEnumAttrs.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
@@ -396,15 +397,26 @@ struct ReussirTokenAllocConversionPattern
     uint64_t alignment = tokenType.getAlign();
     uint64_t size = tokenType.getSize();
     auto indexType = converter->getIndexType();
+    auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
 
-    // Create constants for alignment and size
-    auto alignConst = mlir::arith::ConstantOp::create(
-        rewriter, loc, mlir::IntegerAttr::get(indexType, alignment));
+    // A statically small, naturally aligned layout takes the sized fast
+    // path: `__reussir_allocate_small(size)` is `mi_malloc_small` behind an
+    // OOM check — no alignment/divisibility recheck, no size
+    // classification. The generic wrapper stays for everything else.
     auto sizeConst = mlir::arith::ConstantOp::create(
         rewriter, loc, mlir::IntegerAttr::get(indexType, size));
+    if (alignment <= 8 && size % alignment == 0 &&
+        size <= kSmallAllocationLimit) {
+      auto allocSmallFunc = moduleOp.lookupSymbol<mlir::LLVM::LLVMFuncOp>(
+          "__reussir_allocate_small");
+      auto funcOp = mlir::LLVM::CallOp::create(rewriter, loc, allocSmallFunc,
+                                               mlir::ValueRange{sizeConst});
+      rewriter.replaceOp(op, funcOp.getResult());
+      return mlir::success();
+    }
 
-    // Create the runtime function call
-    auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
+    auto alignConst = mlir::arith::ConstantOp::create(
+        rewriter, loc, mlir::IntegerAttr::get(indexType, alignment));
     auto allocFunc =
         moduleOp.lookupSymbol<mlir::LLVM::LLVMFuncOp>("__reussir_allocate");
     auto funcOp = mlir::LLVM::CallOp::create(
@@ -3189,6 +3201,8 @@ void ensureRuntimeFunctions(mlir::ModuleOp module,
   addRuntimeFunction(body, "__reussir_release_rigid_object", {llvmPtrType}, {});
   auto allocFunc = addRuntimeFunction(body, "__reussir_allocate",
                                       {indexType, indexType}, {llvmPtrType});
+  auto allocSmallFunc = addRuntimeFunction(body, "__reussir_allocate_small",
+                                           {indexType}, {llvmPtrType});
   auto deallocFunc = addRuntimeFunction(
       body, "__reussir_deallocate", {llvmPtrType, indexType, indexType}, {});
   // Add common runtime attributes.
@@ -3202,6 +3216,14 @@ void ensureRuntimeFunctions(mlir::ModuleOp module,
   allocFunc.setResultAttr(0, "llvm.noundef", builder.getUnitAttr());
   allocFunc.setArgAttr(0, "llvm.noundef", builder.getUnitAttr());
   allocFunc.setArgAttr(1, "llvm.noundef", builder.getUnitAttr());
+
+  // The small entry has no alignment parameter — its contract (natural
+  // alignment, size <= kSmallAllocationLimit) is discharged by the compiler
+  // at emission; see ReussirTokenAllocConversionPattern.
+  allocSmallFunc->setAttr("passthrough", passthroughAlloc);
+  allocSmallFunc.setResultAttr(0, "llvm.noalias", builder.getUnitAttr());
+  allocSmallFunc.setResultAttr(0, "llvm.noundef", builder.getUnitAttr());
+  allocSmallFunc.setArgAttr(0, "llvm.noundef", builder.getUnitAttr());
 
   auto passthroughDealloc = builder.getStrArrayAttr(
       {"mustprogress", "nounwind", "willreturn", "nocallback"});

--- a/lib/LLVMPass/AllocationSimplication/RuntimeFunctionAttributor.cpp
+++ b/lib/LLVMPass/AllocationSimplication/RuntimeFunctionAttributor.cpp
@@ -51,6 +51,42 @@ bool setAllocateAttributes(llvm::Function &fn) {
   return changed;
 }
 
+// `__reussir_allocate_small(size)`: same allocation family and kind as the
+// generic entry, but the size is the sole argument (allocsize index 0) and
+// there is no alignment parameter — the natural-alignment contract is
+// discharged by the compiler at every call site.
+bool setAllocateSmallAttributes(llvm::Function &fn) {
+  bool changed = false;
+  llvm::LLVMContext &ctx = fn.getContext();
+  constexpr auto allocKind =
+      llvm::AllocFnKind::Alloc | llvm::AllocFnKind::Uninitialized;
+
+  if (!fn.hasFnAttribute(llvm::Attribute::AllocKind) ||
+      fn.getFnAttribute(llvm::Attribute::AllocKind).getAllocKind() !=
+          allocKind) {
+    fn.addFnAttr(llvm::Attribute::getWithAllocKind(ctx, allocKind));
+    changed = true;
+  }
+
+  auto hasExpectedAllocSize = [&] {
+    if (!fn.hasFnAttribute(llvm::Attribute::AllocSize))
+      return false;
+    auto args = fn.getFnAttribute(llvm::Attribute::AllocSize).getAllocSizeArgs();
+    return args.first == 0 && !args.second.has_value();
+  };
+  if (!hasExpectedAllocSize()) {
+    fn.addFnAttr(llvm::Attribute::getWithAllocSizeArgs(ctx, 0, std::nullopt));
+    changed = true;
+  }
+
+  if (fn.getFnAttribute("alloc-family").getValueAsString() != "reussir") {
+    fn.addFnAttr("alloc-family", "reussir");
+    changed = true;
+  }
+
+  return changed;
+}
+
 bool setReallocateAttributes(llvm::Function &fn) {
   bool changed = false;
   llvm::LLVMContext &ctx = fn.getContext();
@@ -119,6 +155,9 @@ RuntimeFunctionAttributorPass::run(llvm::Module &module,
 
   if (auto *allocate = module.getFunction("__reussir_allocate"))
     changed |= setAllocateAttributes(*allocate);
+
+  if (auto *allocateSmall = module.getFunction("__reussir_allocate_small"))
+    changed |= setAllocateSmallAttributes(*allocateSmall);
 
   if (auto *deallocate = module.getFunction("__reussir_deallocate"))
     changed |= setDeallocateAttributes(*deallocate);

--- a/tests/integration/conversion/rc_create_fused_lowering.mlir
+++ b/tests/integration/conversion/rc_create_fused_lowering.mlir
@@ -108,7 +108,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
 // CHECK-LABEL: define ptr @mk_compound
 // CHECK-NOT: alloca %"List::Cons"
-// CHECK: %[[ALLOC:.*]] = call ptr @__reussir_allocate(i64 8, i64 24)
+// CHECK: %[[ALLOC:.*]] = call ptr @__reussir_allocate_small(i64 24)
 // CHECK: %[[COUNT:.*]] = getelementptr { i32, %"List::Cons" }, ptr %[[ALLOC]], i32 0, i32 0
 // CHECK: %[[PAYLOAD:.*]] = getelementptr { i32, %"List::Cons" }, ptr %[[ALLOC]], i32 0, i32 1
 // CHECK: %[[FIELD0:.*]] = getelementptr %"List::Cons", ptr %[[PAYLOAD]], i32 0, i32 0
@@ -122,7 +122,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK-NOT: alloca %"List::Cons"
 // The box IS the fused-header variant: the count overlays field 0 and is
 // stored after the element is initialized.
-// CHECK: %[[ALLOC:.*]] = call ptr @__reussir_allocate(i64 8, i64 24)
+// CHECK: %[[ALLOC:.*]] = call ptr @__reussir_allocate_small(i64 24)
 // CHECK: %[[COUNT:.*]] = getelementptr %List, ptr %[[ALLOC]], i32 0, i32 0
 // CHECK: %[[VARIANT:.*]] = getelementptr %List, ptr %[[ALLOC]], i32 0, i32 0
 // CHECK: %[[TAGPTR:.*]] = getelementptr %List, ptr %[[VARIANT]], i32 0, i32 1

--- a/tests/integration/conversion/record_ops.mlir
+++ b/tests/integration/conversion/record_ops.mlir
@@ -59,7 +59,7 @@ module {
 // CHECK: store %"List::Cons" %[[cons_loaded]], ptr %[[value_ptr]], align 8
 // CHECK: %[[loaded:[0-9]+]] = load %List, ptr %[[alloca]], align 8
 // CHECK: call void @llvm.lifetime.end.p0({{.*}}ptr %[[alloca]])
-// CHECK: %[[allocated:[0-9]+]] = call ptr @__reussir_allocate(i64 8, i64 24)
+// CHECK: %[[allocated:[0-9]+]] = call ptr @__reussir_allocate_small(i64 24)
 // CHECK: %[[count_ptr:[0-9]+]] = getelementptr %List, ptr %[[allocated]], i32 0, i32 0
 // CHECK: %[[box_ptr:[0-9]+]] = getelementptr %List, ptr %[[allocated]], i32 0, i32 0
 // CHECK: store %List %[[loaded]], ptr %[[box_ptr]], align 8

--- a/tests/integration/conversion/token_alloc_small.mlir
+++ b/tests/integration/conversion/token_alloc_small.mlir
@@ -1,0 +1,30 @@
+// RUN: %reussir-opt %s --convert-to-llvm | %FileCheck %s
+
+// A statically small, naturally aligned token takes the sized fast path
+// (`__reussir_allocate_small(size)` = mi_malloc_small behind the OOM check);
+// an over-aligned or over-sized layout keeps the generic entry with its
+// runtime alignment handling.
+
+// CHECK-LABEL: llvm.func @small_natural
+// CHECK: %[[SZ:.+]] = llvm.mlir.constant(40 : i64)
+// CHECK: llvm.call @__reussir_allocate_small(%[[SZ]])
+func.func @small_natural() -> !reussir.token<align: 8, size: 40> {
+  %t = reussir.token.alloc : !reussir.token<align: 8, size: 40>
+  return %t : !reussir.token<align: 8, size: 40>
+}
+
+// CHECK-LABEL: llvm.func @large_natural
+// CHECK-NOT: allocate_small
+// CHECK: llvm.call @__reussir_allocate(
+func.func @large_natural() -> !reussir.token<align: 8, size: 4096> {
+  %t = reussir.token.alloc : !reussir.token<align: 8, size: 4096>
+  return %t : !reussir.token<align: 8, size: 4096>
+}
+
+// CHECK-LABEL: llvm.func @over_aligned
+// CHECK-NOT: allocate_small
+// CHECK: llvm.call @__reussir_allocate(
+func.func @over_aligned() -> !reussir.token<align: 64, size: 128> {
+  %t = reussir.token.alloc : !reussir.token<align: 64, size: 128>
+  return %t : !reussir.token<align: 64, size: 128>
+}

--- a/tests/integration/conversion/token_ops.mlir
+++ b/tests/integration/conversion/token_ops.mlir
@@ -1,10 +1,9 @@
 // RUN: %reussir-opt %s --convert-to-llvm | %FileCheck %s
 module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>>} {
   // CHECK-LABEL: llvm.func @token_alloc() -> !llvm.ptr attributes {sym_visibility = "private"} {
-  // CHECK: %0 = llvm.mlir.constant(8 : [[INDEX_T:i[0-9]+]]) : [[INDEX_T]]
-  // CHECK: %1 = llvm.mlir.constant(64 : [[INDEX_T]]) : [[INDEX_T]]
-  // CHECK: %2 = llvm.call @__reussir_allocate(%0, %1) : ([[INDEX_T]], [[INDEX_T]]) -> !llvm.ptr
-  // CHECK: llvm.return %2 : !llvm.ptr
+  // CHECK: %0 = llvm.mlir.constant(64 : [[INDEX_T:i[0-9]+]]) : [[INDEX_T]]
+  // CHECK: %1 = llvm.call @__reussir_allocate_small(%0) : ([[INDEX_T]]) -> !llvm.ptr
+  // CHECK: llvm.return %1 : !llvm.ptr
   // CHECK: }
   func.func private @token_alloc() 
     -> !reussir.token<align: 8, size: 64> {


### PR DESCRIPTION
First of three PRs for #400. Point 2: constant allocation layouts are lost at the runtime boundary — \`__reussir_allocate(8, 40)\` rechecks alignment/divisibility (including a \`div\`) and mimalloc reclassifies the size, all discharged statically here.

- **rt**: \`__reussir_allocate_small(size)\` = \`mi_malloc_small\` behind the same OOM contract; fallback backend uses plain \`malloc\` (sanitizer-interposable); registered in the JIT symbol table. The \`size <= 1024\` precondition is load-bearing (\`mi_malloc_small\` indexes \`pages_free_direct\` without a release-mode bounds check) and lives as a shared contract constant in \`AllocatorBinModel.h\`.
- **backend**: the \`token.alloc\` lowering picks the small entry for constant layouts with \`align <= 8\` dividing \`size\` and \`size <= 1024\`; everything else keeps the generic wrapper. \`RuntimeFunctionAttributor\` stamps \`allocsize(0)\` / \`allockind("alloc,uninitialized")\` / \`alloc-family "reussir"\` so \`dereferenceable\` inference keeps working (visible as \`dereferenceable_or_null(40)\` at rbtree call sites).

## Measurements (x64 9950X, ThinLTO + -march=native, hyperfine 3w/10-15r)

| bench | main | this PR |
|---|---|---|
| rbtree | 214.5 ± 3.1 ms | 223.9 ± 2.6 ms |
| functional-queue | 69.1 ± 1.4 ms | **66.6 ± 1.3 ms** |
| nbe-closure | 189.6 ± 1.4 ms | **185.6 ± 2.1 ms** |
| derive | 540.7 ± 11.1 ms | 546.6 ± 8.4 ms |

rbtree executes **90M fewer instructions** (3.990G → 3.900G — exactly the deleted checks at ~2.5M allocations) with 10M fewer branches; the wall-time scatter (±4% both directions, matching cycle/branch-miss deltas at equal instruction counts) is code-layout jitter, not intrinsic cost. The wall-clock harvest of #400's 6.6 ms probe requires the entry to *fold at call sites* — this PR is the enabling contract; the follow-up is either emitting the fast path in generated IR or a plugin-LTO runtime artifact.

All 337 lit tests + unit tests + rt nextest (both allocator backends) pass. New lit test pins the small/generic split (small-natural / large-natural / over-aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786490040&installation_id=144622820&pr_number=405&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F405&signature=47bba2d24a64e0238125719ee6a73c00865c073d0a78bb43f94fd2707a93d1fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->