### PR TITLE
[frontend] expose Cell intrinsics dispatched on the operand type

### DIFF
--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -974,6 +974,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match *family {
             "math" => Some(self.infer_math_intrinsic(fc, span)),
             "array" => Some(self.infer_array_intrinsic(fc, span)),
+            "cell" => Some(self.infer_cell_intrinsic(fc, span)),
             other => {
                 self.error(
                     span,
@@ -1066,6 +1067,187 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
         let op = IntrinsicOp::Math { func, flag };
         self.mk_expr(ExprKind::Intrinsic { op, args }, result, span)
+    }
+
+    /// (CELL) The shared-cell intrinsics, spelled `core::intrinsic::cell::*`
+    /// and dispatched on the operand's cell flavor. `alloc`/`get`/`set` work
+    /// on both a plain `Cell<T>` and an exclusive `RefCell<T>`; `rmw` and
+    /// `in_use` require a `RefCell` operand. A cell operand is borrowed;
+    /// values transferred into `alloc`/`set`, and the update closure passed
+    /// to `rmw`, are consumed according to the ordinary owned calling
+    /// convention. `rmw` checks `update : T -> T`, moving the stored value
+    /// through the callback without the clone performed by `get`; `in_use`
+    /// reads the exclusive cell's guard flag as a `bool`.
+    ///
+    /// `alloc` has no cell operand to dispatch on: it defaults to a plain
+    /// `Cell`, and an explicit type argument naming the cell type selects
+    /// the flavor (`alloc<RefCell<i64>>(1)`).
+    fn infer_cell_intrinsic(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
+        use crate::intrinsic::{CellFn, IntrinsicOp};
+
+        let name = self.sym(fc.name.basename).to_string();
+        let Some(func) = CellFn::parse(&name) else {
+            self.error(
+                span,
+                format!("unknown cell intrinsic `core::intrinsic::cell::{name}`"),
+            );
+            return self.poison(span);
+        };
+        if func != CellFn::Alloc && !fc.ty_args.is_empty() {
+            self.error(
+                span,
+                format!("`core::intrinsic::cell::{name}` takes no type arguments"),
+            );
+            return self.poison(span);
+        }
+
+        let op = IntrinsicOp::Cell { func };
+        match func {
+            CellFn::Alloc => {
+                let [value] = fc.args.as_slice() else {
+                    self.error(span, "`core::intrinsic::cell::alloc` expects one argument");
+                    return self.poison(span);
+                };
+                let result = match fc.ty_args.as_slice() {
+                    [] | [None] => None,
+                    [Some(t)] => {
+                        let ty = self.eval_type(t);
+                        let resolved = self.infer.shallow_resolve(ty);
+                        let TyKind::Cell { .. } = *resolved.kind() else {
+                            let shown = self.infer.resolve(resolved);
+                            self.error(
+                                span,
+                                format!(
+                                    "the type argument of `core::intrinsic::cell::alloc` must \
+                                     be `Cell<T>` or `RefCell<T>`, found `{}`",
+                                    self.ty_display(shown)
+                                ),
+                            );
+                            return self.poison(span);
+                        };
+                        Some(resolved)
+                    }
+                    _ => {
+                        self.error(
+                            span,
+                            "`core::intrinsic::cell::alloc` takes at most one type argument \
+                             (the cell type)",
+                        );
+                        return self.poison(span);
+                    }
+                };
+                let value = match result {
+                    Some(cell_ty) => {
+                        let TyKind::Cell { elem, .. } = *cell_ty.kind() else {
+                            unreachable!("checked above");
+                        };
+                        self.check_expr(value, elem)
+                    }
+                    None => self.infer_expr(value),
+                };
+                let result = result.unwrap_or_else(|| self.tcx.mk_cell(value.ty, false));
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![value],
+                    },
+                    result,
+                    span,
+                )
+            }
+            CellFn::Get | CellFn::InUse => {
+                let [cell] = fc.args.as_slice() else {
+                    self.error(
+                        span,
+                        format!("`core::intrinsic::cell::{name}` expects one argument"),
+                    );
+                    return self.poison(span);
+                };
+                let cell = self.infer_expr(cell);
+                let Some(elem) = self.cell_element(cell.ty, func, &name, span) else {
+                    return self.poison(span);
+                };
+                let result = if func == CellFn::InUse {
+                    self.tcx.mk_bool()
+                } else {
+                    elem
+                };
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![cell],
+                    },
+                    result,
+                    span,
+                )
+            }
+            CellFn::Set | CellFn::Rmw => {
+                let [cell, value] = fc.args.as_slice() else {
+                    self.error(
+                        span,
+                        format!("`core::intrinsic::cell::{name}` expects two arguments"),
+                    );
+                    return self.poison(span);
+                };
+                let cell = self.infer_expr(cell);
+                let Some(elem) = self.cell_element(cell.ty, func, &name, span) else {
+                    return self.poison(span);
+                };
+                let expected = if func == CellFn::Rmw {
+                    self.tcx.mk_closure(&[elem], elem)
+                } else {
+                    elem
+                };
+                let value = self.check_expr(value, expected);
+                let result = self.tcx.mk_unit();
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![cell, value],
+                    },
+                    result,
+                    span,
+                )
+            }
+        }
+    }
+
+    /// Return the element of a cell operand, diagnosing a non-cell value and
+    /// an exclusive-only operation applied to a plain `Cell`.
+    fn cell_element(
+        &mut self,
+        ty: Ty<'tcx>,
+        func: crate::intrinsic::CellFn,
+        method: &str,
+        span: Option<Span>,
+    ) -> Option<Ty<'tcx>> {
+        let resolved = self.infer.shallow_resolve(ty);
+        if let TyKind::Cell { elem, exclusive } = *resolved.kind() {
+            if func.requires_exclusive() && !exclusive {
+                let shown = self.infer.resolve(resolved);
+                self.error(
+                    span,
+                    format!(
+                        "`core::intrinsic::cell::{method}` requires an exclusive cell, found \
+                         `{}`; use a `RefCell`",
+                        self.ty_display(shown)
+                    ),
+                );
+                return None;
+            }
+            Some(elem)
+        } else {
+            let shown = self.infer.resolve(resolved);
+            self.error(
+                span,
+                format!(
+                    "`core::intrinsic::cell::{method}` expects a cell as its first argument, \
+                     found `{}`",
+                    self.ty_display(shown)
+                ),
+            );
+            None
+        }
     }
 
     /// (ARR) The `core::intrinsic::array` family (issue #344) — special

--- a/tests/integration/frontend/cell.rr
+++ b/tests/integration/frontend/cell.rr
@@ -1,0 +1,98 @@
+// The builtin Cell/RefCell types and their intrinsic-only operations must
+// survive both textual frontend IRs with the same types and resolved
+// intrinsic names. All operations live in the single `core::intrinsic::cell`
+// namespace and dispatch on the operand's cell flavor: get/set work on both,
+// while the guarded rmw and the in_use flag read require a RefCell.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %rrc %s --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=MLIR
+// RUN: %rrc %s --emit mlir-llvm --no-source-locations -Oaggressive -o - | %FileCheck %s --check-prefix=FUSED
+
+struct [shared] Boxed {
+    value: i64
+}
+
+struct [value] Holder {
+    cell: Cell<Boxed>
+}
+
+// HIR: pub fn #plain(v0 (c): Cell<i64>, v1 (replacement): i64) -> i64
+// HIR: intrinsic#cell#get#0(v0 : Cell<i64>
+// HIR: intrinsic#cell#set#0(v0 : Cell<i64>{{.*}}v1 : i64
+// MIR: pub fn @_RC5plain(v0 (c): Cell<i64>, v1 (replacement): i64) -> i64
+// MIR: intrinsic#cell#get#0(v0 : Cell<i64>
+// MIR: intrinsic#cell#set#0(v0 : Cell<i64>{{.*}}v1 : i64
+// MLIR-LABEL: func.func @_RC5plain
+// MLIR: %[[OLD:.+]] = reussir.cell.get(%arg0 : !reussir.rc<!reussir.cell<i64>>) : i64
+// MLIR: reussir.cell.set(%arg1 : i64, %arg0 : !reussir.rc<!reussir.cell<i64>>)
+// MLIR: reussir.cell.get
+pub fn plain(c: Cell<i64>, replacement: i64) -> i64 {
+    let old = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, replacement);
+    old + core::intrinsic::cell::get(c)
+}
+
+// A Cell member is stored as the bare cell payload. Projection materializes
+// the shared rc<Cell<...>> link, just like closure/array members.
+// MLIR-LABEL: func.func @_RC6bump_h
+// MLIR-SAME: !reussir.record<compound "_RC6Holder" [value] {!reussir.cell<!reussir.rc<!reussir.record<compound "_RC5Boxed" {i64}>>>}>
+// MLIR: reussir.record.extract
+// MLIR-SAME: !reussir.rc<!reussir.cell<!reussir.rc<!reussir.record<compound "_RC5Boxed" {i64}>>>>
+// MLIR: reussir.cell.set
+// MLIR: reussir.cell.get
+pub fn bump_h(h: Holder, replacement: Boxed) -> i64 {
+    core::intrinsic::cell::set(h.cell, replacement);
+    core::intrinsic::cell::get(h.cell).value
+}
+
+// alloc has no cell operand to dispatch on: it defaults to a plain Cell, and
+// an explicit type argument selects the exclusive flavor. The two flavors
+// nest freely.
+// HIR: pub fn #nested() -> Cell<RefCell<i64>>
+// HIR: intrinsic#cell#alloc#0(intrinsic#cell#alloc#0(1 : i64) : RefCell<i64>
+// MIR: pub fn @_RC6nested() -> Cell<RefCell<i64>>
+// MIR: intrinsic#cell#alloc#0(intrinsic#cell#alloc#0(1 : i64) : RefCell<i64>
+// MLIR-LABEL: func.func @_RC6nested
+// MLIR: %[[INNER:.+]] = reussir.cell.create value(%{{.+}} : i64) : !reussir.rc<!reussir.cell<i64 exclusive>>
+// MLIR: reussir.cell.create value(%[[INNER]] : !reussir.rc<!reussir.cell<i64 exclusive>>) : !reussir.rc<!reussir.cell<!reussir.rc<!reussir.cell<i64 exclusive>>>>
+pub fn nested() -> Cell<RefCell<i64>> {
+    core::intrinsic::cell::alloc(core::intrinsic::cell::alloc<RefCell<i64>>(1))
+}
+
+// The exclusive operations: rmw moves the element through the updater, and
+// in_use reads the guard flag. Same namespace, dispatched on the RefCell
+// operand.
+// HIR: pub fn #guarded(v0 (c): RefCell<i64>, v1 (replacement): i64) -> i64
+// HIR: intrinsic#cell#get#0(v0 : RefCell<i64>
+// HIR: intrinsic#cell#set#0(v0 : RefCell<i64>{{.*}}v1 : i64
+// HIR: intrinsic#cell#rmw#0(v0 : RefCell<i64>{{.*}}closure[]
+// HIR: intrinsic#cell#in_use#0(v0 : RefCell<i64>
+// MIR: pub fn @_RC7guarded(v0 (c): RefCell<i64>, v1 (replacement): i64) -> i64
+// MIR: intrinsic#cell#rmw#0(v0 : RefCell<i64>{{.*}}closure[]
+// MIR: intrinsic#cell#in_use#0(v0 : RefCell<i64>
+// MLIR-LABEL: func.func @_RC7guarded
+// MLIR: %[[OLD:.+]] = reussir.cell.get(%arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>) : i64
+// MLIR: reussir.cell.set(%arg1 : i64, %arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>)
+// MLIR: reussir.closure.create
+// MLIR: reussir.cell.rmw(%arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>) {
+// MLIR: ^bb0(%[[CURRENT:.+]]: i64):
+// MLIR: reussir.rc.inc
+// MLIR: reussir.closure.eval
+// MLIR: reussir.cell.yield(%{{.+}} : i64)
+// MLIR: reussir.rc.dec
+// MLIR: %[[FLAG:.+]] = reussir.cell.in_use(%arg0 : !reussir.rc<!reussir.cell<i64 exclusive>>) : i1
+// MLIR: reussir.cell.get
+pub fn guarded(c: RefCell<i64>, replacement: i64) -> i64 {
+    let old = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, replacement);
+    core::intrinsic::cell::rmw(c, |x| x + 1);
+    let busy = core::intrinsic::cell::in_use(c);
+    if busy { 0 } else { old + core::intrinsic::cell::get(c) }
+}
+
+// Structural beta reduction is intentionally enabled through cell.rmw: a
+// literal updater fuses completely at aggressive optimization.
+// FUSED-LABEL: llvm.func @_RC7guarded
+// FUSED-NOT: closure
+// FUSED: llvm.add

--- a/tests/integration/frontend/cell_e2e.c
+++ b/tests/integration/frontend/cell_e2e.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t test_scalar_ffi(void);
+extern int64_t test_managed_element_ffi(void);
+extern int64_t test_nested_cell_ffi(void);
+extern int64_t test_record_member_ffi(void);
+extern int64_t test_generic_ffi(void);
+extern int64_t test_in_use_ffi(void);
+extern int64_t test_rc_cycle_ffi(void);
+
+static int check(const char *name, int64_t got, int64_t want) {
+  if (got == want)
+    return 0;
+  fprintf(stderr, "%s: got %lld, want %lld\n", name, (long long)got,
+          (long long)want);
+  return 1;
+}
+
+int main(void) {
+  int failures = 0;
+  failures += check("scalar", test_scalar_ffi(), 32);
+  failures += check("managed_element", test_managed_element_ffi(), 16);
+  failures += check("nested_cell", test_nested_cell_ffi(), 24);
+  failures += check("record_member", test_record_member_ffi(), 42);
+  failures += check("generic", test_generic_ffi(), 41);
+  failures += check("in_use", test_in_use_ffi(), 7);
+  failures += check("rc_cycle", test_rc_cycle_ffi(), 42);
+  return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/cell_e2e.rr
+++ b/tests/integration/frontend/cell_e2e.rr
@@ -1,0 +1,114 @@
+// End-to-end Cell/RefCell semantics: managed elements, nested cells, guarded
+// RMW and in_use on the exclusive flavor, temporary borrowed cells, and cell
+// projection from a record. All operations share the `core::intrinsic::cell`
+// namespace and dispatch on the operand's cell flavor; `alloc` selects the
+// exclusive flavor with an explicit type argument.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/cell_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/cell_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+struct [shared] Boxed {
+    value: i64
+}
+
+struct [value] Holder {
+    cell: RefCell<Boxed>
+}
+
+struct [shared] CycleNode {
+    value: i64,
+    next: Cell<Nullable<CycleNode>>
+}
+
+pub fn test_scalar() -> i64 {
+    let c = core::intrinsic::cell::alloc<RefCell<i64>>(10);
+    let before = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, 20);
+    core::intrinsic::cell::rmw(c, |x| x + 2);
+    before + core::intrinsic::cell::get(c)
+}
+extern "C" trampoline "test_scalar_ffi" = test_scalar;
+
+// The exclusive cell owns a shared record. get clones it, set drops the old
+// value, and RMW moves the current record through the updater without an
+// extra clone.
+pub fn test_managed_element() -> i64 {
+    let c = core::intrinsic::cell::alloc<RefCell<Boxed>>(Boxed { value: 5 });
+    let first = core::intrinsic::cell::get(c);
+    core::intrinsic::cell::set(c, Boxed { value: 8 });
+    core::intrinsic::cell::rmw(c, |x| Boxed { value: x.value + 3 });
+    first.value + core::intrinsic::cell::get(c).value
+}
+extern "C" trampoline "test_managed_element_ffi" = test_managed_element;
+
+// outer (a plain Cell) owns an exclusive inner; get(outer) clones the inner
+// RefCell reference. RMW directly on another temporary clone must release
+// that temporary only after the body.
+pub fn test_nested_cell() -> i64 {
+    let inner = core::intrinsic::cell::alloc<RefCell<i64>>(3);
+    let outer = core::intrinsic::cell::alloc(inner);
+    let alias = core::intrinsic::cell::get(outer);
+    core::intrinsic::cell::set(alias, 7);
+    core::intrinsic::cell::rmw(core::intrinsic::cell::get(outer), |x| x + 5);
+    core::intrinsic::cell::get(alias)
+        + core::intrinsic::cell::get(core::intrinsic::cell::get(outer))
+}
+extern "C" trampoline "test_nested_cell_ffi" = test_nested_cell;
+
+// A projected RefCell is an owned clone of the shared link while the Holder
+// keeps its member. Both the updater and subsequent read borrow those
+// projections.
+pub fn test_record_member() -> i64 {
+    let h = Holder { cell: core::intrinsic::cell::alloc<RefCell<Boxed>>(Boxed { value: 40 }) };
+    core::intrinsic::cell::rmw(h.cell, |x| Boxed { value: x.value + 2 });
+    core::intrinsic::cell::get(h.cell).value
+}
+extern "C" trampoline "test_record_member_ffi" = test_record_member;
+
+fn generic_get<T>(c: Cell<T>) -> T {
+    core::intrinsic::cell::get(c)
+}
+
+pub fn test_generic() -> i64 {
+    generic_get(core::intrinsic::cell::alloc(41))
+}
+extern "C" trampoline "test_generic_ffi" = test_generic;
+
+// Outside any rmw body the guard flag reads false, including through a
+// generic instantiation.
+fn generic_busy<T>(c: RefCell<T>) -> bool {
+    core::intrinsic::cell::in_use(c)
+}
+
+pub fn test_in_use() -> i64 {
+    let c = core::intrinsic::cell::alloc<RefCell<i64>>(6);
+    let busy = generic_busy(c);
+    if busy { 0 } else { core::intrinsic::cell::get(c) + 1 }
+}
+extern "C" trampoline "test_in_use_ffi" = test_in_use;
+
+// `node` owns a reference to `link`, then `link` is updated to own `node`:
+//
+//     node -> link -> node
+//
+// Plain reference counting cannot collect that cycle. Clearing the cell breaks
+// it explicitly; the sanitizer wrapper verifies that recursively dropping the
+// node also releases its nested Cell reference. `get` must clone the nullable
+// element (the acquisition fixed by the exclusive-cell backend rework), or
+// the read below would use freed memory once the cell is cleared.
+pub fn test_rc_cycle() -> i64 {
+    let link = core::intrinsic::cell::alloc(Nullable::Null);
+    let node = CycleNode { value: 42, next: link };
+    core::intrinsic::cell::set(link, Nullable::NonNull { node });
+    let value = match core::intrinsic::cell::get(link) {
+        Nullable::NonNull(node) => node.value,
+        Nullable::Null => -1
+    };
+    core::intrinsic::cell::set(link, Nullable::Null);
+    value
+}
+extern "C" trampoline "test_rc_cycle_ffi" = test_rc_cycle;

--- a/tests/integration/frontend/cell_errors.rr
+++ b/tests/integration/frontend/cell_errors.rr
@@ -1,0 +1,52 @@
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+// Cell and RefCell are root builtin type constructors.
+// CHECK-DAG: `Cell` takes exactly one type argument
+fn missing_type(c: Cell) -> i64 { 0 }
+
+// CHECK-DAG: `RefCell` takes exactly one type argument
+fn missing_ref_type(c: RefCell) -> i64 { 0 }
+
+// CHECK-DAG: record name `Cell` is reserved for the builtin type
+struct Cell { value: i64 }
+
+// CHECK-DAG: record name `RefCell` is reserved for the builtin type
+struct RefCell { value: i64 }
+
+// A mutable `[field]` link must still point at a regional record, not a Cell.
+// CHECK-DAG: a `[field]` link element must be a regional record
+struct [regional] BadLink { value: [field] Cell<i64> }
+
+// CHECK: unknown cell intrinsic `core::intrinsic::cell::swap`
+fn unknown(c: Cell<i64>) -> i64 { core::intrinsic::cell::swap(c) }
+
+// Read-modify-write and the guard flag dispatch on the operand and demand
+// the exclusive flavor.
+// CHECK: `core::intrinsic::cell::rmw` requires an exclusive cell, found `Cell<i64>`; use a `RefCell`
+fn plain_rmw(c: Cell<i64>) -> unit {
+    core::intrinsic::cell::rmw(c, |x| x)
+}
+
+// CHECK: `core::intrinsic::cell::in_use` requires an exclusive cell, found `Cell<i64>`; use a `RefCell`
+fn plain_in_use(c: Cell<i64>) -> bool { core::intrinsic::cell::in_use(c) }
+
+// CHECK: `core::intrinsic::cell::get` expects a cell as its first argument, found `i64`
+fn not_cell(x: i64) -> i64 { core::intrinsic::cell::get(x) }
+
+// CHECK: type mismatch: expected `i64`, found `bool`
+fn wrong_set(c: Cell<i64>) -> unit { core::intrinsic::cell::set(c, true) }
+
+// CHECK: type mismatch: expected `i64 -> i64`, found `bool -> bool`
+fn wrong_rmw(c: RefCell<i64>) -> unit {
+    core::intrinsic::cell::rmw(c, |x: bool| x)
+}
+
+// alloc's optional type argument must name the cell type, not the element.
+// CHECK: the type argument of `core::intrinsic::cell::alloc` must be `Cell<T>` or `RefCell<T>`, found `i64`
+fn elem_type_arg() -> Cell<i64> { core::intrinsic::cell::alloc<i64>(1) }
+
+// CHECK: `bool` does not implement `Integral`
+fn wrong_alloc() -> RefCell<bool> { core::intrinsic::cell::alloc<RefCell<bool>>(1) }
+
+// CHECK: `core::intrinsic::cell::get` takes no type arguments
+fn typed_get(c: Cell<i64>) -> i64 { core::intrinsic::cell::get<i64>(c) }

--- a/tests/integration/sanitizer/e2e/cell.rr
+++ b/tests/integration/sanitizer/e2e/cell.rr
@@ -1,0 +1,23 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/cell_e2e.rr. The managed-element and nested-cell
+// cases exercise recursive RC destruction; the RC-cycle case forms
+// `node -> Cell -> node` and then explicitly breaks it (its get-clone is the
+// nullable acquisition the backend rework fixed), while RMW tests both
+// literal-closure execution and aggressive structural beta reduction.
+// `--sanitizer address` instruments the generated code itself; shadow-based
+// sanitizers require the arch-independent nullary variant encoding.
+
+// RUN: %rrc %S/../../frontend/cell_e2e.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/cell_e2e.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/cell_e2e.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/cell_e2e.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/cell_e2e.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/cell_e2e.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe


### PR DESCRIPTION
## Stack

6 of 7. Depends on #420. Reworked on top of the merged exclusive-cell backend (#422).

## Summary

- expose `core::intrinsic::cell::{alloc,get,set,rmw,in_use}` to source programs in a single namespace; operations dispatch on the operand's cell flavor, with `rmw`/`in_use` demanding an exclusive `RefCell`
- `alloc` has no cell operand to dispatch on: it defaults to a plain `Cell`, and an explicit type argument selects the flavor (`alloc<RefCell<i64>>(1)`)
- type-check allocation, clone-style reads, replacement writes, `(RefCell<T>, T -> T) -> ()` read-modify-write, and the `RefCell<T> -> bool` guard-flag read
- diagnose exclusive-only operations on a plain `Cell` ("requires an exclusive cell, found `Cell<i64>`; use a `RefCell`")
- keep cell interaction intrinsic-only
- add focused positive and diagnostic frontend lit coverage

## Validation

- `cargo check --workspace`
- `cargo test -p reussir-core` (251 passed)
- focused lit tests: `frontend/cell.rr` and `frontend/cell_errors.rr` (2 passed, also verified against upstream FileCheck)