### PR TITLE
[misc]provision libomp in the dev shell, bump mlir-sync, and default the nightly preserve_most feature on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "mlir_sync"
 version = "0.1.0"
-source = "git+https://github.com/reussir-lang/mlir-sync.git?rev=a0337795eb7ce85d2c988440a50a48e11f27a929#a0337795eb7ce85d2c988440a50a48e11f27a929"
+source = "git+https://github.com/reussir-lang/mlir-sync.git?rev=3b9412ea23464e262fcfb8f5f4d2538ddb17fadc#3b9412ea23464e262fcfb8f5f4d2538ddb17fadc"
 dependencies = [
  "portable_futex",
 ]
@@ -1680,7 +1680,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 [[package]]
 name = "portable_futex"
 version = "0.1.0"
-source = "git+https://github.com/reussir-lang/mlir-sync.git?rev=a0337795eb7ce85d2c988440a50a48e11f27a929#a0337795eb7ce85d2c988440a50a48e11f27a929"
+source = "git+https://github.com/reussir-lang/mlir-sync.git?rev=3b9412ea23464e262fcfb8f5f4d2538ddb17fadc#3b9412ea23464e262fcfb8f5f4d2538ddb17fadc"
 dependencies = [
  "linux-raw-sys 0.11.0",
  "syscalls",

--- a/cmake/MlirSync.cmake
+++ b/cmake/MlirSync.cmake
@@ -12,10 +12,23 @@ include(FetchContent)
 # `sync-opt` tool that we do not need here.
 set(SYNC_ENABLE_TESTS OFF CACHE BOOL "Build sync dialect integration tests" FORCE)
 
+# Default the sync backend to the preserve_most calling convention on the
+# futex slow paths: ConvertSyncToSTD annotates the runtime declarations and
+# calls with #llvm.cconv<preserve_mostcc>, keeping lock fast paths free of
+# caller-saved register spills. The matching runtime side is unconditional —
+# reussir-rt always builds mlir_sync with its `nightly` feature (see
+# crates/reussir-rt/Cargo.toml), so a preserve_most-annotated call always
+# lands on a preserve_most callee. Turning this OFF only drops the caller
+# annotation, which is still ABI-safe (a preserve_most callee saves a
+# superset of what a C-convention caller expects).
+option(MLIR_SYNC_ENABLE_NIGHTLY_FEATURE
+  "Annotate sync runtime slow-path declarations and calls with preserve_most"
+  ON)
+
 FetchContent_Declare(
   mlirsync
   GIT_REPOSITORY https://github.com/reussir-lang/mlir-sync.git
-  GIT_TAG a0337795eb7ce85d2c988440a50a48e11f27a929
+  GIT_TAG 3b9412ea23464e262fcfb8f5f4d2538ddb17fadc
 )
 
 FetchContent_MakeAvailable(mlirsync)

--- a/crates/reussir-rt/Cargo.toml
+++ b/crates/reussir-rt/Cargo.toml
@@ -21,8 +21,13 @@ libmimalloc-sys = { version = "0.1.44", optional = true, features = ["extended"]
 # lowered lock-guarded cell code calls them, so the runtime carries them for
 # every consumer. Keep the rev in lockstep with cmake/MlirSync.cmake's
 # GIT_TAG. The crate's `panic-handler` feature stays off — std supplies the
-# panic machinery here.
-mlir_sync = { git = "https://github.com/reussir-lang/mlir-sync.git", rev = "a0337795eb7ce85d2c988440a50a48e11f27a929" }
+# panic machinery here. `nightly` is unconditional (the workspace pins a
+# nightly toolchain): the slow paths get the extern "rust-cold" ABI (LLVM
+# preserve_most), matching the annotation the backend emits under
+# MLIR_SYNC_ENABLE_NIGHTLY_FEATURE (Reussir's default). A preserve_most
+# callee saves a superset of what a C-convention caller expects, so an
+# unannotated call site remains safe.
+mlir_sync = { git = "https://github.com/reussir-lang/mlir-sync.git", rev = "3b9412ea23464e262fcfb8f5f4d2538ddb17fadc", features = ["nightly"] }
 num_enum = "0.7.4"
 smallvec = "1.15.1"
 stacker.workspace = true

--- a/flake.nix
+++ b/flake.nix
@@ -198,6 +198,14 @@
             pkgs.libxml2
           ];
 
+          # libomp: the OpenMP e2e lit tests probe `clang -fopenmp` and are
+          # skipped when it fails. As a buildInput the cc wrapper injects
+          # omp.h (-isystem) and libomp.so (-L) via NIX_CFLAGS_COMPILE /
+          # NIX_LDFLAGS, which `packages` (nativeBuildInputs) would not.
+          buildInputs = [
+            llvmPkgs.openmp
+          ];
+
           # --- CMake discovery: tell cmake exactly where the LLVM/MLIR configs are
           LLVM_DIR = "${llvmMlirJoin}/lib/cmake/llvm";
           MLIR_DIR = "${llvmMlirJoin}/lib/cmake/mlir";
@@ -245,7 +253,11 @@
             # zlib: rustc links rrc without an rpath entry for it (LLVM's
             # system-libs pull in -lz), so the binary needs it findable at
             # run time — lit tests execute build/bin/rrc directly.
-            export LD_LIBRARY_PATH="${llvmPkgs.llvm.lib}/lib:${llvmPkgs.mlir}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            # openmp: the lit OpenMP probe links via the wrapper's NIX_LDFLAGS
+            # (no rpath — `-print-file-name=libomp.so` does not see wrapper
+            # -L paths), so the probe binary finds libomp.so only through
+            # LD_LIBRARY_PATH.
+            export LD_LIBRARY_PATH="${llvmPkgs.llvm.lib}/lib:${llvmPkgs.mlir}/lib:${llvmPkgs.openmp}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
             # crates/reussir-rt/CMakeLists.txt sets LOCAL_RUSTUP_HOME = build/.rustup
             # and then tries to run `rustup toolchain install <channel>-<host-triple>`

--- a/tests/integration/conversion/convert_to_std_sync.mlir
+++ b/tests/integration/conversion/convert_to_std_sync.mlir
@@ -22,7 +22,7 @@ module {
 // STD: scf.while
 // STD: sync.raw_rwlock.load_state
 // STD: sync.raw_rwlock.cmpxchg_state
-// STD: func.call @mlir_sync_rwlock_read_lock_slow_path
+// STD: func.call @mlir_sync_rwlock_read_lock_slow_path{{.*}} {CConv = #llvm.cconv<preserve_mostcc>}
 // STD: sync.rwlock.get_payload
 // STD: memref.load
 // STD: sync.raw_rwlock.read_unlock_fast
@@ -34,6 +34,6 @@ module {
 // LLVM-NOT: sync.
 // LLVM: llvm.load
 // LLVM: llvm.cmpxchg
-// LLVM: llvm.call @mlir_sync_rwlock_read_lock_slow_path
+// LLVM: llvm.call preserve_mostcc @mlir_sync_rwlock_read_lock_slow_path
 // LLVM: llvm.atomicrmw sub
 // LLVM-NOT: sync.

--- a/tests/integration/conversion/flatlock_cell_get_set.mlir
+++ b/tests/integration/conversion/flatlock_cell_get_set.mlir
@@ -24,7 +24,7 @@ module {
   // STD: sync.combining_lock.has_tail %[[VIEW]]
   // STD: sync.combining_lock.try_acquire %[[VIEW]]
   // STD: "sync.combining_lock.capture"
-  // STD: func.call @mlir_sync_combining_lock_attach_slow_path
+  // STD: func.call @mlir_sync_combining_lock_attach_slow_path{{.*}} {CConv = #llvm.cconv<preserve_mostcc>}
   // STD: %[[SLOT:.+]] = reussir.ref.from_memref(%[[PAYLOAD]] : memref<i64>) : !reussir.ref<i64 field atomic>
   // STD: reussir.ref.acquire(%[[SLOT]]
   // STD: %[[VALUE:.+]] = reussir.ref.load(%[[SLOT]]
@@ -35,7 +35,7 @@ module {
   // LLVM-LABEL: define i64 @get_i64
   // LLVM: load atomic ptr, ptr %{{.+}} monotonic
   // LLVM: atomicrmw xchg ptr %{{.+}}, i8 1 acquire
-  // LLVM: call void @mlir_sync_combining_lock_attach_slow_path
+  // LLVM: call preserve_mostcc void @mlir_sync_combining_lock_attach_slow_path
   // LLVM: ret i64
   func.func @get_i64(%cell: !flatlock_i64) -> i64 {
     %value = reussir.cell.get(%cell : !flatlock_i64) : i64
@@ -55,7 +55,7 @@ module {
   // STD: return
   // LLVM-LABEL: define void @set_i64
   // LLVM: atomicrmw xchg ptr %{{.+}}, i8 1 acquire
-  // LLVM: call void @mlir_sync_combining_lock_attach_slow_path
+  // LLVM: call preserve_mostcc void @mlir_sync_combining_lock_attach_slow_path
   // LLVM: ret void
   func.func @set_i64(%value: i64, %cell: !flatlock_i64) {
     reussir.cell.set(%value : i64, %cell : !flatlock_i64)

--- a/tests/integration/conversion/flatlock_cell_rmw.mlir
+++ b/tests/integration/conversion/flatlock_cell_rmw.mlir
@@ -27,7 +27,7 @@ module {
   // STD: return %[[RESULT]]
   // LLVM-LABEL: define i64 @rmw_addi
   // LLVM: atomicrmw xchg ptr %{{.+}}, i8 1 acquire
-  // LLVM: call void @mlir_sync_combining_lock_attach_slow_path
+  // LLVM: call preserve_mostcc void @mlir_sync_combining_lock_attach_slow_path
   // LLVM: ret i64
   func.func @rmw_addi(%delta: i64, %cell: !flatlock_i64) -> i64 {
     %old = reussir.cell.rmw(%cell : !flatlock_i64) -> i64 {

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -13,6 +13,17 @@ config.excludes = ['Inputs']
 config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = os.path.join(config.test_output_root, 'test')
 
+# Toolchain wrappers that inject flags through the environment (e.g. Nix's
+# clang wrapper reading NIX_CFLAGS_COMPILE/NIX_LDFLAGS, which are only honored
+# together with the wrapper's NIX_CC_WRAPPER_* role markers) need these
+# variables to survive lit's environment scrubbing. Without them, `%cc
+# -fopenmp` links fine in the probe below (a direct subprocess of this
+# config, full environment) but fails inside RUN lines with `cannot find
+# -lomp`.
+for _var, _value in os.environ.items():
+    if _var.startswith('NIX_') or _var in ('LIBRARY_PATH', 'LD_LIBRARY_PATH'):
+        config.environment[_var] = _value
+
 def sh_path(path):
     return path.replace('\\', '/') if isinstance(path, str) else path
 


### PR DESCRIPTION
## Summary

- **flake.nix**: add `llvmPackages.openmp` as a buildInput and put its lib on `LD_LIBRARY_PATH`, so the lit OpenMP probe (`clang -fopenmp`) succeeds and the contended e2e suite actually runs in the dev shell instead of being marked unsupported.
- **lit.cfg.py**: forward `NIX_*`/`LIBRARY_PATH`/`LD_LIBRARY_PATH` through lit's environment scrubbing (mirrors mlir-sync's lit.cfg) — without it, RUN lines fail with `cannot find -lomp` even though the probe passes.
- **mlir-sync pin**: `a033779` → `3b9412e` in both `cmake/MlirSync.cmake` (GIT_TAG) and `crates/reussir-rt/Cargo.toml` (kept in lockstep per the in-tree comment), picking up the rust-cold / preserve_most runtime export work.
- **Nightly feature on by default**: `MLIR_SYNC_ENABLE_NIGHTLY_FEATURE` defaults ON (ConvertSyncToSTD annotates slow-path declarations and calls with `#llvm.cconv<preserve_mostcc>`), and reussir-rt enables `mlir_sync/nightly` unconditionally so the runtime always exports the slow paths as `extern "rust-cold"`. The pairing is mismatch-safe by construction: a preserve_most callee saves a superset of what a C-convention caller expects, so `-DMLIR_SYNC_ENABLE_NIGHTLY_FEATURE=OFF` only forgoes the optimization.

## Verification

- `clang -fopenmp` probe compiles, links, and runs in the fresh dev shell.
- Annotation verified through the full lowering chain: `func.call ... {CConv = #llvm.cconv<preserve_mostcc>}` after `--reussir-convert-to-std` → `llvm.call preserve_mostcc` after `--convert-to-llvm` → `call preserve_mostcc void @mlir_sync_*_slow_path` in translated LLVM IR (FileCheck lines updated to pin this).
- Callee side verified in the compiled `libreussir_rt.so`: `mlir_sync_mutex_lock_slow_path`'s prologue saves `rax/rcx/rdx/rsi/r8/r9/r10` and scratches only `r11` — preserve_most codegen, not the C convention.
- OpenMP e2e tests (mutex, flatlock, atomic-rc, incl. the ASan variant) now execute and pass under real contention, exercising the new ABI on both sides.
- Full integration suite: 366 passed, 8 unsupported, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786842399&installation_id=144622820&pr_number=435&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F435&signature=a19f8a3fe35b2e976cd8484c9018eab41db16f84033e9e009b3a7b05c5f42ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->