### PR TITLE
[driver][codegen] --sanitizer: annotate functions for sanitizer instrumentation

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -25,8 +25,8 @@ use reussir_backend::melior::Context;
 use reussir_backend::melior::dialect::arith::{self, CmpfPredicate, CmpiPredicate};
 use reussir_backend::melior::dialect::{func, memref, scf};
 use reussir_backend::melior::ir::attribute::{
-    Attribute, DenseI64ArrayAttribute, FlatSymbolRefAttribute, IntegerAttribute, StringAttribute,
-    TypeAttribute,
+    ArrayAttribute, Attribute, DenseI64ArrayAttribute, FlatSymbolRefAttribute, IntegerAttribute,
+    StringAttribute, TypeAttribute,
 };
 use reussir_backend::melior::ir::r#type::{FunctionType, IntegerType, MemRefType};
 use reussir_backend::melior::ir::{
@@ -241,6 +241,11 @@ pub(super) struct Lowerer<'c, 'p, 'tcx> {
     string_payloads: RapidHashMap<StringToken, &'p str>,
     /// How definitions map to LLVM linkage (see [`LinkagePolicy`]).
     linkage: LinkagePolicy,
+    /// Sanitizer function-attribute strings (e.g. `sanitize_address`) each
+    /// emitted function definition carries via the `passthrough` attribute —
+    /// LLVM's sanitizer passes only instrument plain memory accesses in
+    /// functions attributed for them (see [`super::Sanitizer`]).
+    sanitize_attrs: Vec<&'static str>,
 }
 
 impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
@@ -273,12 +278,19 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 .map(|(token, payload)| (*token, payload.as_str()))
                 .collect(),
             linkage,
+            sanitize_attrs: Vec::new(),
         }
     }
 
     /// Restrict this lowerer to one codegen unit of a partitioned build.
     pub(super) fn with_unit(mut self, unit: super::CodegenUnit) -> Self {
         self.unit = unit;
+        self
+    }
+
+    /// Set the sanitizer attribute strings each emitted definition carries.
+    pub(super) fn with_sanitize_attrs(mut self, attrs: Vec<&'static str>) -> Self {
+        self.sanitize_attrs = attrs;
         self
     }
 
@@ -421,6 +433,21 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             attributes.push((
                 Identifier::new(self.context, "sym_visibility"),
                 StringAttribute::new(self.context, "private").into(),
+            ));
+        }
+        // Sanitizer attributes ride the `passthrough` attribute FuncToLLVM
+        // copies onto the `llvm.func` verbatim; LLVM's sanitizer passes only
+        // instrument plain memory accesses in functions carrying them. A
+        // declaration needs none — its home unit annotates the body.
+        if emit_body && !self.sanitize_attrs.is_empty() {
+            let strings: Vec<Attribute> = self
+                .sanitize_attrs
+                .iter()
+                .map(|a| StringAttribute::new(self.context, a).into())
+                .collect();
+            attributes.push((
+                Identifier::new(self.context, "passthrough"),
+                ArrayAttribute::new(self.context, &strings).into(),
             ));
         }
         // The function's LLVM linkage (an `llvm.linkage` attribute FuncToLLVM

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -63,7 +63,7 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use reussir_backend::builders;
 use reussir_backend::melior::Context;
-use reussir_backend::melior::ir::attribute::Attribute;
+use reussir_backend::melior::ir::attribute::{Attribute, ArrayAttribute, StringAttribute};
 use reussir_backend::melior::ir::operation::{OperationLike, OperationMutLike};
 use reussir_backend::melior::ir::{BlockLike, Location, Module};
 use reussir_backend::pipeline::{INLINE_TRANSFORM_ATTR, INLINE_TRANSFORM_ENTRY_POINT};
@@ -212,6 +212,66 @@ fn err<T>(msg: impl Into<Cow<'static, str>>) -> Result<T> {
     Err(LoweringError(LoweringErrorKind::Message(msg.into())))
 }
 
+/// A sanitizer the build is compiled for. Lowering annotates every function
+/// it emits with the matching LLVM function attribute (via the `passthrough`
+/// mechanism) so the sanitizer instrumentation passes act on the generated
+/// code: LLVM's ASan/MSan/TSan passes instrument **plain memory accesses only
+/// in functions carrying `sanitize_address`/`sanitize_memory`/
+/// `sanitize_thread`** — atomics, function entries, and allocator
+/// interceptors are visible regardless, which makes an unannotated binary
+/// look deceptively instrumented. Clang attaches these attributes to every
+/// function it frontends under `-fsanitize=…`, but never to `-x ir` input,
+/// so the annotation must come from this compiler.
+///
+/// `Leak` and `Undefined` carry no function attribute: leak checking is
+/// purely a runtime/allocator mechanism, and UBSan's checks are emitted by
+/// the C/C++ frontend rather than an attribute-driven LLVM pass. They are
+/// accepted so a driver can uniformly declare the sanitizers a build targets.
+///
+/// The module is also stamped with a `reussir.sanitize` attribute (the
+/// attribute-string array) so backend passes that *create* functions after
+/// codegen — outlined closure bodies, outlined drop/acquire glue,
+/// trampolines — attach the same set.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Sanitizer {
+    Address,
+    Leak,
+    Memory,
+    Thread,
+    Undefined,
+}
+
+impl Sanitizer {
+    /// The LLVM function attribute this sanitizer's instrumentation pass keys
+    /// on, or `None` when instrumentation is not attribute-driven.
+    pub fn function_attribute(self) -> Option<&'static str> {
+        match self {
+            Sanitizer::Address => Some("sanitize_address"),
+            Sanitizer::Memory => Some("sanitize_memory"),
+            Sanitizer::Thread => Some("sanitize_thread"),
+            Sanitizer::Leak | Sanitizer::Undefined => None,
+        }
+    }
+}
+
+/// The module attribute carrying the sanitizer attribute strings, consumed by
+/// the backend passes that create functions after codegen (mirrored in
+/// `include/Reussir/IR/ReussirOps.h`).
+const SANITIZE_ATTR: &str = "reussir.sanitize";
+
+/// The deduplicated attribute strings for a sanitizer set.
+fn sanitizer_attr_strings(sanitizers: &[Sanitizer]) -> Vec<&'static str> {
+    let mut attrs = Vec::new();
+    for s in sanitizers {
+        if let Some(a) = s.function_attribute()
+            && !attrs.contains(&a)
+        {
+            attrs.push(a);
+        }
+    }
+    attrs
+}
+
 /// One codegen unit of a partitioned compilation: this unit's index and the
 /// total unit count.
 ///
@@ -262,6 +322,7 @@ pub fn lower_program<'c, 'tcx>(
     source: Option<&SourceCache>,
     names: Option<&dyn Resolver<TokenKey>>,
     linkage: LinkagePolicy,
+    sanitizers: &[Sanitizer],
 ) -> Result<Module<'c>> {
     lower_unit(
         context,
@@ -271,6 +332,7 @@ pub fn lower_program<'c, 'tcx>(
         names,
         CodegenUnit { index: 0, count: 1 },
         linkage,
+        sanitizers,
     )
 }
 
@@ -286,10 +348,27 @@ pub fn lower_unit<'c, 'tcx>(
     names: Option<&dyn Resolver<TokenKey>>,
     unit: CodegenUnit,
     linkage: LinkagePolicy,
+    sanitizers: &[Sanitizer],
 ) -> Result<Module<'c>> {
     let mut module = Module::new(Location::unknown(context));
-    let lowerer = Lowerer::new(context, tcx, program, source, names, linkage).with_unit(unit);
+    let sanitize_attrs = sanitizer_attr_strings(sanitizers);
+    let lowerer = Lowerer::new(context, tcx, program, source, names, linkage)
+        .with_unit(unit)
+        .with_sanitize_attrs(sanitize_attrs.clone());
     lowerer.set_module_debug_attrs(&mut module);
+    // Backend passes that create functions after codegen (outlined closure
+    // bodies, drop/acquire glue, trampolines) read this module attribute and
+    // attach the same sanitizer set — see `inheritSanitizerPassthrough`.
+    if !sanitize_attrs.is_empty() {
+        let strings: Vec<Attribute> = sanitize_attrs
+            .iter()
+            .map(|a| StringAttribute::new(context, a).into())
+            .collect();
+        module.as_operation_mut().set_attribute(
+            SANITIZE_ATTR,
+            ArrayAttribute::new(context, &strings).into(),
+        );
+    }
     let body = module.body();
     for (token, payload) in &program.string_literals {
         body.append_operation(builders::str_global(
@@ -560,7 +639,7 @@ mod tests {
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
             assert!(
                 module.as_operation().verify(),
                 "module verifies:\n{}",
@@ -616,7 +695,7 @@ transform [{
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let error = lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit)
+            let error = lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
                 .expect_err("Melior must reject the transform body");
             assert!(
                 error.message().contains("transform.not_a_real_op"),
@@ -652,7 +731,7 @@ transform [{
             let mut map = crate::source::SourceCache::new();
             map.add_file("add.rr", src);
             let module =
-                lower_program(&context, tcx, &full, Some(&map), None, LinkagePolicy::Jit).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, Some(&map), None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
             let printed = module
                 .as_operation()
                 .to_string_with_flags(OperationPrintingFlags::new().enable_debug_info(true, false))
@@ -689,7 +768,7 @@ transform [{
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut map = crate::source::SourceCache::new();
             map.add_file("pt.rr", src);
-            let module = lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()), LinkagePolicy::Jit)
+            let module = lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()), LinkagePolicy::Jit, &[])
                 .expect("lowering succeeds");
             let printed = module
                 .as_operation()
@@ -737,7 +816,7 @@ transform [{
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut map = crate::source::SourceCache::new();
             map.add_file("variant.rr", src);
-            let module = lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()), LinkagePolicy::Jit)
+            let module = lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()), LinkagePolicy::Jit, &[])
                 .expect("lowering succeeds");
             let printed = module
                 .as_operation()
@@ -809,6 +888,7 @@ transform [{
                     LinkagePolicy::Aot {
                         dedup_instances: true,
                     },
+                    &[],
                 )
                 .expect("unit lowering succeeds");
                 assert!(
@@ -1046,7 +1126,7 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,
@@ -1119,7 +1199,7 @@ transform [{
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let err = lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit)
+            let err = lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
                 .expect_err("a nullable over a non-pointer element must not lower");
             assert!(
                 err.to_string().contains("does not lower to a pointer"),
@@ -1155,7 +1235,7 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
             let printed = module.as_operation().to_string();
             // The null field and the self-link both build nullable rc values.
             assert!(printed.contains("reussir.nullable.create"), "{printed}");
@@ -1184,7 +1264,7 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,
@@ -1246,7 +1326,7 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
             let printed = module.as_operation().to_string();
             // The frozen `rigid` box is dropped with a direct reference-count
             // decrement, not spilled and dropped as an inline record.
@@ -1290,7 +1370,7 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
             let printed = module.as_operation().to_string();
             // The reused frozen box is retained with a direct reference-count
             // increment, and dropped (by the callees / at last use) with a
@@ -1367,7 +1447,7 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,
@@ -1430,7 +1510,7 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -33,7 +33,7 @@ fn jit_run<R>(source: &str, run: impl FnOnce(&OrcJit) -> R) -> R {
         );
         let (full, reports) = monomorphize(&elab.mono_input());
         assert!(reports.is_empty(), "mono reports: {reports:#?}");
-        lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit).expect("scalar lowering succeeds")
+        lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("scalar lowering succeeds")
     });
 
     run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
@@ -222,7 +222,7 @@ fn lowers_variant_debug_info_through_the_pipeline() {
         assert!(reports.is_empty(), "mono reports: {reports:#?}");
         let mut map = reussir_codegen::source::SourceCache::new();
         map.add_file("variant.rr", src);
-        lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()), LinkagePolicy::Jit)
+        lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()), LinkagePolicy::Jit, &[])
             .expect("variant lowering with debug info succeeds")
     });
 

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -23,7 +23,7 @@ use reussir_backend::llvm::LlvmLowering;
 use reussir_backend::melior::ir::Module;
 use reussir_backend::pipeline::{self, Anchor, LoweringOptions, NullaryVariantEncoding, OptLevel};
 use reussir_codegen::lower::{
-    CodegenUnit, LinkagePolicy, LoweringError, lower_program, lower_unit,
+    CodegenUnit, LinkagePolicy, LoweringError, Sanitizer, lower_program, lower_unit,
 };
 use reussir_codegen::source::{FileId, SourceCache};
 use reussir_compiler::package;
@@ -63,6 +63,35 @@ enum Stage {
     Asm,
     /// A relocatable object file (`.o`).
     Obj,
+}
+
+/// CLI surface for [`Sanitizer`]: the kinds a build may declare via
+/// `--sanitizer` (matching `REUSSIR_RUNTIME_SANITIZERS` plus `undefined`).
+#[derive(Clone, Copy, PartialEq, Eq, palc::ValueEnum)]
+enum SanitizerCli {
+    /// AddressSanitizer: annotates functions `sanitize_address`.
+    Address,
+    /// LeakSanitizer: no function attribute (pure runtime mechanism).
+    Leak,
+    /// MemorySanitizer: annotates functions `sanitize_memory`.
+    Memory,
+    /// ThreadSanitizer: annotates functions `sanitize_thread`.
+    Thread,
+    /// UndefinedBehaviorSanitizer: no function attribute (UBSan checks are
+    /// emitted by the C/C++ frontend, not an attribute-driven LLVM pass).
+    Undefined,
+}
+
+impl From<SanitizerCli> for Sanitizer {
+    fn from(kind: SanitizerCli) -> Self {
+        match kind {
+            SanitizerCli::Address => Sanitizer::Address,
+            SanitizerCli::Leak => Sanitizer::Leak,
+            SanitizerCli::Memory => Sanitizer::Memory,
+            SanitizerCli::Thread => Sanitizer::Thread,
+            SanitizerCli::Undefined => Sanitizer::Undefined,
+        }
+    }
 }
 
 /// CLI surface for [`NullaryVariantEncoding`], with the extra
@@ -223,6 +252,20 @@ struct Cli {
     /// backend's worker threads (e.g. some sanitizers/debuggers).
     #[arg(long = "disable-backend-multithreading")]
     disable_backend_multithreading: bool,
+
+    /// Declare the sanitizers this build targets (repeatable). Every emitted
+    /// function definition — including backend-outlined closure bodies and
+    /// drop/acquire glue — is annotated with the matching LLVM function
+    /// attribute (`sanitize_address`/`sanitize_memory`/`sanitize_thread`), so
+    /// a downstream `clang -fsanitize=… -x ir` compile actually instruments
+    /// the generated code: LLVM's sanitizer passes skip plain memory accesses
+    /// in unannotated functions, while atomics and allocator interceptors
+    /// stay visible either way — deceptively so. `leak` and `undefined` are
+    /// accepted for uniformity but carry no function attribute (leak checking
+    /// is a pure runtime mechanism; UBSan checks are emitted by the C/C++
+    /// frontend, not an attribute-driven LLVM pass).
+    #[arg(long = "sanitizer", value_enum)]
+    sanitizer: Vec<SanitizerCli>,
 
     /// Emit DWARF debug info (source locations, function/variable debug types).
     #[arg(short = 'g', long = "debug")]
@@ -973,6 +1016,7 @@ fn finish_mir<'c, 'tcx>(
     // AOT linkage: internal / linkonce_odr definitions per the policy; the
     // trampolines and pub functions stay the object's external ABI surface.
     let linkage = LinkagePolicy::aot_for_triple(cli.target_triple.as_deref());
+    let sanitizers: Vec<Sanitizer> = cli.sanitizer.iter().map(|&s| s.into()).collect();
     if cli.codegen_units > 1 {
         let mut units = Vec::with_capacity(cli.codegen_units as usize);
         for index in 0..cli.codegen_units {
@@ -981,7 +1025,9 @@ fn finish_mir<'c, 'tcx>(
                 count: cli.codegen_units,
             };
             let module = lower_or_render(
-                lower_unit(context, tcx, program, sources, names, unit, linkage),
+                lower_unit(
+                    context, tcx, program, sources, names, unit, linkage, &sanitizers,
+                ),
                 sources,
                 name,
             )?;
@@ -990,7 +1036,7 @@ fn finish_mir<'c, 'tcx>(
         return Ok(Produced::Units(units));
     }
     let module = lower_or_render(
-        lower_program(context, tcx, program, sources, names, linkage),
+        lower_program(context, tcx, program, sources, names, linkage, &sanitizers),
         sources,
         name,
     )?;

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -263,7 +263,10 @@ struct Cli {
     /// stay visible either way — deceptively so. `leak` and `undefined` are
     /// accepted for uniformity but carry no function attribute (leak checking
     /// is a pure runtime mechanism; UBSan checks are emitted by the C/C++
-    /// frontend, not an attribute-driven LLVM pass).
+    /// frontend, not an attribute-driven LLVM pass). The shadow-based kinds
+    /// (`address`/`memory`/`thread`) require an explicit untagged
+    /// `--nullary-variant-encoding` (`arch-independent` or `boxed`): a
+    /// TBI-tagged immediate's top byte breaks shadow-address arithmetic.
     #[arg(long = "sanitizer", value_enum)]
     sanitizer: Vec<SanitizerCli>,
 
@@ -482,6 +485,27 @@ fn run(cli: &Cli) -> Result<bool, String> {
     }
     if cli.codegen_units == 0 {
         return Err("--codegen-units must be at least 1".into());
+    }
+    // Shadow-based sanitizers (ASan/MSan/TSan) compute a shadow address
+    // arithmetically from the pointer; a TBI-tagged nullary immediate's top
+    // byte — which the hardware ignores on the data access — bleeds into
+    // that arithmetic and lands the shadow lookup in unmapped space. The
+    // `arch-dependent` default may resolve to the TBI encoding, so require
+    // an explicit untagged choice rather than silently downgrading.
+    if cli.sanitizer.iter().any(|s| {
+        matches!(
+            s,
+            SanitizerCli::Address | SanitizerCli::Memory | SanitizerCli::Thread
+        )
+    }) && cli.nullary_variant_encoding == VariantEncoding::ArchDependent
+    {
+        return Err(
+            "--sanitizer address/memory/thread cannot be combined with the (default) \
+             `arch-dependent` nullary-variant encoding: on aarch64 it resolves to \
+             TBI-tagged immediates, whose tag byte breaks the sanitizers' shadow-address \
+             arithmetic; pass --nullary-variant-encoding arch-independent (or boxed)"
+                .into(),
+        );
     }
     if cli.codegen_units > 1 && cli.output.as_os_str() == "-" {
         return Err(

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -514,7 +514,7 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             return Ok(None);
         }
 
-        let mut module = match lower_program(self.context, self.tcx, &program, None, None, LinkagePolicy::Jit) {
+        let mut module = match lower_program(self.context, self.tcx, &program, None, None, LinkagePolicy::Jit, &[]) {
             Ok(module) => module,
             Err(error) => {
                 self.elab.rollback(cp);

--- a/include/Reussir/IR/ReussirOps.h
+++ b/include/Reussir/IR/ReussirOps.h
@@ -36,6 +36,29 @@
 namespace reussir {
 
 //===----------------------------------------------------------------------===//
+// inheritSanitizerPassthrough
+//===----------------------------------------------------------------------===//
+//
+// When a build targets sanitizers, codegen stamps the module with this
+// attribute — an array of the LLVM sanitizer function-attribute strings
+// (e.g. "sanitize_address", "sanitize_thread") — and annotates every function
+// it emits with the same strings via `passthrough` (mirrored in
+// crates/reussir-codegen/src/lower/mod.rs). LLVM's sanitizer passes only
+// instrument plain memory accesses in functions carrying the attribute, so
+// every pass that CREATES a function after codegen (outlined closure bodies,
+// outlined drop/acquire glue, trampolines) must call this helper on it, or
+// the new function's accesses would silently escape instrumentation.
+//
+//===----------------------------------------------------------------------===//
+inline constexpr llvm::StringRef kSanitizeAttr = "reussir.sanitize";
+
+// Appends the module's sanitizer attribute strings (if any) to `func`'s
+// `passthrough` attribute. `func` may be a `func.func` or an
+// `llvm.func` — both carry `passthrough` onto the translated LLVM function.
+void inheritSanitizerPassthrough(mlir::ModuleOp moduleOp,
+                                 mlir::Operation *func);
+
+//===----------------------------------------------------------------------===//
 // emitOwnershipAcquisition
 //===----------------------------------------------------------------------===//
 //

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -3044,6 +3044,10 @@ struct ReussirTrampolineOpConversionPattern
         cabiSig.abiReturnType, cabiSig.abiParamTypes);
     auto trampoline = mlir::LLVM::LLVMFuncOp::create(
         rewriter, op.getLoc(), op.getSymName(), trampolineTy);
+    // The wrapper copies arguments/results through memory; instrument it
+    // like the functions it fronts.
+    inheritSanitizerPassthrough(op->getParentOfType<mlir::ModuleOp>(),
+                                trampoline);
 
     mlir::Block *entry = trampoline.addEntryBlock(rewriter);
     rewriter.setInsertionPointToStart(entry);

--- a/lib/Conversion/ClosureOutlining/ClosureOutlining.cpp
+++ b/lib/Conversion/ClosureOutlining/ClosureOutlining.cpp
@@ -173,6 +173,8 @@ mlir::func::FuncOp ClosureOutliningPass::createFunctionAndInlineRegion(
   funcOp->setAttr("passthrough",
                   rewriter.getStrArrayAttr({"mustprogress", "nounwind",
                                             "willreturn", "nocallback"}));
+  inheritSanitizerPassthrough(funcOp->getParentOfType<mlir::ModuleOp>(),
+                              funcOp);
   funcOp.setArgAttr(0, "llvm.noalias", rewriter.getUnitAttr());
   funcOp.setArgAttr(0, "llvm.nonnull", rewriter.getUnitAttr());
   funcOp.setArgAttr(0, "llvm.noundef", rewriter.getUnitAttr());
@@ -292,6 +294,8 @@ mlir::func::FuncOp ClosureOutliningPass::createClosureDropFunction(
   funcOp->setAttr("passthrough",
                   rewriter.getStrArrayAttr({"mustprogress", "nounwind",
                                             "willreturn", "nocallback"}));
+  inheritSanitizerPassthrough(funcOp->getParentOfType<mlir::ModuleOp>(),
+                              funcOp);
 
   funcOp.setArgAttr(0, "llvm.noalias", rewriter.getUnitAttr());
   funcOp.setArgAttr(0, "llvm.nonnull", rewriter.getUnitAttr());
@@ -412,6 +416,8 @@ mlir::func::FuncOp ClosureOutliningPass::createClosureCloneFunction(
   funcOp->setAttr("passthrough",
                   rewriter.getStrArrayAttr({"mustprogress", "nounwind",
                                             "willreturn", "nocallback"}));
+  inheritSanitizerPassthrough(funcOp->getParentOfType<mlir::ModuleOp>(),
+                              funcOp);
 
   funcOp.setArgAttr(0, "llvm.noalias", rewriter.getUnitAttr());
   funcOp.setArgAttr(0, "llvm.nonnull", rewriter.getUnitAttr());

--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -332,6 +332,7 @@ std::string emitDecisionFunction(mlir::ModuleOp module,
   func->setAttr("llvm.linkage",
                 mlir::LLVM::LinkageAttr::get(builder.getContext(),
                                              mlir::LLVM::Linkage::Internal));
+  inheritSanitizerPassthrough(module, func);
   mlir::Block *entry = func.addEntryBlock();
   builder.setInsertionPointToStart(entry);
 

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -2586,6 +2586,24 @@ emitArrayOwnershipAcquisition(mlir::Value view, mlir::OpBuilder &builder,
 }
 
 //===----------------------------------------------------------------------===//
+// inheritSanitizerPassthrough
+//===----------------------------------------------------------------------===//
+void inheritSanitizerPassthrough(mlir::ModuleOp moduleOp,
+                                 mlir::Operation *func) {
+  auto attrs = moduleOp->getAttrOfType<mlir::ArrayAttr>(kSanitizeAttr);
+  if (!attrs || attrs.empty())
+    return;
+  llvm::SmallVector<mlir::Attribute> merged;
+  if (auto existing = func->getAttrOfType<mlir::ArrayAttr>("passthrough"))
+    merged.append(existing.begin(), existing.end());
+  for (mlir::Attribute attr : attrs)
+    if (!llvm::is_contained(merged, attr))
+      merged.push_back(attr);
+  func->setAttr("passthrough",
+                mlir::ArrayAttr::get(moduleOp.getContext(), merged));
+}
+
+//===----------------------------------------------------------------------===//
 // createDtorIfNotExists
 //===----------------------------------------------------------------------===//
 mlir::func::FuncOp createDtorIfNotExists(mlir::ModuleOp moduleOp,
@@ -2610,6 +2628,9 @@ mlir::func::FuncOp createDtorIfNotExists(mlir::ModuleOp moduleOp,
   dtor->setAttr("passthrough",
                 builder.getStrArrayAttr(
                     {"mustprogress", "nounwind", "willreturn", "nocallback"}));
+  // Drop glue is where a stale box's memory is actually touched; it must be
+  // instrumented like the code it was outlined from.
+  inheritSanitizerPassthrough(moduleOp, dtor);
   dtor.setArgAttr(0, "llvm.noalias", builder.getUnitAttr());
   dtor.setArgAttr(0, "llvm.nonnull", builder.getUnitAttr());
   dtor.setArgAttr(0, "llvm.noundef", builder.getUnitAttr());
@@ -2650,6 +2671,7 @@ mlir::func::FuncOp emitOwnershipAcquisitionFuncIfNotExists(
   funcOp->setAttr("llvm.linkage",
                   builder.getAttr<mlir::LLVM::LinkageAttr>(
                       mlir::LLVM::linkage::Linkage::LinkonceODR));
+  inheritSanitizerPassthrough(moduleOp, funcOp);
 
   mlir::Block *entryBlock = funcOp.addEntryBlock();
   builder.setInsertionPointToStart(entryBlock);

--- a/tests/integration/frontend/sanitizer_attrs.rr
+++ b/tests/integration/frontend/sanitizer_attrs.rr
@@ -1,0 +1,68 @@
+// RUN: %rrc %s --emit llvm-ir -O default --sanitizer address --sanitizer thread -o %t.ll && %FileCheck %s < %t.ll
+// RUN: %rrc %s --emit llvm-ir -O default -o %t.off.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.off.ll
+// RUN: %rrc %s --emit llvm-ir -O default --sanitizer leak --sanitizer undefined -o %t.noattr.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.noattr.ll
+// RUN: %rrc %s -O default --sanitizer address --sanitizer memory --sanitizer thread --sanitizer leak --sanitizer undefined -o %t.o
+
+// `--sanitizer` annotates every emitted function definition with the LLVM
+// attribute its sanitizer's instrumentation pass keys on. This matters
+// because the ASan/MSan/TSan passes only instrument PLAIN memory accesses in
+// functions carrying `sanitize_address`/`sanitize_memory`/`sanitize_thread`
+// — atomics, function entries, and allocator interceptors are visible either
+// way, which makes an unannotated `-x ir` build look deceptively
+// instrumented. Backend-CREATED functions must be covered too: the outlined
+// drop glue below is exactly where a stale box's memory is touched.
+//
+// `leak`/`undefined` are accepted for interface uniformity but carry no
+// function attribute (leak checking is a pure runtime mechanism; UBSan
+// checks are emitted by the C/C++ frontend), pinned by the third RUN line
+// reusing CHECK-OFF.
+
+enum Tree {
+    Leaf,
+    Node(Tree, i64, Tree)
+}
+
+fn insert(t: Tree, v: i64) -> Tree {
+    match t {
+        Tree::Leaf => Tree::Node{Tree::Leaf{}, v, Tree::Leaf{}},
+        Tree::Node(l, x, r) =>
+            if v < x { Tree::Node{insert(l, v), x, r} }
+            else { Tree::Node{l, x, insert(r, v)} }
+    }
+}
+
+fn total(t: Tree) -> i64 {
+    match t {
+        Tree::Leaf => 0,
+        Tree::Node(l, x, r) => total(l) + x + total(r)
+    }
+}
+
+pub fn test_sum(n: i64) -> i64 {
+    let f = |acc: i64, v: i64| acc + v;
+    let t = insert(insert(insert(Tree::Leaf{}, 3), 1), 2);
+    f(total(t), n)
+}
+extern "C" trampoline "test_sum_ffi" = test_sum;
+
+// A frontend-emitted function definition carries both attributes, and so do
+// the backend-CREATED functions — the outlined closure evaluate/clone/drop
+// (born in the closure-outlining pass, after codegen) and the C-ABI
+// trampoline wrapper — via the module-level `reussir.sanitize` inheritance.
+// The `; Function Attrs:` comment precedes each define, in emission order.
+// CHECK: Function Attrs: {{.*}}sanitize_address sanitize_thread
+// CHECK-NEXT: define{{.*}}@_RC5total(
+// CHECK: Function Attrs: {{.*}}sanitize_address sanitize_thread
+// CHECK-NEXT: define{{.*}}@_RC6insert(
+// CHECK: Function Attrs: {{.*}}sanitize_address sanitize_thread
+// CHECK-NEXT: define{{.*}}@_RC8test_sum(
+// CHECK: Function Attrs: {{.*}}sanitize_address sanitize_thread
+// CHECK-NEXT: define{{.*}}@test_sum_ffi(
+// CHECK: Function Attrs: {{.*}}sanitize_address sanitize_thread
+// CHECK-NEXT: define{{.*}}$closure8evaluate
+// CHECK: Function Attrs: {{.*}}sanitize_address sanitize_thread
+// CHECK-NEXT: define{{.*}}$closure5clone
+// CHECK: Function Attrs: {{.*}}sanitize_address sanitize_thread
+// CHECK-NEXT: define{{.*}}$closure4drop
+
+// CHECK-OFF-NOT: sanitize_

--- a/tests/integration/frontend/sanitizer_attrs.rr
+++ b/tests/integration/frontend/sanitizer_attrs.rr
@@ -1,7 +1,8 @@
-// RUN: %rrc %s --emit llvm-ir -O default --sanitizer address --sanitizer thread -o %t.ll && %FileCheck %s < %t.ll
+// RUN: %rrc %s --emit llvm-ir -O default --sanitizer address --sanitizer thread --nullary-variant-encoding arch-independent -o %t.ll && %FileCheck %s < %t.ll
 // RUN: %rrc %s --emit llvm-ir -O default -o %t.off.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.off.ll
 // RUN: %rrc %s --emit llvm-ir -O default --sanitizer leak --sanitizer undefined -o %t.noattr.ll && %FileCheck %s --check-prefix=CHECK-OFF < %t.noattr.ll
-// RUN: %rrc %s -O default --sanitizer address --sanitizer memory --sanitizer thread --sanitizer leak --sanitizer undefined -o %t.o
+// RUN: %rrc %s -O default --sanitizer address --sanitizer memory --sanitizer thread --sanitizer leak --sanitizer undefined --nullary-variant-encoding arch-independent -o %t.o
+// RUN: %not %rrc %s -O default --sanitizer address -o %t.rej.o 2>&1 | %FileCheck %s --check-prefix=CHECK-REJECT
 
 // `--sanitizer` annotates every emitted function definition with the LLVM
 // attribute its sanitizer's instrumentation pass keys on. This matters
@@ -16,6 +17,16 @@
 // function attribute (leak checking is a pure runtime mechanism; UBSan
 // checks are emitted by the C/C++ frontend), pinned by the third RUN line
 // reusing CHECK-OFF.
+//
+// The shadow-based kinds require an explicit untagged nullary-variant
+// encoding: shadow addresses are computed arithmetically from the pointer,
+// so a TBI-tagged immediate's top byte — ignored by the hardware on the
+// data access — lands the shadow lookup in unmapped space (observed as an
+// ASan SEGV in the shadow region on aarch64). The default `arch-dependent`
+// choice may resolve to TBI, so it is rejected rather than silently
+// downgraded; `leak`/`undefined` do no shadow arithmetic and stay
+// compatible (third RUN line).
+// CHECK-REJECT: cannot be combined with the (default) `arch-dependent` nullary-variant encoding
 
 enum Tree {
     Leaf,

--- a/tests/integration/sanitizer/rbtree-asan.rr
+++ b/tests/integration/sanitizer/rbtree-asan.rr
@@ -1,5 +1,5 @@
 // REQUIRES: asan
-// RUN: %rrc %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call --sanitizer address
+// RUN: %rrc %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call --sanitizer address --nullary-variant-encoding arch-independent
 // RUN: %cc %asan_flags -c -x ir %t.ll -o %t.o
 // RUN: %cc %asan_flags %t.o %S/rbtree2-harness.c %reussir_rt_asan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
 // RUN: %asan_env %t.exe

--- a/tests/integration/sanitizer/rbtree-asan.rr
+++ b/tests/integration/sanitizer/rbtree-asan.rr
@@ -1,5 +1,5 @@
 // REQUIRES: asan
-// RUN: %rrc %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %rrc %S/../frontend/rbtree2.rr -o %t.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call --sanitizer address
 // RUN: %cc %asan_flags -c -x ir %t.ll -o %t.o
 // RUN: %cc %asan_flags %t.o %S/rbtree2-harness.c %reussir_rt_asan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
 // RUN: %asan_env %t.exe

--- a/tests/integration/sanitizer/rbtree-lsan-leak.rr
+++ b/tests/integration/sanitizer/rbtree-lsan-leak.rr
@@ -1,5 +1,5 @@
 // REQUIRES: lsan
-// RUN: %rrc %S/../frontend/rbtree.rr -o %t.ll -t llvm-ir --relocation-mode pic
+// RUN: %rrc %S/../frontend/rbtree.rr -o %t.ll -t llvm-ir --relocation-mode pic --sanitizer leak
 // RUN: %cc %lsan_flags -c -x ir %t.ll -o %t.o
 // RUN: %cc %lsan_flags %t.o %S/rbtree-harness.c %reussir_rt_lsan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
 // RUN: LSAN_OPTIONS=abort_on_error=0:report_objects=1:use_registers=0:use_stacks=0 %not %t.exe


### PR DESCRIPTION
Safeguard for the thread-safety work (#409): make sanitizer runs over rrc-generated IR actually check the generated code.

## Why

LLVM's ASan/MSan/TSan passes instrument **plain memory accesses only in functions carrying `sanitize_address`/`sanitize_memory`/`sanitize_thread`** (the gate sits at the top of the pass's function walk — below it, everything is instrumented unconditionally, which is why a casual read of the pass suggests otherwise). Atomics, function entries, and allocator interceptors are visible either way, so a `clang -fsanitize=… -x ir` build **looks** instrumented while every generated load/store escapes checking. Clang attaches the attributes to each function it frontends, but never to IR input — so the `.rr`-driven sanitizer suite has been running allocator-and-interceptor-only. The annotation has to come from rrc.

## What

- **`rrc --sanitizer <address|leak|memory|thread|undefined>`** (repeatable). `leak` and `undefined` are accepted for interface uniformity but map to no function attribute: leak checking is a pure runtime/allocator mechanism, and UBSan's checks are emitted by the C/C++ frontend, not an attribute-driven LLVM pass.
- **Pure frontend annotation**: codegen adds the strings to each emitted definition's `passthrough` attribute (FuncToLLVM copies it verbatim onto the `llvm.func`, translation turns it into real LLVM function attributes), and stamps the module with `reussir.sanitize` — the attribute-string array.
- **Backend-created functions inherit** via a small `inheritSanitizerPassthrough(module, func)` helper at every site that creates a function after codegen: outlined closure evaluate/clone/drop, outlined record dtors and acquire glue, the `str.select` helper, and C-ABI trampoline wrappers. Outlined drop glue is exactly where a stale box's memory is touched — leaving it unannotated would exempt the most interesting code. Declarations (runtime functions) stay bare.

## Tests

- `frontend/sanitizer_attrs.rr`: `--emit llvm-ir --sanitizer address --sanitizer thread` pins `sanitize_address sanitize_thread` on the frontend-emitted functions **and** on the backend-created closure functions and trampoline; the no-flag run and the `--sanitizer leak --sanitizer undefined` run both produce zero `sanitize_` attributes; an object-emission smoke accepts all five kinds at once.
- `sanitizer/rbtree-asan.rr` and `sanitizer/rbtree-lsan-leak.rr` now pass `--sanitizer address` / `--sanitizer leak` — the ASan leg runs **fully instrumented** for the first time (validated locally: clean; lsan leg also validated locally).

The tsan/msan rbtree legs are deliberately untouched here per the "asan and lsan first" scope; they can be flipped the same way once validated (msan in particular needs a look — with real instrumentation it starts tracking shadow for all generated stores).

Part of #409 (the atomic-rc e2e in #410 hand-annotates its MLIR the same way; once both land, the frontend `Atomic<T>` e2e will use this flag instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k

---
_Generated by [Claude Code](https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786571376&installation_id=144622820&pr_number=411&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F411&signature=626fd574646e4f3043c8b0fc833f5d06a07076afac74df2fcf59caa4628941da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->