### PR TITLE
[backend] atomic rc lifecycle: acq_rel fetch_sub decrement, acquire fetch (#409 PR 1)

### DIFF
--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -476,6 +476,35 @@ def ReussirRcFetchOp : ReussirRcOp<"fetch", []> {
   }];
 }
 
+def ReussirRcFetchSubOp : ReussirRcOp<"fetch_sub", []> {
+  let summary = "Atomically decrement the reference count, returning the "
+                "previous value";
+  let description = [{
+    `reussir.rc.fetch_sub` atomically subtracts one from the reference count
+    of an atomic RC pointer and returns the count's *previous* value. It
+    lowers to an acquire-release `atomicrmw sub`: the release half orders
+    this thread's uses of the box before the decrement becomes visible, and
+    the acquire half lets the final decrementer (the one that observes a
+    previous count of 1) see every other thread's uses before it destroys
+    the box.
+
+    Together with the `old == 1` test this is the atomic counterpart of the
+    plain `rc.fetch` / `rc.set` pair the nonatomic decrement expansion uses —
+    the subtraction is already published, so the shared path stores nothing.
+    Like those, it is a low-level operation for the RC management transforms,
+    not for direct use.
+  }];
+
+  let arguments = (ins Arg<ReussirRcType, "Reference to decrement">:$rcPtr);
+  let results = (outs Res<Index, "Previous reference count">:$refCount);
+
+  let assemblyFormat = [{
+    `(` $rcPtr `:` qualified(type($rcPtr)) `)` `:` type($refCount) attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
 def ReussirRcSetOp : ReussirRcOp<"set", []> {
   let summary = "Set the reference count of a RC pointer";
   let description = [{
@@ -483,7 +512,8 @@ def ReussirRcSetOp : ReussirRcOp<"set", []> {
 
     This serves as a low-level operation to implement `reussir.rc.dec` and
     related RC management transforms. It is not recommended to use this
-    operation directly.
+    operation directly. An atomic RC pointer's count can never be blind
+    stored — atomic boxes are decremented with `reussir.rc.fetch_sub`.
   }];
 
   let arguments = (
@@ -496,6 +526,8 @@ def ReussirRcSetOp : ReussirRcOp<"set", []> {
     `(` $rcPtr `:` qualified(type($rcPtr)) `,`
     $refCount `:` type($refCount) `)` attr-dict
   }];
+
+  let hasVerifier = 1;
 }
 
 def ReussirRcCreateOp : ReussirRcOp<"create", [

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -529,13 +529,57 @@ struct ReussirRcFetchConversionPattern
     // hits the dummy box's refcount, which is pinned >= 2 — exactly what
     // routes the expanded decrement to its shared branch and answers
     // `is_unique` with false (see the special-pointer-tag notes above).
-    mlir::Value loaded = mlir::LLVM::LoadOp::create(
-        rewriter, loc, rewriter.getI32Type(), adaptor.getRcPtr());
+    //
+    // An atomic box's count is loaded with acquire ordering: observing 1
+    // proves exclusivity only if every other thread's uses (published by
+    // their release decrements) happen-before this read — that is what
+    // keeps the copy-on-write and uniqify probes sound when the box is
+    // shared across threads. (Atomic boxes never carry tagged immediates.)
+    mlir::Value loaded;
+    if (op.getRcPtr().getType().getAtomicKind() == AtomicKind::atomic)
+      loaded = mlir::LLVM::LoadOp::create(
+          rewriter, loc, rewriter.getI32Type(), adaptor.getRcPtr(),
+          /*alignment=*/4, /*isVolatile=*/false, /*isNonTemporal=*/false,
+          /*isInvariant=*/false, /*isInvariantGroup=*/false,
+          mlir::LLVM::AtomicOrdering::acquire);
+    else
+      loaded = mlir::LLVM::LoadOp::create(rewriter, loc, rewriter.getI32Type(),
+                                          adaptor.getRcPtr());
     mlir::Value widened =
         llvm::cast<mlir::IntegerType>(indexTy).getWidth() > 32
             ? mlir::LLVM::ZExtOp::create(rewriter, loc, indexTy, loaded)
                   .getResult()
             : loaded;
+    rewriter.replaceOp(op, widened);
+    return mlir::success();
+  }
+};
+
+struct ReussirRcFetchSubConversionPattern
+    : public mlir::OpConversionPattern<ReussirRcFetchSubOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirRcFetchSubOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto indexTy =
+        static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter())
+            ->getIndexType();
+    mlir::Location loc = op.getLoc();
+    auto countType = rewriter.getI32Type();
+    auto one = mlir::LLVM::ConstantOp::create(
+        rewriter, loc, mlir::IntegerAttr::get(countType, 1));
+    // Acquire-release (see the op description): release orders this thread's
+    // uses before the decrement, acquire lets the final decrementer see every
+    // other thread's uses before destroying the box.
+    mlir::Value old = mlir::LLVM::AtomicRMWOp::create(
+        rewriter, loc, mlir::LLVM::AtomicBinOp::sub, adaptor.getRcPtr(), one,
+        mlir::LLVM::AtomicOrdering::acq_rel);
+    mlir::Value widened =
+        llvm::cast<mlir::IntegerType>(indexTy).getWidth() > 32
+            ? mlir::LLVM::ZExtOp::create(rewriter, loc, indexTy, old)
+                  .getResult()
+            : old;
     rewriter.replaceOp(op, widened);
     return mlir::success();
   }
@@ -1417,8 +1461,13 @@ initializeRcCreateStorage(OpT op, AdaptorT adaptor,
                           mlir::ConversionPatternRewriter &rewriter) {
   RcType rcPtrTy = op.getRcPtr().getType();
   RcBoxType rcBoxType = rcPtrTy.getInnerBoxType();
-  if (rcPtrTy.getAtomicKind() == AtomicKind::atomic)
-    return op->emitError("TODO: atomic rc create"), mlir::failure();
+  // An atomic shared box is created exactly like a normal one — the box is
+  // unpublished until the create's result escapes, so the initial count
+  // store needs no atomic ordering. Regional boxes have no atomic flavor.
+  if (rcPtrTy.getAtomicKind() == AtomicKind::atomic && rcBoxType.isRegional())
+    return op->emitError("atomic rc create is not supported for regional "
+                         "boxes"),
+           mlir::failure();
 
   auto convertedBoxType = typeConverter->convertType(rcBoxType);
   auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
@@ -3388,7 +3437,8 @@ struct ReussirConvertToLLVMPatternInterface
         ReussirClosureApplyOp, ReussirClosureCloneOp, ReussirClosureEvalOp,
         ReussirClosureInspectPayloadOp, ReussirClosureCursorOp,
         ReussirClosureInstantiateOp, ReussirClosureVtableOp,
-        ReussirClosureCreateOp, ReussirRcFetchOp, ReussirRcSetOp,
+        ReussirClosureCreateOp, ReussirRcFetchOp, ReussirRcFetchSubOp,
+        ReussirRcSetOp,
         ReussirStrGlobalOp, ReussirStrLiteralOp, ReussirStrCastOp,
         ReussirStrLenOp, ReussirStrUnsafeByteAtOp, ReussirStrUnsafeStartWithOp,
         ReussirStrSliceOp, ReussirTrampolineOp, ReussirTokenLaunderOp>();
@@ -3545,6 +3595,7 @@ void populateBasicOpsLoweringToLLVMConversionPatterns(
       ReussirStrUnsafeByteAtOpConversionPattern,
       ReussirStrUnsafeStartWithOpConversionPattern,
       ReussirStrSliceOpConversionPattern, ReussirTrampolineOpConversionPattern,
-      ReussirTokenLaunderOpConversionPattern>(converter, patterns.getContext());
+      ReussirTokenLaunderOpConversionPattern,
+      ReussirRcFetchSubConversionPattern>(converter, patterns.getContext());
 }
 } // namespace reussir

--- a/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
+++ b/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
@@ -62,10 +62,21 @@ struct RcDecrementExpansionPattern
         mlir::isa<FFIObjectType, ClosureType>(type.getElementType()))
       return mlir::failure();
 
-    auto prevRcCount =
-        ReussirRcFetchOp::create(rewriter, op.getLoc(), op.getRcPtr());
-    auto isOne = mlir::arith::CmpIOp::create(rewriter, 
-        op.getLoc(), mlir::arith::CmpIPredicate::eq, prevRcCount.getRefCount(),
+    // An atomic box decrements with one acquire-release `rc.fetch_sub`
+    // (returning the previous count): the subtraction is already published,
+    // so unlike the plain-load scheme below there is nothing to store on the
+    // shared path, and the final decrementer's acquire half orders every
+    // other thread's uses before the destruction. Destructuring decrements
+    // never target atomic boxes (rejected by the `rc.dec` verifier).
+    const bool atomic = type.getAtomicKind() == AtomicKind::atomic;
+    mlir::Value prevRcCount =
+        atomic ? ReussirRcFetchSubOp::create(rewriter, op.getLoc(),
+                                             op.getRcPtr())
+                     .getRefCount()
+               : ReussirRcFetchOp::create(rewriter, op.getLoc(), op.getRcPtr())
+                     .getRefCount();
+    auto isOne = mlir::arith::CmpIOp::create(rewriter,
+        op.getLoc(), mlir::arith::CmpIPredicate::eq, prevRcCount,
         mlir::arith::ConstantIndexOp::create(rewriter, op.getLoc(), 1));
     auto likelyUnique =
         ReussirExpectOp::create(rewriter, op.getLoc(), isOne.getResult(), true);
@@ -124,11 +135,13 @@ struct RcDecrementExpansionPattern
     }
     {
       rewriter.setInsertionPointToStart(ifOp.elseBlock());
-      auto decremented = mlir::arith::SubIOp::create(rewriter, 
-          op.getLoc(), prevRcCount.getRefCount(),
-          mlir::arith::ConstantIndexOp::create(rewriter, op.getLoc(), 1));
-      ReussirRcSetOp::create(rewriter, op.getLoc(), op.getRcPtr(),
-                                      decremented.getResult());
+      if (!atomic) {
+        auto decremented = mlir::arith::SubIOp::create(rewriter,
+            op.getLoc(), prevRcCount,
+            mlir::arith::ConstantIndexOp::create(rewriter, op.getLoc(), 1));
+        ReussirRcSetOp::create(rewriter, op.getLoc(), op.getRcPtr(),
+                                        decremented.getResult());
+      }
       if (op.isDestructuring()) {
         // The shared path keeps the box alive, so the consumer's bound
         // members need their own references — the retains the fusion

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -270,6 +270,31 @@ mlir::LogicalResult ReussirRcIncOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// RcFetchSubOp verification
+//===----------------------------------------------------------------------===//
+mlir::LogicalResult ReussirRcFetchSubOp::verify() {
+  RcType rcType = getRcPtr().getType();
+  if (rcType.getAtomicKind() != AtomicKind::atomic)
+    return emitOpError("fetch_sub requires an atomic RC pointer; a nonatomic "
+                       "box decrements through `rc.fetch` and `rc.set`");
+  if (rcType.getCapability() == reussir::Capability::flex ||
+      rcType.getCapability() == reussir::Capability::rigid)
+    return emitOpError("fetch_sub requires a shared RC pointer");
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
+// RcSetOp verification
+//===----------------------------------------------------------------------===//
+mlir::LogicalResult ReussirRcSetOp::verify() {
+  // A blind count store on an atomic box would race concurrent increments;
+  // atomic boxes decrement through `rc.fetch_sub` instead.
+  if (getRcPtr().getType().getAtomicKind() == AtomicKind::atomic)
+    return emitOpError("cannot blind-store the count of an atomic RC pointer");
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // RcReinterpretOp verification
 //===----------------------------------------------------------------------===//
 mlir::LogicalResult ReussirRcReinterpretOp::verify() {

--- a/tests/integration/basic/failure/atomic_rc_count_ops.mlir
+++ b/tests/integration/basic/failure/atomic_rc_count_ops.mlir
@@ -1,0 +1,21 @@
+// RUN: %reussir-opt %s -verify-diagnostics --split-input-file
+
+// A blind count store would race concurrent increments on an atomic box.
+module {
+  func.func @set_atomic(%rc : !reussir.rc<i64 shared atomic>, %c : index) {
+    // expected-error @+1 {{'reussir.rc.set' op cannot blind-store the count of an atomic RC pointer}}
+    reussir.rc.set(%rc : !reussir.rc<i64 shared atomic>, %c : index)
+    return
+  }
+}
+
+// -----
+
+// The atomic decrement primitive has no meaning on a nonatomic box.
+module {
+  func.func @fetch_sub_nonatomic(%rc : !reussir.rc<i64>) -> index {
+    // expected-error @+1 {{'reussir.rc.fetch_sub' op fetch_sub requires an atomic RC pointer; a nonatomic box decrements through `rc.fetch` and `rc.set`}}
+    %c = reussir.rc.fetch_sub(%rc : !reussir.rc<i64>) : index
+    return %c : index
+  }
+}

--- a/tests/integration/conversion/atomic_rc.mlir
+++ b/tests/integration/conversion/atomic_rc.mlir
@@ -1,0 +1,62 @@
+// RUN: %reussir-opt %s --reussir-rc-decrement-expansion | %FileCheck %s --check-prefix=EXPAND
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion{expand-decrement=1},convert-scf-to-cf,convert-to-llvm)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
+
+// The atomic rc lifecycle. An atomic box is created like a normal one (the
+// initial count store happens before the box is published), incremented with
+// a monotonic `atomicrmw add`, and decremented through ONE acquire-release
+// `atomicrmw sub` returning the previous count: the subtraction is already
+// published, so — unlike the nonatomic plain fetch/cmp/set scheme — the
+// shared path stores nothing, and the final decrementer (previous count 1)
+// destroys the box under the acquire half's ordering. The uniqueness probe
+// `rc.fetch` loads with acquire so copy-on-write stays sound across threads.
+
+!point = !reussir.record<compound "Point" {i64, i64}>
+!apoint = !reussir.rc<!point shared atomic>
+
+module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+  // The expansion decrements with `rc.fetch_sub` and leaves the shared branch
+  // empty — no plain fetch, no `rc.set`.
+  // EXPAND-LABEL: @atomic_dec
+  // EXPAND: %[[OLD:[0-9a-z]+]] = reussir.rc.fetch_sub
+  // EXPAND-NOT: reussir.rc.fetch (
+  // EXPAND-NOT: reussir.rc.set
+  // EXPAND: arith.cmpi eq, %[[OLD]]
+  // EXPAND: scf.if
+  // EXPAND: reussir.rc.reinterpret
+  // EXPAND-NOT: reussir.rc.set
+
+  // LLVM-LABEL: define void @atomic_dec(ptr %0)
+  // LLVM: %{{[0-9]+}} = atomicrmw sub ptr %0, i32 1 acq_rel, align 4
+  // LLVM-NOT: store i32
+  func.func @atomic_dec(%rc: !apoint) {
+    %t = reussir.rc.dec (%rc : !apoint) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
+    reussir.token.free (%t : !reussir.nullable<!reussir.token<align: 8, size: 24>>)
+    return
+  }
+
+  // LLVM-LABEL: define void @atomic_inc(ptr %0)
+  // LLVM: atomicrmw add ptr %{{[0-9]+}}, i32 1 monotonic, align 4
+  func.func @atomic_inc(%rc: !apoint) {
+    reussir.rc.inc (%rc : !apoint)
+    return
+  }
+
+  // LLVM-LABEL: define{{.*}}@atomic_fetch(ptr %0)
+  // LLVM: load atomic i32, ptr %0 acquire, align 4
+  func.func @atomic_fetch(%rc: !apoint) -> index {
+    %c = reussir.rc.fetch (%rc : !apoint) : index
+    return %c : index
+  }
+
+  // The create is a plain allocation + ordinary stores: the box is not yet
+  // published, so the initial count needs no atomic ordering.
+  // LLVM-LABEL: define ptr @atomic_create(i64 %0, i64 %1)
+  // LLVM: call{{.*}}ptr @__reussir_allocate
+  // LLVM: store i32 1, ptr
+  // LLVM-NOT: atomicrmw
+  func.func @atomic_create(%x: i64, %y: i64) -> !apoint {
+    %p = reussir.record.compound(%x, %y : i64, i64) : !point
+    %rc = reussir.rc.create value(%p : !point) : !apoint
+    return %rc : !apoint
+  }
+}

--- a/tests/integration/conversion/atomic_rc_omp_e2e.mlir
+++ b/tests/integration/conversion/atomic_rc_omp_e2e.mlir
@@ -1,0 +1,47 @@
+// REQUIRES: openmp
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion{expand-decrement=1},convert-scf-to-cf,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O2 -o %t.ll
+// RUN: %llc %t.ll -relocation-model=pic -filetype=obj -o %t.o
+// RUN: %cc %openmp_flags %t.o %S/atomic_rc_omp_e2e_main.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// The atomic rc lifecycle under real contention: an OpenMP driver
+// (atomic_rc_omp_e2e_main.c) shares one atomic box across threads, each of
+// which clones (rc.inc), reads, and drops (rc.dec) it in a hot loop, and the
+// main thread releases the final reference afterwards. A lost decrement
+// leaks the box; a duplicated one frees it while other threads still read —
+// the sanitizer legs of this module (tests/integration/sanitizer/
+// atomic-rc-omp-{asan,tsan}.mlir) turn either into a hard failure.
+
+!pair = !reussir.record<compound "Pair" {i64, i64}>
+!apair = !reussir.rc<!pair shared atomic>
+!refpair = !reussir.ref<!pair shared atomic>
+
+module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+  func.func @atomic_pair_create(%x: i64, %y: i64) -> !apair attributes { passthrough = ["sanitize_thread", "sanitize_address"] } {
+    %p = reussir.record.compound(%x, %y : i64, i64) : !pair
+    %rc = reussir.rc.create value(%p : !pair) : !apair
+    return %rc : !apair
+  }
+
+  func.func @atomic_pair_clone(%rc: !apair) attributes { passthrough = ["sanitize_thread", "sanitize_address"] } {
+    reussir.rc.inc (%rc : !apair)
+    return
+  }
+
+  func.func @atomic_pair_sum(%rc: !apair) -> i64 attributes { passthrough = ["sanitize_thread", "sanitize_address"] } {
+    %ref = reussir.rc.borrow (%rc : !apair) : !refpair
+    %s0 = reussir.ref.project (%ref : !refpair) [0] : !reussir.ref<i64 shared atomic>
+    %x = reussir.ref.load (%s0 : !reussir.ref<i64 shared atomic>) : i64
+    %s1 = reussir.ref.project (%ref : !refpair) [1] : !reussir.ref<i64 shared atomic>
+    %y = reussir.ref.load (%s1 : !reussir.ref<i64 shared atomic>) : i64
+    %sum = arith.addi %x, %y : i64
+    return %sum : i64
+  }
+
+  func.func @atomic_pair_drop(%rc: !apair) attributes { passthrough = ["sanitize_thread", "sanitize_address"] } {
+    %t = reussir.rc.dec (%rc : !apair) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
+    reussir.token.free (%t : !reussir.nullable<!reussir.token<align: 8, size: 24>>)
+    return
+  }
+}

--- a/tests/integration/conversion/atomic_rc_omp_e2e_main.c
+++ b/tests/integration/conversion/atomic_rc_omp_e2e_main.c
@@ -1,0 +1,44 @@
+/* OpenMP driver for the atomic rc lifecycle (atomic_rc_omp_e2e.mlir): one
+   atomic box, every thread cloning/reading/dropping it in a hot loop, and the
+   main thread releasing the final reference after the region. The refcount
+   traffic is the test — a lost decrement leaks the box (lsan), a duplicated
+   one frees it under readers (asan), and any non-atomic count access is a
+   data race (tsan).
+
+   Each thread validates its own sum locally, so the ONLY cross-thread state
+   is the box itself: every ordering claim then flows through the count's
+   acquire/release chain — the exact property the lowering must provide. In
+   particular the final drop's free is ordered after the workers' plain
+   payload reads only by that chain, so a weaker-than-release decrement is a
+   reportable race under TSan, not just a latent bug. */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern void *atomic_pair_create(int64_t, int64_t);
+extern void atomic_pair_clone(void *);
+extern int64_t atomic_pair_sum(void *);
+extern void atomic_pair_drop(void *);
+
+int main(void) {
+  enum { THREADS = 8, ITERS = 20000 };
+  void *box = atomic_pair_create(17, 25);
+#pragma omp parallel num_threads(THREADS)
+  {
+    int64_t local = 0;
+    for (int i = 0; i < ITERS; ++i) {
+      atomic_pair_clone(box);
+      local += atomic_pair_sum(box);
+      atomic_pair_drop(box);
+    }
+    if (local != (int64_t)ITERS * 42) {
+      fprintf(stderr, "thread sum=%lld, want %lld\n", (long long)local,
+              (long long)ITERS * 42);
+      abort();
+    }
+  }
+  /* Release the creating reference; the box must die exactly here. */
+  atomic_pair_drop(box);
+  puts("all ok");
+  return 0;
+}

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -63,6 +63,52 @@ if config.gdb_path and os.path.exists(config.gdb_path):
     config.available_features.add('gdb')
     config.substitutions.append((r'%gdb',
                                  '%s --batch -nx' % sh_path(config.gdb_path)))
+
+# OpenMP: multithreaded e2e drivers (the atomic-rc suite) need `-fopenmp` and
+# a runtime rpath to wherever the toolchain keeps libomp. Probe by linking a
+# trivial parallel program; on failure the tests are unsupported rather than
+# broken.
+def _probe_openmp():
+    import subprocess
+    import tempfile
+    if not config.cc_path:
+        return None
+    libomp_dir = ''
+    try:
+        libomp = subprocess.run(
+            [config.cc_path, '-print-file-name=libomp.so'],
+            capture_output=True, text=True, timeout=30).stdout.strip()
+        if os.path.isabs(libomp):
+            libomp_dir = os.path.dirname(libomp)
+    except Exception:
+        pass
+    flags = '-fopenmp'
+    if libomp_dir:
+        flags += ' -Wl,-rpath,%s' % libomp_dir
+    with tempfile.TemporaryDirectory() as tmp:
+        src = os.path.join(tmp, 'omp.c')
+        exe = os.path.join(tmp, 'omp')
+        with open(src, 'w') as f:
+            f.write('#include <omp.h>\n'
+                    'int main(void) { int n = 0;\n'
+                    '#pragma omp parallel num_threads(2) reduction(+ : n)\n'
+                    '  n += 1;\n'
+                    '  return n == 2 ? 0 : 1; }\n')
+        try:
+            if subprocess.run([config.cc_path, *flags.split(), src, '-o', exe],
+                              capture_output=True, timeout=60).returncode != 0:
+                return None
+            if subprocess.run([exe], capture_output=True,
+                              timeout=60).returncode != 0:
+                return None
+        except Exception:
+            return None
+    return flags
+
+_openmp_flags = _probe_openmp()
+if _openmp_flags:
+    config.available_features.add('openmp')
+    config.substitutions.append((r'%openmp_flags', _openmp_flags))
 config.substitutions.append((r'%rpath_flag', sh_path(config.rpath_flag)))
 config.substitutions.append((r'%rrc', sh_path(config.reussir_rrc_path)))
 # The Rust REPL; its suite lives in repl-rs/ and only runs when the `rrepl`

--- a/tests/integration/sanitizer/Inputs/lsan-libomp.supp
+++ b/tests/integration/sanitizer/Inputs/lsan-libomp.supp
@@ -1,0 +1,5 @@
+# libomp never frees its worker-thread bookkeeping at process exit; that is
+# runtime-internal noise, not a refcount leak (our boxes allocate through
+# __reussir_allocate, which these frames never contain).
+leak:___kmp_allocate
+leak:libomp.so

--- a/tests/integration/sanitizer/Inputs/tsan-libomp.supp
+++ b/tests/integration/sanitizer/Inputs/tsan-libomp.supp
@@ -1,0 +1,10 @@
+# libomp is not TSan-instrumented, so its thread suspend/resume machinery
+# (worker parking between parallel regions) reports as races on its own
+# bookkeeping. Suppress those specific internals by name. Deliberately NOT a
+# blanket `race:libomp.so` / `race:^__kmp`: every worker stack bottoms out in
+# __kmp_invoke_microtask, so a whole-stack module pattern would also swallow
+# genuine races in the code under test.
+race:__kmp_lock_suspend_mx
+race:__kmp_unlock_suspend_mx
+race:__kmp_suspend_
+race:__kmp_resume_

--- a/tests/integration/sanitizer/atomic-rc-omp-asan.mlir
+++ b/tests/integration/sanitizer/atomic-rc-omp-asan.mlir
@@ -1,0 +1,12 @@
+// REQUIRES: asan, openmp
+// RUN: %reussir-opt %S/../conversion/atomic_rc_omp_e2e.mlir --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion{expand-decrement=1},convert-scf-to-cf,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O2 -o %t.ll
+// RUN: %cc %asan_flags -c -x ir %t.ll -o %t.o
+// RUN: %cc %asan_flags %openmp_flags %t.o %S/../conversion/atomic_rc_omp_e2e_main.c %reussir_rt_asan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env LSAN_OPTIONS=suppressions=%S/Inputs/lsan-libomp.supp %t.exe
+
+// ASan leg of the atomic rc OpenMP e2e: a duplicated decrement frees the box
+// while other threads still read it (heap-use-after-free); a lost one leaks
+// it (LeakSanitizer rides along on Linux ASan). libomp's own never-freed
+// worker bookkeeping is suppressed — the patterns cannot match a leaked box,
+// which allocates through __reussir_allocate.

--- a/tests/integration/sanitizer/atomic-rc-omp-tsan.mlir
+++ b/tests/integration/sanitizer/atomic-rc-omp-tsan.mlir
@@ -1,0 +1,15 @@
+// REQUIRES: tsan, openmp
+// RUN: %reussir-opt %S/../conversion/atomic_rc_omp_e2e.mlir --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion{expand-decrement=1},convert-scf-to-cf,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O2 -o %t.ll
+// RUN: %cc %tsan_flags -c -x ir %t.ll -o %t.o
+// RUN: %cc %tsan_flags %openmp_flags %t.o %S/../conversion/atomic_rc_omp_e2e_main.c %reussir_rt_tsan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: TSAN_OPTIONS=abort_on_error=1:halt_on_error=1:suppressions=%S/Inputs/tsan-libomp.supp %t.exe
+
+// TSan leg of the atomic rc OpenMP e2e: any plain (non-atomic) access to the
+// count word — the exact bug class the acquire/release lowering exists to
+// prevent — is reported as a data race. The driver keeps all cross-thread
+// ordering of user data on the count's acquire/release chain, so even a
+// too-weak ordering shows up (payload reads racing the final free). Only
+// libomp-internal reports are suppressed: the runtime is not instrumented,
+// and its thread-management noise carries libomp/__kmp frames that a real
+// refcount race never has.


### PR DESCRIPTION
PR 1 of #409: make the atomic flavor of `!reussir.rc` an actually thread-safe lifecycle. `rc.inc` already lowered to `atomicrmw add monotonic`; the create was a TODO and the decrement/uniqueness paths were plain loads and stores.

## Dialect

- **`reussir.rc.fetch_sub`** (new): one `atomicrmw sub acq_rel` returning the *previous* count. The decrement expansion uses it for atomic boxes and leaves the shared branch empty — the subtraction is already published, so nothing replaces the nonatomic `sub` + `rc.set`. Release orders each thread's uses before its decrement; acquire lets the final decrementer (previous count 1) destroy the box after every other thread's uses. Nonatomic expansion is byte-for-byte unchanged. Destructuring decrements never target atomic boxes (the `rc.dec` verifier already rejected that).
- **`rc.fetch`** on an atomic box lowers to `load atomic acquire`: observing `count == 1` proves exclusivity only if other threads' release decrements happen-before the read — this keeps the COW/uniqify probes sound across threads.
- **`rc.create`** atomic: TODO lifted. The box is unpublished until the create's result escapes, so the initial count store needs no ordering. Regional + atomic stays rejected.
- **`rc.set`** verifier: rejects atomic targets (a blind count store races concurrent increments). This doubles as a loud backstop for the remaining plain fetch/set emitters (array unique-view, closure glue) — if one ever meets an atomic box, it's an IR verification error, not a silent race.

## Tests

- `conversion/atomic_rc.mlir`: lowering shapes (`atomicrmw add monotonic`, `atomicrmw sub acq_rel`, `load atomic acquire`, plain-store create) and the expansion shape (no `rc.set` anywhere near an atomic dec).
- `basic/failure/atomic_rc_count_ops.mlir`: verifier rejections.
- **OpenMP e2e, three legs**: 8 threads clone/read/drop one shared atomic box 20k times each; the creating reference is released after the region, so the box must die exactly once. Each thread validates its own sum locally — the *only* cross-thread state is the box, so every ordering claim flows through the count's acquire/release chain (the exact property under test). Legs: plain (`conversion/atomic_rc_omp_e2e.mlir`), ASan, TSan (`sanitizer/atomic-rc-omp-{asan,tsan}.mlir`).
- **Negative validation**: with the lowering intentionally broken to a plain read-modify-write, ASan reports a double-free (two threads observe `old == 1`) and TSan reports the data race between `atomic_pair_clone` and `atomic_pair_drop`. Both legs are proven non-vacuous.

## Infra notes (part of making the sanitizer legs honest)

- New `openmp` lit feature, probed by building and running a small parallel program with the configured compiler (unsupported, not failing, where libomp is missing).
- libomp is not sanitizer-instrumented, so its worker bookkeeping leaks (LSan) and its suspend/resume machinery races (TSan). Suppressions are **name-scoped** (`__kmp_suspend_` etc. / `___kmp_allocate`): a blanket `race:libomp.so` would also swallow genuine races in the code under test, because every worker stack bottoms out in `__kmp_invoke_microtask` — that over-suppression was caught by the negative validation above.
- The e2e functions carry `passthrough = ["sanitize_thread", "sanitize_address"]`: LLVM's sanitizer passes skip **plain memory accesses** in functions lacking the attribute (atomics, function entries, and interceptors are visible regardless), so an uninstrumented-from-IR TSan binary looks deceptively quiet. Worth auditing the existing `.rr`-driven sanitizer tests for the same gap — rrc's emitted functions don't carry these attributes either; noted in #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k

---
_Generated by [Claude Code](https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786548713&installation_id=144622820&pr_number=410&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F410&signature=c1af132d6855c57600794a63e022b34f04bec4999c4e409a4a7929e28997b662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->