### PR TITLE
[mlir] add mlir-sync dependency and lock-guarded cell kinds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ message(STATUS "Tablegen output directory: ${MLIR_TABLEGEN_OUTPUT_DIR}")
 # Include Immer
 include(cmake/Immer.cmake)
 
+# Include the mlir-sync `sync` dialect (synchronization primitives). Reussir's
+# lock-guarded cells lower onto this dialect.
+include(cmake/MlirSync.cmake)
+
 # Detect object format
 include(cmake/ObjectFormat.cmake)
 
@@ -76,6 +80,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${MLIR_TABLEGEN_OUTPUT_DIR}
     ${immer_SOURCE_DIR}
+    ${MLIR_SYNC_INCLUDE_DIRS}
 )
 
 include_directories(SYSTEM

--- a/cmake/MlirSync.cmake
+++ b/cmake/MlirSync.cmake
@@ -1,0 +1,30 @@
+include(FetchContent)
+
+# reussir-lang/mlir-sync provides the `sync` dialect: portable synchronization
+# primitives (mutex, reader-writer lock, flat-combining lock, once) with an
+# inlined fast path and a futex-style runtime slow path, plus conversions that
+# split their control flow into `scf`/`func` (`convert-sync-to-std`) and lower
+# the remaining bridge operations to LLVM (`convert-sync-to-llvm`). Reussir's
+# lock-guarded cells (mutex/flatlock/rwlock) are lowered onto this dialect.
+#
+# mlir-sync discovers LLVM/MLIR through the same LLVM_DIR/MLIR_DIR this build
+# already resolved, so no extra configuration is needed. Its own tests build a
+# `sync-opt` tool that we do not need here.
+set(SYNC_ENABLE_TESTS OFF CACHE BOOL "Build sync dialect integration tests" FORCE)
+
+FetchContent_Declare(
+  mlirsync
+  GIT_REPOSITORY https://github.com/reussir-lang/mlir-sync.git
+  GIT_TAG 010db3444a38cc1cb1f11c3d6a862bfaa91b68ae
+)
+
+FetchContent_MakeAvailable(mlirsync)
+
+# The sync dialect libraries rely on the directory-scoped `include_directories`
+# of their own project, so linking against them does not propagate the header
+# search paths. Expose both the source headers and the tablegen-generated
+# `.h.inc` files to the rest of the Reussir build.
+set(MLIR_SYNC_INCLUDE_DIRS
+    ${mlirsync_SOURCE_DIR}/include
+    ${mlirsync_BINARY_DIR}/include
+    CACHE INTERNAL "mlir-sync include directories")

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -50,6 +50,9 @@ pub enum ReussirCellKind {
     Plain = 0,
     Exclusive = 1,
     Atomic = 2,
+    Mutex = 3,
+    Flatlock = 4,
+    Rwlock = 5,
 }
 
 /// Record flavour. Mirrors `reussir::RecordKind`.

--- a/crates/reussir-backend/src/dialect/ty.rs
+++ b/crates/reussir-backend/src/dialect/ty.rs
@@ -80,6 +80,27 @@ pub fn atomic_cell(element: Type) -> Type {
     cell_with_kind(element, ReussirCellKind::Atomic)
 }
 
+/// Creates a mutex-guarded cell payload, `!reussir.cell<T mutex>`. Like an
+/// atomic cell, it must be managed by an RC pointer that is shared and atomic
+/// (`rc(_, Shared, Atomic)`).
+pub fn mutex_cell(element: Type) -> Type {
+    cell_with_kind(element, ReussirCellKind::Mutex)
+}
+
+/// Creates a flat-combining-lock-guarded cell payload,
+/// `!reussir.cell<T flatlock>`. Like an atomic cell, it must be managed by an
+/// RC pointer that is shared and atomic (`rc(_, Shared, Atomic)`).
+pub fn flatlock_cell(element: Type) -> Type {
+    cell_with_kind(element, ReussirCellKind::Flatlock)
+}
+
+/// Creates a reader-writer-lock-guarded cell payload,
+/// `!reussir.cell<T rwlock>`. Like an atomic cell, it must be managed by an RC
+/// pointer that is shared and atomic (`rc(_, Shared, Atomic)`).
+pub fn rwlock_cell(element: Type) -> Type {
+    cell_with_kind(element, ReussirCellKind::Rwlock)
+}
+
 /// Creates a `!reussir.ref<element, capability, atomicKind>` type.
 pub fn r#ref(element: Type, capability: ReussirCapability, atomic_kind: ReussirAtomicKind) -> Type {
     unsafe {

--- a/include/Reussir-c/Types.h
+++ b/include/Reussir-c/Types.h
@@ -53,6 +53,9 @@ typedef enum ReussirCellKind {
   ReussirCellKindPlain = 0,
   ReussirCellKindExclusive = 1,
   ReussirCellKindAtomic = 2,
+  ReussirCellKindMutex = 3,
+  ReussirCellKindFlatlock = 4,
+  ReussirCellKindRwlock = 5,
 } ReussirCellKind;
 
 // Record flavour. Mirrors `reussir::RecordKind`.

--- a/include/Reussir/IR/ReussirAttrs.td
+++ b/include/Reussir/IR/ReussirAttrs.td
@@ -37,12 +37,22 @@ def AtomicKind
 //===----------------------------------------------------------------------===//
 // A single enum deliberately models these as alternatives. In particular,
 // `exclusive` and `atomic` are storage strategies, not independent flags.
+//
+// `mutex`, `flatlock`, and `rwlock` wrap the payload in a synchronization
+// primitive from the `sync` dialect (mlir-sync): a mutex, a flat-combining
+// lock, and a reader-writer lock respectively. Like `atomic`, they only exist
+// to be shared across threads, so they carry the same requirement of living in
+// an atomic shared RC box.
 def CK_Plain : I32EnumAttrCase<"plain", 0>;
 def CK_Exclusive : I32EnumAttrCase<"exclusive", 1>;
 def CK_Atomic : I32EnumAttrCase<"atomic", 2>;
+def CK_Mutex : I32EnumAttrCase<"mutex", 3>;
+def CK_Flatlock : I32EnumAttrCase<"flatlock", 4>;
+def CK_Rwlock : I32EnumAttrCase<"rwlock", 5>;
 def CellKind
     : I32EnumAttr<"CellKind", "cell storage kind",
-                  [CK_Plain, CK_Exclusive, CK_Atomic]> {
+                  [CK_Plain, CK_Exclusive, CK_Atomic, CK_Mutex, CK_Flatlock,
+                   CK_Rwlock]> {
   let cppNamespace = "::reussir";
 }
 

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -349,8 +349,15 @@ def ReussirCellType
     the direct and region forms of `reussir.cell.rmw`. Atomic and exclusive
     are distinct, mutually exclusive storage kinds.
 
-    An atomic cell only exists to be shared across threads, so it is always
-    managed by an atomic shared RC pointer
+    A `mutex`, `flatlock`, or `rwlock` cell (`!reussir.cell<T mutex>`,
+    `!reussir.cell<T flatlock>`, `!reussir.cell<T rwlock>`) wraps an arbitrary
+    payload `T` in a synchronization primitive from the `sync` dialect: a
+    mutex, a flat-combining lock, and a reader-writer lock respectively. Access
+    to the payload is mediated by a lock-holding critical-section region rather
+    than by whole-element get/set.
+
+    An atomic, mutex, flatlock, or rwlock cell only exists to be shared across
+    threads, so it is always managed by an atomic shared RC pointer
     (`!reussir.rc<!reussir.cell<T atomic> atomic>`): the box refcount and the
     payload slot are atomic together. Plain and exclusive cells may sit in
     either box flavor.
@@ -378,6 +385,21 @@ def ReussirCellType
     mlir::Type getElementType() const { return getEleTy(); }
     bool getExclusive() const { return getKind() == CellKind::exclusive; }
     bool getAtomic() const { return getKind() == CellKind::atomic; }
+    bool getMutex() const { return getKind() == CellKind::mutex; }
+    bool getFlatlock() const { return getKind() == CellKind::flatlock; }
+    bool getRwlock() const { return getKind() == CellKind::rwlock; }
+    /// Whether this is a lock-guarded cell (mutex/flatlock/rwlock), whose
+    /// payload is protected by a `sync` dialect synchronization primitive.
+    bool getLockGuarded() const {
+      return getKind() == CellKind::mutex || getKind() == CellKind::flatlock ||
+             getKind() == CellKind::rwlock;
+    }
+    /// Whether this cell must be managed by an atomic shared RC box because it
+    /// is meant to be shared across threads: atomic scalars and lock-guarded
+    /// cells share that requirement.
+    bool requiresAtomicSharedBox() const {
+      return getAtomic() || getLockGuarded();
+    }
   }];
 }
 //===----------------------------------------------------------------------===//

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -901,14 +901,16 @@ RcType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     return mlir::failure();
   }
 
-  // An atomic cell only exists to be shared across threads, so the box
-  // managing it must itself be shared with an atomic refcount.
+  // An atomic scalar or lock-guarded cell only exists to be shared across
+  // threads, so the box managing it must itself be shared with an atomic
+  // refcount.
   if (auto cellTy = llvm::dyn_cast<CellType>(eleTy);
-      cellTy && cellTy.getAtomic() &&
+      cellTy && cellTy.requiresAtomicSharedBox() &&
       (capability != reussir::Capability::shared ||
        atomicKind != reussir::AtomicKind::atomic)) {
-    emitError() << "an atomic cell must be managed by an atomic shared RC "
-                   "pointer, got capability "
+    emitError() << "a cell of kind '" << stringifyCellKind(cellTy.getKind())
+                << "' must be managed by an atomic shared RC pointer, got "
+                   "capability "
                 << stringifyCapability(capability) << " and atomic kind "
                 << stringifyAtomicKind(atomicKind);
     return mlir::failure();
@@ -1005,6 +1007,12 @@ mlir::Type CellType::parse(mlir::AsmParser &parser) {
     kind = CellKind::exclusive;
   else if (mlir::succeeded(parser.parseOptionalKeyword("atomic")))
     kind = CellKind::atomic;
+  else if (mlir::succeeded(parser.parseOptionalKeyword("mutex")))
+    kind = CellKind::mutex;
+  else if (mlir::succeeded(parser.parseOptionalKeyword("flatlock")))
+    kind = CellKind::flatlock;
+  else if (mlir::succeeded(parser.parseOptionalKeyword("rwlock")))
+    kind = CellKind::rwlock;
   if (parser.parseGreater())
     return {};
   return CellType::getChecked(parser.getEncodedSourceLoc(loc),
@@ -1017,6 +1025,12 @@ void CellType::print(mlir::AsmPrinter &printer) const {
     printer << " exclusive";
   else if (getAtomic())
     printer << " atomic";
+  else if (getMutex())
+    printer << " mutex";
+  else if (getFlatlock())
+    printer << " flatlock";
+  else if (getRwlock())
+    printer << " rwlock";
   printer << ">";
 }
 
@@ -1055,6 +1069,13 @@ CellType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
 // cell carries a trailing i1 in-use flag: one byte after the element, padded
 // to the element's alignment — the same layout LLVM derives for
 // `{element, i1}`.
+//
+// Lock-guarded cells (mutex/flatlock/rwlock) have no reussir-level physical
+// layout: their storage is a `sync` synchronization primitive wrapping the
+// payload, materialized when the cell type is converted to the corresponding
+// `!sync.*` type during lowering. They are therefore never allocated directly
+// through this interface, and the fall-through below only reflects the inline
+// payload, not the (larger) lock storage.
 llvm::TypeSize
 CellType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
                             mlir::DataLayoutEntryListRef params) const {
@@ -1415,12 +1436,13 @@ mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap) {
     return nullableTy;
   }
   if (targetCap == Capability::shared) {
-    // An atomic cell member is managed by an atomic shared RC box (see
-    // `RcType::verify`); every other shared member keeps the default
-    // nonatomic refcount.
+    // An atomic scalar or lock-guarded cell member is managed by an atomic
+    // shared RC box (see `RcType::verify`); every other shared member keeps
+    // the default nonatomic refcount.
     auto cellTy = llvm::dyn_cast<CellType>(type);
-    AtomicKind atomicKind =
-        cellTy && cellTy.getAtomic() ? AtomicKind::atomic : AtomicKind::normal;
+    AtomicKind atomicKind = cellTy && cellTy.requiresAtomicSharedBox()
+                                ? AtomicKind::atomic
+                                : AtomicKind::normal;
     return RcType::get(type.getContext(), type, Capability::shared, atomicKind);
   }
   if (targetCap == Capability::regional)

--- a/tests/integration/basic/failure/atomic_cell_rc_kind.mlir
+++ b/tests/integration/basic/failure/atomic_cell_rc_kind.mlir
@@ -2,7 +2,7 @@
 
 // An atomic cell only exists to be shared across threads, so the box managing
 // it must be a shared RC pointer with an atomic refcount.
-// expected-error @+1 {{an atomic cell must be managed by an atomic shared RC pointer, got capability shared and atomic kind normal}}
+// expected-error @+1 {{a cell of kind 'atomic' must be managed by an atomic shared RC pointer, got capability shared and atomic kind normal}}
 !bad_nonatomic_box = !reussir.rc<!reussir.cell<i64 atomic>>
 
 module {
@@ -12,7 +12,7 @@ module {
 
 // The shared-capability half of the invariant: even with an atomic refcount,
 // a regional (flex/rigid) box cannot manage an atomic cell.
-// expected-error @+1 {{an atomic cell must be managed by an atomic shared RC pointer, got capability flex and atomic kind atomic}}
+// expected-error @+1 {{a cell of kind 'atomic' must be managed by an atomic shared RC pointer, got capability flex and atomic kind atomic}}
 !bad_flex_box = !reussir.rc<!reussir.cell<i64 atomic> flex atomic>
 
 module {

--- a/tests/integration/basic/failure/lock_cell_rc_kind.mlir
+++ b/tests/integration/basic/failure/lock_cell_rc_kind.mlir
@@ -1,0 +1,28 @@
+// RUN: %reussir-opt %s -verify-diagnostics -split-input-file
+
+// A mutex cell, like an atomic cell, only exists to be shared across threads,
+// so the box managing it must be a shared RC pointer with an atomic refcount.
+// expected-error @+1 {{a cell of kind 'mutex' must be managed by an atomic shared RC pointer, got capability shared and atomic kind normal}}
+!bad_mutex_box = !reussir.rc<!reussir.cell<i64 mutex>>
+
+module {
+}
+
+// -----
+
+// A flatlock (flat-combining lock) cell carries the same requirement.
+// expected-error @+1 {{a cell of kind 'flatlock' must be managed by an atomic shared RC pointer, got capability shared and atomic kind normal}}
+!bad_flatlock_box = !reussir.rc<!reussir.cell<i64 flatlock>>
+
+module {
+}
+
+// -----
+
+// The shared-capability half of the invariant holds for rwlock cells too:
+// even with an atomic refcount, a regional (flex/rigid) box is rejected.
+// expected-error @+1 {{a cell of kind 'rwlock' must be managed by an atomic shared RC pointer, got capability flex and atomic kind atomic}}
+!bad_rwlock_box = !reussir.rc<!reussir.cell<i64 rwlock> flex atomic>
+
+module {
+}

--- a/tests/integration/basic/success/lock_cell.mlir
+++ b/tests/integration/basic/success/lock_cell.mlir
@@ -1,0 +1,20 @@
+// RUN: %reussir-opt %s | %reussir-opt | %FileCheck %s
+
+// Lock-guarded cells (mutex / flatlock / rwlock) wrap an arbitrary payload in a
+// `sync` synchronization primitive and, like atomic cells, are always managed
+// by an atomic shared RC box. This test pins down the type syntax roundtrip.
+
+!mutex_cell = !reussir.rc<!reussir.cell<i64 mutex> atomic>
+!flatlock_cell = !reussir.rc<!reussir.cell<!reussir.rc<i32> flatlock> atomic>
+!rwlock_cell = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+
+module {
+  // CHECK-LABEL: func.func @lock_cell_types
+  // CHECK-SAME: !reussir.rc<!reussir.cell<i64 mutex> atomic>
+  // CHECK-SAME: !reussir.rc<!reussir.cell<!reussir.rc<i32> flatlock> atomic>
+  // CHECK-SAME: !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+  func.func @lock_cell_types(%m: !mutex_cell, %f: !flatlock_cell,
+                             %w: !rwlock_cell) {
+    return
+  }
+}

--- a/tests/unittest/cases/cell.cpp
+++ b/tests/unittest/cases/cell.cpp
@@ -131,4 +131,69 @@ TEST_F(ReussirTest, AtomicCellMemberProjectsToAtomicSharedRc) {
   EXPECT_EQ(projected.getCapability(), Capability::shared);
   EXPECT_EQ(projected.getAtomicKind(), AtomicKind::atomic);
 }
+
+TEST_F(ReussirTest, ParseMutexCellTypeTest) {
+  withType<CellType>(SIMPLE_LAYOUT, R"(!reussir.cell<i64 mutex>)",
+                     [](mlir::ModuleOp, CellType type) {
+                       EXPECT_EQ(type.getKind(), CellKind::mutex);
+                       EXPECT_TRUE(type.getMutex());
+                       EXPECT_TRUE(type.getLockGuarded());
+                       EXPECT_TRUE(type.requiresAtomicSharedBox());
+                       EXPECT_FALSE(type.getExclusive());
+                       EXPECT_FALSE(type.getAtomic());
+                     });
+}
+
+TEST_F(ReussirTest, ParseFlatlockCellTypeTest) {
+  withType<CellType>(SIMPLE_LAYOUT, R"(!reussir.cell<i64 flatlock>)",
+                     [](mlir::ModuleOp, CellType type) {
+                       EXPECT_EQ(type.getKind(), CellKind::flatlock);
+                       EXPECT_TRUE(type.getFlatlock());
+                       EXPECT_TRUE(type.getLockGuarded());
+                       EXPECT_TRUE(type.requiresAtomicSharedBox());
+                     });
+}
+
+TEST_F(ReussirTest, ParseRwlockCellTypeTest) {
+  withType<CellType>(SIMPLE_LAYOUT, R"(!reussir.cell<i64 rwlock>)",
+                     [](mlir::ModuleOp, CellType type) {
+                       EXPECT_EQ(type.getKind(), CellKind::rwlock);
+                       EXPECT_TRUE(type.getRwlock());
+                       EXPECT_TRUE(type.getLockGuarded());
+                       EXPECT_TRUE(type.requiresAtomicSharedBox());
+                     });
+}
+
+TEST_F(ReussirTest, LockCellsWrapArbitraryPayloads) {
+  // Unlike an atomic scalar, a lock-guarded cell protects an arbitrary payload,
+  // including managed RC types, so the atomic element-type restriction does not
+  // apply. Constructing one through `getChecked` must succeed.
+  mlir::Type rcType = RcType::get(context.get(),
+                                  mlir::IntegerType::get(context.get(), 64),
+                                  Capability::shared, AtomicKind::normal);
+  auto loc = mlir::UnknownLoc::get(context.get());
+  for (CellKind kind :
+       {CellKind::mutex, CellKind::flatlock, CellKind::rwlock}) {
+    auto cellType = CellType::getChecked(loc, context.get(), rcType, kind);
+    ASSERT_TRUE(cellType);
+    EXPECT_EQ(cellType.getKind(), kind);
+    EXPECT_EQ(cellType.getElementType(), rcType);
+  }
+}
+
+TEST_F(ReussirTest, LockCellMembersProjectToAtomicSharedRc) {
+  auto i64Type = mlir::IntegerType::get(context.get(), 64);
+  // Like atomic cells, lock-guarded cells are shared across threads, so their
+  // box must be shared with an atomic refcount (see `RcType::verify`).
+  for (CellKind kind :
+       {CellKind::mutex, CellKind::flatlock, CellKind::rwlock}) {
+    auto cellType = CellType::get(context.get(), i64Type, kind);
+    auto projected = llvm::dyn_cast<RcType>(
+        getProjectedType(cellType, /*fieldCap=*/false, Capability::value));
+    ASSERT_TRUE(projected);
+    EXPECT_EQ(projected.getElementType(), cellType);
+    EXPECT_EQ(projected.getCapability(), Capability::shared);
+    EXPECT_EQ(projected.getAtomicKind(), AtomicKind::atomic);
+  }
+}
 } // namespace reussir

--- a/tool/reussir-opt/CMakeLists.txt
+++ b/tool/reussir-opt/CMakeLists.txt
@@ -9,6 +9,8 @@ add_mlir_tool(reussir-opt
     MLIRReussir
     MLIRReussirConversion
     MLIRReussirTransformation
+    MLIRSync
+    MLIRSyncConversion
     ${dialect_libs}
     ${conversion_libs}
     ${extension_libs}
@@ -19,8 +21,10 @@ target_link_libraries(reussir-opt
     MLIRReussir
     MLIRReussirConversion
     MLIRReussirTransformation
-    ${dialect_libs} 
-    ${conversion_libs} 
+    MLIRSync
+    MLIRSyncConversion
+    ${dialect_libs}
+    ${conversion_libs}
     ${extension_libs}
     MLIROptLib
 )

--- a/tool/reussir-opt/main.cpp
+++ b/tool/reussir-opt/main.cpp
@@ -19,14 +19,26 @@
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/Transformation/Passes.h"
 
+#include "Sync/Conversion/ConvertSyncToLLVM.h"
+#include "Sync/Conversion/Passes.h"
+#include "Sync/IR/SyncDialect.h"
+
 int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);
   registry.insert<reussir::ReussirDialect>();
+  registry.insert<mlir::sync::SyncDialect>();
   reussir::registerReussirBasicOpsLoweringInterface(registry);
+  mlir::sync::registerConvertSyncToLLVMInterface(registry);
   mlir::registerConvertToLLVMDependentDialectLoading(registry);
   mlir::registerAllExtensions(registry);
   mlir::registerAllPasses();
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return mlir::sync::createConvertSyncToSTDPass();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return mlir::sync::createConvertSyncToLLVMPass();
+  });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return reussir::createReussirBasicOpsLoweringPass();
   });


### PR DESCRIPTION
## Summary

Sets up `reussir-lang/mlir-sync` as a build dependency and introduces three lock-guarded `CellKind`s (`mutex`, `flatlock`, `rwlock`) at the type-system level — verification and requirements, no lowering yet.

First of three stacked PRs:
1. **this PR** — pull in `sync` + the cell kinds;
2. #431 — lower lock-guarded cells onto the `sync` dialect (storage lowering + guards);
3. #430 — the `reussir.cell.read_with` region op.

## mlir-sync dependency

- New `cmake/MlirSync.cmake` fetches `reussir-lang/mlir-sync` (pinned commit) via FetchContent, exposes its headers, and links `MLIRSync`/`MLIRSyncConversion` into `reussir-opt`.
- `reussir-opt` registers the `sync` dialect and the `convert-sync-to-std` / `convert-sync-to-llvm` passes.

The `sync` dialect provides portable synchronization primitives (mutex, reader-writer lock, flat-combining lock, once) with an inlined fast path and a futex-style runtime slow path — the substrate lock-guarded cells lower onto in the follow-ups.

## Lock-guarded cell kinds

- `CellKind` gains `mutex`, `flatlock` (flat-combining lock), and `rwlock` alongside `atomic`.
- Like an atomic cell, a lock-guarded cell only exists to be shared across threads, so it carries the same requirement of living in an atomic shared RC pointer (`RcType::verify`), and its member storage projects to an atomic shared RC box.
- Unlike an atomic scalar, a lock cell protects an arbitrary payload, so the byte-addressable-scalar element restriction does not apply.
- The physical lock storage is realized when the cell type is converted to the corresponding `!sync.*` type during lowering (#431); this PR is type-system + dependency wiring only.

Threaded through the type syntax (`mutex`/`flatlock`/`rwlock` keywords), the `CellKind` enum, the C API, and the Rust dialect surface (`mutex_cell` / `flatlock_cell` / `rwlock_cell`).

## Tests

- Type-syntax roundtrip and RC-box verification failures (lit).
- C++ unittests for the new kinds, arbitrary-payload acceptance, and atomic-shared-box member projection.

Built and tested against LLVM/MLIR 22.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1gUwhmbfF4UHkWK2voU3f