### PR TITLE
[mlir] add reussir.cell.read_with and lower rwlock cells onto the sync dialect

### DIFF
--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -104,7 +104,9 @@ def ReussirSCFOpsLoweringPass : ReussirLoweringPass<"scf-ops"> {
                            "::reussir::ReussirDialect",
                            "::mlir::math::MathDialect",
                            "::mlir::memref::MemRefDialect",
+                           "::mlir::ptr::PtrDialect",
                            "::mlir::scf::SCFDialect",
+                           "::mlir::sync::SyncDialect",
                            "::mlir::tensor::TensorDialect",
                            "::mlir::ub::UBDialect"];
 }

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1178,6 +1178,41 @@ def ReussirCellInUseOp : ReussirCellOp<"in_use", []> {
   let hasVerifier = 1;
 }
 
+def ReussirCellReadWithOp
+    : ReussirCellOp<"read_with", [RecursiveMemoryEffects]> {
+  let summary = "Read an rwlock cell payload while holding the read lock";
+  let description = [{
+    `reussir.cell.read_with` is the read-only, shared-lock counterpart of the
+    region form of `reussir.cell.rmw`. It applies only to a reader-writer-lock
+    cell (`!reussir.cell<T rwlock>`): it acquires the rwlock for shared read
+    access, runs its single-block body with a zero-ranked `memref<T>` view of
+    the inline payload, and releases the read lock on exit — the body executes
+    as a continuous region under the held read lock.
+
+    Because the lock is shared, the body only observes the payload; it neither
+    moves the element out nor replaces it. The body terminates with
+    `reussir.scf.yield`, optionally producing one operation result computed from
+    the payload while the lock is held.
+
+    ```mlir
+    %sum = reussir.cell.read_with(
+        %cell : !reussir.rc<!reussir.cell<i64 rwlock> atomic>) -> i64 {
+      ^bb0(%view: memref<i64>):
+        %v = memref.load %view[] : memref<i64>
+        reussir.scf.yield %v : i64
+    }
+    ```
+  }];
+  let arguments = (ins Arg<ReussirRcCellType, "rwlock cell to read">:$cell);
+  let results = (outs Res<Optional<AnyType>, "body output">:$output);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    `(` $cell `:` qualified(type($cell)) `)` (`->` type($output)^)?
+    $body attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
 def ReussirCellYieldOp
     : ReussirCellOp<"yield", [ReturnLike, Terminator,
                               ParentOneOf<["::reussir::ReussirCellRmwOp"]>]> {
@@ -1611,7 +1646,8 @@ def ReussirScfYieldOp
           "yield", [ReturnLike, Terminator,
                     ParentOneOf<["::reussir::ReussirNullableDispatchOp",
                                  "::reussir::ReussirRecordDispatchOp",
-                                 "::reussir::ReussirArrayWithUniqueViewOp"]>]> {
+                                 "::reussir::ReussirArrayWithUniqueViewOp",
+                                 "::reussir::ReussirCellReadWithOp"]>]> {
   let summary = "Yield a value from a scf operation";
   let description = [{
     `reussir.scf.yield` terminates a high-level structured control flow operation.

--- a/lib/Conversion/SCFOpsLowering/CMakeLists.txt
+++ b/lib/Conversion/SCFOpsLowering/CMakeLists.txt
@@ -14,4 +14,6 @@ add_mlir_conversion_library(MLIRReussirSCFOpsLowering
   MLIRSCFDialect
   MLIRFuncDialect
   MLIRTransforms
+  MLIRSync
+  MLIRSyncConvertSyncToSTD
 )

--- a/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
+++ b/lib/Conversion/SCFOpsLowering/SCFOpsLowering.cpp
@@ -14,7 +14,11 @@
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
 #include "Reussir/Transformation/SpecialPointerTag.h"
+#include "Sync/Conversion/ConvertSyncToSTD.h"
+#include "Sync/IR/SyncOps.h"
+#include "Sync/IR/SyncTypes.h"
 #include <llvm/ADT/ArrayRef.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 #include <llvm/ADT/MapVector.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
@@ -30,6 +34,7 @@
 #include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/Ptr/IR/PtrDialect.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/Dialect/UB/IR/UBOps.h>
@@ -1471,6 +1476,47 @@ public:
     return mlir::success();
   }
 };
+
+// `reussir.cell.read_with` on an rwlock cell becomes a
+// `sync.rwlock.read_critical_section` over a zero-ranked memref view of the
+// cell storage (which is physically an `!sync.rwlock<T>`). The body — already
+// written against a `memref<T>` payload view — is moved verbatim into the sync
+// region, and its `reussir.scf.yield` terminator is retargeted to `sync.yield`.
+// The freshly created sync region op is lowered to `scf`/`func` by the
+// convert-sync-to-std pass run at the end of this pass (its remaining
+// fast-path/bridge operations survive to the basic-ops lowering).
+class ReussirCellReadWithOpRewritePattern
+    : public mlir::OpConversionPattern<ReussirCellReadWithOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirCellReadWithOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    mlir::Location loc = op.getLoc();
+    CellAccess access = borrowCell(op.getCell(), loc, rewriter);
+    mlir::Type elementType = access.cellType.getElementType();
+    auto rwlockType =
+        mlir::sync::RwLockType::get(rewriter.getContext(), elementType);
+    auto memrefType = mlir::MemRefType::get({}, rwlockType);
+    mlir::Value rwlockMemref =
+        ReussirRefAsMemRefOp::create(rewriter, loc, memrefType, access.cellRef);
+    auto criticalSection = mlir::sync::SyncRwLockReadCriticalSectionOp::create(
+        rewriter, loc, op.getResultTypes(), rwlockMemref);
+    rewriter.inlineRegionBefore(op.getBody(), criticalSection.getBody(),
+                                criticalSection.getBody().end());
+    mlir::Block &body = criticalSection.getBody().front();
+    auto yield = llvm::cast<ReussirScfYieldOp>(body.getTerminator());
+    rewriter.setInsertionPoint(yield);
+    mlir::sync::SyncYieldOp::create(rewriter, yield.getLoc(),
+                                    yield.getValue()
+                                        ? mlir::ValueRange{yield.getValue()}
+                                        : mlir::ValueRange{});
+    rewriter.eraseOp(yield);
+    rewriter.replaceOp(op, criticalSection.getResults());
+    return mlir::success();
+  }
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -1492,7 +1538,8 @@ struct SCFOpsLoweringPass
                            mlir::func::FuncDialect, mlir::linalg::LinalgDialect,
                            mlir::math::MathDialect, mlir::memref::MemRefDialect,
                            mlir::scf::SCFDialect, mlir::tensor::TensorDialect,
-                           mlir::ub::UBDialect, reussir::ReussirDialect>();
+                           mlir::ub::UBDialect, reussir::ReussirDialect,
+                           mlir::sync::SyncDialect>();
     target.addDynamicallyLegalOp<ReussirArrayViewOp>([](ReussirArrayViewOp op) {
       return llvm::isa<mlir::MemRefType>(op.getView().getType());
     });
@@ -1527,11 +1574,34 @@ struct SCFOpsLoweringPass
         ReussirNullableDispatchOp, ReussirRecordDispatchOp, ReussirScfYieldOp,
         ReussirClosureUniqifyOp, ReussirArrayWithUniqueViewOp,
         ReussirTokenEnsureOp, ReussirStrByteAtOp, ReussirStrSelectOp,
-        ReussirStrStartWithOp, ReussirCellCreateOp, ReussirCellInUseOp>();
+        ReussirStrStartWithOp, ReussirCellCreateOp, ReussirCellInUseOp,
+        ReussirCellReadWithOp>();
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))
       signalPassFailure();
+
+    // Second phase: lower the `sync` control-flow region operations emitted by
+    // the read_with lowering (and any other sync high-level ops) into
+    // `scf`/`func`, keeping the straight-line fast-path and bridge operations
+    // for the basic-ops LLVM lowering. This is the sync -> STD half of the
+    // "lower to STD during SCF lowering" split. It is gated on the presence of
+    // sync operations so the greedy driver's folding never perturbs modules
+    // that contain no lock-guarded cells.
+    bool hasSyncOps = false;
+    getOperation()->walk([&](mlir::Operation *nested) {
+      if (llvm::isa_and_present<mlir::sync::SyncDialect>(nested->getDialect())) {
+        hasSyncOps = true;
+        return mlir::WalkResult::interrupt();
+      }
+      return mlir::WalkResult::advance();
+    });
+    if (hasSyncOps) {
+      mlir::RewritePatternSet syncPatterns(&getContext());
+      mlir::sync::populateConvertSyncToSTDPatterns(syncPatterns);
+      if (failed(applyPatternsGreedily(getOperation(), std::move(syncPatterns))))
+        signalPassFailure();
+    }
   }
 };
 } // namespace
@@ -1550,7 +1620,8 @@ void populateSCFOpsLoweringConversionPatterns(
       ReussirStrStartWithOpRewritePattern, ReussirCellCreateOpRewritePattern,
       ReussirCellGetOpRewritePattern, ReussirCellSetOpRewritePattern,
       ReussirCellRmwOpRewritePattern, ReussirAtomicCellRmwOpRewritePattern,
-      ReussirCellInUseOpRewritePattern>(patterns.getContext());
+      ReussirCellInUseOpRewritePattern, ReussirCellReadWithOpRewritePattern>(
+      patterns.getContext());
 }
 
 } // namespace reussir

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -1540,6 +1540,48 @@ mlir::LogicalResult ReussirCellInUseOp::verify() {
   return mlir::success();
 }
 
+mlir::LogicalResult ReussirCellReadWithOp::verify() {
+  auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
+  if (mlir::failed(cellType))
+    return mlir::failure();
+  if (!(*cellType).getRwlock())
+    return emitOpError(
+               "read_with requires a reader-writer-lock cell, got a cell of "
+               "kind '")
+           << stringifyCellKind((*cellType).getKind()) << "'";
+
+  mlir::Type elementType = (*cellType).getElementType();
+  // The body observes the payload through a zero-ranked memref view (like
+  // `sync.rwlock.read_critical_section`), so the element must be a valid
+  // memref element type.
+  if (!mlir::MemRefType::isValidElementType(elementType))
+    return emitOpError("rwlock cell element must be a valid memref element "
+                       "type to be read through read_with, got ")
+           << elementType;
+  auto expectedView = mlir::MemRefType::get({}, elementType);
+
+  if (!llvm::hasSingleElement(getBody()))
+    return emitOpError("body must contain exactly one block");
+  mlir::Block &block = getBody().front();
+  if (block.getNumArguments() != 1)
+    return emitOpError("body must accept exactly one payload view argument");
+  if (block.getArgument(0).getType() != expectedView)
+    return emitOpError("body argument must be a zero-ranked memref view of the "
+                       "cell element, expected ")
+           << expectedView << ", got " << block.getArgument(0).getType();
+  if (block.empty() || !llvm::isa<ReussirScfYieldOp>(block.getTerminator()))
+    return emitOpError("body must terminate with reussir.scf.yield");
+
+  auto yield = llvm::cast<ReussirScfYieldOp>(block.getTerminator());
+  if (static_cast<bool>(getOutput()) != static_cast<bool>(yield.getValue()))
+    return emitOpError("body must yield exactly one output when the operation "
+                       "has a result");
+  if (getOutput() && getOutput().getType() != yield.getValue().getType())
+    return emitOpError("body output type must match operation result type, got ")
+           << yield.getValue().getType() << " and " << getOutput().getType();
+  return mlir::success();
+}
+
 mlir::LogicalResult ReussirRefAsMemRefOp::verify() {
   auto memrefType = llvm::cast<mlir::MemRefType>(getMemref().getType());
   if (memrefType.getRank() != 0)
@@ -2262,7 +2304,12 @@ mlir::LogicalResult ReussirScfYieldOp::verify() {
                                            : mlir::Type{};
     allowImplicitArrayResult =
         expectedType && expectedType == arrayParent.getArray().getType();
-  } else
+  } else if (auto readWithParent =
+                 getOperation()->getParentOfType<ReussirCellReadWithOp>())
+    expectedType = readWithParent.getOutput()
+                       ? readWithParent.getOutput().getType()
+                       : mlir::Type{};
+  else
     llvm_unreachable("unexpected parent operation");
 
   if (expectedType && !yieldedType && !allowImplicitArrayResult)

--- a/tests/integration/basic/failure/read_with_cell_kind.mlir
+++ b/tests/integration/basic/failure/read_with_cell_kind.mlir
@@ -1,0 +1,29 @@
+// RUN: %reussir-opt %s -verify-diagnostics -split-input-file
+
+// read_with holds a *read* lock, so it only applies to a reader-writer-lock
+// cell; a mutex cell has no shared-read mode.
+!mutex_cell = !reussir.rc<!reussir.cell<i64 mutex> atomic>
+
+func.func @read_mutex(%cell: !mutex_cell) {
+  // expected-error @+1 {{read_with requires a reader-writer-lock cell, got a cell of kind 'mutex'}}
+  reussir.cell.read_with(%cell : !mutex_cell) {
+    ^bb0(%view: memref<i64>):
+      reussir.scf.yield
+  }
+  return
+}
+
+// -----
+
+// The body observes the payload through a zero-ranked memref view whose element
+// type must match the cell element.
+!rwlock_cell = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+
+func.func @read_wrong_view(%cell: !rwlock_cell) {
+  // expected-error @+1 {{body argument must be a zero-ranked memref view of the cell element, expected 'memref<i64>', got 'memref<i32>'}}
+  reussir.cell.read_with(%cell : !rwlock_cell) {
+    ^bb0(%view: memref<i32>):
+      reussir.scf.yield
+  }
+  return
+}

--- a/tests/integration/basic/success/lock_cell.mlir
+++ b/tests/integration/basic/success/lock_cell.mlir
@@ -17,4 +17,17 @@ module {
                              %w: !rwlock_cell) {
     return
   }
+
+  // CHECK-LABEL: func.func @rwlock_read_with
+  // CHECK: reussir.cell.read_with(%{{.*}} : !reussir.rc<!reussir.cell<i64 rwlock> atomic>) -> i64
+  // CHECK-NEXT: ^bb0(%{{.*}}: memref<i64>):
+  // CHECK: reussir.scf.yield %{{.*}} : i64
+  func.func @rwlock_read_with(%w: !rwlock_cell) -> i64 {
+    %v = reussir.cell.read_with(%w : !rwlock_cell) -> i64 {
+      ^bb0(%view: memref<i64>):
+        %loaded = memref.load %view[] : memref<i64>
+        reussir.scf.yield %loaded : i64
+    }
+    return %v : i64
+  }
 }

--- a/tests/integration/conversion/rwlock_cell.mlir
+++ b/tests/integration/conversion/rwlock_cell.mlir
@@ -1,0 +1,45 @@
+// RUN: %reussir-opt %s | %FileCheck %s --check-prefix=ROUNDTRIP
+// RUN: %reussir-opt %s --reussir-lowering-scf-ops | %FileCheck %s --check-prefix=SCF
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-acquire-drop-expansion,reussir-lowering-scf-ops,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
+
+!rwlock_i64 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+
+module {
+  // The read_with region prints back verbatim, handing its body a zero-ranked
+  // memref view of the payload.
+  // ROUNDTRIP-LABEL: func.func @rwlock_read
+  // ROUNDTRIP: reussir.cell.read_with(%{{.*}} : !reussir.rc<!reussir.cell<i64 rwlock> atomic>) -> i64
+  // ROUNDTRIP: ^bb0(%{{.*}}: memref<i64>):
+  // ROUNDTRIP: reussir.scf.yield
+
+  // SCF lowering expands read_with into a sync read critical section that is
+  // further lowered to the rwlock read-lock fast path (an scf.while CAS loop)
+  // plus the payload load, releasing with the read-unlock fast path. The raw
+  // sync fast-path/bridge ops survive for the LLVM lowering.
+  // SCF-LABEL: func.func @rwlock_read
+  // SCF: reussir.ref.as_memref(%{{.*}}) : memref<!sync.rwlock<i64>>
+  // SCF: sync.rwlock.get_raw_rwlock
+  // SCF: scf.while
+  // SCF: sync.raw_rwlock.cmpxchg_state
+  // SCF: sync.rwlock.get_payload
+  // SCF: memref.load
+  // SCF: sync.raw_rwlock.read_unlock_fast
+  // SCF-NOT: reussir.cell.read_with
+
+  // The whole thing bottoms out in a cmpxchg-based read lock, an inline
+  // payload load, and an atomicrmw-based read unlock, with the runtime slow
+  // paths called on contention.
+  // LLVM-LABEL: define i64 @rwlock_read
+  // LLVM: cmpxchg ptr
+  // LLVM: call void @mlir_sync_rwlock_read_lock_slow_path
+  // LLVM: atomicrmw sub ptr
+  // LLVM: call void @mlir_sync_rwlock_unlock_slow_path
+  func.func @rwlock_read(%cell: !rwlock_i64) -> i64 {
+    %v = reussir.cell.read_with(%cell : !rwlock_i64) -> i64 {
+      ^bb0(%view: memref<i64>):
+        %loaded = memref.load %view[] : memref<i64>
+        reussir.scf.yield %loaded : i64
+    }
+    return %v : i64
+  }
+}


### PR DESCRIPTION
## Summary

Introduces `reussir.cell.read_with` — the read-only, shared-lock counterpart of the region form of `reussir.cell.rmw` — and lowers it onto a `sync` rwlock read critical section.

Stacked on #429 (base branch `claude/cell-kind-lock-guarded-8sw92m`); the diff here is just the second commit. #429 already added the lock-cell storage lowering (`cell → sync` type conversion, `convert-sync-to-llvm` wiring) and the `reussir.ref.as_memref` bridge this PR consumes.

## `reussir.cell.read_with`

Applies only to an rwlock cell. It acquires the reader-writer lock for shared read access, runs its single-block body with a zero-ranked `memref<T>` view of the inline payload, and releases the read lock on exit — the body runs as a continuous region under the held read lock. It terminates with `reussir.scf.yield` and optionally yields one result computed from the payload while the lock is held.

```mlir
%sum = reussir.cell.read_with(
    %cell : !reussir.rc<!reussir.cell<i64 rwlock> atomic>) -> i64 {
  ^bb0(%view: memref<i64>):
    %v = memref.load %view[] : memref<i64>
    reussir.scf.yield %v : i64
}
```

## Lowering

Follows the established high-level-SCF / straight-line-LLVM split:

- **SCF lowering** rewrites `read_with` into a `sync.rwlock.read_critical_section` over a `memref<!sync.rwlock<T>>` view of the cell storage (via `reussir.ref.as_memref`), then runs `convert-sync-to-std` to expand it into the rwlock read-lock fast path (an `scf.while` CAS loop) plus the payload load and read-unlock, leaving the raw sync fast-path/bridge ops for the LLVM stage. The second phase is gated on the presence of sync ops so the greedy driver never perturbs sync-free modules.
- **Basic lowering** (already wired for the sync dialect in #429) lowers the remaining sync operations to LLVM through the `convert-sync-to-llvm` interface.

End-to-end verified to LLVM IR: RC box `{i32, {{i32,i32}, i64}}`, a `cmpxchg`-based read lock, an inline payload load, an `atomicrmw sub` read unlock, and runtime slow-path calls on contention.

## Scope

`flatlock`/`mutex` region ops and the lifecycle (create/drop/init) of lock cells are out of scope here — only rwlock's `read_with` — so the lowering test borrows the cell as a function argument.

## Tests

- `read_with` roundtrip and verification failures (non-rwlock cell, wrong view type).
- Full SCF → LLVM conversion test asserting the read-lock CAS loop, payload load, atomic unlock, and slow-path calls.

Built and tested against LLVM/MLIR 22.1; full `conversion` + `basic` lit suites pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1gUwhmbfF4UHkWK2voU3f