### PR TITLE
[core] model Cell/RefCell intrinsic ownership

### DIFF
--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -301,6 +301,94 @@ pub fn nullable_dispatch<'c>(
     builder.build().expect("valid reussir.nullable.dispatch")
 }
 
+/// `reussir.cell.create value(%value : T) : !reussir.rc<!reussir.cell<T>>`
+/// — move a value into a fresh shared cell. The token-instantiation pass fills
+/// the optional allocation token.
+pub fn cell_create<'c>(
+    value: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.cell.create", location)
+        .add_operands(&[value])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.cell.create")
+}
+
+/// `reussir.cell.get(%cell : rc<cell<T>>) : T` — clone the stored value.
+pub fn cell_get<'c>(
+    cell: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.cell.get", location)
+        .add_operands(&[cell])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.cell.get")
+}
+
+/// `reussir.cell.set(%value : T, %cell : rc<cell<T>>)` — replace the stored
+/// value, consuming `value` and dropping the old element.
+pub fn cell_set<'c>(
+    value: Value<'c, '_>,
+    cell: Value<'c, '_>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.cell.set", location)
+        .add_operands(&[value, cell])
+        .build()
+        .expect("valid reussir.cell.set")
+}
+
+/// `reussir.cell.rmw(%cell) { ... }` — move the current element through a
+/// single-block body and store its yielded replacement.
+pub fn cell_rmw<'c>(
+    cell: Value<'c, '_>,
+    result_type: Option<Type<'c>>,
+    body: Region<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let mut builder = OperationBuilder::new("reussir.cell.rmw", location)
+        .add_operands(&[cell])
+        .add_regions([body]);
+    if let Some(result_type) = result_type {
+        builder = builder.add_results(&[result_type]);
+    }
+    builder.build().expect("valid reussir.cell.rmw")
+}
+
+/// `reussir.cell.yield(%replacement : T)` — terminate a cell RMW body.
+pub fn cell_yield<'c>(
+    replacement: Value<'c, '_>,
+    output: Option<Value<'c, '_>>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let mut operands = vec![replacement];
+    if let Some(output) = output {
+        operands.push(output);
+    }
+    OperationBuilder::new("reussir.cell.yield", location)
+        .add_operands(&operands)
+        .build()
+        .expect("valid reussir.cell.yield")
+}
+
+/// `reussir.cell.in_use(%cell : rc<cell<T exclusive>>) : i1` — observe the
+/// exclusive cell's in-use flag (true while an rmw body holds the element).
+pub fn cell_in_use<'c>(
+    cell: Value<'c, '_>,
+    result_type: Type<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    OperationBuilder::new("reussir.cell.in_use", location)
+        .add_operands(&[cell])
+        .add_results(&[result_type])
+        .build()
+        .expect("valid reussir.cell.in_use")
+}
+
 /// `reussir.region.run (-> <result_type>)? { <body> }` — execute a region scope.
 ///
 /// The body region's single block takes a `!reussir.region` argument (the arena

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -626,36 +626,37 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             // builder over the (scalar) operands. Each family owns its own
             // dialect ops and attributes; the backend pipeline's dialect
             // conversions take the emitted op from there.
-            Intrinsic { op, args } => {
-                let mut operands = Vec::with_capacity(args.len());
-                for a in args.iter() {
-                    let v = self.expr(block, env, a)?.ok_or_else(|| {
-                        LoweringError("intrinsic operand produced no value".into())
-                    })?;
-                    operands.push(v);
-                }
-                let result = self.tys.mlir_ty(e.ty)?;
-                let built = match op {
-                    IntrinsicOp::Math { func, flag } => {
-                        let fastmath =
-                            reussir_core::intrinsic::FastMath(*flag)
-                                .mlir_attr()
-                                .map(|text| {
-                                    Attribute::parse(self.context, &text)
-                                        .expect("valid fastmath attribute")
-                                });
-                        super::math::math_operation(
-                            self.context,
-                            *func,
-                            &operands,
-                            result,
-                            fastmath,
-                            loc,
-                        )
+            Intrinsic { op, args } => match op {
+                IntrinsicOp::Math { func, flag } => {
+                    let mut operands = Vec::with_capacity(args.len());
+                    for a in args.iter() {
+                        let v = self.expr(block, env, a)?.ok_or_else(|| {
+                            LoweringError("intrinsic operand produced no value".into())
+                        })?;
+                        operands.push(v);
                     }
-                };
-                Ok(Some(self.append(block, built)))
-            }
+                    let result = self.tys.mlir_ty(e.ty)?;
+                    let fastmath =
+                        reussir_core::intrinsic::FastMath(*flag)
+                            .mlir_attr()
+                            .map(|text| {
+                                Attribute::parse(self.context, &text)
+                                    .expect("valid fastmath attribute")
+                            });
+                    let built = super::math::math_operation(
+                        self.context,
+                        *func,
+                        &operands,
+                        result,
+                        fastmath,
+                        loc,
+                    );
+                    Ok(Some(self.append(block, built)))
+                }
+                IntrinsicOp::Cell { .. } => {
+                    err("Cell intrinsic lowering is introduced in the next stack layer")
+                }
+            },
             Cmp(l, op, r) => self.cmp(block, env, l, *op, r).map(Some),
             Cast(x, t) => self.cast(block, env, x, *t),
             If(c, t, f) => self.lower_if(block, env, c, t, f, e.ty),

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -35,7 +35,7 @@ use reussir_backend::melior::ir::{
 
 use reussir_core::full::mir::{self, DecisionTree, Expr, ExprKind, SwitchCases};
 use reussir_core::full::ownership::{OwnershipTable, RcOp, RecordTable, analyze_function};
-use reussir_core::intrinsic::{ArrayFn, IntrinsicOp};
+use reussir_core::intrinsic::{ArrayFn, CellFn, IntrinsicOp};
 use reussir_core::literal::{self, Integer};
 use reussir_core::semi::hir::{ArithOp, CmpOp, ExprId, VarId};
 use reussir_core::semi::ty::{Flexivity, IntTy, Ty, TyCtxt, TyKind};
@@ -653,9 +653,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     );
                     Ok(Some(self.append(block, built)))
                 }
-                IntrinsicOp::Cell { .. } => {
-                    err("Cell intrinsic lowering is introduced in the next stack layer")
-                }
+                IntrinsicOp::Cell { func } => self.lower_cell_intrinsic(block, env, e, *func, args),
             },
             Cmp(l, op, r) => self.cmp(block, env, l, *op, r).map(Some),
             Cast(x, t) => self.cast(block, env, x, *t),
@@ -2176,6 +2174,15 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 proj_cap: ref_cap,
                 is_link: true,
             })
+        } else if matches!(field_ty.kind(), TyKind::Cell { .. }) {
+            // A cell member is stored as a bare payload type in the record
+            // declaration, but dialect projection materializes a shared rc link.
+            Ok(ProjectedMember {
+                field_ty,
+                elem_ty: self.tys.mlir_ty(field_ty)?,
+                proj_cap: ref_cap,
+                is_link: true,
+            })
         } else {
             Ok(ProjectedMember {
                 field_ty,
@@ -2691,6 +2698,114 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let region = Region::new();
         region.append_block(block);
         Ok(region)
+    }
+
+    // ----- built-in cell operations -----
+
+    fn lower_cell_intrinsic<'b>(
+        &self,
+        block: &'b Block<'c>,
+        env: &mut Env<'c, 'b, 'tcx>,
+        e: &Expr<'tcx>,
+        func: CellFn,
+        args: &'tcx [Expr<'tcx>],
+    ) -> Result<Option<Value<'c, 'b>>> {
+        let loc = self.loc();
+        match func {
+            CellFn::Alloc => {
+                let value = self
+                    .expr(block, env, &args[0])?
+                    .ok_or_else(|| LoweringError("cell element produced no value".into()))?;
+                let result_ty = self.tys.mlir_ty(e.ty)?;
+                Ok(Some(self.append(
+                    block,
+                    builders::cell_create(value, result_ty, loc),
+                )))
+            }
+            CellFn::Get => {
+                let base = &args[0];
+                let cell = self
+                    .expr(block, env, base)?
+                    .ok_or_else(|| LoweringError("cell operand produced no value".into()))?;
+                self.remember_temp(env, base, cell);
+                let result_ty = self.tys.mlir_ty(e.ty)?;
+                Ok(Some(
+                    self.append(block, builders::cell_get(cell, result_ty, loc)),
+                ))
+            }
+            CellFn::Set => {
+                let base = &args[0];
+                let cell = self
+                    .expr(block, env, base)?
+                    .ok_or_else(|| LoweringError("cell operand produced no value".into()))?;
+                self.remember_temp(env, base, cell);
+                let value = self
+                    .expr(block, env, &args[1])?
+                    .ok_or_else(|| LoweringError("cell element produced no value".into()))?;
+                block.append_operation(builders::cell_set(value, cell, loc));
+                Ok(None)
+            }
+            CellFn::InUse => {
+                let base = &args[0];
+                if !matches!(
+                    *base.ty.kind(),
+                    TyKind::Cell {
+                        exclusive: true,
+                        ..
+                    }
+                ) {
+                    return err("cell in_use operand is not an exclusive cell");
+                }
+                let cell = self
+                    .expr(block, env, base)?
+                    .ok_or_else(|| LoweringError("cell operand produced no value".into()))?;
+                self.remember_temp(env, base, cell);
+                let result_ty = self.tys.mlir_ty(e.ty)?;
+                Ok(Some(self.append(
+                    block,
+                    builders::cell_in_use(cell, result_ty, loc),
+                )))
+            }
+            CellFn::Rmw => {
+                let base = &args[0];
+                let cell = self
+                    .expr(block, env, base)?
+                    .ok_or_else(|| LoweringError("cell operand produced no value".into()))?;
+                self.remember_temp(env, base, cell);
+                let kernel = &args[1];
+                let closure = self
+                    .expr(block, env, kernel)?
+                    .ok_or_else(|| LoweringError("cell update closure produced no value".into()))?;
+                let TyKind::Cell {
+                    elem,
+                    exclusive: true,
+                } = *base.ty.kind()
+                else {
+                    return err("cell RMW operand is not an exclusive cell");
+                };
+                let elem_ty = self.tys.mlir_ty(elem)?;
+                let body = Block::new(&[(elem_ty, loc)]);
+                let current = body
+                    .argument(0)
+                    .expect("cell RMW body takes the current element")
+                    .into();
+                // Preserve the updater's outer owner while eval consumes one
+                // reference. Structural beta reduction removes this pair for a
+                // literal closure nested in cell.rmw.
+                body.append_operation(dialect::rc_inc(self.context, closure, loc).into());
+                let replacement = self
+                    .call_kernel(&body, closure, kernel.ty, &[current])?
+                    .ok_or_else(|| LoweringError("cell update closure returned unit".into()))?;
+                body.append_operation(builders::cell_yield(replacement, None, loc));
+                let region = Region::new();
+                region.append_block(body);
+                block.append_operation(builders::cell_rmw(cell, None, region, loc));
+                // The intrinsic consumes the updater closure; the in-region inc
+                // paid only for the eval above.
+                block.append_operation(dialect::rc_dec(self.context, closure, loc).into());
+                Ok(None)
+            }
+        }
     }
 
     // ----- built-in array operations (issue #344) -----

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -605,8 +605,13 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             ExprKind::Seq(es) => self.place_seq(es, live_after),
             ExprKind::Call { args, .. }
             | ExprKind::Ctor { args, .. }
-            | ExprKind::Variant { args, .. }
-            | ExprKind::Intrinsic { args, .. } => self.place_args(args, live_after),
+            | ExprKind::Variant { args, .. } => self.place_args(args, live_after),
+            ExprKind::Intrinsic { op, args } => match op {
+                crate::intrinsic::IntrinsicOp::Cell { func } => {
+                    self.place_cell_intrinsic(e, func, args, live_after)
+                }
+                crate::intrinsic::IntrinsicOp::Math { .. } => self.place_args(args, live_after),
+            },
             ExprKind::NullableCall(opt) => {
                 if let Some(x) = opt {
                     self.place(x, live_after);
@@ -632,6 +637,60 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 self.place_closure_call(target, args, live_after)
             }
             ExprKind::ArrayOp { op, args } => self.place_array_op(e, op, args, live_after),
+        }
+    }
+
+    /// Place a cell intrinsic's operands. `alloc` consumes its sole value like
+    /// an ordinary call. The other operations borrow their first (cell)
+    /// operand for the duration of the operation and consume any remaining
+    /// value/closure operands.
+    fn place_cell_intrinsic(
+        &mut self,
+        e: &Expr<'tcx>,
+        func: crate::intrinsic::CellFn,
+        args: &'tcx [Expr<'tcx>],
+        live_after: &VarSet,
+    ) {
+        if func == crate::intrinsic::CellFn::Alloc {
+            self.place_args(args, live_after);
+            return;
+        }
+
+        let base = &args[0];
+        let mut borrowed = VarSet::default();
+        let base_is_var = if let ExprKind::Var(x) = base.kind {
+            borrowed.insert(x);
+            true
+        } else {
+            false
+        };
+
+        // Keep a named cell owner live across every other operand; those
+        // operands otherwise follow the ordinary left-to-right consuming rule.
+        let mut live = live_after.clone();
+        live.union_with(&borrowed);
+        for i in 0..args.len() {
+            if i == 0 && base_is_var {
+                continue;
+            }
+            let mut la = live.clone();
+            for later in &args[i + 1..] {
+                la.union_with(&self.free(later));
+            }
+            self.place(&args[i], &la);
+            if i == 0 {
+                // The operation only borrows an anonymous cell result, so its
+                // sole owner must be released after the operation completes.
+                self.add_after(e.id, RcOp::DropValue(base.id));
+            }
+        }
+
+        if base_is_var {
+            for v in borrowed.iter() {
+                if !live_after.contains(v) {
+                    self.add_after(e.id, RcOp::Drop(v));
+                }
+            }
         }
     }
 

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -305,6 +305,26 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
         self.tcx.mk_closure(params, ret)
     }
 
+    fn cell_ty(&self, elem: Ty<'tcx>, exclusive: bool) -> Ty<'tcx> {
+        self.tcx.mk_cell(elem, exclusive)
+    }
+
+    fn cell_op(
+        &mut self,
+        func: crate::intrinsic::CellFn,
+        args: Vec<Expr<'tcx>>,
+        ty: Ty<'tcx>,
+    ) -> Expr<'tcx> {
+        let args = self.tcx.alloc_slice(&args);
+        self.mk(
+            ExprKind::Intrinsic {
+                op: crate::intrinsic::IntrinsicOp::Cell { func },
+                args,
+            },
+            ty,
+        )
+    }
+
     /// `target(args)` — an indirect call through a closure value.
     fn closure_call(
         &mut self,
@@ -730,12 +750,26 @@ fn interp<'tcx>(
         }
         ExprKind::Call { args, .. }
         | ExprKind::Ctor { args, .. }
-        | ExprKind::Variant { args, .. }
-        | ExprKind::Intrinsic { args, .. } => {
+        | ExprKind::Variant { args, .. } => {
             for a in args {
                 interp(a, ot, rr, rc);
             }
         }
+        ExprKind::Intrinsic { op, args } => match op {
+            crate::intrinsic::IntrinsicOp::Cell { func }
+                if func != crate::intrinsic::CellFn::Alloc =>
+            {
+                interp_borrow(&args[0], ot, rr, rc);
+                for a in &args[1..] {
+                    interp(a, ot, rr, rc);
+                }
+            }
+            _ => {
+                for a in args {
+                    interp(a, ot, rr, rc);
+                }
+            }
+        },
         ExprKind::NullableCall(opt) => {
             if let Some(x) = opt {
                 interp(x, ot, rr, rc);
@@ -1866,6 +1900,112 @@ fn flex_record_assembly_still_incs_its_rigid_field() {
         assert!(
             ot.before(a_r_id).is_empty(),
             "the later use of r is its last ⇒ moved"
+        );
+    });
+}
+
+// ----- cells -----
+
+#[test]
+fn cell_set_borrows_cell_and_consumes_replacement() {
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let elem = b.shared();
+        let cell_ty = b.cell_ty(elem, false);
+        let c = b.fresh_var();
+        let value = b.fresh_var();
+
+        let base = b.var(c, cell_ty);
+        let replacement = b.var(value, elem);
+        let replacement_id = replacement.id;
+        let unit = tcx.mk_unit();
+        let body = b.cell_op(crate::intrinsic::CellFn::Set, vec![base, replacement], unit);
+        let body_id = body.id;
+        let params = vec![b.param(c, cell_ty), b.param(value, elem)];
+        let func = b.function("set", params, unit, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.before(replacement_id).is_empty(),
+            "the replacement's last owner is moved into the cell"
+        );
+        assert_eq!(ot.after(body_id), &[RcOp::Drop(c)]);
+    });
+}
+
+#[test]
+fn cell_rmw_borrows_cell_and_consumes_updater() {
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let elem = b.i64();
+        let cell_ty = b.cell_ty(elem, true);
+        let update_ty = b.closure_ty(&[elem], elem);
+        let c = b.fresh_var();
+        let update = b.fresh_var();
+
+        let base = b.var(c, cell_ty);
+        let updater = b.var(update, update_ty);
+        let updater_id = updater.id;
+        let unit = tcx.mk_unit();
+        let body = b.cell_op(crate::intrinsic::CellFn::Rmw, vec![base, updater], unit);
+        let body_id = body.id;
+        let params = vec![b.param(c, cell_ty), b.param(update, update_ty)];
+        let func = b.function("rmw", params, unit, body);
+        let ot = run(tcx, &func, &b);
+
+        assert!(
+            ot.before(updater_id).is_empty(),
+            "the updater's last owner is consumed by rmw"
+        );
+        assert_eq!(ot.after(body_id), &[RcOp::Drop(c)]);
+    });
+}
+
+#[test]
+fn cell_get_releases_a_temporary_cell_after_the_borrow() {
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let elem = b.shared();
+        let cell_ty = b.cell_ty(elem, false);
+        let x = b.fresh_var();
+
+        let value = b.var(x, elem);
+        let alloc = b.cell_op(crate::intrinsic::CellFn::Alloc, vec![value], cell_ty);
+        let alloc_id = alloc.id;
+        let body = b.cell_op(crate::intrinsic::CellFn::Get, vec![alloc], elem);
+        let body_id = body.id;
+        let param = b.param(x, elem);
+        let func = b.function("get_temp", vec![param], elem, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.after(body_id),
+            &[RcOp::DropValue(alloc_id)],
+            "the temporary cell owner outlives get and is then released"
+        );
+    });
+}
+
+#[test]
+fn refcell_in_use_borrows_the_cell() {
+    with_tcx(|tcx| {
+        let mut b = MirBuilder::new(tcx);
+        let elem = b.shared();
+        let cell_ty = b.cell_ty(elem, true);
+        let c = b.fresh_var();
+
+        let base = b.var(c, cell_ty);
+        let boolean = tcx.mk_bool();
+        let body = b.cell_op(crate::intrinsic::CellFn::InUse, vec![base], boolean);
+        let body_id = body.id;
+        let params = vec![b.param(c, cell_ty)];
+        let func = b.function("in_use", params, boolean, body);
+        let ot = run(tcx, &func, &b);
+
+        assert_eq!(
+            ot.after(body_id),
+            &[RcOp::Drop(c)],
+            "the flag read borrows the cell; its last owner drops after"
         );
     });
 }

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -1,15 +1,10 @@
-//! The built-in `core` package's math intrinsics.
+//! The built-in `core::intrinsic` operation families.
 //!
-//! Reussir source reaches them as `core::intrinsic::math::<name>(args…, flag)`
-//! — the package name `core` is reserved, so the path can never collide with
-//! user code. Each intrinsic maps 1:1 onto an MLIR `math` dialect op; the
-//! trailing argument is always a **constant** `i32` fast-math flag
-//! ([`FastMath`]), and the value operands share one `FloatingPoint`-bounded
-//! type (given as an optional explicit type argument, or inferred).
-//!
-//! The surfaced set matches the reference frontend: the float unary group,
-//! the `is*` classification checks (returning `bool`), the float binary
-//! group, `fma`, and `fpowi` (float base, `i32` exponent).
+//! Reussir source reaches these as `core::intrinsic::<family>::<name>(…)` — the
+//! package name `core` is reserved, so the path cannot collide with user code.
+//! [`IntrinsicOp`] is the resolved family-independent representation carried by
+//! HIR and MIR; each family defines its own names, checking, ownership contract,
+//! and code generation.
 
 /// The shape of a math intrinsic's value arguments (the fast-math flag is an
 /// extra trailing argument in the surface form, not counted here).
@@ -175,6 +170,62 @@ pub enum ArrayFn {
     Fold,
 }
 
+/// A built-in operation on a shared mutable [`Cell`](crate::semi::ty::TyKind::Cell),
+/// spelled `core::intrinsic::cell::<fn>` and dispatched on the operand's
+/// cell flavor. A plain `Cell` supports only whole-element
+/// `alloc`/`get`/`set`; an exclusive `RefCell` additionally supports the
+/// guarded `rmw` and the `in_use` observation of its guard flag. The
+/// operation itself does not record the flavor — operand and result types
+/// carry it, the checker enforces it, and the dialect verifier re-checks
+/// it after lowering.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum CellFn {
+    /// `alloc(value)`: move `value` into a fresh cell.
+    Alloc,
+    /// `get(cell)`: clone the value currently stored in `cell`.
+    Get,
+    /// `set(cell, value)`: replace and drop the old value.
+    Set,
+    /// `rmw(cell, update)`: move the value through `update` and store its
+    /// result. Exclusive cells (`RefCell`) only.
+    Rmw,
+    /// `in_use(cell)`: whether the element is currently moved out into an
+    /// active `rmw` updater. Exclusive cells (`RefCell`) only.
+    InUse,
+}
+
+impl CellFn {
+    /// Parse a surface / textual-IR name.
+    pub fn parse(name: &str) -> Option<CellFn> {
+        match name {
+            "alloc" => Some(CellFn::Alloc),
+            "get" => Some(CellFn::Get),
+            "set" => Some(CellFn::Set),
+            "rmw" => Some(CellFn::Rmw),
+            "in_use" => Some(CellFn::InUse),
+            _ => None,
+        }
+    }
+
+    /// The surface name, also used by the textual IR.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CellFn::Alloc => "alloc",
+            CellFn::Get => "get",
+            CellFn::Set => "set",
+            CellFn::Rmw => "rmw",
+            CellFn::InUse => "in_use",
+        }
+    }
+
+    /// Whether this operation exists only on an exclusive cell (`RefCell`).
+    /// The checker rejects these on a plain `Cell` operand, and lowering
+    /// re-derives the flavor from the monomorphized operand type.
+    pub fn requires_exclusive(self) -> bool {
+        matches!(self, CellFn::Rmw | CellFn::InUse)
+    }
+}
+
 impl ArrayFn {
     /// Parse a surface / textual-IR name.
     pub fn parse(name: &str) -> Option<ArrayFn> {
@@ -219,6 +270,9 @@ impl ArrayFn {
 pub enum IntrinsicOp {
     /// `core::intrinsic::math::<func>`, with an `arith.fastmath` flag.
     Math { func: MathFn, flag: u32 },
+    /// `core::intrinsic::cell::<func>`; cell operations have no immediates
+    /// and dispatch on the operand's cell flavor rather than encoding it.
+    Cell { func: CellFn },
 }
 
 impl IntrinsicOp {
@@ -226,6 +280,7 @@ impl IntrinsicOp {
     pub fn family(self) -> &'static str {
         match self {
             IntrinsicOp::Math { .. } => "math",
+            IntrinsicOp::Cell { .. } => "cell",
         }
     }
 
@@ -233,6 +288,7 @@ impl IntrinsicOp {
     pub fn name(self) -> &'static str {
         match self {
             IntrinsicOp::Math { func, .. } => func.as_str(),
+            IntrinsicOp::Cell { func, .. } => func.as_str(),
         }
     }
 
@@ -240,6 +296,7 @@ impl IntrinsicOp {
     pub fn imm(self) -> u32 {
         match self {
             IntrinsicOp::Math { flag, .. } => flag,
+            IntrinsicOp::Cell { .. } => 0,
         }
     }
 
@@ -250,6 +307,9 @@ impl IntrinsicOp {
             "math" => Some(IntrinsicOp::Math {
                 func: MathFn::parse(name)?,
                 flag: imm,
+            }),
+            "cell" if imm == 0 => Some(IntrinsicOp::Cell {
+                func: CellFn::parse(name)?,
             }),
             _ => None,
         }
@@ -271,6 +331,13 @@ mod tests {
                 func: MathFn::Fma,
                 flag: 127,
             },
+            IntrinsicOp::Cell {
+                func: CellFn::Alloc,
+            },
+            IntrinsicOp::Cell { func: CellFn::Rmw },
+            IntrinsicOp::Cell {
+                func: CellFn::InUse,
+            },
         ] {
             assert_eq!(
                 IntrinsicOp::parse(op.family(), op.name(), op.imm()),
@@ -278,6 +345,12 @@ mod tests {
             );
         }
         assert_eq!(IntrinsicOp::parse("math", "nope", 0), None);
+        assert_eq!(IntrinsicOp::parse("cell", "get", 1), None);
+        assert!(
+            IntrinsicOp::parse("cell", "in_use", 0).is_some(),
+            "one textual family; the operand type carries the flavor"
+        );
+        assert_eq!(IntrinsicOp::parse("refcell", "in_use", 0), None);
         assert_eq!(IntrinsicOp::parse("atomic", "sqrt", 0), None);
     }
 
@@ -294,6 +367,15 @@ mod tests {
         }
         assert_eq!(MathFn::parse("log"), None);
         assert_eq!(MathFn::parse("sincos"), None);
+        for f in [
+            CellFn::Alloc,
+            CellFn::Get,
+            CellFn::Set,
+            CellFn::Rmw,
+            CellFn::InUse,
+        ] {
+            assert_eq!(CellFn::parse(f.as_str()), Some(f));
+        }
     }
 
     #[test]

--- a/crates/reussir-core/src/lib.rs
+++ b/crates/reussir-core/src/lib.rs
@@ -9,7 +9,7 @@
 //! interner and adds the ground-only invariant and v0 symbol mangling.
 
 pub mod full;
-/// The built-in `core` package's math intrinsics (`core::intrinsic::math`).
+/// The built-in `core::intrinsic` operation families.
 pub mod intrinsic;
 /// The shared logos lexer for the textual IR (both the MIR and HIR grammars).
 pub mod ir_lex;

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -974,6 +974,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match *family {
             "math" => Some(self.infer_math_intrinsic(fc, span)),
             "array" => Some(self.infer_array_intrinsic(fc, span)),
+            "cell" => Some(self.infer_cell_intrinsic(fc, span)),
             other => {
                 self.error(
                     span,
@@ -1066,6 +1067,187 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
         let op = IntrinsicOp::Math { func, flag };
         self.mk_expr(ExprKind::Intrinsic { op, args }, result, span)
+    }
+
+    /// (CELL) The shared-cell intrinsics, spelled `core::intrinsic::cell::*`
+    /// and dispatched on the operand's cell flavor. `alloc`/`get`/`set` work
+    /// on both a plain `Cell<T>` and an exclusive `RefCell<T>`; `rmw` and
+    /// `in_use` require a `RefCell` operand. A cell operand is borrowed;
+    /// values transferred into `alloc`/`set`, and the update closure passed
+    /// to `rmw`, are consumed according to the ordinary owned calling
+    /// convention. `rmw` checks `update : T -> T`, moving the stored value
+    /// through the callback without the clone performed by `get`; `in_use`
+    /// reads the exclusive cell's guard flag as a `bool`.
+    ///
+    /// `alloc` has no cell operand to dispatch on: it defaults to a plain
+    /// `Cell`, and an explicit type argument naming the cell type selects
+    /// the flavor (`alloc<RefCell<i64>>(1)`).
+    fn infer_cell_intrinsic(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
+        use crate::intrinsic::{CellFn, IntrinsicOp};
+
+        let name = self.sym(fc.name.basename).to_string();
+        let Some(func) = CellFn::parse(&name) else {
+            self.error(
+                span,
+                format!("unknown cell intrinsic `core::intrinsic::cell::{name}`"),
+            );
+            return self.poison(span);
+        };
+        if func != CellFn::Alloc && !fc.ty_args.is_empty() {
+            self.error(
+                span,
+                format!("`core::intrinsic::cell::{name}` takes no type arguments"),
+            );
+            return self.poison(span);
+        }
+
+        let op = IntrinsicOp::Cell { func };
+        match func {
+            CellFn::Alloc => {
+                let [value] = fc.args.as_slice() else {
+                    self.error(span, "`core::intrinsic::cell::alloc` expects one argument");
+                    return self.poison(span);
+                };
+                let result = match fc.ty_args.as_slice() {
+                    [] | [None] => None,
+                    [Some(t)] => {
+                        let ty = self.eval_type(t);
+                        let resolved = self.infer.shallow_resolve(ty);
+                        let TyKind::Cell { .. } = *resolved.kind() else {
+                            let shown = self.infer.resolve(resolved);
+                            self.error(
+                                span,
+                                format!(
+                                    "the type argument of `core::intrinsic::cell::alloc` must \
+                                     be `Cell<T>` or `RefCell<T>`, found `{}`",
+                                    self.ty_display(shown)
+                                ),
+                            );
+                            return self.poison(span);
+                        };
+                        Some(resolved)
+                    }
+                    _ => {
+                        self.error(
+                            span,
+                            "`core::intrinsic::cell::alloc` takes at most one type argument \
+                             (the cell type)",
+                        );
+                        return self.poison(span);
+                    }
+                };
+                let value = match result {
+                    Some(cell_ty) => {
+                        let TyKind::Cell { elem, .. } = *cell_ty.kind() else {
+                            unreachable!("checked above");
+                        };
+                        self.check_expr(value, elem)
+                    }
+                    None => self.infer_expr(value),
+                };
+                let result = result.unwrap_or_else(|| self.tcx.mk_cell(value.ty, false));
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![value],
+                    },
+                    result,
+                    span,
+                )
+            }
+            CellFn::Get | CellFn::InUse => {
+                let [cell] = fc.args.as_slice() else {
+                    self.error(
+                        span,
+                        format!("`core::intrinsic::cell::{name}` expects one argument"),
+                    );
+                    return self.poison(span);
+                };
+                let cell = self.infer_expr(cell);
+                let Some(elem) = self.cell_element(cell.ty, func, &name, span) else {
+                    return self.poison(span);
+                };
+                let result = if func == CellFn::InUse {
+                    self.tcx.mk_bool()
+                } else {
+                    elem
+                };
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![cell],
+                    },
+                    result,
+                    span,
+                )
+            }
+            CellFn::Set | CellFn::Rmw => {
+                let [cell, value] = fc.args.as_slice() else {
+                    self.error(
+                        span,
+                        format!("`core::intrinsic::cell::{name}` expects two arguments"),
+                    );
+                    return self.poison(span);
+                };
+                let cell = self.infer_expr(cell);
+                let Some(elem) = self.cell_element(cell.ty, func, &name, span) else {
+                    return self.poison(span);
+                };
+                let expected = if func == CellFn::Rmw {
+                    self.tcx.mk_closure(&[elem], elem)
+                } else {
+                    elem
+                };
+                let value = self.check_expr(value, expected);
+                let result = self.tcx.mk_unit();
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![cell, value],
+                    },
+                    result,
+                    span,
+                )
+            }
+        }
+    }
+
+    /// Return the element of a cell operand, diagnosing a non-cell value and
+    /// an exclusive-only operation applied to a plain `Cell`.
+    fn cell_element(
+        &mut self,
+        ty: Ty<'tcx>,
+        func: crate::intrinsic::CellFn,
+        method: &str,
+        span: Option<Span>,
+    ) -> Option<Ty<'tcx>> {
+        let resolved = self.infer.shallow_resolve(ty);
+        if let TyKind::Cell { elem, exclusive } = *resolved.kind() {
+            if func.requires_exclusive() && !exclusive {
+                let shown = self.infer.resolve(resolved);
+                self.error(
+                    span,
+                    format!(
+                        "`core::intrinsic::cell::{method}` requires an exclusive cell, found \
+                         `{}`; use a `RefCell`",
+                        self.ty_display(shown)
+                    ),
+                );
+                return None;
+            }
+            Some(elem)
+        } else {
+            let shown = self.infer.resolve(resolved);
+            self.error(
+                span,
+                format!(
+                    "`core::intrinsic::cell::{method}` expects a cell as its first argument, \
+                     found `{}`",
+                    self.ty_display(shown)
+                ),
+            );
+            None
+        }
     }
 
     /// (ARR) The `core::intrinsic::array` family (issue #344) — special

--- a/tests/integration/frontend/cell.rr
+++ b/tests/integration/frontend/cell.rr
@@ -1,0 +1,98 @@
+// The builtin Cell/RefCell types and their intrinsic-only operations must
+// survive both textual frontend IRs with the same types and resolved
+// intrinsic names. All operations live in the single `core::intrinsic::cell`
+// namespace and dispatch on the operand's cell flavor: get/set work on both,
+// while the guarded rmw and the in_use flag read require a RefCell.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %rrc %s --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=MLIR
+// RUN: %rrc %s --emit mlir-llvm --no-source-locations -Oaggressive -o - | %FileCheck %s --check-prefix=FUSED
+
+struct [shared] Boxed {
+    value: i64
+}
+
+struct [value] Holder {
+    cell: Cell<Boxed>
+}
+
+// HIR: pub fn #plain(v0 (c): Cell<i64>, v1 (replacement): i64) -> i64
+// HIR: intrinsic#cell#get#0(v0 : Cell<i64>
+// HIR: intrinsic#cell#set#0(v0 : Cell<i64>{{.*}}v1 : i64
+// MIR: pub fn @_RC5plain(v0 (c): Cell<i64>, v1 (replacement): i64) -> i64
+// MIR: intrinsic#cell#get#0(v0 : Cell<i64>
+// MIR: intrinsic#cell#set#0(v0 : Cell<i64>{{.*}}v1 : i64
+// MLIR-LABEL: func.func @_RC5plain
+// MLIR: %[[OLD:.+]] = reussir.cell.get(%arg0 : !reussir.rc<!reussir.cell<i64>>) : i64
+// MLIR: reussir.cell.set(%arg1 : i64, %arg0 : !reussir.rc<!reussir.cell<i64>>)
+// MLIR: reussir.cell.get
+pub fn plain(c: Cell<i64>, replacement: i64) -> i64 {
+    let old = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, replacement);
+    old + core::intrinsic::cell::get(c)
+}
+
+// A Cell member is stored as the bare cell payload. Projection materializes
+// the shared rc<Cell<...>> link, just like closure/array members.
+// MLIR-LABEL: func.func @_RC6bump_h
+// MLIR-SAME: !reussir.record<compound "_RC6Holder" [value] {!reussir.cell<!reussir.rc<!reussir.record<compound "_RC5Boxed" {i64}>>>}>
+// MLIR: reussir.record.extract
+// MLIR-SAME: !reussir.rc<!reussir.cell<!reussir.rc<!reussir.record<compound "_RC5Boxed" {i64}>>>>
+// MLIR: reussir.cell.set
+// MLIR: reussir.cell.get
+pub fn bump_h(h: Holder, replacement: Boxed) -> i64 {
+    core::intrinsic::cell::set(h.cell, replacement);
+    core::intrinsic::cell::get(h.cell).value
+}
+
+// alloc has no cell operand to dispatch on: it defaults to a plain Cell, and
+// an explicit type argument selects the exclusive flavor. The two flavors
+// nest freely.
+// HIR: pub fn #nested() -> Cell<RefCell<i64>>
+// HIR: intrinsic#cell#alloc#0(intrinsic#cell#alloc#0(1 : i64) : RefCell<i64>
+// MIR: pub fn @_RC6nested() -> Cell<RefCell<i64>>
+// MIR: intrinsic#cell#alloc#0(intrinsic#cell#alloc#0(1 : i64) : RefCell<i64>
+// MLIR-LABEL: func.func @_RC6nested
+// MLIR: %[[INNER:.+]] = reussir.cell.create value(%{{.+}} : i64) : !reussir.rc<!reussir.cell<i64 exclusive>>
+// MLIR: reussir.cell.create value(%[[INNER]] : !reussir.rc<!reussir.cell<i64 exclusive>>) : !reussir.rc<!reussir.cell<!reussir.rc<!reussir.cell<i64 exclusive>>>>
+pub fn nested() -> Cell<RefCell<i64>> {
+    core::intrinsic::cell::alloc(core::intrinsic::cell::alloc<RefCell<i64>>(1))
+}
+
+// The exclusive operations: rmw moves the element through the updater, and
+// in_use reads the guard flag. Same namespace, dispatched on the RefCell
+// operand.
+// HIR: pub fn #guarded(v0 (c): RefCell<i64>, v1 (replacement): i64) -> i64
+// HIR: intrinsic#cell#get#0(v0 : RefCell<i64>
+// HIR: intrinsic#cell#set#0(v0 : RefCell<i64>{{.*}}v1 : i64
+// HIR: intrinsic#cell#rmw#0(v0 : RefCell<i64>{{.*}}closure[]
+// HIR: intrinsic#cell#in_use#0(v0 : RefCell<i64>
+// MIR: pub fn @_RC7guarded(v0 (c): RefCell<i64>, v1 (replacement): i64) -> i64
+// MIR: intrinsic#cell#rmw#0(v0 : RefCell<i64>{{.*}}closure[]
+// MIR: intrinsic#cell#in_use#0(v0 : RefCell<i64>
+// MLIR-LABEL: func.func @_RC7guarded
+// MLIR: %[[OLD:.+]] = reussir.cell.get(%arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>) : i64
+// MLIR: reussir.cell.set(%arg1 : i64, %arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>)
+// MLIR: reussir.closure.create
+// MLIR: reussir.cell.rmw(%arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>) {
+// MLIR: ^bb0(%[[CURRENT:.+]]: i64):
+// MLIR: reussir.rc.inc
+// MLIR: reussir.closure.eval
+// MLIR: reussir.cell.yield(%{{.+}} : i64)
+// MLIR: reussir.rc.dec
+// MLIR: %[[FLAG:.+]] = reussir.cell.in_use(%arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>) : i1
+// MLIR: reussir.cell.get
+pub fn guarded(c: RefCell<i64>, replacement: i64) -> i64 {
+    let old = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, replacement);
+    core::intrinsic::cell::rmw(c, |x| x + 1);
+    let busy = core::intrinsic::cell::in_use(c);
+    if busy { 0 } else { old + core::intrinsic::cell::get(c) }
+}
+
+// Structural beta reduction is intentionally enabled through cell.rmw: a
+// literal updater fuses completely at aggressive optimization.
+// FUSED-LABEL: llvm.func @_RC7guarded
+// FUSED-NOT: closure
+// FUSED: llvm.add

--- a/tests/integration/frontend/cell_e2e.c
+++ b/tests/integration/frontend/cell_e2e.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t test_scalar_ffi(void);
+extern int64_t test_managed_element_ffi(void);
+extern int64_t test_nested_cell_ffi(void);
+extern int64_t test_record_member_ffi(void);
+extern int64_t test_generic_ffi(void);
+extern int64_t test_in_use_ffi(void);
+extern int64_t test_rc_cycle_ffi(void);
+
+static int check(const char *name, int64_t got, int64_t want) {
+  if (got == want)
+    return 0;
+  fprintf(stderr, "%s: got %lld, want %lld\n", name, (long long)got,
+          (long long)want);
+  return 1;
+}
+
+int main(void) {
+  int failures = 0;
+  failures += check("scalar", test_scalar_ffi(), 32);
+  failures += check("managed_element", test_managed_element_ffi(), 16);
+  failures += check("nested_cell", test_nested_cell_ffi(), 24);
+  failures += check("record_member", test_record_member_ffi(), 42);
+  failures += check("generic", test_generic_ffi(), 41);
+  failures += check("in_use", test_in_use_ffi(), 7);
+  failures += check("rc_cycle", test_rc_cycle_ffi(), 42);
+  return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/cell_e2e.rr
+++ b/tests/integration/frontend/cell_e2e.rr
@@ -1,0 +1,114 @@
+// End-to-end Cell/RefCell semantics: managed elements, nested cells, guarded
+// RMW and in_use on the exclusive flavor, temporary borrowed cells, and cell
+// projection from a record. All operations share the `core::intrinsic::cell`
+// namespace and dispatch on the operand's cell flavor; `alloc` selects the
+// exclusive flavor with an explicit type argument.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/cell_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/cell_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+struct [shared] Boxed {
+    value: i64
+}
+
+struct [value] Holder {
+    cell: RefCell<Boxed>
+}
+
+struct [shared] CycleNode {
+    value: i64,
+    next: Cell<Nullable<CycleNode>>
+}
+
+pub fn test_scalar() -> i64 {
+    let c = core::intrinsic::cell::alloc<RefCell<i64>>(10);
+    let before = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, 20);
+    core::intrinsic::cell::rmw(c, |x| x + 2);
+    before + core::intrinsic::cell::get(c)
+}
+extern "C" trampoline "test_scalar_ffi" = test_scalar;
+
+// The exclusive cell owns a shared record. get clones it, set drops the old
+// value, and RMW moves the current record through the updater without an
+// extra clone.
+pub fn test_managed_element() -> i64 {
+    let c = core::intrinsic::cell::alloc<RefCell<Boxed>>(Boxed { value: 5 });
+    let first = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, Boxed { value: 8 });
+    core::intrinsic::cell::rmw(c, |x| Boxed { value: x.value + 3 });
+    first.value + core::intrinsic::cell::get(c).value
+}
+extern "C" trampoline "test_managed_element_ffi" = test_managed_element;
+
+// outer (a plain Cell) owns an exclusive inner; get(outer) clones the inner
+// RefCell reference. RMW directly on another temporary clone must release
+// that temporary only after the body.
+pub fn test_nested_cell() -> i64 {
+    let inner = core::intrinsic::cell::alloc<RefCell<i64>>(3);
+    let outer = core::intrinsic::cell::alloc(inner);
+    let alias = core::intrinsic::cell::get(outer);
+    core::intrinsic::cell::set(alias, 7);
+    core::intrinsic::cell::rmw(core::intrinsic::cell::get(outer), |x| x + 5);
+    core::intrinsic::cell::get(alias)
+        + core::intrinsic::cell::get(core::intrinsic::cell::get(outer))
+}
+extern "C" trampoline "test_nested_cell_ffi" = test_nested_cell;
+
+// A projected RefCell is an owned clone of the shared link while the Holder
+// keeps its member. Both the updater and subsequent read borrow those
+// projections.
+pub fn test_record_member() -> i64 {
+    let h = Holder { cell: core::intrinsic::cell::alloc<RefCell<Boxed>>(Boxed { value: 40 }) };
+    core::intrinsic::cell::rmw(h.cell, |x| Boxed { value: x.value + 2 });
+    core::intrinsic::cell::get(h.cell).value
+}
+extern "C" trampoline "test_record_member_ffi" = test_record_member;
+
+fn generic_get<T>(c: Cell<T>) -> T {
+    core::intrinsic::cell::get(c)
+}
+
+pub fn test_generic() -> i64 {
+    generic_get(core::intrinsic::cell::alloc(41))
+}
+extern "C" trampoline "test_generic_ffi" = test_generic;
+
+// Outside any rmw body the guard flag reads false, including through a
+// generic instantiation.
+fn generic_busy<T>(c: RefCell<T>) -> bool {
+    core::intrinsic::cell::in_use(c)
+}
+
+pub fn test_in_use() -> i64 {
+    let c = core::intrinsic::cell::alloc<RefCell<i64>>(6);
+    let busy = generic_busy(c);
+    if busy { 0 } else { core::intrinsic::cell::get(c) + 1 }
+}
+extern "C" trampoline "test_in_use_ffi" = test_in_use;
+
+// `node` owns a reference to `link`, then `link` is updated to own `node`:
+//
+//     node -> link -> node
+//
+// Plain reference counting cannot collect that cycle. Clearing the cell breaks
+// it explicitly; the sanitizer wrapper verifies that recursively dropping the
+// node also releases its nested Cell reference. `get` must clone the nullable
+// element (the acquisition fixed by the exclusive-cell backend rework), or
+// the read below would use freed memory once the cell is cleared.
+pub fn test_rc_cycle() -> i64 {
+    let link = core::intrinsic::cell::alloc(Nullable::Null);
+    let node = CycleNode { value: 42, next: link };
+    core::intrinsic::cell::set(link, Nullable::NonNull { node });
+    let value = match core::intrinsic::cell::get(link) {
+        Nullable::NonNull(node) => node.value,
+        Nullable::Null => -1
+    };
+    core::intrinsic::cell::set(link, Nullable::Null);
+    value
+}
+extern "C" trampoline "test_rc_cycle_ffi" = test_rc_cycle;

--- a/tests/integration/frontend/cell_errors.rr
+++ b/tests/integration/frontend/cell_errors.rr
@@ -1,0 +1,52 @@
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+// Cell and RefCell are root builtin type constructors.
+// CHECK-DAG: `Cell` takes exactly one type argument
+fn missing_type(c: Cell) -> i64 { 0 }
+
+// CHECK-DAG: `RefCell` takes exactly one type argument
+fn missing_ref_type(c: RefCell) -> i64 { 0 }
+
+// CHECK-DAG: record name `Cell` is reserved for the builtin type
+struct Cell { value: i64 }
+
+// CHECK-DAG: record name `RefCell` is reserved for the builtin type
+struct RefCell { value: i64 }
+
+// A mutable `[field]` link must still point at a regional record, not a Cell.
+// CHECK-DAG: a `[field]` link element must be a regional record
+struct [regional] BadLink { value: [field] Cell<i64> }
+
+// CHECK: unknown cell intrinsic `core::intrinsic::cell::swap`
+fn unknown(c: Cell<i64>) -> i64 { core::intrinsic::cell::swap(c) }
+
+// Read-modify-write and the guard flag dispatch on the operand and demand
+// the exclusive flavor.
+// CHECK: `core::intrinsic::cell::rmw` requires an exclusive cell, found `Cell<i64>`; use a `RefCell`
+fn plain_rmw(c: Cell<i64>) -> unit {
+    core::intrinsic::cell::rmw(c, |x| x)
+}
+
+// CHECK: `core::intrinsic::cell::in_use` requires an exclusive cell, found `Cell<i64>`; use a `RefCell`
+fn plain_in_use(c: Cell<i64>) -> bool { core::intrinsic::cell::in_use(c) }
+
+// CHECK: `core::intrinsic::cell::get` expects a cell as its first argument, found `i64`
+fn not_cell(x: i64) -> i64 { core::intrinsic::cell::get(x) }
+
+// CHECK: type mismatch: expected `i64`, found `bool`
+fn wrong_set(c: Cell<i64>) -> unit { core::intrinsic::cell::set(c, true) }
+
+// CHECK: type mismatch: expected `i64 -> i64`, found `bool -> bool`
+fn wrong_rmw(c: RefCell<i64>) -> unit {
+    core::intrinsic::cell::rmw(c, |x: bool| x)
+}
+
+// alloc's optional type argument must name the cell type, not the element.
+// CHECK: the type argument of `core::intrinsic::cell::alloc` must be `Cell<T>` or `RefCell<T>`, found `i64`
+fn elem_type_arg() -> Cell<i64> { core::intrinsic::cell::alloc<i64>(1) }
+
+// CHECK: `bool` does not implement `Integral`
+fn wrong_alloc() -> RefCell<bool> { core::intrinsic::cell::alloc<RefCell<bool>>(1) }
+
+// CHECK: `core::intrinsic::cell::get` takes no type arguments
+fn typed_get(c: Cell<i64>) -> i64 { core::intrinsic::cell::get<i64>(c) }

--- a/tests/integration/sanitizer/e2e/cell.rr
+++ b/tests/integration/sanitizer/e2e/cell.rr
@@ -1,0 +1,23 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/cell_e2e.rr. The managed-element and nested-cell
+// cases exercise recursive RC destruction; the RC-cycle case forms
+// `node -> Cell -> node` and then explicitly breaks it (its get-clone is the
+// nullable acquisition the backend rework fixed), while RMW tests both
+// literal-closure execution and aggressive structural beta reduction.
+// `--sanitizer address` instruments the generated code itself; shadow-based
+// sanitizers require the arch-independent nullary variant encoding.
+
+// RUN: %rrc %S/../../frontend/cell_e2e.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/cell_e2e.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/cell_e2e.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/cell_e2e.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/cell_e2e.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/cell_e2e.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe


### PR DESCRIPTION
## Stack

3 of 7. Depends on #417. Reworked on top of the merged exclusive-cell backend (#422).

## Summary

- add the `cell::{alloc,get,set,rmw,in_use}` intrinsic identities and textual round trips in a single `cell` family; the operand and result types carry the cell flavor, so the operation does not encode it
- mark `rmw`/`in_use` as requiring an exclusive cell (`RefCell`), for the checker and lowering to enforce against the operand type
- define ownership placement: cell operands are borrowed, replacements and updaters are consumed, `get` returns a cloned value, and `in_use` reads the guard flag without touching the element
- prepare codegen dispatch for the lowering supplied later in the stack

The surface checker does not expose these intrinsics in this layer, so the deliberately deferred lowering path is unreachable from source programs.

## Validation

- `cargo check --workspace`
- intrinsic unit tests (7 passed)