### PR TITLE
[mlir] restrict atomic cells to atomic shared RC boxes

### DIFF
--- a/crates/reussir-backend/src/dialect/ty.rs
+++ b/crates/reussir-backend/src/dialect/ty.rs
@@ -67,13 +67,15 @@ pub fn cell(element: Type, exclusive: bool) -> Type {
 }
 
 /// Creates a cell payload using one storage strategy. `Atomic` is an inline
-/// atomic arithmetic scalar inside the shared RC box; it is independent of
-/// the RC pointer's own refcount atomicity.
+/// atomic arithmetic scalar inside the shared RC box; an atomic cell must be
+/// managed by an RC pointer that is itself shared with an atomic refcount
+/// (`rc(_, Shared, Atomic)`).
 pub fn cell_with_kind(element: Type, kind: ReussirCellKind) -> Type {
     unsafe { Type::from_raw(sys::reussirCellTypeGetWithKind(element.to_raw(), kind)) }
 }
 
 /// Creates an RC-contained atomic scalar payload, `!reussir.cell<T atomic>`.
+/// The managing RC pointer must be shared and atomic.
 pub fn atomic_cell(element: Type) -> Type {
     cell_with_kind(element, ReussirCellKind::Atomic)
 }

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1149,7 +1149,7 @@ def ReussirCellRmwOp : ReussirCellOp<"rmw", []> {
 
     ```mlir
     %old = reussir.cell.rmw addi(%delta : i64,
-        %cell : !reussir.rc<!reussir.cell<i64 atomic>>) -> i64
+        %cell : !reussir.rc<!reussir.cell<i64 atomic> atomic>) -> i64
     ```
   }];
   let arguments = (ins OptionalAttr<AtomicRMWKindAttr>:$kind,

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -348,6 +348,12 @@ def ReussirCellType
     primitive. Atomic cells use atomic get/set operations and support both
     the direct and region forms of `reussir.cell.rmw`. Atomic and exclusive
     are distinct, mutually exclusive storage kinds.
+
+    An atomic cell only exists to be shared across threads, so it is always
+    managed by an atomic shared RC pointer
+    (`!reussir.rc<!reussir.cell<T atomic> atomic>`): the box refcount and the
+    payload slot are atomic together. Plain and exclusive cells may sit in
+    either box flavor.
   }];
   let parameters = (ins "mlir::Type":$eleTy, "reussir::CellKind":$kind);
   let genVerifyDecl = 1;

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -740,9 +740,11 @@ struct ReussirRefStoreConversionPattern
 //===----------------------------------------------------------------------===//
 // Atomic cell lowering
 //===----------------------------------------------------------------------===//
-// Cell atomicity describes the payload slot itself. It is intentionally
-// independent of RcType::getAtomicKind(), which controls only the RC box's
-// refcount operations.
+// Cell atomicity describes the payload slot itself, while
+// RcType::getAtomicKind() controls the RC box's refcount operations. An
+// atomic cell requires an atomic shared RC box (enforced by RcType::verify),
+// so the two are atomic together; the patterns below nevertheless key only
+// on the cell kind.
 static mlir::Value
 atomicCellSlotPtr(RcType rcType, mlir::Value convertedCell, mlir::Location loc,
                   const mlir::TypeConverter *typeConverter,

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -901,6 +901,19 @@ RcType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     return mlir::failure();
   }
 
+  // An atomic cell only exists to be shared across threads, so the box
+  // managing it must itself be shared with an atomic refcount.
+  if (auto cellTy = llvm::dyn_cast<CellType>(eleTy);
+      cellTy && cellTy.getAtomic() &&
+      (capability != reussir::Capability::shared ||
+       atomicKind != reussir::AtomicKind::atomic)) {
+    emitError() << "an atomic cell must be managed by an atomic shared RC "
+                   "pointer, got capability "
+                << stringifyCapability(capability) << " and atomic kind "
+                << stringifyAtomicKind(atomicKind);
+    return mlir::failure();
+  }
+
   return mlir::success();
 }
 //===----------------------------------------------------------------------===//
@@ -1401,8 +1414,15 @@ mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap) {
     NullableType nullableTy = NullableType::get(type.getContext(), rcTy);
     return nullableTy;
   }
-  if (targetCap == Capability::shared)
-    return RcType::get(type.getContext(), type, Capability::shared);
+  if (targetCap == Capability::shared) {
+    // An atomic cell member is managed by an atomic shared RC box (see
+    // `RcType::verify`); every other shared member keeps the default
+    // nonatomic refcount.
+    auto cellTy = llvm::dyn_cast<CellType>(type);
+    AtomicKind atomicKind =
+        cellTy && cellTy.getAtomic() ? AtomicKind::atomic : AtomicKind::normal;
+    return RcType::get(type.getContext(), type, Capability::shared, atomicKind);
+  }
   if (targetCap == Capability::regional)
     return RcType::get(type.getContext(), type, Capability::rigid);
   return type;

--- a/tests/integration/basic/failure/atomic_cell_rc_kind.mlir
+++ b/tests/integration/basic/failure/atomic_cell_rc_kind.mlir
@@ -1,0 +1,19 @@
+// RUN: %reussir-opt %s -verify-diagnostics -split-input-file
+
+// An atomic cell only exists to be shared across threads, so the box managing
+// it must be a shared RC pointer with an atomic refcount.
+// expected-error @+1 {{an atomic cell must be managed by an atomic shared RC pointer, got capability shared and atomic kind normal}}
+!bad_nonatomic_box = !reussir.rc<!reussir.cell<i64 atomic>>
+
+module {
+}
+
+// -----
+
+// The shared-capability half of the invariant: even with an atomic refcount,
+// a regional (flex/rigid) box cannot manage an atomic cell.
+// expected-error @+1 {{an atomic cell must be managed by an atomic shared RC pointer, got capability flex and atomic kind atomic}}
+!bad_flex_box = !reussir.rc<!reussir.cell<i64 atomic> flex atomic>
+
+module {
+}

--- a/tests/integration/basic/failure/cell.mlir
+++ b/tests/integration/basic/failure/cell.mlir
@@ -5,7 +5,7 @@
 !excl_cell_i64 = !reussir.cell<i64 exclusive>
 !rc_excl_cell_i64 = !reussir.rc<!excl_cell_i64>
 !atomic_cell_i64 = !reussir.cell<i64 atomic>
-!rc_atomic_cell_i64 = !reussir.rc<!atomic_cell_i64>
+!rc_atomic_cell_i64 = !reussir.rc<!atomic_cell_i64 atomic>
 
 module {
   func.func @create_type_mismatch(%value: i32) {

--- a/tests/integration/conversion/atomic_cell.mlir
+++ b/tests/integration/conversion/atomic_cell.mlir
@@ -2,8 +2,8 @@
 // RUN: %reussir-opt %s --reussir-lowering-scf-ops | %FileCheck %s --check-prefix=SCF
 // RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-acquire-drop-expansion,reussir-lowering-scf-ops,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
 
-!atomic_i64 = !reussir.rc<!reussir.cell<i64 atomic>>
-!atomic_f32 = !reussir.rc<!reussir.cell<f32 atomic>>
+!atomic_i64 = !reussir.rc<!reussir.cell<i64 atomic> atomic>
+!atomic_f32 = !reussir.rc<!reussir.cell<f32 atomic> atomic>
 
 module {
   // Atomic Cell creation is structural initialization, not an atomic access,
@@ -17,7 +17,7 @@ module {
   }
 
   // ROUNDTRIP-LABEL: func.func @atomic_get
-  // ROUNDTRIP-SAME: !reussir.rc<!reussir.cell<i64 atomic>>
+  // ROUNDTRIP-SAME: !reussir.rc<!reussir.cell<i64 atomic> atomic>
   // SCF-LABEL: func.func @atomic_get
   // SCF: reussir.cell.get
   // LLVM-LABEL: define i64 @atomic_get
@@ -28,7 +28,7 @@ module {
   }
 
   // ROUNDTRIP-LABEL: func.func @atomic_get_monotonic
-  // ROUNDTRIP: reussir.cell.get(%{{.+}} : !reussir.rc<!reussir.cell<i64 atomic>>) ordering(monotonic) : i64
+  // ROUNDTRIP: reussir.cell.get(%{{.+}} : !reussir.rc<!reussir.cell<i64 atomic> atomic>) ordering(monotonic) : i64
   // LLVM-LABEL: define i64 @atomic_get_monotonic
   // LLVM: load atomic i64, ptr %{{.+}} monotonic, align 8
   func.func @atomic_get_monotonic(%cell: !atomic_i64) -> i64 {
@@ -46,7 +46,7 @@ module {
   }
 
   // ROUNDTRIP-LABEL: func.func @atomic_set_seq_cst
-  // ROUNDTRIP: reussir.cell.set(%{{.+}} : i64, %{{.+}} : !reussir.rc<!reussir.cell<i64 atomic>>) ordering(seq_cst)
+  // ROUNDTRIP: reussir.cell.set(%{{.+}} : i64, %{{.+}} : !reussir.rc<!reussir.cell<i64 atomic> atomic>) ordering(seq_cst)
   // LLVM-LABEL: define void @atomic_set_seq_cst
   // LLVM: store atomic i64 %{{.+}}, ptr %{{.+}} seq_cst, align 8
   func.func @atomic_set_seq_cst(%value: i64, %cell: !atomic_i64) {
@@ -55,7 +55,7 @@ module {
   }
 
   // ROUNDTRIP-LABEL: func.func @direct_add
-  // ROUNDTRIP: reussir.cell.rmw addi(%{{.+}} : i64, %{{.+}} : !reussir.rc<!reussir.cell<i64 atomic>>) ordering(acquire) -> i64
+  // ROUNDTRIP: reussir.cell.rmw addi(%{{.+}} : i64, %{{.+}} : !reussir.rc<!reussir.cell<i64 atomic> atomic>) ordering(acquire) -> i64
   // SCF-LABEL: func.func @direct_add
   // SCF: reussir.cell.rmw addi
   // LLVM-LABEL: define i64 @direct_add
@@ -69,10 +69,10 @@ module {
   // multiply into an scf.while retry loop committed with the weak
   // ref.cmpxchg bridge; the LLVM lowering never touches control flow.
   // SCF-LABEL: func.func @direct_multiply
-  // SCF: %[[MUL_INIT:.+]] = reussir.cell.get(%{{.+}} : !reussir.rc<!reussir.cell<i64 atomic>>) ordering(monotonic) : i64
+  // SCF: %[[MUL_INIT:.+]] = reussir.cell.get(%{{.+}} : !reussir.rc<!reussir.cell<i64 atomic> atomic>) ordering(monotonic) : i64
   // SCF: scf.while (%[[MUL_EXPECTED:.+]] = %[[MUL_INIT]]) : (i64) -> i64
   // SCF: arith.muli %[[MUL_EXPECTED]], %{{.+}} : i64
-  // SCF: %[[MUL_OBSERVED:.+]], %[[MUL_OK:.+]] = reussir.ref.cmpxchg(%[[MUL_EXPECTED]] : i64, %{{.+}} : i64, %{{.+}} : !reussir.ref<i64 field>) weak ordering(acq_rel) : i64, i1
+  // SCF: %[[MUL_OBSERVED:.+]], %[[MUL_OK:.+]] = reussir.ref.cmpxchg(%[[MUL_EXPECTED]] : i64, %{{.+}} : i64, %{{.+}} : !reussir.ref<i64 field atomic>) weak ordering(acq_rel) : i64, i1
   // SCF: %[[MUL_RETRY:.+]] = arith.xori %[[MUL_OK]], %{{.+}} : i1
   // SCF: scf.condition(%[[MUL_RETRY]]) %[[MUL_OBSERVED]] : i64
   // SCF-NOT: reussir.cell.rmw
@@ -93,11 +93,11 @@ module {
   // optional output is computed on each attempt but only the successful
   // attempt's value leaves the loop.
   // ROUNDTRIP-LABEL: func.func @region_rmw
-  // ROUNDTRIP: reussir.cell.rmw(%{{.+}} : !reussir.rc<!reussir.cell<i64 atomic>>) ordering(seq_cst) -> i64 {
+  // ROUNDTRIP: reussir.cell.rmw(%{{.+}} : !reussir.rc<!reussir.cell<i64 atomic> atomic>) ordering(seq_cst) -> i64 {
   // SCF-LABEL: func.func @region_rmw
-  // SCF: %[[INIT:.+]] = reussir.cell.get(%{{.+}} : !reussir.rc<!reussir.cell<i64 atomic>>) ordering(monotonic) : i64
+  // SCF: %[[INIT:.+]] = reussir.cell.get(%{{.+}} : !reussir.rc<!reussir.cell<i64 atomic> atomic>) ordering(monotonic) : i64
   // SCF: scf.while (%[[EXPECTED:.+]] = %[[INIT]]) : (i64) -> (i64, i64)
-  // SCF: %[[OBSERVED:.+]], %[[OK:.+]] = reussir.ref.cmpxchg(%[[EXPECTED]] : i64, %{{.+}} : i64, %{{.+}} : !reussir.ref<i64 field>) weak ordering(seq_cst) : i64, i1
+  // SCF: %[[OBSERVED:.+]], %[[OK:.+]] = reussir.ref.cmpxchg(%[[EXPECTED]] : i64, %{{.+}} : i64, %{{.+}} : !reussir.ref<i64 field atomic>) weak ordering(seq_cst) : i64, i1
   // SCF: %[[RETRY:.+]] = arith.xori %[[OK]], %{{.+}} : i1
   // SCF: scf.condition(%[[RETRY]]) %[[OBSERVED]], %{{.+}} : i64, i64
   // SCF-NOT: reussir.cell.rmw
@@ -142,10 +142,10 @@ module {
   // lowering compares integer bit patterns, avoiding an invalid
   // floating-point llvm.cmpxchg.
   // LLVM-LABEL: define float @region_float
-  // ROUNDTRIP: reussir.cell.rmw(%{{.+}} : !reussir.rc<!reussir.cell<f32 atomic>>) ordering(release) -> f32 {
+  // ROUNDTRIP: reussir.cell.rmw(%{{.+}} : !reussir.rc<!reussir.cell<f32 atomic> atomic>) ordering(release) -> f32 {
   // SCF-LABEL: func.func @region_float
   // SCF: scf.while
-  // SCF: reussir.ref.cmpxchg(%{{.+}} : f32, %{{.+}} : f32, %{{.+}} : !reussir.ref<f32 field>) weak ordering(release) : f32, i1
+  // SCF: reussir.ref.cmpxchg(%{{.+}} : f32, %{{.+}} : f32, %{{.+}} : !reussir.ref<f32 field atomic>) weak ordering(release) : f32, i1
   // LLVM: load atomic float, ptr %{{.+}} monotonic, align 4
   // LLVM: fadd float
   // LLVM: bitcast float %{{.+}} to i32

--- a/tests/unittest/cases/cell.cpp
+++ b/tests/unittest/cases/cell.cpp
@@ -63,18 +63,18 @@ TEST_F(ReussirTest, ParseAtomicCellOrderingTest) {
       R"mlir(
         module {
           func.func @test(
-              %cell: !reussir.rc<!reussir.cell<i64 atomic>>,
+              %cell: !reussir.rc<!reussir.cell<i64 atomic> atomic>,
               %value: i64) -> i64 {
             %loaded = reussir.cell.get(
-                %cell : !reussir.rc<!reussir.cell<i64 atomic>>
+                %cell : !reussir.rc<!reussir.cell<i64 atomic> atomic>
               ) ordering(monotonic) : i64
             reussir.cell.set(
                 %value : i64,
-                %cell : !reussir.rc<!reussir.cell<i64 atomic>>
+                %cell : !reussir.rc<!reussir.cell<i64 atomic> atomic>
               ) ordering(seq_cst)
             %old = reussir.cell.rmw addi(
                 %loaded : i64,
-                %cell : !reussir.rc<!reussir.cell<i64 atomic>>
+                %cell : !reussir.rc<!reussir.cell<i64 atomic> atomic>
               ) ordering(acquire) -> i64
             return %old : i64
           }
@@ -116,5 +116,19 @@ TEST_F(ReussirTest, CellMemberProjectsToSharedRc) {
   EXPECT_EQ(memberStorageType(context.get(), cellType, /*isField=*/false,
                               /*memBoxInternal=*/true),
             cellType);
+}
+
+TEST_F(ReussirTest, AtomicCellMemberProjectsToAtomicSharedRc) {
+  auto i64Type = mlir::IntegerType::get(context.get(), 64);
+  auto cellType = CellType::get(context.get(), i64Type, CellKind::atomic);
+
+  // An atomic cell member is one shared rc box like any other cell, but its
+  // box refcount must be atomic (see `RcType::verify`).
+  auto projected = llvm::dyn_cast<RcType>(
+      getProjectedType(cellType, /*fieldCap=*/false, Capability::value));
+  ASSERT_TRUE(projected);
+  EXPECT_EQ(projected.getElementType(), cellType);
+  EXPECT_EQ(projected.getCapability(), Capability::shared);
+  EXPECT_EQ(projected.getAtomicKind(), AtomicKind::atomic);
 }
 } // namespace reussir


### PR DESCRIPTION
An atomic cell exists to be shared across threads, so the box managing it
must itself use an atomic refcount. RcType::verify now rejects an RC of an
atomic cell unless the RC is shared with an atomic kind, and
getProjectedType projects an atomic cell record member to an atomic shared
RC box instead of the default nonatomic one.

The atomic cell access patterns are unchanged: they still key on the cell
kind alone; only the box refcount discipline is tightened.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D4kMPsUrpFauQ6LLGWKetj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786722972&installation_id=144622820&pr_number=428&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F428&signature=04eae4b3fc7f4962fcc653bf9e762a0a3de52c61094097000ebcd75574cc3770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->