### PR TITLE
[frontend] add the Arc<T> builtin type for atomic rc coloring

### DIFF
--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -518,6 +518,7 @@ fn scalar_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
         TyKind::Record { .. } => err("record type reached scalar lowering without a layout"),
         TyKind::Array { .. } => err("array type reached scalar lowering without its rc wrapper"),
         TyKind::Cell { .. } => err("cell type reached scalar lowering without its rc wrapper"),
+        TyKind::Arc(_) => err("`Arc` lowering is not implemented yet"),
         TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),
         // Intercepted by [`TypeCtx::mlir_ty`]; reaching here is a bug.
         TyKind::Closure { .. } => err("closure type reached scalar lowering without an rc wrapper"),

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -152,6 +152,11 @@ impl<'a> Mangler<'a> {
                 let name = if exclusive { "RefCell" } else { "Cell" };
                 self.path_with_args_segs(out, &[name], &[elem]);
             }
+            TyKind::Arc(inner) => {
+                // `Arc<X>` is a root built-in type constructor too: a synthetic
+                // one-segment record applied to the colored record.
+                self.path_with_args_segs(out, &["Arc"], &[inner]);
+            }
             TyKind::Array { elem, dims } => {
                 // An array mangles as a synthetic record whose identifier
                 // carries the extents (`Array512x512`), applied to the element.
@@ -344,6 +349,10 @@ mod tests {
             assert_eq!(m.mangle_ty(cell), "_RIC4CelllE");
             let refcell = tcx.mk_cell(tcx.mk_int(IntTy::Signed(32)), true);
             assert_eq!(m.mangle_ty(refcell), "_RIC7RefCelllE");
+            // `Arc<i32>` → `IC3ArclE` (a synthetic root record, like the
+            // others; a real inner is always a `[shared]` record).
+            let arc = tcx.mk_arc(tcx.mk_int(IntTy::Signed(32)));
+            assert_eq!(m.mangle_ty(arc), "_RIC3ArclE");
         });
     }
 

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -273,6 +273,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let inner = self.ty(inner);
                 self.tcx.mk_cell(inner, *exclusive)
             }
+            raw::Ty::Arc(inner) => {
+                let inner = self.ty(inner);
+                self.tcx.mk_arc(inner)
+            }
             raw::Ty::Record { cap: c, path, args } => {
                 let def = self.record_def(path);
                 let args: Vec<Ty<'tcx>> = args.iter().map(|a| self.ty(a)).collect();
@@ -762,6 +766,22 @@ mod tests {
             }
             pub fn mixed(c: Cell<RefCell<i64>>) -> Cell<RefCell<i64>> {
                 c
+            }
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrips_arcs() {
+        roundtrip(
+            r#"
+            struct Data { value: i64 }
+            fn generic<T>(a: T) -> T { a }
+            pub fn use_arc(a: Arc<Data>) -> Arc<Data> {
+                generic(a)
+            }
+            pub fn maybe(a: Nullable<Arc<Data>>) -> Nullable<Arc<Data>> {
+                a
             }
             "#,
         );

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -125,6 +125,7 @@ Ty: raw::Ty = {
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
     "Cell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: false },
     "RefCell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: true },
+    "Arc" "<" <t:Ty> ">" => raw::Ty::Arc(Box::new(t)),
     <cap:Cap> <path:TyPathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
     "[" <elem:Ty> ";" <dims:CommaPlus<"int">> "]"
@@ -354,6 +355,7 @@ extern {
         "Nullable" => Token::Nullable,
         "Cell" => Token::Cell,
         "RefCell" => Token::RefCell,
+        "Arc" => Token::Arc,
         "NonNull" => Token::NonNull,
         "Null" => Token::Null,
         "poison" => Token::Poison,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -267,6 +267,7 @@ impl Render<'_> {
             TyKind::Cell { elem, exclusive } => {
                 text(if exclusive { "RefCell<" } else { "Cell<" }) + self.ty(elem) + text(">")
             }
+            TyKind::Arc(inner) => text("Arc<") + self.ty(inner) + text(">"),
             TyKind::Array { elem, dims } => {
                 let mut d = text("[") + self.ty(elem) + text(";");
                 for (i, extent) in dims.iter().enumerate() {

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -211,6 +211,7 @@ pub enum Ty {
         inner: Box<Ty>,
         exclusive: bool,
     },
+    Arc(Box<Ty>),
     /// `[cap] path<args>` — a regional/value record type.
     Record {
         cap: Cap,

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -38,6 +38,15 @@
 //! record instance is finalized — reporting any non-regional (value/shared)
 //! instantiation. The *flexivity* rules (flex capture/return/assign) are a
 //! separate concern enforced at the Semi stage on concrete records, not here.
+//!
+//! # `Arc` inner check at the instantiation boundary
+//!
+//! `ty_eval` rejects a concrete `Arc` inner that is not a shared rc box (a
+//! `[shared]` record, an array, or a closure) but lets a generic inner
+//! (`Arc<T>`) through. An instantiation — e.g. a trampoline's explicit type
+//! arguments — is the first point where such a type grounds, so mono re-walks
+//! every substituted type and reports any `Arc<i32>`/`Arc<Cell<…>>` it finds
+//! (see [`arc_inner_rejection`]).
 
 use std::collections::VecDeque;
 
@@ -58,6 +67,7 @@ use crate::semi::hir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{DefId, Flexivity, Ty, TyCtxt, TyKind};
 use crate::semi::ty::{FpTy, IntTy};
+use crate::semi::ty_eval::arc_inner_rejection;
 use crate::surface::Span;
 use crate::utils::string::StringToken;
 
@@ -116,6 +126,8 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         queue: VecDeque::new(),
         seen: FxHashSet::default(),
         records: FxHashSet::default(),
+        record_defs: input.records,
+        reported_arcs: FxHashSet::default(),
         reports: Vec::new(),
         cur_file: FileId::ROOT,
         ids: mir::ExprIdGen::default(),
@@ -138,6 +150,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             continue;
         };
         driver.cur_file = func.file;
+        driver.reported_arcs.clear();
 
         // Bind this instance's generics, then ground the signature and lower the
         // body into the MIR.
@@ -162,6 +175,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             .map(|(name, var, ty)| {
                 let ty = subst_ty(tcx, *ty, &subst);
                 driver.note_records(ty);
+                driver.check_arc_inners(ty, func.span);
                 mir::Param {
                     name: *name,
                     var: *var,
@@ -171,6 +185,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             .collect();
         let return_ty = subst_ty(tcx, func.return_ty, &subst);
         driver.note_records(return_ty);
+        driver.check_arc_inners(return_ty, func.span);
         let body = func.body.as_ref().map(|b| driver.lower_ref(b, &subst));
 
         let symbol = driver.symbol_of(inst.def, inst.ty_args);
@@ -418,6 +433,13 @@ struct Driver<'a, 'tcx> {
     seen: FxHashSet<Instance<'tcx>>,
     /// Ground record instances whose layout is needed (keyed flex-independently).
     records: FxHashSet<(DefId, &'tcx [Ty<'tcx>])>,
+    /// Record definitions (for their default capability) — the deferred `Arc`
+    /// inner check needs to tell a `[shared]` record from the rest.
+    record_defs: &'a FxHashMap<DefId, Record<'tcx>>,
+    /// `Arc` types already reported by the deferred inner check; cleared per
+    /// function instance so an offending instantiation reports once, not once
+    /// per mention in the body.
+    reported_arcs: FxHashSet<Ty<'tcx>>,
     reports: Vec<Report>,
     /// The declaration file of the item currently being instantiated; stamped
     /// onto reports so multi-file diagnostics point into the right source.
@@ -493,6 +515,50 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             TyKind::Cell { elem: inner, .. } => self.note_records(inner),
             TyKind::Arc(inner) => self.note_records(inner),
             TyKind::Array { elem, .. } => self.note_records(elem),
+            _ => {}
+        }
+    }
+
+    /// The deferred half of the `Arc` inner check (see the module docs):
+    /// `ty_eval` lets a generic inner (`Arc<T>`) through, so a ground
+    /// instantiation is the first point where an `Arc` of a non-box —
+    /// `Arc<i32>`, `Arc<Cell<…>>` — can exist. Walk a substituted type and
+    /// report every such `Arc`, once per type per function instance (see
+    /// [`reported_arcs`](Self::reported_arcs)).
+    fn check_arc_inners(&mut self, ty: Ty<'tcx>, span: Option<Span>) {
+        match *ty.kind() {
+            TyKind::Arc(inner) => {
+                let rejection = arc_inner_rejection(
+                    |def| self.record_defs.get(&def).map(|r| r.default_cap),
+                    inner,
+                );
+                if let Some(kind) = rejection
+                    && self.reported_arcs.insert(ty)
+                {
+                    self.error(
+                        span,
+                        format!(
+                            "this instantiation grounds an `Arc` inner type that is not a \
+                             `[shared]` record, array, or closure ({kind})"
+                        ),
+                    );
+                }
+                self.check_arc_inners(inner, span);
+            }
+            TyKind::Record { args, .. } => {
+                for &arg in args {
+                    self.check_arc_inners(arg, span);
+                }
+            }
+            TyKind::Closure { params, ret } => {
+                for &p in params {
+                    self.check_arc_inners(p, span);
+                }
+                self.check_arc_inners(ret, span);
+            }
+            TyKind::Nullable(inner) => self.check_arc_inners(inner, span),
+            TyKind::Cell { elem: inner, .. } => self.check_arc_inners(inner, span),
+            TyKind::Array { elem, .. } => self.check_arc_inners(elem, span),
             _ => {}
         }
     }
@@ -593,6 +659,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
     fn lower_expr(&mut self, e: &Expr<'tcx>, subst: &Subst<'tcx>) -> mir::Expr<'tcx> {
         let ty = subst_ty(self.tcx, e.ty, subst);
         self.note_records(ty);
+        self.check_arc_inners(ty, e.span);
         let kind = self.lower_kind(&e.kind, subst);
         self.check_literal_range(&kind, ty, e.span);
         mir::Expr {
@@ -1506,6 +1573,49 @@ mod tests {
                 "expected a regionality diagnostic, got {reports:#?}"
             );
         });
+    }
+
+    #[test]
+    fn arc_generic_rejects_non_box_instantiation() {
+        // `ty_eval` defers a generic `Arc` inner; a trampoline's explicit type
+        // arguments are the first point where it grounds. `Arc<i32>` and
+        // `Arc<Cell<i32>>` must be rejected here — `Arc` takes only a shared
+        // rc box (a `[shared]` record, an array, or a closure).
+        let src = r#"
+            fn passthrough<T>(a: Arc<T>) -> Arc<T> { a }
+            extern "C" trampoline "bad_scalar" = passthrough<i32>;
+            extern "C" trampoline "bad_cell" = passthrough<Cell<i32>>;
+        "#;
+        let reports = mono_reports(src);
+        assert!(
+            reports.iter().any(|m| m.contains(
+                "grounds an `Arc` inner type that is not a `[shared]` record, \
+                 array, or closure (not an rc box)"
+            )),
+            "{reports:#?}"
+        );
+        assert!(
+            reports.iter().any(|m| m.contains(
+                "grounds an `Arc` inner type that is not a `[shared]` record, \
+                 array, or closure (a cell)"
+            )),
+            "{reports:#?}"
+        );
+    }
+
+    #[test]
+    fn arc_generic_accepts_shared_box_instantiations() {
+        // A `[shared]` record, an array, and a closure are all shared rc
+        // boxes, so grounding `Arc<T>` at them is fine.
+        let src = r#"
+            struct Data { value: i64 }
+            fn passthrough<T>(a: Arc<T>) -> Arc<T> { a }
+            extern "C" trampoline "ok_record" = passthrough<Data>;
+            extern "C" trampoline "ok_array" = passthrough<[f64; 8]>;
+            extern "C" trampoline "ok_closure" = passthrough<(i64) -> i64>;
+        "#;
+        let reports = mono_reports(src);
+        assert!(reports.is_empty(), "{reports:#?}");
     }
 
     #[test]

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -356,6 +356,7 @@ fn ty_depth(ty: Ty<'_>) -> usize {
     match *ty.kind() {
         TyKind::Nullable(inner) => 1 + ty_depth(inner),
         TyKind::Cell { elem: inner, .. } => 1 + ty_depth(inner),
+        TyKind::Arc(inner) => 1 + ty_depth(inner),
         TyKind::Array { elem, .. } => 1 + ty_depth(elem),
         TyKind::Record { args, .. } => 1 + args.iter().map(|&a| ty_depth(a)).max().unwrap_or(0),
         TyKind::Closure { params, ret } => {
@@ -490,6 +491,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             }
             TyKind::Nullable(inner) => self.note_records(inner),
             TyKind::Cell { elem: inner, .. } => self.note_records(inner),
+            TyKind::Arc(inner) => self.note_records(inner),
             TyKind::Array { elem, .. } => self.note_records(elem),
             _ => {}
         }
@@ -525,6 +527,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             }
             TyKind::Nullable(inner) => self.discover_records(inner, worklist),
             TyKind::Cell { elem: inner, .. } => self.discover_records(inner, worklist),
+            TyKind::Arc(inner) => self.discover_records(inner, worklist),
             TyKind::Array { elem, .. } => self.discover_records(elem, worklist),
             _ => {}
         }
@@ -1231,6 +1234,7 @@ mod tests {
             }
             TyKind::Nullable(inner) => is_ground(inner),
             TyKind::Cell { elem: inner, .. } => is_ground(inner),
+            TyKind::Arc(inner) => is_ground(inner),
             TyKind::Array { elem, .. } => is_ground(elem),
             _ => true,
         }

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -335,6 +335,9 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
                 }
             }
             TyKind::Closure { .. } => true,
+            // An arc is its inner shared record behind an atomically counted
+            // box — always managed.
+            TyKind::Arc(_) => true,
             TyKind::Nullable(inner) => self.is_rr(inner),
             TyKind::Int(_)
             | TyKind::Fp(_)

--- a/crates/reussir-core/src/full/subst.rs
+++ b/crates/reussir-core/src/full/subst.rs
@@ -36,6 +36,7 @@ pub fn subst_ty<'tcx>(tcx: &TyCtxt<'tcx>, ty: Ty<'tcx>, subst: &Subst<'tcx>) -> 
         }
         TyKind::Nullable(inner) => tcx.mk_nullable(subst_ty(tcx, inner, subst)),
         TyKind::Cell { elem, exclusive } => tcx.mk_cell(subst_ty(tcx, elem, subst), exclusive),
+        TyKind::Arc(inner) => tcx.mk_arc(subst_ty(tcx, inner, subst)),
         TyKind::Array { elem, dims } => tcx.mk_array(subst_ty(tcx, elem, subst), dims),
         TyKind::Int(_)
         | TyKind::Fp(_)

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -90,6 +90,8 @@ pub enum Token<'a> {
     Cell,
     #[token("RefCell")]
     RefCell,
+    #[token("Arc")]
+    Arc,
     #[token("NonNull")]
     NonNull,
     #[token("Null")]

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -994,6 +994,70 @@ mod tests {
         );
     }
 
+    // ----- arc-shared-inner -----
+
+    #[test]
+    fn rejects_arc_of_scalar() {
+        let src = "fn f(x: Arc<i32>) -> i32 { 0 }";
+        assert!(
+            has_error(src, "is not a `[shared]` record (not a record)"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_arc_of_value_record() {
+        let src = "struct [value] Pair { a: i32 }\nfn f(x: Arc<Pair>) -> i32 { 0 }";
+        assert!(
+            has_error(src, "is not a `[shared]` record (a `[value]` record)"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_arc_of_regional_record() {
+        let src = "struct [regional] C { v: i32, next: [field] C }\n\
+                   fn f(x: Arc<C>) -> i32 { 0 }";
+        assert!(
+            has_error(src, "is not a `[shared]` record (a `[regional]` record)"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_arc_arity() {
+        let src = "struct Pair { a: i32 }\nfn f(x: Arc<Pair, Pair>) -> i32 { 0 }";
+        assert!(
+            has_error(src, "`Arc` takes exactly one type argument"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_arc_record_member() {
+        let src = "struct Pair { a: i32 }\nstruct Holder { p: Arc<Pair> }";
+        assert!(
+            has_error(src, "an `Arc` record member is not supported yet"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn accepts_arc_of_shared_record_and_generic() {
+        // A `[shared]` record inner is the intended case; a generic inner is
+        // deferred to the instantiation check.
+        let src = "struct Pair { a: i32 }\n\
+                   fn f(x: Arc<Pair>) -> i32 { 0 }\n\
+                   fn g<T>(x: Arc<T>) -> i32 { 0 }\n\
+                   fn h(x: Nullable<Arc<Pair>>) -> i32 { 0 }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
     // ----- region-flex-checks -----
 
     #[test]

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1000,7 +1000,38 @@ mod tests {
     fn rejects_arc_of_scalar() {
         let src = "fn f(x: Arc<i32>) -> i32 { 0 }";
         assert!(
-            has_error(src, "is not a `[shared]` record (not a record)"),
+            has_error(
+                src,
+                "is not a `[shared]` record, array, or closure (not an rc box)"
+            ),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_arc_of_cell() {
+        // A cell is a shared box, but synchronization is the cell's own axis;
+        // `Arc` must not stack a second discipline on top of it.
+        let src = "fn f(x: Arc<Cell<i32>>) -> i32 { 0 }";
+        assert!(
+            has_error(
+                src,
+                "is not a `[shared]` record, array, or closure (a cell)"
+            ),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_arc_of_arc() {
+        let src = "struct Pair { a: i32 }\nfn f(x: Arc<Arc<Pair>>) -> i32 { 0 }";
+        assert!(
+            has_error(
+                src,
+                "is not a `[shared]` record, array, or closure (already an `Arc`)"
+            ),
             "{:#?}",
             reports_of(src)
         );
@@ -1010,7 +1041,10 @@ mod tests {
     fn rejects_arc_of_value_record() {
         let src = "struct [value] Pair { a: i32 }\nfn f(x: Arc<Pair>) -> i32 { 0 }";
         assert!(
-            has_error(src, "is not a `[shared]` record (a `[value]` record)"),
+            has_error(
+                src,
+                "is not a `[shared]` record, array, or closure (a `[value]` record)"
+            ),
             "{:#?}",
             reports_of(src)
         );
@@ -1021,7 +1055,10 @@ mod tests {
         let src = "struct [regional] C { v: i32, next: [field] C }\n\
                    fn f(x: Arc<C>) -> i32 { 0 }";
         assert!(
-            has_error(src, "is not a `[shared]` record (a `[regional]` record)"),
+            has_error(
+                src,
+                "is not a `[shared]` record, array, or closure (a `[regional]` record)"
+            ),
             "{:#?}",
             reports_of(src)
         );
@@ -1055,6 +1092,15 @@ mod tests {
                    fn f(x: Arc<Pair>) -> i32 { 0 }\n\
                    fn g<T>(x: Arc<T>) -> i32 { 0 }\n\
                    fn h(x: Nullable<Arc<Pair>>) -> i32 { 0 }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn accepts_arc_of_array_and_closure() {
+        // Arrays and closures are single shared rc boxes like a `[shared]`
+        // record, so they take the atomic coloring the same way.
+        let src = "fn f(x: Arc<[f64; 8]>) -> i32 { 0 }\n\
+                   fn g(x: Arc<(i64) -> i64>) -> i32 { 0 }";
         assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
     }
 

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -454,6 +454,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.push_ty_display(out, elem);
                 out.push('>');
             }
+            TyKind::Arc(inner) => {
+                out.push_str("Arc<");
+                self.push_ty_display(out, inner);
+                out.push('>');
+            }
             TyKind::Array { elem, dims } => {
                 out.push('[');
                 self.push_ty_display(out, elem);
@@ -961,7 +966,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
         }
         let name = rec.name;
-        if matches!(self.sym(name), "Cell" | "RefCell") {
+        if matches!(self.sym(name), "Cell" | "RefCell" | "Arc") {
             self.error(
                 span,
                 format!(
@@ -1083,6 +1088,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (name, ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
+                        self.reject_arc_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -1095,6 +1101,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
+                        self.reject_arc_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -1108,7 +1115,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         let (name, tys) = &v.value;
                         Variant {
                             name: *name,
-                            fields: tys.iter().map(|t| self.eval_type(t)).collect(),
+                            fields: tys
+                                .iter()
+                                .map(|t| {
+                                    let fty = self.eval_type(t);
+                                    self.reject_arc_member(fty, span);
+                                    fty
+                                })
+                                .collect(),
                         }
                     })
                     .collect(),
@@ -1207,6 +1221,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     /// Enforce that a `[field]` link's element is regional. The element (peeled
     /// from the `Nullable` link) must be a regional record: a concrete
+    /// Reject a record member whose slot is directly `Arc<…>`: the MLIR record
+    /// encoding names an rc-managed member by its capability and has no
+    /// per-member atomic axis yet, so an arc cannot sit inline in a record.
+    fn reject_arc_member(&mut self, fty: Ty<'tcx>, span: Option<Span>) {
+        if matches!(fty.kind(), TyKind::Arc(_)) {
+            self.error(span, "an `Arc` record member is not supported yet");
+        }
+    }
+
     /// value/shared element is rejected here; a generic element records a
     /// requirement checked at the monomorphization call boundary.
     fn note_link_element(
@@ -1229,10 +1252,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 flex: Flexivity::Irrelevant,
                 ..
             } => self.error(span, "a `[field]` link element must be a regional record"),
-            // Arrays and cells are pointer-like (one shared rc box), so the
-            // `Nullable` check lets them through — but a `[field]` link stores
-            // a regional record, never a shared box.
-            TyKind::Array { .. } | TyKind::Cell { .. } => {
+            // Arrays, cells, and arcs are pointer-like (one shared rc box), so
+            // the `Nullable` check lets them through — but a `[field]` link
+            // stores a regional record, never a shared box.
+            TyKind::Array { .. } | TyKind::Cell { .. } | TyKind::Arc(_) => {
                 self.error(span, "a `[field]` link element must be a regional record")
             }
             // Regional records are fine; non-record elements are already rejected

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -271,6 +271,7 @@ pub(super) fn ty_has_hole(ty: crate::semi::ty::Ty<'_>) -> bool {
         }
         TyKind::Nullable(inner) => ty_has_hole(*inner),
         TyKind::Cell { elem: inner, .. } => ty_has_hole(*inner),
+        TyKind::Arc(inner) => ty_has_hole(*inner),
         TyKind::Array { elem, .. } => ty_has_hole(*elem),
         _ => false,
     }
@@ -290,6 +291,7 @@ pub(super) fn collect_holes(ty: crate::semi::ty::Ty<'_>, out: &mut Vec<HoleId>) 
         }
         TyKind::Nullable(inner) => collect_holes(*inner, out),
         TyKind::Cell { elem: inner, .. } => collect_holes(*inner, out),
+        TyKind::Arc(inner) => collect_holes(*inner, out),
         TyKind::Array { elem, .. } => collect_holes(*elem, out),
         _ => {}
     }

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -321,6 +321,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let inner = self.ty(inner);
                 self.tcx.mk_cell(inner, *exclusive)
             }
+            raw::Ty::Arc(inner) => {
+                let inner = self.ty(inner);
+                self.tcx.mk_arc(inner)
+            }
             raw::Ty::Record { cap, path, args } => {
                 let def = self.record_def(path);
                 let args: Vec<Ty<'tcx>> = args.iter().map(|a| self.ty(a)).collect();
@@ -817,6 +821,24 @@ mod tests {
             }
             pub fn mixed(c: Cell<RefCell<i64>>) -> Cell<RefCell<i64>> {
                 c
+            }
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrips_arcs() {
+        roundtrip(
+            r#"
+            struct Data { value: i64 }
+            pub fn use_arc(a: Arc<Data>) -> Arc<Data> {
+                a
+            }
+            pub fn maybe(a: Nullable<Arc<Data>>) -> Nullable<Arc<Data>> {
+                a
+            }
+            pub fn generic<T>(a: Arc<T>) -> Arc<T> {
+                a
             }
             "#,
         );

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -182,6 +182,7 @@ Ty: raw::Ty = {
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
     "Cell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: false },
     "RefCell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: true },
+    "Arc" "<" <t:Ty> ">" => raw::Ty::Arc(Box::new(t)),
     <cap:Cap> "#" <path:PathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
     "[" <elem:Ty> ";" <dims:CommaPlus<"int">> "]"
@@ -388,6 +389,7 @@ extern {
         "Nullable" => Token::Nullable,
         "Cell" => Token::Cell,
         "RefCell" => Token::RefCell,
+        "Arc" => Token::Arc,
         "NonNull" => Token::NonNull,
         "Null" => Token::Null,
         "poison" => Token::Poison,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -319,6 +319,7 @@ impl<'a> Printer<'a> {
             TyKind::Cell { elem, exclusive } => {
                 text(if exclusive { "RefCell<" } else { "Cell<" }) + self.ty(elem) + text(">")
             }
+            TyKind::Arc(inner) => text("Arc<") + self.ty(inner) + text(">"),
             TyKind::Array { elem, dims } => {
                 let mut d = text("[") + self.ty(elem) + text(";");
                 for (i, extent) in dims.iter().enumerate() {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -179,6 +179,7 @@ pub enum Ty {
         inner: Box<Ty>,
         exclusive: bool,
     },
+    Arc(Box<Ty>),
     Record {
         cap: Cap,
         path: String,

--- a/crates/reussir-core/src/semi/infer.rs
+++ b/crates/reussir-core/src/semi/infer.rs
@@ -175,7 +175,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// map an unknown hole to its class representative). `resolve` realizes the
     /// judgment σ ⊢ τ ⇓ τ′ ("τ zonks to τ′"), a read-only pass that leaves σ
     /// unchanged. K ranges over the structural constructors with children —
-    /// Record, Closure, Array, Cell, Nullable — and the rebuilt node is re-interned:
+    /// Record, Closure, Array, Cell, Nullable, Arc — and the rebuilt node is re-interned:
     ///
     /// ```text
     ///   ⟦τ⟧ = K(τ₁ … τₙ)      σ ⊢ τᵢ ⇓ τ′ᵢ   (1 ≤ i ≤ n)
@@ -208,6 +208,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             TyKind::Nullable(inner) => {
                 let inner = self.resolve(*inner);
                 self.tcx.mk_nullable(inner)
+            }
+            TyKind::Arc(inner) => {
+                let inner = self.resolve(*inner);
+                self.tcx.mk_arc(inner)
             }
             TyKind::Array { elem, dims } => {
                 let elem = self.resolve(*elem);
@@ -303,6 +307,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.unify(*r1, *r2)
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify(*x, *y),
+            (TyKind::Arc(x), TyKind::Arc(y)) => self.unify(*x, *y),
             (
                 TyKind::Cell {
                     elem: x,
@@ -366,6 +371,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.occurs(h, *ret)
             }
             TyKind::Nullable(inner) => self.occurs(h, *inner),
+            TyKind::Arc(inner) => self.occurs(h, *inner),
             TyKind::Cell { elem: inner, .. } => self.occurs(h, *inner),
             TyKind::Array { elem, .. } => self.occurs(h, *elem),
             _ => false,
@@ -518,6 +524,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.unify_instantiated(*r1, inst, *r2)
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify_instantiated(*x, inst, *y),
+            (TyKind::Arc(x), TyKind::Arc(y)) => self.unify_instantiated(*x, inst, *y),
             (
                 TyKind::Cell {
                     elem: x,
@@ -585,6 +592,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             TyKind::Nullable(inner) => {
                 let inner = self.materialize(*inner, inst);
                 self.tcx.mk_nullable(inner)
+            }
+            TyKind::Arc(inner) => {
+                let inner = self.materialize(*inner, inst);
+                self.tcx.mk_arc(inner)
             }
             TyKind::Array { elem, dims } => {
                 let elem = self.materialize(*elem, inst);

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -156,6 +156,11 @@ pub enum TyKind<'tcx> {
         exclusive: bool,
     },
     Nullable(Ty<'tcx>),
+    /// An atomically reference-counted coloring of a `[shared]` record:
+    /// `Arc<X>` is the same nominal `X` behind a box whose refcount is
+    /// adjusted with atomic operations, so the value may cross threads. Only
+    /// the rc discipline differs — reads (projection, matching) see `X`.
+    Arc(Ty<'tcx>),
     /// A rigid type parameter in scope.
     Generic(GenericId),
     /// A unification variable.
@@ -282,6 +287,10 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn mk_nullable(&self, inner: Ty<'tcx>) -> Ty<'tcx> {
         self.mk(TyKind::Nullable(inner))
+    }
+
+    pub fn mk_arc(&self, inner: Ty<'tcx>) -> Ty<'tcx> {
+        self.mk(TyKind::Arc(inner))
     }
 
     pub fn mk_record(&self, def: DefId, args: &[Ty<'tcx>], flex: Flexivity) -> Ty<'tcx> {

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -39,7 +39,7 @@
 //! binding. Generics are left uncolored — their modality is resolved at
 //! monomorphization.
 
-use crate::semi::ty::{Flexivity, FpTy, IntTy, Ty, TyKind};
+use crate::semi::ty::{DefId, Flexivity, FpTy, IntTy, Ty, TyKind};
 use crate::surface::{self, FpType, IntegralType, TypeKind};
 
 use super::ctxt::{DefaultCap, Elaborator};
@@ -146,22 +146,25 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
 
         // The built-in atomic-rc coloring (a root builtin: never
-        // module-qualified). `Arc<X>` is the `[shared]` record `X` behind a
-        // box whose refcount is adjusted atomically, so the value may cross
-        // threads; everything but the rc discipline is `X`'s own.
+        // module-qualified). `Arc<X>` is the shared rc box `X` — a `[shared]`
+        // record, an array, or a closure — whose refcount is adjusted
+        // atomically, so the value may cross threads; everything but the rc
+        // discipline is `X`'s own.
         if path.segments.is_empty() && self.sym(key) == "Arc" {
             return match args {
                 [inner] => {
                     let inner = self.eval_type(inner);
-                    // Only a `[shared]` record can be arc-colored: the box
-                    // layout is the record's own, with atomic counting. A
-                    // generic/hole/bottom inner is deferred — resolved inners
-                    // are re-checked at monomorphization.
-                    if let Some(kind) = self.non_shared_record_kind(inner) {
+                    // Only a shared rc box can be arc-colored: the box layout
+                    // is the inner type's own, with atomic counting. A
+                    // generic/hole/bottom inner is deferred to the
+                    // instantiation check (it lands with `Arc` construction;
+                    // until then a generic inner can only be grounded from an
+                    // already-checked `Arc` annotation).
+                    if let Some(kind) = self.arc_inner_rejection(inner) {
                         self.error(
                             Some(span),
                             format!(
-                                "`Arc` inner type `{}` is not a `[shared]` record ({kind})",
+                                "`Arc` inner type `{}` is not a `[shared]` record, array, or closure ({kind})",
                                 self.ty_display(inner)
                             ),
                         );
@@ -180,19 +183,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         return self.eval_record_type_expr(path, args, span, key);
     }
 
-    /// Why `t` cannot be the inner of an `Arc`, or `None` when it can (a
-    /// `[shared]` record) or the answer must wait (generic/hole/bottom, settled
-    /// by the monomorphization-time instantiation check).
-    pub(crate) fn non_shared_record_kind(&self, t: Ty<'tcx>) -> Option<&'static str> {
-        match t.kind() {
-            TyKind::Record { def, .. } => match self.records[def].default_cap {
-                DefaultCap::Shared => None,
-                DefaultCap::Value => Some("a `[value]` record"),
-                DefaultCap::Regional => Some("a `[regional]` record"),
-            },
-            TyKind::Generic(_) | TyKind::Hole(_) | TyKind::Bottom => None,
-            _ => Some("not a record"),
-        }
+    /// [`arc_inner_rejection`] against this elaborator's record table.
+    pub(crate) fn arc_inner_rejection(&self, t: Ty<'tcx>) -> Option<&'static str> {
+        arc_inner_rejection(|def| self.records.get(&def).map(|r| r.default_cap), t)
     }
 
     /// Evaluate a statically shaped array type (`[f64; 512]`,
@@ -364,6 +357,38 @@ pub(crate) fn is_plain_scalar_or_deferred(t: Ty<'_>) -> bool {
             | TyKind::Hole(_)
             | TyKind::Bottom
     )
+}
+
+/// Why `t` cannot be the inner of an `Arc`, or `None` when it can — a shared
+/// rc box: a `[shared]` record, an array, or a closure — or when the answer
+/// must wait (generic/hole/bottom). `cap_of` looks up a record's default
+/// capability; an unknown record defers rather than rejecting. Shared between
+/// `ty_eval` (a concrete annotation) and monomorphization (the deferred half:
+/// a generic inner is first grounded by an instantiation, e.g. a trampoline's
+/// explicit type arguments).
+pub fn arc_inner_rejection<'tcx>(
+    cap_of: impl FnOnce(DefId) -> Option<DefaultCap>,
+    t: Ty<'tcx>,
+) -> Option<&'static str> {
+    match t.kind() {
+        TyKind::Record { def, .. } => match cap_of(*def) {
+            Some(DefaultCap::Shared) | None => None,
+            Some(DefaultCap::Value) => Some("a `[value]` record"),
+            Some(DefaultCap::Regional) => Some("a `[regional]` record"),
+        },
+        // An array or a closure is one shared rc box exactly like a
+        // `[shared]` record, so it takes the atomic coloring the same way.
+        TyKind::Array { .. } | TyKind::Closure { .. } => None,
+        TyKind::Generic(_) | TyKind::Hole(_) | TyKind::Bottom => None,
+        // A cell is a shared box too, but synchronization is the cell's own
+        // axis (plain vs exclusive, and the atomic flavor at the MLIR level)
+        // — `Arc` must not stack a second discipline on top.
+        TyKind::Cell { .. } => Some("a cell"),
+        TyKind::Arc(_) => Some("already an `Arc`"),
+        TyKind::Nullable(_) => Some("a nullable"),
+        // Scalars, `str`, unit: not rc-managed boxes at all.
+        _ => Some("not an rc box"),
+    }
 }
 
 fn is_concretely_non_pointer(t: Ty<'_>) -> bool {

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -145,9 +145,54 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             };
         }
 
+        // The built-in atomic-rc coloring (a root builtin: never
+        // module-qualified). `Arc<X>` is the `[shared]` record `X` behind a
+        // box whose refcount is adjusted atomically, so the value may cross
+        // threads; everything but the rc discipline is `X`'s own.
+        if path.segments.is_empty() && self.sym(key) == "Arc" {
+            return match args {
+                [inner] => {
+                    let inner = self.eval_type(inner);
+                    // Only a `[shared]` record can be arc-colored: the box
+                    // layout is the record's own, with atomic counting. A
+                    // generic/hole/bottom inner is deferred — resolved inners
+                    // are re-checked at monomorphization.
+                    if let Some(kind) = self.non_shared_record_kind(inner) {
+                        self.error(
+                            Some(span),
+                            format!(
+                                "`Arc` inner type `{}` is not a `[shared]` record ({kind})",
+                                self.ty_display(inner)
+                            ),
+                        );
+                    }
+                    self.tcx.mk_arc(inner)
+                }
+                _ => {
+                    self.error(Some(span), "`Arc` takes exactly one type argument");
+                    self.tcx.mk(TyKind::Bottom)
+                }
+            };
+        }
+
         // A user record, resolved to its def — bare in the current module, or
         // module-qualified (`utils::math::Widget`, `root::…`, `super::…`).
         return self.eval_record_type_expr(path, args, span, key);
+    }
+
+    /// Why `t` cannot be the inner of an `Arc`, or `None` when it can (a
+    /// `[shared]` record) or the answer must wait (generic/hole/bottom, settled
+    /// by the monomorphization-time instantiation check).
+    pub(crate) fn non_shared_record_kind(&self, t: Ty<'tcx>) -> Option<&'static str> {
+        match t.kind() {
+            TyKind::Record { def, .. } => match self.records[def].default_cap {
+                DefaultCap::Shared => None,
+                DefaultCap::Value => Some("a `[value]` record"),
+                DefaultCap::Regional => Some("a `[regional]` record"),
+            },
+            TyKind::Generic(_) | TyKind::Hole(_) | TyKind::Bottom => None,
+            _ => Some("not a record"),
+        }
     }
 
     /// Evaluate a statically shaped array type (`[f64; 512]`,

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -634,6 +634,9 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
                 let name = if exclusive { "RefCell" } else { "Cell" };
                 format!("{name}<{}>", Self::render_ty_with(elab, elem))
             }
+            TyKind::Arc(inner) => {
+                format!("Arc<{}>", Self::render_ty_with(elab, inner))
+            }
             TyKind::Array { elem, dims } => {
                 let dims: Vec<String> = dims.iter().map(|d| d.to_string()).collect();
                 format!(

--- a/tests/integration/frontend/arc.rr
+++ b/tests/integration/frontend/arc.rr
@@ -33,3 +33,17 @@ fn passthrough<T>(a: Arc<T>) -> Arc<T> {
 pub fn call_passthrough(a: Arc<Data>) -> Arc<Data> {
     passthrough(a)
 }
+
+// An array and a closure are single shared rc boxes like a [shared] record,
+// so they take the atomic coloring the same way.
+// HIR: pub fn #arr(v0 (a): Arc<[f64; 8]>) -> Arc<[f64; 8]>
+// MIR-DAG: pub fn @_RC3arr(v0 (a): Arc<[f64; 8]>) -> Arc<[f64; 8]>
+pub fn arr(a: Arc<[f64; 8]>) -> Arc<[f64; 8]> {
+    a
+}
+
+// HIR: pub fn #clo(v0 (f): Arc<(i64) -> i64>) -> Arc<(i64) -> i64>
+// MIR-DAG: pub fn @_RC3clo(v0 (f): Arc<(i64) -> i64>) -> Arc<(i64) -> i64>
+pub fn clo(f: Arc<(i64) -> i64>) -> Arc<(i64) -> i64> {
+    f
+}

--- a/tests/integration/frontend/arc.rr
+++ b/tests/integration/frontend/arc.rr
@@ -1,0 +1,35 @@
+// The builtin Arc type constructor colors a [shared] record as atomically
+// reference-counted. At the type level it must survive both textual frontend
+// IRs unchanged (construction and lowering land in follow-up changes).
+
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=MIR
+
+struct [shared] Data {
+    value: i64
+}
+
+// HIR: pub fn #use_arc(v0 (a): Arc<#Data>) -> Arc<#Data>
+// MIR-DAG: pub fn @_RC7use_arc(v0 (a): Arc<Data>) -> Arc<Data>
+pub fn use_arc(a: Arc<Data>) -> Arc<Data> {
+    a
+}
+
+// HIR: pub fn #maybe(v0 (n): Nullable<Arc<#Data>>) -> Nullable<Arc<#Data>>
+// MIR-DAG: pub fn @_RC5maybe(v0 (n): Nullable<Arc<Data>>) -> Nullable<Arc<Data>>
+pub fn maybe(n: Nullable<Arc<Data>>) -> Nullable<Arc<Data>> {
+    n
+}
+
+// A generic inner is deferred to the instantiation check; the instance
+// grounds `Arc<$0>` at `Arc<Data>`.
+// HIR: fn #passthrough<$0>(v0 (a): Arc<$0>) -> Arc<$0>
+// MIR-DAG: fn @_RIC11passthroughC4DataE(v0 (a): Arc<Data>) -> Arc<Data>
+fn passthrough<T>(a: Arc<T>) -> Arc<T> {
+    a
+}
+
+// HIR: pub fn #call_passthrough(v0 (a): Arc<#Data>) -> Arc<#Data>
+pub fn call_passthrough(a: Arc<Data>) -> Arc<Data> {
+    passthrough(a)
+}

--- a/tests/integration/frontend/arc_errors.rr
+++ b/tests/integration/frontend/arc_errors.rr
@@ -7,16 +7,22 @@ fn missing_type(a: Arc) -> i64 { 0 }
 // CHECK-DAG: record name `Arc` is reserved for the builtin type
 struct Arc { value: i64 }
 
-// Only a [shared] record can be arc-colored.
-// CHECK-DAG: `Arc` inner type `i64` is not a `[shared]` record (not a record)
+// Only a shared rc box — a [shared] record, an array, or a closure — can be
+// arc-colored.
+// CHECK-DAG: `Arc` inner type `i64` is not a `[shared]` record, array, or closure (not an rc box)
 fn scalar_inner(a: Arc<i64>) -> i64 { 0 }
 
+// A cell is a shared box, but synchronization is the cell's own axis; Arc
+// must not stack a second discipline on top of it.
+// CHECK-DAG: `Arc` inner type `Cell<i64>` is not a `[shared]` record, array, or closure (a cell)
+fn cell_inner(a: Arc<Cell<i64>>) -> i64 { 0 }
+
 struct [value] Flat { value: i64 }
-// CHECK-DAG: `Arc` inner type `Flat` is not a `[shared]` record (a `[value]` record)
+// CHECK-DAG: `Arc` inner type `Flat` is not a `[shared]` record, array, or closure (a `[value]` record)
 fn value_inner(a: Arc<Flat>) -> i64 { 0 }
 
 struct [regional] Node { value: i64, next: [field] Node }
-// CHECK-DAG: `Arc` inner type `[regional] Node` is not a `[shared]` record (a `[regional]` record)
+// CHECK-DAG: `Arc` inner type `[regional] Node` is not a `[shared]` record, array, or closure (a `[regional]` record)
 fn regional_inner(a: Arc<Node>) -> i64 { 0 }
 
 // An arc cannot sit inline in a record member yet (the MLIR record encoding
@@ -28,3 +34,7 @@ struct Holder { a: Arc<Shared> }
 // A mutable `[field]` link stores a regional record, never a shared box.
 // CHECK-DAG: a `[field]` link element must be a regional record
 struct [regional] BadLink { value: [field] Arc<Shared> }
+
+// An arc is already atomically counted; wrapping it again double-boxes.
+// CHECK-DAG: `Arc` inner type `Arc<Shared>` is not a `[shared]` record, array, or closure (already an `Arc`)
+fn nested_inner(a: Arc<Arc<Shared>>) -> i64 { 0 }

--- a/tests/integration/frontend/arc_errors.rr
+++ b/tests/integration/frontend/arc_errors.rr
@@ -1,0 +1,30 @@
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+// Arc is a root builtin type constructor.
+// CHECK-DAG: `Arc` takes exactly one type argument
+fn missing_type(a: Arc) -> i64 { 0 }
+
+// CHECK-DAG: record name `Arc` is reserved for the builtin type
+struct Arc { value: i64 }
+
+// Only a [shared] record can be arc-colored.
+// CHECK-DAG: `Arc` inner type `i64` is not a `[shared]` record (not a record)
+fn scalar_inner(a: Arc<i64>) -> i64 { 0 }
+
+struct [value] Flat { value: i64 }
+// CHECK-DAG: `Arc` inner type `Flat` is not a `[shared]` record (a `[value]` record)
+fn value_inner(a: Arc<Flat>) -> i64 { 0 }
+
+struct [regional] Node { value: i64, next: [field] Node }
+// CHECK-DAG: `Arc` inner type `[regional] Node` is not a `[shared]` record (a `[regional]` record)
+fn regional_inner(a: Arc<Node>) -> i64 { 0 }
+
+// An arc cannot sit inline in a record member yet (the MLIR record encoding
+// has no per-member atomic axis).
+struct [shared] Shared { value: i64 }
+// CHECK-DAG: an `Arc` record member is not supported yet
+struct Holder { a: Arc<Shared> }
+
+// A mutable `[field]` link stores a regional record, never a shared box.
+// CHECK-DAG: a `[field]` link element must be a regional record
+struct [regional] BadLink { value: [field] Arc<Shared> }


### PR DESCRIPTION
First PR of the `Arc<T>` stack. `Arc<X>` is a specially colored version of the `[shared]` record `X`: same object, but behind a box whose refcount is adjusted atomically so the value may cross threads. This PR adds the type constructor end-to-end at the type level, with lossless HIR/MIR textual roundtrip; construction, transparent reads, and the `!reussir.rc<..., atomic>` lowering follow in the stack.

### What's here

- **`TyKind::Arc(inner)`** with `mk_arc`, threaded through every structural walk: infer (resolve/unify/occurs/materialize), subst, mono (depth, record discovery, groundness), trait-solver hole scans, `is_rr` (always managed), and diagnostics rendering.
- **Elaboration rules** (`ty_eval`): `Arc` is a root builtin taking exactly one type argument; the inner must be a `[shared]` record. A `[value]`/`[regional]` record or non-record is rejected with the reason spelled out; generic/hole inners are deferred to the instantiation check (settled when the lowering lands, mirroring how `Nullable` defers its pointer-like check).
- **Scoping guards**: `Arc` joins `Cell`/`RefCell` as a reserved record name; a direct `Arc` record member is rejected for now (the MLIR record encoding names rc-managed members by capability and has no per-member atomic axis yet — `Nullable<Arc<X>>` stays fine since a nullable carries the full pointer type); a `[field]` link cannot store an arc.
- **Roundtrip**: `Arc<...>` added to the shared IR lexer, both lalrpop grammars, both printers, and both re-intern passes; mangles as a synthetic root record (`Arc<i32>` → `_RIC3ArclE`) like the other builtin constructors.
- **Codegen placeholder**: the scalar-lowering fallback rejects `Arc` with a clear "not implemented yet" error so the workspace stays green until the atomic-rc lowering PR.

### Stack

1. **this PR** — type representation + surface type + roundtrip
2. ctor expressions (`Arc<Inner> { ... }`, `Arc<Enum<..>>::Variant(..)`) with arc coloring on compound/variant calls
3. transparent reads (projection/matching peel the arc)
4. codegen: lower to `rc<..., shared, atomic>`, atomic-aware borrows/refcounts, e2e `atomicrmw` tests

### Testing

- 8 new unit tests (elaboration accept/reject matrix, HIR + MIR roundtrips incl. a generic instantiated at `Arc<Data>`, mangling golden value)
- 2 new lit tests: `frontend/arc.rr` (HIR/MIR FileCheck) and `frontend/arc_errors.rr` (full diagnostic matrix)
- `cargo test --workspace` and the full lit suite (359 discovered) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786688472&installation_id=144622820&pr_number=424&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F424&signature=ede9e85f9b995063bcb3a1767d929af8ab451e8d8cc8fadedc8193e99cc3fc83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->