### PR TITLE
[backend] generalize structural beta reduction

### DIFF
--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -53,7 +53,8 @@ def ReussirClosureBetaReductionPass
     is erased. Any other root leaves the fused eval, which the SCF-ops
     lowering expands as ONE uniqueness resolution + unchecked applies +
     plain eval — the intermediate uniqueness checks of the folded chain
-    collapse into one.
+    collapse into one. The same reduction applies when the closure is carried
+    through a nest containing only LoopLike operations and `cell.rmw`.
 
     Runs after the inliner (so cross-function create→eval pairs are visible)
     and before token instantiation / closure outlining (bodies are still

--- a/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
+++ b/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
@@ -36,29 +36,30 @@
 //    `token.alloc` are erased. Evals spliced out of the body are re-queued
 //    by the driver, which is what makes the reduction recursive.
 //
-//  * LOOPINLINE: the loop-carried redex, in its general frontend shape —
+//  * STRUCTURALINLINE: a redex carried into a supported structured region,
+//    in its general frontend shape —
 //
 //      %c = create {body}; (uniqify; apply cap)*     // capture binding
-//      loop* {                                       // any LoopLike nest
-//        rc.inc %c; (uniqify; apply x_i)*; eval(...) // per-iteration chain
+//      structural* {                                 // LoopLike or cell.rmw
+//        rc.inc %c; (uniqify; apply x_i)*; eval(...) // per-execution chain
 //      }
 //      rc.dec %c
 //
-//    (`scf.for` and `affine.for` alike). The body is spliced into the loop
-//    at the eval and the closure box vanishes: its create / per-iteration
-//    inc+chain / trailing dec traffic is self-contained (a fresh box
-//    nothing else can observe), so erasing all of it is count-neutral. The
-//    per-iteration uniqify is a *genuine* guard — the carried box is
-//    shared, so it clones every iteration — but the clone is itself a fresh
-//    box the chain consumes whole: cloning inc'd the stored captures out
+//    The body is spliced into the innermost region at the eval and the closure
+//    box vanishes: its create / per-execution inc+chain / trailing dec traffic
+//    is self-contained (a fresh box nothing else can observe), so erasing all
+//    of it is count-neutral. The per-execution uniqify is a *genuine* guard —
+//    the carried box is shared, so it clones every execution — but the clone
+//    is itself a fresh box the chain consumes whole: cloning inc'd the stored
+//    captures out
 //    and the eval consumed them, a wash the fused form reproduces. Capture
 //    counts are preserved, not reasoned about: each rc-typed capture bound
-//    *outside* the loop gains a per-iteration `rc.inc` at the splice point
-//    (the inlined body consumes its capture parameters each iteration) and
-//    one `rc.dec` where the box's dec stood (the box's drop used to release
-//    the ref the apply consumed). Captures bound *inside* the loop were
-//    consumed once per iteration before and still are — they just take
-//    their seat in the substitution pack.
+//    *outside* the structure gains a per-execution `rc.inc` at the splice
+//    point (the inlined body consumes its capture parameters each execution)
+//    and one `rc.dec` where the box's dec stood (the box's drop used to
+//    release the ref the apply consumed). Captures bound *inside* the
+//    structure were consumed once per execution before and still are — they
+//    just take their seat in the substitution pack.
 //
 // Fused evals that bottom out anywhere else survive the pass; the SCF-ops
 // lowering re-expands them into unchecked applies + plain eval, so the net
@@ -173,174 +174,182 @@ struct InlineCreateIntoEvalPattern
   }
 };
 
-// LOOPINLINE: a beta redex carried through a loop nest. See the file
-// comment for the ownership accounting.
-struct InlineLoopCarriedCreatePattern
+// STRUCTURALINLINE: beta-reduce a redex carried through a nest consisting
+// only of LoopLike operations and cell.rmw. See the file comment for the
+// ownership accounting. This intentionally does not accept arbitrary
+// region-holding operations.
+mlir::LogicalResult structuralBetaReduction(ReussirClosureEvalOp eval,
+                                            mlir::PatternRewriter &rewriter) {
+  // Peel the per-execution links: single-use `uniqify | apply` ops in the
+  // eval's own block, down to the value carried across the region boundary. The
+  // uniqify here is a *genuine* guard (the carried box is shared, so it
+  // clones every execution) — but the clone is a fresh box the fused
+  // chain consumes whole, so erasing it is count-neutral; cloning used to
+  // inc the stored captures out and the eval consumed them, a wash the
+  // fused form reproduces exactly. Per-execution applied args were
+  // consumed once per execution before and still are: they need no
+  // adjustment, only a seat in the substitution pack.
+  llvm::SmallVector<mlir::Operation *> localChain;
+  llvm::SmallVector<mlir::Value> localCaps; // collected top-down
+  mlir::Value carried = eval.getClosure();
+  while (true) {
+    mlir::Operation *def = carried.getDefiningOp();
+    if (!def)
+      return mlir::failure();
+    if (def->getBlock() != eval->getBlock())
+      break; // `carried` crosses the innermost structural boundary
+    if (!carried.hasOneUse())
+      return mlir::failure();
+    if (auto apply = llvm::dyn_cast<ReussirClosureApplyOp>(def)) {
+      localChain.push_back(def);
+      localCaps.push_back(apply.getArg());
+      carried = apply.getClosure();
+    } else if (auto uniqify = llvm::dyn_cast<ReussirClosureUniqifyOp>(def)) {
+      localChain.push_back(def);
+      carried = uniqify.getClosure();
+    } else {
+      return mlir::failure();
+    }
+  }
+  mlir::Operation *top = carried.getDefiningOp();
+  mlir::Block *defBlock = top->getBlock();
+
+  // Every region between the carried value and the eval must be one of the
+  // deliberately supported structural operations: a LoopLike operation or
+  // cell.rmw. The chain must dominate the complete nest from outside.
+  mlir::Operation *walk = eval;
+  while (walk->getBlock() != defBlock) {
+    mlir::Operation *parent = walk->getParentOp();
+    if (!parent ||
+        !llvm::isa<mlir::LoopLikeOpInterface, ReussirCellRmwOp>(parent))
+      return mlir::failure();
+    walk = parent;
+  }
+  mlir::Operation *outermostStructure = walk;
+
+  // The chain below the structurally carried value: linear (every local link
+  // single-use), one block, bottoming at an inlined create. Every uniqify
+  // over such a chain is a runtime no-op — the value is unique by
+  // construction, fresh from the create with no use between the links.
+  llvm::SmallVector<mlir::Operation *> outerChain;
+  llvm::SmallVector<mlir::Value> outerCaps; // collected top-down
+  ReussirClosureCreateOp create;
+  mlir::Value link = carried;
+  while (true) {
+    mlir::Operation *def = link.getDefiningOp();
+    if (!def || def->getBlock() != defBlock)
+      return mlir::failure();
+    if (link != carried && !link.hasOneUse())
+      return mlir::failure();
+    if (auto apply = llvm::dyn_cast<ReussirClosureApplyOp>(def)) {
+      outerChain.push_back(def);
+      outerCaps.push_back(apply.getArg());
+      link = apply.getClosure();
+    } else if (auto uniqify = llvm::dyn_cast<ReussirClosureUniqifyOp>(def)) {
+      outerChain.push_back(def);
+      link = uniqify.getClosure();
+    } else if ((create = llvm::dyn_cast<ReussirClosureCreateOp>(def))) {
+      outerChain.push_back(def);
+      break;
+    } else {
+      return mlir::failure();
+    }
+  }
+  if (!create.isInlined())
+    return mlir::failure();
+  mlir::Value token = create.getToken();
+  if (token && !token.getDefiningOp<ReussirTokenAllocOp>())
+    return mlir::failure();
+  // Walking top-down visits the last application first; the body's
+  // parameters bind in application order — outer applies first, then the
+  // region-local ones, then the eval's pack.
+  std::reverse(outerCaps.begin(), outerCaps.end());
+  std::reverse(localCaps.begin(), localCaps.end());
+
+  mlir::Block &body = create.getBody().front();
+  if (body.getNumArguments() !=
+      outerCaps.size() + localCaps.size() + eval.getArgs().size())
+    return mlir::failure();
+
+  // The carried value's remaining uses: exactly one per-execution inc
+  // beside the eval, and exactly one plain dec after the nest at the
+  // chain's level.
+  mlir::Operation *firstLink =
+      localChain.empty() ? eval.getOperation() : localChain.back();
+  llvm::SmallVector<ReussirRcIncOp> incs;
+  ReussirRcDecOp dec;
+  for (mlir::Operation *user : carried.getUsers()) {
+    if (user == firstLink)
+      continue;
+    if (auto inc = llvm::dyn_cast<ReussirRcIncOp>(user)) {
+      if (inc->getBlock() != eval->getBlock() || !inc->isBeforeInBlock(eval))
+        return mlir::failure();
+      incs.push_back(inc);
+      continue;
+    }
+    if (auto d = llvm::dyn_cast<ReussirRcDecOp>(user)) {
+      if (dec || d->getBlock() != defBlock ||
+          !outermostStructure->isBeforeInBlock(d))
+        return mlir::failure();
+      dec = d;
+      continue;
+    }
+    return mlir::failure();
+  }
+  if (incs.size() != 1 || !dec || dec.getNumResults() != 0)
+    return mlir::failure();
+
+  // Per-execution ownership for the rc-typed captures the box stored:
+  // the inlined body consumes its capture parameters each execution (see
+  // the file comment).
+  rewriter.setInsertionPoint(eval);
+  for (mlir::Value cap : outerCaps)
+    if (llvm::isa<RcType>(cap.getType()))
+      ReussirRcIncOp::create(rewriter, eval.getLoc(), cap);
+
+  auto yield = llvm::cast<ReussirClosureYieldOp>(body.getTerminator());
+  llvm::SmallVector<mlir::Value> args(outerCaps);
+  llvm::append_range(args, localCaps);
+  llvm::append_range(args, eval.getArgs());
+  rewriter.inlineBlockBefore(&body, eval, args);
+  // The yield may refer directly to a body argument; fetch it only after
+  // inlining has replaced that argument with its value from `args`.
+  mlir::Value yielded = yield.getValue();
+  rewriter.eraseOp(yield);
+  if (eval.getNumResults())
+    rewriter.replaceOp(eval, yielded);
+  else
+    rewriter.eraseOp(eval);
+
+  // The box's dec used to release the captures the outer applies
+  // consumed; release them directly where it stood.
+  rewriter.setInsertionPoint(dec);
+  for (mlir::Value cap : outerCaps)
+    if (llvm::isa<RcType>(cap.getType()))
+      ReussirRcDecOp::create(rewriter, dec.getLoc(),
+                             /*nullableToken=*/NullableType{}, cap,
+                             /*destructureTag=*/mlir::IntegerAttr{},
+                             /*boundMembers=*/mlir::DenseI64ArrayAttr{});
+  for (mlir::Operation *op : localChain)
+    rewriter.eraseOp(op);
+  for (ReussirRcIncOp inc : incs)
+    rewriter.eraseOp(inc);
+  rewriter.eraseOp(dec);
+  for (mlir::Operation *op : outerChain)
+    rewriter.eraseOp(op);
+  if (token && token.use_empty())
+    rewriter.eraseOp(token.getDefiningOp());
+  return mlir::success();
+}
+
+struct InlineStructurallyCarriedCreatePattern
     : public mlir::OpRewritePattern<ReussirClosureEvalOp> {
   using OpRewritePattern::OpRewritePattern;
 
   mlir::LogicalResult
   matchAndRewrite(ReussirClosureEvalOp eval,
                   mlir::PatternRewriter &rewriter) const override {
-    // Peel the per-iteration links: single-use `uniqify | apply` ops in the
-    // eval's own block, down to the value carried across iterations. The
-    // uniqify here is a *genuine* guard (the carried box is shared, so it
-    // clones every iteration) — but the clone is a fresh box the fused
-    // chain consumes whole, so erasing it is count-neutral; cloning used to
-    // inc the stored captures out and the eval consumed them, a wash the
-    // fused form reproduces exactly. Per-iteration applied args were
-    // consumed once per iteration before and still are: they need no
-    // adjustment, only a seat in the substitution pack.
-    llvm::SmallVector<mlir::Operation *> innerChain;
-    llvm::SmallVector<mlir::Value> innerCaps; // collected top-down
-    mlir::Value carried = eval.getClosure();
-    while (true) {
-      mlir::Operation *def = carried.getDefiningOp();
-      if (!def)
-        return mlir::failure();
-      if (def->getBlock() != eval->getBlock())
-        break; // left the loop body: `carried` is the loop-carried value
-      if (!carried.hasOneUse())
-        return mlir::failure();
-      if (auto apply = llvm::dyn_cast<ReussirClosureApplyOp>(def)) {
-        innerChain.push_back(def);
-        innerCaps.push_back(apply.getArg());
-        carried = apply.getClosure();
-      } else if (auto uniqify = llvm::dyn_cast<ReussirClosureUniqifyOp>(def)) {
-        innerChain.push_back(def);
-        carried = uniqify.getClosure();
-      } else {
-        return mlir::failure();
-      }
-    }
-    mlir::Operation *top = carried.getDefiningOp();
-    mlir::Block *defBlock = top->getBlock();
-
-    // Every region between the carried value and the eval must be a loop
-    // (any dialect implementing `LoopLikeOpInterface`): the eval then runs
-    // once per iteration of a nest the chain dominates from outside.
-    mlir::Operation *walk = eval;
-    while (walk->getBlock() != defBlock) {
-      mlir::Operation *parent = walk->getParentOp();
-      if (!parent || !llvm::isa<mlir::LoopLikeOpInterface>(parent))
-        return mlir::failure();
-      walk = parent;
-    }
-    mlir::Operation *outermostLoop = walk;
-
-    // The chain below the loop-carried value: linear (every inner link
-    // single-use), one block, bottoming at an inlined create. Every uniqify
-    // over such a chain is a runtime no-op — the value is unique by
-    // construction, fresh from the create with no use between the links.
-    llvm::SmallVector<mlir::Operation *> outerChain;
-    llvm::SmallVector<mlir::Value> outerCaps; // collected top-down
-    ReussirClosureCreateOp create;
-    mlir::Value link = carried;
-    while (true) {
-      mlir::Operation *def = link.getDefiningOp();
-      if (!def || def->getBlock() != defBlock)
-        return mlir::failure();
-      if (link != carried && !link.hasOneUse())
-        return mlir::failure();
-      if (auto apply = llvm::dyn_cast<ReussirClosureApplyOp>(def)) {
-        outerChain.push_back(def);
-        outerCaps.push_back(apply.getArg());
-        link = apply.getClosure();
-      } else if (auto uniqify = llvm::dyn_cast<ReussirClosureUniqifyOp>(def)) {
-        outerChain.push_back(def);
-        link = uniqify.getClosure();
-      } else if ((create = llvm::dyn_cast<ReussirClosureCreateOp>(def))) {
-        outerChain.push_back(def);
-        break;
-      } else {
-        return mlir::failure();
-      }
-    }
-    if (!create.isInlined())
-      return mlir::failure();
-    mlir::Value token = create.getToken();
-    if (token && !token.getDefiningOp<ReussirTokenAllocOp>())
-      return mlir::failure();
-    // Walking top-down visits the last application first; the body's
-    // parameters bind in application order — outer applies first, then the
-    // per-iteration ones, then the eval's pack.
-    std::reverse(outerCaps.begin(), outerCaps.end());
-    std::reverse(innerCaps.begin(), innerCaps.end());
-
-    mlir::Block &body = create.getBody().front();
-    if (body.getNumArguments() !=
-        outerCaps.size() + innerCaps.size() + eval.getArgs().size())
-      return mlir::failure();
-
-    // The carried value's remaining uses: exactly one per-iteration inc
-    // beside the eval, and exactly one plain dec after the nest at the
-    // chain's level.
-    mlir::Operation *firstLink =
-        innerChain.empty() ? eval.getOperation() : innerChain.back();
-    llvm::SmallVector<ReussirRcIncOp> incs;
-    ReussirRcDecOp dec;
-    for (mlir::Operation *user : carried.getUsers()) {
-      if (user == firstLink)
-        continue;
-      if (auto inc = llvm::dyn_cast<ReussirRcIncOp>(user)) {
-        if (inc->getBlock() != eval->getBlock() || !inc->isBeforeInBlock(eval))
-          return mlir::failure();
-        incs.push_back(inc);
-        continue;
-      }
-      if (auto d = llvm::dyn_cast<ReussirRcDecOp>(user)) {
-        if (dec || d->getBlock() != defBlock ||
-            !outermostLoop->isBeforeInBlock(d))
-          return mlir::failure();
-        dec = d;
-        continue;
-      }
-      return mlir::failure();
-    }
-    if (incs.size() != 1 || !dec || dec.getNumResults() != 0)
-      return mlir::failure();
-
-    // Per-iteration ownership for the rc-typed captures the box stored:
-    // the inlined body consumes its capture parameters each iteration (see
-    // the file comment).
-    rewriter.setInsertionPoint(eval);
-    for (mlir::Value cap : outerCaps)
-      if (llvm::isa<RcType>(cap.getType()))
-        ReussirRcIncOp::create(rewriter, eval.getLoc(), cap);
-
-    auto yield = llvm::cast<ReussirClosureYieldOp>(body.getTerminator());
-    llvm::SmallVector<mlir::Value> args(outerCaps);
-    llvm::append_range(args, innerCaps);
-    llvm::append_range(args, eval.getArgs());
-    rewriter.inlineBlockBefore(&body, eval, args);
-    // The yield may refer directly to a body argument; fetch it only after
-    // inlining has replaced that argument with its value from `args`.
-    mlir::Value yielded = yield.getValue();
-    rewriter.eraseOp(yield);
-    if (eval.getNumResults())
-      rewriter.replaceOp(eval, yielded);
-    else
-      rewriter.eraseOp(eval);
-
-    // The box's dec used to release the captures the outer applies
-    // consumed; release them directly where it stood.
-    rewriter.setInsertionPoint(dec);
-    for (mlir::Value cap : outerCaps)
-      if (llvm::isa<RcType>(cap.getType()))
-        ReussirRcDecOp::create(rewriter, dec.getLoc(),
-                               /*nullableToken=*/NullableType{}, cap,
-                               /*destructureTag=*/mlir::IntegerAttr{},
-                               /*boundMembers=*/mlir::DenseI64ArrayAttr{});
-    for (mlir::Operation *op : innerChain)
-      rewriter.eraseOp(op);
-    for (ReussirRcIncOp inc : incs)
-      rewriter.eraseOp(inc);
-    rewriter.eraseOp(dec);
-    for (mlir::Operation *op : outerChain)
-      rewriter.eraseOp(op);
-    if (token && token.use_empty())
-      rewriter.eraseOp(token.getDefiningOp());
-    return mlir::success();
+    return structuralBetaReduction(eval, rewriter);
   }
 };
 
@@ -352,8 +361,8 @@ struct ClosureBetaReductionPass
   void runOnOperation() override {
     mlir::RewritePatternSet patterns(&getContext());
     patterns.add<FoldApplyIntoEvalPattern, StripNoopUniqifyPattern,
-                 InlineCreateIntoEvalPattern, InlineLoopCarriedCreatePattern>(
-        &getContext());
+                 InlineCreateIntoEvalPattern,
+                 InlineStructurallyCarriedCreatePattern>(&getContext());
     if (mlir::failed(
             mlir::applyPatternsGreedily(getOperation(), std::move(patterns))))
       signalPassFailure();

--- a/tests/integration/conversion/closure_beta_structural.mlir
+++ b/tests/integration/conversion/closure_beta_structural.mlir
@@ -1,0 +1,140 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(func.func(reussir-closure-beta-reduction))' \
+// RUN: | %FileCheck %s
+
+// Structural beta reduction accepts exactly LoopLike operations and
+// reussir.cell.rmw as region boundaries. The existing loop tests cover pure
+// loop nests; this file covers rmw alone, rmw nested under a loop, ownership
+// accounting for an rc capture, and rejection of an unrelated region op.
+
+!rc_cell = !reussir.rc<!reussir.cell<i64>>
+!rc_i64 = !reussir.rc<i64>
+
+module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>>} {
+  func.func @cell_rmw(%cell: !rc_cell) -> i64 {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %closure = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%value: i64):
+          %next = arith.addi %value, %value : i64
+          reussir.closure.yield %next : i64
+      }
+    }
+    %old = reussir.cell.rmw(%cell : !rc_cell) -> i64 {
+      ^bb0(%current: i64):
+        reussir.rc.inc(%closure : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+        %unique = reussir.closure.uniqify(%closure : !reussir.rc<!reussir.closure<(i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64) -> i64>>
+        %bound = reussir.closure.apply(%current : i64) to (%unique : !reussir.rc<!reussir.closure<(i64) -> i64>>) : !reussir.rc<!reussir.closure<() -> i64>>
+        %next = reussir.closure.eval(%bound : !reussir.rc<!reussir.closure<() -> i64>>) : i64
+        reussir.cell.yield(%next : i64) output(%current : i64)
+    }
+    reussir.rc.dec(%closure : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+    return %old : i64
+  }
+
+  func.func @cell_rmw_rc_capture(%capture: !rc_i64, %cell: !rc_cell) -> i64 {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 40>
+    %closure = reussir.closure.create -> !reussir.rc<!reussir.closure<(!rc_i64, i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 40>)
+      body {
+        ^bb0(%owned: !rc_i64, %value: i64):
+          reussir.rc.dec(%owned : !rc_i64)
+          %next = arith.addi %value, %value : i64
+          reussir.closure.yield %next : i64
+      }
+    }
+    %captured = reussir.closure.apply(%capture : !rc_i64) to (%closure : !reussir.rc<!reussir.closure<(!rc_i64, i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64) -> i64>>
+    %old = reussir.cell.rmw(%cell : !rc_cell) -> i64 {
+      ^bb0(%current: i64):
+        reussir.rc.inc(%captured : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+        %unique = reussir.closure.uniqify(%captured : !reussir.rc<!reussir.closure<(i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64) -> i64>>
+        %bound = reussir.closure.apply(%current : i64) to (%unique : !reussir.rc<!reussir.closure<(i64) -> i64>>) : !reussir.rc<!reussir.closure<() -> i64>>
+        %next = reussir.closure.eval(%bound : !reussir.rc<!reussir.closure<() -> i64>>) : i64
+        reussir.cell.yield(%next : i64) output(%current : i64)
+    }
+    reussir.rc.dec(%captured : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+    return %old : i64
+  }
+
+  func.func @loop_and_cell_rmw(%cell: !rc_cell, %n: index) {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %closure = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%value: i64):
+          %next = arith.addi %value, %value : i64
+          reussir.closure.yield %next : i64
+      }
+    }
+    %lb = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    scf.for %i = %lb to %n step %step {
+      reussir.cell.rmw(%cell : !rc_cell) {
+        ^bb0(%current: i64):
+          reussir.rc.inc(%closure : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+          %unique = reussir.closure.uniqify(%closure : !reussir.rc<!reussir.closure<(i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64) -> i64>>
+          %bound = reussir.closure.apply(%current : i64) to (%unique : !reussir.rc<!reussir.closure<(i64) -> i64>>) : !reussir.rc<!reussir.closure<() -> i64>>
+          %next = reussir.closure.eval(%bound : !reussir.rc<!reussir.closure<() -> i64>>) : i64
+          reussir.cell.yield(%next : i64)
+      }
+    }
+    reussir.rc.dec(%closure : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+    return
+  }
+
+  // scf.if is intentionally not part of the narrow structural set.
+  func.func @unsupported_if(%cond: i1) {
+    %token = reussir.token.alloc : !reussir.token<align: 8, size: 32>
+    %closure = reussir.closure.create -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      token(%token : !reussir.token<align: 8, size: 32>)
+      body {
+        ^bb0(%value: i64):
+          reussir.closure.yield %value : i64
+      }
+    }
+    scf.if %cond {
+      %zero = arith.constant 0 : i64
+      reussir.rc.inc(%closure : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+      %unique = reussir.closure.uniqify(%closure : !reussir.rc<!reussir.closure<(i64) -> i64>>) : !reussir.rc<!reussir.closure<(i64) -> i64>>
+      %bound = reussir.closure.apply(%zero : i64) to (%unique : !reussir.rc<!reussir.closure<(i64) -> i64>>) : !reussir.rc<!reussir.closure<() -> i64>>
+      %result = reussir.closure.eval(%bound : !reussir.rc<!reussir.closure<() -> i64>>) : i64
+    }
+    reussir.rc.dec(%closure : !reussir.rc<!reussir.closure<(i64) -> i64>>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @cell_rmw
+// CHECK-NOT: reussir.token.alloc
+// CHECK-NOT: reussir.closure
+// CHECK-NOT: reussir.rc.inc
+// CHECK: reussir.cell.rmw
+// CHECK: %[[NEXT:.+]] = arith.addi %[[CURRENT:.+]], %[[CURRENT]] : i64
+// CHECK: reussir.cell.yield(%[[NEXT]] : i64) output(%[[CURRENT]] : i64)
+// CHECK-NOT: reussir.rc.dec
+
+// CHECK-LABEL: func.func @cell_rmw_rc_capture
+// CHECK-NOT: reussir.closure
+// CHECK: reussir.cell.rmw
+// CHECK: reussir.rc.inc(%arg0 : !reussir.rc<i64>)
+// CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)
+// CHECK: arith.addi
+// CHECK: reussir.cell.yield
+// CHECK: }
+// CHECK: reussir.rc.dec(%arg0 : !reussir.rc<i64>)
+
+// CHECK-LABEL: func.func @loop_and_cell_rmw
+// CHECK-NOT: reussir.closure
+// CHECK-NOT: reussir.rc.inc
+// CHECK: scf.for
+// CHECK: reussir.cell.rmw
+// CHECK: arith.addi
+// CHECK: reussir.cell.yield
+// CHECK-NOT: reussir.rc.dec
+
+// CHECK-LABEL: func.func @unsupported_if
+// CHECK: reussir.closure.create
+// CHECK: scf.if
+// CHECK: reussir.closure.eval
+// CHECK: reussir.rc.dec


### PR DESCRIPTION
## Summary
- extract the loop-carried closure rewrite into structuralBetaReduction
- allow only LoopLike operations and reussir.cell.rmw as structural boundaries
- preserve RC capture accounting across RMW and mixed loop/RMW nests
- add positive RMW coverage and a negative scf.if scope guard

## Tests
- ctest --test-dir build --output-on-failure
- ninja -C build rrc-test reussir-codegen-test reussir-backend-test
- ninja -C build check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786595146&installation_id=144622820&pr_number=414&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F414&signature=d24f1f67aa5bbd6912d11140757573fbcefe03daea01fd8072ad7552c874e7d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->