### PR TITLE
[mlir] rework cells: exclusive flavor with in-use flag, triviality-driven get

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -241,7 +241,7 @@ unsafe extern "C" {
         atomic_kind: ReussirAtomicKind,
     ) -> MlirType;
     pub fn reussirNullableTypeGet(pointer_type: MlirType) -> MlirType;
-    pub fn reussirCellTypeGet(element_type: MlirType) -> MlirType;
+    pub fn reussirCellTypeGet(element_type: MlirType, exclusive: bool) -> MlirType;
     pub fn reussirRefTypeGet(
         element_type: MlirType,
         capability: ReussirCapability,

--- a/crates/reussir-backend/src/dialect/mod.rs
+++ b/crates/reussir-backend/src/dialect/mod.rs
@@ -69,7 +69,8 @@ mod tests {
             ),
             (ty::region(&context), "!reussir.region"),
             (ty::raw_ptr(i32_ty), "!reussir.raw_ptr<"),
-            (ty::cell(i32_ty), "!reussir.cell<"),
+            (ty::cell(i32_ty, false), "!reussir.cell<"),
+            (ty::cell(i32_ty, true), "!reussir.cell<i32 exclusive>"),
             (ty::array(&[2, 3], i32_ty), "!reussir.array<"),
             (
                 ty::str(&context, ty::ReussirLifeScope::Global),

--- a/crates/reussir-backend/src/dialect/ty.rs
+++ b/crates/reussir-backend/src/dialect/ty.rs
@@ -56,10 +56,12 @@ pub fn nullable(pointer: Type) -> Type {
     unsafe { Type::from_raw(sys::reussirNullableTypeGet(pointer.to_raw())) }
 }
 
-/// Creates a `!reussir.cell<element>` payload type. Values of this type are
-/// managed through a shared `!reussir.rc` cell box.
-pub fn cell(element: Type) -> Type {
-    unsafe { Type::from_raw(sys::reussirCellTypeGet(element.to_raw())) }
+/// Creates a `!reussir.cell<element [exclusive]>` payload type. Values of
+/// this type are managed through a shared `!reussir.rc` cell box. An
+/// exclusive cell supports `reussir.cell.rmw` and carries a trailing in-use
+/// flag guarding every access.
+pub fn cell(element: Type, exclusive: bool) -> Type {
+    unsafe { Type::from_raw(sys::reussirCellTypeGet(element.to_raw(), exclusive)) }
 }
 
 /// Creates a `!reussir.ref<element, capability, atomicKind>` type.

--- a/include/Reussir-c/Types.h
+++ b/include/Reussir-c/Types.h
@@ -81,8 +81,10 @@ MlirType reussirRcTypeGet(MlirType elementType, ReussirCapability capability,
 // `!reussir.nullable<ptrTy>`. The context is taken from `pointerType`.
 MlirType reussirNullableTypeGet(MlirType pointerType);
 
-// `!reussir.cell<elementType>`. The context is taken from `elementType`.
-MlirType reussirCellTypeGet(MlirType elementType);
+// `!reussir.cell<elementType [exclusive]>`. The context is taken from
+// `elementType`. An exclusive cell supports `reussir.cell.rmw` and carries a
+// trailing in-use flag.
+MlirType reussirCellTypeGet(MlirType elementType, bool exclusive);
 
 // `!reussir.ref<eleTy [, capability [, atomicKind]]>`. The context is taken
 // from `elementType`.

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1072,6 +1072,11 @@ def ReussirCellGetOp : ReussirCellOp<"get", []> {
     `reussir.cell.get` loads the cell element with clone semantics. Managed
     ownership reachable from the element is acquired before the value is
     returned.
+
+    On an exclusive cell, the access lowers to a branch on the in-use flag:
+    when the element is currently moved out into a `reussir.cell.rmw` body,
+    the access panics and the result is a poison value on that (unreachable)
+    path; otherwise the element is loaded and acquired.
   }];
   let arguments = (ins Arg<ReussirRcCellType, "cell to read">:$cell);
   let results = (outs Res<AnyType, "cloned value">:$value);
@@ -1088,6 +1093,11 @@ def ReussirCellSetOp : ReussirCellOp<"set", []> {
     It does not acquire or otherwise adjust ownership of the incoming value;
     the caller is responsible for supplying the ownership transferred into the
     cell.
+
+    On an exclusive cell, the access lowers to a branch on the in-use flag
+    and panics when the element is currently moved out into a
+    `reussir.cell.rmw` body; the replacement is only performed on the
+    not-in-use path.
   }];
   let arguments = (ins Arg<AnyType, "replacement value">:$value,
       Arg<ReussirRcCellType, "cell to update">:$cell);
@@ -1104,6 +1114,14 @@ def ReussirCellRmwOp : ReussirCellOp<"rmw", []> {
     `reussir.cell.rmw` moves the current element into its single-block body.
     The body yields the replacement element and may additionally yield one
     operation result. This transfer performs no implicit acquire or drop.
+
+    The operation requires an exclusive cell: the whole read-modify-write is
+    the not-in-use arm of a branch on the cell's trailing in-use flag. The
+    flag is raised while the body runs, so any reentrant access through an
+    alias of the same cell (another `rmw`, or a `get`/`set`) panics — with a
+    poison result on the panicked path — instead of observing or
+    double-releasing the moved-out element. The flag is cleared once the
+    replacement element is stored back.
   }];
   let arguments = (ins Arg<ReussirRcCellType, "cell to update">:$cell);
   let results = (outs Res<Optional<AnyType>, "body output">:$output);
@@ -1111,6 +1129,22 @@ def ReussirCellRmwOp : ReussirCellOp<"rmw", []> {
   let assemblyFormat = [{
     `(` $cell `:` qualified(type($cell)) `)`
     (`->` type($output)^)? $body attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
+def ReussirCellInUseOp : ReussirCellOp<"in_use", []> {
+  let summary = "Observe whether an exclusive cell is currently in use";
+  let description = [{
+    `reussir.cell.in_use` loads the trailing in-use flag of an exclusive
+    cell. It returns true while the cell element is moved out into an active
+    `reussir.cell.rmw` body, letting front ends implement checked access
+    instead of panicking.
+  }];
+  let arguments = (ins Arg<ReussirRcCellType, "cell to query">:$cell);
+  let results = (outs Res<I1, "whether the cell is in use">:$inUse);
+  let assemblyFormat = [{
+    `(` $cell `:` qualified(type($cell)) `)` `:` type($inUse) attr-dict
   }];
   let hasVerifier = 1;
 }

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -323,8 +323,7 @@ def ReussirNullableType
 //===----------------------------------------------------------------------===//
 def ReussirCellType
     : ReussirType<"Cell", "cell",
-                  [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-                   MutableType]> {
+                  [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
   let summary = "Reussir mutable cell payload type";
   let description = [{
     `reussir.cell` is the one-element mutable payload of a shared reference
@@ -333,9 +332,24 @@ def ReussirCellType
     is represented by that shared RC pointer, like closures and arrays.
 
     The element is stored inline in the cell box and may itself be an RC type.
+
+    A plain cell (`!reussir.cell<T>`) supports only whole-element access
+    (`reussir.cell.get`/`reussir.cell.set`). An exclusive cell
+    (`!reussir.cell<T exclusive>`) additionally supports in-place
+    read-modify-write (`reussir.cell.rmw`): its storage carries a trailing
+    `i1` in-use flag recording whether the element is currently moved out
+    into an rmw body, and every access is guarded against that state. The
+    flag is addressed as slot `[1]` of the cell reference and can be
+    observed with `reussir.cell.in_use`.
   }];
-  let parameters = (ins "mlir::Type":$eleTy);
-  let assemblyFormat = "`<` $eleTy `>`";
+  let parameters = (ins "mlir::Type":$eleTy, "bool":$exclusive);
+  let hasCustomAssemblyFormat = 1;
+  let skipDefaultBuilders = 1;
+  let builders = [TypeBuilder<(ins "mlir::Type":$eleTy,
+                                  CArg<"bool", "false">:$exclusive),
+                              [{
+      return $_get($_ctxt, eleTy, exclusive);
+    }]>];
   let extraClassDeclaration = [{
     mlir::Type getElementType() const { return getEleTy(); }
   }];
@@ -345,8 +359,7 @@ def ReussirCellType
 //===----------------------------------------------------------------------===//
 def ReussirRefType
     : ReussirType<"Ref", "ref",
-                  [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-                   MutableType]> {
+                  [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
   let summary = "Reussir Reference Type";
   let description = [{
     A reference type that is used to represent a reference to an object in Reussir.

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -68,9 +68,9 @@ MlirType reussirNullableTypeGet(MlirType pointerType) {
   return wrap(NullableType::get(ptr.getContext(), ptr));
 }
 
-MlirType reussirCellTypeGet(MlirType elementType) {
+MlirType reussirCellTypeGet(MlirType elementType, bool exclusive) {
   mlir::Type ele = unwrap(elementType);
-  return wrap(CellType::get(ele.getContext(), ele));
+  return wrap(CellType::get(ele.getContext(), ele, exclusive));
 }
 
 MlirType reussirRefTypeGet(MlirType elementType, ReussirCapability capability,

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -47,13 +47,14 @@ namespace reussir {
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct CellSlot {
+struct CellAccess {
   CellType cellType;
-  mlir::Value slotRef;
+  mlir::Value cellRef;
+  reussir::AtomicKind atomicKind;
 };
 
-static CellSlot materializeCellSlot(mlir::Value cell, mlir::Location loc,
-                                    mlir::PatternRewriter &rewriter) {
+static CellAccess borrowCell(mlir::Value cell, mlir::Location loc,
+                             mlir::PatternRewriter &rewriter) {
   RcType rcType = llvm::cast<RcType>(cell.getType());
   CellType cellType = llvm::cast<CellType>(rcType.getElementType());
   RefType cellRefType =
@@ -61,12 +62,68 @@ static CellSlot materializeCellSlot(mlir::Value cell, mlir::Location loc,
                    rcType.getAtomicKind());
   mlir::Value cellRef =
       ReussirRcBorrowOp::create(rewriter, loc, cellRefType, cell);
+  return {cellType, cellRef, rcType.getAtomicKind()};
+}
+
+static mlir::Value projectCellSlot(const CellAccess &access, mlir::Location loc,
+                                   mlir::PatternRewriter &rewriter) {
   RefType slotRefType =
-      RefType::get(rewriter.getContext(), cellType.getElementType(),
-                   Capability::field, rcType.getAtomicKind());
-  mlir::Value slotRef = ReussirRefProjectOp::create(
-      rewriter, loc, slotRefType, cellRef, rewriter.getIndexAttr(0));
-  return {cellType, slotRef};
+      RefType::get(rewriter.getContext(), access.cellType.getElementType(),
+                   Capability::field, access.atomicKind);
+  return ReussirRefProjectOp::create(rewriter, loc, slotRefType, access.cellRef,
+                                     rewriter.getIndexAttr(0));
+}
+
+// The trailing i1 in-use flag of an exclusive cell, addressed as slot [1].
+static mlir::Value projectCellFlag(const CellAccess &access, mlir::Location loc,
+                                   mlir::PatternRewriter &rewriter) {
+  assert(access.cellType.getExclusive() &&
+         "only exclusive cells carry an in-use flag");
+  RefType flagRefType =
+      RefType::get(rewriter.getContext(), rewriter.getI1Type(),
+                   Capability::field, access.atomicKind);
+  return ReussirRefProjectOp::create(rewriter, loc, flagRefType, access.cellRef,
+                                     rewriter.getIndexAttr(1));
+}
+
+static void storeCellFlag(const CellAccess &access, bool inUse,
+                          mlir::Location loc, mlir::PatternRewriter &rewriter) {
+  mlir::Value flagRef = projectCellFlag(access, loc, rewriter);
+  mlir::Value flag = mlir::arith::ConstantOp::create(
+      rewriter, loc, rewriter.getIntegerAttr(rewriter.getI1Type(), inUse));
+  ReussirRefStoreOp::create(rewriter, loc, flagRef, flag);
+}
+
+// An exclusive-cell payload access lowers to a two-armed `scf.if` over the
+// in-use flag: while an rmw body runs, the element is moved out of the slot,
+// so a reentrant get/set/rmw through an alias of the same cell would clone
+// or release stale storage. The in-use arm panics and yields poison results;
+// the caller emits the actual access into the (returned) else arm, so even
+// at the IR level the panicked path never touches the moved-out slot. Plain
+// cells carry no flag and stay unguarded.
+static mlir::scf::IfOp createGuardedAccess(const CellAccess &access,
+                                           mlir::Location loc,
+                                           mlir::PatternRewriter &rewriter,
+                                           llvm::StringRef message,
+                                           mlir::TypeRange resultTypes) {
+  assert(access.cellType.getExclusive() &&
+         "only exclusive cell accesses are guarded");
+  mlir::Value flagRef = projectCellFlag(access, loc, rewriter);
+  mlir::Value flag =
+      ReussirRefLoadOp::create(rewriter, loc, rewriter.getI1Type(), flagRef);
+  auto unlikelyInUse = ReussirExpectOp::create(rewriter, loc, flag, false);
+  auto ifOp = mlir::scf::IfOp::create(rewriter, loc, resultTypes,
+                                      unlikelyInUse.getLikely(),
+                                      /*addThenBlock=*/true,
+                                      /*addElseBlock=*/true);
+  mlir::OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(ifOp.thenBlock());
+  ReussirPanicOp::create(rewriter, loc, rewriter.getStringAttr(message));
+  llvm::SmallVector<mlir::Value> poisons;
+  for (mlir::Type type : resultTypes)
+    poisons.push_back(mlir::ub::PoisonOp::create(rewriter, loc, type));
+  mlir::scf::YieldOp::create(rewriter, loc, poisons);
+  return ifOp;
 }
 
 class DropExpansionPattern : public mlir::OpRewritePattern<ReussirRefDropOp> {
@@ -441,10 +498,12 @@ public:
     auto created = ReussirRcCreateOp::create(
         rewriter, op.getLoc(), op.getCell().getType(), poison, op.getToken(),
         mlir::Value{}, mlir::FlatSymbolRefAttr{}, mlir::UnitAttr{});
-    CellSlot access =
-        materializeCellSlot(created.getRcPtr(), op.getLoc(), rewriter);
-    ReussirRefStoreOp::create(rewriter, op.getLoc(), access.slotRef,
-                              op.getValue());
+    CellAccess access = borrowCell(created.getRcPtr(), op.getLoc(), rewriter);
+    mlir::Value slotRef = projectCellSlot(access, op.getLoc(), rewriter);
+    ReussirRefStoreOp::create(rewriter, op.getLoc(), slotRef, op.getValue());
+    // A fresh exclusive cell starts out not in use.
+    if (cellType.getExclusive())
+      storeCellFlag(access, /*inUse=*/false, op.getLoc(), rewriter);
     rewriter.replaceOp(op, created.getRcPtr());
     return mlir::success();
   }
@@ -458,23 +517,44 @@ public:
   mlir::LogicalResult
   matchAndRewrite(ReussirCellGetOp op,
                   mlir::PatternRewriter &rewriter) const override {
-    CellSlot access = materializeCellSlot(op.getCell(), op.getLoc(), rewriter);
-    mlir::Value value = ReussirRefLoadOp::create(
-        rewriter, op.getLoc(), access.cellType.getElementType(),
-        access.slotRef);
-    mlir::Type valueType = value.getType();
-    if (auto rcType = llvm::dyn_cast<RcType>(valueType)) {
-      ReussirRcIncOp::create(rewriter, op.getLoc(), value);
-    } else if (!isTriviallyCopyable(valueType)) {
-      // Acquire the exact SSA value loaded above, rather than loading the
-      // mutable slot a second time. The spill only provides addressability for
-      // recursive aggregate acquisition and is eliminated after lowering.
-      RefType spilledType = RefType::get(rewriter.getContext(), valueType);
-      mlir::Value spilled = ReussirRefSpilledOp::create(rewriter, op.getLoc(),
-                                                        spilledType, value);
-      ReussirRefAcquireOp::create(rewriter, op.getLoc(), spilled);
+    CellAccess access = borrowCell(op.getCell(), op.getLoc(), rewriter);
+    auto emitLoadAndAcquire = [&]() -> mlir::Value {
+      mlir::Value slotRef = projectCellSlot(access, op.getLoc(), rewriter);
+      mlir::Value value = ReussirRefLoadOp::create(
+          rewriter, op.getLoc(), access.cellType.getElementType(), slotRef);
+      mlir::Type valueType = value.getType();
+      // Cloning is triviality-driven: every non-trivial element must acquire
+      // the managed ownership reachable from it — a bare RC pointer retains
+      // directly, anything else (records, nullables, ...) routes through
+      // `ref.acquire`.
+      if (!isTriviallyCopyable(valueType)) {
+        if (llvm::isa<RcType>(valueType)) {
+          ReussirRcIncOp::create(rewriter, op.getLoc(), value);
+        } else {
+          // Acquire the exact SSA value loaded above, rather than loading
+          // the mutable slot a second time. The spill only provides
+          // addressability for recursive aggregate acquisition and is
+          // eliminated after lowering.
+          RefType spilledType = RefType::get(rewriter.getContext(), valueType);
+          mlir::Value spilled = ReussirRefSpilledOp::create(
+              rewriter, op.getLoc(), spilledType, value);
+          ReussirRefAcquireOp::create(rewriter, op.getLoc(), spilled);
+        }
+      }
+      return value;
+    };
+    if (!access.cellType.getExclusive()) {
+      rewriter.replaceOp(op, emitLoadAndAcquire());
+      return mlir::success();
     }
-    rewriter.replaceOp(op, value);
+    auto guarded =
+        createGuardedAccess(access, op.getLoc(), rewriter,
+                            "cell.get on an exclusive cell that is in use",
+                            {access.cellType.getElementType()});
+    rewriter.setInsertionPointToStart(guarded.elseBlock());
+    mlir::Value value = emitLoadAndAcquire();
+    mlir::scf::YieldOp::create(rewriter, op.getLoc(), value);
+    rewriter.replaceOp(op, guarded.getResults());
     return mlir::success();
   }
 };
@@ -487,10 +567,22 @@ public:
   mlir::LogicalResult
   matchAndRewrite(ReussirCellSetOp op,
                   mlir::PatternRewriter &rewriter) const override {
-    CellSlot access = materializeCellSlot(op.getCell(), op.getLoc(), rewriter);
-    ReussirRefDropOp::create(rewriter, op.getLoc(), access.slotRef);
-    ReussirRefStoreOp::create(rewriter, op.getLoc(), access.slotRef,
-                              op.getValue());
+    CellAccess access = borrowCell(op.getCell(), op.getLoc(), rewriter);
+    auto emitDropAndStore = [&]() {
+      mlir::Value slotRef = projectCellSlot(access, op.getLoc(), rewriter);
+      ReussirRefDropOp::create(rewriter, op.getLoc(), slotRef);
+      ReussirRefStoreOp::create(rewriter, op.getLoc(), slotRef, op.getValue());
+    };
+    if (access.cellType.getExclusive()) {
+      auto guarded = createGuardedAccess(
+          access, op.getLoc(), rewriter,
+          "cell.set on an exclusive cell that is in use", {});
+      rewriter.setInsertionPointToStart(guarded.elseBlock());
+      emitDropAndStore();
+      mlir::scf::YieldOp::create(rewriter, op.getLoc());
+    } else {
+      emitDropAndStore();
+    }
     rewriter.eraseOp(op);
     return mlir::success();
   }
@@ -504,23 +596,55 @@ public:
   mlir::LogicalResult
   matchAndRewrite(ReussirCellRmwOp op,
                   mlir::PatternRewriter &rewriter) const override {
-    CellSlot access = materializeCellSlot(op.getCell(), op.getLoc(), rewriter);
+    // The verifier guarantees an exclusive cell here. The whole
+    // read-modify-write becomes the guarded arm: raise the in-use flag for
+    // the body so any reentrant access to the cell panics while its element
+    // is moved out, and clear it with the replacement store.
+    CellAccess access = borrowCell(op.getCell(), op.getLoc(), rewriter);
+    auto guarded = createGuardedAccess(
+        access, op.getLoc(), rewriter,
+        "cell.rmw on an exclusive cell that is in use", op->getResultTypes());
+    rewriter.setInsertionPointToStart(guarded.elseBlock());
+    storeCellFlag(access, /*inUse=*/true, op.getLoc(), rewriter);
+    mlir::Value slotRef = projectCellSlot(access, op.getLoc(), rewriter);
     mlir::Value oldValue = ReussirRefLoadOp::create(
-        rewriter, op.getLoc(), access.cellType.getElementType(),
-        access.slotRef);
+        rewriter, op.getLoc(), access.cellType.getElementType(), slotRef);
 
     mlir::Block &body = op.getBody().front();
     auto yield = llvm::cast<ReussirCellYieldOp>(body.getTerminator());
-    rewriter.inlineBlockBefore(&body, op, mlir::ValueRange{oldValue});
+    rewriter.inlineBlockBefore(&body, guarded.elseBlock(),
+                               guarded.elseBlock()->end(),
+                               mlir::ValueRange{oldValue});
     rewriter.setInsertionPoint(yield);
-    ReussirRefStoreOp::create(rewriter, yield.getLoc(), access.slotRef,
+    ReussirRefStoreOp::create(rewriter, yield.getLoc(), slotRef,
                               yield.getNewValue());
-    mlir::Value output = yield.getOutput();
+    storeCellFlag(access, /*inUse=*/false, yield.getLoc(), rewriter);
+    mlir::scf::YieldOp::create(rewriter, yield.getLoc(),
+                               yield.getOutput()
+                                   ? mlir::ValueRange{yield.getOutput()}
+                                   : mlir::ValueRange{});
     rewriter.eraseOp(yield);
-    if (output)
-      rewriter.replaceOp(op, output);
+    if (op->getNumResults() != 0)
+      rewriter.replaceOp(op, guarded.getResults());
     else
       rewriter.eraseOp(op);
+    return mlir::success();
+  }
+};
+
+class CellInUseExpansionPattern
+    : public mlir::OpRewritePattern<ReussirCellInUseOp> {
+public:
+  using mlir::OpRewritePattern<ReussirCellInUseOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirCellInUseOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    CellAccess access = borrowCell(op.getCell(), op.getLoc(), rewriter);
+    mlir::Value flagRef = projectCellFlag(access, op.getLoc(), rewriter);
+    rewriter.replaceOp(op,
+                       ReussirRefLoadOp::create(rewriter, op.getLoc(),
+                                                rewriter.getI1Type(), flagRef));
     return mlir::success();
   }
 };
@@ -555,8 +679,8 @@ void populateAcquireDropExpansionConversionPatterns(
   patterns.add<DropExpansionPattern>(patterns.getContext(), outlineRecord);
   patterns.add<AcquireExpansionPattern>(patterns.getContext(), outlineRecord);
   patterns.add<CellCreateExpansionPattern, CellGetExpansionPattern,
-               CellSetExpansionPattern, CellRmwExpansionPattern>(
-      patterns.getContext());
+               CellSetExpansionPattern, CellRmwExpansionPattern,
+               CellInUseExpansionPattern>(patterns.getContext());
 }
 
 } // namespace reussir

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -233,9 +233,14 @@ void populateReussirToLLVMTypeConversions(mlir::LLVMTypeConverter &converter) {
   // A cell is a semantic one-field wrapper. Keeping the wrapper in the LLVM
   // type makes `ref.project [0]` the uniform way to address its mutable slot,
   // while its data-layout interface intentionally matches the inner value.
-  converter.addConversion([&converter](CellType type) {
-    return mlir::LLVM::LLVMStructType::getLiteral(
-        type.getContext(), {converter.convertType(type.getElementType())});
+  // An exclusive cell additionally carries a trailing i1 in-use flag,
+  // addressed as `ref.project [1]`.
+  converter.addConversion([&converter](CellType type) -> mlir::Type {
+    llvm::SmallVector<mlir::Type> members{
+        converter.convertType(type.getElementType())};
+    if (type.getExclusive())
+      members.push_back(mlir::IntegerType::get(type.getContext(), 1));
+    return mlir::LLVM::LLVMStructType::getLiteral(type.getContext(), members);
   });
 
   converter.addConversion([&converter](RcBoxType type) -> mlir::Type {

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -1250,6 +1250,9 @@ mlir::LogicalResult ReussirCellRmwOp::verify() {
   auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
   if (mlir::failed(cellType))
     return mlir::failure();
+  if (!(*cellType).getExclusive())
+    return emitOpError(
+        "read-modify-write requires an exclusive cell, got a plain cell");
   if (!llvm::hasSingleElement(getBody()))
     return emitOpError("body must contain exactly one block");
   mlir::Block &block = getBody().front();
@@ -1276,6 +1279,16 @@ mlir::LogicalResult ReussirCellRmwOp::verify() {
     return emitOpError(
                "body output type must match operation result type, got ")
            << yield.getOutput().getType() << " and " << getOutput().getType();
+  return mlir::success();
+}
+
+mlir::LogicalResult ReussirCellInUseOp::verify() {
+  auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
+  if (mlir::failed(cellType))
+    return mlir::failure();
+  if (!(*cellType).getExclusive())
+    return emitOpError(
+        "in-use flag only exists on an exclusive cell, got a plain cell");
   return mlir::success();
 }
 
@@ -1309,12 +1322,20 @@ mlir::LogicalResult ReussirRefProjectOp::verify() {
   mlir::Type elementType = refType.getElementType();
   if (auto cellType = llvm::dyn_cast<CellType>(elementType)) {
     size_t index = getIndex().getZExtValue();
-    if (index != 0)
-      return emitOpError("cell projection index must be zero, got ") << index;
-    if (projectedType.getElementType() != cellType.getElementType())
-      return emitOpError("projected cell element type mismatch: expected ")
-             << cellType.getElementType() << ", got "
-             << projectedType.getElementType();
+    mlir::Type expectedSlotType;
+    if (index == 0) {
+      expectedSlotType = cellType.getElementType();
+    } else if (index == 1 && cellType.getExclusive()) {
+      expectedSlotType = mlir::IntegerType::get(getContext(), 1);
+    } else {
+      return emitOpError("cell projection index must be zero")
+             << (cellType.getExclusive() ? " (element) or one (in-use flag)"
+                                         : "")
+             << ", got " << index;
+    }
+    if (projectedType.getElementType() != expectedSlotType)
+      return emitOpError("projected cell slot type mismatch: expected ")
+             << expectedSlotType << ", got " << projectedType.getElementType();
     if (projectedType.getCapability() != Capability::field)
       return emitOpError("a cell slot projection must have field capability");
     if (projectedType.getAtomicKind() != refType.getAtomicKind())
@@ -2549,6 +2570,12 @@ mlir::LogicalResult ReussirRefAcquireOp::verify() {
   if (llvm::isa<ArrayType, CellType>(elementType))
     return mlir::success();
 
+  // A nullable RC pointer acquires by dispatching on nullness and retaining
+  // the wrapped box on the nonnull path.
+  if (auto nullableType = llvm::dyn_cast<NullableType>(elementType);
+      nullableType && llvm::isa<RcType>(nullableType.getPtrTy()))
+    return mlir::success();
+
   return emitOpError("unsupported element type for acquisition: ")
          << elementType;
 }
@@ -2635,6 +2662,31 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
                   builder, loc, getArrayViewMemRefType(arrayType), value)
                   .getView();
           return emitArrayOwnershipAcquisition(view, builder, loc);
+        }
+
+        // A nullable RC pointer is the drop-side dual of
+        // `rewriteDropNullable`: dispatch on nullness and retain the wrapped
+        // box on the nonnull path. Without this branch a non-trivial
+        // nullable would silently fall through as a no-op and lose its +1.
+        if (auto nullableType = llvm::dyn_cast<NullableType>(elementType)) {
+          if (!llvm::isa<RcType>(nullableType.getPtrTy()))
+            return mlir::success();
+          auto loaded =
+              ReussirRefLoadOp::create(builder, loc, nullableType, value);
+          auto dispatcher = ReussirNullableDispatchOp::create(
+              builder, loc, mlir::Type{}, loaded);
+          mlir::Block *nullBlock = builder.createBlock(
+              &dispatcher.getNullRegion(), dispatcher.getNullRegion().begin());
+          builder.setInsertionPointToStart(nullBlock);
+          ReussirScfYieldOp::create(builder, loc, nullptr);
+          mlir::Block *nonNullBlock =
+              builder.createBlock(&dispatcher.getNonNullRegion(),
+                                  dispatcher.getNonNullRegion().begin(),
+                                  {nullableType.getPtrTy()}, {loc});
+          builder.setInsertionPointToStart(nonNullBlock);
+          ReussirRcIncOp::create(builder, loc, nonNullBlock->getArgument(0));
+          ReussirScfYieldOp::create(builder, loc, nullptr);
+          return mlir::success();
         }
 
         // A cell is a one-field mutable payload. Projecting its slot also

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -978,12 +978,42 @@ void RcType::print(mlir::AsmPrinter &printer) const {
 REUSSIR_POINTER_LIKE_DATA_LAYOUT_INTERFACE(NullableType);
 
 //===----------------------------------------------------------------------===//
+// Reussir Cell Type Parse/Print
+//===----------------------------------------------------------------------===//
+mlir::Type CellType::parse(mlir::AsmParser &parser) {
+  if (parser.parseLess())
+    return {};
+  mlir::Type eleTy;
+  if (parser.parseType(eleTy))
+    return {};
+  bool exclusive = mlir::succeeded(parser.parseOptionalKeyword("exclusive"));
+  if (parser.parseGreater())
+    return {};
+  return CellType::get(parser.getContext(), eleTy, exclusive);
+}
+
+void CellType::print(mlir::AsmPrinter &printer) const {
+  printer << "<" << getElementType();
+  if (getExclusive())
+    printer << " exclusive";
+  printer << ">";
+}
+
+//===----------------------------------------------------------------------===//
 // Reussir Cell Type DataLayoutInterface
 //===----------------------------------------------------------------------===//
+// A plain cell is layout-identical to its element. An exclusive cell carries
+// a trailing i1 in-use flag: one byte after the element, padded to the
+// element's alignment — the same layout LLVM derives for `{element, i1}`.
 llvm::TypeSize
 CellType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
                             mlir::DataLayoutEntryListRef params) const {
-  return dataLayout.getTypeSizeInBits(getElementType());
+  llvm::TypeSize elementSize = dataLayout.getTypeSize(getElementType());
+  if (!getExclusive())
+    return dataLayout.getTypeSizeInBits(getElementType());
+  uint64_t align = dataLayout.getTypeABIAlignment(getElementType());
+  return llvm::TypeSize::getFixed(
+      8 * llvm::alignTo(elementSize.getFixedValue() + 1, align));
 }
 
 uint64_t CellType::getABIAlignment(const mlir::DataLayout &dataLayout,

--- a/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
@@ -234,6 +234,21 @@ llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
         break;
       if (llvm::isa<ReussirRegionCleanupOp>(next))
         break;
+      // `reussir.cell.set` implicitly releases the old cell element. Like
+      // `ref.drop`, the released rc is reachable only *through* the cell, so
+      // no operand alias query can prove it disjoint from the incremented
+      // pointer; cancelling across it could let the release hit zero while
+      // the value is still live. A set of a trivially-copyable element
+      // expands to a plain store and stays transparent.
+      if (auto setOp = llvm::dyn_cast<ReussirCellSetOp>(next);
+          setOp &&
+          !isTriviallyCopyable(setOp.getCell().getType().getElementType()))
+        break;
+      // A `reussir.cell.rmw` body is arbitrary nested code (it may drop the
+      // moved-out element or anything else) that this same-block scan never
+      // visits — treat the whole op as opaque.
+      if (llvm::isa<ReussirCellRmwOp>(next))
+        break;
       // Count-*observing* ops: `array.with_unique_view`, `closure.uniqify`
       // and a standalone `rc.is_unique` read `count == 1` to decide between
       // in-place mutation and a defensive clone. The inc/dec pair around them

--- a/tests/integration/basic/failure/cell.mlir
+++ b/tests/integration/basic/failure/cell.mlir
@@ -2,6 +2,8 @@
 
 !cell_i64 = !reussir.cell<i64>
 !rc_cell_i64 = !reussir.rc<!cell_i64>
+!excl_cell_i64 = !reussir.cell<i64 exclusive>
+!rc_excl_cell_i64 = !reussir.rc<!excl_cell_i64>
 
 module {
   func.func @create_type_mismatch(%value: i32) {
@@ -29,13 +31,49 @@ module {
     return
   }
 
-  func.func @rmw_argument_mismatch(%cell: !rc_cell_i64) {
-    // expected-error @+1 {{body argument type must match cell element type, expected 'i64', got 'i32'}}
+  func.func @rmw_requires_exclusive(%cell: !rc_cell_i64) {
+    // expected-error @+1 {{read-modify-write requires an exclusive cell, got a plain cell}}
     reussir.cell.rmw(%cell : !rc_cell_i64) {
+      ^bb0(%old: i64):
+        reussir.cell.yield(%old : i64)
+    }
+    return
+  }
+
+  func.func @rmw_argument_mismatch(%cell: !rc_excl_cell_i64) {
+    // expected-error @+1 {{body argument type must match cell element type, expected 'i64', got 'i32'}}
+    reussir.cell.rmw(%cell : !rc_excl_cell_i64) {
       ^bb0(%old: i32):
         %zero = arith.constant 0 : i64
         reussir.cell.yield(%zero : i64)
     }
+    return
+  }
+
+  func.func @in_use_requires_exclusive(%cell: !rc_cell_i64) {
+    // expected-error @+1 {{in-use flag only exists on an exclusive cell, got a plain cell}}
+    %flag = reussir.cell.in_use(%cell : !rc_cell_i64) : i1
+    return
+  }
+
+  func.func @plain_cell_has_no_flag_slot(%ref: !reussir.ref<!cell_i64>) {
+    // expected-error @+1 {{cell projection index must be zero, got 1}}
+    %flag = reussir.ref.project(%ref : !reussir.ref<!cell_i64>) [1]
+      : !reussir.ref<i1 field>
+    return
+  }
+
+  func.func @flag_slot_type_mismatch(%ref: !reussir.ref<!excl_cell_i64>) {
+    // expected-error @+1 {{projected cell slot type mismatch: expected 'i1', got 'i64'}}
+    %flag = reussir.ref.project(%ref : !reussir.ref<!excl_cell_i64>) [1]
+      : !reussir.ref<i64 field>
+    return
+  }
+
+  func.func @exclusive_flag_out_of_range(%ref: !reussir.ref<!excl_cell_i64>) {
+    // expected-error @+1 {{cell projection index must be zero (element) or one (in-use flag), got 2}}
+    %flag = reussir.ref.project(%ref : !reussir.ref<!excl_cell_i64>) [2]
+      : !reussir.ref<i1 field>
     return
   }
 }

--- a/tests/integration/basic/success/cell.mlir
+++ b/tests/integration/basic/success/cell.mlir
@@ -3,23 +3,36 @@
 !inner = !reussir.rc<i64>
 !cell = !reussir.cell<!inner>
 !rc_cell = !reussir.rc<!cell>
+!excl_cell = !reussir.cell<!inner exclusive>
+!rc_excl_cell = !reussir.rc<!excl_cell>
 
 module {
   func.func @cell_ops(%initial: !inner, %replacement: !inner) -> i64 {
     %cell = reussir.cell.create value(%initial : !inner) : !rc_cell
     %cloned = reussir.cell.get(%cell : !rc_cell) : !inner
     reussir.cell.set(%replacement : !inner, %cell : !rc_cell)
-    %answer = reussir.cell.rmw(%cell : !rc_cell) -> i64 {
+    reussir.rc.dec(%cloned : !inner)
+    reussir.rc.dec(%cell : !rc_cell)
+    %zero = arith.constant 0 : i64
+    return %zero : i64
+  }
+
+  func.func @exclusive_cell_ops(%initial: !inner, %replacement: !inner) -> i64 {
+    %cell = reussir.cell.create value(%initial : !inner) : !rc_excl_cell
+    %cloned = reussir.cell.get(%cell : !rc_excl_cell) : !inner
+    reussir.cell.set(%replacement : !inner, %cell : !rc_excl_cell)
+    %answer = reussir.cell.rmw(%cell : !rc_excl_cell) -> i64 {
       ^bb0(%old: !inner):
         %c42 = arith.constant 42 : i64
         reussir.cell.yield(%old : !inner) output(%c42 : i64)
     }
-    reussir.cell.rmw(%cell : !rc_cell) {
+    reussir.cell.rmw(%cell : !rc_excl_cell) {
       ^bb0(%old: !inner):
         reussir.cell.yield(%old : !inner)
     }
+    %in_use = reussir.cell.in_use(%cell : !rc_excl_cell) : i1
     reussir.rc.dec(%cloned : !inner)
-    reussir.rc.dec(%cell : !rc_cell)
+    reussir.rc.dec(%cell : !rc_excl_cell)
     return %answer : i64
   }
 }
@@ -28,7 +41,13 @@ module {
 // CHECK: %[[CELL_VALUE:.+]] = reussir.cell.create value(%{{.+}} : !reussir.rc<i64>) : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>
 // CHECK: %{{.+}} = reussir.cell.get(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>) : !reussir.rc<i64>
 // CHECK: reussir.cell.set(%{{.+}} : !reussir.rc<i64>, %[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>)
-// CHECK: reussir.cell.rmw(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>) -> i64
+
+// CHECK-LABEL: func.func @exclusive_cell_ops
+// CHECK: %[[CELL_VALUE:.+]] = reussir.cell.create value(%{{.+}} : !reussir.rc<i64>) : !reussir.rc<!reussir.cell<!reussir.rc<i64> exclusive>>
+// CHECK: %{{.+}} = reussir.cell.get(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64> exclusive>>) : !reussir.rc<i64>
+// CHECK: reussir.cell.set(%{{.+}} : !reussir.rc<i64>, %[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64> exclusive>>)
+// CHECK: reussir.cell.rmw(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64> exclusive>>) -> i64
 // CHECK: reussir.cell.yield(%{{.+}} : !reussir.rc<i64>) output(%{{.+}} : i64)
-// CHECK: reussir.cell.rmw(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64>>>)
+// CHECK: reussir.cell.rmw(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64> exclusive>>)
 // CHECK: reussir.cell.yield(%{{.+}} : !reussir.rc<i64>)
+// CHECK: %{{.+}} = reussir.cell.in_use(%[[CELL_VALUE]] : !reussir.rc<!reussir.cell<!reussir.rc<i64> exclusive>>) : i1

--- a/tests/integration/conversion/cell_ops.mlir
+++ b/tests/integration/conversion/cell_ops.mlir
@@ -5,8 +5,12 @@
 // RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion,reussir-lowering-scf-ops,reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},reussir-lowering-scf-ops,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
 
 !inner = !reussir.rc<i64>
+!nullable_inner = !reussir.nullable<!inner>
 !rc_cell = !reussir.rc<!reussir.cell<!inner>>
 !rc_i64_cell = !reussir.rc<!reussir.cell<i64>>
+!rc_nullable_cell = !reussir.rc<!reussir.cell<!nullable_inner>>
+!rc_excl_cell = !reussir.rc<!reussir.cell<!inner exclusive>>
+!rc_i64_excl_cell = !reussir.rc<!reussir.cell<i64 exclusive>>
 !holder = !reussir.record<compound "CellHolder" [value] {
   !reussir.cell<i64>
 }>
@@ -18,6 +22,22 @@ module {
   func.func @create_cell(%value: !inner) -> !rc_cell {
     %cell = reussir.cell.create value(%value : !inner) : !rc_cell
     return %cell : !rc_cell
+  }
+
+  // An exclusive cell box carries the trailing in-use flag: the payload
+  // widens from 8 to 16 bytes (element + flag padded to alignment), so the
+  // box token is 8 bytes larger. The flag starts out false.
+  // TOKEN-LABEL: func.func @create_exclusive_cell
+  // TOKEN: %[[TOKEN:.+]] = reussir.token.alloc : <align : 8, size : 24>
+  // TOKEN: reussir.cell.create value(%{{.+}} : !reussir.rc<i64>) token(%[[TOKEN]] : !reussir.token<align : 8, size : 24>)
+  // EXPAND-LABEL: func.func @create_exclusive_cell
+  // EXPAND: %[[FALSE:.+]] = arith.constant false
+  // EXPAND: reussir.ref.store
+  // EXPAND: %[[FLAG:.+]] = reussir.ref.project{{.*}}[1] : !reussir.ref<i1 field>
+  // EXPAND: reussir.ref.store(%[[FLAG]] : !reussir.ref<i1 field>) (%[[FALSE]] : i1)
+  func.func @create_exclusive_cell(%value: !inner) -> !rc_excl_cell {
+    %cell = reussir.cell.create value(%value : !inner) : !rc_excl_cell
+    return %cell : !rc_excl_cell
   }
 
   // TOKEN-LABEL: func.func @drop_cell
@@ -34,6 +54,7 @@ module {
 
   // EXPAND-LABEL: func.func @get_cell
   // EXPAND: %[[BORROW:.+]] = reussir.rc.borrow
+  // EXPAND-NOT: reussir.ref.project{{.*}}[1]
   // EXPAND: %[[SLOT:.+]] = reussir.ref.project(%[[BORROW]]
   // EXPAND: %[[VALUE:.+]] = reussir.ref.load(%[[SLOT]]
   // EXPAND-NEXT: reussir.rc.inc(%[[VALUE]]
@@ -46,6 +67,22 @@ module {
   func.func @get_cell(%cell: !rc_cell) -> !inner {
     %value = reussir.cell.get(%cell : !rc_cell) : !inner
     return %value : !inner
+  }
+
+  // A non-trivial, non-RC element (here a nullable RC pointer) must also be
+  // acquired on get: the clone dispatches on nullness and retains the wrapped
+  // box on the nonnull path.
+  // EXPAND-LABEL: func.func @get_nullable_cell
+  // EXPAND: %[[VALUE:.+]] = reussir.ref.load
+  // EXPAND: %[[SPILL:.+]] = reussir.ref.spilled(%[[VALUE]]
+  // EXPAND: %[[RELOAD:.+]] = reussir.ref.load(%[[SPILL]]
+  // EXPAND: reussir.nullable.dispatch(%[[RELOAD]]
+  // EXPAND: ^{{.+}}(%[[NONNULL:.+]]: !reussir.rc<i64>):
+  // EXPAND: reussir.rc.inc(%[[NONNULL]]
+  // EXPAND: return %[[VALUE]]
+  func.func @get_nullable_cell(%cell: !rc_nullable_cell) -> !nullable_inner {
+    %value = reussir.cell.get(%cell : !rc_nullable_cell) : !nullable_inner
+    return %value : !nullable_inner
   }
 
   // EXPAND-LABEL: func.func @set_cell
@@ -61,18 +98,66 @@ module {
     return
   }
 
+  // Every payload access to an exclusive cell lowers to a branch on the
+  // in-use flag: the in-use arm panics and yields poison, the free arm
+  // performs the access.
+  // EXPAND-LABEL: func.func @get_exclusive_cell
+  // EXPAND: %[[POISON:.+]] = ub.poison : !reussir.rc<i64>
+  // EXPAND: %[[FLAG:.+]] = reussir.ref.project{{.*}}[1] : !reussir.ref<i1 field>
+  // EXPAND: %[[INUSE:.+]] = reussir.ref.load(%[[FLAG]]
+  // EXPAND: %[[EXPECT:.+]] = reussir.expect(%[[INUSE]] : i1, false)
+  // EXPAND: %[[RESULT:.+]] = scf.if %[[EXPECT]] -> (!reussir.rc<i64>)
+  // EXPAND: reussir.panic "cell.get on an exclusive cell that is in use"
+  // EXPAND: scf.yield %[[POISON]]
+  // EXPAND: } else {
+  // EXPAND: %[[VALUE:.+]] = reussir.ref.load
+  // EXPAND: reussir.rc.inc(%[[VALUE]]
+  // EXPAND: scf.yield %[[VALUE]]
+  // EXPAND: return %[[RESULT]]
+  func.func @get_exclusive_cell(%cell: !rc_excl_cell) -> !inner {
+    %value = reussir.cell.get(%cell : !rc_excl_cell) : !inner
+    return %value : !inner
+  }
+
+  // EXPAND-LABEL: func.func @set_exclusive_cell
+  // EXPAND: %[[EXPECT:.+]] = reussir.expect
+  // EXPAND: scf.if %[[EXPECT]]
+  // EXPAND: reussir.panic "cell.set on an exclusive cell that is in use"
+  // EXPAND: } else {
+  // EXPAND: %[[OLD:.+]] = reussir.ref.load
+  // EXPAND: reussir.rc.dec(%[[OLD]]
+  // EXPAND: reussir.ref.store
+  func.func @set_exclusive_cell(%value: !inner, %cell: !rc_excl_cell) {
+    reussir.cell.set(%value : !inner, %cell : !rc_excl_cell)
+    return
+  }
+
+  // The whole read-modify-write is the free arm of the flag branch: raise
+  // the flag, move the element through the body, clear the flag with the
+  // replacement store. The moved element sees no retain or release, and the
+  // panicked arm yields poison.
   // EXPAND-LABEL: func.func @rmw_cell
+  // EXPAND-DAG: %[[FALSE:.+]] = arith.constant false
+  // EXPAND-DAG: %[[TRUE:.+]] = arith.constant true
+  // EXPAND-DAG: %[[POISON:.+]] = ub.poison : !reussir.rc<i64>
   // EXPAND-NOT: reussir.rc.inc
   // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: %[[RESULT:.+]] = scf.if %{{.+}} -> (!reussir.rc<i64>)
+  // EXPAND: reussir.panic "cell.rmw on an exclusive cell that is in use"
+  // EXPAND: scf.yield %[[POISON]]
+  // EXPAND: } else {
+  // EXPAND: reussir.ref.store(%{{.+}} : !reussir.ref<i1 field>) (%[[TRUE]] : i1)
   // EXPAND: %[[OLD:.+]] = reussir.ref.load
   // EXPAND-NOT: reussir.rc.inc
   // EXPAND-NOT: reussir.rc.dec
   // EXPAND: reussir.ref.store
+  // EXPAND: reussir.ref.store(%{{.+}} : !reussir.ref<i1 field>) (%[[FALSE]] : i1)
+  // EXPAND: scf.yield %[[OLD]]
   // EXPAND-NOT: reussir.rc.inc
   // EXPAND-NOT: reussir.rc.dec
-  // EXPAND: return %[[OLD]]
-  func.func @rmw_cell(%value: !inner, %cell: !rc_cell) -> !inner {
-    %old = reussir.cell.rmw(%cell : !rc_cell) -> !inner {
+  // EXPAND: return %[[RESULT]]
+  func.func @rmw_cell(%value: !inner, %cell: !rc_excl_cell) -> !inner {
+    %old = reussir.cell.rmw(%cell : !rc_excl_cell) -> !inner {
       ^bb0(%current: !inner):
         reussir.cell.yield(%value : !inner) output(%current : !inner)
     }
@@ -82,6 +167,7 @@ module {
   // EXPAND-LABEL: func.func @rmw_i64
   // EXPAND-NOT: reussir.rc.inc
   // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: reussir.ref.store{{.*}}(%{{.+}} : i1)
   // EXPAND: %[[OLD:.+]] = reussir.ref.load
   // EXPAND-NOT: reussir.rc.inc
   // EXPAND-NOT: reussir.rc.dec
@@ -91,15 +177,25 @@ module {
   // EXPAND: reussir.ref.store{{.*}}(%[[NEXT]] : i64)
   // EXPAND-NOT: reussir.rc.inc
   // EXPAND-NOT: reussir.rc.dec
+  // EXPAND: scf.yield %[[OLD]]
   // EXPAND: return
-  func.func @rmw_i64(%cell: !rc_i64_cell) -> i64 {
-    %old = reussir.cell.rmw(%cell : !rc_i64_cell) -> i64 {
+  func.func @rmw_i64(%cell: !rc_i64_excl_cell) -> i64 {
+    %old = reussir.cell.rmw(%cell : !rc_i64_excl_cell) -> i64 {
       ^bb0(%current: i64):
         %one = arith.constant 1 : i64
         %next = arith.addi %current, %one : i64
         reussir.cell.yield(%next : i64) output(%current : i64)
     }
     return %old : i64
+  }
+
+  // EXPAND-LABEL: func.func @in_use
+  // EXPAND: %[[FLAG:.+]] = reussir.ref.project{{.*}}[1] : !reussir.ref<i1 field>
+  // EXPAND: %[[LOADED:.+]] = reussir.ref.load(%[[FLAG]] : !reussir.ref<i1 field>) : i1
+  // EXPAND: return %[[LOADED]]
+  func.func @in_use(%cell: !rc_excl_cell) -> i1 {
+    %flag = reussir.cell.in_use(%cell : !rc_excl_cell) : i1
+    return %flag : i1
   }
 
   // A non-cell borrow remains eligible for invariant.group, proving that the
@@ -123,5 +219,16 @@ module {
       : !reussir.ref<!rc_i64_cell>
     %cell = reussir.ref.load(%slot : !reussir.ref<!rc_i64_cell>) : !rc_i64_cell
     return %cell : !rc_i64_cell
+  }
+
+  // The exclusive flag lives at struct index 1: the guarded fast path loads
+  // it, and the box payload lowers as {element, i1}.
+  // LLVM-LABEL: define i1 @in_use_lowering(ptr %[[CELL:.+]])
+  // LLVM: %[[FLAG_PTR:.+]] = getelementptr { ptr, i1 }, ptr %{{.+}}, i32 0, i32 1
+  // LLVM: %[[FLAG:.+]] = load i1, ptr %[[FLAG_PTR]]
+  // LLVM: ret i1 %[[FLAG]]
+  func.func @in_use_lowering(%cell: !rc_excl_cell) -> i1 {
+    %flag = reussir.cell.in_use(%cell : !rc_excl_cell) : i1
+    return %flag : i1
   }
 }

--- a/tests/integration/conversion/cell_ops.mlir
+++ b/tests/integration/conversion/cell_ops.mlir
@@ -223,7 +223,7 @@ module {
 
   // The exclusive flag lives at struct index 1: the guarded fast path loads
   // it, and the box payload lowers as {element, i1}.
-  // LLVM-LABEL: define i1 @in_use_lowering(ptr %[[CELL:.+]])
+  // LLVM-LABEL: define i1 @in_use_lowering(ptr
   // LLVM: %[[FLAG_PTR:.+]] = getelementptr { ptr, i1 }, ptr %{{.+}}, i32 0, i32 1
   // LLVM: %[[FLAG:.+]] = load i1, ptr %[[FLAG_PTR]]
   // LLVM: ret i1 %[[FLAG]]

--- a/tests/integration/conversion/closure_beta_structural.mlir
+++ b/tests/integration/conversion/closure_beta_structural.mlir
@@ -7,7 +7,7 @@
 // loop nests; this file covers rmw alone, rmw nested under a loop, ownership
 // accounting for an rc capture, and rejection of an unrelated region op.
 
-!rc_cell = !reussir.rc<!reussir.cell<i64>>
+!rc_cell = !reussir.rc<!reussir.cell<i64 exclusive>>
 !rc_i64 = !reussir.rc<i64>
 
 module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>>} {

--- a/tests/integration/conversion/inc_dec_cancellation_across_cell.mlir
+++ b/tests/integration/conversion/inc_dec_cancellation_across_cell.mlir
@@ -1,0 +1,60 @@
+// RUN: %reussir-opt %s --reussir-inc-dec-cancellation | %FileCheck %s
+
+// `reussir-inc-dec-cancellation` must not cancel an `rc.inc` against a later
+// aliased `rc.dec` across cell mutation ops. `cell.set` implicitly releases
+// the old cell element — the released rc is reachable only *through* the
+// cell, so no operand alias query can prove it disjoint from the incremented
+// pointer. A `cell.rmw` body is arbitrary nested code the same-block scan
+// never visits. Both are opaque, exactly like an unexpanded `ref.drop`.
+
+!box = !reussir.record<compound "Box" {i64}>
+!rc_box = !reussir.rc<!box>
+!cell = !reussir.rc<!reussir.cell<!rc_box>>
+!excl_cell = !reussir.rc<!reussir.cell<!rc_box exclusive>>
+!scalar_cell = !reussir.rc<!reussir.cell<i64>>
+
+module {
+  func.func @retain_across_cell_set(%v: !rc_box, %rc: !rc_box, %cell: !cell) {
+    // The cell may hold the very rc being retained; the set's implicit drop
+    // of the old element must keep this pair alive.
+    reussir.rc.inc (%rc : !rc_box)
+    reussir.cell.set(%v : !rc_box, %cell : !cell)
+    reussir.rc.dec (%rc : !rc_box)
+    return
+  }
+
+  func.func @retain_across_cell_rmw(%v: !rc_box, %rc: !rc_box, %cell: !excl_cell) {
+    reussir.rc.inc (%rc : !rc_box)
+    reussir.cell.rmw(%cell : !excl_cell) {
+      ^bb0(%old: !rc_box):
+        reussir.rc.dec (%old : !rc_box)
+        reussir.cell.yield(%v : !rc_box)
+    }
+    reussir.rc.dec (%rc : !rc_box)
+    return
+  }
+
+  func.func @cancel_across_trivial_cell_set(%v: i64, %rc: !rc_box, %cell: !scalar_cell) {
+    // A set of a trivially-copyable element expands to a plain store — it
+    // cannot release anything, so it stays transparent and the pair cancels.
+    reussir.rc.inc (%rc : !rc_box)
+    reussir.cell.set(%v : i64, %cell : !scalar_cell)
+    reussir.rc.dec (%rc : !rc_box)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @retain_across_cell_set
+// CHECK:       reussir.rc.inc
+// CHECK:       reussir.cell.set
+// CHECK:       reussir.rc.dec
+
+// CHECK-LABEL: func.func @retain_across_cell_rmw
+// CHECK:       reussir.rc.inc
+// CHECK:       reussir.cell.rmw
+// CHECK:       reussir.rc.dec
+
+// CHECK-LABEL: func.func @cancel_across_trivial_cell_set
+// CHECK-NOT:   reussir.rc.inc
+// CHECK:       reussir.cell.set
+// CHECK-NOT:   reussir.rc.dec

--- a/tests/integration/sanitizer/cell-asan.mlir
+++ b/tests/integration/sanitizer/cell-asan.mlir
@@ -10,13 +10,20 @@
 
 // This one lifecycle catches all Cell ownership edges with ASan+LSan:
 // - get must retain the nested Rc before its returned clone is released;
+// - get of a non-RC managed element (a nullable RC pointer) must equally
+//   retain through the acquisition glue — the case that used to silently
+//   lose its +1 and read freed memory;
 // - set must release the old nested Rc but must not retain the incoming one;
-// - rmw must move old/new values without either retain or release;
+// - rmw (exclusive cells only) must move old/new values without either
+//   retain or release, and must maintain the in-use flag;
 // - the final cell decrement must recursively release its nested Rc.
 
 !inner = !reussir.rc<i64>
+!nullable_inner = !reussir.nullable<!inner>
 !cell = !reussir.rc<!reussir.cell<!inner>>
-!scalar_cell = !reussir.rc<!reussir.cell<i64>>
+!excl_cell = !reussir.rc<!reussir.cell<!inner exclusive>>
+!nullable_cell = !reussir.rc<!reussir.cell<!nullable_inner>>
+!scalar_cell = !reussir.rc<!reussir.cell<i64 exclusive>>
 
 module attributes {reussir.sanitize = ["sanitize_address"]} {
   func.func private @read_inner(%value: !inner) -> i64
@@ -46,6 +53,8 @@ module attributes {reussir.sanitize = ["sanitize_address"]} {
     %c22 = arith.constant 22 : i64
     %c33 = arith.constant 33 : i64
     %c44 = arith.constant 44 : i64
+    %c55 = arith.constant 55 : i64
+    %c66 = arith.constant 66 : i64
 
     %v1 = reussir.rc.create value(%c11 : i64) : !inner
     %cell = reussir.cell.create value(%v1 : !inner) : !cell
@@ -64,26 +73,52 @@ module attributes {reussir.sanitize = ["sanitize_address"]} {
     func.call @require_equal(%got22, %c22) : (i64, i64) -> ()
     reussir.rc.dec(%clone2 : !inner)
 
-    // rmw moves v2 out and v3 in. Returning the old value must not retain it.
+    // rmw needs an exclusive cell: it moves v3 out and v4 in. Returning the
+    // old value must not retain it, and the in-use flag must read false
+    // outside the body.
     %v3 = reussir.rc.create value(%c33 : i64) : !inner
-    %old = reussir.cell.rmw(%cell : !cell) -> !inner {
+    %ecell = reussir.cell.create value(%v3 : !inner) : !excl_cell
+    %v4 = reussir.rc.create value(%c44 : i64) : !inner
+    %old = reussir.cell.rmw(%ecell : !excl_cell) -> !inner {
       ^bb0(%current: !inner):
-        reussir.cell.yield(%v3 : !inner) output(%current : !inner)
+        reussir.cell.yield(%v4 : !inner) output(%current : !inner)
     }
-    %old22 = func.call @read_inner(%old) : (!inner) -> i64
-    func.call @require_equal(%old22, %c22) : (i64, i64) -> ()
+    %old33 = func.call @read_inner(%old) : (!inner) -> i64
+    func.call @require_equal(%old33, %c33) : (i64, i64) -> ()
     reussir.rc.dec(%old : !inner)
 
-    %clone3 = reussir.cell.get(%cell : !cell) : !inner
-    %got33 = func.call @read_inner(%clone3) : (!inner) -> i64
-    func.call @require_equal(%got33, %c33) : (i64, i64) -> ()
+    %idle = reussir.cell.in_use(%ecell : !excl_cell) : i1
+    scf.if %idle {
+      reussir.panic "exclusive cell must be idle outside rmw"
+    }
+
+    %clone3 = reussir.cell.get(%ecell : !excl_cell) : !inner
+    %got44 = func.call @read_inner(%clone3) : (!inner) -> i64
+    func.call @require_equal(%got44, %c44) : (i64, i64) -> ()
     reussir.rc.dec(%clone3 : !inner)
 
-    // Replacing v3 checks another old-value drop. The cell's final decrement
-    // must recursively release v4.
-    %v4 = reussir.rc.create value(%c44 : i64) : !inner
-    reussir.cell.set(%v4 : !inner, %cell : !cell)
+    // Replacing v2 checks another old-value drop. The cells' final
+    // decrements must recursively release their elements.
+    %v5 = reussir.rc.create value(%c55 : i64) : !inner
+    reussir.cell.set(%v5 : !inner, %cell : !cell)
     reussir.rc.dec(%cell : !cell)
+    reussir.rc.dec(%ecell : !excl_cell)
+
+    // A nullable element is managed but not a bare RC pointer: its get-clone
+    // must retain through the acquisition glue. Without that +1 the set(null)
+    // below frees the box while %nclone still reads it (ASan catches the
+    // use-after-free), and the trailing decrements double-release.
+    %v6 = reussir.rc.create value(%c66 : i64) : !inner
+    %nonnull = reussir.nullable.create (%v6 : !inner) : !nullable_inner
+    %ncell = reussir.cell.create value(%nonnull : !nullable_inner) : !nullable_cell
+    %nclone = reussir.cell.get(%ncell : !nullable_cell) : !nullable_inner
+    %null = reussir.nullable.create : !nullable_inner
+    reussir.cell.set(%null : !nullable_inner, %ncell : !nullable_cell)
+    %ncoerced = reussir.nullable.coerce (%nclone : !nullable_inner) : !inner
+    %got66 = func.call @read_inner(%ncoerced) : (!inner) -> i64
+    func.call @require_equal(%got66, %c66) : (i64, i64) -> ()
+    reussir.rc.dec(%ncoerced : !inner)
+    reussir.rc.dec(%ncell : !nullable_cell)
 
     // Also execute both rmw and ordinary get/set for a trivial payload.
     %scalar = reussir.cell.create value(%c5 : i64) : !scalar_cell

--- a/tests/unittest/cases/cell.cpp
+++ b/tests/unittest/cases/cell.cpp
@@ -21,6 +21,23 @@ TEST_F(ReussirTest, ParseCellTypeTest) {
                      });
 }
 
+TEST_F(ReussirTest, ParseExclusiveCellTypeTest) {
+  withType<CellType>(
+      SIMPLE_LAYOUT, R"(!reussir.cell<!reussir.rc<i64> exclusive>)",
+      [](mlir::ModuleOp module, CellType type) {
+        EXPECT_TRUE(type.getExclusive());
+        EXPECT_TRUE(llvm::isa<RcType>(type.getElementType()));
+
+        // The trailing i1 in-use flag adds one byte, padded back to the
+        // element's alignment: a pointer element yields a 16-byte cell.
+        mlir::DataLayout layout(module);
+        EXPECT_EQ(layout.getTypeSize(type),
+                  2 * layout.getTypeSize(type.getElementType()));
+        EXPECT_EQ(layout.getTypeABIAlignment(type),
+                  layout.getTypeABIAlignment(type.getElementType()));
+      });
+}
+
 TEST_F(ReussirTest, CellMemberProjectsToSharedRc) {
   auto i64Type = mlir::IntegerType::get(context.get(), 64);
   auto cellType = CellType::get(context.get(), i64Type);


### PR DESCRIPTION
Backend rework of the cell dialect ahead of the frontend Cell series (#415–#421). Two changes, per review findings on the stack:

## 1. `cell.get` acquisition is now triviality-driven (fixes a use-after-free)

The get expansion special-cased RC elements (`rc.inc`) and silently skipped acquisition for every other managed element. On `Cell<Nullable<Rc<T>>>` the returned clone lost its +1, so the next `set` released the box under the live clone — ASan-proven heap-use-after-free on the stack's `test_rc_cycle` (see review on #415).

- Get now dispatches on `isTriviallyCopyable`: any non-trivial element is acquired — bare RC pointers retain directly, everything else routes through `ref.acquire`.
- `emitOwnershipAcquisition` gains the missing nullable branch (the exact dual of `rewriteDropNullable`): dispatch on nullness, retain the wrapped box on the nonnull path. Previously non-trivial nullables fell through the Ref case as a silent no-op.
- The `ref.acquire` verifier accepts nullable-of-RC references.
- New `@get_nullable_cell` conversion checks plus a `Cell<Nullable<Rc<i64>>>` get/set lifecycle in the ASan e2e test that reads the clone *after* `set(null)` — the exact pattern that used to read freed memory.

## 2. Plain cells are get/set-only; `cell<exclusive>` carries an in-use flag and owns `rmw`

`cell.rmw` moves the element out of the slot while its body runs; a reentrant access through an alias of the same cell (via a closure calling back into it) would clone or double-release the stale slot, and nothing recorded that state. Now:

- `!reussir.cell<T exclusive>`: new type flavor. Storage carries a trailing `i1` in-use flag — data layout and the LLVM lowering become `{T, i1}` (plain cells are unchanged, layout-identical to `T`). The flag is addressed as `ref.project [1]` with field capability.
- `cell.rmw` requires an exclusive cell (verifier-enforced); plain cells support only whole-element `get`/`set`.
- Every exclusive payload access lowers to a branch on the flag (lifted to `scf.if` at expansion time): the in-use arm panics and yields poison, the free arm performs the access. `rmw`'s free arm raises the flag, moves the element through the inlined body, and clears the flag with the replacement store — so even at the IR level the panicked path never touches the moved-out slot.
- `cell.create` initializes the flag to false.
- New `reussir.cell.in_use` op loads the flag, so front ends can build checked access (`try_borrow`-style) instead of panicking.
- CAPI/Rust bindings: `reussirCellTypeGet` takes an `exclusive` flag.

## Also

- `cell.set`/`cell.rmw` become inc/dec cancellation barriers (review finding on the stack): a set releases the old element *through* the cell — invisible to operand alias queries, exactly like an unexpanded `ref.drop` — and an rmw body is nested code the same-block scan never visits. Trivial-element sets stay transparent. Regression test included.
- Dropped the spurious `MutableType` trait from `CellType` and `RefType`: it declares mutable *type storage* (what `RecordType` needs for recursive completion via `mutate()`), not mutable values; neither type has a `mutate()` and nothing queries the trait. Happy to revert the `RefType` half if you want it separate.

## Testing

- `cell_ops.mlir`: exclusive create/get/set/rmw/in_use codegen (guard shape, flag init/raise/clear, poison arm), nullable get acquisition, token sizing for the widened exclusive box (16→24), `{ptr, i1}` LLVM struct pin.
- `basic/{success,failure}/cell.mlir`: exclusive roundtrips; rmw/in_use rejected on plain cells; flag-slot projection verifier coverage.
- `cell-asan.mlir` e2e: rmw + in_use on exclusive cells, plus the nullable UAF lifecycle, under ASan+LSan.
- New `inc_dec_cancellation_across_cell.mlir`; unittest layout/parse coverage for the exclusive flavor; `cargo test -p reussir-backend` for the CAPI binding.
- Full lit suite (349 pass / 1 unsupported), ctest 20/20.

Frontend series rework (#415–#421) to follow once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k

---
_Generated by [Claude Code](https://claude.ai/code/session_01EraJ62V8juEK39QccGns6k)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786634187&installation_id=144622820&pr_number=422&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F422&signature=e8f39a22f9f5390fbd970c65efc9ddcfc5b4bcb2b6b7532df8342eff68a5b9ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->