### PR TITLE
[frontend] add Arc constructors for shared structs and enums

### DIFF
--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -776,12 +776,19 @@ mod tests {
         roundtrip(
             r#"
             struct Data { value: i64 }
+            enum List<T> { Nil, Cons(T, List<T>) }
             fn generic<T>(a: T) -> T { a }
             pub fn use_arc(a: Arc<Data>) -> Arc<Data> {
                 generic(a)
             }
             pub fn maybe(a: Nullable<Arc<Data>>) -> Nullable<Arc<Data>> {
                 a
+            }
+            pub fn make(v: i64) -> Arc<Data> {
+                Arc<Data> { value: v }
+            }
+            pub fn make_list() -> Arc<List<i64>> {
+                Arc<List<i64>>::Cons{1, List::Nil}
             }
             "#,
         );

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1085,6 +1085,51 @@ mod tests {
     }
 
     #[test]
+    fn infers_arc_ctors() {
+        // The struct and variant arc constructors type at `Arc<R>`.
+        let src = "struct Pair { a: i32 }\n\
+                   enum List<T> { Nil, Cons(T, List<T>) }\n\
+                   fn f(v: i32) -> Arc<Pair> { Arc<Pair> { a: v } }\n\
+                   fn g() -> Arc<List<i32>> { Arc<List<i32>>::Cons{1, List::Nil} }\n\
+                   fn h() -> Arc<List<i32>> { Arc<List<i32>>::Nil }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn arc_ctor_is_not_the_plain_record_type() {
+        // The arc coloring is part of the type: an arc'd constructor does not
+        // check against the bare record.
+        let src = "struct Pair { a: i32 }\nfn f() -> Pair { Arc<Pair> { a: 1 } }";
+        assert!(!reports_of(src).is_empty(), "expected a type mismatch");
+    }
+
+    #[test]
+    fn rejects_arc_ctor_of_non_shared_record() {
+        let src = "struct [value] Pair { a: i32 }\nfn f() -> i32 { Arc<Pair> { a: 1 }; 0 }";
+        assert!(
+            has_error(
+                src,
+                "`Arc` constructs a `[shared]` record; `Pair` is not one"
+            ),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_arc_ctor_without_inner_type() {
+        let src = "struct Pair { a: i32 }\nfn f() -> i32 { Arc { a: 1 }; 0 }";
+        assert!(
+            has_error(
+                src,
+                "`Arc` construction takes exactly one explicit type argument"
+            ),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
     fn accepts_arc_of_shared_record_and_generic() {
         // A `[shared]` record inner is the intended case; a generic inner is
         // deferred to the instantiation check.

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1488,6 +1488,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         if qualifier.map(|k| self.sym(k)) == Some("Nullable") {
             return self.infer_nullable(self.sym(path.basename), args, span);
         }
+        // The built-in arc-coloring constructors (a root builtin, never
+        // module-qualified): `Arc<Inner>{…}` builds the `[shared]` struct
+        // `Inner` behind an atomically counted box, `Arc<Enum<…>>::Variant{…}`
+        // the enum flavor. `Arc<X>` is a specially colored version of `X`, so
+        // the constructor is the inner record's own, at the arc'd type.
+        if path.segments.is_empty() && self.sym(path.basename) == "Arc" {
+            return self.infer_arc_ctor(ty_args, None, args, span);
+        }
+        if path.segments.len() == 1 && self.sym(path.segments[0]) == "Arc" {
+            return self.infer_arc_ctor(ty_args, Some(path.basename), args, span);
+        }
         if let Some(enum_key) = qualifier {
             // The qualifier resolving to an enum wins (`Enum::Variant`); a
             // qualifier that is a module path instead falls through to a
@@ -1509,6 +1520,64 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
         // A bare struct constructor.
         self.infer_struct(path.basename, ty_args, args, span)
+    }
+
+    /// (ARC) `Γ ⊢ Arc<Inner>{args} ⇒ (CompoundCall{…} : Arc<R>)` and
+    /// `Γ ⊢ Arc<Enum<…>>::Variant{args} ⇒ (VariantCall{…} : Arc<R>)`: the inner
+    /// type names the `[shared]` record being built; the payload is checked
+    /// exactly like the plain constructor and only the node's type is wrapped.
+    /// The box is atomically counted from birth — an arc is never re-colored
+    /// from an existing plain shared value.
+    fn infer_arc_ctor(
+        &mut self,
+        ty_args: &[Option<surface::Type>],
+        variant: Option<TokenKey>,
+        args: &[(Option<TokenKey>, surface::Expr)],
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
+        let [Some(inner)] = ty_args else {
+            self.error(
+                span,
+                "`Arc` construction takes exactly one explicit type argument \
+                 (the `[shared]` record being built)",
+            );
+            return self.poison(span);
+        };
+        let surface::TypeKind::TypeExpr(ipath, iargs) = inner.kind() else {
+            self.error(
+                span,
+                "`Arc` constructs a `[shared]` record; this inner type is not one",
+            );
+            return self.poison(span);
+        };
+        let Some(def) = self.resolve_record_ref(&ipath) else {
+            let shown = self.path_display(&ipath);
+            self.error(span, format!("unknown record `{shown}`"));
+            return self.poison(span);
+        };
+        if !matches!(
+            self.records[&def].default_cap,
+            super::ctxt::DefaultCap::Shared
+        ) {
+            let shown = self.path_display(&ipath);
+            self.error(
+                span,
+                format!("`Arc` constructs a `[shared]` record; `{shown}` is not one"),
+            );
+            return self.poison(span);
+        }
+        self.record_use(ipath.basename);
+        let iargs: Vec<Option<surface::Type>> = iargs.iter().cloned().map(Some).collect();
+        let mut e = match variant {
+            None => self.infer_struct_def(def, ipath.basename, &iargs, args, span),
+            Some(v) => self.infer_variant(def, ipath.basename, v, &iargs, args, span),
+        };
+        // Wrap only a successfully built constructor; an error path stays the
+        // poison it already is.
+        if matches!(e.ty.kind(), TyKind::Record { .. }) {
+            e.ty = self.tcx.mk_arc(e.ty);
+        }
+        e
     }
 
     /// (NULL) the built-in nullable constructors: `Nullable::NonNull(e)` with `e ⇒ T`

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -831,6 +831,7 @@ mod tests {
         roundtrip(
             r#"
             struct Data { value: i64 }
+            enum List<T> { Nil, Cons(T, List<T>) }
             pub fn use_arc(a: Arc<Data>) -> Arc<Data> {
                 a
             }
@@ -839,6 +840,15 @@ mod tests {
             }
             pub fn generic<T>(a: Arc<T>) -> Arc<T> {
                 a
+            }
+            pub fn make(v: i64) -> Arc<Data> {
+                Arc<Data> { value: v }
+            }
+            pub fn make_list() -> Arc<List<i64>> {
+                Arc<List<i64>>::Cons{1, List::Nil}
+            }
+            pub fn make_nil() -> Arc<List<i64>> {
+                Arc<List<i64>>::Nil
             }
             "#,
         );

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -249,6 +249,18 @@ fn path_of(node: &ResolvedNode) -> Path {
     Path { basename, segments }
 }
 
+/// Merge every direct `Path` child of a call node into one path: committed
+/// mid-path type arguments (`Arc<List<i32>>::Cons{…}`) split the spelling
+/// into two path nodes around the argument list.
+fn call_path_of(node: &ResolvedNode) -> Path {
+    let mut segments: SmallVec<[TokenKey; 2]> = SmallVec::new();
+    for p in nodes(node).filter(|n| n.kind() == PathKind) {
+        segments.extend(tokens(p).filter(|t| t.kind().is_ident_like()).map(key));
+    }
+    let basename = segments.pop().expect("non-empty path");
+    Path { basename, segments }
+}
+
 /// `(name, bounds)` declarations from a `GenericParamList` child.
 fn generics_of(node: &ResolvedNode) -> SmallVec<[(TokenKey, Vec<Path>); 2]> {
     let Some(list) = child_node(node, GenericParamList) else {
@@ -784,18 +796,18 @@ impl Expr {
             }
             VarExpr => ExprKind::Var(path_of(child_node(node, PathKind).expect("variable path"))),
             FuncCallExpr => {
-                let path = child_node(node, PathKind).expect("function path");
+                child_node(node, PathKind).expect("function path");
                 let args = child_node(node, ArgList)
                     .map(|l| expr_children(l).map(Expr::new).collect())
                     .unwrap_or_default();
                 ExprKind::FuncCallExpr(Box::new(FuncCall {
-                    name: path_of(path),
+                    name: call_path_of(node),
                     ty_args: type_args_of(node),
                     args,
                 }))
             }
             CtorCallExpr => {
-                let path = child_node(node, PathKind).expect("constructor path");
+                child_node(node, PathKind).expect("constructor path");
                 let args = child_node(node, CtorArgList)
                     .map(|l| {
                         nodes(l)
@@ -815,7 +827,7 @@ impl Expr {
                     })
                     .unwrap_or_default();
                 ExprKind::CtorCallExpr(Box::new(CtorCall {
-                    name: path_of(path),
+                    name: call_path_of(node),
                     ty_args: type_args_of(node),
                     args,
                 }))

--- a/crates/reussir-syntax/src/parser/expr.rs
+++ b/crates/reussir-syntax/src/parser/expr.rs
@@ -503,6 +503,13 @@ impl Parser<'_> {
         if self.at(LAngle) {
             has_ty_args = self.try_type_arg_list();
         }
+        // Committed type arguments may sit mid-path (`Arc<List<i32>>::Cons`):
+        // the trailing segments continue the constructor path as a second
+        // path node, merged back together during lowering.
+        if has_ty_args && self.at(PathSep) {
+            self.bump();
+            self.path();
+        }
         if self.at(LBrace) && allow_struct {
             self.ctor_arg_list();
             m.complete(self, CtorCallExpr)

--- a/tests/integration/frontend/arc.rr
+++ b/tests/integration/frontend/arc.rr
@@ -23,7 +23,7 @@ pub fn maybe(n: Nullable<Arc<Data>>) -> Nullable<Arc<Data>> {
 
 // A generic inner is deferred to the instantiation check; the instance
 // grounds `Arc<$0>` at `Arc<Data>`.
-// HIR: fn #passthrough<$0>(v0 (a): Arc<$0>) -> Arc<$0>
+// HIR: fn #passthrough<[[G:\$[0-9]+]]>(v0 (a): Arc<[[G]]>) -> Arc<[[G]]>
 // MIR-DAG: fn @_RIC11passthroughC4DataE(v0 (a): Arc<Data>) -> Arc<Data>
 fn passthrough<T>(a: Arc<T>) -> Arc<T> {
     a
@@ -46,4 +46,27 @@ pub fn arr(a: Arc<[f64; 8]>) -> Arc<[f64; 8]> {
 // MIR-DAG: pub fn @_RC3clo(v0 (f): Arc<(i64) -> i64>) -> Arc<(i64) -> i64>
 pub fn clo(f: Arc<(i64) -> i64>) -> Arc<(i64) -> i64> {
     f
+}
+
+enum List<T> {
+    Nil,
+    Cons(T, List<T>)
+}
+
+// The arc constructors are the inner record's own, at the arc'd type: the
+// coloring lives entirely in the node type, so both textual IRs carry it
+// without a dedicated expression form.
+// HIR: pub fn #make(v0 (v): i64) -> Arc<#Data>
+// HIR-NEXT: #Data{v0 : i64} : Arc<#Data>
+// MIR-DAG: pub fn @_RC4make(v0 (v): i64) -> Arc<Data>
+// MIR-DAG: @_RC4Data{v0 : i64} : Arc<Data>
+pub fn make(v: i64) -> Arc<Data> {
+    Arc<Data> { value: v }
+}
+
+// HIR: pub fn #make_list() -> Arc<#List::<i64>>
+// HIR-NEXT: #List::<i64>#1(1 : i64, #List::<i64>#0() : #List::<i64>) : Arc<#List::<i64>>
+// MIR-DAG: pub fn @_RC9make_list() -> Arc<List::<i64>>
+pub fn make_list() -> Arc<List<i64>> {
+    Arc<List<i64>>::Cons{1, List::Nil}
 }

--- a/tests/integration/frontend/arc_errors.rr
+++ b/tests/integration/frontend/arc_errors.rr
@@ -38,3 +38,15 @@ struct [regional] BadLink { value: [field] Arc<Shared> }
 // An arc is already atomically counted; wrapping it again double-boxes.
 // CHECK-DAG: `Arc` inner type `Arc<Shared>` is not a `[shared]` record, array, or closure (already an `Arc`)
 fn nested_inner(a: Arc<Arc<Shared>>) -> i64 { 0 }
+
+// The arc constructors demand an explicit `[shared]` record inner.
+// CHECK-DAG: `Arc` construction takes exactly one explicit type argument
+fn ctor_no_inner() -> i64 { Arc { value: 1 }; 0 }
+
+// CHECK-DAG: `Arc` constructs a `[shared]` record; `Flat` is not one
+fn ctor_value_inner() -> i64 { Arc<Flat> { value: 1 }; 0 }
+
+// The arc coloring is part of the type: an arc'd constructor does not check
+// against the bare record.
+// CHECK-DAG: type mismatch
+fn ctor_is_colored() -> Shared { Arc<Shared> { value: 1 } }


### PR DESCRIPTION
Second PR of the `Arc<T>` stack (on top of #424, now merged; rebased onto `main`).

`Arc<Inner> { ... }` constructs the `[shared]` struct `Inner` directly into an atomically counted box; `Arc<Enum<...>>::Variant{...}` is the enum flavor. Per the language design, `Arc<X>` is a specially colored version of `X`, so the ctor is the inner record's own spelling — payload checking is exactly the plain ctor's, and only the node's type becomes `Arc<R>`. The box is atomic from birth; there is deliberately no re-coloring of an existing plain shared value.

Of the shared rc boxes an `Arc` may color under #424's final rule — a `[shared]` record, an array, or a closure — this PR covers the **record constructors**. Arrays and closures are built by their own expression forms; their arc'd construction is not part of this change, so the ctor rule demands an inner that names a `[shared]` record specifically.

### Key design point: no new IR forms

Every HIR/MIR expression prints with its type (`Atom : Ty`), so the arc coloring is fully carried by the node type: `#Data{v0 : i64} : Arc<#Data>` (HIR) and `@_RC4Data{v0 : i64} : Arc<Data>` (MIR) round-trip losslessly with **zero grammar or expression-enum changes**. Codegen will dispatch on the ctor node's `Arc` type to pick the atomic rc box.

### Changes

- **Parser**: committed type arguments may sit mid-path (`Arc<List<i32>>::Cons{...}`) — the trailing segments continue the ctor path as a second path node; previously this was a parse error, so no existing spelling changes meaning. Surface lowering merges the split path.
- **Checking**: `infer_ctor` dispatches an `Arc` head (root builtin, never module-qualified) to the arc-ctor rule; the explicit inner type must name a `[shared]` record, diagnosed otherwise. Nullary variants work as bare paths (`Arc<List<i32>>::Nil`).
- The coloring is part of the type: `fn f() -> Pair { Arc<Pair>{...} }` reports ``type mismatch: expected `Pair`, found `Arc<Pair>` ``.

### Testing

- 4 new unit tests (ctor acceptance incl. nullary variants, colored-type mismatch, non-shared inner, missing inner type) + ctor bodies added to both HIR/MIR roundtrip tests
- `frontend/arc.rr` extended with HIR+MIR FileCheck for struct and variant arc ctors; `frontend/arc_errors.rr` covers the ctor diagnostics
- `cargo test --workspace` and the full lit suite pass after the rebase onto `main` (268 unit tests, 120 frontend lit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786689270&installation_id=144622820&pr_number=425&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F425&signature=41126c665db89ac5bde3632abd7f841c87735248f9ebad164785f596cad130ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
