### PR TITLE
[codegen] lower Arc to an atomically counted rc box

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -834,7 +834,16 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         inner_ty: Type<'c>,
     ) -> Result<Value<'c, 'b>> {
         let loc = self.loc();
-        if self.tys.is_shared_record(e.ty) {
+        if matches!(e.ty.kind(), TyKind::Arc(_)) {
+            // An arc'd constructor allocates its box atomically counted from
+            // birth (`!reussir.rc<…, shared atomic>`); everything else about
+            // the payload is the plain shared record's.
+            let rc_ty = self.tys.mlir_ty(e.ty)?;
+            Ok(self.append(
+                block,
+                builders::rc_create(self.context, payload, rc_ty, loc),
+            ))
+        } else if self.tys.is_shared_record(e.ty) {
             let rc_ty = self.tys.rc_type(inner_ty);
             Ok(self.append(
                 block,
@@ -1355,7 +1364,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let mut tags = Vec::with_capacity(subtrees.len());
         for (i, subtree) in subtrees.iter().enumerate() {
             let payload_ty = self.tys.variant_payload_of(enum_ty, i)?;
-            let arg_ref_ty = self.tys.ref_type_with_cap(payload_ty, cap);
+            let arg_ref_ty = self.tys.borrow_ref_type(enum_ty, payload_ty, cap);
             let arm_block = Block::new(&[(arg_ref_ty, loc)]);
             let arg: Value<'c, '_> = arm_block
                 .argument(0)
@@ -1843,7 +1852,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             Cursor::Value { val, ty } => {
                 let inner = self.tys.record_inner_of(ty)?;
                 if let Some(cap) = self.record_ref_cap(ty)? {
-                    let ref_ty = self.tys.ref_type_with_cap(inner, cap);
+                    let ref_ty = self.tys.borrow_ref_type(ty, inner, cap);
                     let reference = self.append(
                         block,
                         dialect::rc_borrow(self.context, ref_ty, val, loc).into(),
@@ -2017,7 +2026,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     // borrow it at its capability to obtain a reference, then
                     // project through that reference.
                     let inner = self.tys.record_inner_of(ty)?;
-                    let ref_ty = self.tys.ref_type_with_cap(inner, cap);
+                    let ref_ty = self.tys.borrow_ref_type(ty, inner, cap);
                     let borrowed = self.append(
                         block,
                         dialect::rc_borrow(self.context, ref_ty, val, loc).into(),

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -1199,6 +1199,78 @@ transform [{
     }
 
     #[test]
+    fn lowers_arc_to_an_atomic_rc_box() {
+        // An arc'd value is the same shared record behind an atomically
+        // counted box: the constructor creates `!reussir.rc<…, atomic>` and a
+        // read borrows it at a matching `shared atomic` reference.
+        let src = r#"
+            struct Data { value: i64 }
+            pub fn make(v: i64) -> Arc<Data> { Arc<Data> { value: v } }
+            pub fn read(a: Arc<Data>) -> i64 { a.value }
+        "#;
+        let mlir = lower_source(src);
+        assert!(mlir.contains("reussir.rc.create"), "{mlir}");
+        assert!(mlir.contains("atomic>"), "{mlir}");
+        assert!(mlir.contains("shared atomic>"), "{mlir}");
+    }
+
+    #[test]
+    fn rejects_arc_instantiated_at_a_non_shared_record() {
+        // A non-box `Arc` inner is diagnosed at elaboration (concrete) and by
+        // mono's instantiation check (generic); the lowering rejection is the
+        // backstop for MIR that reaches codegen without those passes (e.g.
+        // directly lowered textual MIR). Strip the reports and drive lowering
+        // directly to exercise it.
+        let src = r#"
+            struct [value] Pair { a: i64 }
+            fn id<T>(x: T) -> T { x }
+            pub fn bad(x: Arc<Pair>) -> Arc<Pair> { id(x) }
+        "#;
+        let context = crate::testing::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            let (full, _) = monomorphize(&elab.mono_input());
+            let err = lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                .expect_err("an arc over a non-shared record must not lower");
+            assert!(
+                err.to_string()
+                    .contains("`Arc` requires a shared rc box inner"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn arc_of_array_reports_unimplemented_lowering() {
+        // An array (or closure) is a valid `Arc` inner at the type level, but
+        // only the `[shared]` record lowering has landed — keep the gap an
+        // explicit error rather than a malformed box.
+        let src = r#"
+            pub fn f(x: Arc<[f64; 8]>) -> Arc<[f64; 8]> { x }
+        "#;
+        let context = crate::testing::context();
+        in_arena(|tcx| {
+            let parse = reussir_syntax::parse(src);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "{:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "{reports:#?}");
+            let err = lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
+                .expect_err("an arc'd array must not lower yet");
+            assert!(
+                err.to_string()
+                    .contains("arc'd arrays and closures do not lower yet"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
     fn rejects_nullable_over_a_non_pointer_element() {
         // The frontend's pointer-like check for a `Nullable` inner is
         // conservative and passes a `[value]` record; that record lowers to an

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -81,10 +81,14 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         }
     }
 
-    /// The record instance for a nominal record type, if known.
+    /// The record instance for a nominal record type, if known. The arc
+    /// coloring is transparent to layout queries: `Arc<X>`'s payload,
+    /// variants, and fields are `X`'s own — only the box's refcount
+    /// discipline differs (see [`mlir_ty`](Self::mlir_ty)).
     pub(super) fn record_of(&self, ty: Ty<'tcx>) -> Option<&'p mir::RecordInstance<'tcx>> {
         match *ty.kind() {
             TyKind::Record { def, args, .. } => self.records.get(&(def, args)).copied(),
+            TyKind::Arc(inner) => self.record_of(inner),
             _ => None,
         }
     }
@@ -150,6 +154,29 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             // A cell is one shared rc box around its payload container. Unlike
             // arrays, its element may itself be a managed type.
             TyKind::Cell { .. } => Ok(self.rc_type(self.cell_inner_of(ty)?)),
+            // The arc coloring: the same shared payload behind a box whose
+            // refcount is adjusted with atomic operations. Of the shared rc
+            // boxes an `Arc` may color (a `[shared]` record, an array, or a
+            // closure), only the record lowering has landed; an array or
+            // closure inner is a valid arc type reported as unimplemented.
+            // Any other inner is kept out by elaboration and mono's
+            // instantiation check — rejecting it here is the backstop for
+            // directly lowered textual MIR.
+            TyKind::Arc(inner) => {
+                if self.is_shared_record(inner) {
+                    Ok(rc(
+                        self.record_inner_of(inner)?,
+                        ReussirCapability::Shared,
+                        ReussirAtomicKind::Atomic,
+                    ))
+                } else if matches!(inner.kind(), TyKind::Array { .. } | TyKind::Closure { .. }) {
+                    err("arc'd arrays and closures do not lower yet: only a `[shared]` \
+                         record inner is implemented")
+                } else {
+                    err("`Arc` requires a shared rc box inner (a `[shared]` record, an \
+                         array, or a closure)")
+                }
+            }
             _ => scalar_ty(self.context, ty),
         }
     }
@@ -167,6 +194,9 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             TyKind::Closure { params, ret } => self.closure_inner(params, ret),
             TyKind::Array { .. } => self.array_inner_of(ty),
             TyKind::Cell { .. } => self.cell_inner_of(ty),
+            // Member capabilities have no atomic axis, so an arc member is
+            // rejected at elaboration; reaching here means a check was missed.
+            TyKind::Arc(_) => err("an `Arc` record member is not supported yet"),
             _ => self.mlir_ty(ty),
         }
     }
@@ -434,6 +464,24 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         r#ref(inner, cap, ReussirAtomicKind::Normal)
     }
 
+    /// The `!reussir.ref` type for borrowing the payload of a managed box of
+    /// MIR type `ty`: an arc'd box hands out an *atomic* reference — the
+    /// dialect requires a borrow's atomic kind to match the box's — and
+    /// everything else borrows normal.
+    pub(super) fn borrow_ref_type(
+        &self,
+        ty: Ty<'tcx>,
+        inner: Type<'c>,
+        cap: ReussirCapability,
+    ) -> Type<'c> {
+        let atomic = if matches!(ty.kind(), TyKind::Arc(_)) {
+            ReussirAtomicKind::Atomic
+        } else {
+            ReussirAtomicKind::Normal
+        };
+        r#ref(inner, cap, atomic)
+    }
+
     /// `!reussir.ref<inner>` with unspecified capability — the form a spilled
     /// stack reference takes, used to acquire/drop an inline value in place.
     pub(super) fn unspecified_ref_type(&self, inner: Type<'c>) -> Type<'c> {
@@ -518,7 +566,7 @@ fn scalar_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
         TyKind::Record { .. } => err("record type reached scalar lowering without a layout"),
         TyKind::Array { .. } => err("array type reached scalar lowering without its rc wrapper"),
         TyKind::Cell { .. } => err("cell type reached scalar lowering without its rc wrapper"),
-        TyKind::Arc(_) => err("`Arc` lowering is not implemented yet"),
+        TyKind::Arc(_) => err("arc type reached scalar lowering without its rc wrapper"),
         TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),
         // Intercepted by [`TypeCtx::mlir_ty`]; reaching here is a bug.
         TyKind::Closure { .. } => err("closure type reached scalar lowering without an rc wrapper"),

--- a/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
+++ b/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
@@ -465,8 +465,9 @@ private:
           getProjectedType(recordType.getMembers()[*singletonTag],
                            recordType.getMemberIsField()[*singletonTag],
                            variantRef.getCapability());
-      RefType coercedType = RefType::get(
-          rewriter.getContext(), targetVariantType, variantRef.getCapability());
+      RefType coercedType =
+          RefType::get(rewriter.getContext(), targetVariantType,
+                       variantRef.getCapability(), variantRef.getAtomicKind());
       auto coerced = reussir::ReussirRecordCoerceOp::create(
           rewriter, op.getLoc(), coercedType,
           rewriter.getIndexAttr(*singletonTag), op.getVariant());

--- a/tests/integration/conversion/record_dispatch_atomic.mlir
+++ b/tests/integration/conversion/record_dispatch_atomic.mlir
@@ -1,0 +1,34 @@
+// RUN: %reussir-opt %s --reussir-convert-to-std | %FileCheck %s
+
+// Dispatching through a reference borrowed from an atomic rc box: the
+// lowering re-derives each singleton arm's coerced reference from the
+// scrutinee, and must propagate the scrutinee reference's atomic kind — a
+// `record.coerce` producing a plain `shared` reference would leave an
+// unresolved materialization against the atomic block argument.
+
+!option_some = !reussir.record<compound "AOption::Some" [value] {i32}>
+!option_none = !reussir.record<compound "AOption::None" [value] {}>
+!option = !reussir.record<variant "AOption" {!option_some, !option_none}>
+
+module {
+  // CHECK-LABEL: func.func @dispatch_atomic
+  // CHECK: reussir.record.coerce
+  // CHECK-SAME: !reussir.ref<!reussir.record<compound "AOption::Some" [value] {i32}> shared atomic>
+  // CHECK-NOT: reussir.record.dispatch
+  func.func @dispatch_atomic(%opt_ref : !reussir.ref<!option shared atomic>) -> i32 {
+    %result = reussir.record.dispatch(%opt_ref : !reussir.ref<!option shared atomic>) -> i32 {
+      [0] -> {
+        ^bb0(%some_ref : !reussir.ref<!option_some shared atomic>):
+          %field_ref = reussir.ref.project(%some_ref : !reussir.ref<!option_some shared atomic>) [0] : !reussir.ref<i32 shared>
+          %extracted = reussir.ref.load(%field_ref : !reussir.ref<i32 shared>) : i32
+          reussir.scf.yield %extracted : i32
+      }
+      [1] -> {
+        ^bb0(%none_ref : !reussir.ref<!option_none shared atomic>):
+          %default = arith.constant -1 : i32
+          reussir.scf.yield %default : i32
+      }
+    }
+    func.return %result : i32
+  }
+}

--- a/tests/integration/frontend/arc.rr
+++ b/tests/integration/frontend/arc.rr
@@ -4,6 +4,8 @@
 
 // RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
 // RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %rrc %s --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=MLIR
+// RUN: %rrc %s --emit mlir-llvm --no-source-locations -Onone -o - | %FileCheck %s --check-prefix=LLVM
 
 struct [shared] Data {
     value: i64
@@ -34,20 +36,6 @@ pub fn call_passthrough(a: Arc<Data>) -> Arc<Data> {
     passthrough(a)
 }
 
-// An array and a closure are single shared rc boxes like a [shared] record,
-// so they take the atomic coloring the same way.
-// HIR: pub fn #arr(v0 (a): Arc<[f64; 8]>) -> Arc<[f64; 8]>
-// MIR-DAG: pub fn @_RC3arr(v0 (a): Arc<[f64; 8]>) -> Arc<[f64; 8]>
-pub fn arr(a: Arc<[f64; 8]>) -> Arc<[f64; 8]> {
-    a
-}
-
-// HIR: pub fn #clo(v0 (f): Arc<(i64) -> i64>) -> Arc<(i64) -> i64>
-// MIR-DAG: pub fn @_RC3clo(v0 (f): Arc<(i64) -> i64>) -> Arc<(i64) -> i64>
-pub fn clo(f: Arc<(i64) -> i64>) -> Arc<(i64) -> i64> {
-    f
-}
-
 enum List<T> {
     Nil,
     Cons(T, List<T>)
@@ -69,6 +57,25 @@ pub fn make(v: i64) -> Arc<Data> {
 // MIR-DAG: pub fn @_RC9make_list() -> Arc<List::<i64>>
 pub fn make_list() -> Arc<List<i64>> {
     Arc<List<i64>>::Cons{1, List::Nil}
+}
+
+// The lowering: an arc'd value is `!reussir.rc<…, atomic>`, constructed
+// atomically counted from birth and borrowed at a matching atomic reference;
+// the projected member references stay plain (atomicity governs the
+// refcount, not the payload accesses).
+// MLIR-DAG: reussir.rc.create value({{.+}} : !reussir.record<compound "_RC4Data" {i64}>) : !reussir.rc<!reussir.record<compound "_RC4Data" {i64}> atomic>
+// MLIR-DAG: : !reussir.ref<!reussir.record<compound "_RC4Data" {i64}> shared atomic>
+// The lowered refcount discipline is a monotonic atomic retain and an
+// acq_rel atomic release.
+// LLVM-DAG: llvm.atomicrmw add {{.+}} monotonic
+// LLVM-DAG: llvm.atomicrmw sub {{.+}} acq_rel
+
+fn read_pair(a: Arc<Data>, b: Arc<Data>) -> i64 {
+    a.value + b.value
+}
+
+pub fn share(a: Arc<Data>) -> i64 {
+    read_pair(a, a)
 }
 
 // Reads see through the arc coloring: projection and matching are the inner

--- a/tests/integration/frontend/arc_boxes.rr
+++ b/tests/integration/frontend/arc_boxes.rr
@@ -1,0 +1,23 @@
+// An array and a closure are single shared rc boxes like a [shared] record,
+// so they take the atomic coloring the same way — at the type level. Their
+// atomic lowering has not landed, so this file stays frontend-only (arc.rr
+// carries the MLIR/LLVM checks for the record lowering) and the lowering gap
+// is checked to stay an explicit error rather than a malformed box.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %not %rrc %s --emit mlir -o - 2>&1 | %FileCheck %s --check-prefix=MLIR
+
+// MLIR: arc'd arrays and closures do not lower yet
+
+// HIR: pub fn #arr(v0 (a): Arc<[f64; 8]>) -> Arc<[f64; 8]>
+// MIR-DAG: pub fn @_RC3arr(v0 (a): Arc<[f64; 8]>) -> Arc<[f64; 8]>
+pub fn arr(a: Arc<[f64; 8]>) -> Arc<[f64; 8]> {
+    a
+}
+
+// HIR: pub fn #clo(v0 (f): Arc<(i64) -> i64>) -> Arc<(i64) -> i64>
+// MIR-DAG: pub fn @_RC3clo(v0 (f): Arc<(i64) -> i64>) -> Arc<(i64) -> i64>
+pub fn clo(f: Arc<(i64) -> i64>) -> Arc<(i64) -> i64> {
+    f
+}

--- a/tests/integration/frontend/arc_e2e.c
+++ b/tests/integration/frontend/arc_e2e.c
@@ -1,0 +1,25 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t test_share_ffi(void);
+extern int64_t test_enum_ffi(void);
+extern int64_t test_nullable_ffi(void);
+extern int64_t test_generic_ffi(void);
+
+static int check(const char *name, int64_t got, int64_t want) {
+  if (got == want)
+    return 0;
+  fprintf(stderr, "%s: got %lld, want %lld\n", name, (long long)got,
+          (long long)want);
+  return 1;
+}
+
+int main(void) {
+  int failures = 0;
+  failures += check("share", test_share_ffi(), 42);
+  failures += check("enum", test_enum_ffi(), 42);
+  failures += check("nullable", test_nullable_ffi(), 11);
+  failures += check("generic", test_generic_ffi(), 9);
+  return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/arc_e2e.rr
+++ b/tests/integration/frontend/arc_e2e.rr
@@ -1,0 +1,67 @@
+// End-to-end Arc semantics: the arc'd constructor allocates an atomically
+// counted box, sharing retains it atomically, reads (projection and
+// matching) are the inner record's own, and the arc colors only the outer
+// box — enum payload links stay plain shared values.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/arc_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/arc_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+struct [shared] Data {
+    value: i64
+}
+
+enum List<T> {
+    Nil,
+    Cons(T, List<T>)
+}
+
+fn read_twice(a: Arc<Data>, b: Arc<Data>) -> i64 {
+    a.value + b.value
+}
+
+// Sharing the arc'd box forces an atomic retain before the extra use.
+pub fn test_share() -> i64 {
+    let a = Arc<Data> { value: 21 };
+    read_twice(a, a)
+}
+extern "C" trampoline "test_share_ffi" = test_share;
+
+// The arc colors only the outer box: the tail links are plain shared lists.
+fn sum(l: List<i64>) -> i64 {
+    match l {
+        List::Cons(x, xs) => x + sum(xs),
+        List::Nil => 0
+    }
+}
+
+pub fn test_enum() -> i64 {
+    let l = Arc<List<i64>>::Cons{7, List::Cons{35, List::Nil}};
+    match l {
+        List::Cons(x, xs) => x + sum(xs),
+        List::Nil => 0
+    }
+}
+extern "C" trampoline "test_enum_ffi" = test_enum;
+
+// An arc is pointer-like, so it sits behind a nullable unchanged.
+pub fn test_nullable() -> i64 {
+    let n = Nullable::NonNull{Arc<Data> { value: 11 }};
+    match n {
+        Nullable::NonNull(a) => a.value,
+        Nullable::Null => 0
+    }
+}
+extern "C" trampoline "test_nullable_ffi" = test_nullable;
+
+fn id<T>(x: T) -> T { x }
+
+// A generic instantiated at an arc'd type keeps the atomic discipline.
+pub fn test_generic() -> i64 {
+    let a = id(Arc<Data> { value: 9 });
+    a.value
+}
+extern "C" trampoline "test_generic_ffi" = test_generic;

--- a/tests/integration/sanitizer/e2e/arc.rr
+++ b/tests/integration/sanitizer/e2e/arc.rr
@@ -1,0 +1,15 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/arc_e2e.rr: atomic retain/release balance on
+// the arc'd boxes (sharing, enum payload links, nullable wrapping, generic
+// instantiation) — a missed atomic decrement leaks, a doubled one
+// double-frees.
+
+// RUN: %rrc %S/../../frontend/arc_e2e.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/arc_e2e.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/arc_e2e.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/arc_e2e.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe


### PR DESCRIPTION
Final PR of the `Arc<T>` stack (on top of #426, now merged; rebased onto `main`).

`Arc<X>` now lowers to `!reussir.rc<…, shared atomic>` — the identical record payload behind a box whose refcount uses the dialect's existing atomic paths: plain initial count store (the box is unpublished at birth), monotonic `atomicrmw add` retain, acq_rel `atomicrmw sub` release with the acquire-ordered uniqueness probe. No new MLIR ops were needed; the frontend finally selects `AtomicKind::Atomic`.

**Scope**: of the shared rc boxes an `Arc` may color — a `[shared]` record, an array, or a closure — this lands the **record lowering**. An arc'd array or closure stays an explicit `arc'd arrays and closures do not lower yet` error (`frontend/arc_boxes.rr` keeps their type-level roundtrip frontend-only and pins the error); any other inner is kept out upstream by elaboration and mono's instantiation check, so the codegen rejection is only the backstop for directly lowered textual MIR.

### Codegen

- **`record_of` peels the arc**: layout queries (payload/variant/field types) see `X` directly, so ctor, projection, and match lowering reuse the plain record machinery. `box_record` branches first on an `Arc`-typed ctor node and creates the box at the atomic rc type.
- **`mlir_ty(Arc<inner>)`** builds the atomic rc for a `[shared]` record inner and keeps the two gaps explicit (unimplemented array/closure, backstop for anything else).
- **Borrows are atomic, projections stay plain**: `rc.borrow` requires the ref's atomic kind to match the box's, so the three borrow sites (projection cursors, variant resolution, dispatch arm payload refs) go through a `borrow_ref_type` helper. Member projections keep `normal` refs — atomicity governs the refcount, not payload accesses — matching the dialect's verifier rules.

### One MLIR fix

The record-dispatch SCF lowering (now hosted by `--reussir-convert-to-std` after the pass consolidation on `main`) rebuilt a singleton arm's coerced reference with the two-parameter `RefType::get`, silently defaulting the atomic kind to `normal` and leaving an unresolved materialization against the atomic block argument. It now propagates the scrutinee reference's atomic kind (`record_dispatch_atomic.mlir` covers this in isolation).

### Testing

- `frontend/arc.rr` gains MLIR-level checks (`rc.create : rc<… atomic>`, `ref<… shared atomic>` borrows) and LLVM-level checks (`atomicrmw add … monotonic`, `atomicrmw sub … acq_rel`); the type-only array/closure cases moved to `frontend/arc_boxes.rr` so `arc.rr` stays fully lowerable
- **`frontend/arc_e2e.rr` + C driver compiles and runs natively**: atomic sharing, an arc'd enum whose tail links stay plain shared boxes, `Nullable<Arc<…>>`, and a generic instantiated at an arc'd type
- `sanitizer/e2e/arc.rr` gates the retain/release balance under ASan+LSan at `-Onone` and `-Oaggressive --reuse-across-call`
- 3 codegen unit tests (atomic box lowering, non-box-inner backstop, arc'd-array unimplemented error); full lit suite (380 passed / 8 env-unsupported) and cargo workspace green after the rebase onto `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786690953&installation_id=144622820&pr_number=427&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F427&signature=bf9fa7df8b4166b46ca05e861361df1022c1a75dd2947f5dd9230323ac001728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
