### PR TITLE
[scf] peel nullary arms into immediate compares at dispatch

### DIFF
--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -716,6 +716,36 @@ def ReussirRcTaggedOp : ReussirRcOp<"tagged", [Pure]> {
   let hasVerifier = 1;
 }
 
+def ReussirRcCompareImmortalOp : ReussirRcOp<"compare_immortal", [Pure]> {
+  let summary = "Test an rc value against a nullary variant's immediate";
+  let description = [{
+    `reussir.rc.compare_immortal` answers whether an rc value *is* the
+    unboxed immediate of the nullary variant arm `tag` — a pure pointer
+    comparison against the arm's per-tag dummy box, no memory access.
+
+    Under the special-pointer-tag scheme every construction of a nullary arm
+    of a taggable type yields the immediate (the scheme invariant at
+    `kSpecialPtrTagAttr`), so for such an arm this comparison is *exact*:
+    true iff the value's tag is `tag`. Dispatch lowering uses it to peel
+    nullary arms off a `record.dispatch` before the generic tag-load
+    dispatch — on x86's `immortal` encoding the tag read is otherwise a
+    dependent load from the dummy box on every iteration of pointer-chasing
+    kernels (issue #400).
+
+    ```mlir
+    %is_leaf = reussir.rc.compare_immortal (%rc : !reussir.rc<...>) tag(1)
+    ```
+  }];
+
+  let arguments = (ins Arg<ReussirRcType, "rc pointer to classify">:$rcPtr,
+                   Arg<IndexAttr, "tag">:$tag);
+  let results = (outs Res<I1, "whether the value is the arm's immediate">:$result);
+  let assemblyFormat = [{
+    `(` $rcPtr `:` qualified(type($rcPtr)) `)` `tag` `(` $tag `)` attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
 def ReussirRcReinterpretOp : ReussirRcOp<"reinterpret", []> {
   let summary = "Reinterpret a Rc pointer into a token";
   let description = [{

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -1592,6 +1592,48 @@ struct ReussirRcTaggedConversionPattern
   }
 };
 
+struct ReussirRcCompareImmortalConversionPattern
+    : public mlir::OpConversionPattern<ReussirRcCompareImmortalOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirRcCompareImmortalOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    // The nullary arm's immediate is a link-time constant: the per-tag
+    // dummy box address (immortal), with `(tag + 1) << 56` folded into the
+    // top byte under TBI. The classification is therefore one pointer
+    // compare — no load, unlike a tag read through the dummy box.
+    mlir::Location loc = op.getLoc();
+    auto indexTy = llvm::cast<mlir::IntegerType>(
+        static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter())
+            ->getIndexType());
+    mlir::Type ptrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    TagEncoding encoding = specialPtrTagEncoding(op);
+    auto dummy = tagDummyBox(op->getParentOfType<mlir::ModuleOp>(), loc,
+                             op.getTag().getZExtValue(), encoding, rewriter);
+    mlir::Value expected = mlir::LLVM::AddressOfOp::create(
+        rewriter, loc, ptrTy, dummy.getSymName());
+    if (encoding == TagEncoding::TBI) {
+      if (indexTy.getWidth() != 64)
+        return op.emitOpError(
+            "the TBI encoding requires a 64-bit target; use the "
+            "arch-independent encoding instead");
+      mlir::Value baseInt =
+          mlir::LLVM::PtrToIntOp::create(rewriter, loc, indexTy, expected);
+      uint64_t encoded = (op.getTag().getZExtValue() + 1) << 56;
+      mlir::Value tagBits = mlir::LLVM::ConstantOp::create(
+          rewriter, loc, indexTy,
+          rewriter.getIntegerAttr(indexTy, static_cast<int64_t>(encoded)));
+      mlir::Value imm =
+          mlir::LLVM::OrOp::create(rewriter, loc, baseInt, tagBits);
+      expected = mlir::LLVM::IntToPtrOp::create(rewriter, loc, ptrTy, imm);
+    }
+    rewriter.replaceOpWithNewOp<mlir::LLVM::ICmpOp>(
+        op, mlir::LLVM::ICmpPredicate::eq, adaptor.getRcPtr(), expected);
+    return mlir::success();
+  }
+};
+
 struct ReussirRcCreateVariantOpConversionPattern
     : public mlir::OpConversionPattern<ReussirRcCreateVariantOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -3470,7 +3512,8 @@ void populateBasicOpsLoweringToLLVMConversionPatterns(
       ReussirNullableCheckConversionPattern,
       ReussirNullableCreateConversionPattern,
       ReussirNullableCoerceConversionPattern, ReussirRcIncConversionPattern,
-      ReussirRcTaggedConversionPattern, ReussirRcDecOpConversionPattern,
+      ReussirRcTaggedConversionPattern,
+      ReussirRcCompareImmortalConversionPattern, ReussirRcDecOpConversionPattern,
       ReussirRcCreateOpConversionPattern,
       ReussirRcCreateCompoundOpConversionPattern,
       ReussirRcCreateVariantOpConversionPattern,

--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -13,6 +13,7 @@
 #include "Reussir/IR/ReussirEnumAttrs.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
+#include "Reussir/Transformation/SpecialPointerTag.h"
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/MapVector.h>
 #include <llvm/ADT/SmallVector.h>
@@ -426,126 +427,220 @@ struct ReussirRecordDispatchOpRewritePattern
   using OpConversionPattern::OpConversionPattern;
 
 private:
-  static mlir::DenseI64ArrayAttr
-  getAllTagsAsSingletons(ReussirRecordDispatchOp op) {
-    llvm::SmallVector<int64_t> allTags;
-    for (auto tagSet : op.getTagSets()) {
-      mlir::DenseI64ArrayAttr tagArray =
-          llvm::cast<mlir::DenseI64ArrayAttr>(tagSet);
-      if (tagArray.size() != 1)
-        return {};
-      allTags.push_back(tagArray[0]);
-    }
-    return mlir::DenseI64ArrayAttr::get(op.getContext(), allTags);
-  }
-  static mlir::Value buildPreDispatcher(ReussirRecordTagOp tag,
-                                        ReussirRecordDispatchOp op,
-                                        mlir::PatternRewriter &rewriter) {
+  // Inline the arm region `idx` into `block`; a singleton arm receives the
+  // scrutinee coerced to its payload type as the block argument.
+  static void inlineArm(ReussirRecordDispatchOp op,
+                        mlir::PatternRewriter &rewriter, unsigned idx,
+                        std::optional<int64_t> singletonTag,
+                        mlir::Block *block) {
     mlir::OpBuilder::InsertionGuard guard(rewriter);
-    llvm::DenseMap<int64_t, int64_t> tagToRegionIdx;
-    llvm::SmallVector<int64_t> allTags;
-    for (auto [idx, tagSet] : llvm::enumerate(op.getTagSets())) {
-      mlir::DenseI64ArrayAttr tagArray =
-          llvm::cast<mlir::DenseI64ArrayAttr>(tagSet);
-      for (auto tag : tagArray.asArrayRef()) {
-        allTags.push_back(tag);
-        tagToRegionIdx[tag] = idx;
-      }
-    };
-    auto indexSwitchOp = mlir::scf::IndexSwitchOp::create(rewriter, 
-        op.getLoc(), rewriter.getIndexType(), tag.getResult(), allTags,
-        allTags.size());
-
-    for (auto [tag, region] :
-         llvm::zip(allTags, indexSwitchOp.getCaseRegions())) {
-      mlir::Block *block = rewriter.createBlock(&region, region.begin());
-      rewriter.setInsertionPointToStart(block);
-      auto constantIdx = mlir::arith::ConstantIndexOp::create(rewriter, 
-          op.getLoc(), tagToRegionIdx[tag]);
-      mlir::scf::YieldOp::create(rewriter, op.getLoc(),
-                                          constantIdx->getResults());
+    rewriter.setInsertionPointToStart(block);
+    llvm::SmallVector<mlir::Value, 1> args;
+    if (singletonTag) {
+      RefType variantRef = op.getVariant().getType();
+      RecordType recordType =
+          llvm::cast<RecordType>(variantRef.getElementType());
+      mlir::Type targetVariantType =
+          getProjectedType(recordType.getMembers()[*singletonTag],
+                           recordType.getMemberIsField()[*singletonTag],
+                           variantRef.getCapability());
+      RefType coercedType = RefType::get(rewriter.getContext(),
+                                         targetVariantType,
+                                         variantRef.getCapability());
+      auto coerced = reussir::ReussirRecordCoerceOp::create(
+          rewriter, op.getLoc(), coercedType,
+          rewriter.getIndexAttr(*singletonTag), op.getVariant());
+      args.push_back(coerced);
     }
-    {
-      mlir::Block *block =
-          rewriter.createBlock(&indexSwitchOp.getDefaultRegion(),
-                               indexSwitchOp.getDefaultRegion().begin());
-      rewriter.setInsertionPointToStart(block);
-      auto poison = mlir::ub::PoisonOp::create(rewriter, 
-          op.getLoc(), rewriter.getIndexType());
-      mlir::scf::YieldOp::create(rewriter, op.getLoc(), poison->getResults());
-    }
-    return indexSwitchOp.getResult(0);
+    rewriter.inlineBlockBefore(&op->getRegion(idx).front(), block,
+                               block->end(), args);
   }
 
-public:
-  mlir::LogicalResult
-  matchAndRewrite(ReussirRecordDispatchOp op,
-                  OpAdaptor adaptor,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    // First, create a RecordTagOps operation to get the tag from the input.
+  // The generic dispatch over the arm subset `setIndices`: read the tag and
+  // switch on it (through a pre-dispatcher when an arm covers several
+  // tags). Emitted at the rewriter's insertion point; returns the switch's
+  // results.
+  static mlir::scf::IndexSwitchOp
+  emitTagDispatch(ReussirRecordDispatchOp op, mlir::PatternRewriter &rewriter,
+                  llvm::ArrayRef<unsigned> setIndices) {
     auto tag = reussir::ReussirRecordTagOp::create(rewriter, op.getLoc(),
-                                                            op.getVariant());
+                                                   op.getVariant());
+    bool allSingletons = llvm::all_of(setIndices, [&](unsigned idx) {
+      return llvm::cast<mlir::DenseI64ArrayAttr>(op.getTagSets()[idx])
+                 .size() == 1;
+    });
 
     mlir::Value outerSwitchValue;
-    mlir::DenseI64ArrayAttr outerSwitchCases;
-
-    if (auto allTags = getAllTagsAsSingletons(op)) {
+    llvm::SmallVector<int64_t> outerSwitchCases;
+    if (allSingletons) {
       outerSwitchValue = tag.getResult();
-      outerSwitchCases = allTags;
+      for (unsigned idx : setIndices)
+        outerSwitchCases.push_back(
+            llvm::cast<mlir::DenseI64ArrayAttr>(op.getTagSets()[idx])[0]);
     } else {
-      outerSwitchValue = buildPreDispatcher(tag, op, rewriter);
-      outerSwitchCases = mlir::DenseI64ArrayAttr::get(
-          op.getContext(),
-          llvm::to_vector(llvm::seq<int64_t>(0, op.getTagSets().size())));
+      // Pre-dispatch: map every covered tag to its arm's case position.
+      llvm::SmallVector<int64_t> allTags;
+      llvm::DenseMap<int64_t, int64_t> tagToCase;
+      for (auto [pos, idx] : llvm::enumerate(setIndices))
+        for (int64_t t :
+             llvm::cast<mlir::DenseI64ArrayAttr>(op.getTagSets()[idx])
+                 .asArrayRef()) {
+          allTags.push_back(t);
+          tagToCase[t] = static_cast<int64_t>(pos);
+        }
+      auto preDispatch = mlir::scf::IndexSwitchOp::create(
+          rewriter, op.getLoc(), rewriter.getIndexType(), tag.getResult(),
+          allTags, allTags.size());
+      for (auto [t, region] :
+           llvm::zip(allTags, preDispatch.getCaseRegions())) {
+        mlir::OpBuilder::InsertionGuard guard(rewriter);
+        mlir::Block *block = rewriter.createBlock(&region, region.begin());
+        rewriter.setInsertionPointToStart(block);
+        auto constantIdx = mlir::arith::ConstantIndexOp::create(
+            rewriter, op.getLoc(), tagToCase[t]);
+        mlir::scf::YieldOp::create(rewriter, op.getLoc(),
+                                   constantIdx->getResults());
+      }
+      {
+        mlir::OpBuilder::InsertionGuard guard(rewriter);
+        mlir::Block *block =
+            rewriter.createBlock(&preDispatch.getDefaultRegion(),
+                                 preDispatch.getDefaultRegion().begin());
+        rewriter.setInsertionPointToStart(block);
+        auto poison = mlir::ub::PoisonOp::create(rewriter, op.getLoc(),
+                                                 rewriter.getIndexType());
+        mlir::scf::YieldOp::create(rewriter, op.getLoc(),
+                                   poison->getResults());
+      }
+      outerSwitchValue = preDispatch.getResult(0);
+      outerSwitchCases = llvm::to_vector(
+          llvm::seq<int64_t>(0, static_cast<int64_t>(setIndices.size())));
     }
 
-    auto indexSwitchOp = mlir::scf::IndexSwitchOp::create(rewriter, 
-        op.getLoc(), op->getResultTypes(), outerSwitchValue, outerSwitchCases,
-        outerSwitchCases.size());
+    auto indexSwitchOp = mlir::scf::IndexSwitchOp::create(
+        rewriter, op.getLoc(), op->getResultTypes(), outerSwitchValue,
+        outerSwitchCases, outerSwitchCases.size());
     // mark default region as unreachable
     {
+      mlir::OpBuilder::InsertionGuard guard(rewriter);
       mlir::Block *block =
           rewriter.createBlock(&indexSwitchOp.getDefaultRegion(),
                                indexSwitchOp.getDefaultRegion().begin());
       rewriter.setInsertionPointToStart(block);
       llvm::SmallVector<mlir::Value, 1> poisonValues;
       if (op.getValue()) {
-        auto poison = mlir::ub::PoisonOp::create(rewriter, 
-            op.getLoc(), op.getValue().getType());
+        auto poison = mlir::ub::PoisonOp::create(rewriter, op.getLoc(),
+                                                 op.getValue().getType());
         poisonValues.push_back(poison);
       }
       mlir::scf::YieldOp::create(rewriter, op.getLoc(), poisonValues);
     }
-    for (auto [idx, tagSet, region] :
-         llvm::enumerate(op.getTagSets(), indexSwitchOp.getCaseRegions())) {
-      mlir::DenseI64ArrayAttr tagArray =
-          llvm::cast<mlir::DenseI64ArrayAttr>(tagSet);
-      llvm::SmallVector<mlir::Value, 1> args;
+    for (auto [idx, region] :
+         llvm::zip(setIndices, indexSwitchOp.getCaseRegions())) {
+      // `createBlock` moves the insertion point into the case; keep the
+      // caller's position (right after the switch) intact.
+      mlir::OpBuilder::InsertionGuard guard(rewriter);
+      auto tagArray =
+          llvm::cast<mlir::DenseI64ArrayAttr>(op.getTagSets()[idx]);
       mlir::Block *block = rewriter.createBlock(&region, region.begin());
-      rewriter.setInsertionPointToStart(block);
-      // if we know exact variant, we need to coerce the variant to the exact
-      // type
-      if (tagArray.size() == 1) {
-        RefType variantRef = op.getVariant().getType();
-        RecordType recordType =
-            llvm::cast<RecordType>(variantRef.getElementType());
-        mlir::Type targetVariantType =
-            getProjectedType(recordType.getMembers()[tagArray[0]],
-                             recordType.getMemberIsField()[tagArray[0]],
-                             variantRef.getCapability());
-        RefType coercedType =
-            RefType::get(rewriter.getContext(), targetVariantType,
-                         variantRef.getCapability());
-        auto coerced = reussir::ReussirRecordCoerceOp::create(rewriter, 
-            op.getLoc(), coercedType, rewriter.getIndexAttr(tagArray[0]),
-            op.getVariant());
-        args.push_back(coerced);
-      }
-      // inline the block, supplying coerced value as the argument
-      rewriter.inlineBlockBefore(&op->getRegion(idx).front(), block,
-                                 block->end(), args);
+      inlineArm(op, rewriter, idx,
+                tagArray.size() == 1
+                    ? std::optional<int64_t>(tagArray[0])
+                    : std::nullopt,
+                block);
     }
-    rewriter.replaceOp(op, indexSwitchOp);
+    return indexSwitchOp;
+  }
+
+public:
+  mlir::LogicalResult
+  matchAndRewrite(ReussirRecordDispatchOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    // Under the immortal encoding a nullary arm's value is always the
+    // per-tag immediate (the scheme invariant at `kSpecialPtrTagAttr`), so
+    // membership is one pointer compare — while the generic tag read is a
+    // dependent *load* through the dummy box on every dispatch (issue
+    // #400). Peel such arms off into `rc.compare_immortal` guards and keep
+    // the unchanged tag dispatch for the rest. The TBI encoding already
+    // reads tags from the pointer's top byte without touching memory, so
+    // only `immortal` peels.
+    auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
+    auto encoding =
+        moduleOp->getAttrOfType<mlir::StringAttr>(kSpecialPtrTagAttr);
+    mlir::TypedValue<RcType> scrutinee;
+    llvm::SmallVector<unsigned> peeled;
+    llvm::SmallVector<unsigned> remaining;
+    RecordType recordType = llvm::cast<RecordType>(
+        op.getVariant().getType().getElementType());
+    if (encoding && encoding.getValue() == kSpecialPtrTagImmortal)
+      if (auto borrow = op.getVariant().getDefiningOp<ReussirRcBorrowOp>();
+          borrow && borrow.getRcPtr().getType().mayCarrySpecialPointerTag())
+        scrutinee = borrow.getRcPtr();
+    for (auto [idx, tagSet] : llvm::enumerate(op.getTagSets())) {
+      auto tagArray = llvm::cast<mlir::DenseI64ArrayAttr>(tagSet);
+      auto arm = tagArray.size() == 1
+                     ? llvm::dyn_cast<RecordType>(
+                           recordType.getMembers()[tagArray[0]])
+                     : RecordType{};
+      if (scrutinee && arm && arm.isCompound() && arm.getComplete() &&
+          arm.getMembers().empty())
+        peeled.push_back(idx);
+      else
+        remaining.push_back(idx);
+    }
+
+    if (peeled.empty()) {
+      auto dispatch = emitTagDispatch(op, rewriter, remaining);
+      rewriter.replaceOp(op, dispatch->getResults());
+      return mlir::success();
+    }
+
+    // One `scf.if` per peeled arm; the innermost else carries the tag
+    // dispatch over the remaining arms (or nothing — the guards are then
+    // exhaustive).
+    mlir::scf::IfOp outermost;
+    for (unsigned idx : peeled) {
+      int64_t tag =
+          llvm::cast<mlir::DenseI64ArrayAttr>(op.getTagSets()[idx])[0];
+      auto isImmediate = ReussirRcCompareImmortalOp::create(
+          rewriter, op.getLoc(), rewriter.getI1Type(), scrutinee,
+          rewriter.getIndexAttr(tag));
+      auto ifOp = mlir::scf::IfOp::create(rewriter, op.getLoc(),
+                                          op->getResultTypes(),
+                                          isImmediate.getResult(), true, true);
+      inlineArm(op, rewriter, idx, tag, ifOp.thenBlock());
+      if (!outermost)
+        outermost = ifOp;
+      else
+        mlir::scf::YieldOp::create(rewriter, op.getLoc(), ifOp->getResults());
+      rewriter.setInsertionPointToStart(ifOp.elseBlock());
+    }
+    if (remaining.empty()) {
+      llvm::SmallVector<mlir::Value, 1> poisonValues;
+      if (op.getValue())
+        poisonValues.push_back(mlir::ub::PoisonOp::create(
+            rewriter, op.getLoc(), op.getValue().getType()));
+      mlir::scf::YieldOp::create(rewriter, op.getLoc(), poisonValues);
+    } else if (remaining.size() == 1) {
+      // The guards decided the dispatch: the last arm needs no tag read at
+      // all — inline it as the residual else (its own yield terminates the
+      // branch). This is the common two-arm shape (rbtree's Leaf/Branch,
+      // QList's Nil/Cons): the hot recursive arm keeps its exact
+      // pre-rewrite body with zero dispatch memory traffic.
+      auto tagArray = llvm::cast<mlir::DenseI64ArrayAttr>(
+          op.getTagSets()[remaining.front()]);
+      mlir::Block *elseBlock = rewriter.getInsertionBlock();
+      inlineArm(op, rewriter, remaining.front(),
+                tagArray.size() == 1 ? std::optional<int64_t>(tagArray[0])
+                                     : std::nullopt,
+                elseBlock);
+    } else {
+      auto dispatch = emitTagDispatch(op, rewriter, remaining);
+      rewriter.setInsertionPointAfter(dispatch);
+      mlir::scf::YieldOp::create(rewriter, op.getLoc(),
+                                 dispatch->getResults());
+    }
+    rewriter.replaceOp(op, outermost->getResults());
     return mlir::success();
   }
 };

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -702,6 +702,22 @@ mlir::LogicalResult ReussirRcTaggedOp::verify() {
   return mlir::success();
 }
 
+mlir::LogicalResult ReussirRcCompareImmortalOp::verify() {
+  RcType rcType = getRcPtr().getType();
+  auto variantType = llvm::dyn_cast<RecordType>(rcType.getElementType());
+  if (!variantType || !variantType.isVariant() || !variantType.getComplete())
+    return emitOpError("RC element type must be a complete variant record");
+  size_t tag = getTag().getZExtValue();
+  if (tag >= variantType.getMembers().size())
+    return emitOpError("tag out of bounds");
+  auto arm = llvm::dyn_cast<RecordType>(variantType.getMembers()[tag]);
+  if (!arm || !arm.isCompound() || !arm.getMembers().empty())
+    return emitOpError("only nullary variant arms have immediates");
+  if (!rcType.mayCarrySpecialPointerTag())
+    return emitOpError("the box type cannot carry a special pointer tag");
+  return mlir::success();
+}
+
 mlir::LogicalResult ReussirRcCreateVariantOp::verify() {
   RecordType variantType = getRecordType();
   if (!variantType)

--- a/tests/integration/conversion/dispatch_compare_immortal.mlir
+++ b/tests/integration/conversion/dispatch_compare_immortal.mlir
@@ -1,0 +1,42 @@
+// RUN: %reussir-opt %s --reussir-lowering-scf-ops | %FileCheck %s
+
+// Under the immortal encoding a nullary arm's value is always the per-tag
+// immediate, so dispatch peels such arms into `rc.compare_immortal` guards
+// (a pointer compare — no load); when a single arm remains it inlines as
+// the residual else with no tag read at all.
+
+!list_ = !reussir.record<variant "List" incomplete>
+!list_nil = !reussir.record<compound "List::Nil" [value] {}>
+!list_cons = !reussir.record<compound "List::Cons" [value] {i64, !list_}>
+!list = !reussir.record<variant "List" {!list_nil, !list_cons}>
+!rc_list = !reussir.rc<!list>
+
+module attributes {reussir.special_ptr_tag = "immortal"} {
+  // CHECK-LABEL: func.func @sum_head(
+  // CHECK: %[[GUARD:.+]] = reussir.rc.compare_immortal(%{{.+}} : !reussir.rc<{{.*}}) tag(0)
+  // CHECK: scf.if %[[GUARD]] -> (i64) {
+  // CHECK:   arith.constant 0
+  // CHECK: } else {
+  // CHECK-NOT: reussir.record.tag
+  // CHECK-NOT: scf.index_switch
+  // CHECK:   reussir.record.coerce
+  // CHECK:   reussir.ref.load
+  // CHECK: }
+  func.func @sum_head(%l: !rc_list) -> i64 {
+    %ref = reussir.rc.borrow (%l : !rc_list) : !reussir.ref<!list>
+    %r = reussir.record.dispatch (%ref : !reussir.ref<!list>) -> i64 {
+      [0] -> {
+        ^bb0(%nil: !reussir.ref<!list_nil>):
+        %zero = arith.constant 0 : i64
+        reussir.scf.yield %zero : i64
+      }
+      [1] -> {
+        ^bb1(%cons: !reussir.ref<!list_cons>):
+        %slot = reussir.ref.project (%cons : !reussir.ref<!list_cons>) [0] : !reussir.ref<i64>
+        %v = reussir.ref.load (%slot : !reussir.ref<i64>) : i64
+        reussir.scf.yield %v : i64
+      }
+    }
+    return %r : i64
+  }
+}


### PR DESCRIPTION
Second of three PRs for #400 (point 1). The x86 \`immortal\` encoding reads every dispatched tag through a dependent load from the per-tag dummy box — 202M dispatched L1 loads on rbtree, ~78% of the residual Koka gap.

## Design (as steered)

- \`record.tag\` lowering is **unchanged**.
- New pure op \`reussir.rc.compare_immortal (%rc) tag(k) → i1\`: whether the value *is* the nullary arm's immediate — one pointer compare against the arm's dummy-box link-time address (top-byte bits folded in under TBI), no memory access. Exact under the scheme invariant (nullary arms of taggable types always construct as immediates).
- The dispatch lowering peels singleton nullary arms into \`scf.if\` guards on it, keeping the original tag + \`scf.index_switch\` as the innermost fallback — the two-level dispatch, with level 1 spelled as compares because switch case values cannot be symbolic addresses.
- **Single-remaining-arm shortcut**: once the guards decide the dispatch, the last arm inlines as the residual else with *no tag read at all*. The common two-arm shape (rbtree \`Leaf\`/\`Branch\`, \`QList\` \`Nil\`/\`Cons\`) does zero dispatch memory traffic — this shortcut is what recovers the probe's numbers; without it the dead single-case switch kept the load and perturbed token reuse (first attempt measured +330M instructions).

## Measurements (x64 9950X, ThinLTO + native, hyperfine 3w/20r)

| | main | this PR | issue #400 probe |
|---|---|---|---|
| rbtree wall | 217.2 ± 3.9 ms | **206.3 ± 10.7 ms** | (199.0 → 182.5) |
| instructions | 3.990G | 4.019G | 4.020G |
| L1-dcache-loads | 2.135G | **1.935G** | 1.933G |
| cycles | 1.013G | **0.948G** (−6.5%) | 0.913G (−9.5%) |

Counters land on the issue's mechanical-rewrite probe almost exactly. functional-queue / derive / nbe-closure / heap unchanged. All 338 lit + unit tests pass; new lit test pins the peel + shortcut shape (guard, no `record.tag`, no `index_switch` in the two-arm case).

Next: the LSB duplicate-tag encoding PR, then a head-to-head of the two on multi-nullary-arm workloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786491454&installation_id=144622820&pr_number=406&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F406&signature=5545d2cf61ad60e53daefe54b7186b9b64b2edd5538844870448bcf70fa7d516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->