### PR TITLE
[nfc] format project sources and test cell names

### DIFF
--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -63,7 +63,7 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use reussir_backend::builders;
 use reussir_backend::melior::Context;
-use reussir_backend::melior::ir::attribute::{Attribute, ArrayAttribute, StringAttribute};
+use reussir_backend::melior::ir::attribute::{ArrayAttribute, Attribute, StringAttribute};
 use reussir_backend::melior::ir::operation::{OperationLike, OperationMutLike};
 use reussir_backend::melior::ir::{BlockLike, Location, Module};
 use reussir_backend::pipeline::{INLINE_TRANSFORM_ATTR, INLINE_TRANSFORM_ENTRY_POINT};
@@ -152,11 +152,7 @@ impl From<Cow<'static, str>> for LoweringErrorKind {
 }
 
 impl LoweringError {
-    fn at_source(
-        message: impl Into<Cow<'static, str>>,
-        file: FileId,
-        span: Option<Span>,
-    ) -> Self {
+    fn at_source(message: impl Into<Cow<'static, str>>, file: FileId, span: Option<Span>) -> Self {
         Self(LoweringErrorKind::Source {
             message: message.into(),
             file,
@@ -364,10 +360,9 @@ pub fn lower_unit<'c, 'tcx>(
             .iter()
             .map(|a| StringAttribute::new(context, a).into())
             .collect();
-        module.as_operation_mut().set_attribute(
-            SANITIZE_ATTR,
-            ArrayAttribute::new(context, &strings).into(),
-        );
+        module
+            .as_operation_mut()
+            .set_attribute(SANITIZE_ATTR, ArrayAttribute::new(context, &strings).into());
     }
     let body = module.body();
     for (token, payload) in &program.string_literals {
@@ -638,8 +633,8 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
-            let module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
+            let module = lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                .expect("lowering succeeds");
             assert!(
                 module.as_operation().verify(),
                 "module verifies:\n{}",
@@ -701,9 +696,7 @@ transform [{
                 error.message().contains("transform.not_a_real_op"),
                 "{error}"
             );
-            let (file, span) = error
-                .source_location()
-                .expect("source-owned diagnostic");
+            let (file, span) = error.source_location().expect("source-owned diagnostic");
             assert_eq!(file, crate::source::FileId::ROOT);
             let span = span.expect("exact malformed-operation span");
             let expected = u32::try_from(source.find("transform.not_a_real_op").unwrap()).unwrap();
@@ -730,8 +723,16 @@ transform [{
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut map = crate::source::SourceCache::new();
             map.add_file("add.rr", src);
-            let module =
-                lower_program(&context, tcx, &full, Some(&map), None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
+            let module = lower_program(
+                &context,
+                tcx,
+                &full,
+                Some(&map),
+                None,
+                LinkagePolicy::Jit,
+                &[],
+            )
+            .expect("lowering succeeds");
             let printed = module
                 .as_operation()
                 .to_string_with_flags(OperationPrintingFlags::new().enable_debug_info(true, false))
@@ -768,8 +769,16 @@ transform [{
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut map = crate::source::SourceCache::new();
             map.add_file("pt.rr", src);
-            let module = lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()), LinkagePolicy::Jit, &[])
-                .expect("lowering succeeds");
+            let module = lower_program(
+                &context,
+                tcx,
+                &full,
+                Some(&map),
+                Some(parse.resolver()),
+                LinkagePolicy::Jit,
+                &[],
+            )
+            .expect("lowering succeeds");
             let printed = module
                 .as_operation()
                 .to_string_with_flags(OperationPrintingFlags::new().enable_debug_info(true, false))
@@ -816,8 +825,16 @@ transform [{
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut map = crate::source::SourceCache::new();
             map.add_file("variant.rr", src);
-            let module = lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()), LinkagePolicy::Jit, &[])
-                .expect("lowering succeeds");
+            let module = lower_program(
+                &context,
+                tcx,
+                &full,
+                Some(&map),
+                Some(parse.resolver()),
+                LinkagePolicy::Jit,
+                &[],
+            )
+            .expect("lowering succeeds");
             let printed = module
                 .as_operation()
                 .to_string_with_flags(OperationPrintingFlags::new().enable_debug_info(true, false))
@@ -1126,7 +1143,8 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                    .expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,
@@ -1235,7 +1253,8 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                    .expect("lowering succeeds");
             let printed = module.as_operation().to_string();
             // The null field and the self-link both build nullable rc values.
             assert!(printed.contains("reussir.nullable.create"), "{printed}");
@@ -1264,7 +1283,8 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                    .expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,
@@ -1326,7 +1346,8 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                    .expect("lowering succeeds");
             let printed = module.as_operation().to_string();
             // The frozen `rigid` box is dropped with a direct reference-count
             // decrement, not spilled and dropped as an inline record.
@@ -1370,7 +1391,8 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                    .expect("lowering succeeds");
             let printed = module.as_operation().to_string();
             // The reused frozen box is retained with a direct reference-count
             // increment, and dropped (by the callees / at last use) with a
@@ -1447,7 +1469,8 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                    .expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,
@@ -1510,7 +1533,8 @@ transform [{
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
             let mut module =
-                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("lowering succeeds");
+                lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                    .expect("lowering succeeds");
             reussir_backend::pipeline::run_lowering_pipeline(
                 &context,
                 &mut module,

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -33,7 +33,8 @@ fn jit_run<R>(source: &str, run: impl FnOnce(&OrcJit) -> R) -> R {
         );
         let (full, reports) = monomorphize(&elab.mono_input());
         assert!(reports.is_empty(), "mono reports: {reports:#?}");
-        lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[]).expect("scalar lowering succeeds")
+        lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+            .expect("scalar lowering succeeds")
     });
 
     run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
@@ -222,8 +223,16 @@ fn lowers_variant_debug_info_through_the_pipeline() {
         assert!(reports.is_empty(), "mono reports: {reports:#?}");
         let mut map = reussir_codegen::source::SourceCache::new();
         map.add_file("variant.rr", src);
-        lower_program(&context, tcx, &full, Some(&map), Some(parse.resolver()), LinkagePolicy::Jit, &[])
-            .expect("variant lowering with debug info succeeds")
+        lower_program(
+            &context,
+            tcx,
+            &full,
+            Some(&map),
+            Some(parse.resolver()),
+            LinkagePolicy::Jit,
+            &[],
+        )
+        .expect("variant lowering with debug info succeeds")
     });
 
     // Pin the optimization prologue off: the DI shapes under test hang off

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -1050,7 +1050,14 @@ fn finish_mir<'c, 'tcx>(
             };
             let module = lower_or_render(
                 lower_unit(
-                    context, tcx, program, sources, names, unit, linkage, &sanitizers,
+                    context,
+                    tcx,
+                    program,
+                    sources,
+                    names,
+                    unit,
+                    linkage,
+                    &sanitizers,
                 ),
                 sources,
                 name,

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1093,10 +1093,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         let (name, tys) = &v.value;
                         Variant {
                             name: *name,
-                            fields: tys
-                                .iter()
-                                .map(|t| self.eval_type(t))
-                                .collect(),
+                            fields: tys.iter().map(|t| self.eval_type(t)).collect(),
                         }
                     })
                     .collect(),

--- a/crates/reussir-repl/src/reflect.rs
+++ b/crates/reussir-repl/src/reflect.rs
@@ -513,9 +513,8 @@ impl<'tcx> Walker<'_, 'tcx> {
                         return Ok(());
                     }
                     let inner = inline_size_align(ty, self.shapes)?;
-                    let fused_variant =
-                        matches!(shape.layout, ShapeLayout::Variants(_))
-                            && shape.default_cap != DefaultCap::Value;
+                    let fused_variant = matches!(shape.layout, ShapeLayout::Variants(_))
+                        && shape.default_cap != DefaultCap::Value;
                     let header = match shape.default_cap {
                         DefaultCap::Value => 4, // unreachable in practice
                         // A shared variant box IS the record: the refcount
@@ -575,10 +574,8 @@ impl<'tcx> Walker<'_, 'tcx> {
                     })
                     .collect();
                 let payload_area = variants_payload_size_align(variants, self.shapes)?;
-                let (_, _, header) =
-                    variant_tag_layout(shape.default_cap, variants.len());
-                let base =
-                    unsafe { payload.add(align_to(header, payload_area.align) as usize) };
+                let (_, _, header) = variant_tag_layout(shape.default_cap, variants.len());
+                let base = unsafe { payload.add(align_to(header, payload_area.align) as usize) };
                 unsafe { self.render_fields(base, &fields, depth, out) }
             }
         }

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -514,7 +514,15 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             return Ok(None);
         }
 
-        let mut module = match lower_program(self.context, self.tcx, &program, None, None, LinkagePolicy::Jit, &[]) {
+        let mut module = match lower_program(
+            self.context,
+            self.tcx,
+            &program,
+            None,
+            None,
+            LinkagePolicy::Jit,
+            &[],
+        ) {
             Ok(module) => module,
             Err(error) => {
                 self.elab.rollback(cp);

--- a/crates/reussir-rt/src/alloc.rs
+++ b/crates/reussir-rt/src/alloc.rs
@@ -295,12 +295,7 @@ unsafe impl std::alloc::GlobalAlloc for ReussirGlobalAlloc {
         unsafe { backend::free(ptr) }
     }
     #[inline]
-    unsafe fn realloc(
-        &self,
-        ptr: *mut u8,
-        layout: std::alloc::Layout,
-        new_size: usize,
-    ) -> *mut u8 {
+    unsafe fn realloc(&self, ptr: *mut u8, layout: std::alloc::Layout, new_size: usize) -> *mut u8 {
         unsafe { backend::realloc(ptr, layout.align().max(GLOBAL_MAX_ALIGN), new_size) }
     }
 }

--- a/include/Reussir-c/Attrs.h
+++ b/include/Reussir-c/Attrs.h
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 //
 // C API constructors for the Reussir debug-info attributes. These attributes
-// describe a value's debug type / variable so the debug-info conversion pass can
-// emit LLVM DI; they use custom storage that the generic MLIR C API cannot
+// describe a value's debug type / variable so the debug-info conversion pass
+// can emit LLVM DI; they use custom storage that the generic MLIR C API cannot
 // build, so the code generator constructs them through these entry points.
 //
 //===----------------------------------------------------------------------===//
@@ -39,8 +39,8 @@ MlirAttribute reussirDBGIntTypeAttrGet(MlirContext context, MlirType innerType,
 MlirAttribute reussirDBGFPTypeAttrGet(MlirContext context, MlirType innerType,
                                       MlirAttribute dbgName);
 
-// One member of a debug record type: a field `name` (`StringAttr`) and its debug
-// type attribute (a `DBG*Type` attribute).
+// One member of a debug record type: a field `name` (`StringAttr`) and its
+// debug type attribute (a `DBG*Type` attribute).
 MlirAttribute reussirDBGRecordMemberAttrGet(MlirContext context,
                                             MlirAttribute name,
                                             MlirAttribute typeAttr);
@@ -48,13 +48,13 @@ MlirAttribute reussirDBGRecordMemberAttrGet(MlirContext context,
 // A debug record (struct / variant) type. `members` is an array of
 // `reussirDBGRecordMemberAttrGet` results; `underlyingType` is the lowered MLIR
 // record used for size/offset computation.
-MlirAttribute reussirDBGRecordTypeAttrGet(MlirContext context, intptr_t nMembers,
-                                          MlirAttribute const *members,
-                                          bool isVariant,
-                                          MlirType underlyingType,
-                                          MlirAttribute dbgName);
+MlirAttribute
+reussirDBGRecordTypeAttrGet(MlirContext context, intptr_t nMembers,
+                            MlirAttribute const *members, bool isVariant,
+                            MlirType underlyingType, MlirAttribute dbgName);
 
-// A debug subprogram (function) attribute: `rawName` is the source function name
+// A debug subprogram (function) attribute: `rawName` is the source function
+// name
 // (`StringAttr`); `typeParams` an array of parameter debug-type attributes.
 MlirAttribute reussirDBGSubprogramAttrGet(MlirContext context,
                                           MlirAttribute rawName,
@@ -62,8 +62,8 @@ MlirAttribute reussirDBGSubprogramAttrGet(MlirContext context,
                                           MlirAttribute const *typeParams);
 
 // A debug type for a reference-counted (boxed) value, wrapping the payload's
-// debug type. `regional` selects the box header to skip past: a shared box has a
-// single ref-count word, a regional box a three-word header.
+// debug type. `regional` selects the box header to skip past: a shared box has
+// a single ref-count word, a regional box a three-word header.
 MlirAttribute reussirDBGBoxedTypeAttrGet(MlirContext context,
                                          MlirAttribute dbgType, bool regional);
 
@@ -76,7 +76,8 @@ MlirAttribute reussirDBGLocalVarAttrGet(MlirContext context,
 // argument index.
 MlirAttribute reussirDBGFuncArgAttrGet(MlirContext context,
                                        MlirAttribute dbgType,
-                                       MlirAttribute argName, unsigned argIndex);
+                                       MlirAttribute argName,
+                                       unsigned argIndex);
 
 // Set an operation's location. Used by the code generator to attach a fused
 // debug-info location (carrying a `DBGLocalVar`) to the op that defines a local

--- a/include/Reussir-c/Types.h
+++ b/include/Reussir-c/Types.h
@@ -129,13 +129,11 @@ MlirType reussirStrTypeGet(MlirContext context, ReussirLifeScope lifeScope);
 // of `nMembers` booleans. `fixed` pins uniform max-arm box sizing on a variant
 // (`#[repr(fixed)]`); pass false for compounds and for variants that use the
 // default per-constructor sizing.
-MlirType reussirRecordTypeGetComplete(MlirContext context, intptr_t nMembers,
-                                      MlirType const *members,
-                                      bool const *memberIsField,
-                                      MlirAttribute name,
-                                      ReussirRecordKind kind,
-                                      ReussirCapability defaultCapability,
-                                      bool fixed);
+MlirType
+reussirRecordTypeGetComplete(MlirContext context, intptr_t nMembers,
+                             MlirType const *members, bool const *memberIsField,
+                             MlirAttribute name, ReussirRecordKind kind,
+                             ReussirCapability defaultCapability, bool fixed);
 
 // An identified, incomplete record type. `name` must be a `StringAttr`.
 // Complete it later with `reussirRecordTypeComplete`.

--- a/include/Reussir/Conversion/Passes.h
+++ b/include/Reussir/Conversion/Passes.h
@@ -14,8 +14,8 @@
 #ifndef REUSSIR_CONVERSION_PASSES_H
 #define REUSSIR_CONVERSION_PASSES_H
 
-#include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/DialectRegistry.h>
 #include <mlir/Pass/Pass.h>
 
 namespace llvm {
@@ -42,11 +42,11 @@ mlir::LogicalResult compilePolymorphicFFI(mlir::ModuleOp moduleOp,
 //===----------------------------------------------------------------------===//
 //
 // Rewrites the `{ tag, payload-union }` debug type the debug-info conversion
-// emits for each enum into a real DWARF `DW_TAG_variant_part` (discriminant plus
-// per-case `DW_AT_discr_value`), so a debugger shows only the active case. Runs
-// on the translated `llvm::Module` because MLIR's `DICompositeTypeAttr` has no
-// discriminator field — the operands only exist at the LLVM-DI level. A no-op
-// for modules without debug info.
+// emits for each enum into a real DWARF `DW_TAG_variant_part` (discriminant
+// plus per-case `DW_AT_discr_value`), so a debugger shows only the active case.
+// Runs on the translated `llvm::Module` because MLIR's `DICompositeTypeAttr`
+// has no discriminator field — the operands only exist at the LLVM-DI level. A
+// no-op for modules without debug info.
 //
 //===----------------------------------------------------------------------===//
 void fixupVariantDebugInfo(llvm::Module &module);

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -45,17 +45,17 @@ def ReussirBasicOpsLoweringPass
     world: a vtable the module has never seen takes the indirect fallback
     arm). See docs/design/closure-wpd.md.
   }];
-  let options = [
-    Option<"closureWpd", "closure-wpd", "bool", /*default=*/"false",
-        "emit whole-program devirtualization artifacts for closure vtables">,
+  let options =
+      [Option<
+           "closureWpd", "closure-wpd", "bool", /*default=*/"false",
+           "emit whole-program devirtualization artifacts for closure vtables">,
   ];
   let dependentDialects = ["::mlir::arith::ArithDialect",
                            "::mlir::memref::MemRefDialect",
                            "::mlir::scf::SCFDialect",
                            "::mlir::math::MathDialect",
                            "::mlir::LLVM::LLVMDialect",
-                           "::mlir::func::FuncDialect",
-                           "::mlir::ub::UBDialect",
+                           "::mlir::func::FuncDialect", "::mlir::ub::UBDialect",
                            "::reussir::ReussirDialect"];
 }
 
@@ -80,8 +80,7 @@ def ReussirDebugInfoConversionPass
 //===----------------------------------------------------------------------===//
 // SCFOpsLowering
 //===----------------------------------------------------------------------===//
-def ReussirSCFOpsLoweringPass
-    : ReussirLoweringPass<"scf-ops"> {
+def ReussirSCFOpsLoweringPass : ReussirLoweringPass<"scf-ops"> {
   let summary = "lower Reussir SCF operations to MLIR SCF operations";
   let description = [{
     `reussir-lowering-scf-ops` lowers Reussir SCF operations to MLIR SCF
@@ -102,8 +101,7 @@ def ReussirSCFOpsLoweringPass
 //===----------------------------------------------------------------------===//
 // AttachRegionVtables
 //===----------------------------------------------------------------------===//
-def ReussirRegionPatternsPass
-    : ReussirLoweringPass<"region-patterns"> {
+def ReussirRegionPatternsPass : ReussirLoweringPass<"region-patterns"> {
   let summary = "attach vtables to regions";
   let description = [{
     `reussir-lowering-region-patterns` will do the following converions:
@@ -111,17 +109,14 @@ def ReussirRegionPatternsPass
     2. convert region run operations to memref alloca_scope operations.
     3. convert yield operations to freeze operations.
   }];
-  let dependentDialects = [
-    "::reussir::ReussirDialect", 
-    "::mlir::memref::MemRefDialect"
-  ];
+  let dependentDialects = ["::reussir::ReussirDialect",
+                           "::mlir::memref::MemRefDialect"];
 }
 
 //===----------------------------------------------------------------------===//
 // AcquireDropExpansion
 //===----------------------------------------------------------------------===//
-def ReussirAcquireDropExpansionPass
-    : Pass<"reussir-acquire-drop-expansion"> {
+def ReussirAcquireDropExpansionPass : Pass<"reussir-acquire-drop-expansion"> {
   let summary = "expand Reussir acquire and drop operations";
   let description = [{
     `reussir-acquire-drop-expansion` expands Reussir acquire and drop operations,
@@ -157,11 +152,13 @@ def ReussirAcquireDropExpansionPass
     should enable `outline-record` option, which converts record destructions to
     outline function calls.
   }];
-  let options = [
-    Option<"outlineRecord", "outline-record", "bool", /*default=*/"false",
-        "whether to outline record destruction and acquisition">,
-    Option<"expandDecrement", "expand-decrement", "bool", /*default=*/"false",
-        "whether to expand rc decrement operations (using the `rc-decrement-expansion` pass)">,
+  let options =
+      [Option<"outlineRecord", "outline-record", "bool", /*default=*/"false",
+              "whether to outline record destruction and acquisition">,
+       Option<"expandDecrement", "expand-decrement", "bool",
+              /*default=*/"false",
+              "whether to expand rc decrement operations (using the "
+              "`rc-decrement-expansion` pass)">,
   ];
   let dependentDialects = ["::reussir::ReussirDialect",
                            "::mlir::ub::UBDialect"];
@@ -170,8 +167,7 @@ def ReussirAcquireDropExpansionPass
 //===----------------------------------------------------------------------===//
 // RcDecrementExpansion
 //===----------------------------------------------------------------------===//
-def ReussirRcDecrementExpansionPass
-    : Pass<"reussir-rc-decrement-expansion"> {
+def ReussirRcDecrementExpansionPass : Pass<"reussir-rc-decrement-expansion"> {
   let summary = "expand Reussir rc decrement operations";
   let description = [{
     `reussir-rc-decrement-expansion` expands Reussir rc decrement operations.
@@ -179,8 +175,8 @@ def ReussirRcDecrementExpansionPass
     of the pipeline.
   }];
 
-  let dependentDialects = ["::reussir::ReussirDialect", 
-                           "::mlir::arith::ArithDialect", 
+  let dependentDialects = ["::reussir::ReussirDialect",
+                           "::mlir::arith::ArithDialect",
                            "::mlir::scf::SCFDialect"];
 }
 
@@ -213,8 +209,7 @@ def ReussirClosureOutliningPass
 
   let dependentDialects = ["::reussir::ReussirDialect",
                            "::mlir::func::FuncDialect",
-                           "::mlir::LLVM::LLVMDialect"
-                          ];
+                           "::mlir::LLVM::LLVMDialect"];
 }
 
 //===----------------------------------------------------------------------===//
@@ -227,12 +222,11 @@ def ReussirCompilePolymorphicFFIPass
     `reussir-compile-polymorphic-ffi` compiles polymorphic FFI template
     into concrete LLVM bitcode and embeds them into the module.
   }];
-  let options = [
-    Option<"optimized", "optimized", "bool", /*default=*/"false",
-        "enable optimizations when compiling FFI templates">,
+  let options = [Option<"optimized", "optimized", "bool", /*default=*/"false",
+                        "enable optimizations when compiling FFI templates">,
   ];
-  let dependentDialects = ["::reussir::ReussirDialect", 
-                           "::mlir::func::FuncDialect", 
+  let dependentDialects = ["::reussir::ReussirDialect",
+                           "::mlir::func::FuncDialect",
                            "::mlir::scf::SCFDialect"];
 }
 
@@ -241,7 +235,8 @@ def ReussirCompilePolymorphicFFIPass
 //===----------------------------------------------------------------------===//
 def ReussirConvertToLLVMPass
     : Pass<"reussir-convert-to-llvm", "::mlir::ModuleOp"> {
-  let summary = "interface-driven convert-to-llvm honoring the module data layout";
+  let summary =
+      "interface-driven convert-to-llvm honoring the module data layout";
   let description = [{
     `reussir-convert-to-llvm` runs the same `ConvertToLLVMPatternInterface`
     driven conversion as the upstream `convert-to-llvm`, but builds its
@@ -279,8 +274,7 @@ def ReussirAttachNativeTargetPass
     - `llvm.target_triple`: The target triple string of the native target.
     - `dlti.dl_spec`: The data layout spec of the native target.
   }];
-  let dependentDialects = ["::mlir::LLVM::LLVMDialect", 
-                           "::mlir::DLTIDialect"];
+  let dependentDialects = ["::mlir::LLVM::LLVMDialect", "::mlir::DLTIDialect"];
 }
 
 #endif // REUSSIR_CONVERSION_PASSES_TD

--- a/include/Reussir/IR/ReussirAttrs.td
+++ b/include/Reussir/IR/ReussirAttrs.td
@@ -17,7 +17,7 @@ include "Reussir/IR/ReussirDialect.td"
 include "mlir/IR/EnumAttr.td"
 
 class ReussirAttr<string name, string attrMnemonic, list<Trait> traits = [],
-  string baseCppClass = "::mlir::Attribute">
+                  string baseCppClass = "::mlir::Attribute">
     : AttrDef<ReussirDialect, name, traits, baseCppClass> {
   let mnemonic = attrMnemonic;
 }
@@ -43,7 +43,6 @@ def CAP_Rigid : I32EnumAttrCase<"rigid", 4>;
 def CAP_Field : I32EnumAttrCase<"field", 5>;
 def CAP_Regional : I32EnumAttrCase<"regional", 6>;
 
-
 def Capability : I32EnumAttr<"Capability", "capability",
                              [CAP_Default, CAP_Value, CAP_Shared, CAP_Flex,
                               CAP_Rigid, CAP_Field, CAP_Regional]> {
@@ -67,8 +66,7 @@ def RecordKind
 def LS_Global : I32EnumAttrCase<"global", 0>;
 def LS_Local : I32EnumAttrCase<"local", 1>;
 
-def LifeScope
-    : I32EnumAttr<"LifeScope", "life scope", [LS_Global, LS_Local]> {
+def LifeScope : I32EnumAttr<"LifeScope", "life scope", [LS_Global, LS_Local]> {
   let cppNamespace = "::reussir";
 }
 
@@ -79,8 +77,8 @@ def TD_Import : I32EnumAttrCase<"Import", 0, "import">;
 def TD_Export : I32EnumAttrCase<"Export", 1, "export">;
 
 def TrampolineDirection
-    : I32EnumAttr<"TrampolineDirection", "trampoline direction",
-                  [TD_Import, TD_Export]> {
+    : I32EnumAttr<"TrampolineDirection",
+                  "trampoline direction", [TD_Import, TD_Export]> {
   let cppNamespace = "::reussir";
 }
 
@@ -91,28 +89,25 @@ def TrampolineDirection
 //===----------------------------------------------------------------------===//
 def Reussir_DBGIntType : ReussirAttr<"DBGIntType", "dbg_inttype"> {
   let description = "Debug integer type attribute";
-  let parameters = (ins 
-    "::mlir::Type":$innerType, 
-    "bool":$isSigned, 
-    "::mlir::StringAttr":$dbgName);
+  let parameters = (ins "::mlir::Type":$innerType, "bool":$isSigned,
+      "::mlir::StringAttr":$dbgName);
   let assemblyFormat = [{
     `<` `signed` `:`  $isSigned `,` $innerType `,` `name` `:` $dbgName `>`
   }];
 }
 def Reussir_DBGFPType : ReussirAttr<"DBGFPType", "dbg_fptype"> {
   let description = "Debug floating point type attribute";
-  let parameters = (ins "::mlir::Type":$innerType, 
-                    "::mlir::StringAttr":$dbgName);
+  let parameters = (ins "::mlir::Type":$innerType,
+      "::mlir::StringAttr":$dbgName);
   let assemblyFormat = [{
     `<` $innerType `,` `name` `:` $dbgName `>`
   }];
 }
-def Reussir_DBGRecordMember : ReussirAttr<"DBGRecordMember", "dbg_record_member"> {
+def Reussir_DBGRecordMember
+    : ReussirAttr<"DBGRecordMember", "dbg_record_member"> {
   let description = "Debug record type attribute";
-  let parameters = (
-    ins "::mlir::StringAttr":$name,
-    "::mlir::Attribute":$typeAttr
-  );
+  let parameters = (ins "::mlir::StringAttr":$name,
+      "::mlir::Attribute":$typeAttr);
   let assemblyFormat = [{
     `<` `name` `:` $name `,` 
         `type` `:` $typeAttr
@@ -121,12 +116,8 @@ def Reussir_DBGRecordMember : ReussirAttr<"DBGRecordMember", "dbg_record_member"
 }
 def Reussir_DBGRecordType : ReussirAttr<"DBGRecordType", "dbg_recordtype"> {
   let description = "Debug record type attribute";
-  let parameters = (ins 
-    "::mlir::ArrayAttr":$members,
-    "bool":$isVariant,
-    "::mlir::Type":$underlyingType,
-    "::mlir::StringAttr":$dbgName
-  );
+  let parameters = (ins "::mlir::ArrayAttr":$members, "bool":$isVariant,
+      "::mlir::Type":$underlyingType, "::mlir::StringAttr":$dbgName);
   let assemblyFormat = [{
     `<` 
         `members` `:` $members `,`
@@ -138,10 +129,9 @@ def Reussir_DBGRecordType : ReussirAttr<"DBGRecordType", "dbg_recordtype"> {
 }
 def Reussir_DBGSubprogram : ReussirAttr<"DBGSubprogram", "dbg_subprogram"> {
   let description = "Debug subprogram attribute";
-  let parameters = (ins
-    "::mlir::StringAttr":$rawName,
-    "::mlir::ArrayAttr":$typeParams
-    
+  let parameters = (ins "::mlir::StringAttr":$rawName,
+      "::mlir::ArrayAttr":$typeParams
+
   );
   let assemblyFormat = [{
     `<`
@@ -154,10 +144,8 @@ def Reussir_DBGSubprogram : ReussirAttr<"DBGSubprogram", "dbg_subprogram"> {
 // For now, let's focus on basic types and unboxed record types
 def Reussir_DBGLocalVar : ReussirAttr<"DBGLocalVar", "dbg_localvar"> {
   let description = "Debug local variable attribute";
-  let parameters = (ins
-    "::mlir::Attribute":$dbgType,
-    "::mlir::StringAttr":$varName
-  );
+  let parameters = (ins "::mlir::Attribute":$dbgType,
+      "::mlir::StringAttr":$varName);
   let assemblyFormat = [{
     `<`
         `type` `:` $dbgType `,`
@@ -169,26 +157,20 @@ def Reussir_DBGLocalVar : ReussirAttr<"DBGLocalVar", "dbg_localvar"> {
 // pointer to a box `{ header, payload }`. `dbgType` describes the payload; the
 // debug-info pass presents the variable as the payload, reached by
 // dereferencing the pointer and skipping the box header (a `DW_OP_deref,
-// DW_OP_plus_uconst` expression on the `dbg.declare`). The two box flavours have
-// different header sizes — a shared box has a single ref-count word, a regional
-// box a three-word `{ status, next, vtable }` header — so `regional` selects
-// which to skip past. Once the `rc` is lowered to an opaque pointer the box type
-// is unrecoverable, hence the flag is carried here.
+// DW_OP_plus_uconst` expression on the `dbg.declare`). The two box flavours
+// have different header sizes — a shared box has a single ref-count word, a
+// regional box a three-word `{ status, next, vtable }` header — so `regional`
+// selects which to skip past. Once the `rc` is lowered to an opaque pointer the
+// box type is unrecoverable, hence the flag is carried here.
 def Reussir_DBGBoxedType : ReussirAttr<"DBGBoxedType", "dbg_boxedtype"> {
   let description = "Debug type for a reference-counted (boxed) value";
-  let parameters = (ins
-    "::mlir::Attribute":$dbgType,
-    "bool":$regional
-  );
+  let parameters = (ins "::mlir::Attribute":$dbgType, "bool":$regional);
   let assemblyFormat = [{ `<` $dbgType `,` `regional` `:` $regional `>` }];
 }
 def Reussir_DBGFuncArg : ReussirAttr<"DBGFuncArg", "dbg_func_arg"> {
   let description = "Debug function argument attribute";
-  let parameters = (ins
-    "::mlir::Attribute":$dbgType,
-    "::mlir::StringAttr":$argName,
-    "unsigned":$argIndex
-  );
+  let parameters = (ins "::mlir::Attribute":$dbgType,
+      "::mlir::StringAttr":$argName, "unsigned":$argIndex);
   let assemblyFormat = [{
     `<`
         `type` `:` $dbgType `,`

--- a/include/Reussir/IR/ReussirDialect.td
+++ b/include/Reussir/IR/ReussirDialect.td
@@ -38,7 +38,7 @@ def ReussirDialect : Dialect {
       "mlir::LLVM::LLVMDialect",
       // UB Dialect
       "mlir::ub::UBDialect",
-    ];
+  ];
   let extraClassDeclaration = [{
   private:
     // Register the builtin Attributes.

--- a/include/Reussir/IR/ReussirInterfaces.td
+++ b/include/Reussir/IR/ReussirInterfaces.td
@@ -29,64 +29,57 @@ def TokenAcceptorInterface : OpInterface<"TokenAcceptor"> {
 
   let cppNamespace = "::reussir";
 
-  let methods = [
-    InterfaceMethod<
-      /*desc=*/"Get the expected token type for this operation.",
-      /*retTy=*/"::reussir::TokenType",
-      /*methodName=*/"getTokenType",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/""
-    >,
-    InterfaceMethod<
-      /*desc=*/"Check whether the operation has been assigned a token.",
-      /*retTy=*/"bool",
-      /*methodName=*/"hasToken",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
+  let methods =
+      [InterfaceMethod<
+           /*desc=*/"Get the expected token type for this operation.",
+           /*retTy=*/"::reussir::TokenType",
+           /*methodName=*/"getTokenType",
+           /*args=*/(ins),
+           /*methodBody=*/"",
+           /*defaultImplementation=*/"">,
+       InterfaceMethod<
+           /*desc=*/"Check whether the operation has been assigned a token.",
+           /*retTy=*/"bool",
+           /*methodName=*/"hasToken",
+           /*args=*/(ins),
+           /*methodBody=*/"",
+           /*defaultImplementation=*/[{
         return $_op.getToken() != nullptr;
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Assign a token value to this operation.",
-      /*retTy=*/"void",
-      /*methodName=*/"assignToken",
-      /*args=*/(ins "::mlir::Value":$token),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
+      }]>,
+       InterfaceMethod<
+           /*desc=*/"Assign a token value to this operation.",
+           /*retTy=*/"void",
+           /*methodName=*/"assignToken",
+           /*args=*/(ins "::mlir::Value":$token),
+           /*methodBody=*/"",
+           /*defaultImplementation=*/[{
         $_op.getTokenMutable().assign(token);
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Remove the token from this operation and return it.",
-      /*retTy=*/"::mlir::Value",
-      /*methodName=*/"removeToken",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
+      }]>,
+       InterfaceMethod<
+           /*desc=*/"Remove the token from this operation and return it.",
+           /*retTy=*/"::mlir::Value",
+           /*methodName=*/"removeToken",
+           /*args=*/(ins),
+           /*methodBody=*/"",
+           /*defaultImplementation=*/[{
         ::mlir::Value token = $_op.getToken();
         $_op.getTokenMutable().clear();
         return token;
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Get the current token value (may be null).",
-      /*retTy=*/"::mlir::Value",
-      /*methodName=*/"getToken",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/""
-    >,
-    InterfaceMethod<
-      /*desc=*/"Get mutable access to the token operand.",
-      /*retTy=*/"::mlir::MutableOperandRange",
-      /*methodName=*/"getTokenMutable",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/""
-    >
-  ];
+      }]>,
+       InterfaceMethod<
+           /*desc=*/"Get the current token value (may be null).",
+           /*retTy=*/"::mlir::Value",
+           /*methodName=*/"getToken",
+           /*args=*/(ins),
+           /*methodBody=*/"",
+           /*defaultImplementation=*/"">,
+       InterfaceMethod<
+           /*desc=*/"Get mutable access to the token operand.",
+           /*retTy=*/"::mlir::MutableOperandRange",
+           /*methodName=*/"getTokenMutable",
+           /*args=*/(ins),
+           /*methodBody=*/"",
+           /*defaultImplementation=*/"">];
 }
 
 //===----------------------------------------------------------------------===//
@@ -103,63 +96,59 @@ def TokenProducerInterface : OpInterface<"TokenProducer"> {
 
   let cppNamespace = "::reussir";
 
-  let methods = [
-    InterfaceMethod<
-      /*desc=*/"Check if the operation should produce a token.",
-      /*retTy=*/"bool",
-      /*methodName=*/"shouldProduceToken",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/""
-    >,
-    InterfaceMethod<
-      /*desc=*/"Check if the operation's token production can be nullable.",
-      /*retTy=*/"bool",
-      /*methodName=*/"isNullable",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/""
-    >,
-    InterfaceMethod<
-      /*desc=*/"Get the token type if shouldProduceToken, otherwise return null.",
-      /*retTy=*/"::reussir::TokenType",
-      /*methodName=*/"getTokenType",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/""
-    >,
-    InterfaceMethod<
-      /*desc=*/"Get the actual produced type (e.g., Nullable<TokenType> if nullable).",
-      /*retTy=*/"::mlir::Type",
-      /*methodName=*/"getProducedType",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
+  let methods = [InterfaceMethod<
+                     /*desc=*/"Check if the operation should produce a token.",
+                     /*retTy=*/"bool",
+                     /*methodName=*/"shouldProduceToken",
+                     /*args=*/(ins),
+                     /*methodBody=*/"",
+                     /*defaultImplementation=*/"">,
+                 InterfaceMethod<
+                     /*desc=*/"Check if the operation's token production can "
+                              "be nullable.",
+                     /*retTy=*/"bool",
+                     /*methodName=*/"isNullable",
+                     /*args=*/(ins),
+                     /*methodBody=*/"",
+                     /*defaultImplementation=*/"">,
+                 InterfaceMethod<
+                     /*desc=*/"Get the token type if shouldProduceToken, "
+                              "otherwise return null.",
+                     /*retTy=*/"::reussir::TokenType",
+                     /*methodName=*/"getTokenType",
+                     /*args=*/(ins),
+                     /*methodBody=*/"",
+                     /*defaultImplementation=*/"">,
+                 InterfaceMethod<
+                     /*desc=*/"Get the actual produced type (e.g., "
+                              "Nullable<TokenType> if nullable).",
+                     /*retTy=*/"::mlir::Type",
+                     /*methodName=*/"getProducedType",
+                     /*args=*/(ins),
+                     /*methodBody=*/"",
+                     /*defaultImplementation=*/[{
         if (!$_op.shouldProduceToken())
           return nullptr;
         ::reussir::TokenType tokenType = $_op.getTokenType();
         if ($_op.isNullable())
           return ::reussir::NullableType::get($_op.getContext(), tokenType);
         return tokenType;
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Get the value being produced.",
-      /*retTy=*/"::mlir::Value",
-      /*methodName=*/"getProducedValue",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/""
-    >,
-    InterfaceMethod<
-      /*desc=*/"Create and return a new produced value if not yet produced.",
-      /*retTy=*/"::mlir::LogicalResult",
-      /*methodName=*/"replaceWithProduced",
-      /*args=*/(ins "::mlir::PatternRewriter &":$builder),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/""
-    >
-  ];
+      }]>,
+                 InterfaceMethod<
+                     /*desc=*/"Get the value being produced.",
+                     /*retTy=*/"::mlir::Value",
+                     /*methodName=*/"getProducedValue",
+                     /*args=*/(ins),
+                     /*methodBody=*/"",
+                     /*defaultImplementation=*/"">,
+                 InterfaceMethod<
+                     /*desc=*/"Create and return a new produced value if not "
+                              "yet produced.",
+                     /*retTy=*/"::mlir::LogicalResult",
+                     /*methodName=*/"replaceWithProduced",
+                     /*args=*/(ins "::mlir::PatternRewriter &":$builder),
+                     /*methodBody=*/"",
+                     /*defaultImplementation=*/"">];
 }
 
 #endif // REUSSIR_IR_REUSSIRINTERFACES_TD

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -91,10 +91,10 @@ def ReussirCctxExtendOp : ReussirCctxOp<"extend", []> {
     context.
   }];
 
-  let arguments = (ins
-      Arg<ReussirCctxType, "context to extend">:$ctx,
+  let arguments = (ins Arg<ReussirCctxType, "context to extend">:$ctx,
       Arg<ReussirRcType, "constructor plugged into the hole">:$rcPtr,
-      Arg<ReussirHoleType, "the plugged constructor's hole to refocus on">:$hole);
+      Arg<ReussirHoleType,
+          "the plugged constructor's hole to refocus on">:$hole);
   let results = (outs Res<ReussirCctxType, "extended context">:$newCtx);
   let hasVerifier = 1;
   let assemblyFormat = [{
@@ -113,8 +113,7 @@ def ReussirCctxApplyOp : ReussirCctxOp<"apply", []> {
     yields `value` itself. The context is consumed.
   }];
 
-  let arguments = (ins
-      Arg<ReussirCctxType, "context to complete">:$ctx,
+  let arguments = (ins Arg<ReussirCctxType, "context to complete">:$ctx,
       Arg<ReussirRcType, "value filling the final hole">:$value);
   let results = (outs Res<ReussirRcType, "completed value">:$result);
   let hasVerifier = 1;
@@ -221,9 +220,8 @@ def ReussirTokenLaunderOp : ReussirTokenOp<"launder", []> {
   }];
   let results = (outs Res<ReussirTokenType,
                           "output token", [MemAlloc<DefaultResource>]>:$result);
-  let arguments =
-      (ins Arg<ReussirTokenType,
-               "input token", [MemFree<DefaultResource>]>:$token);
+  let arguments = (ins Arg<ReussirTokenType,
+                           "input token", [MemFree<DefaultResource>]>:$token);
   let assemblyFormat = [{
     `(` $token `:` type($token) `)` `:` type($result) attr-dict
   }];
@@ -303,9 +301,11 @@ def ReussirNullableCreateOp : ReussirNullableOp<"create", []> {
   }];
 }
 
-// this is a high-level scf operation, 
+// this is a high-level scf operation,
 // should be expanded before basic ops lowering pass
-def ReussirNullableDispatchOp : ReussirNullableOp<"dispatch", [DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
+def ReussirNullableDispatchOp
+    : ReussirNullableOp<
+          "dispatch", [DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
   let summary = "Dispatch a nullable token";
   let description = [{
     `reussir.nullable.dispatch` is a high-level structured control flow operation.
@@ -329,11 +329,11 @@ def ReussirNullableDispatchOp : ReussirNullableOp<"dispatch", [DeclareOpInterfac
     }
     ```
   }];
-  
+
   let arguments = (ins Arg<ReussirNullableType, "nullable pointer">:$nullable);
   let results = (outs Res<Optional<AnyType>, "dispatched value">:$value);
   let regions = (region SizedRegion<1>:$nonNullRegion,
-                 SizedRegion<1>:$nullRegion);
+      SizedRegion<1>:$nullRegion);
 
   let assemblyFormat = [{
     `(` $nullable `:` type($nullable) `)` ( `->` type($value)^)? `{` `\n`
@@ -360,9 +360,9 @@ def ReussirNullableCoerceOp : ReussirNullableOp<"coerce", []> {
     ```
   }];
 
-  let results = (outs Res<ReussirNonNullPointerType, "non-null pointer">:$nonnull);
-  let arguments =
-      (ins Arg<ReussirNullableType, "nullable pointer">:$nullable);
+  let results =
+      (outs Res<ReussirNonNullPointerType, "non-null pointer">:$nonnull);
+  let arguments = (ins Arg<ReussirNullableType, "nullable pointer">:$nullable);
   let assemblyFormat = [{
     `(` $nullable `:` type($nullable) `)` `:` type($nonnull) attr-dict
   }];
@@ -393,10 +393,9 @@ def ReussirRcIncOp : ReussirRcOp<"inc", []> {
   let hasVerifier = 1;
 }
 
-def ReussirRcDecOp : ReussirRcOp<"dec", [
-  DeclareOpInterfaceMethods<TokenProducerInterface>,
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>
-]> {
+def ReussirRcDecOp
+    : ReussirRcOp<"dec", [DeclareOpInterfaceMethods<TokenProducerInterface>,
+                          DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Decrement reference count";
   let description = [{
     `reussir.rc.dec` decrements the reference count of a RC pointer.
@@ -411,13 +410,11 @@ def ReussirRcDecOp : ReussirRcOp<"dec", [
     __reussir_release_rigid_object. There is no token shall be returned.
   }];
 
-  let arguments = (
-    ins Arg<ReussirRcType, "Reference to decrement">:$rcPtr,
-    OptionalAttr<IndexAttr>:$destructureTag,
-    OptionalAttr<DenseI64ArrayAttr>:$boundMembers
-  );
-  let results =
-      (outs Res<Optional<ReussirNullableTokenType>, "Nullable token">:$nullableToken);
+  let arguments = (ins Arg<ReussirRcType, "Reference to decrement">:$rcPtr,
+      OptionalAttr<IndexAttr>:$destructureTag,
+      OptionalAttr<DenseI64ArrayAttr>:$boundMembers);
+  let results = (outs Res<Optional<ReussirNullableTokenType>,
+                          "Nullable token">:$nullableToken);
 
   let extraClassDeclaration = [{
     /// Whether this decrement *destructures* its box: the consumer took
@@ -516,11 +513,8 @@ def ReussirRcSetOp : ReussirRcOp<"set", []> {
     stored — atomic boxes are decremented with `reussir.rc.fetch_sub`.
   }];
 
-  let arguments = (
-    ins
-      Arg<ReussirRcType, "Reference to update">:$rcPtr,
-      Arg<Index, "New reference count">:$refCount
-  );
+  let arguments = (ins Arg<ReussirRcType, "Reference to update">:$rcPtr,
+      Arg<Index, "New reference count">:$refCount);
 
   let assemblyFormat = [{
     `(` $rcPtr `:` qualified(type($rcPtr)) `,`
@@ -530,11 +524,11 @@ def ReussirRcSetOp : ReussirRcOp<"set", []> {
   let hasVerifier = 1;
 }
 
-def ReussirRcCreateOp : ReussirRcOp<"create", [
-  AttrSizedOperandSegments,
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-  DeclareOpInterfaceMethods<TokenAcceptorInterface>
-]> {
+def ReussirRcCreateOp
+    : ReussirRcOp<
+          "create", [AttrSizedOperandSegments,
+                     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+                     DeclareOpInterfaceMethods<TokenAcceptorInterface>]> {
   let summary = "Create a RC pointer";
   let description = [{
     `reussir.rc.create` creates a RC pointer from a value.
@@ -572,13 +566,9 @@ def ReussirRcCreateOp : ReussirRcOp<"create", [
     ```
   }];
 
-  let arguments = (ins 
-      Arg<AnyType, "value">:$value, 
-      Optional<ReussirTokenType>:$token,
-      Optional<ReussirRegionType>:$region,
-      OptionalAttr<FlatSymbolRefAttr>:$vtable,
-      UnitAttr:$skipRc
-  );
+  let arguments = (ins Arg<AnyType, "value">:$value,
+      Optional<ReussirTokenType>:$token, Optional<ReussirRegionType>:$region,
+      OptionalAttr<FlatSymbolRefAttr>:$vtable, UnitAttr:$skipRc);
   let results = (outs Res<ReussirRcType, "Created RC pointer">:$rcPtr);
 
   let assemblyFormat = [{
@@ -604,11 +594,11 @@ def ReussirRcCreateOp : ReussirRcOp<"create", [
   }];
 }
 
-def ReussirRcCreateCompoundOp : ReussirRcOp<"create_compound", [
-  AttrSizedOperandSegments,
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-  DeclareOpInterfaceMethods<TokenAcceptorInterface>
-]> {
+def ReussirRcCreateCompoundOp
+    : ReussirRcOp<"create_compound",
+                  [AttrSizedOperandSegments,
+                   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+                   DeclareOpInterfaceMethods<TokenAcceptorInterface>]> {
   let summary = "Create a RC pointer from a compound record payload";
   let description = [{
     `reussir.rc.create_compound` fuses `reussir.record.compound` and
@@ -616,17 +606,12 @@ def ReussirRcCreateCompoundOp : ReussirRcOp<"create_compound", [
     directly into the RC box payload.
   }];
 
-  let arguments = (ins
-      Variadic<AnyType>:$fields,
-      Optional<ReussirTokenType>:$token,
-      Optional<ReussirRegionType>:$region,
-      OptionalAttr<FlatSymbolRefAttr>:$vtable,
-      UnitAttr:$skipRc,
+  let arguments = (ins Variadic<AnyType>:$fields,
+      Optional<ReussirTokenType>:$token, Optional<ReussirRegionType>:$region,
+      OptionalAttr<FlatSymbolRefAttr>:$vtable, UnitAttr:$skipRc,
       OptionalAttr<DenseI64ArrayAttr>:$skipFields,
-      OptionalAttr<DenseI64ArrayAttr>:$holeFields
-  );
-  let results = (outs
-      Res<ReussirRcType, "Created RC pointer">:$rcPtr,
+      OptionalAttr<DenseI64ArrayAttr>:$holeFields);
+  let results = (outs Res<ReussirRcType, "Created RC pointer">:$rcPtr,
       Variadic<ReussirHoleType>:$holes);
 
   let assemblyFormat = [{
@@ -656,11 +641,11 @@ def ReussirRcCreateCompoundOp : ReussirRcOp<"create_compound", [
   }];
 }
 
-def ReussirRcCreateVariantOp : ReussirRcOp<"create_variant", [
-  AttrSizedOperandSegments,
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-  DeclareOpInterfaceMethods<TokenAcceptorInterface>
-]> {
+def ReussirRcCreateVariantOp
+    : ReussirRcOp<"create_variant",
+                  [AttrSizedOperandSegments,
+                   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+                   DeclareOpInterfaceMethods<TokenAcceptorInterface>]> {
   let summary = "Create a RC pointer from a variant record payload";
   let description = [{
     `reussir.rc.create_variant` fuses `reussir.record.variant` and
@@ -669,19 +654,13 @@ def ReussirRcCreateVariantOp : ReussirRcOp<"create_variant", [
     directly to represent a fully fused `variant(compound(...))` materialization.
   }];
 
-  let arguments = (ins
-      Arg<IndexAttr, "tag">:$tag,
-      Optional<AnyType>:$value,
-      Variadic<AnyType>:$fields,
-      Optional<ReussirTokenType>:$token,
+  let arguments = (ins Arg<IndexAttr, "tag">:$tag, Optional<AnyType>:$value,
+      Variadic<AnyType>:$fields, Optional<ReussirTokenType>:$token,
       Optional<ReussirRegionType>:$region,
-      OptionalAttr<FlatSymbolRefAttr>:$vtable,
-      UnitAttr:$skipRc,
+      OptionalAttr<FlatSymbolRefAttr>:$vtable, UnitAttr:$skipRc,
       OptionalAttr<DenseI64ArrayAttr>:$skipFields,
-      OptionalAttr<DenseI64ArrayAttr>:$holeFields
-  );
-  let results = (outs
-      Res<ReussirRcType, "Created RC pointer">:$rcPtr,
+      OptionalAttr<DenseI64ArrayAttr>:$holeFields);
+  let results = (outs Res<ReussirRcType, "Created RC pointer">:$rcPtr,
       Variadic<ReussirHoleType>:$holes);
 
   let hasVerifier = 1;
@@ -770,8 +749,9 @@ def ReussirRcCompareImmortalOp : ReussirRcOp<"compare_immortal", [Pure]> {
   }];
 
   let arguments = (ins Arg<ReussirRcType, "rc pointer to classify">:$rcPtr,
-                   Arg<IndexAttr, "tag">:$tag);
-  let results = (outs Res<I1, "whether the value is the arm's immediate">:$result);
+      Arg<IndexAttr, "tag">:$tag);
+  let results =
+      (outs Res<I1, "whether the value is the arm's immediate">:$result);
   let assemblyFormat = [{
     `(` $rcPtr `:` qualified(type($rcPtr)) `)` `tag` `(` $tag `)` attr-dict
   }];
@@ -862,7 +842,8 @@ def ReussirRcAssumeUniqueOp : ReussirRcOp<"assume_unique", []> {
     `reussir.rc.assume_unique` asserts that a RC pointer is unique and is
     intended to lower to `llvm.assume`.
   }];
-  let arguments = (ins Arg<ReussirRcType, "RC pointer to assume unique">:$rcPtr);
+  let arguments =
+      (ins Arg<ReussirRcType, "RC pointer to assume unique">:$rcPtr);
   let assemblyFormat = [{
     `(` $rcPtr `:` qualified(type($rcPtr)) `)` attr-dict
   }];
@@ -933,7 +914,7 @@ def ReussirRecordTagOp : ReussirRecordOp<"tag", []> {
 
     The input must be a reference to a variant record.
   }];
-  
+
   let arguments = (ins Arg<ReussirRefType, "variant record">:$variant);
   let results = (outs Res<Index, "tag">:$tag);
 
@@ -944,10 +925,11 @@ def ReussirRecordTagOp : ReussirRecordOp<"tag", []> {
   let hasVerifier = 1;
 }
 
-
-// This is a high-level scf operation, 
+// This is a high-level scf operation,
 // should be expanded before basic ops lowering pass
-def ReussirRecordDispatchOp : ReussirRecordOp<"dispatch", [DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
+def ReussirRecordDispatchOp
+    : ReussirRecordOp<
+          "dispatch", [DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
   let summary = "Dispatch a record";
   let description = [{
     `reussir.record.dispatch` is a high-level structured control flow operation.
@@ -969,7 +951,7 @@ def ReussirRecordDispatchOp : ReussirRecordOp<"dispatch", [DeclareOpInterfaceMet
     region indices to the actual regions.
   }];
 
-  let arguments = (ins Arg<ReussirRefType, "variant record">:$variant, 
+  let arguments = (ins Arg<ReussirRefType, "variant record">:$variant,
       ArrayAttr:$tagSets);
   let results = (outs Res<Optional<AnyType>, "output value">:$value);
   let regions = (region VariadicRegion<SizedRegion<1>>:$regions);
@@ -990,9 +972,7 @@ def ReussirRecordCoerceOp : ReussirRecordOp<"coerce", []> {
   }];
 
   let results = (outs Res<ReussirRefType, "coerced pointer">:$coerced);
-  let arguments =
-      (ins 
-      IndexAttr:$tag,
+  let arguments = (ins IndexAttr:$tag,
       Arg<ReussirRefType, "variant reference">:$variant);
   let assemblyFormat = [{
     `[` $tag `]` 
@@ -1017,10 +997,8 @@ def ReussirArrayProjectOp : ReussirArrayOp<"project", []> {
     Otherwise, the result is another statically shaped memref with one fewer
     dimension.
   }];
-  let arguments = (ins
-    Arg<AnyType, "array view to project">:$view,
-    Arg<Index, "dynamic index">:$index
-  );
+  let arguments = (ins Arg<AnyType, "array view to project">:$view,
+      Arg<Index, "dynamic index">:$index);
   let results = (outs Res<AnyType, "projected lane or subview">:$projected);
   let assemblyFormat = [{
     `(` $view `:` qualified(type($view)) `)` `[` $index `:` type($index) `]`
@@ -1045,7 +1023,8 @@ def ReussirArrayViewOp : ReussirArrayOp<"view", []> {
 }
 
 def ReussirArrayWithUniqueViewOp : ReussirArrayOp<"with_unique_view", []> {
-  let summary = "Ensure a unique RC array, expose a mutable view, and run a region";
+  let summary =
+      "Ensure a unique RC array, expose a mutable view, and run a region";
   let description = [{
     `reussir.array.with_unique_view` makes sure the input RC array is unique,
     clones it when needed, then executes the body region with a mutable view of
@@ -1067,19 +1046,17 @@ def ReussirArrayWithUniqueViewOp : ReussirArrayOp<"with_unique_view", []> {
 class ReussirCellOp<string mnemonic, list<Trait> traits>
     : ReussirOp<"cell."#mnemonic, traits>;
 
-def ReussirCellCreateOp : ReussirCellOp<"create", [
-  DeclareOpInterfaceMethods<TokenAcceptorInterface>
-]> {
+def ReussirCellCreateOp
+    : ReussirCellOp<
+          "create", [DeclareOpInterfaceMethods<TokenAcceptorInterface>]> {
   let summary = "Create a shared reference-counted cell";
   let description = [{
     `reussir.cell.create` stores `value` in a fresh shared RC cell. The
     allocation token is optional until token instantiation assigns one, and
     must match the complete RC cell box layout when present.
   }];
-  let arguments = (ins
-    Arg<AnyType, "initial value">:$value,
-    Optional<ReussirTokenType>:$token
-  );
+  let arguments = (ins Arg<AnyType, "initial value">:$value,
+      Optional<ReussirTokenType>:$token);
   let results = (outs Res<ReussirRcCellType, "created cell">:$cell);
   let assemblyFormat = [{
     `value` `(` $value `:` type($value) `)`
@@ -1112,10 +1089,8 @@ def ReussirCellSetOp : ReussirCellOp<"set", []> {
     the caller is responsible for supplying the ownership transferred into the
     cell.
   }];
-  let arguments = (ins
-    Arg<AnyType, "replacement value">:$value,
-    Arg<ReussirRcCellType, "cell to update">:$cell
-  );
+  let arguments = (ins Arg<AnyType, "replacement value">:$value,
+      Arg<ReussirRcCellType, "cell to update">:$cell);
   let assemblyFormat = [{
     `(` $value `:` type($value) `,` $cell `:` qualified(type($cell)) `)`
     attr-dict
@@ -1140,15 +1115,12 @@ def ReussirCellRmwOp : ReussirCellOp<"rmw", []> {
   let hasVerifier = 1;
 }
 
-def ReussirCellYieldOp : ReussirCellOp<"yield", [
-  ReturnLike, Terminator,
-  ParentOneOf<["::reussir::ReussirCellRmwOp"]>
-]> {
+def ReussirCellYieldOp
+    : ReussirCellOp<"yield", [ReturnLike, Terminator,
+                              ParentOneOf<["::reussir::ReussirCellRmwOp"]>]> {
   let summary = "Yield a replacement and optional output from cell.rmw";
-  let arguments = (ins
-    Arg<AnyType, "replacement value">:$newValue,
-    Arg<Optional<AnyType>, "optional operation output">:$output
-  );
+  let arguments = (ins Arg<AnyType, "replacement value">:$newValue,
+      Arg<Optional<AnyType>, "optional operation output">:$output);
   let assemblyFormat = [{
     `(` $newValue `:` type($newValue) `)`
     (`output` `(` $output^ `:` type($output) `)`)? attr-dict
@@ -1260,10 +1232,8 @@ def ReussirRefLoadOp : ReussirReferenceOp<"load", []> {
     `reussir.ref.load` loads a reference.
   }];
 
-  let arguments = (ins
-    Arg<ReussirRefType, "reference to load">:$ref,
-    UnitAttr:$invariant_group
-  );
+  let arguments = (ins Arg<ReussirRefType, "reference to load">:$ref,
+      UnitAttr:$invariant_group);
   let results = (outs Res<AnyType, "loaded value">:$value);
 
   let assemblyFormat = [{
@@ -1301,11 +1271,8 @@ def ReussirRefDropOp : ReussirReferenceOp<"drop", []> {
     When variant is specified, the inner element must be a variant record type and
     the index must be inbound.
   }];
-  let arguments = (
-    ins Arg<ReussirRefType, "reference to drop">:$ref,
-    UnitAttr:$inlined,
-    OptionalAttr<IndexAttr>:$variant 
-  );
+  let arguments = (ins Arg<ReussirRefType, "reference to drop">:$ref,
+      UnitAttr:$inlined, OptionalAttr<IndexAttr>:$variant);
 
   let assemblyFormat = [{
     `(` $ref `:` qualified(type($ref)) `)` 
@@ -1316,12 +1283,9 @@ def ReussirRefDropOp : ReussirReferenceOp<"drop", []> {
     attr-dict
   }];
 
-  let builders = [
-    OpBuilder<(ins "mlir::Value":$ref),
-    [{
+  let builders = [OpBuilder<(ins "mlir::Value":$ref), [{
       return build($_builder, $_state, ref, false, nullptr);
-    }]>
-  ];
+    }]>];
 
   let hasVerifier = 1;
 }
@@ -1342,11 +1306,8 @@ def ReussirRefAcquireOp : ReussirReferenceOp<"acquire", []> {
     When variant is specified, the inner element must be a variant record type and
     the index must be inbound.
   }];
-  let arguments = (
-    ins Arg<ReussirRefType, "reference to acquire">:$ref,
-    UnitAttr:$inlined,
-    OptionalAttr<IndexAttr>:$variant
-  );
+  let arguments = (ins Arg<ReussirRefType, "reference to acquire">:$ref,
+      UnitAttr:$inlined, OptionalAttr<IndexAttr>:$variant);
 
   let assemblyFormat = [{
     `(` $ref `:` qualified(type($ref)) `)`
@@ -1357,12 +1318,9 @@ def ReussirRefAcquireOp : ReussirReferenceOp<"acquire", []> {
     attr-dict
   }];
 
-  let builders = [
-    OpBuilder<(ins "mlir::Value":$ref),
-    [{
+  let builders = [OpBuilder<(ins "mlir::Value":$ref), [{
       return build($_builder, $_state, ref, false, nullptr);
-    }]>
-  ];
+    }]>];
 
   let hasVerifier = 1;
 }
@@ -1372,13 +1330,9 @@ def ReussirRefDiffOp : ReussirReferenceOp<"diff", []> {
   let description = [{
     `reussir.ref.diff` computes the difference (target - base) between two refernece pointers.
   }];
-  let arguments = (ins 
-    Arg<ReussirRefType, "base reference">:$base,
-    Arg<ReussirRefType, "target reference">:$target
-  );
-  let results = (outs
-    Res<Index, "difference">:$difference
-  );
+  let arguments = (ins Arg<ReussirRefType, "base reference">:$base,
+      Arg<ReussirRefType, "target reference">:$target);
+  let results = (outs Res<Index, "difference">:$difference);
   let assemblyFormat = [{
     $base `,` $target `:` functional-type(operands, results) attr-dict
   }];
@@ -1389,14 +1343,10 @@ def ReussirRefCmpOp : ReussirReferenceOp<"cmp", []> {
   let description = [{
     `reussir.ref.cmp` computes the difference (target - base) between two refernece pointers.
   }];
-  let arguments = (ins 
-    Arith_CmpIPredicateAttr:$predicate,
-    Arg<ReussirRefType, "left-hand side">:$lhs,
-    Arg<ReussirRefType, "right-hand side">:$rhs
-  );
-  let results = (outs
-    Res<I1, "compare result">:$flag
-  );
+  let arguments = (ins Arith_CmpIPredicateAttr:$predicate,
+      Arg<ReussirRefType, "left-hand side">:$lhs,
+      Arg<ReussirRefType, "right-hand side">:$rhs);
+  let results = (outs Res<I1, "compare result">:$flag);
   let assemblyFormat = [{
     $predicate $lhs `,` $rhs `:` functional-type(operands, results) attr-dict
   }];
@@ -1412,10 +1362,8 @@ def ReussirRefMemcpyOp : ReussirReferenceOp<"memcpy", []> {
     This is a low-level operation that does not perform any reference counting
     or ownership transfer. It simply copies the bytes from source to destination.
   }];
-  let arguments = (ins 
-    Arg<ReussirRefType, "source reference">:$src,
-    Arg<ReussirRefType, "destination reference">:$dst
-  );
+  let arguments = (ins Arg<ReussirRefType, "source reference">:$src,
+      Arg<ReussirRefType, "destination reference">:$dst);
   let assemblyFormat = [{
     $src `to` $dst `:` type($src) `to` type($dst) attr-dict
   }];
@@ -1449,10 +1397,9 @@ def ReussirRegionRunOp
 }
 
 def ReussirRegionYieldOp
-    : ReussirRegionOp<
-          "yield", [Terminator,
-                    ParentOneOf<["::reussir::ReussirRegionRunOp"]>,
-                    ]> {
+    : ReussirRegionOp<"yield", [Terminator,
+                                ParentOneOf<["::reussir::ReussirRegionRunOp"]>,
+]> {
   let summary = "Yield a value from a region";
   let description = [{
     `reussir.region.yield` yields a value from a region.
@@ -1464,10 +1411,9 @@ def ReussirRegionYieldOp
   let hasVerifier = 1;
 }
 
-def ReussirRegionVTableOp 
-    : ReussirRegionOp<"vtable", [
-        Symbol, DeclareOpInterfaceMethods<SymbolUserOpInterface>
-    ]> {
+def ReussirRegionVTableOp
+    : ReussirRegionOp<"vtable", [Symbol, DeclareOpInterfaceMethods<
+                                             SymbolUserOpInterface>]> {
   let summary = "Create a vtable for a region";
   let description = [{
     `reussir.region.vtable` creates a vtable for objects managed via flex/rigid
@@ -1493,11 +1439,8 @@ def ReussirRegionVTableOp
     ```
     Similarly, all offsets are relative to the header start (not the object start).
   }];
-  let arguments = (ins
-    SymbolNameAttr:$sym_name,
-    TypeAttr:$type,
-    OptionalAttr<FlatSymbolRefAttr>:$drop
-  );
+  let arguments = (ins SymbolNameAttr:$sym_name, TypeAttr:$type,
+      OptionalAttr<FlatSymbolRefAttr>:$drop);
   let assemblyFormat = [{
     $sym_name `{`
       `type` `(` $type `)`
@@ -1506,10 +1449,9 @@ def ReussirRegionVTableOp
   }];
 }
 
-// The following are intermediate placeholder operations for high-level constructs
-// that should be lowered before code generation.
-def ReussirRegionCreateOp
-    : ReussirRegionOp<"create", []> {
+// The following are intermediate placeholder operations for high-level
+// constructs that should be lowered before code generation.
+def ReussirRegionCreateOp : ReussirRegionOp<"create", []> {
   let summary = "Create a region";
   let description = [{
     `reussir.region.create` creates a region. This is just a alloca operation
@@ -1521,8 +1463,7 @@ def ReussirRegionCreateOp
   }];
 }
 
-def ReussirRegionCleanupOp
-    : ReussirRegionOp<"cleanup", []> {
+def ReussirRegionCleanupOp : ReussirRegionOp<"cleanup", []> {
   let summary = "Cleanup a region";
   let description = [{
     `reussir.region.cleanup` cleans up a region. This is a placeholder for
@@ -1541,13 +1482,12 @@ def ReussirRegionCleanupOp
 class ReussirScfOp<string mnemonic, list<Trait> traits>
     : ReussirOp<"scf."#mnemonic, traits>;
 
-def ReussirScfYieldOp : ReussirScfOp<"yield", [
-  ReturnLike, Terminator,
-  ParentOneOf<[
-    "::reussir::ReussirNullableDispatchOp", 
-    "::reussir::ReussirRecordDispatchOp",
-    "::reussir::ReussirArrayWithUniqueViewOp"
-  ]>]> {
+def ReussirScfYieldOp
+    : ReussirScfOp<
+          "yield", [ReturnLike, Terminator,
+                    ParentOneOf<["::reussir::ReussirNullableDispatchOp",
+                                 "::reussir::ReussirRecordDispatchOp",
+                                 "::reussir::ReussirArrayWithUniqueViewOp"]>]> {
   let summary = "Yield a value from a scf operation";
   let description = [{
     `reussir.scf.yield` terminates a high-level structured control flow operation.
@@ -1566,11 +1506,11 @@ def ReussirScfYieldOp : ReussirScfOp<"yield", [
 class ReussirClosureOp<string mnemonic, list<Trait> traits>
     : ReussirOp<"closure."#mnemonic, traits>;
 
-
-def ReussirClosureCreateOp : ReussirClosureOp<"create", [
-  IsolatedFromAbove, DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-  DeclareOpInterfaceMethods<TokenAcceptorInterface>
-]> {
+def ReussirClosureCreateOp
+    : ReussirClosureOp<
+          "create", [IsolatedFromAbove,
+                     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+                     DeclareOpInterfaceMethods<TokenAcceptorInterface>]> {
   let summary = "Create a closure";
   let description = [{
     `reussir.closure.create` creates a closure. 
@@ -1639,10 +1579,8 @@ def ReussirClosureCreateOp : ReussirClosureOp<"create", [
 
     Similarly, the drop operation consists of if protected drop functions.
   }];
-  let arguments = (ins
-    Optional<ReussirTokenType>:$token,
-    OptionalAttr<FlatSymbolRefAttr>:$vtable
-  );
+  let arguments = (ins Optional<ReussirTokenType>:$token,
+      OptionalAttr<FlatSymbolRefAttr>:$vtable);
   let regions = (region MaxSizedRegion<1>:$body);
   let results = (outs Res<RcClosureType, "created closure">:$closure);
 
@@ -1661,11 +1599,10 @@ def ReussirClosureCreateOp : ReussirClosureOp<"create", [
   let hasVerifier = 1;
 }
 
-def ReussirClosureYieldOp : ReussirClosureOp<"yield", [
-  ReturnLike, Terminator,
-  ParentOneOf<[
-    "::reussir::ReussirClosureCreateOp"
-  ]>]> {
+def ReussirClosureYieldOp
+    : ReussirClosureOp<
+          "yield", [ReturnLike, Terminator,
+                    ParentOneOf<["::reussir::ReussirClosureCreateOp"]>]> {
   let summary = "Yield from a closure";
   let description = [{
     `reussir.closure.yield` yields from a closure.
@@ -1681,20 +1618,16 @@ def ReussirClosureYieldOp : ReussirClosureOp<"yield", [
   let hasVerifier = 1;
 }
 
-def ReussirClosureVtableOp : ReussirClosureOp<"vtable", [
-  Symbol, DeclareOpInterfaceMethods<SymbolUserOpInterface>
-]> {
+def ReussirClosureVtableOp
+    : ReussirClosureOp<"vtable", [Symbol, DeclareOpInterfaceMethods<
+                                              SymbolUserOpInterface>]> {
   let summary = "Create a vtable";
   let description = [{
     `reussir.closure.vtable` creates a vtable for closures. The VTable is in charge of
     record the function pointer and corresponding drop and clone functions.
   }];
-  let arguments = (ins
-    SymbolNameAttr:$sym_name,
-    FlatSymbolRefAttr:$func,
-    FlatSymbolRefAttr:$drop,
-    FlatSymbolRefAttr:$clone
-  );
+  let arguments = (ins SymbolNameAttr:$sym_name, FlatSymbolRefAttr:$func,
+      FlatSymbolRefAttr:$drop, FlatSymbolRefAttr:$clone);
 
   let assemblyFormat = [{
     $sym_name `{`
@@ -1723,10 +1656,8 @@ def ReussirClosureApplyOp : ReussirClosureOp<"apply", []> {
     ```
   }];
   let hasVerifier = 1;
-  let arguments = (ins
-    Arg<AnyType, "argument to apply">:$arg,
-    Arg<RcClosureType, "closure to apply">:$closure
-  );
+  let arguments = (ins Arg<AnyType, "argument to apply">:$arg,
+      Arg<RcClosureType, "closure to apply">:$closure);
   let results = (outs Res<RcClosureType, "applied closure">:$applied);
   let assemblyFormat = [{
     `(` $arg `:` type($arg) `)` `to` `(` $closure `:` qualified(type($closure)) `)`
@@ -1758,10 +1689,8 @@ def ReussirClosureEvalOp : ReussirClosureOp<"eval", []> {
       with (%a, %b : i32, i32) : i32
     ```
   }];
-  let arguments = (ins
-    Arg<RcClosureType, "closure to evaluate">:$closure,
-    Variadic<AnyType>:$args
-  );
+  let arguments = (ins Arg<RcClosureType, "closure to evaluate">:$closure,
+      Variadic<AnyType>:$args);
   let results = (outs Res<Optional<AnyType>, "result of the closure">:$result);
   let assemblyFormat = [{
     `(` $closure `:` qualified(type($closure)) `)`
@@ -1826,10 +1755,8 @@ def ReussirClosureWpdTestOp : ReussirClosureOp<"wpd_test", []> {
     lowers it to `llvm.type.test(%vtable, !"id")` + `llvm.assume` during
     `translateModuleToLLVMIR`.
   }];
-  let arguments = (ins
-    Arg<AnyType, "lowered pointer to the vtable">:$vtable,
-    StrAttr:$id
-  );
+  let arguments = (ins Arg<AnyType, "lowered pointer to the vtable">:$vtable,
+      StrAttr:$id);
   let assemblyFormat = [{
     `(` $vtable `:` type($vtable) `)` `id` `(` $id `)` attr-dict
   }];
@@ -1841,9 +1768,8 @@ def ReussirClosureInspectPayloadOp : ReussirClosureOp<"inspect_payload", []> {
     `reussir.closure.inspect_payload` serves as an low-level intermediate operation
     that achieves the conversion from ClosureBox reference to subfield reference.
   }];
-  let arguments = (ins 
-    IndexAttr:$payloadIndex,
-    Arg<ReussirClosureBoxRefType, "reference to closure box">:$closureBoxRef);
+  let arguments = (ins IndexAttr:$payloadIndex,
+      Arg<ReussirClosureBoxRefType, "reference to closure box">:$closureBoxRef);
   let results = (outs Res<ReussirRefType, "subfield reference">:$payloadRef);
   let assemblyFormat = [{
     `[` $payloadIndex `]` `(` $closureBoxRef `)` `:` 
@@ -1857,9 +1783,8 @@ def ReussirClosureCursorOp : ReussirClosureOp<"cursor", []> {
     `reussir.closure.cursor` operation extracts the cursor pointer from the
     closure box pointer as an i8 reference.
   }];
-  let arguments = (ins 
-    IndexAttr:$payloadIndex,
-    Arg<ReussirClosureBoxRefType, "reference to closure box">:$closureBoxRef);
+  let arguments = (ins IndexAttr:$payloadIndex,
+      Arg<ReussirClosureBoxRefType, "reference to closure box">:$closureBoxRef);
   let results = (outs Res<ReussirRefType, "i8 reference">:$cursor);
   let assemblyFormat = [{
    `(` $closureBoxRef `:` qualified(type($closureBoxRef)) `)` `:`
@@ -1874,10 +1799,9 @@ def ReussirClosureInstantiateOp : ReussirClosureOp<"instantiate", []> {
     `reussir.closure.instantiate` operation instantiate a token into a special
     RC-wrapped payload box and setting the refcnt to 1.
   }];
-  let arguments = (ins
-    Arg<ReussirTokenType, "source token">:$token
-  );
-  let results = (outs Res<ReussirRcType, "pointer to the payload box">:$closureBoxRc);
+  let arguments = (ins Arg<ReussirTokenType, "source token">:$token);
+  let results =
+      (outs Res<ReussirRcType, "pointer to the payload box">:$closureBoxRc);
   let assemblyFormat = [{
     `(` $token `:` qualified(type($token)) `)` `:` qualified(type($closureBoxRc)) attr-dict
   }];
@@ -1889,10 +1813,8 @@ def ReussirClosureTransferOp : ReussirClosureOp<"transfer", []> {
   let description = [{
     `reussir.closure.transfer` copy bytes between two closure boxes.
   }];
-  let arguments = (ins 
-    Arg<ReussirClosureBoxRefType, "source reference">:$src,
-    Arg<ReussirClosureBoxRefType, "destination reference">:$dst
-  );
+  let arguments = (ins Arg<ReussirClosureBoxRefType, "source reference">:$src,
+      Arg<ReussirClosureBoxRefType, "destination reference">:$dst);
   let assemblyFormat = [{
     $src `to` $dst `:` type($src) `to` type($dst) attr-dict
   }];
@@ -1914,11 +1836,9 @@ def ReussirPolyFFIOp : ReussirOp<"polyffi", []> {
     meaning that instantiate the FFI format of the type.
   }];
 
-  let arguments = (ins
-    OptionalAttr<StrAttr>:$moduleTexture,
-    OptionalAttr<ElementsAttr>:$compiledModule,
-    OptionalAttr<DictionaryAttr>:$substitutions
-  );
+  let arguments = (ins OptionalAttr<StrAttr>:$moduleTexture,
+      OptionalAttr<ElementsAttr>:$compiledModule,
+      OptionalAttr<DictionaryAttr>:$substitutions);
 
   let assemblyFormat = [{
     oilist (
@@ -1949,9 +1869,9 @@ def ReussirStrGlobalOp : ReussirStrOp<"global", [Symbol]> {
   }];
 }
 
-def ReussirStrLiteralOp : ReussirStrOp<"literal", [
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>
-]> {
+def ReussirStrLiteralOp
+    : ReussirStrOp<
+          "literal", [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Create a global string literal";
   let description = [{
     `reussir.str.literal` creates a reference to a global string literal.
@@ -1981,8 +1901,8 @@ def ReussirStrByteAtOp : ReussirStrOp<"byte_at", []> {
   let description = [{
     `reussir.str.byte_at` returns the character at a byte offset. Return 0 if the index is out of bounds.
   }];
-  let arguments = (ins Arg<ReussirStrType, "String to get character from">:$str, 
-    Arg<Index, "Index of character to get">:$index);
+  let arguments = (ins Arg<ReussirStrType, "String to get character from">:$str,
+      Arg<Index, "Index of character to get">:$index);
   let results = (outs Res<I8, "Character at index">:$charVal);
   let assemblyFormat = [{
     `(` $str `:` type($str) `)` 
@@ -1997,8 +1917,8 @@ def ReussirStrUnsafeByteAtOp : ReussirStrOp<"unsafe_byte_at", []> {
     `reussir.str.unsafe_byte_at` returns the character at a byte offset. 
     Undefined behavior if the index is out of bounds.
   }];
-  let arguments = (ins Arg<ReussirStrType, "String to get character from">:$str, 
-    Arg<Index, "Index of character to get">:$index);
+  let arguments = (ins Arg<ReussirStrType, "String to get character from">:$str,
+      Arg<Index, "Index of character to get">:$index);
   let results = (outs Res<I8, "Character at index">:$charVal);
   let assemblyFormat = [{
     `(` $str `:` type($str) `)` 
@@ -2008,16 +1928,16 @@ def ReussirStrUnsafeByteAtOp : ReussirStrOp<"unsafe_byte_at", []> {
 }
 
 def ReussirStrCastOp : ReussirStrOp<"cast", []> {
-   let summary = "Cast a global string literal to a local string literal";
-   let description = [{
+  let summary = "Cast a global string literal to a local string literal";
+  let description = [{
     `reussir.str.cast` casts a global string literal to a local string literal.
    }];
-   let arguments = (ins Arg<ReussirStrType, "Global string literal">:$globalStr);
-   let results = (outs Res<ReussirStrType, "Local string literal">:$localStr);
-   let assemblyFormat = [{
+  let arguments = (ins Arg<ReussirStrType, "Global string literal">:$globalStr);
+  let results = (outs Res<ReussirStrType, "Local string literal">:$localStr);
+  let assemblyFormat = [{
     `(` $globalStr `:` type($globalStr) `)` `:` type($localStr) attr-dict
    }];
-   let hasVerifier = 1;
+  let hasVerifier = 1;
 }
 
 def ReussirStrSelectOp : ReussirStrOp<"select", []> {
@@ -2025,23 +1945,25 @@ def ReussirStrSelectOp : ReussirStrOp<"select", []> {
   let description = [{
     `reussir.str.select` selects the first matched pattern of the string.
   }];
-  let arguments = (ins Arg<ReussirStrType, "String to select">:$str, 
-    Arg<ArrayAttr, "Patterns to match">:$patterns);
-  let results = (outs Res<Index, "Selected pattern">:$selected, 
-    Res<I1, "Matched found">:$found);
+  let arguments = (ins Arg<ReussirStrType, "String to select">:$str,
+      Arg<ArrayAttr, "Patterns to match">:$patterns);
+  let results = (outs Res<Index, "Selected pattern">:$selected,
+      Res<I1, "Matched found">:$found);
   let assemblyFormat = [{
     `(` $str `)` $patterns `:` functional-type(operands, results) attr-dict
   }];
 }
 
 def ReussirStrStartWithOp : ReussirStrOp<"startswith", []> {
-   let summary = "Check if the string starts with a prefix";
-   let description = [{
+  let summary = "Check if the string starts with a prefix";
+  let description = [{
     `reussir.str.startswith` checks if the string starts with a prefix.
    }];
-   let arguments = (ins Arg<ReussirStrType, "String to check">:$str, Arg<StrAttr, "Prefix to check">:$prefix);
-   let results = (outs Res<I1, "Whether the string starts with the prefix">:$startsWith);
-   let assemblyFormat = [{
+  let arguments = (ins Arg<ReussirStrType, "String to check">:$str,
+      Arg<StrAttr, "Prefix to check">:$prefix);
+  let results =
+      (outs Res<I1, "Whether the string starts with the prefix">:$startsWith);
+  let assemblyFormat = [{
     `(` $str `:` type($str) `)` 
     $prefix 
     `:` type($startsWith) attr-dict
@@ -2049,14 +1971,16 @@ def ReussirStrStartWithOp : ReussirStrOp<"startswith", []> {
 }
 
 def ReussirStrUnsafeStartWithOp : ReussirStrOp<"unsafe_startswith", []> {
-   let summary = "Check if the string starts with a prefix without bounds check";
-   let description = [{
+  let summary = "Check if the string starts with a prefix without bounds check";
+  let description = [{
     `reussir.str.unsafe_startswith` checks if the string starts with a prefix.
     Undefined behavior if the prefix is longer than the string.
    }];
-   let arguments = (ins Arg<ReussirStrType, "String to check">:$str, Arg<StrAttr, "Prefix to check">:$prefix);
-   let results = (outs Res<I1, "Whether the string starts with the prefix">:$startsWith);
-   let assemblyFormat = [{
+  let arguments = (ins Arg<ReussirStrType, "String to check">:$str,
+      Arg<StrAttr, "Prefix to check">:$prefix);
+  let results =
+      (outs Res<I1, "Whether the string starts with the prefix">:$startsWith);
+  let assemblyFormat = [{
     `(` $str `:` type($str) `)` 
     $prefix 
     `:` type($startsWith) attr-dict
@@ -2069,16 +1993,17 @@ def ReussirStrSliceOp : ReussirStrOp<"slice", []> {
     `reussir.str.slice` returns a substring starting from the given offset.
     If offset is greater than length, returns an empty string.
   }];
-  let arguments = (ins Arg<ReussirStrType, "String to slice">:$str, Arg<Index, "Byte offset">:$offset);
+  let arguments = (ins Arg<ReussirStrType, "String to slice">:$str,
+      Arg<Index, "Byte offset">:$offset);
   let results = (outs Res<ReussirStrType, "Sliced string">:$result);
   let assemblyFormat = [{
     `(` $str `:` type($str) `)` `[` $offset `]` `:` type($result) attr-dict
   }];
 }
 
-def ReussirTrampolineOp : ReussirOp<"trampoline", [
-  Symbol, DeclareOpInterfaceMethods<SymbolUserOpInterface>
-]> {
+def ReussirTrampolineOp
+    : ReussirOp<"trampoline", [Symbol, DeclareOpInterfaceMethods<
+                                           SymbolUserOpInterface>]> {
   let summary = "Trampoline for FFI calls";
   let description = [{
     `reussir.trampoline` describes an FFI boundary shim. The `direction`
@@ -2100,13 +2025,12 @@ def ReussirTrampolineOp : ReussirOp<"trampoline", [
 
     Currently only the `"C"` ABI is supported.
   }];
-  let arguments = (ins 
-    DefaultValuedAttr<TrampolineDirection,
-                      "::reussir::TrampolineDirection::Export">:$direction,
-    Arg<FlatSymbolRefAttr, "Wrapped target function">:$target,
-    Arg<StrAttr, "ABI Name">:$abi_name,
-    Arg<SymbolNameAttr, "Trampoline symbol name">:$sym_name
-  );
+  let arguments = (ins DefaultValuedAttr<
+                       TrampolineDirection,
+                       "::reussir::TrampolineDirection::Export">:$direction,
+      Arg<FlatSymbolRefAttr, "Wrapped target function">:$target,
+      Arg<StrAttr, "ABI Name">:$abi_name,
+      Arg<SymbolNameAttr, "Trampoline symbol name">:$sym_name);
   let assemblyFormat = [{
     $direction $abi_name $sym_name `=` $target attr-dict
   }];

--- a/include/Reussir/IR/ReussirTypeDetails.h
+++ b/include/Reussir/IR/ReussirTypeDetails.h
@@ -101,7 +101,8 @@ struct RecordTypeStorage : public mlir::TypeStorage {
   llvm::LogicalResult mutate(mlir::TypeStorageAllocator &allocator,
                              llvm::ArrayRef<mlir::Type> members,
                              llvm::ArrayRef<bool> memberIsField,
-                             reussir::Capability defaultCapability, bool fixed) {
+                             reussir::Capability defaultCapability,
+                             bool fixed) {
 
     // Anonymous records cannot mutate.
     if (!name)
@@ -109,10 +110,9 @@ struct RecordTypeStorage : public mlir::TypeStorage {
 
     // Mutation of complete records are allowed if they change nothing.
     if (complete)
-      return llvm::success(members == this->members &&
-                           memberIsField == this->memberIsField &&
-                           defaultCapability == this->defaultCapability &&
-                           fixed == this->fixed);
+      return llvm::success(
+          members == this->members && memberIsField == this->memberIsField &&
+          defaultCapability == this->defaultCapability && fixed == this->fixed);
 
     // Mutate incomplete records.
     this->members = allocator.copyInto(members);

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -258,10 +258,9 @@ def ReussirRegionType
 // Reussir Rc Type
 //===----------------------------------------------------------------------===//
 def ReussirRcType
-    : ReussirType<
-          "Rc", "rc",
-          [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-           MemRefElementTypeInterface]> {
+    : ReussirType<"Rc", "rc",
+                  [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+                   MemRefElementTypeInterface]> {
   let summary = "Reussir Reference Counted Type";
   let description = [{
     `reussir.rc` represents a reference counted object. It is used to manage the
@@ -323,9 +322,9 @@ def ReussirNullableType
 // Reussir Cell Type
 //===----------------------------------------------------------------------===//
 def ReussirCellType
-    : ReussirType<
-          "Cell", "cell",
-          [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>, MutableType]> {
+    : ReussirType<"Cell", "cell",
+                  [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+                   MutableType]> {
   let summary = "Reussir mutable cell payload type";
   let description = [{
     `reussir.cell` is the one-element mutable payload of a shared reference
@@ -407,8 +406,7 @@ def ReussirHoleType
 //===----------------------------------------------------------------------===//
 // Reussir Constructor Context Type
 //===----------------------------------------------------------------------===//
-def ReussirCctxType
-    : ReussirType<"Cctx", "cctx"> {
+def ReussirCctxType : ReussirType<"Cctx", "cctx"> {
   let summary = "Reussir first-class constructor context";
   let description = [{
     `reussir.cctx` is a first-class constructor context (Koka-style `ctx`): a
@@ -502,8 +500,7 @@ def ReussirRcBoxType
 //===----------------------------------------------------------------------===//
 // Reussir Closure Type
 //===----------------------------------------------------------------------===//
-def ReussirClosureType
-    : ReussirType<"Closure", "closure"> {
+def ReussirClosureType : ReussirType<"Closure", "closure"> {
   let summary = "Reussir Closure Type";
   let description = [{
     `reussir.closure` represents a closure. 
@@ -511,10 +508,8 @@ def ReussirClosureType
     RcBox wrapping a ClosureBox. The ClosureBox contains the payload values
     captured by the closure.
   }];
-  let parameters = (ins
-    ArrayRefParameter<"::mlir::Type">:$inputTypes,
-    OptionalParameter<"::mlir::Type">:$outputType
-  );
+  let parameters = (ins ArrayRefParameter<"::mlir::Type">:$inputTypes,
+      OptionalParameter<"::mlir::Type">:$outputType);
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{
     static constexpr size_t VTABLE_DROP_INDEX = 0;
@@ -524,7 +519,8 @@ def ReussirClosureType
 }
 
 def ReussirClosureBoxType
-    : ReussirType<"ClosureBox", "closure_box", [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
+    : ReussirType<"ClosureBox", "closure_box",
+                  [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
   let summary = "Reussir Closure Box Type";
   let description = [{
     `reussir.closure` represents a closure. It roughly corresponds to the 
@@ -537,9 +533,7 @@ def ReussirClosureBoxType
     }
     ```
   }];
-  let parameters = (ins
-    ArrayRefParameter<"::mlir::Type">:$payloadTypes
-  );
+  let parameters = (ins ArrayRefParameter<"::mlir::Type">:$payloadTypes);
   let assemblyFormat = "`<` $payloadTypes `>`";
   let extraClassDeclaration = [{
     static constexpr size_t VTABLE_INDEX = 0;
@@ -548,10 +542,9 @@ def ReussirClosureBoxType
 }
 
 def ReussirArrayType
-    : ReussirType<
-          "Array", "array",
-          [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-           ShapedTypeInterface]> {
+    : ReussirType<"Array", "array",
+                  [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+                   ShapedTypeInterface]> {
   let summary = "Reussir fixed-size inline array type";
   let description = [{
     `reussir.array` represents a statically shaped inline array payload.
@@ -573,8 +566,8 @@ def ReussirArrayType
 
 def ReussirViewType
     : ReussirType<
-          "View", "view",
-          [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
+          "View",
+          "view", [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
   let summary = "Reussir array view type";
   let description = [{
     `reussir.view` represents a temporary region-scoped view of an array payload.
@@ -590,31 +583,25 @@ def ReussirViewType
   }];
 }
 
-def ReussirFFIObjectType
-    : ReussirType<"FFIObject", "ffi_object", []> {
+def ReussirFFIObjectType : ReussirType<"FFIObject", "ffi_object", []> {
   let summary = "Reussir FFIObject Object Type";
   let description = [{
     `reussir.ffi_object` is a special opaque type that is always
     behind a RC pointer. Its dec operation, however, is handled by an FFI call.
   }];
-  let parameters = (ins
-    "::mlir::StringAttr":$ffiName,
-    "::mlir::FlatSymbolRefAttr":$cleanupHook
-  );
+  let parameters = (ins "::mlir::StringAttr":$ffiName,
+      "::mlir::FlatSymbolRefAttr":$cleanupHook);
   let assemblyFormat = "`<` $ffiName `,` $cleanupHook `>`";
 }
 
-def ReussirStrType
-  : ReussirType<"Str", "str", []> {
+def ReussirStrType : ReussirType<"Str", "str", []> {
   let summary = "Reussir String Reference Type";
   let description = [{
     `reussir.str` is for str reference. Unlike rust, it only has two variants:
     - *global*: can be materialized
     - *local*: should not be materialized
   }];
-  let parameters = (ins
-    "::reussir::LifeScope":$lifeScope
-  );
+  let parameters = (ins "::reussir::LifeScope":$lifeScope);
   let assemblyFormat = "`<` $lifeScope `>`";
 }
 
@@ -627,13 +614,16 @@ def RcClosureType : Type<CPred<[{
   ::llvm::isa<::reussir::ClosureType>(
     ::llvm::cast<::reussir::RcType>($_self).getElementType()) &&
   !::llvm::cast<::reussir::RcType>($_self).isRegional()
-  }]>, "Reussir rc closure type", "::reussir::RcType">;
+  }]>,
+                         "Reussir rc closure type", "::reussir::RcType">;
 
-def ReussirNullableTokenType : Type<CPred<[{
+def ReussirNullableTokenType
+    : Type<CPred<[{
   ::llvm::isa<::reussir::NullableType>($_self) && 
   ::llvm::isa<::reussir::TokenType>(
     ::llvm::cast<::reussir::NullableType>($_self).getPtrTy())
-  }]>, "Reussir nullable token type", "::reussir::NullableType">;
+  }]>,
+           "Reussir nullable token type", "::reussir::NullableType">;
 
 def ReussirCompoundType
     : Type<CPred<[{
@@ -644,40 +634,43 @@ def ReussirVariantType : Type<CPred<[{
   ::llvm::cast<::reussir::RecordType>($_self).isVariant()}]>,
                               "Reussir variant type", "::reussir::RecordType">;
 
-def ReussirRcClosureType
-    : Type<CPred<[{
+def ReussirRcClosureType : Type<CPred<[{
     ::llvm::isa<::reussir::ClosureType>(
       ::llvm::cast<::reussir::RcType>($_self).getElementType())
-    }]>, "Reussir rc closure type", "::reussir::RcType">;
+    }]>,
+                                "Reussir rc closure type", "::reussir::RcType">;
 
 def ReussirClosureBoxRefType
     : Type<CPred<[{
     ::llvm::isa<::reussir::ClosureBoxType>(
       ::llvm::cast<::reussir::RefType>($_self).getElementType())
-    }]>, "Reussir closure box reference type", "::reussir::RefType">;
+    }]>,
+           "Reussir closure box reference type", "::reussir::RefType">;
 
 def ReussirArrayPayloadType
     : Type<CPred<[{
     ::llvm::isa<::reussir::ArrayType>($_self)
-    }]>, "Reussir array payload type", "::reussir::ArrayType">;
+    }]>,
+           "Reussir array payload type", "::reussir::ArrayType">;
 
 def ReussirArrayViewType
     : Type<CPred<[{
     ::llvm::isa<::reussir::ViewType>($_self)
-    }]>, "Reussir array view type", "::reussir::ViewType">;
+    }]>,
+           "Reussir array view type", "::reussir::ViewType">;
 
-def ReussirRcArrayType
-    : Type<CPred<[{
+def ReussirRcArrayType : Type<CPred<[{
     ::llvm::isa<::reussir::RcType>($_self) &&
     ::llvm::isa<::reussir::ArrayType>(
       ::llvm::cast<::reussir::RcType>($_self).getElementType())
-    }]>, "Reussir rc array type", "::reussir::RcType">;
+    }]>,
+                              "Reussir rc array type", "::reussir::RcType">;
 
-def ReussirRcCellType
-    : Type<CPred<[{
+def ReussirRcCellType : Type<CPred<[{
     ::llvm::isa<::reussir::RcType>($_self) &&
     ::llvm::isa<::reussir::CellType>(
       ::llvm::cast<::reussir::RcType>($_self).getElementType())
-    }]>, "Reussir rc cell type", "::reussir::RcType">;
+    }]>,
+                             "Reussir rc cell type", "::reussir::RcType">;
 
 #endif // REUSSIR_IR_REUSSIRTYPES_TD

--- a/include/Reussir/LLVMPass/AllocationSimplication.h
+++ b/include/Reussir/LLVMPass/AllocationSimplication.h
@@ -25,4 +25,3 @@ public:
 };
 
 } // namespace reussir::llvmpass
-

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -149,9 +149,10 @@ def ReussirTokenReusePass
     `reussir-token-reuse` reuses tokens for operations.
   }];
 
-  let options = [
-    Option<"reuseAcrossCall", "reuse-across-call", "bool", /*default=*/"false",
-        "allow token reuse across function calls (may increase peak heap usage)">,
+  let options = [Option<"reuseAcrossCall", "reuse-across-call", "bool",
+                        /*default=*/"false",
+                        "allow token reuse across function calls (may increase "
+                        "peak heap usage)">,
   ];
 
   let dependentDialects = ["::reussir::ReussirDialect"];
@@ -175,7 +176,8 @@ def ReussirInvariantGroupAnalysisPass
 
 def ReussirUniqueCarryingRecursionAnalysisPass
     : Pass<"reussir-unique-carrying-recursion-analysis", "::mlir::ModuleOp"> {
-  let summary = "analyze uniqueness-carrying recursion and outline unique clones";
+  let summary =
+      "analyze uniqueness-carrying recursion and outline unique clones";
   let description = [{
     `reussir-unique-carrying-recursion-analysis` computes, per rc-typed
     function result, whether the returned value is on every path either
@@ -203,7 +205,8 @@ def ReussirUniqueCarryingRecursionAnalysisPass
 
 def ReussirTRMCRecursionAnalysisPass
     : Pass<"reussir-trmc-recursion-analysis", "::mlir::ModuleOp"> {
-  let summary = "tail recursion modulo constructors via first-class constructor contexts";
+  let summary =
+      "tail recursion modulo constructors via first-class constructor contexts";
   let description = [{
     `reussir-trmc-recursion-analysis` splits every directly self-recursive
     function returning an rc-boxed value whose recursion feeds a fused
@@ -220,8 +223,7 @@ def ReussirTRMCRecursionAnalysisPass
   }];
   let dependentDialects = ["::reussir::ReussirDialect",
                            "::mlir::func::FuncDialect",
-                           "::mlir::scf::SCFDialect",
-                           "::mlir::ub::UBDialect",
+                           "::mlir::scf::SCFDialect", "::mlir::ub::UBDialect",
                            "::mlir::LLVM::LLVMDialect"];
 }
 

--- a/lib/CAPI/Attrs.cpp
+++ b/lib/CAPI/Attrs.cpp
@@ -8,8 +8,9 @@
 
 #include "Reussir-c/Attrs.h"
 
-// Complete mlir::DialectVersion before MLIR C API headers reach BytecodeWriter.h;
-// MSVC's STL rejects destroying unique_ptr<T> when T is only forward declared.
+// Complete mlir::DialectVersion before MLIR C API headers reach
+// BytecodeWriter.h; MSVC's STL rejects destroying unique_ptr<T> when T is only
+// forward declared.
 #include <mlir/Bytecode/BytecodeImplementation.h>
 #include <mlir/CAPI/IR.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -56,11 +57,10 @@ MlirAttribute reussirDBGRecordMemberAttrGet(MlirContext context,
       DBGRecordMemberAttr::get(unwrap(context), str(name), unwrap(typeAttr)));
 }
 
-MlirAttribute reussirDBGRecordTypeAttrGet(MlirContext context, intptr_t nMembers,
-                                          MlirAttribute const *members,
-                                          bool isVariant,
-                                          MlirType underlyingType,
-                                          MlirAttribute dbgName) {
+MlirAttribute
+reussirDBGRecordTypeAttrGet(MlirContext context, intptr_t nMembers,
+                            MlirAttribute const *members, bool isVariant,
+                            MlirType underlyingType, MlirAttribute dbgName) {
   auto memberArray =
       mlir::ArrayAttr::get(unwrap(context), unwrapAttrs(nMembers, members));
   return wrap(DBGRecordTypeAttr::get(unwrap(context), memberArray, isVariant,

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -8,8 +8,9 @@
 
 #include "Reussir-c/Dialects.h"
 
-// Complete mlir::DialectVersion before MLIR C API headers reach BytecodeWriter.h;
-// MSVC's STL rejects destroying unique_ptr<T> when T is only forward declared.
+// Complete mlir::DialectVersion before MLIR C API headers reach
+// BytecodeWriter.h; MSVC's STL rejects destroying unique_ptr<T> when T is only
+// forward declared.
 #include <mlir/Bytecode/BytecodeImplementation.h>
 #include <mlir/CAPI/IR.h>
 #include <mlir/CAPI/Registration.h>
@@ -42,7 +43,8 @@
 #include "Reussir/Conversion/Passes.h"
 #include "Reussir/IR/ReussirDialect.h"
 
-MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Reussir, reussir, ::reussir::ReussirDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Reussir, reussir,
+                                      ::reussir::ReussirDialect)
 
 namespace {
 // Populates a registry with the Reussir dialect plus the minimal set of
@@ -79,10 +81,11 @@ void populateReussirRegistry(mlir::DialectRegistry &registry) {
   mlir::linalg::registerTransformDialectExtension(registry);
   mlir::scf::registerTransformDialectExtension(registry);
 
-  // Register the ConvertToLLVMPatternInterface for exactly the dialects that can
-  // reach the ConvertToLLVM pass, plus Reussir's own lowering interface. These
-  // are the conversion-interface registration APIs (distinct from the dialects
-  // themselves); without them a loaded dialect's promised interface is fatal.
+  // Register the ConvertToLLVMPatternInterface for exactly the dialects that
+  // can reach the ConvertToLLVM pass, plus Reussir's own lowering interface.
+  // These are the conversion-interface registration APIs (distinct from the
+  // dialects themselves); without them a loaded dialect's promised interface is
+  // fatal.
   ::reussir::registerReussirBasicOpsLoweringInterface(registry);
   mlir::arith::registerConvertArithToLLVMInterface(registry);
   mlir::registerConvertFuncToLLVMInterface(registry);

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -14,11 +14,11 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/MC/TargetRegistry.h>
-#include <llvm/TargetParser/SubtargetFeature.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/CBindingWrapping.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/TargetParser/Host.h>
+#include <llvm/TargetParser/SubtargetFeature.h>
 #include <llvm/TargetParser/Triple.h>
 #include <llvm/Transforms/IPO/LowerTypeTests.h>
 #include <llvm/Transforms/IPO/WholeProgramDevirt.h>
@@ -33,8 +33,7 @@
 #include <tpde-llvm/LLVMCompiler.hpp>
 #endif
 
-void reussirRunBackendLLVMPipeline(LLVMModuleRef module,
-                                   ReussirJitOptLevel opt,
+void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt,
                                    LLVMTargetMachineRef machine) {
   if (opt == ReussirJitOptNone || opt == ReussirJitOptTpde)
     return;
@@ -54,9 +53,8 @@ void reussirRunBackendLLVMPipeline(LLVMModuleRef module,
     if (triple.getTriple().empty())
       triple = llvm::Triple(llvm::sys::getDefaultTargetTriple());
     std::string lookupError;
-    if (const llvm::Target *target =
-            llvm::TargetRegistry::lookupTarget(triple.getTriple(),
-                                               lookupError)) {
+    if (const llvm::Target *target = llvm::TargetRegistry::lookupTarget(
+            triple.getTriple(), lookupError)) {
       llvm::SubtargetFeatures features;
       for (const auto &[name, enabled] : llvm::sys::getHostCPUFeatures())
         features.AddFeature(name, enabled);

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -8,8 +8,9 @@
 
 #include "Reussir-c/Types.h"
 
-// Complete mlir::DialectVersion before MLIR C API headers reach BytecodeWriter.h;
-// MSVC's STL rejects destroying unique_ptr<T> when T is only forward declared.
+// Complete mlir::DialectVersion before MLIR C API headers reach
+// BytecodeWriter.h; MSVC's STL rejects destroying unique_ptr<T> when T is only
+// forward declared.
 #include <mlir/Bytecode/BytecodeImplementation.h>
 #include <mlir/CAPI/IR.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -126,13 +127,11 @@ MlirType reussirStrTypeGet(MlirContext context, ReussirLifeScope lifeScope) {
   return wrap(StrType::get(unwrap(context), static_cast<LifeScope>(lifeScope)));
 }
 
-MlirType reussirRecordTypeGetComplete(MlirContext context, intptr_t nMembers,
-                                      MlirType const *members,
-                                      bool const *memberIsField,
-                                      MlirAttribute name,
-                                      ReussirRecordKind kind,
-                                      ReussirCapability defaultCapability,
-                                      bool fixed) {
+MlirType
+reussirRecordTypeGetComplete(MlirContext context, intptr_t nMembers,
+                             MlirType const *members, bool const *memberIsField,
+                             MlirAttribute name, ReussirRecordKind kind,
+                             ReussirCapability defaultCapability, bool fixed) {
   llvm::SmallVector<mlir::Type> memberTypes = unwrapTypes(nMembers, members);
   llvm::ArrayRef<bool> fields(memberIsField, nMembers);
   if (name.ptr)
@@ -155,7 +154,8 @@ MlirType reussirRecordTypeGetIncomplete(MlirContext context, MlirAttribute name,
 void reussirRecordTypeComplete(MlirType record, intptr_t nMembers,
                                MlirType const *members,
                                bool const *memberIsField,
-                               ReussirCapability defaultCapability, bool fixed) {
+                               ReussirCapability defaultCapability,
+                               bool fixed) {
   llvm::SmallVector<mlir::Type> memberTypes = unwrapTypes(nMembers, members);
   llvm::ArrayRef<bool> fields(memberIsField, nMembers);
   llvm::cast<RecordType>(unwrap(record))

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -86,35 +86,37 @@ private:
 
   mlir::LogicalResult rewriteDropArray(ArrayType arrayType, ReussirRefDropOp op,
                                        mlir::PatternRewriter &rewriter) const {
-    mlir::Value view =
-        ReussirArrayViewOp::create(rewriter, 
-                op.getLoc(),
-                mlir::MemRefType::get(arrayType.getShape(), arrayType.getElementType()),
-                op.getRef())
-            .getView();
-    auto recurse =
-        [&](auto &&self, mlir::Value currentView,
-            ArrayType currentType) -> mlir::LogicalResult {
-      for (int64_t index : llvm::seq<int64_t>(0, currentType.getShape().front())) {
-        auto idx = mlir::arith::ConstantIndexOp::create(rewriter, op.getLoc(), index);
+    mlir::Value view = ReussirArrayViewOp::create(
+                           rewriter, op.getLoc(),
+                           mlir::MemRefType::get(arrayType.getShape(),
+                                                 arrayType.getElementType()),
+                           op.getRef())
+                           .getView();
+    auto recurse = [&](auto &&self, mlir::Value currentView,
+                       ArrayType currentType) -> mlir::LogicalResult {
+      for (int64_t index :
+           llvm::seq<int64_t>(0, currentType.getShape().front())) {
+        auto idx =
+            mlir::arith::ConstantIndexOp::create(rewriter, op.getLoc(), index);
         if (currentType.getRank() == 1) {
           RefType projectedRefType = rewriter.getType<RefType>(
               currentType.getElementType(), Capability::unspecified);
-          auto projected = ReussirArrayProjectOp::create(rewriter, 
-              op.getLoc(), projectedRefType, currentView, idx.getResult());
+          auto projected = ReussirArrayProjectOp::create(
+              rewriter, op.getLoc(), projectedRefType, currentView,
+              idx.getResult());
           if (!isTriviallyCopyable(currentType.getElementType()))
             ReussirRefDropOp::create(rewriter, op.getLoc(),
-                                              projected.getProjected());
+                                     projected.getProjected());
           continue;
         }
         auto droppedType = currentType.dropFront();
-        auto projected = ReussirArrayProjectOp::create(rewriter, 
-            op.getLoc(),
+        auto projected = ReussirArrayProjectOp::create(
+            rewriter, op.getLoc(),
             mlir::MemRefType::get(droppedType.getShape(),
                                   droppedType.getElementType()),
             currentView, idx.getResult());
-        if (mlir::failed(self(self, projected.getProjected(),
-                              currentType.dropFront())))
+        if (mlir::failed(
+                self(self, projected.getProjected(), currentType.dropFront())))
           return mlir::failure();
       }
       return mlir::success();
@@ -141,10 +143,10 @@ private:
     }
     mlir::Value loaded =
         ReussirRefLoadOp::create(rewriter, op.getLoc(), rcType, op.getRef());
-    auto dec = ReussirRcDecOp::create(rewriter, op.getLoc(), nullableType,
-                                      loaded,
-                                      /*destructureTag=*/mlir::IntegerAttr{},
-                                      /*boundMembers=*/mlir::DenseI64ArrayAttr{});
+    auto dec =
+        ReussirRcDecOp::create(rewriter, op.getLoc(), nullableType, loaded,
+                               /*destructureTag=*/mlir::IntegerAttr{},
+                               /*boundMembers=*/mlir::DenseI64ArrayAttr{});
     // This leaf member-decrement is created *after* token instantiation, so
     // the max-arm token computed above never saw `getTokenType()` — the
     // single source of truth for the box's per-constructor layout.
@@ -176,8 +178,8 @@ private:
       RefType projectedRefTy =
           RefType::get(op.getContext(), projectedTy, refCap);
       mlir::IntegerAttr index = rewriter.getIndexAttr(idx);
-      mlir::Value projectedVal = ReussirRefProjectOp::create(rewriter, 
-          op.getLoc(), projectedRefTy, op.getRef(), index);
+      mlir::Value projectedVal = ReussirRefProjectOp::create(
+          rewriter, op.getLoc(), projectedRefTy, op.getRef(), index);
       ReussirRefDropOp::create(rewriter, op.getLoc(), projectedVal);
     }
     rewriter.eraseOp(op);
@@ -193,8 +195,9 @@ private:
     for (auto idx : llvm::seq<int64_t>(0, recordType.getMembers().size()))
       tagSets.push_back(rewriter.getDenseI64ArrayAttr({idx}));
     auto tagSetsAttr = rewriter.getArrayAttr(tagSets);
-    auto dispatcher = ReussirRecordDispatchOp::create(rewriter, 
-        op.getLoc(), mlir::Type{}, op.getRef(), tagSetsAttr, tagSets.size());
+    auto dispatcher = ReussirRecordDispatchOp::create(
+        rewriter, op.getLoc(), mlir::Type{}, op.getRef(), tagSetsAttr,
+        tagSets.size());
     for (auto [idx, memberTy, memberIsField] : llvm::enumerate(
              recordType.getMembers(), recordType.getMemberIsField())) {
       auto projectedTy = getProjectedType(memberTy, memberIsField, refCap);
@@ -206,7 +209,7 @@ private:
       rewriter.setInsertionPointToStart(block);
       if (!memberIsField && !isTriviallyCopyable(projectedTy))
         ReussirRefDropOp::create(rewriter, op.getLoc(), block->getArgument(0),
-                                          true, nullptr);
+                                 true, nullptr);
 
       ReussirScfYieldOp::create(rewriter, op.getLoc(), nullptr);
     }
@@ -221,8 +224,9 @@ private:
     assert(recordType.isVariant());
     auto targetType = recordType.getMembers()[tag];
     auto targetRefType = rewriter.getType<RefType>(targetType, refCap);
-    auto targetRef = ReussirRecordCoerceOp::create(rewriter, 
-        op.getLoc(), targetRefType, rewriter.getIndexAttr(tag), op.getRef());
+    auto targetRef =
+        ReussirRecordCoerceOp::create(rewriter, op.getLoc(), targetRefType,
+                                      rewriter.getIndexAttr(tag), op.getRef());
     ReussirRefDropOp::create(rewriter, op.getLoc(), targetRef);
     rewriter.eraseOp(op);
     return mlir::success();
@@ -232,10 +236,10 @@ private:
   rewriteDropNullable(NullableType nullableType, ReussirRefDropOp op,
                       mlir::PatternRewriter &rewriter) const {
     if (auto rcType = llvm::dyn_cast<RcType>(nullableType.getPtrTy())) {
-      mlir::Value loaded = ReussirRefLoadOp::create(rewriter, 
-          op.getLoc(), nullableType, op.getRef());
-      auto dispatcher = ReussirNullableDispatchOp::create(rewriter, 
-          op.getLoc(), mlir::Type{}, loaded);
+      mlir::Value loaded = ReussirRefLoadOp::create(rewriter, op.getLoc(),
+                                                    nullableType, op.getRef());
+      auto dispatcher = ReussirNullableDispatchOp::create(rewriter, op.getLoc(),
+                                                          mlir::Type{}, loaded);
       // do nothing if null
       mlir::Block *nullBlock = rewriter.createBlock(
           &dispatcher.getNullRegion(), dispatcher.getNullRegion().begin());
@@ -256,10 +260,10 @@ private:
         TokenType tokenType = TokenType::get(op.getContext(), align, size);
         retNullableTy = NullableType::get(op.getContext(), tokenType);
       }
-      auto dec = ReussirRcDecOp::create(rewriter, op.getLoc(), retNullableTy,
-                                        nonNullBlock->getArgument(0),
-                                        /*destructureTag=*/mlir::IntegerAttr{},
-                                        /*boundMembers=*/mlir::DenseI64ArrayAttr{});
+      auto dec = ReussirRcDecOp::create(
+          rewriter, op.getLoc(), retNullableTy, nonNullBlock->getArgument(0),
+          /*destructureTag=*/mlir::IntegerAttr{},
+          /*boundMembers=*/mlir::DenseI64ArrayAttr{});
       // Route through `getTokenType()` (the per-constructor source of
       // truth); the max-arm token above would free non-uniform arms at the
       // wrong size. Result has no users yet — retyping in place is safe.
@@ -324,7 +328,8 @@ public:
             mlir::ModuleOp moduleOp = op->getParentOfType<mlir::ModuleOp>();
             mlir::func::FuncOp dtor =
                 createDtorIfNotExists(moduleOp, recordType, rewriter);
-            mlir::func::CallOp::create(rewriter, op.getLoc(), dtor, op.getRef());
+            mlir::func::CallOp::create(rewriter, op.getLoc(), dtor,
+                                       op.getRef());
             rewriter.eraseOp(op);
             return llvm::success();
           }
@@ -388,7 +393,7 @@ public:
             emitOwnershipAcquisitionFuncIfNotExists(moduleOp, recordType,
                                                     rewriter);
         mlir::func::CallOp::create(rewriter, op.getLoc(), acquireFunc,
-                                            op.getRef());
+                                   op.getRef());
         rewriter.eraseOp(op);
         return mlir::success();
       }
@@ -399,8 +404,8 @@ public:
         auto targetType = recordType.getMembers()[tag];
         auto targetRefType =
             rewriter.getType<RefType>(targetType, refType.getCapability());
-        auto targetRef = ReussirRecordCoerceOp::create(rewriter, 
-            op.getLoc(), targetRefType, rewriter.getIndexAttr(tag),
+        auto targetRef = ReussirRecordCoerceOp::create(
+            rewriter, op.getLoc(), targetRefType, rewriter.getIndexAttr(tag),
             op.getRef());
         ReussirRefAcquireOp::create(rewriter, op.getLoc(), targetRef);
         rewriter.eraseOp(op);

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -57,10 +57,10 @@
 #include "Reussir/Conversion/TypeConverter.h"
 #include "Reussir/IR/ReussirAttrs.h"
 #include "Reussir/IR/ReussirDialect.h"
-#include "Reussir/Support/AllocatorBinModel.h"
 #include "Reussir/IR/ReussirEnumAttrs.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
+#include "Reussir/Support/AllocatorBinModel.h"
 #include "Reussir/Transformation/SpecialPointerTag.h"
 #include "mlir/IR/Location.h"
 #include "mlir/Support/LLVM.h"
@@ -1660,8 +1660,8 @@ struct ReussirRcCompareImmortalConversionPattern
     TagEncoding encoding = specialPtrTagEncoding(op);
     auto dummy = tagDummyBox(op->getParentOfType<mlir::ModuleOp>(), loc,
                              op.getTag().getZExtValue(), encoding, rewriter);
-    mlir::Value expected = mlir::LLVM::AddressOfOp::create(
-        rewriter, loc, ptrTy, dummy.getSymName());
+    mlir::Value expected = mlir::LLVM::AddressOfOp::create(rewriter, loc, ptrTy,
+                                                           dummy.getSymName());
     if (encoding == TagEncoding::TBI) {
       if (indexTy.getWidth() != 64)
         return op.emitOpError(
@@ -3035,9 +3035,9 @@ struct ReussirRefMemcpyConversionPattern
     auto sizeVal = mlir::LLVM::ConstantOp::create(
         rewriter, op.getLoc(), converter->getIndexType(),
         rewriter.getIntegerAttr(converter->getIndexType(), size));
-    rewriter.replaceOpWithNewOp<mlir::LLVM::MemcpyOp>(
-        op, adaptor.getDst(), adaptor.getSrc(), sizeVal,
-        /*isVolatile=*/false);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::MemcpyOp>(op, adaptor.getDst(),
+                                                      adaptor.getSrc(), sizeVal,
+                                                      /*isVolatile=*/false);
     return mlir::success();
   }
 };
@@ -3439,15 +3439,15 @@ struct ReussirConvertToLLVMPatternInterface
         ReussirRecordCoerceOp, ReussirRegionVTableOp, ReussirRcFreezeOp,
         ReussirRegionCleanupOp, ReussirRegionCreateOp, ReussirRcReinterpretOp,
         ReussirCellCreateOp, ReussirCellGetOp, ReussirCellSetOp,
-        ReussirCellRmwOp, ReussirCellYieldOp,
-        ReussirClosureApplyOp, ReussirClosureCloneOp, ReussirClosureEvalOp,
+        ReussirCellRmwOp, ReussirCellYieldOp, ReussirClosureApplyOp,
+        ReussirClosureCloneOp, ReussirClosureEvalOp,
         ReussirClosureInspectPayloadOp, ReussirClosureCursorOp,
         ReussirClosureInstantiateOp, ReussirClosureVtableOp,
         ReussirClosureCreateOp, ReussirRcFetchOp, ReussirRcFetchSubOp,
-        ReussirRcSetOp,
-        ReussirStrGlobalOp, ReussirStrLiteralOp, ReussirStrCastOp,
-        ReussirStrLenOp, ReussirStrUnsafeByteAtOp, ReussirStrUnsafeStartWithOp,
-        ReussirStrSliceOp, ReussirTrampolineOp, ReussirTokenLaunderOp>();
+        ReussirRcSetOp, ReussirStrGlobalOp, ReussirStrLiteralOp,
+        ReussirStrCastOp, ReussirStrLenOp, ReussirStrUnsafeByteAtOp,
+        ReussirStrUnsafeStartWithOp, ReussirStrSliceOp, ReussirTrampolineOp,
+        ReussirTokenLaunderOp>();
     // `reussir.closure.wpd_test` is created BY the dispatch conversion
     // patterns above, already in its final form (operand = the loaded vtable
     // pointer), and must survive conversion: the LLVM dialect cannot express
@@ -3569,8 +3569,8 @@ void populateBasicOpsLoweringToLLVMConversionPatterns(
       ReussirNullableCreateConversionPattern,
       ReussirNullableCoerceConversionPattern, ReussirRcIncConversionPattern,
       ReussirRcTaggedConversionPattern,
-      ReussirRcCompareImmortalConversionPattern, ReussirRcDecOpConversionPattern,
-      ReussirRcCreateOpConversionPattern,
+      ReussirRcCompareImmortalConversionPattern,
+      ReussirRcDecOpConversionPattern, ReussirRcCreateOpConversionPattern,
       ReussirRcCreateCompoundOpConversionPattern,
       ReussirRcCreateVariantOpConversionPattern,
       ReussirRcBorrowOpConversionPattern, ReussirRcIsUniqueOpConversionPattern,

--- a/lib/Conversion/BasicOpsLowering/CABISignatureConversion.cpp
+++ b/lib/Conversion/BasicOpsLowering/CABISignatureConversion.cpp
@@ -1,4 +1,5 @@
-//===-- CABISignatureConversion.cpp - C ABI signature conversion -*- C++ -*-===//
+//===-- CABISignatureConversion.cpp - C ABI signature conversion -*- C++
+//-*-===//
 //
 // Part of the Reussir project, dual licensed under the Apache License v2.0 or
 // the MIT License.
@@ -26,11 +27,12 @@ CABISignature evaluateCABISignatureForC(mlir::Type returnType,
   sig.abiReturnType = returnType;
   sig.returnStorageType = returnType;
   auto ptrType = mlir::LLVM::LLVMPointerType::get(returnType.getContext());
-  const bool trivialReturn =
-      mlir::isa<mlir::LLVM::LLVMVoidType>(returnType) || isTrivialFFIType(returnType);
+  const bool trivialReturn = mlir::isa<mlir::LLVM::LLVMVoidType>(returnType) ||
+                             isTrivialFFIType(returnType);
   const bool trivialParams =
       paramTypes.size() < 4 &&
-      llvm::all_of(paramTypes, [](mlir::Type type) { return isTrivialFFIType(type); });
+      llvm::all_of(
+          paramTypes, [](mlir::Type type) { return isTrivialFFIType(type); });
 
   sig.isTrivial = trivialReturn && trivialParams;
   if (sig.isTrivial) {
@@ -38,7 +40,8 @@ CABISignature evaluateCABISignatureForC(mlir::Type returnType,
     return sig;
   }
 
-  if (!mlir::isa<mlir::LLVM::LLVMVoidType>(returnType) && !isTrivialFFIType(returnType)) {
+  if (!mlir::isa<mlir::LLVM::LLVMVoidType>(returnType) &&
+      !isTrivialFFIType(returnType)) {
     sig.hasReturnPtr = true;
     sig.returnPtrIndex = 0;
     sig.abiReturnType = mlir::LLVM::LLVMVoidType::get(returnType.getContext());
@@ -48,8 +51,8 @@ CABISignature evaluateCABISignatureForC(mlir::Type returnType,
   if (!paramTypes.empty()) {
     sig.hasPackedArgs = true;
     sig.packedArgsIndex = sig.abiParamTypes.size();
-    sig.packedArgsType =
-        mlir::LLVM::LLVMStructType::getLiteral(returnType.getContext(), paramTypes);
+    sig.packedArgsType = mlir::LLVM::LLVMStructType::getLiteral(
+        returnType.getContext(), paramTypes);
     sig.abiParamTypes.push_back(ptrType);
   }
 

--- a/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
+++ b/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
@@ -153,9 +153,9 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
             // A record reached recursively reappears with the same name (the
             // frontend's forward-declared placeholder). If this name is already
             // being built, emit a `rec-self` placeholder tied to that
-            // occurrence's `recId` instead of expanding again — LLVM resolves it
-            // back to the enclosing composite, giving the recursive field a real
-            // pointee type the debugger can descend.
+            // occurrence's `recId` instead of expanding again — LLVM resolves
+            // it back to the enclosing composite, giving the recursive field a
+            // real pointee type the debugger can descend.
             RecursionState localState;
             RecursionState *state = recState ? recState : &localState;
             if (auto it = state->ancestors.find(name);
@@ -164,8 +164,7 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
               return mlir::Attribute(
                   mlir::LLVM::DICompositeTypeAttr::getRecSelf(it->second));
             }
-            auto recId =
-                mlir::DistinctAttr::create(mlir::UnitAttr::get(ctx));
+            auto recId = mlir::DistinctAttr::create(mlir::UnitAttr::get(ctx));
             state->ancestors.insert({name, recId});
 
             auto makeComposite =
@@ -181,15 +180,15 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                   /*associated=*/nullptr, members);
             };
 
-            // The debug type, size, and alignment (bits) for one member. A boxed
-            // (rc) member is a *pointer* to the payload composite — not the
-            // composite inlined: the `DW_OP_deref` expression that presents a
-            // boxed *variable* as its payload applies only to that variable's
-            // slot, never to a field. Emitting it as a pointer is also what keeps
-            // a recursive record (a field whose box points back to the record)
-            // from sending the debugger into an unbounded layout recursion.
-            auto memberType =
-                [&](mlir::Attribute typeAttr)
+            // The debug type, size, and alignment (bits) for one member. A
+            // boxed (rc) member is a *pointer* to the payload composite — not
+            // the composite inlined: the `DW_OP_deref` expression that presents
+            // a boxed *variable* as its payload applies only to that variable's
+            // slot, never to a field. Emitting it as a pointer is also what
+            // keeps a recursive record (a field whose box points back to the
+            // record) from sending the debugger into an unbounded layout
+            // recursion.
+            auto memberType = [&](mlir::Attribute typeAttr)
                 -> std::optional<
                     std::tuple<mlir::LLVM::DITypeAttr, uint64_t, uint64_t>> {
               auto diType = translateDBGAttrToLLVM<mlir::LLVM::DITypeAttr>(
@@ -209,16 +208,15 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                 // at the view offset: past the refcount word (one shared,
                 // three regional), or at the tag (record + 4) for a
                 // fused-header variant whose composite is the tag-first view.
-                auto payloadUnderlying =
-                    getUnderlyingTypeFromDbgAttr(typeAttr);
+                auto payloadUnderlying = getUnderlyingTypeFromDbgAttr(typeAttr);
                 if (!payloadUnderlying)
                   return std::nullopt;
                 uint64_t payloadBits =
                     dataLayout.getTypeSizeInBits(payloadUnderlying);
                 uint64_t payloadAlignBytes =
                     dataLayout.getTypeABIAlignment(payloadUnderlying);
-                uint64_t valueOffBytes = boxedViewOffset(
-                    dataLayout, ctx, boxed, payloadUnderlying);
+                uint64_t valueOffBytes =
+                    boxedViewOffset(dataLayout, ctx, boxed, payloadUnderlying);
                 uint64_t valueBits =
                     boxedFusedVariant(boxed) ? payloadBits - 32 : payloadBits;
                 auto valueMember = mlir::LLVM::DIDerivedTypeAttr::get(
@@ -230,21 +228,23 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                 // match engages on the wrapper (and its pointers) and can
                 // collapse the box to its payload's active case.
                 mlir::StringAttr boxName = mlir::StringAttr::get(ctx, "");
-                if (auto payloadRec = llvm::dyn_cast_if_present<
-                        DBGRecordTypeAttr>(boxed.getDbgType()))
+                if (auto payloadRec =
+                        llvm::dyn_cast_if_present<DBGRecordTypeAttr>(
+                            boxed.getDbgType()))
                   boxName = mlir::StringAttr::get(
                       ctx, payloadRec.getDbgName().getValue() + "$box");
-                auto pointee = makeComposite(
-                    llvm::dwarf::DW_TAG_structure_type, boxName,
-                    valueOffBytes * 8 + valueBits, payloadAlignBytes * 8,
-                    {valueMember});
+                auto pointee =
+                    makeComposite(llvm::dwarf::DW_TAG_structure_type, boxName,
+                                  valueOffBytes * 8 + valueBits,
+                                  payloadAlignBytes * 8, {valueMember});
                 auto pointer = mlir::LLVM::DIDerivedTypeAttr::get(
                     ctx, llvm::dwarf::DW_TAG_pointer_type,
                     /*name=*/mlir::StringAttr{}, pointee, ptrBits, ptrAlignBits,
                     /*offsetInBits=*/0, /*address space=*/std::nullopt,
                     /*extraData=*/nullptr);
-                return std::make_tuple(mlir::cast<mlir::LLVM::DITypeAttr>(pointer),
-                                       ptrBits, ptrAlignBits);
+                return std::make_tuple(
+                    mlir::cast<mlir::LLVM::DITypeAttr>(pointer), ptrBits,
+                    ptrAlignBits);
               }
               auto underlying = getUnderlyingTypeFromDbgAttr(typeAttr);
               if (!underlying)
@@ -354,9 +354,8 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                     auto [fieldTy, fieldBits, fieldAlignBits] = *fieldInfo;
                     payloadAlignBytes =
                         std::max(payloadAlignBytes, fieldAlignBits / 8);
-                    info.fields.push_back(
-                        {fieldAttr.getName(), fieldTy, fieldBits,
-                         fieldAlignBits});
+                    info.fields.push_back({fieldAttr.getName(), fieldTy,
+                                           fieldBits, fieldAlignBits});
                   }
                 } else {
                   // Not a record payload: model it as the case's single field.
@@ -378,9 +377,9 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
               // variant `{minimal-width tag, payload}` (tag at 0, payload at
               // its natural alignment past the tag). Every offset below is
               // view-relative.
-              mlir::Type tagIntTy =
-                  recordTy ? mlir::Type(recordTy.getTagType())
-                           : mlir::Type(mlir::IndexType::get(ctx));
+              mlir::Type tagIntTy = recordTy
+                                        ? mlir::Type(recordTy.getTagType())
+                                        : mlir::Type(mlir::IndexType::get(ctx));
               uint64_t tagSizeBits = dataLayout.getTypeSizeInBits(tagIntTy);
               uint64_t tagSizeBytes = dataLayout.getTypeSize(tagIntTy);
               bool fusedHeader = recordTy && recordTy.hasFusedHeader();
@@ -410,34 +409,35 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                   fieldSizes.push_back(field.sizeBits);
                   fieldAligns.push_back(field.alignBits);
                 }
-                auto offsets = physicalOffsets(info.record, fieldSizes,
-                                               fieldAligns,
-                                               payloadOffsetBytes * 8);
+                auto offsets =
+                    physicalOffsets(info.record, fieldSizes, fieldAligns,
+                                    payloadOffsetBytes * 8);
                 llvm::SmallVector<mlir::LLVM::DINodeAttr> fields;
                 for (auto [field, offset] : llvm::zip(info.fields, offsets))
                   fields.push_back(mlir::LLVM::DIDerivedTypeAttr::get(
                       ctx, llvm::dwarf::DW_TAG_member, field.name, field.type,
                       field.sizeBits, field.alignBits, offset,
                       /*address space=*/std::nullopt, /*extraData=*/nullptr));
-                auto caseComposite = makeComposite(
-                    llvm::dwarf::DW_TAG_structure_type, info.name,
-                    viewSizeBits, alignInBits, fields);
+                auto caseComposite =
+                    makeComposite(llvm::dwarf::DW_TAG_structure_type, info.name,
+                                  viewSizeBits, alignInBits, fields);
                 cases.push_back(mlir::LLVM::DIDerivedTypeAttr::get(
                     ctx, llvm::dwarf::DW_TAG_member, info.name, caseComposite,
                     viewSizeBits, alignInBits, /*offsetInBits=*/0,
                     /*address space=*/std::nullopt, /*extraData=*/nullptr));
               }
-              auto payloadUnion = makeComposite(
-                  llvm::dwarf::DW_TAG_union_type, mlir::StringAttr::get(ctx, ""),
-                  viewSizeBits, payloadAlignBytes * 8, cases);
+              auto payloadUnion =
+                  makeComposite(llvm::dwarf::DW_TAG_union_type,
+                                mlir::StringAttr::get(ctx, ""), viewSizeBits,
+                                payloadAlignBytes * 8, cases);
               auto payloadMember = mlir::LLVM::DIDerivedTypeAttr::get(
                   ctx, llvm::dwarf::DW_TAG_member,
                   mlir::StringAttr::get(ctx, "payload"), payloadUnion,
                   viewSizeBits, payloadAlignBytes * 8,
                   /*offsetInBits=*/0, /*address space=*/std::nullopt,
                   /*extraData=*/nullptr);
-              llvm::SmallVector<mlir::LLVM::DINodeAttr> members = {tagMember,
-                                                                   payloadMember};
+              llvm::SmallVector<mlir::LLVM::DINodeAttr> members = {
+                  tagMember, payloadMember};
               auto composite =
                   makeComposite(llvm::dwarf::DW_TAG_structure_type, name,
                                 viewSizeBits, alignInBits, members);
@@ -502,40 +502,38 @@ RetType translateDBGAttrToLLVM(mlir::ModuleOp moduleOp, mlir::Attribute dbgAttr,
                     moduleOp, boxed.getDbgType(), diFile, diCU, funcOp,
                     funcScope, loc, recState);
               })
-          .template Case<DBGSubprogramAttr>(
-              [&](DBGSubprogramAttr spAttr) -> mlir::Attribute {
-                auto linkageName = funcOp.getSymNameAttr();
-                llvm::SmallVector<mlir::LLVM::DINodeAttr> argTypes;
-                for (auto paramAttr : spAttr.getTypeParams()) {
-                  auto paramTy = translateDBGAttrToLLVM<mlir::LLVM::DITypeAttr>(
-                      moduleOp, paramAttr, diFile, diCU, funcOp, funcScope,
-                      loc);
-                  if (!paramTy)
-                    return nullptr;
-                  argTypes.push_back(paramTy);
-                }
-                // TODO: function type is not emitted now
-                auto emptyRoutine = mlir::LLVM::DISubroutineTypeAttr::get(
-                    moduleOp.getContext(), {});
-                // Extract the line from the function's location. The fifth and
-                // sixth arguments are `line` and `scopeLine` (both lines) — not
-                // line/column.
-                auto [line, col] = extractLineCol(loc);
-                (void)col;
-                auto res = mlir::LLVM::DISubprogramAttr::get(
-                    moduleOp.getContext(),
-                    mlir::DistinctAttr::create(
-                        mlir::UnitAttr::get(moduleOp.getContext())),
-                    false,
-                    mlir::DistinctAttr::create(
-                        mlir::UnitAttr::get(moduleOp.getContext())),
-                    diCU, diFile, spAttr.getRawName(), linkageName, diFile,
-                    line, /*scopeLine=*/line,
-                    mlir::LLVM::DISubprogramFlags::Definition, emptyRoutine, {},
-                    {});
+          .template Case<DBGSubprogramAttr>([&](DBGSubprogramAttr spAttr)
+                                                -> mlir::Attribute {
+            auto linkageName = funcOp.getSymNameAttr();
+            llvm::SmallVector<mlir::LLVM::DINodeAttr> argTypes;
+            for (auto paramAttr : spAttr.getTypeParams()) {
+              auto paramTy = translateDBGAttrToLLVM<mlir::LLVM::DITypeAttr>(
+                  moduleOp, paramAttr, diFile, diCU, funcOp, funcScope, loc);
+              if (!paramTy)
+                return nullptr;
+              argTypes.push_back(paramTy);
+            }
+            // TODO: function type is not emitted now
+            auto emptyRoutine = mlir::LLVM::DISubroutineTypeAttr::get(
+                moduleOp.getContext(), {});
+            // Extract the line from the function's location. The fifth and
+            // sixth arguments are `line` and `scopeLine` (both lines) — not
+            // line/column.
+            auto [line, col] = extractLineCol(loc);
+            (void)col;
+            auto res = mlir::LLVM::DISubprogramAttr::get(
+                moduleOp.getContext(),
+                mlir::DistinctAttr::create(
+                    mlir::UnitAttr::get(moduleOp.getContext())),
+                false,
+                mlir::DistinctAttr::create(
+                    mlir::UnitAttr::get(moduleOp.getContext())),
+                diCU, diFile, spAttr.getRawName(), linkageName, diFile, line,
+                /*scopeLine=*/line, mlir::LLVM::DISubprogramFlags::Definition,
+                emptyRoutine, {}, {});
 
-                return res;
-              })
+            return res;
+          })
           .template Case<DBGLocalVarAttr>(
               [&](DBGLocalVarAttr localVarAttr) -> mlir::Attribute {
                 auto underlyingTy =
@@ -595,8 +593,8 @@ void spillAndDeclare(mlir::OpBuilder &builder, mlir::Location loc,
   auto one = mlir::LLVM::ConstantOp::create(builder, loc, builder.getI32Type(),
                                             builder.getI32IntegerAttr(1));
   auto ptrType = mlir::LLVM::LLVMPointerType::get(context);
-  auto slot = mlir::LLVM::AllocaOp::create(builder, loc, ptrType,
-                                           value.getType(), one);
+  auto slot =
+      mlir::LLVM::AllocaOp::create(builder, loc, ptrType, value.getType(), one);
   mlir::LLVM::StoreOp::create(builder, loc, value, slot);
   mlir::LLVM::DbgDeclareOp::create(builder, loc, slot, varInfo, expr);
 }
@@ -709,14 +707,15 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
               auto &entryBlock = funcOp.getBody().front();
               builder.setInsertionPointToStart(&entryBlock);
               // Spill the argument to a stack slot and describe *that* with
-              // `dbg.declare`. A `dbg.value` on the SSA argument goes stale once
-              // its registers are reused (right after the prologue spills it),
-              // so a debugger reads garbage; a stack slot is a stable location.
+              // `dbg.declare`. A `dbg.value` on the SSA argument goes stale
+              // once its registers are reused (right after the prologue spills
+              // it), so a debugger reads garbage; a stack slot is a stable
+              // location.
               //
               // The spill is emitted at a line-0 (prologue) location so it is
-              // covered by the function prologue: a debugger setting a breakpoint
-              // on the function skips to the first body statement, by which point
-              // the argument has been stored and is inspectable.
+              // covered by the function prologue: a debugger setting a
+              // breakpoint on the function skips to the first body statement,
+              // by which point the argument has been stored and is inspectable.
               mlir::Location prologueLoc = mlir::FileLineColLoc::get(
                   context, funcFileAttr.getName().getValue(),
                   /*line=*/0, /*column=*/0);
@@ -730,13 +729,13 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
         funcOp->removeAttr("reussir.dbg_func_args");
       }
       // Local variables: codegen tags the op defining a `let` binding with a
-      // `DBGLocalVar` on its fused location. Conversion copies that location onto
-      // every op it expands the definition into, so to describe the variable just
-      // once we pick the op whose result *escapes* the tagged group — i.e. is
-      // used by an op that does not carry the same metadata; that is the value
-      // the rest of the program sees. We spill it and `dbg.declare` it (declaring
-      // each variable once), then strip the Reussir metadata off every tagged op
-      // so they translate cleanly.
+      // `DBGLocalVar` on its fused location. Conversion copies that location
+      // onto every op it expands the definition into, so to describe the
+      // variable just once we pick the op whose result *escapes* the tagged
+      // group — i.e. is used by an op that does not carry the same metadata;
+      // that is the value the rest of the program sees. We spill it and
+      // `dbg.declare` it (declaring each variable once), then strip the Reussir
+      // metadata off every tagged op so they translate cleanly.
       //
       // Declaration is deferred to after the walk so the escape check sees the
       // original, un-stripped locations.
@@ -774,8 +773,9 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
         }
         if (escapes) {
           auto localVarAttr = llvm::dyn_cast<DBGLocalVarAttr>(meta);
-          auto expr = localVarAttr ? boxedExpr(moduleOp, localVarAttr.getDbgType())
-                                   : mlir::LLVM::DIExpressionAttr{};
+          auto expr = localVarAttr
+                          ? boxedExpr(moduleOp, localVarAttr.getDbgType())
+                          : mlir::LLVM::DIExpressionAttr{};
           toDeclare.push_back({op, varLoc, localVar, expr});
         } else {
           declared.erase(localVar);
@@ -793,11 +793,11 @@ void lowerFusedDBGAttributeInLocations(mlir::ModuleOp moduleOp) {
 }
 
 namespace {
-// Runs the fused-debug-info → LLVM DI conversion as a standalone pass. It must be
-// scheduled after `convert-to-llvm`, when functions are `llvm.func` (carrying the
-// fused subprogram location and `reussir.dbg_func_args` the conversion preserves):
-// a function's debug info only survives LLVM-IR translation once its `llvm.func`
-// has a `DISubprogram`.
+// Runs the fused-debug-info → LLVM DI conversion as a standalone pass. It must
+// be scheduled after `convert-to-llvm`, when functions are `llvm.func`
+// (carrying the fused subprogram location and `reussir.dbg_func_args` the
+// conversion preserves): a function's debug info only survives LLVM-IR
+// translation once its `llvm.func` has a `DISubprogram`.
 struct DebugInfoConversionPass
     : public impl::ReussirDebugInfoConversionPassBase<DebugInfoConversionPass> {
   using Base::Base;

--- a/lib/Conversion/BasicOpsLowering/VariantDebugInfo.cpp
+++ b/lib/Conversion/BasicOpsLowering/VariantDebugInfo.cpp
@@ -74,15 +74,14 @@ void rewriteVariant(LLVMContext &ctx, DICompositeType *composite,
   DIFile *file = composite->getFile();
   uint64_t payloadOffset = v.payload->getOffsetInBits();
 
-  // The discriminant is the tag member, marked artificial (compiler-synthesised,
-  // not a source field). Scoped to the enum itself, matching what rustc emits.
-  // It keeps the tag's own offset: 0 for a value variant, 4 for a fused-header
-  // one (past the overlaid refcount slot).
+  // The discriminant is the tag member, marked artificial
+  // (compiler-synthesised, not a source field). Scoped to the enum itself,
+  // matching what rustc emits. It keeps the tag's own offset: 0 for a value
+  // variant, 4 for a fused-header one (past the overlaid refcount slot).
   auto *discriminator = DIDerivedType::get(
       ctx, dwarf::DW_TAG_member, /*Name=*/StringRef(), file, /*Line=*/0,
       /*Scope=*/composite, /*BaseType=*/v.tag->getBaseType(),
-      v.tag->getSizeInBits(), v.tag->getAlignInBits(),
-      v.tag->getOffsetInBits(),
+      v.tag->getSizeInBits(), v.tag->getAlignInBits(), v.tag->getOffsetInBits(),
       /*DWARFAddressSpace=*/std::nullopt, /*PtrAuthData=*/std::nullopt,
       DINode::FlagArtificial);
 
@@ -104,7 +103,8 @@ void rewriteVariant(LLVMContext &ctx, DICompositeType *composite,
         /*Scope=*/composite, caseMember->getBaseType(),
         caseMember->getSizeInBits(), caseMember->getAlignInBits(),
         payloadOffset, /*DWARFAddressSpace=*/std::nullopt,
-        /*PtrAuthData=*/std::nullopt, DINode::FlagZero, /*ExtraData=*/discrValue));
+        /*PtrAuthData=*/std::nullopt, DINode::FlagZero,
+        /*ExtraData=*/discrValue));
     ++index;
   }
 

--- a/lib/Conversion/ClosureOutlining/ClosureOutlining.cpp
+++ b/lib/Conversion/ClosureOutlining/ClosureOutlining.cpp
@@ -131,8 +131,8 @@ void ClosureOutliningPass::runOnOperation() {
         rewriter.getContext(), evaluateFunction.getName());
 
     ReussirClosureVtableOp::create(rewriter, op.getLoc(),
-                                            rewriter.getStringAttr(vtableName),
-                                            evaluateAttr, dropAttr, cloneAttr);
+                                   rewriter.getStringAttr(vtableName),
+                                   evaluateAttr, dropAttr, cloneAttr);
 
     // Fourth, update the closure to use
     // outlined version (e.g. remove the
@@ -164,8 +164,8 @@ mlir::func::FuncOp ClosureOutliningPass::createFunctionAndInlineRegion(
       rewriter.getFunctionType(specializedRcType, resultTypes);
 
   // Create the function
-  auto funcOp = mlir::func::FuncOp::create(rewriter, op.getLoc(), invokeName,
-                                           funcType);
+  auto funcOp =
+      mlir::func::FuncOp::create(rewriter, op.getLoc(), invokeName, funcType);
   funcOp.setPrivate();
   funcOp->setAttr("llvm.linkage",
                   mlir::LLVM::LinkageAttr::get(rewriter.getContext(),
@@ -201,8 +201,8 @@ mlir::func::FuncOp ClosureOutliningPass::createFunctionAndInlineRegion(
         rewriter.getType<RefType>(payloadType, Capability::unspecified);
 
     // Get reference to this payload field
-    mlir::Value payloadRef = ReussirClosureInspectPayloadOp::create(rewriter, 
-        loc, payloadRefType, rewriter.getIndexAttr(i), closureBoxRef);
+    mlir::Value payloadRef = ReussirClosureInspectPayloadOp::create(
+        rewriter, loc, payloadRefType, rewriter.getIndexAttr(i), closureBoxRef);
 
     // Load the payload value
     mlir::Value payloadValue =
@@ -229,18 +229,19 @@ mlir::func::FuncOp ClosureOutliningPass::createFunctionAndInlineRegion(
 
     // Only write the decremented count when the closure remains shared.
     auto one = mlir::arith::ConstantIndexOp::create(rewriter, yieldLoc, 1);
-    auto isShared = mlir::arith::CmpIOp::create(rewriter, 
-        yieldLoc, mlir::arith::CmpIPredicate::ugt, fetch.getRefCount(), one);
+    auto isShared = mlir::arith::CmpIOp::create(rewriter, yieldLoc,
+                                                mlir::arith::CmpIPredicate::ugt,
+                                                fetch.getRefCount(), one);
 
     auto ifOp =
         mlir::scf::IfOp::create(rewriter, yieldLoc, mlir::TypeRange{}, isShared,
-                                         /*addThenRegion=*/true,
-                                         /*addElseRegion=*/true);
+                                /*addThenRegion=*/true,
+                                /*addElseRegion=*/true);
 
     // Inside the then block: decrement the refcount and skip the free.
     rewriter.setInsertionPointToStart(ifOp.thenBlock());
-    auto decremented = mlir::arith::SubIOp::create(rewriter, 
-        yieldLoc, fetch.getRefCount(), one);
+    auto decremented = mlir::arith::SubIOp::create(rewriter, yieldLoc,
+                                                   fetch.getRefCount(), one);
     ReussirRcSetOp::create(rewriter, yieldLoc, rcPtr, decremented.getResult());
     mlir::scf::YieldOp::create(rewriter, yieldLoc);
 
@@ -311,12 +312,13 @@ mlir::func::FuncOp ClosureOutliningPass::createClosureDropFunction(
 
   // Only write the decremented count when the closure remains shared.
   auto one = mlir::arith::ConstantIndexOp::create(rewriter, loc, 1);
-  auto isShared = mlir::arith::CmpIOp::create(rewriter, 
-      loc, mlir::arith::CmpIPredicate::ugt, fetch.getRefCount(), one);
+  auto isShared = mlir::arith::CmpIOp::create(
+      rewriter, loc, mlir::arith::CmpIPredicate::ugt, fetch.getRefCount(), one);
 
-  auto ifOp = mlir::scf::IfOp::create(rewriter, loc, mlir::TypeRange{}, isShared,
-                                               /*addThenRegion=*/true,
-                                               /*addElseRegion=*/true);
+  auto ifOp =
+      mlir::scf::IfOp::create(rewriter, loc, mlir::TypeRange{}, isShared,
+                              /*addThenRegion=*/true,
+                              /*addElseRegion=*/true);
 
   // Inside the then block: decrement the refcount and skip the drop.
   rewriter.setInsertionPointToStart(ifOp.thenBlock());
@@ -339,8 +341,8 @@ mlir::func::FuncOp ClosureOutliningPass::createClosureDropFunction(
   auto payloadTypes = closureBoxType.getPayloadTypes();
   RefType cursorRefType =
       rewriter.getType<RefType>(rewriter.getI8Type(), Capability::unspecified);
-  mlir::Value cursorRef = ReussirClosureCursorOp::create(rewriter, 
-      loc, cursorRefType, rewriter.getIndexAttr(0), closureBoxRef);
+  mlir::Value cursorRef = ReussirClosureCursorOp::create(
+      rewriter, loc, cursorRefType, rewriter.getIndexAttr(0), closureBoxRef);
 
   // For each payload field, check if cursor is strictly greater than the field
   // pointer and if so, add a drop operation for the field
@@ -352,19 +354,20 @@ mlir::func::FuncOp ClosureOutliningPass::createClosureDropFunction(
         rewriter.getType<RefType>(payloadType, Capability::unspecified);
 
     // Get reference to this payload field
-    mlir::Value payloadRef = ReussirClosureInspectPayloadOp::create(rewriter, 
-        loc, payloadRefType, rewriter.getIndexAttr(i), closureBoxRef);
+    mlir::Value payloadRef = ReussirClosureInspectPayloadOp::create(
+        rewriter, loc, payloadRefType, rewriter.getIndexAttr(i), closureBoxRef);
 
     // Compare cursor with payload reference: if cursor > payload, the field
     // was initialized and needs to be dropped
-    auto cursorGtPayload = ReussirRefCmpOp::create(rewriter, 
-        loc, rewriter.getI1Type(), mlir::arith::CmpIPredicate::ugt, cursorRef,
-        payloadRef);
+    auto cursorGtPayload = ReussirRefCmpOp::create(
+        rewriter, loc, rewriter.getI1Type(), mlir::arith::CmpIPredicate::ugt,
+        cursorRef, payloadRef);
 
     // Conditionally drop the field if it was initialized
-    auto dropIfOp = mlir::scf::IfOp::create(rewriter, 
-        loc, mlir::TypeRange{}, cursorGtPayload, /*addThenRegion=*/true,
-        /*addElseRegion=*/false);
+    auto dropIfOp =
+        mlir::scf::IfOp::create(rewriter, loc, mlir::TypeRange{},
+                                cursorGtPayload, /*addThenRegion=*/true,
+                                /*addElseRegion=*/false);
     rewriter.setInsertionPointToStart(dropIfOp.thenBlock());
     ReussirRefDropOp::create(rewriter, loc, payloadRef);
     mlir::scf::YieldOp::create(rewriter, loc);
@@ -444,8 +447,8 @@ mlir::func::FuncOp ClosureOutliningPass::createClosureCloneFunction(
   mlir::Value token = ReussirTokenAllocOp::create(rewriter, loc, tokenType);
 
   // Allocate assemble space on stack first
-  mlir::Value dstRc = ReussirClosureInstantiateOp::create(rewriter, 
-      loc, specializedRcType, token);
+  mlir::Value dstRc = ReussirClosureInstantiateOp::create(
+      rewriter, loc, specializedRcType, token);
 
   // Borrow the destination closure box
   mlir::Value dstClosureBoxRef =
@@ -459,12 +462,12 @@ mlir::func::FuncOp ClosureOutliningPass::createClosureCloneFunction(
   auto payloadTypes = closureBoxType.getPayloadTypes();
   RefType cursorRefType =
       rewriter.getType<RefType>(rewriter.getI8Type(), Capability::unspecified);
-  mlir::Value srcCursorRef = ReussirClosureCursorOp::create(rewriter, 
-      loc, cursorRefType, rewriter.getIndexAttr(0), srcClosureBoxRef);
+  mlir::Value srcCursorRef = ReussirClosureCursorOp::create(
+      rewriter, loc, cursorRefType, rewriter.getIndexAttr(0), srcClosureBoxRef);
 
   // Transfer the closure box contents, including header and applied arguments
   ReussirClosureTransferOp::create(rewriter, loc, srcClosureBoxRef,
-                                            dstClosureBoxRef);
+                                   dstClosureBoxRef);
 
   // For each payload field, check if cursor is greater than the field
   // pointer and if so, copy the data and emit ownership acquisition
@@ -476,23 +479,26 @@ mlir::func::FuncOp ClosureOutliningPass::createClosureCloneFunction(
         rewriter.getType<RefType>(payloadType, Capability::unspecified);
 
     // Get reference to source payload field
-    mlir::Value srcPayloadRef = ReussirClosureInspectPayloadOp::create(rewriter, 
-        loc, payloadRefType, rewriter.getIndexAttr(i), srcClosureBoxRef);
+    mlir::Value srcPayloadRef = ReussirClosureInspectPayloadOp::create(
+        rewriter, loc, payloadRefType, rewriter.getIndexAttr(i),
+        srcClosureBoxRef);
 
     // Get reference to destination payload field
-    mlir::Value dstPayloadRef = ReussirClosureInspectPayloadOp::create(rewriter, 
-        loc, payloadRefType, rewriter.getIndexAttr(i), dstClosureBoxRef);
+    mlir::Value dstPayloadRef = ReussirClosureInspectPayloadOp::create(
+        rewriter, loc, payloadRefType, rewriter.getIndexAttr(i),
+        dstClosureBoxRef);
 
     // Compare cursor with payload reference: if cursor > payload, the field
     // was initialized and needs to be copied
-    auto cursorGtPayload = ReussirRefCmpOp::create(rewriter, 
-        loc, rewriter.getI1Type(), mlir::arith::CmpIPredicate::ugt,
+    auto cursorGtPayload = ReussirRefCmpOp::create(
+        rewriter, loc, rewriter.getI1Type(), mlir::arith::CmpIPredicate::ugt,
         srcCursorRef, srcPayloadRef);
 
     // Conditionally copy the field if it was initialized
-    auto copyIfOp = mlir::scf::IfOp::create(rewriter, 
-        loc, mlir::TypeRange{}, cursorGtPayload, /*addThenRegion=*/true,
-        /*addElseRegion=*/false);
+    auto copyIfOp =
+        mlir::scf::IfOp::create(rewriter, loc, mlir::TypeRange{},
+                                cursorGtPayload, /*addThenRegion=*/true,
+                                /*addElseRegion=*/false);
     rewriter.setInsertionPointToStart(copyIfOp.thenBlock());
 
     // Emit ownership acquisition for non-trivially copyable types

--- a/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
+++ b/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
@@ -70,19 +70,19 @@ struct RcDecrementExpansionPattern
     // never target atomic boxes (rejected by the `rc.dec` verifier).
     const bool atomic = type.getAtomicKind() == AtomicKind::atomic;
     mlir::Value prevRcCount =
-        atomic ? ReussirRcFetchSubOp::create(rewriter, op.getLoc(),
-                                             op.getRcPtr())
-                     .getRefCount()
-               : ReussirRcFetchOp::create(rewriter, op.getLoc(), op.getRcPtr())
-                     .getRefCount();
-    auto isOne = mlir::arith::CmpIOp::create(rewriter,
-        op.getLoc(), mlir::arith::CmpIPredicate::eq, prevRcCount,
+        atomic
+            ? ReussirRcFetchSubOp::create(rewriter, op.getLoc(), op.getRcPtr())
+                  .getRefCount()
+            : ReussirRcFetchOp::create(rewriter, op.getLoc(), op.getRcPtr())
+                  .getRefCount();
+    auto isOne = mlir::arith::CmpIOp::create(
+        rewriter, op.getLoc(), mlir::arith::CmpIPredicate::eq, prevRcCount,
         mlir::arith::ConstantIndexOp::create(rewriter, op.getLoc(), 1));
     auto likelyUnique =
         ReussirExpectOp::create(rewriter, op.getLoc(), isOne.getResult(), true);
     auto ifOp =
         mlir::scf::IfOp::create(rewriter, op.getLoc(), op->getResultTypes(),
-                                         likelyUnique.getLikely(), true, true);
+                                likelyUnique.getLikely(), true, true);
     RefType borrowedRefType = rewriter.getType<RefType>(
         type.getElementType(), Capability::unspecified, type.getAtomicKind());
     TokenType tokenType = llvm::cast<TokenType>(
@@ -117,30 +117,30 @@ struct RcDecrementExpansionPattern
           // immediately and hide it from that optimization.
           auto projectedRefTy = rewriter.getType<RefType>(
               projectedTy, Capability::unspecified, type.getAtomicKind());
-          mlir::Value slot = ReussirRefProjectOp::create(
-              rewriter, op.getLoc(), projectedRefTy, coerced,
-              rewriter.getIndexAttr(idx));
+          mlir::Value slot =
+              ReussirRefProjectOp::create(rewriter, op.getLoc(), projectedRefTy,
+                                          coerced, rewriter.getIndexAttr(idx));
           ReussirRefDropOp::create(rewriter, op.getLoc(), slot);
         }
       } else {
-        mlir::Value ref = ReussirRcBorrowOp::create(rewriter, 
-            op.getLoc(), borrowedRefType, op.getRcPtr());
+        mlir::Value ref = ReussirRcBorrowOp::create(
+            rewriter, op.getLoc(), borrowedRefType, op.getRcPtr());
         ReussirRefDropOp::create(rewriter, op.getLoc(), ref);
       }
-      mlir::Value token = ReussirRcReinterpretOp::create(rewriter, 
-          op.getLoc(), tokenType, op.getRcPtr());
-      mlir::Value nonnull = ReussirNullableCreateOp::create(rewriter, 
-          op.getLoc(), op.getNullableToken().getType(), token);
+      mlir::Value token = ReussirRcReinterpretOp::create(
+          rewriter, op.getLoc(), tokenType, op.getRcPtr());
+      mlir::Value nonnull = ReussirNullableCreateOp::create(
+          rewriter, op.getLoc(), op.getNullableToken().getType(), token);
       mlir::scf::YieldOp::create(rewriter, op.getLoc(), nonnull);
     }
     {
       rewriter.setInsertionPointToStart(ifOp.elseBlock());
       if (!atomic) {
-        auto decremented = mlir::arith::SubIOp::create(rewriter,
-            op.getLoc(), prevRcCount,
+        auto decremented = mlir::arith::SubIOp::create(
+            rewriter, op.getLoc(), prevRcCount,
             mlir::arith::ConstantIndexOp::create(rewriter, op.getLoc(), 1));
         ReussirRcSetOp::create(rewriter, op.getLoc(), op.getRcPtr(),
-                                        decremented.getResult());
+                               decremented.getResult());
       }
       if (op.isDestructuring()) {
         // The shared path keeps the box alive, so the consumer's bound
@@ -148,8 +148,8 @@ struct RcDecrementExpansionPattern
         // erased.
         op.rematerializeBoundRetains(rewriter);
       }
-      auto null = ReussirNullableCreateOp::create(rewriter, 
-          op.getLoc(), op.getNullableToken().getType(), nullptr);
+      auto null = ReussirNullableCreateOp::create(
+          rewriter, op.getLoc(), op.getNullableToken().getType(), nullptr);
       mlir::scf::YieldOp::create(rewriter, op.getLoc(), null->getResults());
     }
     ifOp->setAttr(kExpandedDecrementAttr, rewriter.getUnitAttr());

--- a/lib/Conversion/RegionPatterns/RegionPatterns.cpp
+++ b/lib/Conversion/RegionPatterns/RegionPatterns.cpp
@@ -53,8 +53,8 @@ private:
     // is left null, which the runtime skips.
     mlir::FlatSymbolRefAttr dropOpRef =
         dropOp ? mlir::SymbolRefAttr::get(dropOp) : mlir::FlatSymbolRefAttr{};
-    auto vtableOp = ReussirRegionVTableOp::create(builder,
-        moduleOp.getLoc(), vtableName, type, dropOpRef);
+    auto vtableOp = ReussirRegionVTableOp::create(builder, moduleOp.getLoc(),
+                                                  vtableName, type, dropOpRef);
     return vtableOp;
   }
 
@@ -89,8 +89,8 @@ struct RegionInlinePattern : public mlir::OpRewritePattern<ReussirRegionRunOp> {
   mlir::LogicalResult
   matchAndRewrite(ReussirRegionRunOp op,
                   mlir::PatternRewriter &rewriter) const override {
-    auto region = ReussirRegionCreateOp::create(rewriter, 
-        op.getLoc(), RegionType::get(op->getContext()));
+    auto region = ReussirRegionCreateOp::create(
+        rewriter, op.getLoc(), RegionType::get(op->getContext()));
     auto yieldOp =
         llvm::cast<ReussirRegionYieldOp>(op.getBody().front().getTerminator());
     rewriter.inlineBlockBefore(&op.getBody().front(), op, region->getResults());
@@ -104,8 +104,8 @@ struct RegionInlinePattern : public mlir::OpRewritePattern<ReussirRegionRunOp> {
     // Create the final value based on the yield value
     mlir::Value finalValue;
     if (rcType && rcType.getCapability() == Capability::flex) {
-      auto freezeOp = ReussirRcFreezeOp::create(rewriter, 
-          op.getLoc(), op->getResult(0).getType(), yieldValue);
+      auto freezeOp = ReussirRcFreezeOp::create(
+          rewriter, op.getLoc(), op->getResult(0).getType(), yieldValue);
       finalValue = freezeOp.getResult();
     } else {
       finalValue = yieldValue;

--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -85,27 +85,27 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
     mlir::Value condition;
     if (p.pattern.empty()) {
       auto len = ReussirStrLenOp::create(builder, loc, builder.getIndexType(),
-                                                 currentSlice);
+                                         currentSlice);
       auto zero = mlir::arith::ConstantIndexOp::create(builder, loc, 0);
-      condition = mlir::arith::CmpIOp::create(builder, 
-          loc, mlir::arith::CmpIPredicate::eq, len.getResult(),
+      condition = mlir::arith::CmpIOp::create(
+          builder, loc, mlir::arith::CmpIPredicate::eq, len.getResult(),
           zero.getResult());
     } else {
-      auto startswith = ReussirStrUnsafeStartWithOp::create(builder, 
-          loc, i1Type, currentSlice, builder.getStringAttr(p.pattern));
+      auto startswith = ReussirStrUnsafeStartWithOp::create(
+          builder, loc, i1Type, currentSlice, builder.getStringAttr(p.pattern));
       auto len = ReussirStrLenOp::create(builder, loc, builder.getIndexType(),
-                                                 currentSlice);
+                                         currentSlice);
       auto expectedLen =
           mlir::arith::ConstantIndexOp::create(builder, loc, p.pattern.size());
-      auto lenOk = mlir::arith::CmpIOp::create(builder, 
-          loc, mlir::arith::CmpIPredicate::eq, len.getResult(),
+      auto lenOk = mlir::arith::CmpIOp::create(
+          builder, loc, mlir::arith::CmpIPredicate::eq, len.getResult(),
           expectedLen.getResult());
-      condition = mlir::arith::AndIOp::create(builder, 
-          loc, startswith.getResult(), lenOk.getResult());
+      condition = mlir::arith::AndIOp::create(
+          builder, loc, startswith.getResult(), lenOk.getResult());
     }
 
-    auto ifOp = mlir::scf::IfOp::create(builder, 
-        loc, mlir::TypeRange{indexType, i1Type}, condition,
+    auto ifOp = mlir::scf::IfOp::create(
+        builder, loc, mlir::TypeRange{indexType, i1Type}, condition,
         /*addThenRegion=*/true, /*addElseRegion=*/true);
 
     {
@@ -114,8 +114,8 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
       auto idx =
           mlir::arith::ConstantIndexOp::create(builder, loc, p.originalIdx);
       auto trueVal = mlir::arith::ConstantIntOp::create(builder, loc, 1, 1);
-      mlir::scf::YieldOp::create(builder, 
-          loc, mlir::ValueRange{idx.getResult(), trueVal.getResult()});
+      mlir::scf::YieldOp::create(
+          builder, loc, mlir::ValueRange{idx.getResult(), trueVal.getResult()});
     }
 
     {
@@ -123,8 +123,9 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
       builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
       auto poison = mlir::ub::PoisonOp::create(builder, loc, indexType);
       auto falseVal = mlir::arith::ConstantIntOp::create(builder, loc, 0, 1);
-      mlir::scf::YieldOp::create(builder, 
-          loc, mlir::ValueRange{poison.getResult(), falseVal.getResult()});
+      mlir::scf::YieldOp::create(
+          builder, loc,
+          mlir::ValueRange{poison.getResult(), falseVal.getResult()});
     }
     return {ifOp.getResult(0), ifOp.getResult(1)};
   }
@@ -144,33 +145,36 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
   if (lcpLen > 0) {
     auto lcp = first.substr(0, lcpLen);
     auto len = ReussirStrLenOp::create(builder, loc, builder.getIndexType(),
-                                               currentSlice);
+                                       currentSlice);
     auto minLen = mlir::arith::ConstantIndexOp::create(builder, loc, lcpLen);
-    auto lenOk = mlir::arith::CmpIOp::create(builder, 
-        loc, mlir::arith::CmpIPredicate::uge, len.getResult(),
+    auto lenOk = mlir::arith::CmpIOp::create(
+        builder, loc, mlir::arith::CmpIPredicate::uge, len.getResult(),
         minLen.getResult());
 
-    auto ifLen = mlir::scf::IfOp::create(builder, 
-        loc, mlir::TypeRange{indexType, i1Type}, lenOk.getResult(),
+    auto ifLen = mlir::scf::IfOp::create(
+        builder, loc, mlir::TypeRange{indexType, i1Type}, lenOk.getResult(),
         /*addThenRegion=*/true, /*addElseRegion=*/true);
 
     {
       mlir::OpBuilder::InsertionGuard guard(builder);
       builder.setInsertionPointToStart(&ifLen.getThenRegion().front());
 
-      auto startswith = ReussirStrUnsafeStartWithOp::create(builder, 
-          loc, i1Type, currentSlice, builder.getStringAttr(lcp));
+      auto startswith = ReussirStrUnsafeStartWithOp::create(
+          builder, loc, i1Type, currentSlice, builder.getStringAttr(lcp));
 
-      auto ifMatch = mlir::scf::IfOp::create(builder, 
-          loc, mlir::TypeRange{indexType, i1Type}, startswith.getResult(),
+      auto ifMatch = mlir::scf::IfOp::create(
+          builder, loc, mlir::TypeRange{indexType, i1Type},
+          startswith.getResult(),
           /*addThenRegion=*/true, /*addElseRegion=*/true);
 
       {
         mlir::OpBuilder::InsertionGuard thenGuard(builder);
         builder.setInsertionPointToStart(&ifMatch.getThenRegion().front());
-        auto offset = mlir::arith::ConstantIndexOp::create(builder, loc, lcpLen);
-        auto nextSlice = ReussirStrSliceOp::create(builder, 
-            loc, currentSlice.getType(), currentSlice, offset.getResult());
+        auto offset =
+            mlir::arith::ConstantIndexOp::create(builder, loc, lcpLen);
+        auto nextSlice =
+            ReussirStrSliceOp::create(builder, loc, currentSlice.getType(),
+                                      currentSlice, offset.getResult());
 
         llvm::SmallVector<PatternInfo> nextPatterns;
         for (const auto &p : patterns) {
@@ -178,8 +182,8 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
         }
         auto res = buildDecisionTree(loc, builder, indexType, i1Type,
                                      nextSlice.getResult(), nextPatterns);
-        mlir::scf::YieldOp::create(builder, 
-            loc, mlir::ValueRange{res.first, res.second});
+        mlir::scf::YieldOp::create(builder, loc,
+                                   mlir::ValueRange{res.first, res.second});
       }
 
       {
@@ -187,8 +191,9 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
         builder.setInsertionPointToStart(&ifMatch.getElseRegion().front());
         auto poison = mlir::ub::PoisonOp::create(builder, loc, indexType);
         auto falseVal = mlir::arith::ConstantIntOp::create(builder, loc, 0, 1);
-        mlir::scf::YieldOp::create(builder, 
-            loc, mlir::ValueRange{poison.getResult(), falseVal.getResult()});
+        mlir::scf::YieldOp::create(
+            builder, loc,
+            mlir::ValueRange{poison.getResult(), falseVal.getResult()});
       }
       mlir::scf::YieldOp::create(builder, loc, ifMatch.getResults());
     }
@@ -198,8 +203,9 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
       builder.setInsertionPointToStart(&ifLen.getElseRegion().front());
       auto poison = mlir::ub::PoisonOp::create(builder, loc, indexType);
       auto falseVal = mlir::arith::ConstantIntOp::create(builder, loc, 0, 1);
-      mlir::scf::YieldOp::create(builder, 
-          loc, mlir::ValueRange{poison.getResult(), falseVal.getResult()});
+      mlir::scf::YieldOp::create(
+          builder, loc,
+          mlir::ValueRange{poison.getResult(), falseVal.getResult()});
     }
 
     return {ifLen.getResult(0), ifLen.getResult(1)};
@@ -217,13 +223,14 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
   }
 
   auto len = ReussirStrLenOp::create(builder, loc, builder.getIndexType(),
-                                             currentSlice);
+                                     currentSlice);
   auto zero = mlir::arith::ConstantIndexOp::create(builder, loc, 0);
-  auto isZero = mlir::arith::CmpIOp::create(builder, 
-      loc, mlir::arith::CmpIPredicate::eq, len.getResult(), zero.getResult());
+  auto isZero =
+      mlir::arith::CmpIOp::create(builder, loc, mlir::arith::CmpIPredicate::eq,
+                                  len.getResult(), zero.getResult());
 
-  auto ifZero = mlir::scf::IfOp::create(builder, 
-      loc, mlir::TypeRange{indexType, i1Type}, isZero.getResult(),
+  auto ifZero = mlir::scf::IfOp::create(
+      builder, loc, mlir::TypeRange{indexType, i1Type}, isZero.getResult(),
       /*addThenRegion=*/true, /*addElseRegion=*/true);
 
   // Then: len == 0
@@ -231,16 +238,17 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
     mlir::OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(&ifZero.getThenRegion().front());
     if (!emptyPatterns.empty()) {
-      auto idx = mlir::arith::ConstantIndexOp::create(builder, 
-          loc, emptyPatterns[0].originalIdx);
+      auto idx = mlir::arith::ConstantIndexOp::create(
+          builder, loc, emptyPatterns[0].originalIdx);
       auto trueVal = mlir::arith::ConstantIntOp::create(builder, loc, 1, 1);
-      mlir::scf::YieldOp::create(builder, 
-          loc, mlir::ValueRange{idx.getResult(), trueVal.getResult()});
+      mlir::scf::YieldOp::create(
+          builder, loc, mlir::ValueRange{idx.getResult(), trueVal.getResult()});
     } else {
       auto poison = mlir::ub::PoisonOp::create(builder, loc, indexType);
       auto falseVal = mlir::arith::ConstantIntOp::create(builder, loc, 0, 1);
-      mlir::scf::YieldOp::create(builder, 
-          loc, mlir::ValueRange{poison.getResult(), falseVal.getResult()});
+      mlir::scf::YieldOp::create(
+          builder, loc,
+          mlir::ValueRange{poison.getResult(), falseVal.getResult()});
     }
   }
 
@@ -252,13 +260,14 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
     if (nonEmptyPatterns.empty()) {
       auto poison = mlir::ub::PoisonOp::create(builder, loc, indexType);
       auto falseVal = mlir::arith::ConstantIntOp::create(builder, loc, 0, 1);
-      mlir::scf::YieldOp::create(builder, 
-          loc, mlir::ValueRange{poison.getResult(), falseVal.getResult()});
+      mlir::scf::YieldOp::create(
+          builder, loc,
+          mlir::ValueRange{poison.getResult(), falseVal.getResult()});
     } else {
-      auto byteAtZero = ReussirStrUnsafeByteAtOp::create(builder, 
-          loc, builder.getI8Type(), currentSlice, zero.getResult());
-      auto byteIndex = mlir::arith::IndexCastOp::create(builder, 
-          loc, builder.getIndexType(), byteAtZero.getResult());
+      auto byteAtZero = ReussirStrUnsafeByteAtOp::create(
+          builder, loc, builder.getI8Type(), currentSlice, zero.getResult());
+      auto byteIndex = mlir::arith::IndexCastOp::create(
+          builder, loc, builder.getIndexType(), byteAtZero.getResult());
 
       llvm::SmallVector<int64_t> cases;
       llvm::MapVector<uint8_t, llvm::SmallVector<PatternInfo>> groups;
@@ -272,12 +281,12 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
       }
 
       auto one = mlir::arith::ConstantIndexOp::create(builder, loc, 1);
-      auto nextSlice = ReussirStrSliceOp::create(builder, 
-          loc, currentSlice.getType(), currentSlice, one.getResult());
+      auto nextSlice = ReussirStrSliceOp::create(
+          builder, loc, currentSlice.getType(), currentSlice, one.getResult());
 
-      auto switchOp = mlir::scf::IndexSwitchOp::create(builder, 
-          loc, mlir::TypeRange{indexType, i1Type}, byteIndex.getResult(), cases,
-          cases.size());
+      auto switchOp = mlir::scf::IndexSwitchOp::create(
+          builder, loc, mlir::TypeRange{indexType, i1Type},
+          byteIndex.getResult(), cases, cases.size());
 
       for (auto [idx, b] : llvm::enumerate(cases)) {
         auto &region = switchOp.getCaseRegions()[idx];
@@ -286,8 +295,8 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
         builder.setInsertionPointToStart(&region.front());
         auto res = buildDecisionTree(loc, builder, indexType, i1Type,
                                      nextSlice.getResult(), groups[b]);
-        mlir::scf::YieldOp::create(builder, 
-            loc, mlir::ValueRange{res.first, res.second});
+        mlir::scf::YieldOp::create(builder, loc,
+                                   mlir::ValueRange{res.first, res.second});
       }
 
       // Default region
@@ -298,8 +307,9 @@ buildDecisionTree(mlir::Location loc, mlir::OpBuilder &builder,
         builder.setInsertionPointToStart(&region.front());
         auto poison = mlir::ub::PoisonOp::create(builder, loc, indexType);
         auto falseVal = mlir::arith::ConstantIntOp::create(builder, loc, 0, 1);
-        mlir::scf::YieldOp::create(builder, 
-            loc, mlir::ValueRange{poison.getResult(), falseVal.getResult()});
+        mlir::scf::YieldOp::create(
+            builder, loc,
+            mlir::ValueRange{poison.getResult(), falseVal.getResult()});
       }
       mlir::scf::YieldOp::create(builder, loc, switchOp.getResults());
     }
@@ -346,7 +356,7 @@ std::string emitDecisionFunction(mlir::ModuleOp module,
                                entry->getArgument(0), patternInfos);
 
   mlir::func::ReturnOp::create(builder, module.getLoc(),
-                                       mlir::ValueRange{res.first, res.second});
+                               mlir::ValueRange{res.first, res.second});
 
   return funcName;
 }
@@ -373,28 +383,31 @@ struct ReussirNullableDispatchOpRewritePattern
   static bool tokenMatchesCondition(mlir::scf::IfOp ifOp,
                                     mlir::OpResult result) {
     unsigned idx = result.getResultNumber();
-    auto thenCreate =
-        ifOp.thenYield().getOperand(idx).getDefiningOp<ReussirNullableCreateOp>();
-    auto elseCreate =
-        ifOp.elseYield().getOperand(idx).getDefiningOp<ReussirNullableCreateOp>();
+    auto thenCreate = ifOp.thenYield()
+                          .getOperand(idx)
+                          .getDefiningOp<ReussirNullableCreateOp>();
+    auto elseCreate = ifOp.elseYield()
+                          .getOperand(idx)
+                          .getDefiningOp<ReussirNullableCreateOp>();
     return thenCreate && elseCreate && thenCreate.getPtr() &&
            !elseCreate.getPtr();
   }
 
   mlir::LogicalResult
-  matchAndRewrite(ReussirNullableDispatchOp op,
-                  OpAdaptor adaptor,
+  matchAndRewrite(ReussirNullableDispatchOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     // First, create a check operation to get the null flag from the input.
-    mlir::Value flag = reussir::ReussirNullableCheckOp::create(rewriter,
-        op.getLoc(), op.getNullable());
+    mlir::Value flag = reussir::ReussirNullableCheckOp::create(
+        rewriter, op.getLoc(), op.getNullable());
     // mark expect not null
     if (op->hasAttr(REUSSIR_EXPANDED_ENSURE_ATTR))
-      flag = reussir::ReussirExpectOp::create(rewriter, op.getLoc(), flag, true);
+      flag =
+          reussir::ReussirExpectOp::create(rewriter, op.getLoc(), flag, true);
 
-    auto scfIfOp = mlir::scf::IfOp::create(rewriter,
-        op.getLoc(), op->getResultTypes(), flag, /*addThenRegion=*/true,
-        /*addElseRegion=*/true);
+    auto scfIfOp =
+        mlir::scf::IfOp::create(rewriter, op.getLoc(), op->getResultTypes(),
+                                flag, /*addThenRegion=*/true,
+                                /*addElseRegion=*/true);
     if (op->hasAttr(REUSSIR_EXPANDED_ENSURE_ATTR))
       if (auto producerIf = mlir::dyn_cast_if_present<mlir::scf::IfOp>(
               op.getNullable().getDefiningOp()))
@@ -410,8 +423,9 @@ struct ReussirNullableDispatchOpRewritePattern
 
     // Now, for the then region, we first create the coerced value
     rewriter.setInsertionPointToStart(&scfIfOp.getThenRegion().front());
-    auto coerced = reussir::ReussirNullableCoerceOp::create(rewriter, 
-        op.getLoc(), op.getNullable().getType().getPtrTy(), op.getNullable());
+    auto coerced = reussir::ReussirNullableCoerceOp::create(
+        rewriter, op.getLoc(), op.getNullable().getType().getPtrTy(),
+        op.getNullable());
     // Then we inline the region, supplying coerced value as the argument
     rewriter.inlineBlockBefore(
         &*op.getNonNullRegion().begin(), &*scfIfOp.getThenRegion().begin(),
@@ -445,16 +459,15 @@ private:
           getProjectedType(recordType.getMembers()[*singletonTag],
                            recordType.getMemberIsField()[*singletonTag],
                            variantRef.getCapability());
-      RefType coercedType = RefType::get(rewriter.getContext(),
-                                         targetVariantType,
-                                         variantRef.getCapability());
+      RefType coercedType = RefType::get(
+          rewriter.getContext(), targetVariantType, variantRef.getCapability());
       auto coerced = reussir::ReussirRecordCoerceOp::create(
           rewriter, op.getLoc(), coercedType,
           rewriter.getIndexAttr(*singletonTag), op.getVariant());
       args.push_back(coerced);
     }
-    rewriter.inlineBlockBefore(&op->getRegion(idx).front(), block,
-                               block->end(), args);
+    rewriter.inlineBlockBefore(&op->getRegion(idx).front(), block, block->end(),
+                               args);
   }
 
   // The generic dispatch over the arm subset `setIndices`: read the tag and
@@ -467,8 +480,8 @@ private:
     auto tag = reussir::ReussirRecordTagOp::create(rewriter, op.getLoc(),
                                                    op.getVariant());
     bool allSingletons = llvm::all_of(setIndices, [&](unsigned idx) {
-      return llvm::cast<mlir::DenseI64ArrayAttr>(op.getTagSets()[idx])
-                 .size() == 1;
+      return llvm::cast<mlir::DenseI64ArrayAttr>(op.getTagSets()[idx]).size() ==
+             1;
     });
 
     mlir::Value outerSwitchValue;
@@ -510,8 +523,7 @@ private:
         rewriter.setInsertionPointToStart(block);
         auto poison = mlir::ub::PoisonOp::create(rewriter, op.getLoc(),
                                                  rewriter.getIndexType());
-        mlir::scf::YieldOp::create(rewriter, op.getLoc(),
-                                   poison->getResults());
+        mlir::scf::YieldOp::create(rewriter, op.getLoc(), poison->getResults());
       }
       outerSwitchValue = preDispatch.getResult(0);
       outerSwitchCases = llvm::to_vector(
@@ -541,13 +553,11 @@ private:
       // `createBlock` moves the insertion point into the case; keep the
       // caller's position (right after the switch) intact.
       mlir::OpBuilder::InsertionGuard guard(rewriter);
-      auto tagArray =
-          llvm::cast<mlir::DenseI64ArrayAttr>(op.getTagSets()[idx]);
+      auto tagArray = llvm::cast<mlir::DenseI64ArrayAttr>(op.getTagSets()[idx]);
       mlir::Block *block = rewriter.createBlock(&region, region.begin());
       inlineArm(op, rewriter, idx,
-                tagArray.size() == 1
-                    ? std::optional<int64_t>(tagArray[0])
-                    : std::nullopt,
+                tagArray.size() == 1 ? std::optional<int64_t>(tagArray[0])
+                                     : std::nullopt,
                 block);
     }
     return indexSwitchOp;
@@ -571,18 +581,18 @@ public:
     mlir::TypedValue<RcType> scrutinee;
     llvm::SmallVector<unsigned> peeled;
     llvm::SmallVector<unsigned> remaining;
-    RecordType recordType = llvm::cast<RecordType>(
-        op.getVariant().getType().getElementType());
+    RecordType recordType =
+        llvm::cast<RecordType>(op.getVariant().getType().getElementType());
     if (encoding && encoding.getValue() == kSpecialPtrTagImmortal)
       if (auto borrow = op.getVariant().getDefiningOp<ReussirRcBorrowOp>();
           borrow && borrow.getRcPtr().getType().mayCarrySpecialPointerTag())
         scrutinee = borrow.getRcPtr();
     for (auto [idx, tagSet] : llvm::enumerate(op.getTagSets())) {
       auto tagArray = llvm::cast<mlir::DenseI64ArrayAttr>(tagSet);
-      auto arm = tagArray.size() == 1
-                     ? llvm::dyn_cast<RecordType>(
-                           recordType.getMembers()[tagArray[0]])
-                     : RecordType{};
+      auto arm =
+          tagArray.size() == 1
+              ? llvm::dyn_cast<RecordType>(recordType.getMembers()[tagArray[0]])
+              : RecordType{};
       if (scrutinee && arm && arm.isCompound() && arm.getComplete() &&
           arm.getMembers().empty())
         peeled.push_back(idx);
@@ -606,9 +616,9 @@ public:
       auto isImmediate = ReussirRcCompareImmortalOp::create(
           rewriter, op.getLoc(), rewriter.getI1Type(), scrutinee,
           rewriter.getIndexAttr(tag));
-      auto ifOp = mlir::scf::IfOp::create(rewriter, op.getLoc(),
-                                          op->getResultTypes(),
-                                          isImmediate.getResult(), true, true);
+      auto ifOp =
+          mlir::scf::IfOp::create(rewriter, op.getLoc(), op->getResultTypes(),
+                                  isImmediate.getResult(), true, true);
       inlineArm(op, rewriter, idx, tag, ifOp.thenBlock());
       if (!outermost)
         outermost = ifOp;
@@ -638,8 +648,7 @@ public:
     } else {
       auto dispatch = emitTagDispatch(op, rewriter, remaining);
       rewriter.setInsertionPointAfter(dispatch);
-      mlir::scf::YieldOp::create(rewriter, op.getLoc(),
-                                 dispatch->getResults());
+      mlir::scf::YieldOp::create(rewriter, op.getLoc(), dispatch->getResults());
     }
     rewriter.replaceOp(op, outermost->getResults());
     return mlir::success();
@@ -650,17 +659,17 @@ struct ReussirClosureUniqifyOpRewritePattern
     : public mlir::OpConversionPattern<ReussirClosureUniqifyOp> {
   using OpConversionPattern::OpConversionPattern;
   mlir::LogicalResult
-  matchAndRewrite(ReussirClosureUniqifyOp op,
-                  OpAdaptor adaptor,
+  matchAndRewrite(ReussirClosureUniqifyOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     // Create a check operation to see if the closure is unique
-    auto isUnique = reussir::ReussirRcIsUniqueOp::create(rewriter, 
-        op.getLoc(), op.getClosure());
+    auto isUnique = reussir::ReussirRcIsUniqueOp::create(rewriter, op.getLoc(),
+                                                         op.getClosure());
 
     // Create an SCF if-else operation
-    auto scfIfOp = mlir::scf::IfOp::create(rewriter, 
-        op.getLoc(), op->getResultTypes(), isUnique, /*addThenRegion=*/true,
-        /*addElseRegion=*/true);
+    auto scfIfOp =
+        mlir::scf::IfOp::create(rewriter, op.getLoc(), op->getResultTypes(),
+                                isUnique, /*addThenRegion=*/true,
+                                /*addElseRegion=*/true);
 
     // In the then region (closure is unique), just return the original
     // closure
@@ -670,8 +679,8 @@ struct ReussirClosureUniqifyOpRewritePattern
     // In the else region (closure is not unique), clone the closure, dec the
     // original rc pointer
     rewriter.setInsertionPointToStart(&scfIfOp.getElseRegion().front());
-    auto cloned = reussir::ReussirClosureCloneOp::create(rewriter, 
-        op.getLoc(), op.getClosure().getType(), op.getClosure());
+    auto cloned = reussir::ReussirClosureCloneOp::create(
+        rewriter, op.getLoc(), op.getClosure().getType(), op.getClosure());
     reussir::ReussirRcDecOp::create(rewriter, op.getLoc(),
                                     /*nullableToken=*/mlir::Type{},
                                     op.getClosure(),
@@ -705,12 +714,12 @@ struct ReussirClosureEvalOpRewritePattern
     auto inputTypes = closureType.getInputTypes();
     mlir::Value cur = op.getClosure();
     for (auto [index, arg] : llvm::enumerate(op.getArgs())) {
-      auto appliedType = RcType::get(
-          rewriter.getContext(),
-          ClosureType::get(rewriter.getContext(),
-                           inputTypes.drop_front(index + 1),
-                           closureType.getOutputType()),
-          rcType.getCapability(), rcType.getAtomicKind());
+      auto appliedType =
+          RcType::get(rewriter.getContext(),
+                      ClosureType::get(rewriter.getContext(),
+                                       inputTypes.drop_front(index + 1),
+                                       closureType.getOutputType()),
+                      rcType.getCapability(), rcType.getAtomicKind());
       cur = ReussirClosureApplyOp::create(rewriter, op.getLoc(), appliedType,
                                           arg, cur);
     }
@@ -750,15 +759,14 @@ static void cloneArrayWithUniqueViewBody(ReussirArrayWithUniqueViewOp op,
 }
 
 static mlir::MemRefType getArrayViewMemRefType(ArrayType arrayType) {
-  return mlir::MemRefType::get(arrayType.getShape(), arrayType.getElementType());
+  return mlir::MemRefType::get(arrayType.getShape(),
+                               arrayType.getElementType());
 }
 
-static mlir::Value materializeArrayViewValue(mlir::Location loc,
-                                             mlir::PatternRewriter &rewriter,
-                                             ArrayType arrayType,
-                                             mlir::Value ref,
-                                             mlir::Type viewType,
-                                             bool writable) {
+static mlir::Value
+materializeArrayViewValue(mlir::Location loc, mlir::PatternRewriter &rewriter,
+                          ArrayType arrayType, mlir::Value ref,
+                          mlir::Type viewType, bool writable) {
   auto memrefType = getArrayViewMemRefType(arrayType);
   auto memrefView =
       ReussirArrayViewOp::create(rewriter, loc, memrefType, ref).getView();
@@ -766,8 +774,9 @@ static mlir::Value materializeArrayViewValue(mlir::Location loc,
     return memrefView;
 
   auto tensorType = llvm::cast<mlir::RankedTensorType>(viewType);
-  return mlir::bufferization::ToTensorOp::create(rewriter, loc, tensorType, memrefView,
-                                               /*restrict=*/true, writable)
+  return mlir::bufferization::ToTensorOp::create(rewriter, loc, tensorType,
+                                                 memrefView,
+                                                 /*restrict=*/true, writable)
       .getResult();
 }
 
@@ -778,12 +787,13 @@ struct ReussirArrayViewOpRewritePattern
   mlir::LogicalResult
   matchAndRewrite(ReussirArrayViewOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto tensorType = llvm::dyn_cast<mlir::RankedTensorType>(op.getView().getType());
+    auto tensorType =
+        llvm::dyn_cast<mlir::RankedTensorType>(op.getView().getType());
     if (!tensorType)
       return rewriter.notifyMatchFailure(op, "expected tensor array view");
 
-    auto arrayType =
-        llvm::cast<ArrayType>(llvm::cast<RefType>(op.getRef().getType()).getElementType());
+    auto arrayType = llvm::cast<ArrayType>(
+        llvm::cast<RefType>(op.getRef().getType()).getElementType());
     auto value = materializeArrayViewValue(op.getLoc(), rewriter, arrayType,
                                            adaptor.getRef(), tensorType,
                                            /*writable=*/false);
@@ -797,8 +807,7 @@ struct ReussirArrayWithUniqueViewOpRewritePattern
   using OpConversionPattern::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(ReussirArrayWithUniqueViewOp op,
-                  OpAdaptor adaptor,
+  matchAndRewrite(ReussirArrayWithUniqueViewOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Location loc = op.getLoc();
     RcType rcType = op.getArray().getType();
@@ -814,43 +823,42 @@ struct ReussirArrayWithUniqueViewOpRewritePattern
                                        /*writable=*/true);
     };
 
-    auto makeClonedArray =
-        [&]() -> std::pair<mlir::Value, mlir::Value> {
+    auto makeClonedArray = [&]() -> std::pair<mlir::Value, mlir::Value> {
       auto borrowedType = RefType::get(rewriter.getContext(), arrayType);
       auto srcRef =
           ReussirRcBorrowOp::create(rewriter, loc, borrowedType, op.getArray());
       RcBoxType rcBoxType = RcBoxType::get(rewriter.getContext(), arrayType,
                                            /*regional=*/false);
       auto dataLayout = mlir::DataLayout::closest(op.getOperation());
-      TokenType tokenType =
-          TokenType::get(rewriter.getContext(),
-                         dataLayout.getTypeABIAlignment(rcBoxType),
-                         dataLayout.getTypeSize(rcBoxType).getFixedValue());
+      TokenType tokenType = TokenType::get(
+          rewriter.getContext(), dataLayout.getTypeABIAlignment(rcBoxType),
+          dataLayout.getTypeSize(rcBoxType).getFixedValue());
       auto token = ReussirTokenAllocOp::create(rewriter, loc, tokenType);
       auto poison = mlir::ub::PoisonOp::create(rewriter, loc, arrayType);
-      auto cloned = ReussirRcCreateOp::create(rewriter, 
-          loc, rcType, poison.getResult(), token.getResult(), mlir::Value{},
-          mlir::FlatSymbolRefAttr{}, mlir::UnitAttr{});
-      auto dstRef =
-          ReussirRcBorrowOp::create(rewriter, loc, borrowedType, cloned.getResult());
+      auto cloned = ReussirRcCreateOp::create(
+          rewriter, loc, rcType, poison.getResult(), token.getResult(),
+          mlir::Value{}, mlir::FlatSymbolRefAttr{}, mlir::UnitAttr{});
+      auto dstRef = ReussirRcBorrowOp::create(rewriter, loc, borrowedType,
+                                              cloned.getResult());
       ReussirRefMemcpyOp::create(rewriter, loc, srcRef.getResult(),
-                                          dstRef.getResult());
+                                 dstRef.getResult());
       ReussirRefAcquireOp::create(rewriter, loc, dstRef.getResult(), false,
-                                           nullptr);
+                                  nullptr);
 
       auto refCount = ReussirRcFetchOp::create(rewriter, loc, op.getArray());
-      auto decremented = mlir::arith::SubIOp::create(rewriter, 
-          loc, refCount.getRefCount(),
+      auto decremented = mlir::arith::SubIOp::create(
+          rewriter, loc, refCount.getRefCount(),
           mlir::arith::ConstantIndexOp::create(rewriter, loc, 1));
-      ReussirRcSetOp::create(rewriter, loc, op.getArray(), decremented.getResult());
+      ReussirRcSetOp::create(rewriter, loc, op.getArray(),
+                             decremented.getResult());
       return {cloned.getResult(), dstRef.getResult()};
     };
 
     auto isUnique =
         reussir::ReussirRcIsUniqueOp::create(rewriter, loc, op.getArray());
-    auto scfIfOp = mlir::scf::IfOp::create(rewriter, 
-        loc, op->getResultTypes(), isUnique, /*addThenRegion=*/true,
-        /*addElseRegion=*/true);
+    auto scfIfOp = mlir::scf::IfOp::create(rewriter, loc, op->getResultTypes(),
+                                           isUnique, /*addThenRegion=*/true,
+                                           /*addElseRegion=*/true);
 
     rewriter.setInsertionPointToStart(&scfIfOp.getThenRegion().front());
     cloneArrayWithUniqueViewBody(op, op.getArray(),
@@ -858,9 +866,9 @@ struct ReussirArrayWithUniqueViewOpRewritePattern
 
     rewriter.setInsertionPointToStart(&scfIfOp.getElseRegion().front());
     auto [clonedArray, clonedRef] = makeClonedArray();
-    auto clonedView = materializeArrayViewValue(loc, rewriter, arrayType,
-                                                clonedRef, viewType,
-                                                /*writable=*/true);
+    auto clonedView =
+        materializeArrayViewValue(loc, rewriter, arrayType, clonedRef, viewType,
+                                  /*writable=*/true);
     cloneArrayWithUniqueViewBody(op, clonedArray, clonedView, rewriter);
 
     rewriter.replaceOp(op, scfIfOp.getResults());
@@ -872,8 +880,7 @@ struct ReussirScfYieldOpRewritePattern
     : public mlir::OpConversionPattern<ReussirScfYieldOp> {
   using OpConversionPattern::OpConversionPattern;
   mlir::LogicalResult
-  matchAndRewrite(ReussirScfYieldOp op,
-                  OpAdaptor adaptor,
+  matchAndRewrite(ReussirScfYieldOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<mlir::scf::YieldOp>(op, op->getOperands());
     return mlir::success();
@@ -884,11 +891,10 @@ struct ReussirTokenEnsureOpRewritePattern
     : public mlir::OpConversionPattern<ReussirTokenEnsureOp> {
   using OpConversionPattern::OpConversionPattern;
   mlir::LogicalResult
-  matchAndRewrite(ReussirTokenEnsureOp op,
-                  OpAdaptor adaptor,
+  matchAndRewrite(ReussirTokenEnsureOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto nullableDispatchOp = ReussirNullableDispatchOp::create(rewriter, 
-        op.getLoc(), op.getType(), op.getNullableToken());
+    auto nullableDispatchOp = ReussirNullableDispatchOp::create(
+        rewriter, op.getLoc(), op.getType(), op.getNullableToken());
 
     {
       mlir::Block *thenBlock =
@@ -920,13 +926,13 @@ struct ReussirTokenEnsureOpRewritePattern
                   : nullptr;
           // it is safe since RC must dominate this path
           if (reinterpretOp)
-            tokenSrc = reussir::ReussirRcReinterpretOp::create(rewriter, 
-                op.getLoc(), op.getType(), reinterpretOp.getRcPtr());
+            tokenSrc = reussir::ReussirRcReinterpretOp::create(
+                rewriter, op.getLoc(), op.getType(), reinterpretOp.getRcPtr());
         }
-      auto launderedToken = ReussirTokenLaunderOp::create(rewriter, 
-          op.getLoc(), op.getType(), tokenSrc);
+      auto launderedToken = ReussirTokenLaunderOp::create(
+          rewriter, op.getLoc(), op.getType(), tokenSrc);
       mlir::scf::YieldOp::create(rewriter, op.getLoc(),
-                                          launderedToken->getResults());
+                                 launderedToken->getResults());
     }
     {
       mlir::Block *elseBlock =
@@ -935,7 +941,7 @@ struct ReussirTokenEnsureOpRewritePattern
       auto allocatedToken =
           ReussirTokenAllocOp::create(rewriter, op.getLoc(), op.getType());
       mlir::scf::YieldOp::create(rewriter, op.getLoc(),
-                                          allocatedToken->getResults());
+                                 allocatedToken->getResults());
     }
     nullableDispatchOp->setAttr(REUSSIR_EXPANDED_ENSURE_ATTR,
                                 rewriter.getUnitAttr());
@@ -986,30 +992,30 @@ struct ReussirStrByteAtOpRewritePattern
     : public mlir::OpConversionPattern<ReussirStrByteAtOp> {
   using OpConversionPattern::OpConversionPattern;
   mlir::LogicalResult
-  matchAndRewrite(ReussirStrByteAtOp op,
-                  OpAdaptor adaptor,
+  matchAndRewrite(ReussirStrByteAtOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Location loc = op.getLoc();
 
     // Get string length
-    auto lenOp = reussir::ReussirStrLenOp::create(rewriter, 
-        loc, rewriter.getIndexType(), op.getStr());
+    auto lenOp = reussir::ReussirStrLenOp::create(
+        rewriter, loc, rewriter.getIndexType(), op.getStr());
 
     // Check if index is within bounds (index < len)
-    auto inBounds = mlir::arith::CmpIOp::create(rewriter, 
-        loc, mlir::arith::CmpIPredicate::ult, op.getIndex(), lenOp.getResult());
+    auto inBounds = mlir::arith::CmpIOp::create(
+        rewriter, loc, mlir::arith::CmpIPredicate::ult, op.getIndex(),
+        lenOp.getResult());
 
     // Create if-else block
-    auto ifOp = mlir::scf::IfOp::create(rewriter, 
-        loc, op.getResult().getType(), inBounds, /*addThenRegion=*/true,
-        /*addElseRegion=*/true);
+    auto ifOp = mlir::scf::IfOp::create(rewriter, loc, op.getResult().getType(),
+                                        inBounds, /*addThenRegion=*/true,
+                                        /*addElseRegion=*/true);
 
     // Then region: Unsafe access
     {
       auto &thenBlock = ifOp.getThenRegion().front();
       rewriter.setInsertionPointToStart(&thenBlock);
-      auto unsafeByte = reussir::ReussirStrUnsafeByteAtOp::create(rewriter, 
-          loc, rewriter.getI8Type(), op.getStr(), op.getIndex());
+      auto unsafeByte = reussir::ReussirStrUnsafeByteAtOp::create(
+          rewriter, loc, rewriter.getI8Type(), op.getStr(), op.getIndex());
       mlir::scf::YieldOp::create(rewriter, loc, unsafeByte.getResult());
     }
 
@@ -1029,14 +1035,13 @@ struct ReussirStrSelectOpRewritePattern
     : public mlir::OpConversionPattern<ReussirStrSelectOp> {
   using OpConversionPattern::OpConversionPattern;
   mlir::LogicalResult
-  matchAndRewrite(ReussirStrSelectOp op,
-                  OpAdaptor adaptor,
+  matchAndRewrite(ReussirStrSelectOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto module = op->getParentOfType<mlir::ModuleOp>();
     auto funcName = emitDecisionFunction(module, rewriter, op.getPatterns());
     auto func = module.lookupSymbol<mlir::func::FuncOp>(funcName);
-    auto call = mlir::func::CallOp::create(rewriter, 
-        op.getLoc(), func, mlir::ValueRange{op.getStr()});
+    auto call = mlir::func::CallOp::create(rewriter, op.getLoc(), func,
+                                           mlir::ValueRange{op.getStr()});
 
     rewriter.replaceOp(op, call.getResults());
     return mlir::success();
@@ -1046,8 +1051,7 @@ struct ReussirStrStartWithOpRewritePattern
     : public mlir::OpConversionPattern<ReussirStrStartWithOp> {
   using OpConversionPattern::OpConversionPattern;
   mlir::LogicalResult
-  matchAndRewrite(ReussirStrStartWithOp op,
-                  OpAdaptor adaptor,
+  matchAndRewrite(ReussirStrStartWithOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Location loc = op.getLoc();
     auto indexType = rewriter.getIndexType();
@@ -1062,20 +1066,21 @@ struct ReussirStrStartWithOpRewritePattern
         mlir::arith::ConstantIndexOp::create(rewriter, loc, prefixLen);
 
     // Check if len >= prefixLen
-    auto isSufficientLen = mlir::arith::CmpIOp::create(rewriter, 
-        loc, mlir::arith::CmpIPredicate::uge, lenOp.getResult(), prefixLenVal);
+    auto isSufficientLen = mlir::arith::CmpIOp::create(
+        rewriter, loc, mlir::arith::CmpIPredicate::uge, lenOp.getResult(),
+        prefixLenVal);
 
     auto resultType = op.getResult().getType();
-    auto ifOp = mlir::scf::IfOp::create(rewriter, 
-        loc, resultType, isSufficientLen, /*addThenRegion=*/true,
-        /*addElseRegion=*/true);
+    auto ifOp = mlir::scf::IfOp::create(rewriter, loc, resultType,
+                                        isSufficientLen, /*addThenRegion=*/true,
+                                        /*addElseRegion=*/true);
 
     // Then region: Unsafe check
     {
       auto &thenBlock = ifOp.getThenRegion().front();
       rewriter.setInsertionPointToStart(&thenBlock);
-      auto unsafeCheck = reussir::ReussirStrUnsafeStartWithOp::create(rewriter, 
-          loc, resultType, op.getStr(), op.getPrefixAttr());
+      auto unsafeCheck = reussir::ReussirStrUnsafeStartWithOp::create(
+          rewriter, loc, resultType, op.getStr(), op.getPrefixAttr());
       mlir::scf::YieldOp::create(rewriter, loc, unsafeCheck.getResult());
     }
 
@@ -1113,18 +1118,16 @@ struct SCFOpsLoweringPass
                            mlir::math::MathDialect, mlir::memref::MemRefDialect,
                            mlir::scf::SCFDialect, mlir::tensor::TensorDialect,
                            mlir::ub::UBDialect, reussir::ReussirDialect>();
-    target.addDynamicallyLegalOp<ReussirArrayViewOp>(
-        [](ReussirArrayViewOp op) {
-          return llvm::isa<mlir::MemRefType>(op.getView().getType());
-        });
+    target.addDynamicallyLegalOp<ReussirArrayViewOp>([](ReussirArrayViewOp op) {
+      return llvm::isa<mlir::MemRefType>(op.getView().getType());
+    });
     // `token.realloc` is a real resize; it always lowers to the direct
     // `__reussir_reallocate` call (BasicOpsLowering), sound on any allocator.
     // A free of a still-nullable token must be null-guarded here; a free of a
     // plain token is legal and lowers to the runtime call directly.
-    target.addDynamicallyLegalOp<ReussirTokenFreeOp>(
-        [](ReussirTokenFreeOp op) {
-          return llvm::isa<TokenType>(op.getToken().getType());
-        });
+    target.addDynamicallyLegalOp<ReussirTokenFreeOp>([](ReussirTokenFreeOp op) {
+      return llvm::isa<TokenType>(op.getToken().getType());
+    });
     // A fused eval (non-empty `with` pack) must be expanded here — the
     // basic-ops lowering only dispatches the plain, fully-applied form.
     target.addDynamicallyLegalOp<ReussirClosureEvalOp>(
@@ -1132,9 +1135,9 @@ struct SCFOpsLoweringPass
 
     target.addIllegalOp<ReussirNullableDispatchOp, ReussirRecordDispatchOp,
                         ReussirScfYieldOp, ReussirClosureUniqifyOp,
-                        ReussirArrayWithUniqueViewOp,
-                        ReussirTokenEnsureOp, ReussirStrByteAtOp,
-                        ReussirStrSelectOp, ReussirStrStartWithOp>();
+                        ReussirArrayWithUniqueViewOp, ReussirTokenEnsureOp,
+                        ReussirStrByteAtOp, ReussirStrSelectOp,
+                        ReussirStrStartWithOp>();
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))
@@ -1146,17 +1149,15 @@ struct SCFOpsLoweringPass
 void populateSCFOpsLoweringConversionPatterns(
     mlir::RewritePatternSet &patterns) {
   // Add conversion patterns for Reussir SCF operations
-  patterns
-      .add<ReussirNullableDispatchOpRewritePattern,
-           ReussirArrayViewOpRewritePattern,
-           ReussirRecordDispatchOpRewritePattern,
-           ReussirClosureUniqifyOpRewritePattern,
-           ReussirClosureEvalOpRewritePattern,
-           ReussirArrayWithUniqueViewOpRewritePattern,
-           ReussirScfYieldOpRewritePattern, ReussirTokenEnsureOpRewritePattern,
-           ReussirNullableTokenFreeOpRewritePattern,
-           ReussirStrByteAtOpRewritePattern, ReussirStrSelectOpRewritePattern,
-           ReussirStrStartWithOpRewritePattern>(patterns.getContext());
+  patterns.add<
+      ReussirNullableDispatchOpRewritePattern, ReussirArrayViewOpRewritePattern,
+      ReussirRecordDispatchOpRewritePattern,
+      ReussirClosureUniqifyOpRewritePattern, ReussirClosureEvalOpRewritePattern,
+      ReussirArrayWithUniqueViewOpRewritePattern,
+      ReussirScfYieldOpRewritePattern, ReussirTokenEnsureOpRewritePattern,
+      ReussirNullableTokenFreeOpRewritePattern,
+      ReussirStrByteAtOpRewritePattern, ReussirStrSelectOpRewritePattern,
+      ReussirStrStartWithOpRewritePattern>(patterns.getContext());
 }
 
 } // namespace reussir

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -11,12 +11,12 @@
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/IR/DataLayout.h>
+#include <memory>
 #include <mlir/Dialect/DLTI/DLTI.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/Target/LLVMIR/Import.h>
-#include <memory>
 
 namespace reussir {
 namespace {
@@ -67,9 +67,9 @@ buildMLIRDataLayout(const mlir::LLVMTypeConverter &converter) {
   if (!dataLayoutString.empty()) {
     layoutModule->setAttr(mlir::LLVM::LLVMDialect::getDataLayoutAttrName(),
                           mlir::StringAttr::get(context, dataLayoutString));
-    layoutModule->setAttr(mlir::DLTIDialect::kDataLayoutAttrName,
-                          mlir::translateDataLayout(converter.getDataLayout(),
-                                                    context));
+    layoutModule->setAttr(
+        mlir::DLTIDialect::kDataLayoutAttrName,
+        mlir::translateDataLayout(converter.getDataLayout(), context));
   }
   return std::make_shared<mlir::DataLayout>(layoutModule);
 }
@@ -164,7 +164,8 @@ convertRecordType(mlir::LLVMTypeConverter &converter,
   }
 
   if (!name)
-    structType = mlir::LLVM::LLVMStructType::getLiteral(type.getContext(), members);
+    structType =
+        mlir::LLVM::LLVMStructType::getLiteral(type.getContext(), members);
   if (name && failed(structType.setBody(members, false)))
     return mlir::failure();
 

--- a/lib/IR/ReussirInterfaces.cpp
+++ b/lib/IR/ReussirInterfaces.cpp
@@ -105,12 +105,11 @@ struct ReussirInlinerInterface : public mlir::DialectInlinerInterface {
   // a body carrying one only inlines outside any enclosing `region.run`.
   bool isLegalToInline(mlir::Region *dest, mlir::Region *src, bool,
                        mlir::IRMapping &) const final {
-    bool sourceRunsRegion =
-        src->walk([](ReussirRegionRunOp) {
-             return mlir::WalkResult::interrupt();
-           }).wasInterrupted();
-    return !sourceRunsRegion ||
-           !dest->getParentOfType<ReussirRegionRunOp>();
+    bool sourceRunsRegion = src->walk([](ReussirRegionRunOp) {
+                                 return mlir::WalkResult::interrupt();
+                               })
+                                .wasInterrupted();
+    return !sourceRunsRegion || !dest->getParentOfType<ReussirRegionRunOp>();
   }
 };
 } // namespace

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -363,8 +363,8 @@ std::pair<reussir::RecordType, mlir::Value>
 ReussirRcDecOp::destructuredPayloadAndRef(mlir::OpBuilder &builder) {
   RcType rcType = getRcPtr().getType();
   auto recordType = llvm::cast<RecordType>(rcType.getElementType());
-  auto refType = builder.getType<RefType>(
-      recordType, Capability::unspecified, rcType.getAtomicKind());
+  auto refType = builder.getType<RefType>(recordType, Capability::unspecified,
+                                          rcType.getAtomicKind());
   mlir::Value ref =
       ReussirRcBorrowOp::create(builder, getLoc(), refType, getRcPtr());
   if (!isVariantDestructuring())
@@ -384,22 +384,21 @@ void ReussirRcDecOp::rematerializeBoundRetains(mlir::OpBuilder &builder) {
   RcType rcType = getRcPtr().getType();
   auto [payload, payloadRef] = destructuredPayloadAndRef(builder);
   for (int64_t idx : getBoundMembersAttr().asArrayRef()) {
-    auto projectedTy =
-        getProjectedType(payload.getMembers()[idx],
-                         payload.getMemberIsField()[idx],
-                         Capability::unspecified);
+    auto projectedTy = getProjectedType(payload.getMembers()[idx],
+                                        payload.getMemberIsField()[idx],
+                                        Capability::unspecified);
     auto projectedRefTy = builder.getType<RefType>(
         projectedTy, Capability::unspecified, rcType.getAtomicKind());
-    mlir::Value slot = ReussirRefProjectOp::create(
-        builder, getLoc(), projectedRefTy, payloadRef,
-        builder.getIndexAttr(idx));
+    mlir::Value slot =
+        ReussirRefProjectOp::create(builder, getLoc(), projectedRefTy,
+                                    payloadRef, builder.getIndexAttr(idx));
     // A shared member retains through a count bump on the loaded pointer; a
     // value-record member retains its embedded children through the slot's
     // acquire (expanded member-wise later); anything trivially copyable
     // needs nothing.
     if (llvm::isa<RcType>(projectedTy)) {
-      mlir::Value member = ReussirRefLoadOp::create(builder, getLoc(),
-                                                    projectedTy, slot);
+      mlir::Value member =
+          ReussirRefLoadOp::create(builder, getLoc(), projectedTy, slot);
       ReussirRcIncOp::create(builder, getLoc(), member);
     } else if (!isTriviallyCopyable(projectedTy)) {
       ReussirRefAcquireOp::create(builder, getLoc(), slot);
@@ -431,8 +430,7 @@ mlir::LogicalResult ReussirRcDecOp::verify() {
         return emitOpError(
             "tagged destructuring decrement requires a variant box");
       int64_t tag = getDestructureTagAttr().getInt();
-      if (tag < 0 ||
-          static_cast<size_t>(tag) >= recordType.getMembers().size())
+      if (tag < 0 || static_cast<size_t>(tag) >= recordType.getMembers().size())
         return emitOpError("destructure tag out of range: ") << tag;
       payload = llvm::dyn_cast<RecordType>(recordType.getMembers()[tag]);
       if (!payload || !payload.getComplete())

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -639,18 +639,17 @@ RecordType::getPackedOrder(const mlir::DataLayout &dataLayout) const {
     return order;
   llvm::SmallVector<uint64_t> aligns(order.size());
   for (uint32_t i = 0; i < order.size(); ++i) {
-    mlir::Type storage = memberStorageType(getContext(), getMembers()[i],
-                                           getMemberIsField()[i]);
+    mlir::Type storage =
+        memberStorageType(getContext(), getMembers()[i], getMemberIsField()[i]);
     aligns[i] = dataLayout.getTypeABIAlignment(storage);
   }
-  llvm::stable_sort(order,
-                    [&](uint32_t a, uint32_t b) { return aligns[a] > aligns[b]; });
+  llvm::stable_sort(
+      order, [&](uint32_t a, uint32_t b) { return aligns[a] > aligns[b]; });
   return order;
 }
 
-uint32_t
-RecordType::getPhysicalMemberIndex(const mlir::DataLayout &dataLayout,
-                                   uint32_t index) const {
+uint32_t RecordType::getPhysicalMemberIndex(const mlir::DataLayout &dataLayout,
+                                            uint32_t index) const {
   llvm::SmallVector<uint32_t> order = getPackedOrder(dataLayout);
   auto *it = llvm::find(order, index);
   assert(it != order.end() && "member index out of range");
@@ -712,9 +711,8 @@ RecordType::getVariantArmAllocSize(const mlir::DataLayout &dataLayout,
   // payload size replaced by arm `tag`'s.
   auto [maxSize, align, _] = getElementRegionLayoutInfo(dataLayout);
   (void)maxSize;
-  mlir::Type member = getProjectedType(getMembers()[tag],
-                                       getMemberIsField()[tag],
-                                       Capability::value);
+  mlir::Type member = getProjectedType(
+      getMembers()[tag], getMemberIsField()[tag], Capability::value);
   llvm::TypeSize armSize = dataLayout.getTypeSize(member);
   llvm::Align finalAlign = std::max(align, llvm::Align(8));
   llvm::TypeSize headerSize =

--- a/lib/LLVMPass/AllocationSimplication/AllocationSimplication.cpp
+++ b/lib/LLVMPass/AllocationSimplication/AllocationSimplication.cpp
@@ -56,10 +56,11 @@ AllocationSimplicationPass::run(llvm::Module &module,
         if (calleeName == "__reussir_reallocate" && call->arg_size() == 5 &&
             isNullPointerArgument(call->getArgOperand(0))) {
           llvm::IRBuilder<> builder(call);
-          llvm::FunctionType *allocateTy = llvm::FunctionType::get(
-              call->getType(),
-              {call->getArgOperand(3)->getType(), call->getArgOperand(4)->getType()},
-              false);
+          llvm::FunctionType *allocateTy =
+              llvm::FunctionType::get(call->getType(),
+                                      {call->getArgOperand(3)->getType(),
+                                       call->getArgOperand(4)->getType()},
+                                      false);
           llvm::FunctionCallee allocateFn =
               module.getOrInsertFunction("__reussir_allocate", allocateTy);
 

--- a/lib/LLVMPass/AllocationSimplication/RuntimeFunctionAttributor.cpp
+++ b/lib/LLVMPass/AllocationSimplication/RuntimeFunctionAttributor.cpp
@@ -71,7 +71,8 @@ bool setAllocateSmallAttributes(llvm::Function &fn) {
   auto hasExpectedAllocSize = [&] {
     if (!fn.hasFnAttribute(llvm::Attribute::AllocSize))
       return false;
-    auto args = fn.getFnAttribute(llvm::Attribute::AllocSize).getAllocSizeArgs();
+    auto args =
+        fn.getFnAttribute(llvm::Attribute::AllocSize).getAllocSizeArgs();
     return args.first == 0 && !args.second.has_value();
   };
   if (!hasExpectedAllocSize()) {

--- a/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
@@ -93,8 +93,7 @@ bool isSingleShotTrivialBranch(mlir::Operation *op) {
 // all of whose paths release. Everything before the release must leave the
 // box's count alone (borrows are fine; anything else touching the pointer,
 // or an opaque op, disqualifies the path).
-bool armReleasesOnAllPaths(mlir::Region &region,
-                           mlir::TypedValue<RcType> rcPtr,
+bool armReleasesOnAllPaths(mlir::Region &region, mlir::TypedValue<RcType> rcPtr,
                            mlir::AliasAnalysis &aliasAnalysis,
                            llvm::SmallVectorImpl<ReussirRcDecOp> &releases) {
   if (!region.hasOneBlock())
@@ -141,8 +140,7 @@ bool armReleasesOnAllPaths(mlir::Region &region,
 // certainly-shared path the arm still needs its own references, so they are
 // rematerialized at the release's position. This is what reduces an inlined
 // read-only predicate (rbtree's `is_red`) to pure tag loads.
-bool cancelIntoDispatch(ReussirRcIncOp incOp,
-                        ReussirRecordDispatchOp dispatch,
+bool cancelIntoDispatch(ReussirRcIncOp incOp, ReussirRecordDispatchOp dispatch,
                         mlir::AliasAnalysis &aliasAnalysis) {
   auto borrow = llvm::dyn_cast_if_present<ReussirRcBorrowOp>(
       dispatch.getVariant().getDefiningOp());

--- a/lib/Transformation/InferVariantTag/InferVariantTag.cpp
+++ b/lib/Transformation/InferVariantTag/InferVariantTag.cpp
@@ -1,4 +1,5 @@
-//===-- InferVariantTag.cpp - Reussir variant tag inference impl -*- C++ -*-===//
+//===-- InferVariantTag.cpp - Reussir variant tag inference impl -*- C++
+//-*-===//
 //
 // Part of the Reussir project, dual licensed under the Apache License v2.0 or
 // the MIT License.

--- a/lib/Transformation/InvariantGroupAnalysis/InvariantGroupAnalysis.cpp
+++ b/lib/Transformation/InvariantGroupAnalysis/InvariantGroupAnalysis.cpp
@@ -1,4 +1,5 @@
-//===-- InvariantGroupAnalysis.cpp - Invariant group analysis ----*- C++ -*-===//
+//===-- InvariantGroupAnalysis.cpp - Invariant group analysis ----*- C++
+//-*-===//
 //
 // Part of the Reussir project, dual licensed under the Apache License v2.0 or
 // the MIT License.
@@ -39,9 +40,7 @@ enum class InvariantState : uint8_t {
 struct InvariantGroupValue {
   InvariantState state = InvariantState::Unknown;
 
-  static InvariantGroupValue getUnknown() {
-    return {InvariantState::Unknown};
-  }
+  static InvariantGroupValue getUnknown() { return {InvariantState::Unknown}; }
   static InvariantGroupValue getSafe() { return {InvariantState::Safe}; }
   static InvariantGroupValue getUnsafe() { return {InvariantState::Unsafe}; }
 
@@ -56,8 +55,7 @@ struct InvariantGroupValue {
       return rhs;
     if (rhs.state == InvariantState::Unknown)
       return lhs;
-    if (lhs.state == InvariantState::Safe &&
-        rhs.state == InvariantState::Safe)
+    if (lhs.state == InvariantState::Safe && rhs.state == InvariantState::Safe)
       return getSafe();
     return getUnsafe();
   }
@@ -110,23 +108,20 @@ public:
 };
 
 mlir::LogicalResult InvariantGroupAnalysis::visitOperation(
-    mlir::Operation *op,
-    llvm::ArrayRef<const InvariantGroupLattice *> operands,
+    mlir::Operation *op, llvm::ArrayRef<const InvariantGroupLattice *> operands,
     llvm::ArrayRef<InvariantGroupLattice *> results) {
 
   // rc.borrow → Safe
   if (llvm::isa<ReussirRcBorrowOp>(op)) {
     for (auto *result : results)
-      propagateIfChanged(result,
-                         result->join(InvariantGroupValue::getSafe()));
+      propagateIfChanged(result, result->join(InvariantGroupValue::getSafe()));
     return mlir::success();
   }
 
   // closure.inspect_payload → Safe
   if (llvm::isa<ReussirClosureInspectPayloadOp>(op)) {
     for (auto *result : results)
-      propagateIfChanged(result,
-                         result->join(InvariantGroupValue::getSafe()));
+      propagateIfChanged(result, result->join(InvariantGroupValue::getSafe()));
     return mlir::success();
   }
 
@@ -156,14 +151,13 @@ mlir::LogicalResult InvariantGroupAnalysis::visitOperation(
       if (recordType && recordType.getComplete()) {
         size_t index = projectOp.getIndex().getZExtValue();
         bool isField = recordType.getMemberIsField()[index];
-        bool isFlex =
-            inputRefType.getCapability() == Capability::flex;
+        bool isFlex = inputRefType.getCapability() == Capability::flex;
 
         if (isFlex && isField) {
           // flex + field projection → Unsafe
           for (auto *result : results)
-            propagateIfChanged(
-                result, result->join(InvariantGroupValue::getUnsafe()));
+            propagateIfChanged(result,
+                               result->join(InvariantGroupValue::getUnsafe()));
           return mlir::success();
         }
       }
@@ -219,8 +213,7 @@ struct InvariantGroupAnalysisPass
     funcOp.walk([&](ReussirRefLoadOp loadOp) {
       auto *lattice =
           solver.lookupState<InvariantGroupLattice>(loadOp.getRef());
-      if (lattice &&
-          lattice->getValue().state == InvariantState::Safe)
+      if (lattice && lattice->getValue().state == InvariantState::Safe)
         loadOp.setInvariantGroupAttr(mlir::UnitAttr::get(ctx));
     });
   }

--- a/lib/Transformation/RcCreateFusion/RcCreateFusion.cpp
+++ b/lib/Transformation/RcCreateFusion/RcCreateFusion.cpp
@@ -66,9 +66,9 @@ bool structurallySameType(mlir::Type lhs, mlir::Type rhs) {
       return false;
     if (lhsRecord.getMembers().size() != rhsRecord.getMembers().size())
       return false;
-    for (auto [lhsMember, rhsMember, lhsField, rhsField] :
-         llvm::zip(lhsRecord.getMembers(), rhsRecord.getMembers(),
-                   lhsRecord.getMemberIsField(), rhsRecord.getMemberIsField())) {
+    for (auto [lhsMember, rhsMember, lhsField, rhsField] : llvm::zip(
+             lhsRecord.getMembers(), rhsRecord.getMembers(),
+             lhsRecord.getMemberIsField(), rhsRecord.getMemberIsField())) {
       if (lhsField != rhsField)
         return false;
       if (!structurallySameType(lhsMember, rhsMember))
@@ -80,19 +80,21 @@ bool structurallySameType(mlir::Type lhs, mlir::Type rhs) {
   return false;
 }
 
-bool isLoadFromCompoundField(mlir::Value value, mlir::TypedValue<RcType> sourceRc,
+bool isLoadFromCompoundField(mlir::Value value,
+                             mlir::TypedValue<RcType> sourceRc,
                              int64_t fieldIndex) {
-  auto load = llvm::dyn_cast_if_present<ReussirRefLoadOp>(value.getDefiningOp());
+  auto load =
+      llvm::dyn_cast_if_present<ReussirRefLoadOp>(value.getDefiningOp());
   if (!load)
     return false;
 
-  auto project =
-      llvm::dyn_cast_if_present<ReussirRefProjectOp>(load.getRef().getDefiningOp());
+  auto project = llvm::dyn_cast_if_present<ReussirRefProjectOp>(
+      load.getRef().getDefiningOp());
   if (!project || project.getIndex().getSExtValue() != fieldIndex)
     return false;
 
-  auto borrow =
-      llvm::dyn_cast_if_present<ReussirRcBorrowOp>(project.getRef().getDefiningOp());
+  auto borrow = llvm::dyn_cast_if_present<ReussirRcBorrowOp>(
+      project.getRef().getDefiningOp());
   return borrow && borrow.getRcPtr() == sourceRc;
 }
 
@@ -105,7 +107,8 @@ bool hasCompatibleFieldPrefix(RecordType sourcePayloadType,
     return false;
   if (fieldIndex < 0)
     return false;
-  if (static_cast<size_t>(fieldIndex) >= sourcePayloadType.getMembers().size() ||
+  if (static_cast<size_t>(fieldIndex) >=
+          sourcePayloadType.getMembers().size() ||
       static_cast<size_t>(fieldIndex) >= targetPayloadType.getMembers().size())
     return false;
 
@@ -120,14 +123,16 @@ bool hasCompatibleFieldPrefix(RecordType sourcePayloadType,
   return true;
 }
 
-bool isLoadFromVariantField(mlir::Value value, mlir::TypedValue<RcType> sourceRc,
+bool isLoadFromVariantField(mlir::Value value,
+                            mlir::TypedValue<RcType> sourceRc,
                             mlir::Type targetPayloadType, int64_t fieldIndex) {
-  auto load = llvm::dyn_cast_if_present<ReussirRefLoadOp>(value.getDefiningOp());
+  auto load =
+      llvm::dyn_cast_if_present<ReussirRefLoadOp>(value.getDefiningOp());
   if (!load)
     return false;
 
-  auto project =
-      llvm::dyn_cast_if_present<ReussirRefProjectOp>(load.getRef().getDefiningOp());
+  auto project = llvm::dyn_cast_if_present<ReussirRefProjectOp>(
+      load.getRef().getDefiningOp());
   if (!project || project.getIndex().getSExtValue() != fieldIndex)
     return false;
 
@@ -136,8 +141,8 @@ bool isLoadFromVariantField(mlir::Value value, mlir::TypedValue<RcType> sourceRc
   if (!coerce)
     return false;
 
-  auto sourcePayloadType =
-      llvm::dyn_cast<RecordType>(coerce.getCoerced().getType().getElementType());
+  auto sourcePayloadType = llvm::dyn_cast<RecordType>(
+      coerce.getCoerced().getType().getElementType());
   auto targetPayloadRecord = llvm::dyn_cast<RecordType>(targetPayloadType);
   if (!hasCompatibleFieldPrefix(sourcePayloadType, targetPayloadRecord,
                                 fieldIndex))
@@ -191,34 +196,34 @@ struct FuseRcCreatePattern : public mlir::OpRewritePattern<ReussirRcCreateOp> {
   mlir::LogicalResult
   matchAndRewrite(ReussirRcCreateOp create,
                   mlir::PatternRewriter &rewriter) const override {
-    auto variant =
-        llvm::dyn_cast_if_present<ReussirRecordVariantOp>(create.getValue().getDefiningOp());
+    auto variant = llvm::dyn_cast_if_present<ReussirRecordVariantOp>(
+        create.getValue().getDefiningOp());
     if (variant) {
       auto compound = llvm::dyn_cast_if_present<ReussirRecordCompoundOp>(
           variant.getValue().getDefiningOp());
-      auto fused = ReussirRcCreateVariantOp::create(rewriter, 
-          create.getLoc(), mlir::TypeRange{create.getRcPtr().getType()},
-          variant.getTagAttr(),
+      auto fused = ReussirRcCreateVariantOp::create(
+          rewriter, create.getLoc(),
+          mlir::TypeRange{create.getRcPtr().getType()}, variant.getTagAttr(),
           compound ? mlir::Value{} : variant.getValue(),
-          compound ? compound.getFields() : mlir::ValueRange{}, create.getToken(),
-          create.getRegion(), create.getVtableAttr(), create.getSkipRcAttr(),
-          mlir::DenseI64ArrayAttr{}, mlir::DenseI64ArrayAttr{});
+          compound ? compound.getFields() : mlir::ValueRange{},
+          create.getToken(), create.getRegion(), create.getVtableAttr(),
+          create.getSkipRcAttr(), mlir::DenseI64ArrayAttr{},
+          mlir::DenseI64ArrayAttr{});
       rewriter.replaceOp(create, fused.getRcPtr());
       eraseDeadRecordMaterialization(rewriter, variant.getOperation());
       return mlir::success();
     }
 
-    auto compound =
-        llvm::dyn_cast_if_present<ReussirRecordCompoundOp>(create.getValue().getDefiningOp());
+    auto compound = llvm::dyn_cast_if_present<ReussirRecordCompoundOp>(
+        create.getValue().getDefiningOp());
     if (!compound)
       return mlir::failure();
 
-    auto fused = ReussirRcCreateCompoundOp::create(rewriter, 
-        create.getLoc(), mlir::TypeRange{create.getRcPtr().getType()},
-        compound.getFields(),
-        create.getToken(), create.getRegion(), create.getVtableAttr(),
-        create.getSkipRcAttr(), mlir::DenseI64ArrayAttr{},
-        mlir::DenseI64ArrayAttr{});
+    auto fused = ReussirRcCreateCompoundOp::create(
+        rewriter, create.getLoc(), mlir::TypeRange{create.getRcPtr().getType()},
+        compound.getFields(), create.getToken(), create.getRegion(),
+        create.getVtableAttr(), create.getSkipRcAttr(),
+        mlir::DenseI64ArrayAttr{}, mlir::DenseI64ArrayAttr{});
     rewriter.replaceOp(create, fused.getRcPtr());
     eraseDeadRecordMaterialization(rewriter, compound.getOperation());
     return mlir::success();
@@ -235,12 +240,10 @@ struct RcCreateFusionPass
     if (mlir::failed(
             mlir::applyPatternsGreedily(getOperation(), std::move(patterns))))
       signalPassFailure();
-    getOperation().walk([](ReussirRcCreateCompoundOp op) {
-      markCompoundAvoidedCopies(op);
-    });
-    getOperation().walk([](ReussirRcCreateVariantOp op) {
-      markVariantAvoidedCopies(op);
-    });
+    getOperation().walk(
+        [](ReussirRcCreateCompoundOp op) { markCompoundAvoidedCopies(op); });
+    getOperation().walk(
+        [](ReussirRcCreateVariantOp op) { markVariantAvoidedCopies(op); });
   }
 };
 

--- a/lib/Transformation/RcCreateSink/RcCreateSink.cpp
+++ b/lib/Transformation/RcCreateSink/RcCreateSink.cpp
@@ -41,11 +41,10 @@ struct SinkRcCreateIntoExpandedEnsurePattern
     return true;
   }
 
-  static ReussirRcCreateOp cloneCreateIntoBranch(mlir::PatternRewriter &rewriter,
-                                                 ReussirRcCreateOp create,
-                                                 mlir::Value branchToken,
-                                                 mlir::scf::YieldOp yieldOp,
-                                                 bool skipRc) {
+  static ReussirRcCreateOp
+  cloneCreateIntoBranch(mlir::PatternRewriter &rewriter,
+                        ReussirRcCreateOp create, mlir::Value branchToken,
+                        mlir::scf::YieldOp yieldOp, bool skipRc) {
     rewriter.setInsertionPoint(yieldOp);
     auto *clonedOp = rewriter.clone(*create.getOperation());
     auto clonedCreate = llvm::cast<ReussirRcCreateOp>(clonedOp);
@@ -59,9 +58,8 @@ struct SinkRcCreateIntoExpandedEnsurePattern
                                  ReussirRcCreateOp create, mlir::Block &block,
                                  bool skipRc) {
     auto yieldOp = llvm::cast<mlir::scf::YieldOp>(block.getTerminator());
-    auto sunkCreate =
-        cloneCreateIntoBranch(rewriter, create, yieldOp.getOperand(0), yieldOp,
-                              skipRc);
+    auto sunkCreate = cloneCreateIntoBranch(
+        rewriter, create, yieldOp.getOperand(0), yieldOp, skipRc);
     rewriter.replaceOpWithNewOp<mlir::scf::YieldOp>(yieldOp,
                                                     sunkCreate.getRcPtr());
   }
@@ -74,8 +72,9 @@ struct SinkRcCreateIntoExpandedEnsurePattern
     if (!isMatchCandidate(create, ifOp))
       return mlir::failure();
 
-    auto newIf = mlir::scf::IfOp::create(rewriter, 
-        ifOp.getLoc(), create.getRcPtr().getType(), ifOp.getCondition(),
+    auto newIf = mlir::scf::IfOp::create(
+        rewriter, ifOp.getLoc(), create.getRcPtr().getType(),
+        ifOp.getCondition(),
         /*addThenRegion=*/true, /*addElseRegion=*/true);
     newIf->setAttrs(ifOp->getAttrs());
     newIf->removeAttr(REUSSIR_EXPANDED_ENSURE_ATTR);

--- a/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
+++ b/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
@@ -56,10 +56,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Reussir/Transformation/Passes.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
+#include "Reussir/Transformation/Passes.h"
 
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Builders.h>
@@ -167,8 +167,8 @@ std::optional<int64_t> loadedMemberIndex(mlir::Value value,
 std::optional<int64_t> acquiredMemberIndex(ReussirRefAcquireOp acquire,
                                            mlir::TypedValue<RcType> box) {
   mlir::Value ref = acquire.getRef();
-  if (auto spilled = llvm::dyn_cast_if_present<ReussirRefSpilledOp>(
-          ref.getDefiningOp()))
+  if (auto spilled =
+          llvm::dyn_cast_if_present<ReussirRefSpilledOp>(ref.getDefiningOp()))
     return loadedMemberIndex(spilled.getValue(), box);
   auto project =
       llvm::dyn_cast_if_present<ReussirRefProjectOp>(ref.getDefiningOp());
@@ -253,8 +253,7 @@ struct RcDispatchFusionPass
       RcType rcType = scrutinee.getType();
       if (rcType.getAtomicKind() != AtomicKind::normal || rcType.isRegional())
         return;
-      auto recordType =
-          llvm::dyn_cast<RecordType>(rcType.getElementType());
+      auto recordType = llvm::dyn_cast<RecordType>(rcType.getElementType());
       if (!recordType || !recordType.isVariant() || !recordType.getComplete())
         return;
       for (auto [tagSetAttr, region] :
@@ -264,9 +263,10 @@ struct RcDispatchFusionPass
           continue;
         // The arm's payload must be a plain record view: fused member
         // handling only understands value/shared members.
-        auto payload = llvm::dyn_cast<RecordType>(
-            recordType.getMembers()[tagSet[0]]);
-        if (!payload || !payload.getComplete() || !payload.hasNoRegionalFields())
+        auto payload =
+            llvm::dyn_cast<RecordType>(recordType.getMembers()[tagSet[0]]);
+        if (!payload || !payload.getComplete() ||
+            !payload.hasNoRegionalFields())
           continue;
         fuseArm(region, tagSet[0], scrutinee);
       }

--- a/lib/Transformation/TRMCRecursionAnalysis/TRMCRecursionAnalysis.cpp
+++ b/lib/Transformation/TRMCRecursionAnalysis/TRMCRecursionAnalysis.cpp
@@ -26,10 +26,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Reussir/Transformation/Passes.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
+#include "Reussir/Transformation/Passes.h"
 
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
@@ -100,13 +100,11 @@ static ReussirRcCreateCompoundOp createCompoundWithHoles(
   return llvm::cast<ReussirRcCreateCompoundOp>(builder.create(state));
 }
 
-static ReussirRcCreateVariantOp
-createVariantWithHoles(mlir::OpBuilder &builder, mlir::Location loc,
-                       RcType rcType, mlir::IntegerAttr tag,
-                       mlir::ValueRange fields, mlir::Value token,
-                       mlir::Value region, mlir::FlatSymbolRefAttr vtable,
-                       bool skipRc, mlir::DenseI64ArrayAttr skipFields,
-                       mlir::DenseI64ArrayAttr holeFields) {
+static ReussirRcCreateVariantOp createVariantWithHoles(
+    mlir::OpBuilder &builder, mlir::Location loc, RcType rcType,
+    mlir::IntegerAttr tag, mlir::ValueRange fields, mlir::Value token,
+    mlir::Value region, mlir::FlatSymbolRefAttr vtable, bool skipRc,
+    mlir::DenseI64ArrayAttr skipFields, mlir::DenseI64ArrayAttr holeFields) {
   mlir::OperationState state(loc, ReussirRcCreateVariantOp::getOperationName());
   state.addAttribute("tag", tag);
   state.addOperands(fields);
@@ -121,10 +119,10 @@ createVariantWithHoles(mlir::OpBuilder &builder, mlir::Location loc,
       resultTypes.push_back(HoleType::get(
           builder.getContext(), fields[static_cast<size_t>(index)].getType()));
   state.addTypes(resultTypes);
-  state.addAttribute("operandSegmentSizes",
-                     builder.getDenseI32ArrayAttr(
-                         {0, static_cast<int32_t>(fields.size()), token ? 1 : 0,
-                          region ? 1 : 0}));
+  state.addAttribute(
+      "operandSegmentSizes",
+      builder.getDenseI32ArrayAttr({0, static_cast<int32_t>(fields.size()),
+                                    token ? 1 : 0, region ? 1 : 0}));
   addOptionalAttr(state, "vtable", vtable);
   if (skipRc)
     state.addAttribute("skipRc", builder.getUnitAttr());
@@ -281,8 +279,7 @@ static TrmcPlan buildPlan(mlir::func::FuncOp funcOp, llvm::StringRef callee) {
   // of the same site: the branches consume the shared call exactly once each
   // along mutually exclusive paths, so after every user is rewritten the
   // call itself dies.
-  auto isLinearizable = [&](mlir::func::CallOp call,
-                            mlir::Operation *create) {
+  auto isLinearizable = [&](mlir::func::CallOp call, mlir::Operation *create) {
     for (mlir::Operation *user : call->getUsers())
       if (!candidates.contains(user) || !isSameCreateSite(create, user, callee))
         return false;
@@ -320,10 +317,10 @@ static void setLeafValue(mlir::Operation *terminator, mlir::Value oldValue,
 // field, recurse into the non-designated fields through fresh single-node
 // contexts, and turn the designated (last) field into the context-threaded
 // tail call.
-static void
-rewriteConstructorLeaf(mlir::Operation *terminator, mlir::Value value,
-                       llvm::ArrayRef<RecursiveFieldInfo> planned,
-                       TrmcRewriteContext &ctx) {
+static void rewriteConstructorLeaf(mlir::Operation *terminator,
+                                   mlir::Value value,
+                                   llvm::ArrayRef<RecursiveFieldInfo> planned,
+                                   TrmcRewriteContext &ctx) {
   mlir::Operation *def = value.getDefiningOp();
   auto compound = llvm::dyn_cast_if_present<ReussirRcCreateCompoundOp>(def);
   auto variant = llvm::dyn_cast_if_present<ReussirRcCreateVariantOp>(def);
@@ -390,10 +387,9 @@ rewriteConstructorLeaf(mlir::Operation *terminator, mlir::Value value,
       holes[recursiveFields.size() - 1]);
   llvm::SmallVector<mlir::Value> args(designated.call.getOperands());
   args.push_back(extended);
-  auto tailCall =
-      mlir::func::CallOp::create(rewriter, designated.call.getLoc(),
-                                 ctx.helperName, mlir::TypeRange{resultType},
-                                 args);
+  auto tailCall = mlir::func::CallOp::create(rewriter, designated.call.getLoc(),
+                                             ctx.helperName,
+                                             mlir::TypeRange{resultType}, args);
 
   setLeafValue(terminator, value, tailCall.getResult(0));
   rewriter.eraseOp(def);
@@ -545,9 +541,9 @@ struct TRMCRecursionAnalysisPass
     });
 
     for (mlir::func::FuncOp funcOp : candidates) {
-      auto ctxType = CctxType::get(
-          funcOp.getContext(),
-          llvm::cast<RcType>(funcOp.getResultTypes().front()));
+      auto ctxType =
+          CctxType::get(funcOp.getContext(),
+                        llvm::cast<RcType>(funcOp.getResultTypes().front()));
       mlir::func::FuncOp helper =
           createTrmcHelper(funcOp, symbolTable, ctxType);
       rewriteOriginalToWrapper(funcOp, helper.getName(), ctxType);

--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -267,8 +267,8 @@ bool isEscapableTokenResult(mlir::OpResult result) {
 mlir::TypedValue<RcType> expandedDecProducerRc(mlir::scf::IfOp scfIf,
                                                unsigned resultIndex) {
   if (resultIndex == 0) {
-    auto expectOp = dyn_cast_or_null<ReussirExpectOp>(
-        scfIf.getCondition().getDefiningOp());
+    auto expectOp =
+        dyn_cast_or_null<ReussirExpectOp>(scfIf.getCondition().getDefiningOp());
     if (!expectOp)
       return nullptr;
     auto cmp = dyn_cast_or_null<mlir::arith::CmpIOp>(
@@ -284,8 +284,7 @@ mlir::TypedValue<RcType> expandedDecProducerRc(mlir::scf::IfOp scfIf,
       continue;
     mlir::Value yielded =
         region.front().getTerminator()->getOperand(resultIndex);
-    auto inner =
-        dyn_cast_or_null<mlir::scf::IfOp>(yielded.getDefiningOp());
+    auto inner = dyn_cast_or_null<mlir::scf::IfOp>(yielded.getDefiningOp());
     if (inner && inner->hasAttr(kExpandedDecrementAttr))
       return expandedDecProducerRc(
           inner, llvm::cast<mlir::OpResult>(yielded).getResultNumber());
@@ -487,10 +486,9 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
                     dyn_cast<TokenType>(nullableType.getPtrTy());
                 if (!producedType)
                   continue;
-                mlir::TypedValue<RcType> producerRc =
-                    expandedDecProducerRc(scfIf, llvm::cast<mlir::OpResult>(
-                                                     tokenVal)
-                                                     .getResultNumber());
+                mlir::TypedValue<RcType> producerRc = expandedDecProducerRc(
+                    scfIf,
+                    llvm::cast<mlir::OpResult>(tokenVal).getResultNumber());
                 int score = hueristic(producedType, producerRc, acceptor,
                                       aliasAnalyzer);
                 if (score >= 0 && (score > bestScore ||
@@ -568,11 +566,11 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
       mlir::Value newToken;
       mlir::Value oldToken = reuse.anchor.getToken();
       if (reuse.realloc)
-        newToken = ReussirTokenReallocOp::create(rewriter, 
-            reuse.anchor->getLoc(), targetType, reuse.token);
+        newToken = ReussirTokenReallocOp::create(
+            rewriter, reuse.anchor->getLoc(), targetType, reuse.token);
       else
-        newToken = ReussirTokenEnsureOp::create(rewriter, 
-            reuse.anchor->getLoc(), targetType, reuse.token);
+        newToken = ReussirTokenEnsureOp::create(
+            rewriter, reuse.anchor->getLoc(), targetType, reuse.token);
       reuse.anchor.assignToken(newToken);
       auto allocOp = llvm::cast<ReussirTokenAllocOp>(oldToken.getDefiningOp());
       rewriter.eraseOp(allocOp);

--- a/lib/Transformation/UniqueCarryingRecursionAnalysis/UniqueCarryingRecursionAnalysis.cpp
+++ b/lib/Transformation/UniqueCarryingRecursionAnalysis/UniqueCarryingRecursionAnalysis.cpp
@@ -83,10 +83,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Reussir/Transformation/Passes.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
+#include "Reussir/Transformation/Passes.h"
 
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/DenseSet.h>
@@ -318,7 +318,8 @@ private:
       return mapped;
     }
 
-    if (auto withUniqueView = llvm::dyn_cast<ReussirArrayWithUniqueViewOp>(op)) {
+    if (auto withUniqueView =
+            llvm::dyn_cast<ReussirArrayWithUniqueViewOp>(op)) {
       auto yieldOp = llvm::dyn_cast<ReussirScfYieldOp>(
           withUniqueView.getBody().front().getTerminator());
       if (!yieldOp)
@@ -357,8 +358,7 @@ private:
     for (mlir::Region &region : op->getRegions()) {
       if (region.empty())
         continue;
-      auto yieldOp =
-          llvm::dyn_cast<YieldOpT>(region.front().getTerminator());
+      auto yieldOp = llvm::dyn_cast<YieldOpT>(region.front().getTerminator());
       if (!yieldOp || resultIndex >= yieldOp->getNumOperands())
         return UniqueCarryingValue::getUnknown();
       joined = UniqueCarryingValue::join(
@@ -424,9 +424,8 @@ computeFunctionSummary(mlir::func::FuncOp funcOp,
 static bool isCarryingUniquenessRegionOp(mlir::Operation *op,
                                          const FunctionSummaryMap &summaries) {
   auto *dialect = op->getDialect();
-  bool supportedOp =
-      (dialect && dialect->getNamespace() == "scf") ||
-      llvm::isa<ReussirArrayWithUniqueViewOp>(op);
+  bool supportedOp = (dialect && dialect->getNamespace() == "scf") ||
+                     llvm::isa<ReussirArrayWithUniqueViewOp>(op);
   if (!supportedOp || !hasRcResults(op->getResultTypes()))
     return false;
   ProvenanceEvaluator evaluator(summaries);
@@ -707,7 +706,8 @@ struct UniqueCarryingRecursionAnalysisPass
     moduleOp.walk([&](mlir::Operation *op) {
       if (llvm::isa<mlir::func::FuncOp>(op))
         return;
-      setCarryingUniquenessAttr(op, isCarryingUniquenessRegionOp(op, summaries));
+      setCarryingUniquenessAttr(op,
+                                isCarryingUniquenessRegionOp(op, summaries));
     });
 
     mlir::SymbolTable symbolTable(moduleOp);

--- a/tests/integration/frontend/closure_e2e.c
+++ b/tests/integration/frontend/closure_e2e.c
@@ -15,8 +15,8 @@ extern int32_t test_partial_false_ffi(void);
 #define ASSERT_EQ(name, actual, expected)                                      \
   do {                                                                         \
     if ((actual) != (expected)) {                                              \
-      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,            \
-              (long long)(expected), (long long)(actual));                      \
+      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,             \
+              (long long)(expected), (long long)(actual));                     \
       abort();                                                                 \
     }                                                                          \
   } while (0)

--- a/tests/integration/frontend/closure_multiplicity.c
+++ b/tests/integration/frontend/closure_multiplicity.c
@@ -14,8 +14,8 @@ extern int32_t test_rc_capture_and_consume_ffi(void);
 #define ASSERT_EQ(name, actual, expected)                                      \
   do {                                                                         \
     if ((actual) != (expected)) {                                              \
-      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,            \
-              (long long)(expected), (long long)(actual));                      \
+      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,             \
+              (long long)(expected), (long long)(actual));                     \
       abort();                                                                 \
     }                                                                          \
   } while (0)

--- a/tests/integration/frontend/closure_nested_capture.c
+++ b/tests/integration/frontend/closure_nested_capture.c
@@ -10,8 +10,8 @@ extern int32_t test_capture_higher_order_ffi(void);
 #define ASSERT_EQ(name, actual, expected)                                      \
   do {                                                                         \
     if ((actual) != (expected)) {                                              \
-      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,            \
-              (long long)(expected), (long long)(actual));                      \
+      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,             \
+              (long long)(expected), (long long)(actual));                     \
       abort();                                                                 \
     }                                                                          \
   } while (0)

--- a/tests/integration/frontend/closure_struct_materialize.c
+++ b/tests/integration/frontend/closure_struct_materialize.c
@@ -14,8 +14,8 @@ extern int32_t test_vbox_pass_multi_ffi(void);
 #define ASSERT_EQ(name, actual, expected)                                      \
   do {                                                                         \
     if ((actual) != (expected)) {                                              \
-      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,            \
-              (long long)(expected), (long long)(actual));                      \
+      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,             \
+              (long long)(expected), (long long)(actual));                     \
       abort();                                                                 \
     }                                                                          \
   } while (0)

--- a/tests/integration/frontend/fn_lift.c
+++ b/tests/integration/frontend/fn_lift.c
@@ -13,8 +13,8 @@ extern int32_t test_generic_partial_ffi(void);
 #define ASSERT_EQ(name, actual, expected)                                      \
   do {                                                                         \
     if ((actual) != (expected)) {                                              \
-      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,            \
-              (long long)(expected), (long long)(actual));                      \
+      fprintf(stderr, "FAIL: %s: expected %lld, got %lld\n", name,             \
+              (long long)(expected), (long long)(actual));                     \
       abort();                                                                 \
     }                                                                          \
   } while (0)

--- a/tests/integration/frontend/multi_cgu_e2e.c
+++ b/tests/integration/frontend/multi_cgu_e2e.c
@@ -16,8 +16,8 @@ extern int64_t run_mixed_ffi(void);
   } while (0)
 
 int main() {
-  ASSERT_EQ("cube", run_cube_ffi(), 729);            // cube(9) = 9^3
+  ASSERT_EQ("cube", run_cube_ffi(), 729);               // cube(9) = 9^3
   ASSERT_EQ("sum_squares", run_sum_squares_ffi(), 385); // 1^2 + ... + 10^2
-  ASSERT_EQ("mixed", run_mixed_ffi(), 110);          // 64 + 16 + (1+4+9+16)
+  ASSERT_EQ("mixed", run_mixed_ffi(), 110);             // 64 + 16 + (1+4+9+16)
   return 0;
 }

--- a/tests/integration/frontend/nullable_match.rr
+++ b/tests/integration/frontend/nullable_match.rr
@@ -46,11 +46,11 @@ pub fn drop_unmatched(v: i32) -> i32 {
     7
 }
 
-struct [regional] Cell { v: u64, next: [field] Cell }
+struct [regional] TestCell { v: u64, next: [field] TestCell }
 
-regional fn mk2(v: u64) -> [flex] Cell {
-    let tail : [flex] Cell = Cell { v: v + 1, next: Nullable::Null };
-    let head : [flex] Cell = Cell { v: v, next: Nullable::Null };
+regional fn mk2(v: u64) -> [flex] TestCell {
+    let tail : [flex] TestCell = TestCell { v: v + 1, next: Nullable::Null };
+    let head : [flex] TestCell = TestCell { v: v, next: Nullable::Null };
     head->next := Nullable::NonNull { tail };
     head
 }

--- a/tests/integration/frontend/rbtree.c
+++ b/tests/integration/frontend/rbtree.c
@@ -3,11 +3,11 @@
 #include <stdlib.h>
 
 typedef struct rc_list {
-    uint32_t refcount; /* fused 8-byte header: i32 count + i32 tag */
-    uint32_t tag;
-    struct rc_list *tail; /* members are packed by descending alignment */
-    int32_t head;
-    int32_t _pad;
+  uint32_t refcount; /* fused 8-byte header: i32 count + i32 tag */
+  uint32_t tag;
+  struct rc_list *tail; /* members are packed by descending alignment */
+  int32_t head;
+  int32_t _pad;
 } rc_list_t;
 
 #define LIST_NIL 0
@@ -22,33 +22,35 @@ typedef struct rc_list {
  * ordinary RC box (also the layout with --disable-special-pointer-tag).
  */
 static inline int64_t list_tag(const rc_list_t *p) {
-    uint64_t top = (uint64_t)(uintptr_t)p >> 56;
-    return top != 0 ? (int64_t)(top - 1) : p->tag;
+  uint64_t top = (uint64_t)(uintptr_t)p >> 56;
+  return top != 0 ? (int64_t)(top - 1) : p->tag;
 }
 
 extern rc_list_t *make_tree_to_list_ffi(int32_t size);
 
 int main(void) {
-    const int32_t n = 256;
-    rc_list_t *p = make_tree_to_list_ffi(n);
+  const int32_t n = 256;
+  rc_list_t *p = make_tree_to_list_ffi(n);
 
-    for (int32_t i = 0; i < n; ++i) {
-        if (list_tag(p) != LIST_CONS) {
-            fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", (int)i);
-            abort();
-        }
-        if (p->head != i) {
-            fprintf(stderr, "FAIL: expected %d at index %d, got %d\n", (int)i, (int)i, (int)p->head);
-            abort();
-        }
-        p = p->tail;
+  for (int32_t i = 0; i < n; ++i) {
+    if (list_tag(p) != LIST_CONS) {
+      fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", (int)i);
+      abort();
     }
-
-    if (list_tag(p) != LIST_NIL) {
-        fprintf(stderr, "FAIL: expected Nil terminator, got tag=%ld\n", (long)list_tag(p));
-        abort();
+    if (p->head != i) {
+      fprintf(stderr, "FAIL: expected %d at index %d, got %d\n", (int)i, (int)i,
+              (int)p->head);
+      abort();
     }
+    p = p->tail;
+  }
 
-    puts("PASS: make_tree_to_list_ffi(256) returned [0..255]");
-    return 0;
+  if (list_tag(p) != LIST_NIL) {
+    fprintf(stderr, "FAIL: expected Nil terminator, got tag=%ld\n",
+            (long)list_tag(p));
+    abort();
+  }
+
+  puts("PASS: make_tree_to_list_ffi(256) returned [0..255]");
+  return 0;
 }

--- a/tests/integration/frontend/rbtree2.c
+++ b/tests/integration/frontend/rbtree2.c
@@ -5,11 +5,11 @@
 extern int32_t fold_test_ffi(int32_t size);
 
 int main(void) {
-    const int32_t n = 4200000;
-    int32_t p = fold_test_ffi(n);
-    if (p != 420000) {
-        fprintf(stderr, "FAIL: expected 420000, got %d\n", (int32_t)p);
-        abort();
-    }
-    return 0;
+  const int32_t n = 4200000;
+  int32_t p = fold_test_ffi(n);
+  if (p != 420000) {
+    fprintf(stderr, "FAIL: expected 420000, got %d\n", (int32_t)p);
+    abort();
+  }
+  return 0;
 }

--- a/tests/integration/frontend/rbtree_to_list.c
+++ b/tests/integration/frontend/rbtree_to_list.c
@@ -20,14 +20,14 @@
  * structure live (refcount >= 1) so we can safely inspect it here.
  */
 typedef struct rc_list {
-    uint32_t         refcount; /* fused 8-byte header: i32 count + i32 tag */
-    uint32_t         tag;
-    struct rc_list  *tail;     /* members are packed by descending alignment */
-    int32_t          head;
-    int32_t          _pad;
+  uint32_t refcount; /* fused 8-byte header: i32 count + i32 tag */
+  uint32_t tag;
+  struct rc_list *tail; /* members are packed by descending alignment */
+  int32_t head;
+  int32_t _pad;
 } rc_list_t;
 
-#define LIST_NIL  0
+#define LIST_NIL 0
 #define LIST_CONS 1
 
 /*
@@ -39,52 +39,52 @@ typedef struct rc_list {
  * ordinary RC box (also the layout with --disable-special-pointer-tag).
  */
 static inline int64_t list_tag(const rc_list_t *p) {
-    uint64_t top = (uint64_t)(uintptr_t)p >> 56;
-    return top != 0 ? (int64_t)(top - 1) : p->tag;
+  uint64_t top = (uint64_t)(uintptr_t)p >> 56;
+  return top != 0 ? (int64_t)(top - 1) : p->tag;
 }
 
 extern rc_list_t *test_to_list_ffi(void);
 
 int main(void) {
-    rc_list_t *list = test_to_list_ffi();
+  rc_list_t *list = test_to_list_ffi();
 
-    /* ---- inspect: print the raw RC structure ---- */
-    printf("List structure (RC layout):\n");
-    rc_list_t *p = list;
-    int idx = 0;
-    while (list_tag(p) == LIST_CONS) {
-        printf("  [%d] @%p  rc=%ld  tag=%ld (Cons)  head=%d  tail=%p\n",
-               idx, (void *)p, (long)p->refcount, (long)list_tag(p),
-               p->head, (void *)p->tail);
-        p = p->tail;
-        idx++;
+  /* ---- inspect: print the raw RC structure ---- */
+  printf("List structure (RC layout):\n");
+  rc_list_t *p = list;
+  int idx = 0;
+  while (list_tag(p) == LIST_CONS) {
+    printf("  [%d] @%p  rc=%ld  tag=%ld (Cons)  head=%d  tail=%p\n", idx,
+           (void *)p, (long)p->refcount, (long)list_tag(p), p->head,
+           (void *)p->tail);
+    p = p->tail;
+    idx++;
+  }
+  printf("  [%d] @%p  tag=%ld (Nil)\n", idx, (void *)p, (long)list_tag(p));
+
+  /* ---- verify: expect [1, 2, 3, 4, 5, 6, 7, 8, 9] ---- */
+  int expected[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  int n = (int)(sizeof(expected) / sizeof(expected[0]));
+
+  p = list;
+  for (int i = 0; i < n; i++) {
+    if (list_tag(p) != LIST_CONS) {
+      fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", i);
+      abort();
     }
-    printf("  [%d] @%p  tag=%ld (Nil)\n", idx, (void *)p, (long)list_tag(p));
-
-    /* ---- verify: expect [1, 2, 3, 4, 5, 6, 7, 8, 9] ---- */
-    int expected[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-    int n = (int)(sizeof(expected) / sizeof(expected[0]));
-
-    p = list;
-    for (int i = 0; i < n; i++) {
-        if (list_tag(p) != LIST_CONS) {
-            fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", i);
-            abort();
-        }
-        if (p->head != expected[i]) {
-            fprintf(stderr, "FAIL: at index %d: expected %d, got %d\n",
-                    i, expected[i], p->head);
-            abort();
-        }
-        p = p->tail;
+    if (p->head != expected[i]) {
+      fprintf(stderr, "FAIL: at index %d: expected %d, got %d\n", i,
+              expected[i], p->head);
+      abort();
     }
+    p = p->tail;
+  }
 
-    if (list_tag(p) != LIST_NIL) {
-        fprintf(stderr, "FAIL: expected Nil at end, got tag %ld\n",
-                (long)list_tag(p));
-        abort();
-    }
+  if (list_tag(p) != LIST_NIL) {
+    fprintf(stderr, "FAIL: expected Nil at end, got tag %ld\n",
+            (long)list_tag(p));
+    abort();
+  }
 
-    printf("PASS: list = [1, 2, 3, 4, 5, 6, 7, 8, 9]\n");
-    return 0;
+  printf("PASS: list = [1, 2, 3, 4, 5, 6, 7, 8, 9]\n");
+  return 0;
 }

--- a/tests/integration/frontend/region.rr
+++ b/tests/integration/frontend/region.rr
@@ -1,19 +1,19 @@
 // RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s -o %t.o
 
-// CHECK: record @_RIC4CellyE : regional struct Cell::<u64> { "value": u64 };
+// CHECK: record @_RIC8TestCellyE : regional struct TestCell::<u64> { "value": u64 };
 // CHECK-EMPTY:
-// CHECK: fn @_RC11freeze_cell() -> [rigid] Cell::<u64> {
-// CHECK-NEXT: region { @_RIC4CellyE{1 : u64} : [flex] Cell::<u64> } : [rigid] Cell::<u64>
+// CHECK: fn @_RC11freeze_cell() -> [rigid] TestCell::<u64> {
+// CHECK-NEXT: region { @_RIC8TestCellyE{1 : u64} : [flex] TestCell::<u64> } : [rigid] TestCell::<u64>
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK: regional fn @_RC17regional_function(v0 (x): u64) -> [flex] Cell::<u64> {
-// CHECK-NEXT: @_RIC4CellyE{v0 : u64} : [flex] Cell::<u64>
+// CHECK: regional fn @_RC17regional_function(v0 (x): u64) -> [flex] TestCell::<u64> {
+// CHECK-NEXT: @_RIC8TestCellyE{v0 : u64} : [flex] TestCell::<u64>
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK: fn @_RC25freeze_cell_with_let_expr() -> [rigid] Cell::<u64> {
-// CHECK-NEXT: region { { let v0 (x) = regional @_RC17regional_function(42 : u64) : [flex] Cell::<u64>;
-// CHECK-NEXT: v0 : [flex] Cell::<u64> } } : [rigid] Cell::<u64>
+// CHECK: fn @_RC25freeze_cell_with_let_expr() -> [rigid] TestCell::<u64> {
+// CHECK-NEXT: region { { let v0 (x) = regional @_RC17regional_function(42 : u64) : [flex] TestCell::<u64>;
+// CHECK-NEXT: v0 : [flex] TestCell::<u64> } } : [rigid] TestCell::<u64>
 // CHECK-NEXT: }
 // CHECK-EMPTY:
 // CHECK: fn @_RC7trivial() -> u64 {
@@ -26,27 +26,27 @@ fn trivial() -> u64 {
     }
 }
 
-struct [regional] Cell<T> {
+struct [regional] TestCell<T> {
     value: T
 }
 
 struct [regional] Container<T> {
-    cell: [field] Cell<T>
+    cell: [field] TestCell<T>
 }
 
-fn freeze_cell() -> Cell<u64> {
+fn freeze_cell() -> TestCell<u64> {
     regional {
-        Cell{value: 1}
+        TestCell{value: 1}
     }
 }
 
-fn freeze_cell_with_let_expr() -> Cell<u64> {
+fn freeze_cell_with_let_expr() -> TestCell<u64> {
     regional {
-        let x : [flex] Cell<u64> = regional_function(42);
+        let x : [flex] TestCell<u64> = regional_function(42);
         x
     }
 }
 
-regional fn regional_function(x : u64) -> [flex] Cell<u64> {
-    Cell{value: x}
+regional fn regional_function(x : u64) -> [flex] TestCell<u64> {
+    TestCell{value: x}
 }

--- a/tests/integration/frontend/regional_cycle.c
+++ b/tests/integration/frontend/regional_cycle.c
@@ -7,16 +7,16 @@ extern uint64_t ring_n_sum_ffi(uint64_t n, uint64_t rounds);
 extern uint64_t make_and_drop_ffi(uint64_t n);
 
 static void expect(const char *what, uint64_t got, uint64_t want) {
-    if (got != want) {
-        fprintf(stderr, "FAIL: %s = %llu, want %llu\n", what,
-                (unsigned long long)got, (unsigned long long)want);
-        abort();
-    }
+  if (got != want) {
+    fprintf(stderr, "FAIL: %s = %llu, want %llu\n", what,
+            (unsigned long long)got, (unsigned long long)want);
+    abort();
+  }
 }
 
 int main(void) {
-    expect("ring3_sum(4)", ring3_sum_ffi(4), 4 * (1 + 2 + 3));
-    expect("ring_n_sum(100, 3)", ring_n_sum_ffi(100, 3), 3 * (100 * 101 / 2));
-    expect("make_and_drop(64)", make_and_drop_ffi(64), 1);
-    return 0;
+  expect("ring3_sum(4)", ring3_sum_ffi(4), 4 * (1 + 2 + 3));
+  expect("ring_n_sum(100, 3)", ring_n_sum_ffi(100, 3), 3 * (100 * 101 / 2));
+  expect("make_and_drop(64)", make_and_drop_ffi(64), 1);
+  return 0;
 }

--- a/tests/integration/frontend/vapp.rr.c
+++ b/tests/integration/frontend/vapp.rr.c
@@ -5,10 +5,10 @@
 extern int32_t vapp_test_ffi(void);
 
 int main(void) {
-    int32_t got = vapp_test_ffi();
-    if (got != 1) {
-        fprintf(stderr, "FAIL: expected 1, got %d\n", got);
-        abort();
-    }
-    return 0;
+  int32_t got = vapp_test_ffi();
+  if (got != 1) {
+    fprintf(stderr, "FAIL: expected 1, got %d\n", got);
+    abort();
+  }
+  return 0;
 }

--- a/tests/integration/sanitizer/rbtree-harness.c
+++ b/tests/integration/sanitizer/rbtree-harness.c
@@ -3,11 +3,11 @@
 #include <stdlib.h>
 
 typedef struct rc_list {
-    uint32_t refcount; /* fused 8-byte header: i32 count + i32 tag */
-    uint32_t tag;
-    struct rc_list *tail; /* members are packed by descending alignment */
-    int32_t head;
-    int32_t _pad;
+  uint32_t refcount; /* fused 8-byte header: i32 count + i32 tag */
+  uint32_t tag;
+  struct rc_list *tail; /* members are packed by descending alignment */
+  int32_t head;
+  int32_t _pad;
 } rc_list_t;
 
 #define LIST_NIL 0
@@ -23,43 +23,45 @@ extern int __lsan_do_recoverable_leak_check(void);
 #endif
 
 static NOINLINE void leak_c_allocation(void) {
-    volatile char *leaked = (volatile char *)malloc(64);
-    if (leaked == NULL) {
-        abort();
-    }
-    leaked[0] = 1;
-    leaked = NULL;
+  volatile char *leaked = (volatile char *)malloc(64);
+  if (leaked == NULL) {
+    abort();
+  }
+  leaked[0] = 1;
+  leaked = NULL;
 }
 
 static NOINLINE void clear_stack_roots(void) {
-    volatile char buffer[4096];
-    for (size_t i = 0; i < sizeof(buffer); ++i) {
-        buffer[i] = 0;
-    }
+  volatile char buffer[4096];
+  for (size_t i = 0; i < sizeof(buffer); ++i) {
+    buffer[i] = 0;
+  }
 }
 
 int main(void) {
-    const int32_t n = 50;
-    rc_list_t *p = make_tree_to_list_ffi(n);
+  const int32_t n = 50;
+  rc_list_t *p = make_tree_to_list_ffi(n);
 
-    for (int32_t i = 0; i < n; ++i) {
-        if (p->tag != LIST_CONS) {
-            fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", (int)i);
-            abort();
-        }
-        if (p->head != i) {
-            fprintf(stderr, "FAIL: expected %d at index %d, got %d\n", (int)i, (int)i, (int)p->head);
-            abort();
-        }
-        p = p->tail;
+  for (int32_t i = 0; i < n; ++i) {
+    if (p->tag != LIST_CONS) {
+      fprintf(stderr, "FAIL: expected Cons at index %d, got Nil\n", (int)i);
+      abort();
     }
-
-    if (p->tag != LIST_NIL) {
-        fprintf(stderr, "FAIL: expected Nil terminator, got tag=%ld\n", (long)p->tag);
-        abort();
+    if (p->head != i) {
+      fprintf(stderr, "FAIL: expected %d at index %d, got %d\n", (int)i, (int)i,
+              (int)p->head);
+      abort();
     }
+    p = p->tail;
+  }
 
-    leak_c_allocation();
-    clear_stack_roots();
-    return __lsan_do_recoverable_leak_check() > 0 ? 1 : 0;
+  if (p->tag != LIST_NIL) {
+    fprintf(stderr, "FAIL: expected Nil terminator, got tag=%ld\n",
+            (long)p->tag);
+    abort();
+  }
+
+  leak_c_allocation();
+  clear_stack_roots();
+  return __lsan_do_recoverable_leak_check() > 0 ? 1 : 0;
 }

--- a/tests/integration/sanitizer/rbtree2-harness.c
+++ b/tests/integration/sanitizer/rbtree2-harness.c
@@ -5,11 +5,11 @@
 extern int32_t fold_test_ffi(int32_t size);
 
 int main(void) {
-    const int32_t n = 1000;
-    int32_t p = fold_test_ffi(n);
-    if (p != 100) {
-        fprintf(stderr, "FAIL: expected 100, got %d\n", (int)p);
-        abort();
-    }
-    return 0;
+  const int32_t n = 1000;
+  int32_t p = fold_test_ffi(n);
+  if (p != 100) {
+    fprintf(stderr, "FAIL: expected 100, got %d\n", (int)p);
+    abort();
+  }
+  return 0;
 }

--- a/tests/unittest/cases/array.cpp
+++ b/tests/unittest/cases/array.cpp
@@ -46,45 +46,43 @@ TEST_F(ReussirTest, RcTypeIsValidMemRefElementType) {
 }
 
 TEST_F(ReussirValueTransformTest, RefToArrayOfRcAcquisition) {
-  testValueAcquisition(
-      "!reussir.ref<!reussir.array<2 x !reussir.rc<i32>>>",
-      [](mlir::func::FuncOp funcOp) {
-        size_t projectCount = 0;
-        size_t incCount = 0;
-        bool foundView = false;
-        for (auto &op : funcOp.getFunctionBody().front()) {
-          if (llvm::isa<ReussirArrayViewOp>(op))
-            foundView = true;
-          if (llvm::isa<ReussirArrayProjectOp>(op))
-            ++projectCount;
-          if (llvm::isa<ReussirRcIncOp>(op))
-            ++incCount;
-        }
-        EXPECT_TRUE(foundView);
-        EXPECT_EQ(projectCount, 2u);
-        EXPECT_EQ(incCount, 2u);
-      });
+  testValueAcquisition("!reussir.ref<!reussir.array<2 x !reussir.rc<i32>>>",
+                       [](mlir::func::FuncOp funcOp) {
+                         size_t projectCount = 0;
+                         size_t incCount = 0;
+                         bool foundView = false;
+                         for (auto &op : funcOp.getFunctionBody().front()) {
+                           if (llvm::isa<ReussirArrayViewOp>(op))
+                             foundView = true;
+                           if (llvm::isa<ReussirArrayProjectOp>(op))
+                             ++projectCount;
+                           if (llvm::isa<ReussirRcIncOp>(op))
+                             ++incCount;
+                         }
+                         EXPECT_TRUE(foundView);
+                         EXPECT_EQ(projectCount, 2u);
+                         EXPECT_EQ(incCount, 2u);
+                       });
 }
 
 TEST_F(ReussirValueTransformTest, RefToNestedArrayOfRcAcquisition) {
-  testValueAcquisition(
-      "!reussir.ref<!reussir.array<2 x 2 x !reussir.rc<i32>>>",
-      [](mlir::func::FuncOp funcOp) {
-        size_t projectCount = 0;
-        size_t incCount = 0;
-        bool foundView = false;
-        for (auto &op : funcOp.getFunctionBody().front()) {
-          if (llvm::isa<ReussirArrayViewOp>(op))
-            foundView = true;
-          if (llvm::isa<ReussirArrayProjectOp>(op))
-            ++projectCount;
-          if (llvm::isa<ReussirRcIncOp>(op))
-            ++incCount;
-        }
-        EXPECT_TRUE(foundView);
-        EXPECT_EQ(projectCount, 6u);
-        EXPECT_EQ(incCount, 4u);
-      });
+  testValueAcquisition("!reussir.ref<!reussir.array<2 x 2 x !reussir.rc<i32>>>",
+                       [](mlir::func::FuncOp funcOp) {
+                         size_t projectCount = 0;
+                         size_t incCount = 0;
+                         bool foundView = false;
+                         for (auto &op : funcOp.getFunctionBody().front()) {
+                           if (llvm::isa<ReussirArrayViewOp>(op))
+                             foundView = true;
+                           if (llvm::isa<ReussirArrayProjectOp>(op))
+                             ++projectCount;
+                           if (llvm::isa<ReussirRcIncOp>(op))
+                             ++incCount;
+                         }
+                         EXPECT_TRUE(foundView);
+                         EXPECT_EQ(projectCount, 6u);
+                         EXPECT_EQ(incCount, 4u);
+                       });
 }
 
 TEST_F(ReussirTest, ArrayViewAllowsTensorResult) {


### PR DESCRIPTION
## Summary

- apply ClangFormat 22.1.8 to every tracked C, C++, header, C++ module, and TableGen source
- apply Rustfmt to the full Cargo workspace
- rename source-test `Cell` declarations to `TestCell` in the regional and nullable-match tests, avoiding a future collision with the builtin Cell type

This is an NFC-only follow-up to #412.

## Testing

- `cargo fmt --all -- --check`
- ClangFormat `--dry-run --Werror` over all tracked C/C++/header/module/TableGen files
- C++ unit tests: 19 passed
- Rust core tests: 245 passed
- Rust runtime tests: 19 passed
- compiler tests: 15 passed
- REPL tests: 4 passed
- backend tests: 10 passed, 1 environment-dependent test ignored
- codegen unit and end-to-end tests: 51 passed
- `ninja -C build check`: 338 passed, 10 unsupported

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786594372&installation_id=144622820&pr_number=413&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F413&signature=d5db4b9b5152a61cd21f892091939e6418cc8ccbce03f4379ebcb4b9202da250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->