### PR TITLE
[frontend] make reads transparent through the Arc coloring

### DIFF
--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -790,6 +790,15 @@ mod tests {
             pub fn make_list() -> Arc<List<i64>> {
                 Arc<List<i64>>::Cons{1, List::Nil}
             }
+            pub fn read(a: Arc<Data>) -> i64 {
+                a.value
+            }
+            pub fn head(l: Arc<List<i64>>) -> i64 {
+                match l {
+                    List::Cons(x, _) => x,
+                    List::Nil => 0
+                }
+            }
             "#,
         );
     }

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1130,6 +1130,28 @@ mod tests {
     }
 
     #[test]
+    fn arc_reads_are_transparent() {
+        // Projection and matching see through the arc coloring; the bound
+        // fields carry their declared (plain) types.
+        let src = "struct Pair { a: i32, b: i32 }\n\
+                   enum List<T> { Nil, Cons(T, List<T>) }\n\
+                   fn f(p: Arc<Pair>) -> i32 { p.a + p.b }\n\
+                   fn g(l: Arc<List<i32>>) -> i32 {\n\
+                       match l { List::Cons(x, xs) => x + len(xs), List::Nil => 0 }\n\
+                   }\n\
+                   fn len<T>(l: List<T>) -> i32 {\n\
+                       match l { List::Cons(_, xs) => 1 + len(xs), List::Nil => 0 }\n\
+                   }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    // There is no write-through-arc test because the interaction cannot be
+    // formed: `Arc` cannot be applied to regional objects (a `[regional]`
+    // inner is rejected), and `[field]` mutable links exist only on regional
+    // objects — so `Arc` and `[field]` never meet. Interior mutability behind
+    // an arc composes via `Cell` instead.
+
+    #[test]
     fn accepts_arc_of_shared_record_and_generic() {
         // A `[shared]` record inner is the intended case; a generic inner is
         // deferred to the instantiation check.

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -877,6 +877,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// (PROJ) `Γ ⊢ base.acc₁.….accₙ ⇒ (Proj(hb,[idxᵢ]) : Tₙ)`: `base ⇒ T₀`, then at each
     /// step the (shallow-resolved) record type's field `accᵢ` gives the next type `Tᵢ`
     /// and its numeric index. A non-record head or missing field poisons.
+    /// Reads see through the arc coloring: `Arc<X>` projects and matches as
+    /// `X` — only the rc discipline differs. Returns the shallow-resolved
+    /// type, unwrapped once if it is an arc.
+    pub(super) fn peel_arc(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
+        let ty = self.infer.shallow_resolve(ty);
+        match ty.kind() {
+            TyKind::Arc(inner) => self.infer.shallow_resolve(*inner),
+            _ => ty,
+        }
+    }
+
     fn infer_access(
         &mut self,
         base: &surface::Expr,
@@ -884,7 +895,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         span: Option<Span>,
     ) -> Expr<'tcx> {
         let base = self.infer_expr(base);
-        let mut cur = self.infer.shallow_resolve(base.ty);
+        let mut cur = self.peel_arc(base.ty);
         let mut indices = Vec::new();
         for acc in accs {
             let TyKind::Record { def, args, flex } = cur.kind() else {

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -850,6 +850,15 @@ mod tests {
             pub fn make_nil() -> Arc<List<i64>> {
                 Arc<List<i64>>::Nil
             }
+            pub fn read(a: Arc<Data>) -> i64 {
+                a.value
+            }
+            pub fn head(l: Arc<List<i64>>) -> i64 {
+                match l {
+                    List::Cons(x, _) => x,
+                    List::Nil => 0
+                }
+            }
             "#,
         );
     }

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -315,7 +315,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         span: Option<Span>,
         ty: Ty<'tcx>,
     ) -> Pat<'tcx> {
-        let ty = self.infer.shallow_resolve(ty);
+        // An `Arc<Enum<…>>` scrutinee dispatches on the inner enum's
+        // constructors; the pattern spelling is the plain one.
+        let ty = self.peel_arc(ty);
         // The built-in nullable constructors, by the same qualifier convention
         // as [`Elaborator::infer_ctor`] on the expression side.
         if ctor.path.segments.last().map(|k| self.sym(*k)) == Some("Nullable") {
@@ -803,6 +805,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// The field types of variant `v` of the enum at `ty`, instantiated with the
     /// enum's type arguments.
     fn variant_field_tys(&mut self, ty: Ty<'tcx>, v: usize) -> Vec<Ty<'tcx>> {
+        let ty = self.peel_arc(ty);
         let TyKind::Record { def, args, .. } = ty.kind() else {
             return Vec::new();
         };
@@ -830,7 +833,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     }
 
     fn variant_count(&mut self, ty: Ty<'tcx>) -> usize {
-        let ty = self.infer.shallow_resolve(ty);
+        let ty = self.peel_arc(ty);
         if let TyKind::Record { def, .. } = ty.kind()
             && let Some(record) = self.records.get(def)
             && let Some(RecordFields::Variants(vs)) = &record.fields

--- a/tests/integration/frontend/arc.rr
+++ b/tests/integration/frontend/arc.rr
@@ -70,3 +70,24 @@ pub fn make(v: i64) -> Arc<Data> {
 pub fn make_list() -> Arc<List<i64>> {
     Arc<List<i64>>::Cons{1, List::Nil}
 }
+
+// Reads see through the arc coloring: projection and matching are the inner
+// record's own, at their declared field types.
+// HIR: pub fn #read(v0 (a): Arc<#Data>) -> i64
+// HIR-NEXT: proj(v0 : Arc<#Data>, 0) : i64
+// MIR-DAG: pub fn @_RC4read(v0 (a): Arc<Data>) -> i64
+// MIR-DAG: proj(v0 : Arc<Data>, 0) : i64
+pub fn read(a: Arc<Data>) -> i64 {
+    a.value
+}
+
+// HIR: pub fn #head(v0 (l): Arc<#List::<i64>>) -> i64
+// HIR-NEXT: match v0 : Arc<#List::<i64>> {
+// MIR-DAG: pub fn @_RC4head(v0 (l): Arc<List::<i64>>) -> i64
+// MIR-DAG: match v0 : Arc<List::<i64>> {
+pub fn head(l: Arc<List<i64>>) -> i64 {
+    match l {
+        List::Cons(x, _) => x,
+        List::Nil => 0
+    }
+}


### PR DESCRIPTION
Third PR of the `Arc<T>` stack (on top of #425, now merged; rebased onto `main`).

Reads see through the arc coloring — `Arc<X>` projects and matches exactly as `X`, with only the rc discipline differing:

- `a.value` on an `Arc<Data>` resolves the field on `Data` and types at the declared field type.
- `match l { List::Cons(x, xs) => ..., List::Nil => ... }` works against an `Arc<List<i32>>` scrutinee with the plain pattern spelling; the match compiler's variant-count and variant-field-type queries peel the arc so decision trees compile unchanged.
- Bound fields carry their **declared** types — destructuring `Arc<List<i32>>` binds the tail at plain `List<i32>` (the arc colors only the outer box; deep cross-thread safety is the `Shared` auto-trait's concern when thread APIs land).

Write transparency is not a question that can arise: `Arc` cannot be applied to regional objects (a `[regional]` inner is rejected — the inner must be a shared rc box), and `[field]` mutable links exist only on regional objects, so `Arc` and `[field]` never meet. Interior mutability behind an arc composes via `Cell` when its lowering lands.

Implementation is one `peel_arc` helper (shallow-resolve, unwrap one arc) wired into the four read sites in `check.rs`/`pattern.rs`.

### Testing

- Unit tests: transparent projection + matching (incl. a recursive plain-tail use). There is deliberately **no** write-through-arc test — the interaction cannot be formed in the first place, per the paragraph above.
- HIR/MIR roundtrips extended with projection and match-on-arc bodies
- `frontend/arc.rr` gains FileCheck coverage of `proj(v0 : Arc<#Data>, 0)` and `match v0 : Arc<#List::<i64>>` at both IR levels
- `cargo test --workspace` and the full lit suite pass after the rebase onto `main` (269 unit tests, 120 frontend lit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786689605&installation_id=144622820&pr_number=426&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F426&signature=0bcedd3fa2719f7cdcc0eea4e44a195e457ace9cecae0a8578ef6c017c810f97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
