### PR TITLE
[nfc] rename remaining Cell test fixtures

### DIFF
--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -301,6 +301,94 @@ pub fn nullable_dispatch<'c>(
     builder.build().expect("valid reussir.nullable.dispatch")
 }
 
+/// `reussir.cell.create value(%value : T) : !reussir.rc<!reussir.cell<T>>`
+/// — move a value into a fresh shared cell. The token-instantiation pass fills
+/// the optional allocation token.
+pub fn cell_create<'c>(
+    value: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.cell.create", location)
+        .add_operands(&[value])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.cell.create")
+}
+
+/// `reussir.cell.get(%cell : rc<cell<T>>) : T` — clone the stored value.
+pub fn cell_get<'c>(
+    cell: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.cell.get", location)
+        .add_operands(&[cell])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.cell.get")
+}
+
+/// `reussir.cell.set(%value : T, %cell : rc<cell<T>>)` — replace the stored
+/// value, consuming `value` and dropping the old element.
+pub fn cell_set<'c>(
+    value: Value<'c, '_>,
+    cell: Value<'c, '_>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.cell.set", location)
+        .add_operands(&[value, cell])
+        .build()
+        .expect("valid reussir.cell.set")
+}
+
+/// `reussir.cell.rmw(%cell) { ... }` — move the current element through a
+/// single-block body and store its yielded replacement.
+pub fn cell_rmw<'c>(
+    cell: Value<'c, '_>,
+    result_type: Option<Type<'c>>,
+    body: Region<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let mut builder = OperationBuilder::new("reussir.cell.rmw", location)
+        .add_operands(&[cell])
+        .add_regions([body]);
+    if let Some(result_type) = result_type {
+        builder = builder.add_results(&[result_type]);
+    }
+    builder.build().expect("valid reussir.cell.rmw")
+}
+
+/// `reussir.cell.yield(%replacement : T)` — terminate a cell RMW body.
+pub fn cell_yield<'c>(
+    replacement: Value<'c, '_>,
+    output: Option<Value<'c, '_>>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let mut operands = vec![replacement];
+    if let Some(output) = output {
+        operands.push(output);
+    }
+    OperationBuilder::new("reussir.cell.yield", location)
+        .add_operands(&operands)
+        .build()
+        .expect("valid reussir.cell.yield")
+}
+
+/// `reussir.cell.in_use(%cell : rc<cell<T exclusive>>) : i1` — observe the
+/// exclusive cell's in-use flag (true while an rmw body holds the element).
+pub fn cell_in_use<'c>(
+    cell: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.cell.in_use", location)
+        .add_operands(&[cell])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.cell.in_use")
+}
+
 /// `reussir.region.run (-> <result_type>)? { <body> }` — execute a region scope.
 ///
 /// The body region's single block takes a `!reussir.region` argument (the arena

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -35,7 +35,7 @@ use reussir_backend::melior::ir::{
 
 use reussir_core::full::mir::{self, DecisionTree, Expr, ExprKind, SwitchCases};
 use reussir_core::full::ownership::{OwnershipTable, RcOp, RecordTable, analyze_function};
-use reussir_core::intrinsic::{ArrayFn, IntrinsicOp};
+use reussir_core::intrinsic::{ArrayFn, CellFn, IntrinsicOp};
 use reussir_core::literal::{self, Integer};
 use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use reussir_core::semi::ty::{Flexivity, IntTy, Ty, TyCtxt, TyKind};
@@ -626,36 +626,35 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             // builder over the (scalar) operands. Each family owns its own
             // dialect ops and attributes; the backend pipeline's dialect
             // conversions take the emitted op from there.
-            Intrinsic { op, args } => {
-                let mut operands = Vec::with_capacity(args.len());
-                for a in args.iter() {
-                    let v = self.expr(block, env, a)?.ok_or_else(|| {
-                        LoweringError("intrinsic operand produced no value".into())
-                    })?;
-                    operands.push(v);
-                }
-                let result = self.tys.mlir_ty(e.ty)?;
-                let built = match op {
-                    IntrinsicOp::Math { func, flag } => {
-                        let fastmath =
-                            reussir_core::intrinsic::FastMath(*flag)
-                                .mlir_attr()
-                                .map(|text| {
-                                    Attribute::parse(self.context, &text)
-                                        .expect("valid fastmath attribute")
-                                });
-                        super::math::math_operation(
-                            self.context,
-                            *func,
-                            &operands,
-                            result,
-                            fastmath,
-                            loc,
-                        )
+            Intrinsic { op, args } => match op {
+                IntrinsicOp::Math { func, flag } => {
+                    let mut operands = Vec::with_capacity(args.len());
+                    for a in args.iter() {
+                        let v = self.expr(block, env, a)?.ok_or_else(|| {
+                            LoweringError("intrinsic operand produced no value".into())
+                        })?;
+                        operands.push(v);
                     }
-                };
-                Ok(Some(self.append(block, built)))
-            }
+                    let result = self.tys.mlir_ty(e.ty)?;
+                    let fastmath =
+                        reussir_core::intrinsic::FastMath(*flag)
+                            .mlir_attr()
+                            .map(|text| {
+                                Attribute::parse(self.context, &text)
+                                    .expect("valid fastmath attribute")
+                            });
+                    let built = super::math::math_operation(
+                        self.context,
+                        *func,
+                        &operands,
+                        result,
+                        fastmath,
+                        loc,
+                    );
+                    Ok(Some(self.append(block, built)))
+                }
+                IntrinsicOp::Cell { func } => self.lower_cell_intrinsic(block, env, e, *func, args),
+            },
             Cmp(l, op, r) => self.cmp(block, env, l, *op, r).map(Some),
             Cast(x, t) => self.cast(block, env, x, *t),
             If(c, t, f) => self.lower_if(block, env, c, t, f, e.ty),
@@ -2175,6 +2174,15 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 proj_cap: ref_cap,
                 is_link: true,
             })
+        } else if matches!(field_ty.kind(), TyKind::Cell { .. }) {
+            // A cell member is stored as a bare payload type in the record
+            // declaration, but dialect projection materializes a shared rc link.
+            Ok(ProjectedMember {
+                field_ty,
+                elem_ty: self.tys.mlir_ty(field_ty)?,
+                proj_cap: ref_cap,
+                is_link: true,
+            })
         } else {
             Ok(ProjectedMember {
                 field_ty,
@@ -2690,6 +2698,114 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let region = Region::new();
         region.append_block(block);
         Ok(region)
+    }
+
+    // ----- built-in cell operations -----
+
+    fn lower_cell_intrinsic<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        e: &Expr<'tcx>,
+        func: CellFn,
+        args: &'tcx [Expr<'tcx>],
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let loc = self.loc();
+        match func {
+            CellFn::Alloc => {
+                let value = self
+                    .expr(block, env, &args[0])?
+                    .ok_or_else(|| LoweringError("cell element produced no value".into()))?;
+                let result_ty = self.tys.mlir_ty(e.ty)?;
+                Ok(Some(self.append(
+                    block,
+                    builders::cell_create(value, result_ty, loc),
+                )))
+            }
+            CellFn::Get => {
+                let base = &args[0];
+                let cell = self
+                    .expr(block, env, base)?
+                    .ok_or_else(|| LoweringError("cell operand produced no value".into()))?;
+                self.remember_temp(env, base, cell);
+                let result_ty = self.tys.mlir_ty(e.ty)?;
+                Ok(Some(
+                    self.append(block, builders::cell_get(cell, result_ty, loc)),
+                ))
+            }
+            CellFn::Set => {
+                let base = &args[0];
+                let cell = self
+                    .expr(block, env, base)?
+                    .ok_or_else(|| LoweringError("cell operand produced no value".into()))?;
+                self.remember_temp(env, base, cell);
+                let value = self
+                    .expr(block, env, &args[1])?
+                    .ok_or_else(|| LoweringError("cell element produced no value".into()))?;
+                block.append_operation(builders::cell_set(value, cell, loc));
+                Ok(None)
+            }
+            CellFn::InUse => {
+                let base = &args[0];
+                if !matches!(
+                    *base.ty.kind(),
+                    TyKind::Cell {
+                        exclusive: true,
+                        ..
+                    }
+                ) {
+                    return err("cell in_use operand is not an exclusive cell");
+                }
+                let cell = self
+                    .expr(block, env, base)?
+                    .ok_or_else(|| LoweringError("cell operand produced no value".into()))?;
+                self.remember_temp(env, base, cell);
+                let result_ty = self.tys.mlir_ty(e.ty)?;
+                Ok(Some(self.append(
+                    block,
+                    builders::cell_in_use(cell, result_ty, loc),
+                )))
+            }
+            CellFn::Rmw => {
+                let base = &args[0];
+                let cell = self
+                    .expr(block, env, base)?
+                    .ok_or_else(|| LoweringError("cell operand produced no value".into()))?;
+                self.remember_temp(env, base, cell);
+                let kernel = &args[1];
+                let closure = self
+                    .expr(block, env, kernel)?
+                    .ok_or_else(|| LoweringError("cell update closure produced no value".into()))?;
+                let TyKind::Cell {
+                    elem,
+                    exclusive: true,
+                } = *base.ty.kind()
+                else {
+                    return err("cell RMW operand is not an exclusive cell");
+                };
+                let elem_ty = self.tys.mlir_ty(elem)?;
+                let body = Block::new(&[(elem_ty, loc)]);
+                let current = body
+                    .argument(0)
+                    .expect("cell RMW body takes the current element")
+                    .into();
+                // Preserve the updater's outer owner while eval consumes one
+                // reference. Structural beta reduction removes this pair for a
+                // literal closure nested in cell.rmw.
+                body.append_operation(dialect::rc_inc(self.context, closure, loc).into());
+                let replacement = self
+                    .call_kernel(&body, closure, kernel.ty, &[current])?
+                    .ok_or_else(|| LoweringError("cell update closure returned unit".into()))?;
+                body.append_operation(builders::cell_yield(replacement, None, loc));
+                let region = Region::new();
+                region.append_block(body);
+                block.append_operation(builders::cell_rmw(cell, None, region, loc));
+                // The intrinsic consumes the updater closure; the in-region inc
+                // paid only for the eval above.
+                block.append_operation(dialect::rc_dec(self.context, closure, loc).into());
+                Ok(None)
+            }
+        }
     }
 
     // ----- built-in array operations (issue #344) -----

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -1103,9 +1103,9 @@ transform [{
         // (`rc.create … region`); a `region-run` scope (`reussir.region.run`)
         // establishes that region and threads it into the regional call.
         let src = r#"
-            struct [regional] Cell { v: i64 }
-            regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
-            pub fn run(n: i64) -> Cell { regional { make(n) } }
+            struct [regional] TestCell { v: i64 }
+            regional fn make(x: i64) -> [flex] TestCell { TestCell { v: x } }
+            pub fn run(n: i64) -> TestCell { regional { make(n) } }
         "#;
         let mlir = lower_source(src);
         // The regional function carries the implicit region parameter and builds
@@ -1129,9 +1129,9 @@ transform [{
         // `region.run` into an allocation scope, attach the box vtable, and
         // freeze the flex result on the way out.
         let src = r#"
-            struct [regional] Cell { v: i64 }
-            regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
-            pub fn run(n: i64) -> Cell { regional { make(n) } }
+            struct [regional] TestCell { v: i64 }
+            regional fn make(x: i64) -> [flex] TestCell { TestCell { v: x } }
+            pub fn run(n: i64) -> TestCell { regional { make(n) } }
         "#;
         let context = reussir_backend::context();
         in_arena(|tcx| {
@@ -1161,8 +1161,8 @@ transform [{
         // (`reussir.ref.project`), and loads the scalar field (`reussir.ref.load`)
         // — the result leaves the region as a plain `i64`, so nothing escapes.
         let src = r#"
-            struct [regional] Cell { v: i64 }
-            regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
+            struct [regional] TestCell { v: i64 }
+            regional fn make(x: i64) -> [flex] TestCell { TestCell { v: x } }
             pub fn run(n: i64) -> i64 { regional { make(n).v } }
         "#;
         let mlir = lower_source(src);
@@ -1181,8 +1181,8 @@ transform [{
         // `field`-capability reference, builds the `Nullable::NonNull{..}` value
         // (`reussir.nullable.create`), and stores it (`reussir.ref.store`).
         let src = r#"
-            struct [regional] Cell { v: i64, next: [field] Cell }
-            regional fn set(c: [flex] Cell, x: [flex] Cell) -> i64 {
+            struct [regional] TestCell { v: i64, next: [field] TestCell }
+            regional fn set(c: [flex] TestCell, x: [flex] TestCell) -> i64 {
                 c->next := Nullable::NonNull{x};
                 c.v
             }
@@ -1229,15 +1229,15 @@ transform [{
     #[test]
     fn lowers_regional_field_construction_and_self_link() {
         // The canonical loop-back shape, now that a `[field]` slot's null is
-        // colored `flex`: construct a `flex` `Cell` whose `[field]` `next` is
+        // colored `flex`: construct a `flex` `TestCell` whose `[field]` `next` is
         // `Nullable::Null` (a null nullable), then link it to itself
         // (`c->next := Nullable::NonNull{c}`) and read a scalar back. Exercises
         // `[field]` construction (null + record-with-nullable-member layout) and
         // assignment together, all the way through the lowering pipeline.
         let src = r#"
-            struct [regional] Cell { v: i64, next: [field] Cell }
+            struct [regional] TestCell { v: i64, next: [field] TestCell }
             regional fn loop_back(seed: i64) -> i64 {
-                let c = Cell { v: seed, next: Nullable::Null };
+                let c = TestCell { v: seed, next: Nullable::Null };
                 c->next := Nullable::NonNull{c};
                 c.v
             }
@@ -1329,8 +1329,8 @@ transform [{
         // transfers ownership (no `dup`): `c` is simply dropped once after the
         // last one.
         let src = r#"
-            struct [regional] Cell { v: i64 }
-            regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
+            struct [regional] TestCell { v: i64 }
+            regional fn make(x: i64) -> [flex] TestCell { TestCell { v: x } }
             pub fn run(n: i64) -> i64 {
                 let c = regional { make(n) };
                 c.v + c.v
@@ -1373,9 +1373,9 @@ transform [{
         // pointer (the managed-rc path), then each callee consumes its own
         // reference. Passing `c` to `take` twice forces exactly this.
         let src = r#"
-            struct [regional] Cell { v: i64 }
-            regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
-            fn take(c: Cell) -> i64 { c.v }
+            struct [regional] TestCell { v: i64 }
+            regional fn make(x: i64) -> [flex] TestCell { TestCell { v: x } }
+            fn take(c: TestCell) -> i64 { c.v }
             pub fn run(n: i64) -> i64 {
                 let c = regional { make(n) };
                 take(c) + take(c)

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -27,9 +27,9 @@ use std::cell::RefCell;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use reussir_backend::dialect::ty::{
-    ReussirAtomicKind, ReussirCapability, ReussirLifeScope, ReussirRecordKind, array, closure,
-    nullable, rc, record_complete_in_place, record_incomplete, record_is_complete, r#ref, region,
-    str as str_type,
+    ReussirAtomicKind, ReussirCapability, ReussirLifeScope, ReussirRecordKind, array, cell,
+    closure, nullable, rc, record_complete_in_place, record_incomplete, record_is_complete, r#ref,
+    region, str as str_type,
 };
 use reussir_backend::melior::Context;
 use reussir_backend::melior::ir::Type;
@@ -108,15 +108,14 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
 
     /// Whether a value of type `ty` is represented as a managed `!reussir.rc<…>`
     /// pointer whose refcount is adjusted directly with `rc.inc`/`rc.dec`: a
-    /// `[shared]` record, a regional record (reference-counted once frozen to
-    /// `rigid` — the only regional coloring that is a resource), or a closure.
+    /// `[shared]` record, a regional record, closure, array, or cell.
     /// This is the complement, among reference-counted values, of an inline
     /// `[value]` record — which is acquired/dropped through a reference instead.
     pub(super) fn is_managed_rc(&self, ty: Ty<'tcx>) -> bool {
         self.is_shared_record(ty)
             || self.is_regional_record(ty)
             || is_closure(ty)
-            || matches!(ty.kind(), TyKind::Array { .. })
+            || matches!(ty.kind(), TyKind::Array { .. } | TyKind::Cell { .. })
     }
 
     /// Lower a ground type to MLIR: records resolve through the layout table, a
@@ -133,9 +132,12 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             // so reject a concrete non-pointer element here rather than build a
             // malformed `nullable<record<…>>` that later passes fall over.
             TyKind::Nullable(inner) => {
-                if !(self.is_shared_record(inner) || self.is_regional_record(inner)) {
+                if !(self.is_shared_record(inner)
+                    || self.is_regional_record(inner)
+                    || matches!(inner.kind(), TyKind::Cell { .. }))
+                {
                     return err("`Nullable` element does not lower to a pointer: only a \
-                         managed `[shared]`/`[regional]` record can sit behind a nullable");
+                         managed `[shared]`/`[regional]` record or Cell can sit behind a nullable");
                 }
                 Ok(nullable(self.mlir_ty(inner)?))
             }
@@ -145,6 +147,9 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             // A statically shaped array is one shared `rc` box holding the whole
             // payload (`!reussir.rc<!reussir.array<dims x elem>>`); see #344.
             TyKind::Array { .. } => Ok(self.rc_type(self.array_inner_of(ty)?)),
+            // A cell is one shared rc box around its payload container. Unlike
+            // arrays, its element may itself be a managed type.
+            TyKind::Cell { .. } => Ok(self.rc_type(self.cell_inner_of(ty)?)),
             _ => scalar_ty(self.context, ty),
         }
     }
@@ -154,15 +159,14 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
     /// whose element capability is `shared`/`regional` to a pointer on its own (a
     /// `!reussir.rc<…>` member is rejected — "use capability instead"). This holds
     /// for a `shared`/`regional` record member (its inner record type), for a
-    /// closure member (its bare `closure` type — a closure is a shared `rc` value
-    /// just like a shared record), and for an array member (its bare `array`
-    /// payload type — an array is one shared `rc` box too). A scalar or `[value]`
-    /// record member is the same as [`mlir_ty`](Self::mlir_ty).
+    /// closure, array, or cell member (its bare payload type). A scalar or
+    /// `[value]` record member is the same as [`mlir_ty`](Self::mlir_ty).
     fn member_ty(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
         match *ty.kind() {
             TyKind::Record { .. } => self.record_inner_of(ty),
             TyKind::Closure { params, ret } => self.closure_inner(params, ret),
             TyKind::Array { .. } => self.array_inner_of(ty),
+            TyKind::Cell { .. } => self.cell_inner_of(ty),
             _ => self.mlir_ty(ty),
         }
     }
@@ -388,6 +392,16 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         Ok(array(&shape, elem))
     }
 
+    /// The `!reussir.cell<T>` payload type inside a cell's shared rc box. The
+    /// element uses full type lowering because cells may recursively own
+    /// managed values.
+    pub(super) fn cell_inner_of(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
+        let TyKind::Cell { elem, exclusive } = *ty.kind() else {
+            return err("cell payload requested for a non-cell type");
+        };
+        Ok(cell(self.mlir_ty(elem)?, exclusive))
+    }
+
     /// `!reussir.rc<inner, shared>` — the pointer type for a heap-allocated,
     /// reference-counted value with the default (non-atomic) box layout.
     pub(super) fn rc_type(&self, inner: Type<'c>) -> Type<'c> {
@@ -503,6 +517,7 @@ fn scalar_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
         TyKind::Str => Ok(str_type(context, ReussirLifeScope::Global)),
         TyKind::Record { .. } => err("record type reached scalar lowering without a layout"),
         TyKind::Array { .. } => err("array type reached scalar lowering without its rc wrapper"),
+        TyKind::Cell { .. } => err("cell type reached scalar lowering without its rc wrapper"),
         TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),
         // Intercepted by [`TypeCtx::mlir_ty`]; reaching here is a bug.
         TyKind::Closure { .. } => err("closure type reached scalar lowering without an rc wrapper"),

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -385,8 +385,8 @@ fn runs_regional_record_construction_and_projection() {
     // as a plain `i64`. Drives the region lifecycle — allocate into the arena,
     // read the field, tear the region down — through the runtime.
     let src = r#"
-        struct [regional] Cell { v: i64 }
-        regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
+        struct [regional] TestCell { v: i64 }
+        regional fn make(x: i64) -> [flex] TestCell { TestCell { v: x } }
         pub fn run(n: i64) -> i64 { regional { make(n).v } }
         extern "C" trampoline "run_ffi" = run;
     "#;
@@ -408,9 +408,9 @@ fn runs_a_reused_frozen_regional_record() {
     // double-free (crash) or leak; the arithmetic result pins it down. This is
     // the runtime check for the managed-rc inc/dec path on a frozen record.
     let src = r#"
-        struct [regional] Cell { v: i64 }
-        regional fn make(x: i64) -> [flex] Cell { Cell { v: x } }
-        fn take(c: Cell) -> i64 { c.v }
+        struct [regional] TestCell { v: i64 }
+        regional fn make(x: i64) -> [flex] TestCell { TestCell { v: x } }
+        fn take(c: TestCell) -> i64 { c.v }
         pub fn run(n: i64) -> i64 {
             let c = regional { make(n) };
             take(c) + take(c)

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -145,6 +145,13 @@ impl<'a> Mangler<'a> {
                 // to its inner type.
                 self.path_with_args_segs(out, &["Nullable"], &[inner]);
             }
+            TyKind::Cell { elem, exclusive } => {
+                // `Cell<T>`/`RefCell<T>` are root built-in type constructors,
+                // represented as synthetic one-segment records in the ABI
+                // spelling.
+                let name = if exclusive { "RefCell" } else { "Cell" };
+                self.path_with_args_segs(out, &[name], &[elem]);
+            }
             TyKind::Array { elem, dims } => {
                 // An array mangles as a synthetic record whose identifier
                 // carries the extents (`Array512x512`), applied to the element.
@@ -332,6 +339,11 @@ mod tests {
             // `Nullable<i32>` → `IC8NullablelE`.
             let nul = tcx.mk_nullable(tcx.mk_int(IntTy::Signed(32)));
             assert_eq!(m.mangle_ty(nul), "_RIC8NullablelE");
+            // `Cell<i32>` → `IC4CelllE`; `RefCell<i32>` → `IC7RefCelllE`.
+            let cell = tcx.mk_cell(tcx.mk_int(IntTy::Signed(32)), false);
+            assert_eq!(m.mangle_ty(cell), "_RIC4CelllE");
+            let refcell = tcx.mk_cell(tcx.mk_int(IntTy::Signed(32)), true);
+            assert_eq!(m.mangle_ty(refcell), "_RIC7RefCelllE");
         });
     }
 

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -782,10 +782,10 @@ mod tests {
     #[test]
     fn roundtrips_regional_flex_signature() {
         // Exercises a turbofished, capability-prefixed record type:
-        // `[flex] Cell::<i32>`.
+        // `[flex] TestCell::<i32>`.
         roundtrip(
-            "struct [regional] Cell<T> { v: T, next: [field] Cell<T> } \
-             regional fn id(c: [flex] Cell<i32>) -> i32 { 0 }",
+            "struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> } \
+             regional fn id(c: [flex] TestCell<i32>) -> i32 { 0 }",
         );
     }
 
@@ -838,9 +838,9 @@ mod tests {
     fn roundtrips_regional_generics() {
         // Mono'd regional record type + flex capability in a signature.
         roundtrip(
-            "struct [regional] Cell<T> { v: T, next: [field] Cell<T> } \
+            "struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> } \
              regional fn foo<T>(bar: [flex] T) -> i32 { 0 } \
-             regional fn use_ok(c: [flex] Cell<i32>) -> i32 { foo(c) }",
+             regional fn use_ok(c: [flex] TestCell<i32>) -> i32 { foo(c) }",
         );
     }
 

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -269,6 +269,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let inner = self.ty(inner);
                 self.tcx.mk_nullable(inner)
             }
+            raw::Ty::Cell { inner, exclusive } => {
+                let inner = self.ty(inner);
+                self.tcx.mk_cell(inner, *exclusive)
+            }
             raw::Ty::Record { cap: c, path, args } => {
                 let def = self.record_def(path);
                 let args: Vec<Ty<'tcx>> = args.iter().map(|a| self.ty(a)).collect();
@@ -737,6 +741,27 @@ mod tests {
             pub fn n(f: (f64, f64) -> f64, a: [f64; 8]) -> f64 { core::intrinsic::array::fold(a, 0.0, f) }
             pub fn b(a: [f64; 8], i: i64, v: f64) -> [f64; 8] {
                 core::intrinsic::array::set(a, i, core::intrinsic::array::get(a, i) + v)
+            }
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrips_cells() {
+        roundtrip(
+            r#"
+            struct [value] Boxed<T> { value: Cell<T> }
+            pub fn use_cell(c: Cell<i64>) -> Cell<i64> {
+                c
+            }
+            pub fn nested(c: Cell<Cell<i64>>) -> Cell<Cell<i64>> {
+                c
+            }
+            pub fn use_refcell(c: RefCell<i64>) -> RefCell<i64> {
+                c
+            }
+            pub fn mixed(c: Cell<RefCell<i64>>) -> Cell<RefCell<i64>> {
+                c
             }
             "#,
         );

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -123,6 +123,8 @@ Ty: raw::Ty = {
     "(" ")" => raw::Ty::Unit,
     "!" => raw::Ty::Bottom,
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
+    "Cell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: false },
+    "RefCell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: true },
     <cap:Cap> <path:TyPathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
     "[" <elem:Ty> ";" <dims:CommaPlus<"int">> "]"
@@ -350,6 +352,8 @@ extern {
         "array" => Token::Array,
         "assign" => Token::Assign,
         "Nullable" => Token::Nullable,
+        "Cell" => Token::Cell,
+        "RefCell" => Token::RefCell,
         "NonNull" => Token::NonNull,
         "Null" => Token::Null,
         "poison" => Token::Poison,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -264,6 +264,9 @@ impl Render<'_> {
             TyKind::Unit => text("()"),
             TyKind::Bottom => text("!"),
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
+            TyKind::Cell { elem, exclusive } => {
+                text(if exclusive { "RefCell<" } else { "Cell<" }) + self.ty(elem) + text(">")
+            }
             TyKind::Array { elem, dims } => {
                 let mut d = text("[") + self.ty(elem) + text(";");
                 for (i, extent) in dims.iter().enumerate() {

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -207,6 +207,10 @@ pub enum Ty {
     Unit,
     Bottom,
     Nullable(Box<Ty>),
+    Cell {
+        inner: Box<Ty>,
+        exclusive: bool,
+    },
     /// `[cap] path<args>` — a regional/value record type.
     Record {
         cap: Cap,

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -1125,12 +1125,12 @@ mod tests {
                 }
             }
 
-            struct [regional] Cell<T> { v: T, next: [field] Cell<T> }
+            struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> }
 
-            regional fn fresh<T>(x: T) -> [flex] Cell<T> { Cell { v: x, next: Nullable::Null } }
+            regional fn fresh<T>(x: T) -> [flex] TestCell<T> { TestCell { v: x, next: Nullable::Null } }
 
             regional fn loop_back(seed: i32) -> i32 {
-                let c = Cell { v: seed, next: Nullable::Null };
+                let c = TestCell { v: seed, next: Nullable::Null };
                 c->next := Nullable::NonNull{c};
                 c.v
             }
@@ -1460,9 +1460,9 @@ mod tests {
         // `foo<T>(bar: [flex] T)` requires T to be regional; instantiating it at a
         // regional record is accepted (no diagnostic).
         let src = r#"
-            struct [regional] Cell<T> { v: T, next: [field] Cell<T> }
+            struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> }
             regional fn foo<T>(bar: [flex] T) -> i32 { 0 }
-            regional fn use_ok(c: [flex] Cell<i32>) -> i32 { foo(c) }
+            regional fn use_ok(c: [flex] TestCell<i32>) -> i32 { foo(c) }
         "#;
         with_full(src, |full| {
             let syms = symbols(full);
@@ -1475,7 +1475,7 @@ mod tests {
         // The same `[flex] T` parameter instantiated at a value record is rejected
         // at the call boundary — only regional records may be flex.
         let src = r#"
-            struct [regional] Cell<T> { v: T, next: [field] Cell<T> }
+            struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> }
             struct Pair { a: i32 }
             regional fn foo<T>(bar: [flex] T) -> i32 { 0 }
             regional fn use_bad(p: Pair) -> i32 { foo(p) }
@@ -1504,9 +1504,9 @@ mod tests {
     fn field_link_generic_accepts_regional() {
         // `Wrapper<T>` with `[field] T` instantiated at a regional record is fine.
         let src = r#"
-            struct [regional] Cell<T> { v: T, next: [field] Cell<T> }
+            struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> }
             struct [regional] Wrapper<T> { inner: [field] T }
-            regional fn use_ok(w: [flex] Wrapper<Cell<i32>>) -> i32 { 0 }
+            regional fn use_ok(w: [flex] Wrapper<TestCell<i32>>) -> i32 { 0 }
         "#;
         with_full(src, |full| {
             let syms = symbols(full);

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -355,6 +355,7 @@ const RECURSION_LIMIT: usize = 128;
 fn ty_depth(ty: Ty<'_>) -> usize {
     match *ty.kind() {
         TyKind::Nullable(inner) => 1 + ty_depth(inner),
+        TyKind::Cell { elem: inner, .. } => 1 + ty_depth(inner),
         TyKind::Array { elem, .. } => 1 + ty_depth(elem),
         TyKind::Record { args, .. } => 1 + args.iter().map(|&a| ty_depth(a)).max().unwrap_or(0),
         TyKind::Closure { params, ret } => {
@@ -488,6 +489,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 self.note_records(ret);
             }
             TyKind::Nullable(inner) => self.note_records(inner),
+            TyKind::Cell { elem: inner, .. } => self.note_records(inner),
             TyKind::Array { elem, .. } => self.note_records(elem),
             _ => {}
         }
@@ -522,6 +524,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 self.discover_records(ret, worklist);
             }
             TyKind::Nullable(inner) => self.discover_records(inner, worklist),
+            TyKind::Cell { elem: inner, .. } => self.discover_records(inner, worklist),
             TyKind::Array { elem, .. } => self.discover_records(elem, worklist),
             _ => {}
         }
@@ -1227,6 +1230,7 @@ mod tests {
                 params.iter().all(|&p| is_ground(p)) && is_ground(ret)
             }
             TyKind::Nullable(inner) => is_ground(inner),
+            TyKind::Cell { elem: inner, .. } => is_ground(inner),
             TyKind::Array { elem, .. } => is_ground(elem),
             _ => true,
         }

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -290,7 +290,7 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
 
     /// Is a value of `ty` reference-counted (needs `dup`/`drop`)?
     ///
-    /// A `Shared` record and a closure are always RR; a `Value` record is RR iff
+    /// A `Shared` record, closure, array, or cell is always RR; a `Value` record is RR iff
     /// some field transitively is; a `Regional` record is RR only when its
     /// [`Flexivity`] is `Rigid` (frozen into a managed object — a `Flex` or
     /// unrefined-regional value is freed with its region); `Nullable(inner)`
@@ -310,6 +310,9 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
             // An array is one rc-managed box regardless of its (Plain)
             // element type.
             TyKind::Array { .. } => true,
+            // A cell is always one shared rc-managed box, independent of its
+            // element type (which the cell's drop recursively releases).
+            TyKind::Cell { .. } => true,
             // The management class is the record table's call (keyed by the
             // canonical, flexivity-erased type); the per-use flexivity then refines
             // the one case where it matters — a regional record.
@@ -602,8 +605,13 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             ExprKind::Seq(es) => self.place_seq(es, live_after),
             ExprKind::Call { args, .. }
             | ExprKind::Ctor { args, .. }
-            | ExprKind::Variant { args, .. }
-            | ExprKind::Intrinsic { args, .. } => self.place_args(args, live_after),
+            | ExprKind::Variant { args, .. } => self.place_args(args, live_after),
+            ExprKind::Intrinsic { op, args } => match op {
+                crate::intrinsic::IntrinsicOp::Cell { func } => {
+                    self.place_cell_intrinsic(e, func, args, live_after)
+                }
+                crate::intrinsic::IntrinsicOp::Math { .. } => self.place_args(args, live_after),
+            },
             ExprKind::NullableCall(opt) => {
                 if let Some(x) = opt {
                     self.place(x, live_after);
@@ -629,6 +637,60 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 self.place_closure_call(target, args, live_after)
             }
             ExprKind::ArrayOp { op, args } => self.place_array_op(e, op, args, live_after),
+        }
+    }
+
+    /// Place a cell intrinsic's operands. `alloc` consumes its sole value like
+    /// an ordinary call. The other operations borrow their first (cell)
+    /// operand for the duration of the operation and consume any remaining
+    /// value/closure operands.
+    fn place_cell_intrinsic(
+        &mut self,
+        e: &Expr<'tcx>,
+        func: crate::intrinsic::CellFn,
+        args: &'tcx [Expr<'tcx>],
+        live_after: &VarSet,
+    ) {
+        if func == crate::intrinsic::CellFn::Alloc {
+            self.place_args(args, live_after);
+            return;
+        }
+
+        let base = &args[0];
+        let mut borrowed = VarSet::default();
+        let base_is_var = if let ExprKind::Var(x) = base.kind {
+            borrowed.insert(x);
+            true
+        } else {
+            false
+        };
+
+        // Keep a named cell owner live across every other operand; those
+        // operands otherwise follow the ordinary left-to-right consuming rule.
+        let mut live = live_after.clone();
+        live.union_with(&borrowed);
+        for i in 0..args.len() {
+            if i == 0 && base_is_var {
+                continue;
+            }
+            let mut la = live.clone();
+            for later in &args[i + 1..] {
+                la.union_with(&self.free(later));
+            }
+            self.place(&args[i], &la);
+            if i == 0 {
+                // The operation only borrows an anonymous cell result, so its
+                // sole owner must be released after the operation completes.
+                self.add_after(e.id, RcOp::DropValue(base.id));
+            }
+        }
+
+        if base_is_var {
+            for v in borrowed.iter() {
+                if !live_after.contains(v) {
+                    self.add_after(e.id, RcOp::Drop(v));
+                }
+            }
         }
     }
 

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -305,6 +305,26 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
         self.tcx.mk_closure(params, ret)
     }
 
+    fn cell_ty(&self, elem: Ty<'tcx>, exclusive: bool) -> Ty<'tcx> {
+        self.tcx.mk_cell(elem, exclusive)
+    }
+
+    fn cell_op(
+        &mut self,
+        func: crate::intrinsic::CellFn,
+        args: Vec<Expr<'tcx>>,
+        ty: Ty<'tcx>,
+    ) -> Expr<'tcx> {
+        let args = self.tcx.alloc_slice(&args);
+        self.mk(
+            ExprKind::Intrinsic {
+                op: crate::intrinsic::IntrinsicOp::Cell { func },
+                args,
+            },
+            ty,
+        )
+    }
+
     /// `target(args)` — an indirect call through a closure value.
     fn closure_call(
         &mut self,
@@ -730,12 +750,26 @@ fn interp<'tcx>(
         }
         ExprKind::Call { args, .. }
         | ExprKind::Ctor { args, .. }
-        | ExprKind::Variant { args, .. }
-        | ExprKind::Intrinsic { args, .. } => {
+        | ExprKind::Variant { args, .. } => {
             for a in args {
                 interp(a, ot, rr, rc);
             }
         }
+        ExprKind::Intrinsic { op, args } => match op {
+            crate::intrinsic::IntrinsicOp::Cell { func }
+                if func != crate::intrinsic::CellFn::Alloc =>
+            {
+                interp_borrow(&args[0], ot, rr, rc);
+                for a in &args[1..] {
+                    interp(a, ot, rr, rc);
+                }
+            }
+            _ => {
+                for a in args {
+                    interp(a, ot, rr, rc);
+                }
+            }
+        },
         ExprKind::NullableCall(opt) => {
             if let Some(x) = opt {
                 interp(x, ot, rr, rc);
@@ -1017,6 +1051,11 @@ fn is_rr_classification() {
             "frozen rigid value is a managed object ⇒ rc"
         );
         assert!(rr.is_rr(tcx.mk_nullable(rc)), "nullable rc is RR");
+        assert!(rr.is_rr(tcx.mk_cell(i64t, false)), "a cell is always RR");
+        assert!(
+            rr.is_rr(tcx.mk_cell(i64t, true)),
+            "an exclusive cell is always RR"
+        );
         assert!(
             !rr.is_rr(tcx.mk_nullable(i64t)),
             "nullable scalar is not RR"
@@ -1861,6 +1900,112 @@ fn flex_record_assembly_still_incs_its_rigid_field() {
         assert!(
             ot.before(a_r_id).is_empty(),
             "the later use of r is its last ⇒ moved"
+        );
+    });
+}
+
+// ----- cells -----
+
+#[test]
+fn cell_set_borrows_cell_and_consumes_replacement() {
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let elem = b.shared();
+        let cell_ty = b.cell_ty(elem, false);
+        let c = b.fresh_var();
+        let value = b.fresh_var();
+
+        let base = b.var(c, cell_ty);
+        let replacement = b.var(value, elem);
+        let replacement_id = replacement.id;
+        let unit = tcx.mk_unit();
+        let body = b.cell_op(crate::intrinsic::CellFn::Set, vec![base, replacement], unit);
+        let body_id = body.id;
+        let params = vec![b.param(c, cell_ty), b.param(value, elem)];
+        let func = b.function("set", params, unit, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.before(replacement_id).is_empty(),
+            "the replacement's last owner is moved into the cell"
+        );
+        assert_eq!(ot.after(body_id), &[RcOp::Drop(c)]);
+    });
+}
+
+#[test]
+fn cell_rmw_borrows_cell_and_consumes_updater() {
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let elem = b.i64();
+        let cell_ty = b.cell_ty(elem, true);
+        let update_ty = b.closure_ty(&[elem], elem);
+        let c = b.fresh_var();
+        let update = b.fresh_var();
+
+        let base = b.var(c, cell_ty);
+        let updater = b.var(update, update_ty);
+        let updater_id = updater.id;
+        let unit = tcx.mk_unit();
+        let body = b.cell_op(crate::intrinsic::CellFn::Rmw, vec![base, updater], unit);
+        let body_id = body.id;
+        let params = vec![b.param(c, cell_ty), b.param(update, update_ty)];
+        let func = b.function("rmw", params, unit, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.before(updater_id).is_empty(),
+            "the updater's last owner is consumed by rmw"
+        );
+        assert_eq!(ot.after(body_id), &[RcOp::Drop(c)]);
+    });
+}
+
+#[test]
+fn cell_get_releases_a_temporary_cell_after_the_borrow() {
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let elem = b.shared();
+        let cell_ty = b.cell_ty(elem, false);
+        let x = b.fresh_var();
+
+        let value = b.var(x, elem);
+        let alloc = b.cell_op(crate::intrinsic::CellFn::Alloc, vec![value], cell_ty);
+        let alloc_id = alloc.id;
+        let body = b.cell_op(crate::intrinsic::CellFn::Get, vec![alloc], elem);
+        let body_id = body.id;
+        let param = b.param(x, elem);
+        let func = b.function("get_temp", vec![param], elem, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.after(body_id),
+            &[RcOp::DropValue(alloc_id)],
+            "the temporary cell owner outlives get and is then released"
+        );
+    });
+}
+
+#[test]
+fn refcell_in_use_borrows_the_cell() {
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let elem = b.shared();
+        let cell_ty = b.cell_ty(elem, true);
+        let c = b.fresh_var();
+
+        let base = b.var(c, cell_ty);
+        let boolean = tcx.mk_bool();
+        let body = b.cell_op(crate::intrinsic::CellFn::InUse, vec![base], boolean);
+        let body_id = body.id;
+        let params = vec![b.param(c, cell_ty)];
+        let func = b.function("in_use", params, boolean, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.after(body_id),
+            &[RcOp::Drop(c)],
+            "the flag read borrows the cell; its last owner drops after"
         );
     });
 }

--- a/crates/reussir-core/src/full/subst.rs
+++ b/crates/reussir-core/src/full/subst.rs
@@ -35,6 +35,7 @@ pub fn subst_ty<'tcx>(tcx: &TyCtxt<'tcx>, ty: Ty<'tcx>, subst: &Subst<'tcx>) -> 
             tcx.mk_closure(&params, subst_ty(tcx, ret, subst))
         }
         TyKind::Nullable(inner) => tcx.mk_nullable(subst_ty(tcx, inner, subst)),
+        TyKind::Cell { elem, exclusive } => tcx.mk_cell(subst_ty(tcx, elem, subst), exclusive),
         TyKind::Array { elem, dims } => tcx.mk_array(subst_ty(tcx, elem, subst), dims),
         TyKind::Int(_)
         | TyKind::Fp(_)

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -1,15 +1,10 @@
-//! The built-in `core` package's math intrinsics.
+//! The built-in `core::intrinsic` operation families.
 //!
-//! Reussir source reaches them as `core::intrinsic::math::<name>(args…, flag)`
-//! — the package name `core` is reserved, so the path can never collide with
-//! user code. Each intrinsic maps 1:1 onto an MLIR `math` dialect op; the
-//! trailing argument is always a **constant** `i32` fast-math flag
-//! ([`FastMath`]), and the value operands share one `FloatingPoint`-bounded
-//! type (given as an optional explicit type argument, or inferred).
-//!
-//! The surfaced set matches the reference frontend: the float unary group,
-//! the `is*` classification checks (returning `bool`), the float binary
-//! group, `fma`, and `fpowi` (float base, `i32` exponent).
+//! Reussir source reaches these as `core::intrinsic::<family>::<name>(…)` — the
+//! package name `core` is reserved, so the path cannot collide with user code.
+//! [`IntrinsicOp`] is the resolved family-independent representation carried by
+//! HIR and MIR; each family defines its own names, checking, ownership contract,
+//! and code generation.
 
 /// The shape of a math intrinsic's value arguments (the fast-math flag is an
 /// extra trailing argument in the surface form, not counted here).
@@ -175,6 +170,62 @@ pub enum ArrayFn {
     Fold,
 }
 
+/// A built-in operation on a shared mutable [`Cell`](crate::semi::ty::TyKind::Cell),
+/// spelled `core::intrinsic::cell::<fn>` and dispatched on the operand's
+/// cell flavor. A plain `Cell` supports only whole-element
+/// `alloc`/`get`/`set`; an exclusive `RefCell` additionally supports the
+/// guarded `rmw` and the `in_use` observation of its guard flag. The
+/// operation itself does not record the flavor — operand and result types
+/// carry it, the checker enforces it, and the dialect verifier re-checks
+/// it after lowering.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum CellFn {
+    /// `alloc(value)`: move `value` into a fresh cell.
+    Alloc,
+    /// `get(cell)`: clone the value currently stored in `cell`.
+    Get,
+    /// `set(cell, value)`: replace and drop the old value.
+    Set,
+    /// `rmw(cell, update)`: move the value through `update` and store its
+    /// result. Exclusive cells (`RefCell`) only.
+    Rmw,
+    /// `in_use(cell)`: whether the element is currently moved out into an
+    /// active `rmw` updater. Exclusive cells (`RefCell`) only.
+    InUse,
+}
+
+impl CellFn {
+    /// Parse a surface / textual-IR name.
+    pub fn parse(name: &str) -> Option<CellFn> {
+        match name {
+            "alloc" => Some(CellFn::Alloc),
+            "get" => Some(CellFn::Get),
+            "set" => Some(CellFn::Set),
+            "rmw" => Some(CellFn::Rmw),
+            "in_use" => Some(CellFn::InUse),
+            _ => None,
+        }
+    }
+
+    /// The surface name, also used by the textual IR.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CellFn::Alloc => "alloc",
+            CellFn::Get => "get",
+            CellFn::Set => "set",
+            CellFn::Rmw => "rmw",
+            CellFn::InUse => "in_use",
+        }
+    }
+
+    /// Whether this operation exists only on an exclusive cell (`RefCell`).
+    /// The checker rejects these on a plain `Cell` operand, and lowering
+    /// re-derives the flavor from the monomorphized operand type.
+    pub fn requires_exclusive(self) -> bool {
+        matches!(self, CellFn::Rmw | CellFn::InUse)
+    }
+}
+
 impl ArrayFn {
     /// Parse a surface / textual-IR name.
     pub fn parse(name: &str) -> Option<ArrayFn> {
@@ -219,6 +270,9 @@ impl ArrayFn {
 pub enum IntrinsicOp {
     /// `core::intrinsic::math::<func>`, with an `arith.fastmath` flag.
     Math { func: MathFn, flag: u32 },
+    /// `core::intrinsic::cell::<func>`; cell operations have no immediates
+    /// and dispatch on the operand's cell flavor rather than encoding it.
+    Cell { func: CellFn },
 }
 
 impl IntrinsicOp {
@@ -226,6 +280,7 @@ impl IntrinsicOp {
     pub fn family(self) -> &'static str {
         match self {
             IntrinsicOp::Math { .. } => "math",
+            IntrinsicOp::Cell { .. } => "cell",
         }
     }
 
@@ -233,6 +288,7 @@ impl IntrinsicOp {
     pub fn name(self) -> &'static str {
         match self {
             IntrinsicOp::Math { func, .. } => func.as_str(),
+            IntrinsicOp::Cell { func, .. } => func.as_str(),
         }
     }
 
@@ -240,6 +296,7 @@ impl IntrinsicOp {
     pub fn imm(self) -> u32 {
         match self {
             IntrinsicOp::Math { flag, .. } => flag,
+            IntrinsicOp::Cell { .. } => 0,
         }
     }
 
@@ -250,6 +307,9 @@ impl IntrinsicOp {
             "math" => Some(IntrinsicOp::Math {
                 func: MathFn::parse(name)?,
                 flag: imm,
+            }),
+            "cell" if imm == 0 => Some(IntrinsicOp::Cell {
+                func: CellFn::parse(name)?,
             }),
             _ => None,
         }
@@ -271,6 +331,13 @@ mod tests {
                 func: MathFn::Fma,
                 flag: 127,
             },
+            IntrinsicOp::Cell {
+                func: CellFn::Alloc,
+            },
+            IntrinsicOp::Cell { func: CellFn::Rmw },
+            IntrinsicOp::Cell {
+                func: CellFn::InUse,
+            },
         ] {
             assert_eq!(
                 IntrinsicOp::parse(op.family(), op.name(), op.imm()),
@@ -278,6 +345,12 @@ mod tests {
             );
         }
         assert_eq!(IntrinsicOp::parse("math", "nope", 0), None);
+        assert_eq!(IntrinsicOp::parse("cell", "get", 1), None);
+        assert!(
+            IntrinsicOp::parse("cell", "in_use", 0).is_some(),
+            "one textual family; the operand type carries the flavor"
+        );
+        assert_eq!(IntrinsicOp::parse("refcell", "in_use", 0), None);
         assert_eq!(IntrinsicOp::parse("atomic", "sqrt", 0), None);
     }
 
@@ -294,6 +367,15 @@ mod tests {
         }
         assert_eq!(MathFn::parse("log"), None);
         assert_eq!(MathFn::parse("sincos"), None);
+        for f in [
+            CellFn::Alloc,
+            CellFn::Get,
+            CellFn::Set,
+            CellFn::Rmw,
+            CellFn::InUse,
+        ] {
+            assert_eq!(CellFn::parse(f.as_str()), Some(f));
+        }
     }
 
     #[test]

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -86,6 +86,10 @@ pub enum Token<'a> {
     Unreachable,
     #[token("Nullable")]
     Nullable,
+    #[token("Cell")]
+    Cell,
+    #[token("RefCell")]
+    RefCell,
     #[token("NonNull")]
     NonNull,
     #[token("Null")]

--- a/crates/reussir-core/src/lib.rs
+++ b/crates/reussir-core/src/lib.rs
@@ -9,7 +9,7 @@
 //! interner and adds the ground-only invariant and v0 symbol mangling.
 
 pub mod full;
-/// The built-in `core` package's math intrinsics (`core::intrinsic::math`).
+/// The built-in `core::intrinsic` operation families.
 pub mod intrinsic;
 /// The shared logos lexer for the textual IR (both the MIR and HIR grammars).
 pub mod ir_lex;

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -606,8 +606,8 @@ mod tests {
     #[test]
     fn colors_regional_struct_fields() {
         check(
-            "struct [regional] Cell<T> { v: T, next: [field] Cell<T> }\n\
-             regional fn make<T>(x: T) -> [flex] Cell<T> { Cell { v: x, next: Nullable::Null } }",
+            "struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> }\n\
+             regional fn make<T>(x: T) -> [flex] TestCell<T> { TestCell { v: x, next: Nullable::Null } }",
             |elab, _tcx| {
                 let f = function(elab, "make");
                 // The return type was colored Flex by the `[flex]` annotation.
@@ -626,9 +626,9 @@ mod tests {
         // Before the fix the construction was `Regional`, and the assignment was
         // rejected with "assignment target must be a flex record".
         check(
-            "struct [regional] Cell<T> { v: T, next: [field] Cell<T> }\n\
+            "struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> }\n\
              regional fn build(seed: i32) -> i32 {\n\
-                 let c = Cell { v: seed, next: Nullable::Null };\n\
+                 let c = TestCell { v: seed, next: Nullable::Null };\n\
                  c->next := Nullable::NonNull{c};\n\
                  0\n\
              }",
@@ -683,7 +683,7 @@ mod tests {
     }
 
     /// Diagnostics spell types the way the surface does (`i32`, `bool`,
-    /// `Nullable<Cell<u64>>`, `[rigid] …`), never the internal `Debug` form
+    /// `Nullable<TestCell<u64>>`, `[rigid] …`), never the internal `Debug` form
     /// (`Int(Signed(32))`).
     #[test]
     fn diagnostics_render_types_in_surface_syntax() {
@@ -710,12 +710,12 @@ mod tests {
 
         let m = messages(
             r#"
-            struct [regional] Cell<T> { v: T }
-            fn f(c: Cell<u64>) -> bool { c }
+            struct [regional] TestCell<T> { v: T }
+            fn f(c: TestCell<u64>) -> bool { c }
             "#,
         );
         assert!(
-            m.contains("expected `bool`, found `[rigid] Cell<u64>`"),
+            m.contains("expected `bool`, found `[rigid] TestCell<u64>`"),
             "record spelling expected: {m}"
         );
 
@@ -833,18 +833,18 @@ mod tests {
     fn field_link_takes_the_bases_view() {
         check(
             r#"
-            struct [regional] Cell { v: u64, next: [field] Cell }
+            struct [regional] TestCell { v: u64, next: [field] TestCell }
 
-            regional fn mk(v: u64) -> [flex] Cell {
-                Cell { v: v, next: Nullable::Null }
+            regional fn mk(v: u64) -> [flex] TestCell {
+                TestCell { v: v, next: Nullable::Null }
             }
 
-            fn frozen_view(v: u64) -> Nullable<Cell> {
+            fn frozen_view(v: u64) -> Nullable<TestCell> {
                 let c = regional { mk(v) };
                 c.next
             }
 
-            regional fn flex_view(c: [flex] Cell) -> [flex] Nullable<Cell> {
+            regional fn flex_view(c: [flex] TestCell) -> [flex] Nullable<TestCell> {
                 c.next
             }
             "#,
@@ -930,8 +930,8 @@ mod tests {
         with_tcx(|tcx| {
             // `c` is a flex regional value; a closure cannot capture it (a flex
             // value cannot be materialized, so it cannot escape its region).
-            let source = "struct [regional] Cell<T> { v: T, next: [field] Cell<T> }\n\
-                          regional fn f(c: [flex] Cell<i32>) -> i32 { let g = || c; 0 }";
+            let source = "struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> }\n\
+                          regional fn f(c: [flex] TestCell<i32>) -> i32 { let g = || c; 0 }";
             let parse = reussir_syntax::parse(source);
             let prog = surface::program(&parse.root);
             let elab = elaborate(tcx, &prog, parse.resolver());
@@ -1014,8 +1014,8 @@ mod tests {
     fn rejects_closure_returning_flex() {
         // The closure body is a captured flex value; returning it would let a
         // non-materializable value escape the region.
-        let src = "struct [regional] Cell<T> { v: T, next: [field] Cell<T> }\n\
-                   regional fn f(c: [flex] Cell<i32>) -> i32 { let g = || c; 0 }";
+        let src = "struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> }\n\
+                   regional fn f(c: [flex] TestCell<i32>) -> i32 { let g = || c; 0 }";
         assert!(
             has_error(src, "closure cannot return a flex value"),
             "{:#?}",
@@ -1064,8 +1064,8 @@ mod tests {
         // `Nullable::Null` stored into a `[field]` slot of a flex record must be
         // colored `flex` (a freshly-built region-local value), not left at the
         // record's default `Regional` — otherwise it reaches the backend uncolored.
-        let src = "struct [regional] Cell { v: i32, next: [field] Cell }\n\
-                   regional fn clear(c: [flex] Cell) -> i32 { c->next := Nullable::Null; c.v }";
+        let src = "struct [regional] TestCell { v: i32, next: [field] TestCell }\n\
+                   regional fn clear(c: [flex] TestCell) -> i32 { c->next := Nullable::Null; c.v }";
         check(src, |elab, _| {
             // Body is `Seq[ Assign(c, next, Nullable::Null), c.v ]`.
             let body = function(elab, "clear").body.as_ref().unwrap();
@@ -1096,9 +1096,9 @@ mod tests {
         // A `[field]` link on a flex record holds region-local (flex) values. A
         // frozen (`rigid`) value — here the result of a `region { }` that escaped
         // its region — is a flexivity mismatch against that flex slot.
-        let src = "struct [regional] Cell { v: i32, next: [field] Cell }\n\
-                   fn frozen() -> Cell { regional { Cell { v: 0, next: Nullable::Null } } }\n\
-                   regional fn t(c: [flex] Cell) -> i32 { c->next := Nullable::NonNull{ frozen() }; c.v }";
+        let src = "struct [regional] TestCell { v: i32, next: [field] TestCell }\n\
+                   fn frozen() -> TestCell { regional { TestCell { v: 0, next: Nullable::Null } } }\n\
+                   regional fn t(c: [flex] TestCell) -> i32 { c->next := Nullable::NonNull{ frozen() }; c.v }";
         assert!(
             has_error(src, "flexivity mismatch"),
             "{:#?}",

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -974,6 +974,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match *family {
             "math" => Some(self.infer_math_intrinsic(fc, span)),
             "array" => Some(self.infer_array_intrinsic(fc, span)),
+            "cell" => Some(self.infer_cell_intrinsic(fc, span)),
             other => {
                 self.error(
                     span,
@@ -1066,6 +1067,187 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
         let op = IntrinsicOp::Math { func, flag };
         self.mk_expr(ExprKind::Intrinsic { op, args }, result, span)
+    }
+
+    /// (CELL) The shared-cell intrinsics, spelled `core::intrinsic::cell::*`
+    /// and dispatched on the operand's cell flavor. `alloc`/`get`/`set` work
+    /// on both a plain `Cell<T>` and an exclusive `RefCell<T>`; `rmw` and
+    /// `in_use` require a `RefCell` operand. A cell operand is borrowed;
+    /// values transferred into `alloc`/`set`, and the update closure passed
+    /// to `rmw`, are consumed according to the ordinary owned calling
+    /// convention. `rmw` checks `update : T -> T`, moving the stored value
+    /// through the callback without the clone performed by `get`; `in_use`
+    /// reads the exclusive cell's guard flag as a `bool`.
+    ///
+    /// `alloc` has no cell operand to dispatch on: it defaults to a plain
+    /// `Cell`, and an explicit type argument naming the cell type selects
+    /// the flavor (`alloc<RefCell<i64>>(1)`).
+    fn infer_cell_intrinsic(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
+        use crate::intrinsic::{CellFn, IntrinsicOp};
+
+        let name = self.sym(fc.name.basename).to_string();
+        let Some(func) = CellFn::parse(&name) else {
+            self.error(
+                span,
+                format!("unknown cell intrinsic `core::intrinsic::cell::{name}`"),
+            );
+            return self.poison(span);
+        };
+        if func != CellFn::Alloc && !fc.ty_args.is_empty() {
+            self.error(
+                span,
+                format!("`core::intrinsic::cell::{name}` takes no type arguments"),
+            );
+            return self.poison(span);
+        }
+
+        let op = IntrinsicOp::Cell { func };
+        match func {
+            CellFn::Alloc => {
+                let [value] = fc.args.as_slice() else {
+                    self.error(span, "`core::intrinsic::cell::alloc` expects one argument");
+                    return self.poison(span);
+                };
+                let result = match fc.ty_args.as_slice() {
+                    [] | [None] => None,
+                    [Some(t)] => {
+                        let ty = self.eval_type(t);
+                        let resolved = self.infer.shallow_resolve(ty);
+                        let TyKind::Cell { .. } = *resolved.kind() else {
+                            let shown = self.infer.resolve(resolved);
+                            self.error(
+                                span,
+                                format!(
+                                    "the type argument of `core::intrinsic::cell::alloc` must \
+                                     be `Cell<T>` or `RefCell<T>`, found `{}`",
+                                    self.ty_display(shown)
+                                ),
+                            );
+                            return self.poison(span);
+                        };
+                        Some(resolved)
+                    }
+                    _ => {
+                        self.error(
+                            span,
+                            "`core::intrinsic::cell::alloc` takes at most one type argument \
+                             (the cell type)",
+                        );
+                        return self.poison(span);
+                    }
+                };
+                let value = match result {
+                    Some(cell_ty) => {
+                        let TyKind::Cell { elem, .. } = *cell_ty.kind() else {
+                            unreachable!("checked above");
+                        };
+                        self.check_expr(value, elem)
+                    }
+                    None => self.infer_expr(value),
+                };
+                let result = result.unwrap_or_else(|| self.tcx.mk_cell(value.ty, false));
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![value],
+                    },
+                    result,
+                    span,
+                )
+            }
+            CellFn::Get | CellFn::InUse => {
+                let [cell] = fc.args.as_slice() else {
+                    self.error(
+                        span,
+                        format!("`core::intrinsic::cell::{name}` expects one argument"),
+                    );
+                    return self.poison(span);
+                };
+                let cell = self.infer_expr(cell);
+                let Some(elem) = self.cell_element(cell.ty, func, &name, span) else {
+                    return self.poison(span);
+                };
+                let result = if func == CellFn::InUse {
+                    self.tcx.mk_bool()
+                } else {
+                    elem
+                };
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![cell],
+                    },
+                    result,
+                    span,
+                )
+            }
+            CellFn::Set | CellFn::Rmw => {
+                let [cell, value] = fc.args.as_slice() else {
+                    self.error(
+                        span,
+                        format!("`core::intrinsic::cell::{name}` expects two arguments"),
+                    );
+                    return self.poison(span);
+                };
+                let cell = self.infer_expr(cell);
+                let Some(elem) = self.cell_element(cell.ty, func, &name, span) else {
+                    return self.poison(span);
+                };
+                let expected = if func == CellFn::Rmw {
+                    self.tcx.mk_closure(&[elem], elem)
+                } else {
+                    elem
+                };
+                let value = self.check_expr(value, expected);
+                let result = self.tcx.mk_unit();
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![cell, value],
+                    },
+                    result,
+                    span,
+                )
+            }
+        }
+    }
+
+    /// Return the element of a cell operand, diagnosing a non-cell value and
+    /// an exclusive-only operation applied to a plain `Cell`.
+    fn cell_element(
+        &mut self,
+        ty: Ty<'tcx>,
+        func: crate::intrinsic::CellFn,
+        method: &str,
+        span: Option<Span>,
+    ) -> Option<Ty<'tcx>> {
+        let resolved = self.infer.shallow_resolve(ty);
+        if let TyKind::Cell { elem, exclusive } = *resolved.kind() {
+            if func.requires_exclusive() && !exclusive {
+                let shown = self.infer.resolve(resolved);
+                self.error(
+                    span,
+                    format!(
+                        "`core::intrinsic::cell::{method}` requires an exclusive cell, found \
+                         `{}`; use a `RefCell`",
+                        self.ty_display(shown)
+                    ),
+                );
+                return None;
+            }
+            Some(elem)
+        } else {
+            let shown = self.infer.resolve(resolved);
+            self.error(
+                span,
+                format!(
+                    "`core::intrinsic::cell::{method}` expects a cell as its first argument, \
+                     found `{}`",
+                    self.ty_display(shown)
+                ),
+            );
+            None
+        }
     }
 
     /// (ARR) The `core::intrinsic::array` family (issue #344) — special

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -449,6 +449,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.push_ty_display(out, inner);
                 out.push('>');
             }
+            TyKind::Cell { elem, exclusive } => {
+                out.push_str(if exclusive { "RefCell<" } else { "Cell<" });
+                self.push_ty_display(out, elem);
+                out.push('>');
+            }
             TyKind::Array { elem, dims } => {
                 out.push('[');
                 self.push_ty_display(out, elem);
@@ -956,6 +961,16 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
         }
         let name = rec.name;
+        if matches!(self.sym(name), "Cell" | "RefCell") {
+            self.error(
+                span,
+                format!(
+                    "record name `{}` is reserved for the builtin type",
+                    self.sym(name)
+                ),
+            );
+            return None;
+        }
         let Some(def) = self.defs.declare_record(name) else {
             self.error(
                 span,
@@ -1214,10 +1229,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 flex: Flexivity::Irrelevant,
                 ..
             } => self.error(span, "a `[field]` link element must be a regional record"),
-            // An array is pointer-like (one shared rc box), so the `Nullable`
-            // check below would let it through — but a `[field]` link stores a
-            // regional record, never a shared box.
-            TyKind::Array { .. } => {
+            // Arrays and cells are pointer-like (one shared rc box), so the
+            // `Nullable` check lets them through — but a `[field]` link stores
+            // a regional record, never a shared box.
+            TyKind::Array { .. } | TyKind::Cell { .. } => {
                 self.error(span, "a `[field]` link element must be a regional record")
             }
             // Regional records are fine; non-record elements are already rejected

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -270,6 +270,7 @@ pub(super) fn ty_has_hole(ty: crate::semi::ty::Ty<'_>) -> bool {
             params.iter().any(|p| ty_has_hole(*p)) || ty_has_hole(*ret)
         }
         TyKind::Nullable(inner) => ty_has_hole(*inner),
+        TyKind::Cell { elem: inner, .. } => ty_has_hole(*inner),
         TyKind::Array { elem, .. } => ty_has_hole(*elem),
         _ => false,
     }
@@ -288,6 +289,7 @@ pub(super) fn collect_holes(ty: crate::semi::ty::Ty<'_>, out: &mut Vec<HoleId>) 
             collect_holes(*ret, out);
         }
         TyKind::Nullable(inner) => collect_holes(*inner, out),
+        TyKind::Cell { elem: inner, .. } => collect_holes(*inner, out),
         TyKind::Array { elem, .. } => collect_holes(*elem, out),
         _ => {}
     }

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -317,6 +317,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let inner = self.ty(inner);
                 self.tcx.mk_nullable(inner)
             }
+            raw::Ty::Cell { inner, exclusive } => {
+                let inner = self.ty(inner);
+                self.tcx.mk_cell(inner, *exclusive)
+            }
             raw::Ty::Record { cap, path, args } => {
                 let def = self.record_def(path);
                 let args: Vec<Ty<'tcx>> = args.iter().map(|a| self.ty(a)).collect();
@@ -792,6 +796,27 @@ mod tests {
             pub fn n(f: (f64, f64) -> f64, a: [f64; 8]) -> f64 { core::intrinsic::array::fold(a, 0.0, f) }
             pub fn b(a: [f64; 8], i: i64, v: f64) -> [f64; 8] {
                 core::intrinsic::array::set(a, i, core::intrinsic::array::get(a, i) + v)
+            }
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrips_cells() {
+        roundtrip(
+            r#"
+            struct [value] Boxed<T> { value: Cell<T> }
+            pub fn use_cell(c: Cell<i64>) -> Cell<i64> {
+                c
+            }
+            pub fn nested(c: Cell<Cell<i64>>) -> Cell<Cell<i64>> {
+                c
+            }
+            pub fn use_refcell(c: RefCell<i64>) -> RefCell<i64> {
+                c
+            }
+            pub fn mixed(c: Cell<RefCell<i64>>) -> Cell<RefCell<i64>> {
+                c
             }
             "#,
         );

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -898,9 +898,9 @@ mod tests {
         // A generic `[flex]`-bound function (so `regional_generics` is non-empty)
         // and a turbofished regional call.
         roundtrip(
-            "struct [regional] Cell<T> { v: T, next: [field] Cell<T> } \
+            "struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> } \
              regional fn foo<T>(bar: [flex] T) -> i32 { 0 } \
-             regional fn use_ok(c: [flex] Cell<i32>) -> i32 { foo(c) }",
+             regional fn use_ok(c: [flex] TestCell<i32>) -> i32 { foo(c) }",
         );
     }
 }

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -180,6 +180,8 @@ Ty: raw::Ty = {
     "!" => raw::Ty::Bottom,
     <g:"generic"> => raw::Ty::Generic(g),
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
+    "Cell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: false },
+    "RefCell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: true },
     <cap:Cap> "#" <path:PathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
     "[" <elem:Ty> ";" <dims:CommaPlus<"int">> "]"
@@ -384,6 +386,8 @@ extern {
         "array" => Token::Array,
         "assign" => Token::Assign,
         "Nullable" => Token::Nullable,
+        "Cell" => Token::Cell,
+        "RefCell" => Token::RefCell,
         "NonNull" => Token::NonNull,
         "Null" => Token::Null,
         "poison" => Token::Poison,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -316,6 +316,9 @@ impl<'a> Printer<'a> {
             TyKind::Generic(g) => text(format!("${}", g.0)),
             TyKind::Hole(_) => unreachable!("a fully elaborated HIR carries no inference holes"),
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
+            TyKind::Cell { elem, exclusive } => {
+                text(if exclusive { "RefCell<" } else { "Cell<" }) + self.ty(elem) + text(">")
+            }
             TyKind::Array { elem, dims } => {
                 let mut d = text("[") + self.ty(elem) + text(";");
                 for (i, extent) in dims.iter().enumerate() {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -175,6 +175,10 @@ pub enum Ty {
     Bottom,
     Generic(u32),
     Nullable(Box<Ty>),
+    Cell {
+        inner: Box<Ty>,
+        exclusive: bool,
+    },
     Record {
         cap: Cap,
         path: String,

--- a/crates/reussir-core/src/semi/infer.rs
+++ b/crates/reussir-core/src/semi/infer.rs
@@ -175,7 +175,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// map an unknown hole to its class representative). `resolve` realizes the
     /// judgment σ ⊢ τ ⇓ τ′ ("τ zonks to τ′"), a read-only pass that leaves σ
     /// unchanged. K ranges over the structural constructors with children —
-    /// Record, Closure, Nullable — and the rebuilt node is re-interned:
+    /// Record, Closure, Array, Cell, Nullable — and the rebuilt node is re-interned:
     ///
     /// ```text
     ///   ⟦τ⟧ = K(τ₁ … τₙ)      σ ⊢ τᵢ ⇓ τ′ᵢ   (1 ≤ i ≤ n)
@@ -212,6 +212,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             TyKind::Array { elem, dims } => {
                 let elem = self.resolve(*elem);
                 self.tcx.mk_array(elem, dims)
+            }
+            TyKind::Cell { elem, exclusive } => {
+                let elem = self.resolve(*elem);
+                self.tcx.mk_cell(elem, *exclusive)
             }
             _ => ty,
         }
@@ -299,6 +303,16 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.unify(*r1, *r2)
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify(*x, *y),
+            (
+                TyKind::Cell {
+                    elem: x,
+                    exclusive: e1,
+                },
+                TyKind::Cell {
+                    elem: y,
+                    exclusive: e2,
+                },
+            ) if e1 == e2 => self.unify(*x, *y),
             (TyKind::Array { elem: e1, dims: d1 }, TyKind::Array { elem: e2, dims: d2 })
                 if d1 == d2 =>
             {
@@ -352,6 +366,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.occurs(h, *ret)
             }
             TyKind::Nullable(inner) => self.occurs(h, *inner),
+            TyKind::Cell { elem: inner, .. } => self.occurs(h, *inner),
             TyKind::Array { elem, .. } => self.occurs(h, *elem),
             _ => false,
         }
@@ -503,6 +518,16 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.unify_instantiated(*r1, inst, *r2)
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify_instantiated(*x, inst, *y),
+            (
+                TyKind::Cell {
+                    elem: x,
+                    exclusive: e1,
+                },
+                TyKind::Cell {
+                    elem: y,
+                    exclusive: e2,
+                },
+            ) if e1 == e2 => self.unify_instantiated(*x, inst, *y),
             (TyKind::Array { elem: e1, dims: d1 }, TyKind::Array { elem: e2, dims: d2 })
                 if d1 == d2 =>
             {
@@ -564,6 +589,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             TyKind::Array { elem, dims } => {
                 let elem = self.materialize(*elem, inst);
                 self.tcx.mk_array(elem, dims)
+            }
+            TyKind::Cell { elem, exclusive } => {
+                let elem = self.materialize(*elem, inst);
+                self.tcx.mk_cell(elem, *exclusive)
             }
             _ => template,
         }

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -146,6 +146,15 @@ pub enum TyKind<'tcx> {
         elem: Ty<'tcx>,
         dims: &'tcx [u64],
     },
+    /// A shared mutable cell. The cell box is always reference-counted; `T`
+    /// may itself contain reference-counted ownership. An `exclusive` cell is
+    /// the surface `RefCell<T>`: it additionally supports in-place
+    /// read-modify-write, guarded at runtime by an in-use flag while the
+    /// element is moved out through the updater.
+    Cell {
+        elem: Ty<'tcx>,
+        exclusive: bool,
+    },
     Nullable(Ty<'tcx>),
     /// A rigid type parameter in scope.
     Generic(GenericId),
@@ -265,6 +274,10 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_array(&self, elem: Ty<'tcx>, dims: &[u64]) -> Ty<'tcx> {
         let dims = self.alloc_slice(dims);
         self.mk(TyKind::Array { elem, dims })
+    }
+
+    pub fn mk_cell(&self, elem: Ty<'tcx>, exclusive: bool) -> Ty<'tcx> {
+        self.mk(TyKind::Cell { elem, exclusive })
     }
 
     pub fn mk_nullable(&self, inner: Ty<'tcx>) -> Ty<'tcx> {

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -94,6 +94,27 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return self.tcx.mk_generic(generic);
         }
 
+        // Built-in type constructors are roots and never module-qualified.
+        // `Cell<T>` is the plain get/set cell; `RefCell<T>` is the exclusive
+        // flavor that additionally supports guarded read-modify-write.
+        if path.segments.is_empty() && matches!(self.sym(key), "Cell" | "RefCell") {
+            let exclusive = self.sym(key) == "RefCell";
+            let name = if exclusive { "RefCell" } else { "Cell" };
+            return match args {
+                [inner] => {
+                    let inner = self.eval_type(inner);
+                    self.tcx.mk_cell(inner, exclusive)
+                }
+                _ => {
+                    self.error(
+                        Some(span),
+                        format!("`{name}` takes exactly one type argument"),
+                    );
+                    self.tcx.mk(TyKind::Bottom)
+                }
+            };
+        }
+
         // The built-in nullable type (a root builtin: never module-qualified).
         if path.segments.is_empty() && self.sym(key) == "Nullable" {
             return match args {
@@ -125,7 +146,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
 
         // A user record, resolved to its def — bare in the current module, or
-        // module-qualified (`utils::math::Cell`, `root::…`, `super::…`).
+        // module-qualified (`utils::math::Widget`, `root::…`, `super::…`).
         return self.eval_record_type_expr(path, args, span, key);
     }
 
@@ -282,9 +303,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 /// Is `t` *concretely* a non-pointer-like type — i.e. one that cannot be the
 /// inner of a `Nullable` (which needs a pointer-like inner to encode the null
 /// case)? Conservative: only the by-value scalars and a nested `Nullable` are
-/// rejected; `Record`/`Closure` are valid inners, and `Generic`/`Hole`/`Bottom`
-/// are deferred (resolved/checked later) so this never reports a false positive
-/// on a not-yet-ground type.
+/// rejected; `Record`/`Closure`/`Array`/`Cell` are valid inners, and
+/// `Generic`/`Hole`/`Bottom` are deferred (resolved/checked later) so this never
+/// reports a false positive on a not-yet-ground type.
 /// Whether `t` qualifies as a Phase-A array element: a plain scalar, or a
 /// generic/hole deferred to the monomorphization-time groundness check.
 pub(crate) fn is_plain_scalar_or_deferred(t: Ty<'_>) -> bool {

--- a/crates/reussir-repl/src/reflect.rs
+++ b/crates/reussir-repl/src/reflect.rs
@@ -166,7 +166,7 @@ fn member_is_pointer<'tcx>(ty: Ty<'tcx>, is_field: bool, shapes: &ShapeTable<'tc
         return true;
     }
     match *ty.kind() {
-        TyKind::Closure { .. } | TyKind::Nullable(_) => true,
+        TyKind::Closure { .. } | TyKind::Nullable(_) | TyKind::Cell { .. } => true,
         TyKind::Record { def, args, .. } => shapes
             .get(&(def, args))
             .is_none_or(|s| s.default_cap != DefaultCap::Value),
@@ -223,7 +223,7 @@ pub fn inline_size_align<'tcx>(
         TyKind::Fp(FpTy::Ieee(64)) => scalar(8),
         TyKind::Fp(FpTy::Float8) => scalar(1),
         TyKind::Unit => Ok(SizeAlign { size: 0, align: 1 }),
-        TyKind::Nullable(_) | TyKind::Closure { .. } => scalar(WORD),
+        TyKind::Nullable(_) | TyKind::Closure { .. } | TyKind::Cell { .. } => scalar(WORD),
         TyKind::Record { def, args, .. } => {
             let shape = shapes
                 .get(&(def, args))
@@ -470,6 +470,9 @@ impl<'tcx> Walker<'_, 'tcx> {
                 }
                 TyKind::Unit => out.push_str("()"),
                 TyKind::Closure { .. } => out.push_str("<closure>"),
+                TyKind::Cell { exclusive, .. } => {
+                    out.push_str(if exclusive { "<refcell>" } else { "<cell>" })
+                }
                 TyKind::Nullable(inner) => {
                     let ptr = addr.cast::<*const u8>().read_unaligned();
                     if ptr.is_null() {

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -630,6 +630,10 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             TyKind::Nullable(inner) => {
                 format!("Nullable<{}>", Self::render_ty_with(elab, inner))
             }
+            TyKind::Cell { elem, exclusive } => {
+                let name = if exclusive { "RefCell" } else { "Cell" };
+                format!("{name}<{}>", Self::render_ty_with(elab, elem))
+            }
             TyKind::Array { elem, dims } => {
                 let dims: Vec<String> = dims.iter().map(|d| d.to_string()).collect();
                 format!(

--- a/tests/integration/frontend/cell.rr
+++ b/tests/integration/frontend/cell.rr
@@ -1,0 +1,98 @@
+// The builtin Cell/RefCell types and their intrinsic-only operations must
+// survive both textual frontend IRs with the same types and resolved
+// intrinsic names. All operations live in the single `core::intrinsic::cell`
+// namespace and dispatch on the operand's cell flavor: get/set work on both,
+// while the guarded rmw and the in_use flag read require a RefCell.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %rrc %s --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=MLIR
+// RUN: %rrc %s --emit mlir-llvm --no-source-locations -Oaggressive -o - | %FileCheck %s --check-prefix=FUSED
+
+struct [shared] Boxed {
+    value: i64
+}
+
+struct [value] Holder {
+    cell: Cell<Boxed>
+}
+
+// HIR: pub fn #plain(v0 (c): Cell<i64>, v1 (replacement): i64) -> i64
+// HIR: intrinsic#cell#get#0(v0 : Cell<i64>
+// HIR: intrinsic#cell#set#0(v0 : Cell<i64>{{.*}}v1 : i64
+// MIR: pub fn @_RC5plain(v0 (c): Cell<i64>, v1 (replacement): i64) -> i64
+// MIR: intrinsic#cell#get#0(v0 : Cell<i64>
+// MIR: intrinsic#cell#set#0(v0 : Cell<i64>{{.*}}v1 : i64
+// MLIR-LABEL: func.func @_RC5plain
+// MLIR: %[[OLD:.+]] = reussir.cell.get(%arg0 : !reussir.rc<!reussir.cell<i64>>) : i64
+// MLIR: reussir.cell.set(%arg1 : i64, %arg0 : !reussir.rc<!reussir.cell<i64>>)
+// MLIR: reussir.cell.get
+pub fn plain(c: Cell<i64>, replacement: i64) -> i64 {
+    let old = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, replacement);
+    old + core::intrinsic::cell::get(c)
+}
+
+// A Cell member is stored as the bare cell payload. Projection materializes
+// the shared rc<Cell<...>> link, just like closure/array members.
+// MLIR-LABEL: func.func @_RC6bump_h
+// MLIR-SAME: !reussir.record<compound "_RC6Holder" [value] {!reussir.cell<!reussir.rc<!reussir.record<compound "_RC5Boxed" {i64}>>>}>
+// MLIR: reussir.record.extract
+// MLIR-SAME: !reussir.rc<!reussir.cell<!reussir.rc<!reussir.record<compound "_RC5Boxed" {i64}>>>>
+// MLIR: reussir.cell.set
+// MLIR: reussir.cell.get
+pub fn bump_h(h: Holder, replacement: Boxed) -> i64 {
+    core::intrinsic::cell::set(h.cell, replacement);
+    core::intrinsic::cell::get(h.cell).value
+}
+
+// alloc has no cell operand to dispatch on: it defaults to a plain Cell, and
+// an explicit type argument selects the exclusive flavor. The two flavors
+// nest freely.
+// HIR: pub fn #nested() -> Cell<RefCell<i64>>
+// HIR: intrinsic#cell#alloc#0(intrinsic#cell#alloc#0(1 : i64) : RefCell<i64>
+// MIR: pub fn @_RC6nested() -> Cell<RefCell<i64>>
+// MIR: intrinsic#cell#alloc#0(intrinsic#cell#alloc#0(1 : i64) : RefCell<i64>
+// MLIR-LABEL: func.func @_RC6nested
+// MLIR: %[[INNER:.+]] = reussir.cell.create value(%{{.+}} : i64) : !reussir.rc<!reussir.cell<i64 exclusive>>
+// MLIR: reussir.cell.create value(%[[INNER]] : !reussir.rc<!reussir.cell<i64 exclusive>>) : !reussir.rc<!reussir.cell<!reussir.rc<!reussir.cell<i64 exclusive>>>>
+pub fn nested() -> Cell<RefCell<i64>> {
+    core::intrinsic::cell::alloc(core::intrinsic::cell::alloc<RefCell<i64>>(1))
+}
+
+// The exclusive operations: rmw moves the element through the updater, and
+// in_use reads the guard flag. Same namespace, dispatched on the RefCell
+// operand.
+// HIR: pub fn #guarded(v0 (c): RefCell<i64>, v1 (replacement): i64) -> i64
+// HIR: intrinsic#cell#get#0(v0 : RefCell<i64>
+// HIR: intrinsic#cell#set#0(v0 : RefCell<i64>{{.*}}v1 : i64
+// HIR: intrinsic#cell#rmw#0(v0 : RefCell<i64>{{.*}}closure[]
+// HIR: intrinsic#cell#in_use#0(v0 : RefCell<i64>
+// MIR: pub fn @_RC7guarded(v0 (c): RefCell<i64>, v1 (replacement): i64) -> i64
+// MIR: intrinsic#cell#rmw#0(v0 : RefCell<i64>{{.*}}closure[]
+// MIR: intrinsic#cell#in_use#0(v0 : RefCell<i64>
+// MLIR-LABEL: func.func @_RC7guarded
+// MLIR: %[[OLD:.+]] = reussir.cell.get(%arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>) : i64
+// MLIR: reussir.cell.set(%arg1 : i64, %arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>)
+// MLIR: reussir.closure.create
+// MLIR: reussir.cell.rmw(%arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>) {
+// MLIR: ^bb0(%[[CURRENT:.+]]: i64):
+// MLIR: reussir.rc.inc
+// MLIR: reussir.closure.eval
+// MLIR: reussir.cell.yield(%{{.+}} : i64)
+// MLIR: reussir.rc.dec
+// MLIR: %[[FLAG:.+]] = reussir.cell.in_use(%arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>) : i1
+// MLIR: reussir.cell.get
+pub fn guarded(c: RefCell<i64>, replacement: i64) -> i64 {
+    let old = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, replacement);
+    core::intrinsic::cell::rmw(c, |x| x + 1);
+    let busy = core::intrinsic::cell::in_use(c);
+    if busy { 0 } else { old + core::intrinsic::cell::get(c) }
+}
+
+// Structural beta reduction is intentionally enabled through cell.rmw: a
+// literal updater fuses completely at aggressive optimization.
+// FUSED-LABEL: llvm.func @_RC7guarded
+// FUSED-NOT: closure
+// FUSED: llvm.add

--- a/tests/integration/frontend/cell_e2e.c
+++ b/tests/integration/frontend/cell_e2e.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t test_scalar_ffi(void);
+extern int64_t test_managed_element_ffi(void);
+extern int64_t test_nested_cell_ffi(void);
+extern int64_t test_record_member_ffi(void);
+extern int64_t test_generic_ffi(void);
+extern int64_t test_in_use_ffi(void);
+extern int64_t test_rc_cycle_ffi(void);
+
+static int check(const char *name, int64_t got, int64_t want) {
+  if (got == want)
+    return 0;
+  fprintf(stderr, "%s: got %lld, want %lld\n", name, (long long)got,
+          (long long)want);
+  return 1;
+}
+
+int main(void) {
+  int failures = 0;
+  failures += check("scalar", test_scalar_ffi(), 32);
+  failures += check("managed_element", test_managed_element_ffi(), 16);
+  failures += check("nested_cell", test_nested_cell_ffi(), 24);
+  failures += check("record_member", test_record_member_ffi(), 42);
+  failures += check("generic", test_generic_ffi(), 41);
+  failures += check("in_use", test_in_use_ffi(), 7);
+  failures += check("rc_cycle", test_rc_cycle_ffi(), 42);
+  return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/cell_e2e.rr
+++ b/tests/integration/frontend/cell_e2e.rr
@@ -1,0 +1,114 @@
+// End-to-end Cell/RefCell semantics: managed elements, nested cells, guarded
+// RMW and in_use on the exclusive flavor, temporary borrowed cells, and cell
+// projection from a record. All operations share the `core::intrinsic::cell`
+// namespace and dispatch on the operand's cell flavor; `alloc` selects the
+// exclusive flavor with an explicit type argument.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/cell_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/cell_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+struct [shared] Boxed {
+    value: i64
+}
+
+struct [value] Holder {
+    cell: RefCell<Boxed>
+}
+
+struct [shared] CycleNode {
+    value: i64,
+    next: Cell<Nullable<CycleNode>>
+}
+
+pub fn test_scalar() -> i64 {
+    let c = core::intrinsic::cell::alloc<RefCell<i64>>(10);
+    let before = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, 20);
+    core::intrinsic::cell::rmw(c, |x| x + 2);
+    before + core::intrinsic::cell::get(c)
+}
+extern "C" trampoline "test_scalar_ffi" = test_scalar;
+
+// The exclusive cell owns a shared record. get clones it, set drops the old
+// value, and RMW moves the current record through the updater without an
+// extra clone.
+pub fn test_managed_element() -> i64 {
+    let c = core::intrinsic::cell::alloc<RefCell<Boxed>>(Boxed { value: 5 });
+    let first = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, Boxed { value: 8 });
+    core::intrinsic::cell::rmw(c, |x| Boxed { value: x.value + 3 });
+    first.value + core::intrinsic::cell::get(c).value
+}
+extern "C" trampoline "test_managed_element_ffi" = test_managed_element;
+
+// outer (a plain Cell) owns an exclusive inner; get(outer) clones the inner
+// RefCell reference. RMW directly on another temporary clone must release
+// that temporary only after the body.
+pub fn test_nested_cell() -> i64 {
+    let inner = core::intrinsic::cell::alloc<RefCell<i64>>(3);
+    let outer = core::intrinsic::cell::alloc(inner);
+    let alias = core::intrinsic::cell::get(outer);
+    core::intrinsic::cell::set(alias, 7);
+    core::intrinsic::cell::rmw(core::intrinsic::cell::get(outer), |x| x + 5);
+    core::intrinsic::cell::get(alias)
+        + core::intrinsic::cell::get(core::intrinsic::cell::get(outer))
+}
+extern "C" trampoline "test_nested_cell_ffi" = test_nested_cell;
+
+// A projected RefCell is an owned clone of the shared link while the Holder
+// keeps its member. Both the updater and subsequent read borrow those
+// projections.
+pub fn test_record_member() -> i64 {
+    let h = Holder { cell: core::intrinsic::cell::alloc<RefCell<Boxed>>(Boxed { value: 40 }) };
+    core::intrinsic::cell::rmw(h.cell, |x| Boxed { value: x.value + 2 });
+    core::intrinsic::cell::get(h.cell).value
+}
+extern "C" trampoline "test_record_member_ffi" = test_record_member;
+
+fn generic_get<T>(c: Cell<T>) -> T {
+    core::intrinsic::cell::get(c)
+}
+
+pub fn test_generic() -> i64 {
+    generic_get(core::intrinsic::cell::alloc(41))
+}
+extern "C" trampoline "test_generic_ffi" = test_generic;
+
+// Outside any rmw body the guard flag reads false, including through a
+// generic instantiation.
+fn generic_busy<T>(c: RefCell<T>) -> bool {
+    core::intrinsic::cell::in_use(c)
+}
+
+pub fn test_in_use() -> i64 {
+    let c = core::intrinsic::cell::alloc<RefCell<i64>>(6);
+    let busy = generic_busy(c);
+    if busy { 0 } else { core::intrinsic::cell::get(c) + 1 }
+}
+extern "C" trampoline "test_in_use_ffi" = test_in_use;
+
+// `node` owns a reference to `link`, then `link` is updated to own `node`:
+//
+//     node -> link -> node
+//
+// Plain reference counting cannot collect that cycle. Clearing the cell breaks
+// it explicitly; the sanitizer wrapper verifies that recursively dropping the
+// node also releases its nested Cell reference. `get` must clone the nullable
+// element (the acquisition fixed by the exclusive-cell backend rework), or
+// the read below would use freed memory once the cell is cleared.
+pub fn test_rc_cycle() -> i64 {
+    let link = core::intrinsic::cell::alloc(Nullable::Null);
+    let node = CycleNode { value: 42, next: link };
+    core::intrinsic::cell::set(link, Nullable::NonNull { node });
+    let value = match core::intrinsic::cell::get(link) {
+        Nullable::NonNull(node) => node.value,
+        Nullable::Null => -1
+    };
+    core::intrinsic::cell::set(link, Nullable::Null);
+    value
+}
+extern "C" trampoline "test_rc_cycle_ffi" = test_rc_cycle;

--- a/tests/integration/frontend/cell_errors.rr
+++ b/tests/integration/frontend/cell_errors.rr
@@ -1,0 +1,52 @@
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+// Cell and RefCell are root builtin type constructors.
+// CHECK-DAG: `Cell` takes exactly one type argument
+fn missing_type(c: Cell) -> i64 { 0 }
+
+// CHECK-DAG: `RefCell` takes exactly one type argument
+fn missing_ref_type(c: RefCell) -> i64 { 0 }
+
+// CHECK-DAG: record name `Cell` is reserved for the builtin type
+struct Cell { value: i64 }
+
+// CHECK-DAG: record name `RefCell` is reserved for the builtin type
+struct RefCell { value: i64 }
+
+// A mutable `[field]` link must still point at a regional record, not a Cell.
+// CHECK-DAG: a `[field]` link element must be a regional record
+struct [regional] BadLink { value: [field] Cell<i64> }
+
+// CHECK: unknown cell intrinsic `core::intrinsic::cell::swap`
+fn unknown(c: Cell<i64>) -> i64 { core::intrinsic::cell::swap(c) }
+
+// Read-modify-write and the guard flag dispatch on the operand and demand
+// the exclusive flavor.
+// CHECK: `core::intrinsic::cell::rmw` requires an exclusive cell, found `Cell<i64>`; use a `RefCell`
+fn plain_rmw(c: Cell<i64>) -> unit {
+    core::intrinsic::cell::rmw(c, |x| x)
+}
+
+// CHECK: `core::intrinsic::cell::in_use` requires an exclusive cell, found `Cell<i64>`; use a `RefCell`
+fn plain_in_use(c: Cell<i64>) -> bool { core::intrinsic::cell::in_use(c) }
+
+// CHECK: `core::intrinsic::cell::get` expects a cell as its first argument, found `i64`
+fn not_cell(x: i64) -> i64 { core::intrinsic::cell::get(x) }
+
+// CHECK: type mismatch: expected `i64`, found `bool`
+fn wrong_set(c: Cell<i64>) -> unit { core::intrinsic::cell::set(c, true) }
+
+// CHECK: type mismatch: expected `i64 -> i64`, found `bool -> bool`
+fn wrong_rmw(c: RefCell<i64>) -> unit {
+    core::intrinsic::cell::rmw(c, |x: bool| x)
+}
+
+// alloc's optional type argument must name the cell type, not the element.
+// CHECK: the type argument of `core::intrinsic::cell::alloc` must be `Cell<T>` or `RefCell<T>`, found `i64`
+fn elem_type_arg() -> Cell<i64> { core::intrinsic::cell::alloc<i64>(1) }
+
+// CHECK: `bool` does not implement `Integral`
+fn wrong_alloc() -> RefCell<bool> { core::intrinsic::cell::alloc<RefCell<bool>>(1) }
+
+// CHECK: `core::intrinsic::cell::get` takes no type arguments
+fn typed_get(c: Cell<i64>) -> i64 { core::intrinsic::cell::get<i64>(c) }

--- a/tests/integration/sanitizer/e2e/cell.rr
+++ b/tests/integration/sanitizer/e2e/cell.rr
@@ -1,0 +1,23 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/cell_e2e.rr. The managed-element and nested-cell
+// cases exercise recursive RC destruction; the RC-cycle case forms
+// `node -> Cell -> node` and then explicitly breaks it (its get-clone is the
+// nullable acquisition the backend rework fixed), while RMW tests both
+// literal-closure execution and aggressive structural beta reduction.
+// `--sanitizer address` instruments the generated code itself; shadow-based
+// sanitizers require the arch-independent nullary variant encoding.
+
+// RUN: %rrc %S/../../frontend/cell_e2e.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/cell_e2e.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/cell_e2e.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/cell_e2e.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/cell_e2e.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/cell_e2e.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe


### PR DESCRIPTION
## Stack

1 of 7. This is the base of the Cell frontend stack.

## Summary

- rename pre-existing test-only `Cell` declarations to `TestCell`
- reserve the unqualified name for the upcoming builtin type
- make no semantic or generated-code changes

## Size

120 changed lines (60 additions, 60 deletions).

## Validation

- `cargo check --workspace`
- `cargo test -p reussir-core`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786601809&installation_id=144622820&pr_number=416&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F416&signature=af63490eb2aa323bf6e3b18d48ea2bd5001fade7c96d965ab1d72aecc02e762d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->