### PR TITLE
[mlir] add shared RC cell operations

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -241,6 +241,7 @@ unsafe extern "C" {
         atomic_kind: ReussirAtomicKind,
     ) -> MlirType;
     pub fn reussirNullableTypeGet(pointer_type: MlirType) -> MlirType;
+    pub fn reussirCellTypeGet(element_type: MlirType) -> MlirType;
     pub fn reussirRefTypeGet(
         element_type: MlirType,
         capability: ReussirCapability,

--- a/crates/reussir-backend/src/dialect/mod.rs
+++ b/crates/reussir-backend/src/dialect/mod.rs
@@ -69,6 +69,7 @@ mod tests {
             ),
             (ty::region(&context), "!reussir.region"),
             (ty::raw_ptr(i32_ty), "!reussir.raw_ptr<"),
+            (ty::cell(i32_ty), "!reussir.cell<"),
             (ty::array(&[2, 3], i32_ty), "!reussir.array<"),
             (
                 ty::str(&context, ty::ReussirLifeScope::Global),

--- a/crates/reussir-backend/src/dialect/ty.rs
+++ b/crates/reussir-backend/src/dialect/ty.rs
@@ -56,6 +56,12 @@ pub fn nullable(pointer: Type) -> Type {
     unsafe { Type::from_raw(sys::reussirNullableTypeGet(pointer.to_raw())) }
 }
 
+/// Creates a `!reussir.cell<element>` payload type. Values of this type are
+/// managed through a shared `!reussir.rc` cell box.
+pub fn cell(element: Type) -> Type {
+    unsafe { Type::from_raw(sys::reussirCellTypeGet(element.to_raw())) }
+}
+
 /// Creates a `!reussir.ref<element, capability, atomicKind>` type.
 pub fn r#ref(element: Type, capability: ReussirCapability, atomic_kind: ReussirAtomicKind) -> Type {
     unsafe {

--- a/include/Reussir-c/Types.h
+++ b/include/Reussir-c/Types.h
@@ -81,6 +81,9 @@ MlirType reussirRcTypeGet(MlirType elementType, ReussirCapability capability,
 // `!reussir.nullable<ptrTy>`. The context is taken from `pointerType`.
 MlirType reussirNullableTypeGet(MlirType pointerType);
 
+// `!reussir.cell<elementType>`. The context is taken from `elementType`.
+MlirType reussirCellTypeGet(MlirType elementType);
+
 // `!reussir.ref<eleTy [, capability [, atomicKind]]>`. The context is taken
 // from `elementType`.
 MlirType reussirRefTypeGet(MlirType elementType, ReussirCapability capability,

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -124,8 +124,9 @@ def ReussirAcquireDropExpansionPass
     : Pass<"reussir-acquire-drop-expansion"> {
   let summary = "expand Reussir acquire and drop operations";
   let description = [{
-    `reussir-acquire-drop-expansion` expands Reussir acquire and drop operations.
-    This is a greedy pattern conversion pass.
+    `reussir-acquire-drop-expansion` expands Reussir acquire and drop operations,
+    together with the ownership-aware Cell operations that produce them. This is
+    a greedy pattern conversion pass.
 
     For drop operations:
     1. it eliminates no-op drop operations.
@@ -135,6 +136,11 @@ def ReussirAcquireDropExpansionPass
     1. it eliminates no-op acquire operations (trivially copyable types).
     2. for normal acquire, it emits ownership acquisition (e.g., rc.inc for Rc
        fields, recursive acquisition for compound/variant records).
+
+    Cell create/get/set/rmw operations are lowered to RC borrow and mutable slot
+    accesses. Get acquires the exact loaded value, set drops the old slot before
+    storing the caller-owned replacement, and rmw moves the old and replacement
+    values through its region without implicit ownership traffic.
 
     Notice that this pass terminates normally for recursive types, as such types
     are backed by RC pointers. The decrement operation will not be inlined at
@@ -157,7 +163,8 @@ def ReussirAcquireDropExpansionPass
     Option<"expandDecrement", "expand-decrement", "bool", /*default=*/"false",
         "whether to expand rc decrement operations (using the `rc-decrement-expansion` pass)">,
   ];
-  let dependentDialects = ["::reussir::ReussirDialect"];
+  let dependentDialects = ["::reussir::ReussirDialect",
+                           "::mlir::ub::UBDialect"];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1062,6 +1062,101 @@ def ReussirArrayWithUniqueViewOp : ReussirArrayOp<"with_unique_view", []> {
 }
 
 //===----------------------------------------------------------------------===//
+// Reussir cell operations
+//===----------------------------------------------------------------------===//
+class ReussirCellOp<string mnemonic, list<Trait> traits>
+    : ReussirOp<"cell."#mnemonic, traits>;
+
+def ReussirCellCreateOp : ReussirCellOp<"create", [
+  DeclareOpInterfaceMethods<TokenAcceptorInterface>
+]> {
+  let summary = "Create a shared reference-counted cell";
+  let description = [{
+    `reussir.cell.create` stores `value` in a fresh shared RC cell. The
+    allocation token is optional until token instantiation assigns one, and
+    must match the complete RC cell box layout when present.
+  }];
+  let arguments = (ins
+    Arg<AnyType, "initial value">:$value,
+    Optional<ReussirTokenType>:$token
+  );
+  let results = (outs Res<ReussirRcCellType, "created cell">:$cell);
+  let assemblyFormat = [{
+    `value` `(` $value `:` type($value) `)`
+    oilist (`token` `(` $token `:` type($token) `)`)
+    `:` qualified(type($cell)) attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
+def ReussirCellGetOp : ReussirCellOp<"get", []> {
+  let summary = "Clone the value stored in a cell";
+  let description = [{
+    `reussir.cell.get` loads the cell element with clone semantics. Managed
+    ownership reachable from the element is acquired before the value is
+    returned.
+  }];
+  let arguments = (ins Arg<ReussirRcCellType, "cell to read">:$cell);
+  let results = (outs Res<AnyType, "cloned value">:$value);
+  let assemblyFormat = [{
+    `(` $cell `:` qualified(type($cell)) `)` `:` type($value) attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
+def ReussirCellSetOp : ReussirCellOp<"set", []> {
+  let summary = "Replace the value stored in a cell";
+  let description = [{
+    `reussir.cell.set` drops the old cell element in place and stores `value`.
+    It does not acquire or otherwise adjust ownership of the incoming value;
+    the caller is responsible for supplying the ownership transferred into the
+    cell.
+  }];
+  let arguments = (ins
+    Arg<AnyType, "replacement value">:$value,
+    Arg<ReussirRcCellType, "cell to update">:$cell
+  );
+  let assemblyFormat = [{
+    `(` $value `:` type($value) `,` $cell `:` qualified(type($cell)) `)`
+    attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
+def ReussirCellRmwOp : ReussirCellOp<"rmw", []> {
+  let summary = "Read, transform, and replace a cell value";
+  let description = [{
+    `reussir.cell.rmw` moves the current element into its single-block body.
+    The body yields the replacement element and may additionally yield one
+    operation result. This transfer performs no implicit acquire or drop.
+  }];
+  let arguments = (ins Arg<ReussirRcCellType, "cell to update">:$cell);
+  let results = (outs Res<Optional<AnyType>, "body output">:$output);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    `(` $cell `:` qualified(type($cell)) `)`
+    (`->` type($output)^)? $body attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
+def ReussirCellYieldOp : ReussirCellOp<"yield", [
+  ReturnLike, Terminator,
+  ParentOneOf<["::reussir::ReussirCellRmwOp"]>
+]> {
+  let summary = "Yield a replacement and optional output from cell.rmw";
+  let arguments = (ins
+    Arg<AnyType, "replacement value">:$newValue,
+    Arg<Optional<AnyType>, "optional operation output">:$output
+  );
+  let assemblyFormat = [{
+    `(` $newValue `:` type($newValue) `)`
+    (`output` `(` $output^ `:` type($output) `)`)? attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // Reussir reference operations
 //===----------------------------------------------------------------------===//
 class ReussirReferenceOp<string mnemonic, list<Trait> traits>

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -318,6 +318,29 @@ def ReussirNullableType
   let parameters = (ins ReussirNonNullPointerType:$ptrTy);
   let assemblyFormat = "`<` $ptrTy `>`";
 }
+
+//===----------------------------------------------------------------------===//
+// Reussir Cell Type
+//===----------------------------------------------------------------------===//
+def ReussirCellType
+    : ReussirType<
+          "Cell", "cell",
+          [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>, MutableType]> {
+  let summary = "Reussir mutable cell payload type";
+  let description = [{
+    `reussir.cell` is the one-element mutable payload of a shared reference
+    counted cell. A cell value is always managed through
+    `!reussir.rc<!reussir.cell<T>>`; when a cell occurs as a record member it
+    is represented by that shared RC pointer, like closures and arrays.
+
+    The element is stored inline in the cell box and may itself be an RC type.
+  }];
+  let parameters = (ins "mlir::Type":$eleTy);
+  let assemblyFormat = "`<` $eleTy `>`";
+  let extraClassDeclaration = [{
+    mlir::Type getElementType() const { return getEleTy(); }
+  }];
+}
 //===----------------------------------------------------------------------===//
 // Reussir Reference Type
 //===----------------------------------------------------------------------===//
@@ -649,5 +672,12 @@ def ReussirRcArrayType
     ::llvm::isa<::reussir::ArrayType>(
       ::llvm::cast<::reussir::RcType>($_self).getElementType())
     }]>, "Reussir rc array type", "::reussir::RcType">;
+
+def ReussirRcCellType
+    : Type<CPred<[{
+    ::llvm::isa<::reussir::RcType>($_self) &&
+    ::llvm::isa<::reussir::CellType>(
+      ::llvm::cast<::reussir::RcType>($_self).getElementType())
+    }]>, "Reussir rc cell type", "::reussir::RcType">;
 
 #endif // REUSSIR_IR_REUSSIRTYPES_TD

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -67,6 +67,11 @@ MlirType reussirNullableTypeGet(MlirType pointerType) {
   return wrap(NullableType::get(ptr.getContext(), ptr));
 }
 
+MlirType reussirCellTypeGet(MlirType elementType) {
+  mlir::Type ele = unwrap(elementType);
+  return wrap(CellType::get(ele.getContext(), ele));
+}
+
 MlirType reussirRefTypeGet(MlirType elementType, ReussirCapability capability,
                            ReussirAtomicKind atomicKind) {
   mlir::Type ele = unwrap(elementType);

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -20,6 +20,7 @@
 #include <llvm/Support/LogicalResult.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>
@@ -46,8 +47,43 @@ namespace reussir {
 //===----------------------------------------------------------------------===//
 
 namespace {
+struct CellSlot {
+  CellType cellType;
+  mlir::Value slotRef;
+};
+
+static CellSlot materializeCellSlot(mlir::Value cell, mlir::Location loc,
+                                    mlir::PatternRewriter &rewriter) {
+  RcType rcType = llvm::cast<RcType>(cell.getType());
+  CellType cellType = llvm::cast<CellType>(rcType.getElementType());
+  RefType cellRefType =
+      RefType::get(rewriter.getContext(), cellType, Capability::unspecified,
+                   rcType.getAtomicKind());
+  mlir::Value cellRef =
+      ReussirRcBorrowOp::create(rewriter, loc, cellRefType, cell);
+  RefType slotRefType =
+      RefType::get(rewriter.getContext(), cellType.getElementType(),
+                   Capability::field, rcType.getAtomicKind());
+  mlir::Value slotRef = ReussirRefProjectOp::create(
+      rewriter, loc, slotRefType, cellRef, rewriter.getIndexAttr(0));
+  return {cellType, slotRef};
+}
+
 class DropExpansionPattern : public mlir::OpRewritePattern<ReussirRefDropOp> {
 private:
+  mlir::LogicalResult rewriteDropCell(CellType cellType, ReussirRefDropOp op,
+                                      mlir::PatternRewriter &rewriter) const {
+    RefType refType = op.getRef().getType();
+    RefType slotType =
+        RefType::get(rewriter.getContext(), cellType.getElementType(),
+                     Capability::field, refType.getAtomicKind());
+    mlir::Value slot = ReussirRefProjectOp::create(
+        rewriter, op.getLoc(), slotType, op.getRef(), rewriter.getIndexAttr(0));
+    ReussirRefDropOp::create(rewriter, op.getLoc(), slot);
+    rewriter.eraseOp(op);
+    return mlir::success();
+  }
+
   mlir::LogicalResult rewriteDropArray(ArrayType arrayType, ReussirRefDropOp op,
                                        mlir::PatternRewriter &rewriter) const {
     mlir::Value view =
@@ -280,6 +316,9 @@ public:
         .Case<ArrayType>([&](ArrayType arrayType) {
           return rewriteDropArray(arrayType, op, rewriter);
         })
+        .Case<CellType>([&](CellType cellType) {
+          return rewriteDropCell(cellType, op, rewriter);
+        })
         .Case<RecordType>([&](RecordType recordType) {
           if (shouldOutline(op, recordType)) {
             mlir::ModuleOp moduleOp = op->getParentOfType<mlir::ModuleOp>();
@@ -378,6 +417,109 @@ public:
   }
 };
 
+//===----------------------------------------------------------------------===//
+// Cell operation expansion patterns
+//===----------------------------------------------------------------------===//
+
+class CellCreateExpansionPattern
+    : public mlir::OpRewritePattern<ReussirCellCreateOp> {
+public:
+  using mlir::OpRewritePattern<ReussirCellCreateOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirCellCreateOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    CellType cellType =
+        llvm::cast<CellType>(op.getCell().getType().getElementType());
+    mlir::Value poison =
+        mlir::ub::PoisonOp::create(rewriter, op.getLoc(), cellType);
+    auto created = ReussirRcCreateOp::create(
+        rewriter, op.getLoc(), op.getCell().getType(), poison, op.getToken(),
+        mlir::Value{}, mlir::FlatSymbolRefAttr{}, mlir::UnitAttr{});
+    CellSlot access =
+        materializeCellSlot(created.getRcPtr(), op.getLoc(), rewriter);
+    ReussirRefStoreOp::create(rewriter, op.getLoc(), access.slotRef,
+                              op.getValue());
+    rewriter.replaceOp(op, created.getRcPtr());
+    return mlir::success();
+  }
+};
+
+class CellGetExpansionPattern
+    : public mlir::OpRewritePattern<ReussirCellGetOp> {
+public:
+  using mlir::OpRewritePattern<ReussirCellGetOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirCellGetOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    CellSlot access = materializeCellSlot(op.getCell(), op.getLoc(), rewriter);
+    mlir::Value value = ReussirRefLoadOp::create(
+        rewriter, op.getLoc(), access.cellType.getElementType(),
+        access.slotRef);
+    mlir::Type valueType = value.getType();
+    if (auto rcType = llvm::dyn_cast<RcType>(valueType)) {
+      ReussirRcIncOp::create(rewriter, op.getLoc(), value);
+    } else if (!isTriviallyCopyable(valueType)) {
+      // Acquire the exact SSA value loaded above, rather than loading the
+      // mutable slot a second time. The spill only provides addressability for
+      // recursive aggregate acquisition and is eliminated after lowering.
+      RefType spilledType = RefType::get(rewriter.getContext(), valueType);
+      mlir::Value spilled = ReussirRefSpilledOp::create(rewriter, op.getLoc(),
+                                                        spilledType, value);
+      ReussirRefAcquireOp::create(rewriter, op.getLoc(), spilled);
+    }
+    rewriter.replaceOp(op, value);
+    return mlir::success();
+  }
+};
+
+class CellSetExpansionPattern
+    : public mlir::OpRewritePattern<ReussirCellSetOp> {
+public:
+  using mlir::OpRewritePattern<ReussirCellSetOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirCellSetOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    CellSlot access = materializeCellSlot(op.getCell(), op.getLoc(), rewriter);
+    ReussirRefDropOp::create(rewriter, op.getLoc(), access.slotRef);
+    ReussirRefStoreOp::create(rewriter, op.getLoc(), access.slotRef,
+                              op.getValue());
+    rewriter.eraseOp(op);
+    return mlir::success();
+  }
+};
+
+class CellRmwExpansionPattern
+    : public mlir::OpRewritePattern<ReussirCellRmwOp> {
+public:
+  using mlir::OpRewritePattern<ReussirCellRmwOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirCellRmwOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    CellSlot access = materializeCellSlot(op.getCell(), op.getLoc(), rewriter);
+    mlir::Value oldValue = ReussirRefLoadOp::create(
+        rewriter, op.getLoc(), access.cellType.getElementType(),
+        access.slotRef);
+
+    mlir::Block &body = op.getBody().front();
+    auto yield = llvm::cast<ReussirCellYieldOp>(body.getTerminator());
+    rewriter.inlineBlockBefore(&body, op, mlir::ValueRange{oldValue});
+    rewriter.setInsertionPoint(yield);
+    ReussirRefStoreOp::create(rewriter, yield.getLoc(), access.slotRef,
+                              yield.getNewValue());
+    mlir::Value output = yield.getOutput();
+    rewriter.eraseOp(yield);
+    if (output)
+      rewriter.replaceOp(op, output);
+    else
+      rewriter.eraseOp(op);
+    return mlir::success();
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -407,6 +549,9 @@ void populateAcquireDropExpansionConversionPatterns(
     mlir::RewritePatternSet &patterns, bool outlineRecord) {
   patterns.add<DropExpansionPattern>(patterns.getContext(), outlineRecord);
   patterns.add<AcquireExpansionPattern>(patterns.getContext(), outlineRecord);
+  patterns.add<CellCreateExpansionPattern, CellGetExpansionPattern,
+               CellSetExpansionPattern, CellRmwExpansionPattern>(
+      patterns.getContext());
 }
 
 } // namespace reussir

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -3438,6 +3438,8 @@ struct ReussirConvertToLLVMPatternInterface
         ReussirArrayViewOp, ReussirRecordTagOp, ReussirRecordExtractOp,
         ReussirRecordCoerceOp, ReussirRegionVTableOp, ReussirRcFreezeOp,
         ReussirRegionCleanupOp, ReussirRegionCreateOp, ReussirRcReinterpretOp,
+        ReussirCellCreateOp, ReussirCellGetOp, ReussirCellSetOp,
+        ReussirCellRmwOp, ReussirCellYieldOp,
         ReussirClosureApplyOp, ReussirClosureCloneOp, ReussirClosureEvalOp,
         ReussirClosureInspectPayloadOp, ReussirClosureCursorOp,
         ReussirClosureInstantiateOp, ReussirClosureVtableOp,

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -229,6 +229,14 @@ void populateReussirToLLVMTypeConversions(mlir::LLVMTypeConverter &converter) {
     return converter.convertType(type.getPtrTy());
   });
 
+  // A cell is a semantic one-field wrapper. Keeping the wrapper in the LLVM
+  // type makes `ref.project [0]` the uniform way to address its mutable slot,
+  // while its data-layout interface intentionally matches the inner value.
+  converter.addConversion([&converter](CellType type) {
+    return mlir::LLVM::LLVMStructType::getLiteral(
+        type.getContext(), {converter.convertType(type.getElementType())});
+  });
+
   converter.addConversion([&converter](RcBoxType type) -> mlir::Type {
     // A box of a fused-header variant IS the variant record: its refcount
     // lives in the record's leading count slot.

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -100,6 +100,21 @@ static mlir::LogicalResult verifyArrayViewType(mlir::Operation *op,
          << " must be a statically shaped memref or tensor";
 }
 
+static mlir::FailureOr<CellType> verifySharedCellOperand(mlir::Operation *op,
+                                                         RcType rcType) {
+  auto cellType = llvm::dyn_cast<CellType>(rcType.getElementType());
+  if (!cellType) {
+    op->emitOpError("expected an RC pointer to a cell, got ") << rcType;
+    return mlir::failure();
+  }
+  if (rcType.getCapability() != Capability::shared) {
+    op->emitOpError("cell RC pointer must have shared capability, got ")
+        << stringifyCapability(rcType.getCapability());
+    return mlir::failure();
+  }
+  return cellType;
+}
+
 mlir::LogicalResult verifyRcCreateLikeOp(mlir::Operation *op, RcType rcType,
                                          mlir::Type valueType,
                                          mlir::Value token,
@@ -1181,6 +1196,110 @@ mlir::LogicalResult ReussirArrayWithUniqueViewOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// Reussir Cell Operations
+//===----------------------------------------------------------------------===//
+mlir::LogicalResult ReussirCellCreateOp::verify() {
+  RcType rcType = getCell().getType();
+  auto cellType = verifySharedCellOperand(getOperation(), rcType);
+  if (mlir::failed(cellType))
+    return mlir::failure();
+  if (getValue().getType() != (*cellType).getElementType())
+    return emitOpError("initial value type must match cell element type, got ")
+           << getValue().getType() << " and " << (*cellType).getElementType();
+
+  if (!getToken())
+    return mlir::success();
+  TokenType expected = getTokenType();
+  TokenType actual = getToken().getType();
+  if (actual.getAlign() != expected.getAlign() ||
+      actual.getSize() != expected.getSize())
+    return emitOpError("token type must match RC cell box layout, expected ")
+           << expected << ", got " << actual;
+  return mlir::success();
+}
+
+TokenType ReussirCellCreateOp::getTokenType() {
+  RcType rcType = getCell().getType();
+  RcBoxType boxType = rcType.getInnerBoxType();
+  auto dataLayout = mlir::DataLayout::closest(getOperation());
+  auto size = dataLayout.getTypeSize(boxType);
+  return TokenType::get(getContext(), dataLayout.getTypeABIAlignment(boxType),
+                        size.getFixedValue());
+}
+
+mlir::LogicalResult ReussirCellGetOp::verify() {
+  auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
+  if (mlir::failed(cellType))
+    return mlir::failure();
+  if (getValue().getType() != (*cellType).getElementType())
+    return emitOpError("result type must match cell element type, expected ")
+           << (*cellType).getElementType() << ", got " << getValue().getType();
+  return mlir::success();
+}
+
+mlir::LogicalResult ReussirCellSetOp::verify() {
+  auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
+  if (mlir::failed(cellType))
+    return mlir::failure();
+  if (getValue().getType() != (*cellType).getElementType())
+    return emitOpError(
+               "replacement value type must match cell element type, expected ")
+           << (*cellType).getElementType() << ", got " << getValue().getType();
+  return mlir::success();
+}
+
+mlir::LogicalResult ReussirCellRmwOp::verify() {
+  auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
+  if (mlir::failed(cellType))
+    return mlir::failure();
+  if (!llvm::hasSingleElement(getBody()))
+    return emitOpError("body must contain exactly one block");
+  mlir::Block &block = getBody().front();
+  if (block.getNumArguments() != 1)
+    return emitOpError("body must accept exactly one cell element argument");
+  if (block.getArgument(0).getType() != (*cellType).getElementType())
+    return emitOpError(
+               "body argument type must match cell element type, expected ")
+           << (*cellType).getElementType() << ", got "
+           << block.getArgument(0).getType();
+  if (block.empty() || !llvm::isa<ReussirCellYieldOp>(block.getTerminator()))
+    return emitOpError("body must terminate with reussir.cell.yield");
+
+  auto yield = llvm::cast<ReussirCellYieldOp>(block.getTerminator());
+  if (yield.getNewValue().getType() != (*cellType).getElementType())
+    return emitOpError("yielded replacement type must match cell element type, "
+                       "expected ")
+           << (*cellType).getElementType() << ", got "
+           << yield.getNewValue().getType();
+  if (static_cast<bool>(getOutput()) != static_cast<bool>(yield.getOutput()))
+    return emitOpError("body must yield exactly one optional output when the "
+                       "operation has a result");
+  if (getOutput() && getOutput().getType() != yield.getOutput().getType())
+    return emitOpError(
+               "body output type must match operation result type, got ")
+           << yield.getOutput().getType() << " and " << getOutput().getType();
+  return mlir::success();
+}
+
+mlir::LogicalResult ReussirCellYieldOp::verify() {
+  auto parent = getOperation()->getParentOfType<ReussirCellRmwOp>();
+  if (!parent)
+    return emitOpError("must be nested directly in reussir.cell.rmw");
+  auto cellType =
+      llvm::cast<CellType>(parent.getCell().getType().getElementType());
+  if (getNewValue().getType() != cellType.getElementType())
+    return emitOpError(
+               "replacement type must match cell element type, expected ")
+           << cellType.getElementType() << ", got " << getNewValue().getType();
+  if (static_cast<bool>(getOutput()) != static_cast<bool>(parent.getOutput()))
+    return emitOpError("optional output must match the parent result");
+  if (getOutput() && getOutput().getType() != parent.getOutput().getType())
+    return emitOpError("output type must match parent result type, expected ")
+           << parent.getOutput().getType() << ", got " << getOutput().getType();
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // Reussir Reference Operations
 //===----------------------------------------------------------------------===//
 // ReferenceProjectOp verification
@@ -1189,8 +1308,24 @@ mlir::LogicalResult ReussirRefProjectOp::verify() {
   RefType refType = getRef().getType();
   RefType projectedType = getProjected().getType();
 
-  // Check that the reference element type is a record type
   mlir::Type elementType = refType.getElementType();
+  if (auto cellType = llvm::dyn_cast<CellType>(elementType)) {
+    size_t index = getIndex().getZExtValue();
+    if (index != 0)
+      return emitOpError("cell projection index must be zero, got ") << index;
+    if (projectedType.getElementType() != cellType.getElementType())
+      return emitOpError("projected cell element type mismatch: expected ")
+             << cellType.getElementType() << ", got "
+             << projectedType.getElementType();
+    if (projectedType.getCapability() != Capability::field)
+      return emitOpError("a cell slot projection must have field capability");
+    if (projectedType.getAtomicKind() != refType.getAtomicKind())
+      return emitOpError("projected cell reference atomic kind must match the "
+                         "source reference");
+    return mlir::success();
+  }
+
+  // Check that the reference element type is a record type
   RecordType recordType = llvm::dyn_cast<RecordType>(elementType);
   if (!recordType)
     return emitOpError("reference element type must be a record type, got: ")
@@ -2413,7 +2548,7 @@ mlir::LogicalResult ReussirRefAcquireOp::verify() {
     return mlir::success();
   }
 
-  if (llvm::isa<ArrayType>(elementType))
+  if (llvm::isa<ArrayType, CellType>(elementType))
     return mlir::success();
 
   return emitOpError("unsupported element type for acquisition: ")
@@ -2502,6 +2637,18 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
                   builder, loc, getArrayViewMemRefType(arrayType), value)
                   .getView();
           return emitArrayOwnershipAcquisition(view, builder, loc);
+        }
+
+        // A cell is a one-field mutable payload. Projecting its slot also
+        // deliberately breaks invariant-group propagation: the same address
+        // may hold different values over the cell's lifetime.
+        if (auto cellType = llvm::dyn_cast<CellType>(elementType)) {
+          RefType slotType =
+              RefType::get(builder.getContext(), cellType.getElementType(),
+                           Capability::field, refType.getAtomicKind());
+          mlir::Value slot = ReussirRefProjectOp::create(
+              builder, loc, slotType, value, builder.getIndexAttr(0));
+          return emitOwnershipAcquisition(slot, builder, loc);
         }
 
         // If reference points to a record, handle fields directly

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -209,6 +209,9 @@ bool isTriviallyCopyable(mlir::Type type) {
       .Case<ArrayType>([](ArrayType arrayType) {
         return isTriviallyCopyable(arrayType.getElementType());
       })
+      .Case<CellType>([](CellType cellType) {
+        return isTriviallyCopyable(cellType.getElementType());
+      })
       // Record types need to check all their members
       .Case<RecordType>([](RecordType recordType) {
         // Incomplete records are considered non-trivially copyable
@@ -242,12 +245,12 @@ bool isTriviallyCopyable(mlir::Type type) {
 // 1. it is a mutable field (isField == true)
 // 2. it is a referential record (either shared or regional)
 // 3. it is a closure
-// 4. it is an array — one shared rc box, like a closure
+// 4. it is an array or cell — one shared rc box, like a closure
 // unless this layout is derived for memory box internal layout, which forces
-// the structure to expand in place. That exemption covers the array case (an
-// array box's payload IS the bare array, laid out inline) but not the closure
-// case (a closure box is a ClosureBoxType — a raw ClosureType is always the
-// pointer to one).
+// the structure to expand in place. That exemption covers arrays and cells
+// (their box payload is the bare value, laid out inline) but not closures (a
+// closure box is a ClosureBoxType — a raw ClosureType is always a pointer to
+// one).
 mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
                              bool isField, bool memBoxInternal) {
   auto ptrTy = mlir::LLVM::LLVMPointerType::get(context);
@@ -258,7 +261,7 @@ mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
        (recordTy &&
         (recordTy.getDefaultCapability() == Capability::shared ||
          recordTy.getDefaultCapability() == Capability::regional)) ||
-       llvm::isa<ArrayType>(rawMember)))
+       llvm::isa<ArrayType, CellType>(rawMember)))
     member = ptrTy;
   if (llvm::isa<ClosureType>(member))
     member = ptrTy;
@@ -977,6 +980,27 @@ void RcType::print(mlir::AsmPrinter &printer) const {
 REUSSIR_POINTER_LIKE_DATA_LAYOUT_INTERFACE(NullableType);
 
 //===----------------------------------------------------------------------===//
+// Reussir Cell Type DataLayoutInterface
+//===----------------------------------------------------------------------===//
+llvm::TypeSize
+CellType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
+                            mlir::DataLayoutEntryListRef params) const {
+  return dataLayout.getTypeSizeInBits(getElementType());
+}
+
+uint64_t CellType::getABIAlignment(const mlir::DataLayout &dataLayout,
+                                   mlir::DataLayoutEntryListRef params) const {
+  return dataLayout.getTypeABIAlignment(getElementType());
+}
+
+MLIR_DATA_LAYOUT_EXPAND_PREFERRED_ALIGN(
+    uint64_t CellType::getPreferredAlignment(
+        const mlir::DataLayout &dataLayout, mlir::DataLayoutEntryListRef params)
+        const {
+          return dataLayout.getTypePreferredAlignment(getElementType());
+        })
+
+//===----------------------------------------------------------------------===//
 // Reussir Reference Type
 //===----------------------------------------------------------------------===//
 // RefType Parse/Print
@@ -1300,8 +1324,8 @@ mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap) {
               return Capability::field;
             return type.getDefaultCapability();
           })
-          // A closure or an array member is one shared rc box.
-          .Case<ClosureType, ArrayType>(
+          // A closure, array, or cell member is one shared rc box.
+          .Case<ClosureType, ArrayType, CellType>(
               [](mlir::Type) -> Capability { return Capability::shared; })
           .Default([](mlir::Type) { return Capability::unspecified; });
   if (targetCap == Capability::field) {

--- a/lib/Transformation/InvariantGroupAnalysis/InvariantGroupAnalysis.cpp
+++ b/lib/Transformation/InvariantGroupAnalysis/InvariantGroupAnalysis.cpp
@@ -135,11 +135,21 @@ mlir::LogicalResult InvariantGroupAnalysis::visitOperation(
     assert(operands.size() >= 1 && "ref.project must have at least 1 operand");
     const auto &inputState = operands[0]->getValue();
 
+    // A cell projection exposes the mutable slot. Even though rc.borrow makes
+    // the containing box identity stable, repeated accesses through this
+    // address may observe different values, so invariant.group must never
+    // propagate across the cell boundary.
+    auto inputRefType = llvm::cast<RefType>(projectOp.getRef().getType());
+    if (llvm::isa<CellType>(inputRefType.getElementType())) {
+      for (auto *result : results)
+        propagateIfChanged(result,
+                           result->join(InvariantGroupValue::getUnsafe()));
+      return mlir::success();
+    }
+
     if (inputState.state == InvariantState::Safe) {
       // Check whether the input ref has flex capability AND the projected
       // field is mutable (memberIsField). If so → Unsafe.
-      auto inputRefType =
-          llvm::cast<RefType>(projectOp.getRef().getType());
       auto recordType =
           llvm::dyn_cast<RecordType>(inputRefType.getElementType());
 

--- a/tests/integration/basic/failure/cell.mlir
+++ b/tests/integration/basic/failure/cell.mlir
@@ -1,0 +1,41 @@
+// RUN: %reussir-opt %s -verify-diagnostics
+
+!cell_i64 = !reussir.cell<i64>
+!rc_cell_i64 = !reussir.rc<!cell_i64>
+
+module {
+  func.func @create_type_mismatch(%value: i32) {
+    // expected-error @+1 {{initial value type must match cell element type, got 'i32' and 'i64'}}
+    %cell = reussir.cell.create value(%value : i32) : !rc_cell_i64
+    return
+  }
+
+  func.func @get_type_mismatch(%cell: !rc_cell_i64) {
+    // expected-error @+1 {{result type must match cell element type, expected 'i64', got 'i32'}}
+    %value = reussir.cell.get(%cell : !rc_cell_i64) : i32
+    return
+  }
+
+  func.func @set_type_mismatch(%cell: !rc_cell_i64, %value: i32) {
+    // expected-error @+1 {{replacement value type must match cell element type, expected 'i64', got 'i32'}}
+    reussir.cell.set(%value : i32, %cell : !rc_cell_i64)
+    return
+  }
+
+  func.func @cell_must_be_shared(%value: i64) {
+    // expected-error @+1 {{cell RC pointer must have shared capability, got rigid}}
+    %cell = reussir.cell.create value(%value : i64)
+      : !reussir.rc<!cell_i64 rigid>
+    return
+  }
+
+  func.func @rmw_argument_mismatch(%cell: !rc_cell_i64) {
+    // expected-error @+1 {{body argument type must match cell element type, expected 'i64', got 'i32'}}
+    reussir.cell.rmw(%cell : !rc_cell_i64) {
+      ^bb0(%old: i32):
+        %zero = arith.constant 0 : i64
+        reussir.cell.yield(%zero : i64)
+    }
+    return
+  }
+}

--- a/tests/integration/basic/success/cell.mlir
+++ b/tests/integration/basic/success/cell.mlir
@@ -1,0 +1,34 @@
+// RUN: %reussir-opt %s | %reussir-opt | %FileCheck %s
+
+!inner = !reussir.rc<i64>
+!cell = !reussir.cell<!inner>
+!rc_cell = !reussir.rc<!cell>
+
+module {
+  func.func @cell_ops(%initial: !inner, %replacement: !inner) -> i64 {
+    %cell = reussir.cell.create value(%initial : !inner) : !rc_cell
+    %cloned = reussir.cell.get(%cell : !rc_cell) : !inner
+    reussir.cell.set(%replacement : !inner, %cell : !rc_cell)
+    %answer = reussir.cell.rmw(%cell : !rc_cell) -> i64 {
+      ^bb0(%old: !inner):
+        %c42 = arith.constant 42 : i64
+        reussir.cell.yield(%old : !inner) output(%c42 : i64)
+    }
+    reussir.cell.rmw(%cell : !rc_cell) {
+      ^bb0(%old: !inner):
+        reussir.cell.yield(%old : !inner)
+    }
+    reussir.rc.dec(%cloned : !inner)
+    reussir.rc.dec(%cell : !rc_cell)
+    return %answer : i64
+  }
+}
+
+// CHECK-LABEL: func.func @cell_ops
+// CHECK: %[[CELL_VALUE:.+]] = reussir.cell.create value(%{{.+}} : !reussir.rc<i64>) : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>
+// CHECK: %{{.+}} = reussir.cell.get(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>) : !reussir.rc<i64>
+// CHECK: reussir.cell.set(%{{.+}} : !reussir.rc<i64>, %[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>)
+// CHECK: reussir.cell.rmw(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>) -> i64
+// CHECK: reussir.cell.yield(%{{.+}} : !reussir.rc<i64>) output(%{{.+}} : i64)
+// CHECK: reussir.cell.rmw(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>)
+// CHECK: reussir.cell.yield(%{{.+}} : !reussir.rc<i64>)

--- a/tests/integration/conversion/cell_ops.mlir
+++ b/tests/integration/conversion/cell_ops.mlir
@@ -1,0 +1,127 @@
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation))' | %FileCheck %s --check-prefix=TOKEN
+// RUN: %reussir-opt %s --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=EXPAND
+// RUN: %reussir-opt %s --reussir-acquire-drop-expansion --reussir-invariant-group-analysis | %FileCheck %s --check-prefix=INVARIANT
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion)' | %FileCheck %s --check-prefix=DROP
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion,reussir-lowering-scf-ops,reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},reussir-lowering-scf-ops,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
+
+!inner = !reussir.rc<i64>
+!rc_cell = !reussir.rc<!reussir.cell<!inner>>
+!rc_i64_cell = !reussir.rc<!reussir.cell<i64>>
+!holder = !reussir.record<compound "CellHolder" [value] {
+  !reussir.cell<i64>
+}>
+
+module {
+  // TOKEN-LABEL: func.func @create_cell
+  // TOKEN: %[[TOKEN:.+]] = reussir.token.alloc : <align : 8, size : 16>
+  // TOKEN: reussir.cell.create value(%{{.+}} : !reussir.rc<i64>) token(%[[TOKEN]] : !reussir.token<align : 8, size : 16>)
+  func.func @create_cell(%value: !inner) -> !rc_cell {
+    %cell = reussir.cell.create value(%value : !inner) : !rc_cell
+    return %cell : !rc_cell
+  }
+
+  // TOKEN-LABEL: func.func @drop_cell
+  // TOKEN: reussir.rc.dec{{.*}}: !reussir.nullable<!reussir.token<align : 8, size : 16>>
+  // DROP-LABEL: func.func @drop_cell
+  // DROP: %[[CELL_REF:.+]] = reussir.rc.borrow{{.*}}!reussir.ref<!reussir.cell<!reussir.rc<i64>>>
+  // DROP: %[[INNER_SLOT:.+]] = reussir.ref.project(%[[CELL_REF]]
+  // DROP: %[[INNER:.+]] = reussir.ref.load(%[[INNER_SLOT]]
+  // DROP: reussir.rc.dec(%[[INNER]] : !reussir.rc<i64>)
+  func.func @drop_cell(%cell: !rc_cell) {
+    reussir.rc.dec(%cell : !rc_cell)
+    return
+  }
+
+  // EXPAND-LABEL: func.func @get_cell
+  // EXPAND: %[[BORROW:.+]] = reussir.rc.borrow
+  // EXPAND: %[[SLOT:.+]] = reussir.ref.project(%[[BORROW]]
+  // EXPAND: %[[VALUE:.+]] = reussir.ref.load(%[[SLOT]]
+  // EXPAND-NEXT: reussir.rc.inc(%[[VALUE]]
+  // EXPAND-NOT: reussir.ref.load
+  // EXPAND: return %[[VALUE]]
+  // INVARIANT-LABEL: func.func @get_cell
+  // INVARIANT: reussir.ref.load
+  // INVARIANT-NOT: invariant_group
+  // INVARIANT: reussir.rc.inc
+  func.func @get_cell(%cell: !rc_cell) -> !inner {
+    %value = reussir.cell.get(%cell : !rc_cell) : !inner
+    return %value : !inner
+  }
+
+  // EXPAND-LABEL: func.func @set_cell
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND: %[[OLD:.+]] = reussir.ref.load
+  // EXPAND-NEXT: %{{.+}} = reussir.rc.dec(%[[OLD]]
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND: reussir.ref.store
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND: return
+  func.func @set_cell(%value: !inner, %cell: !rc_cell) {
+    reussir.cell.set(%value : !inner, %cell : !rc_cell)
+    return
+  }
+
+  // EXPAND-LABEL: func.func @rmw_cell
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: %[[OLD:.+]] = reussir.ref.load
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: reussir.ref.store
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: return %[[OLD]]
+  func.func @rmw_cell(%value: !inner, %cell: !rc_cell) -> !inner {
+    %old = reussir.cell.rmw(%cell : !rc_cell) -> !inner {
+      ^bb0(%current: !inner):
+        reussir.cell.yield(%value : !inner) output(%current : !inner)
+    }
+    return %old : !inner
+  }
+
+  // EXPAND-LABEL: func.func @rmw_i64
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: %[[OLD:.+]] = reussir.ref.load
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: %[[NEXT:.+]] = arith.addi %[[OLD]]
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: reussir.ref.store{{.*}}(%[[NEXT]] : i64)
+  // EXPAND-NOT: reussir.rc.inc
+  // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: return
+  func.func @rmw_i64(%cell: !rc_i64_cell) -> i64 {
+    %old = reussir.cell.rmw(%cell : !rc_i64_cell) -> i64 {
+      ^bb0(%current: i64):
+        %one = arith.constant 1 : i64
+        %next = arith.addi %current, %one : i64
+        reussir.cell.yield(%next : i64) output(%current : i64)
+    }
+    return %old : i64
+  }
+
+  // A non-cell borrow remains eligible for invariant.group, proving that the
+  // negative cell checks above are caused by the mutable projection boundary.
+  // INVARIANT-LABEL: func.func @control_invariant
+  // INVARIANT: reussir.ref.load{{.*}}invariant_group
+  func.func @control_invariant(%value: !inner) -> i64 {
+    %ref = reussir.rc.borrow(%value : !inner) : !reussir.ref<i64>
+    %loaded = reussir.ref.load(%ref : !reussir.ref<i64>) : i64
+    return %loaded : i64
+  }
+
+  // A raw Cell member occupies one shared pointer slot and projects as
+  // Rc<Cell>, matching closure/array member materialization.
+  // LLVM: %CellHolder = type { ptr }
+  // LLVM-LABEL: define ptr @project_cell_member(ptr %{{.+}})
+  // LLVM: getelementptr %CellHolder, ptr %{{.+}}, i32 0, i32 0
+  // LLVM: load ptr
+  func.func @project_cell_member(%holder: !reussir.ref<!holder>) -> !rc_i64_cell {
+    %slot = reussir.ref.project(%holder : !reussir.ref<!holder>) [0]
+      : !reussir.ref<!rc_i64_cell>
+    %cell = reussir.ref.load(%slot : !reussir.ref<!rc_i64_cell>) : !rc_i64_cell
+    return %cell : !rc_i64_cell
+  }
+}

--- a/tests/integration/sanitizer/cell-asan.mlir
+++ b/tests/integration/sanitizer/cell-asan.mlir
@@ -1,0 +1,106 @@
+// REQUIRES: asan
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-closure-outlining,reussir-lowering-region-patterns,func.func(reussir-inc-dec-cancellation),reussir-rc-decrement-expansion,func.func(reussir-infer-variant-tag),reussir-acquire-drop-expansion,reussir-lowering-scf-ops,func.func(reussir-inc-dec-cancellation),reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-lowering-scf-ops,func.func(reussir-rc-create-sink),func.func(reussir-rc-create-fusion),reussir-trmc-recursion-analysis,reussir-compile-polymorphic-ffi,canonicalize,control-flow-sink,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,cse,canonicalize)' \
+// RUN:   -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O2 -o %t.ll
+// RUN: %cc %asan_flags -c -x ir %t.ll -o %t.o
+// RUN: %cc %asan_flags %t.o %reussir_rt_asan -o %t.exe \
+// RUN:   %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.exe
+
+// This one lifecycle catches all Cell ownership edges with ASan+LSan:
+// - get must retain the nested Rc before its returned clone is released;
+// - set must release the old nested Rc but must not retain the incoming one;
+// - rmw must move old/new values without either retain or release;
+// - the final cell decrement must recursively release its nested Rc.
+
+!inner = !reussir.rc<i64>
+!cell = !reussir.rc<!reussir.cell<!inner>>
+!scalar_cell = !reussir.rc<!reussir.cell<i64>>
+
+module attributes {reussir.sanitize = ["sanitize_address"]} {
+  func.func private @read_inner(%value: !inner) -> i64
+      attributes {llvm.linkage = #llvm.linkage<internal>,
+                  passthrough = ["sanitize_address"]} {
+    %ref = reussir.rc.borrow(%value : !inner) : !reussir.ref<i64>
+    %loaded = reussir.ref.load(%ref : !reussir.ref<i64>) : i64
+    return %loaded : i64
+  }
+
+  func.func private @require_equal(%actual: i64, %expected: i64)
+      attributes {llvm.linkage = #llvm.linkage<internal>,
+                  passthrough = ["sanitize_address"]} {
+    %wrong = arith.cmpi ne, %actual, %expected : i64
+    scf.if %wrong {
+      reussir.panic "cell value mismatch"
+    }
+    return
+  }
+
+  func.func @main() -> i32 attributes {passthrough = ["sanitize_address"]} {
+    %c0_i32 = arith.constant 0 : i32
+    %c5 = arith.constant 5 : i64
+    %c6 = arith.constant 6 : i64
+    %c9 = arith.constant 9 : i64
+    %c11 = arith.constant 11 : i64
+    %c22 = arith.constant 22 : i64
+    %c33 = arith.constant 33 : i64
+    %c44 = arith.constant 44 : i64
+
+    %v1 = reussir.rc.create value(%c11 : i64) : !inner
+    %cell = reussir.cell.create value(%v1 : !inner) : !cell
+
+    // A returned get value owns a clone independent of the cell.
+    %clone1 = reussir.cell.get(%cell : !cell) : !inner
+    %got11 = func.call @read_inner(%clone1) : (!inner) -> i64
+    func.call @require_equal(%got11, %c11) : (i64, i64) -> ()
+    reussir.rc.dec(%clone1 : !inner)
+
+    // set drops v1 and transfers v2 into the slot without retaining v2.
+    %v2 = reussir.rc.create value(%c22 : i64) : !inner
+    reussir.cell.set(%v2 : !inner, %cell : !cell)
+    %clone2 = reussir.cell.get(%cell : !cell) : !inner
+    %got22 = func.call @read_inner(%clone2) : (!inner) -> i64
+    func.call @require_equal(%got22, %c22) : (i64, i64) -> ()
+    reussir.rc.dec(%clone2 : !inner)
+
+    // rmw moves v2 out and v3 in. Returning the old value must not retain it.
+    %v3 = reussir.rc.create value(%c33 : i64) : !inner
+    %old = reussir.cell.rmw(%cell : !cell) -> !inner {
+      ^bb0(%current: !inner):
+        reussir.cell.yield(%v3 : !inner) output(%current : !inner)
+    }
+    %old22 = func.call @read_inner(%old) : (!inner) -> i64
+    func.call @require_equal(%old22, %c22) : (i64, i64) -> ()
+    reussir.rc.dec(%old : !inner)
+
+    %clone3 = reussir.cell.get(%cell : !cell) : !inner
+    %got33 = func.call @read_inner(%clone3) : (!inner) -> i64
+    func.call @require_equal(%got33, %c33) : (i64, i64) -> ()
+    reussir.rc.dec(%clone3 : !inner)
+
+    // Replacing v3 checks another old-value drop. The cell's final decrement
+    // must recursively release v4.
+    %v4 = reussir.rc.create value(%c44 : i64) : !inner
+    reussir.cell.set(%v4 : !inner, %cell : !cell)
+    reussir.rc.dec(%cell : !cell)
+
+    // Also execute both rmw and ordinary get/set for a trivial payload.
+    %scalar = reussir.cell.create value(%c5 : i64) : !scalar_cell
+    %before = reussir.cell.rmw(%scalar : !scalar_cell) -> i64 {
+      ^bb0(%current: i64):
+        %one = arith.constant 1 : i64
+        %next = arith.addi %current, %one : i64
+        reussir.cell.yield(%next : i64) output(%current : i64)
+    }
+    func.call @require_equal(%before, %c5) : (i64, i64) -> ()
+    %after = reussir.cell.get(%scalar : !scalar_cell) : i64
+    func.call @require_equal(%after, %c6) : (i64, i64) -> ()
+    reussir.cell.set(%c9 : i64, %scalar : !scalar_cell)
+    %set_value = reussir.cell.get(%scalar : !scalar_cell) : i64
+    func.call @require_equal(%set_value, %c9) : (i64, i64) -> ()
+    reussir.rc.dec(%scalar : !scalar_cell)
+
+    return %c0_i32 : i32
+  }
+}

--- a/tests/unittest/cases/cell.cpp
+++ b/tests/unittest/cases/cell.cpp
@@ -1,0 +1,41 @@
+#include "Reussir/IR/ReussirTypes.h"
+
+#include <gtest/gtest.h>
+#include <mlir/Dialect/LLVMIR/LLVMTypes.h>
+#include <mlir/Interfaces/DataLayoutInterfaces.h>
+
+import reussir.test;
+
+namespace reussir {
+TEST_F(ReussirTest, ParseCellTypeTest) {
+  withType<CellType>(SIMPLE_LAYOUT, R"(!reussir.cell<!reussir.rc<i64>>)",
+                     [](mlir::ModuleOp module, CellType type) {
+                       EXPECT_TRUE(llvm::isa<RcType>(type.getElementType()));
+
+                       mlir::DataLayout layout(module);
+                       EXPECT_EQ(layout.getTypeSize(type),
+                                 layout.getTypeSize(type.getElementType()));
+                       EXPECT_EQ(
+                           layout.getTypeABIAlignment(type),
+                           layout.getTypeABIAlignment(type.getElementType()));
+                     });
+}
+
+TEST_F(ReussirTest, CellMemberProjectsToSharedRc) {
+  auto i64Type = mlir::IntegerType::get(context.get(), 64);
+  auto cellType = CellType::get(context.get(), i64Type);
+
+  auto projected = llvm::dyn_cast<RcType>(
+      getProjectedType(cellType, /*fieldCap=*/false, Capability::value));
+  ASSERT_TRUE(projected);
+  EXPECT_EQ(projected.getElementType(), cellType);
+  EXPECT_EQ(projected.getCapability(), Capability::shared);
+
+  mlir::Type storage = memberStorageType(context.get(), cellType,
+                                         /*isField=*/false);
+  EXPECT_TRUE(llvm::isa<mlir::LLVM::LLVMPointerType>(storage));
+  EXPECT_EQ(memberStorageType(context.get(), cellType, /*isField=*/false,
+                              /*memBoxInternal=*/true),
+            cellType);
+}
+} // namespace reussir


### PR DESCRIPTION
## Summary

- add the `!reussir.cell<T>` payload type and shared-RC `cell.create`, `cell.get`, `cell.set`, and `cell.rmw` operations
- lower Cell ownership so `get` clones the stored value, `set` drops only the replaced value, and `rmw` moves values without implicit retain/drop traffic
- recursively destroy managed Cell payloads, preserve exact allocation-token sizing, and stop `invariant.group` propagation at mutable Cell projections
- materialize Cell record members as shared RC pointers, matching closure and array projection behavior
- expose the Cell type through the C and Rust MLIR dialect APIs

## Testing

- `ctest --test-dir build --output-on-failure` — 19 passed
- `ninja -C build reussir-backend-test` — 10 passed, 1 environment-dependent test ignored
- `ninja -C build check` — 338 passed, 10 unsupported
- nested `Rc<Cell<Rc<i64>>>` lifecycle passed under ASan and LeakSanitizer, covering get retention, set replacement drop, ownership-neutral rmw, and recursive final destruction

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786593439&installation_id=144622820&pr_number=412&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F412&signature=510319c4592aaa7ab6cd4ad8fd1c5f8a168c89422ad0b71176bf3dc8157166b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->