### PR TITLE
[backend] lower rwlock cell operations

### DIFF
--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1171,7 +1171,8 @@ def ReussirCellRmwOp : ReussirCellOp<"rmw", []> {
     On an rwlock cell, the region form is the same borrow inside a
     `sync.rwlock.write_critical_section`: storing the replacement mutates the
     protected slot, so the read-modify-write holds the lock exclusively even
-    when the body never writes.
+    when the body never writes. Read-only transactions that want to share
+    the lock use `reussir.cell.rdlock` instead.
 
     On an atomic cell, the region is a retryable, memory-effect-free
     computation and is committed with compare-exchange. It may run more than
@@ -1194,6 +1195,42 @@ def ReussirCellRmwOp : ReussirCellOp<"rmw", []> {
   let results = (outs Res<Optional<AnyType>, "body output">:$output);
   let regions = (region MaxSizedRegion<1>:$body);
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
+def ReussirCellRdlockOp : ReussirCellOp<"rdlock", []> {
+  let summary = "Run a read transaction over an rwlock cell";
+  let description = [{
+    `reussir.cell.rdlock` executes its single-block body inside a
+    `sync.rwlock.read_critical_section` over an rwlock cell: a longer read
+    transaction that shares the lock with concurrent gets and other read
+    transactions instead of serializing behind the write lock. Only rwlock
+    cells are accepted — every other lock kind reads through its exclusive
+    critical section via `cell.get`/`cell.rmw`.
+
+    Unlike `reussir.cell.rmw`, the body does not borrow the element. The
+    element is cloned into the body — loaded and acquired exactly like
+    `reussir.cell.get` (safe under the shared lock: the acquisition bumps the
+    element's own atomic counts, never the protected slot) — and the cell
+    keeps its element untouched. The body owns the clone and must consume it.
+    Nothing is stored back: the body terminates with `reussir.scf.yield`,
+    which carries only the optional operation result.
+
+    ```mlir
+    %len = reussir.cell.rdlock(%cell : !reussir.rc<!reussir.cell<!inner rwlock> atomic>) -> i64 {
+      ^bb0(%value: !inner):
+        %len = func.call @inspect(%value) : (!inner) -> i64
+        reussir.scf.yield %len : i64
+    }
+    ```
+  }];
+  let arguments = (ins Arg<ReussirRcCellType, "cell to read">:$cell);
+  let results = (outs Res<Optional<AnyType>, "body output">:$output);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    `(` $cell `:` qualified(type($cell)) `)` (`->` type($output)^)?
+    $body attr-dict
+  }];
   let hasVerifier = 1;
 }
 
@@ -1628,7 +1665,8 @@ def ReussirScfYieldOp
           "yield", [ReturnLike, Terminator,
                     ParentOneOf<["::reussir::ReussirNullableDispatchOp",
                                  "::reussir::ReussirRecordDispatchOp",
-                                 "::reussir::ReussirArrayWithUniqueViewOp"]>]> {
+                                 "::reussir::ReussirArrayWithUniqueViewOp",
+                                 "::reussir::ReussirCellRdlockOp"]>]> {
   let summary = "Yield a value from a scf operation";
   let description = [{
     `reussir.scf.yield` terminates a high-level structured control flow operation.

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1168,6 +1168,11 @@ def ReussirCellRmwOp : ReussirCellOp<"rmw", []> {
     possibly on the combining thread serving the waiter's request; the
     optional output returns to the caller through a captured stack slot.
 
+    On an rwlock cell, the region form is the same borrow inside a
+    `sync.rwlock.write_critical_section`: storing the replacement mutates the
+    protected slot, so the read-modify-write holds the lock exclusively even
+    when the body never writes.
+
     On an atomic cell, the region is a retryable, memory-effect-free
     computation and is committed with compare-exchange. It may run more than
     once under contention; the optional output comes from the successful
@@ -1175,7 +1180,7 @@ def ReussirCellRmwOp : ReussirCellOp<"rmw", []> {
     operand, returns the old element, and lowers to an LLVM atomic RMW. Both
     atomic forms accept an optional ordering that defaults to `acq_rel`.
     Atomic RMW orderings unsupported by LLVM are rejected, as is any ordering
-    on an exclusive, mutex, or flatlock cell; the direct form is atomic-only.
+    on an exclusive or lock-guarded cell; the direct form is atomic-only.
 
     ```mlir
     %old = reussir.cell.rmw addi(%delta : i64,

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1083,12 +1083,16 @@ def ReussirCellGetOp : ReussirCellOp<"get", []> {
     the mutex through a `sync.mutex.critical_section` region. On a flatlock
     cell they run inside a `sync.combining_lock.critical_section`, whose body
     may be served by a combining thread: the cloned value returns to the
-    caller through a captured stack slot rather than a region result.
+    caller through a captured stack slot rather than a region result. On an
+    rwlock cell they run inside a `sync.rwlock.read_critical_section`:
+    concurrent gets share the read lock, and the acquisition only bumps the
+    element's own (atomic) counts, never the protected slot.
 
     On an atomic cell, this is an atomic load. The optional ordering defaults
     to `acquire`; load orderings unsupported by LLVM are rejected. Atomic cell
     elements are arithmetic primitives, so clone ownership is trivial. An
-    ordering cannot be attached to a plain, exclusive, mutex, or flatlock cell access.
+    ordering cannot be attached to a plain, exclusive, or lock-guarded cell
+    access.
   }];
   let arguments = (ins OptionalAttr<AtomicOrdering>:$ordering,
       Arg<ReussirRcCellType, "cell to read">:$cell);
@@ -1117,13 +1121,15 @@ def ReussirCellSetOp : ReussirCellOp<"set", []> {
     replacement execute while holding the mutex through a
     `sync.mutex.critical_section` region. On a flatlock cell they run inside a
     `sync.combining_lock.critical_section`, possibly served by a combining
-    thread.
+    thread. On an rwlock cell they run inside a
+    `sync.rwlock.write_critical_section`: the replacement mutates the
+    protected slot, so it takes the lock exclusively.
 
     On an atomic cell, this is an atomic store. The optional ordering defaults
     to `release`; store orderings unsupported by LLVM are rejected. No old
     managed value needs to be dropped because atomic cell elements are
-    arithmetic primitives. An ordering cannot be attached to a plain or
-    exclusive or mutex or flatlock cell access.
+    arithmetic primitives. An ordering cannot be attached to a plain,
+    exclusive, or lock-guarded cell access.
   }];
   let arguments = (ins OptionalAttr<AtomicOrdering>:$ordering,
       Arg<AnyType, "replacement value">:$value,

--- a/include/Reussir/IR/ReussirTypes.h
+++ b/include/Reussir/IR/ReussirTypes.h
@@ -46,11 +46,11 @@ mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap);
 mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
                              bool isField, bool memBoxInternal = false);
 class CellType;
-// The `sync` primitive type physically backing a lock-guarded cell with a
-// lowered access path: `!sync.mutex<T>` for a mutex cell,
-// `!sync.combining_lock<T>` for a flatlock cell. Null for every other cell
-// kind (rwlock included until its operations are implemented) — callers use
-// this both to compute the cell's layout and to type its storage views.
+// The `sync` primitive type physically backing a lock-guarded cell:
+// `!sync.mutex<T>` for a mutex cell, `!sync.combining_lock<T>` for a flatlock
+// cell, `!sync.rwlock<T>` for an rwlock cell. Null for every other cell kind —
+// callers use this both to compute the cell's layout and to type its storage
+// views.
 mlir::Type lockGuardedStorageType(CellType type);
 
 namespace scanner {

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -356,8 +356,8 @@ def ReussirCellType
     payload is mediated by a lock-holding critical-section region, which views
     the payload through a zero-ranked memref — so `T` must be a valid memref
     element type (an RC pointer qualifies; records and nullables do not).
-    Mutex whole-element get/set operations lower to such regions, and mutex
-    and flatlock cells are constructable through `cell.create` (backed by the
+    Mutex whole-element get/set operations lower to such regions, and every
+    lock-guarded cell is constructable through `cell.create` (backed by the
     corresponding `sync` init); the remaining lock operations become available
     as their lowerings are implemented.
 

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -70,12 +70,20 @@ private:
         auto critical = mlir::sync::SyncMutexCriticalSectionOp::create(
             rewriter, op.getLoc(), mlir::TypeRange{}, storageView);
         criticalBody = &critical.getBody();
-      } else {
+      } else if (cellType.getFlatlock()) {
         auto critical =
             mlir::sync::SyncCombiningLockCriticalSectionOp::create(
                 rewriter, op.getLoc(), storageView,
                 /*combine_limit=*/mlir::IntegerAttr{});
         criticalBody = &critical.getBody();
+      } else if (cellType.getRwlock()) {
+        // Releasing the payload mutates managed state behind the slot, so the
+        // drop takes the write side, uniform with set/rmw.
+        auto critical = mlir::sync::SyncRwLockWriteCriticalSectionOp::create(
+            rewriter, op.getLoc(), mlir::TypeRange{}, storageView);
+        criticalBody = &critical.getBody();
+      } else {
+        llvm_unreachable("unhandled lock-guarded cell kind");
       }
       mlir::OpBuilder::InsertionGuard guard(rewriter);
       mlir::Block *body = rewriter.createBlock(

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -3648,7 +3648,7 @@ struct ReussirConvertToLLVMPatternInterface
         ReussirRecordCoerceOp, ReussirRegionVTableOp, ReussirRcFreezeOp,
         ReussirRegionCleanupOp, ReussirRegionCreateOp, ReussirRcReinterpretOp,
         ReussirCellCreateOp, ReussirCellGetOp, ReussirCellSetOp,
-        ReussirCellRmwOp, ReussirCellYieldOp,
+        ReussirCellRmwOp, ReussirCellRdlockOp, ReussirCellYieldOp,
         ReussirClosureApplyOp, ReussirClosureCloneOp, ReussirClosureEvalOp,
         ReussirClosureInspectPayloadOp, ReussirClosureCursorOp,
         ReussirClosureInstantiateOp, ReussirClosureVtableOp,

--- a/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
+++ b/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
@@ -1592,6 +1592,42 @@ public:
         rewriter.eraseOp(op);
       return mlir::success();
     }
+    // An rwlock read-modify-write stores its replacement into the protected
+    // slot, so the borrow runs inside a write critical section — exclusive
+    // like the mutex path, with the optional output leaving as a region
+    // result. The transfer keeps the region form's move semantics.
+    if (access.cellType.getKind() == CellKind::rwlock) {
+      mlir::Value lockView = getLockStorageView(access, op.getLoc(), rewriter);
+      auto critical = mlir::sync::SyncRwLockWriteCriticalSectionOp::create(
+          rewriter, op.getLoc(), op->getResultTypes(), lockView);
+      {
+        mlir::OpBuilder::InsertionGuard guard(rewriter);
+        mlir::Block *criticalBody =
+            addCriticalSectionBody(critical, access, op.getLoc(), rewriter);
+        rewriter.setInsertionPointToStart(criticalBody);
+        mlir::Value slotRef =
+            getLockPayloadRef(criticalBody, access, op.getLoc(), rewriter);
+        mlir::Value oldValue = ReussirRefLoadOp::create(
+            rewriter, op.getLoc(), access.cellType.getElementType(), slotRef);
+        mlir::Block &body = op.getBody().front();
+        auto yield = llvm::cast<ReussirCellYieldOp>(body.getTerminator());
+        rewriter.inlineBlockBefore(&body, criticalBody, criticalBody->end(),
+                                   mlir::ValueRange{oldValue});
+        rewriter.setInsertionPoint(yield);
+        ReussirRefStoreOp::create(rewriter, yield.getLoc(), slotRef,
+                                  yield.getNewValue());
+        mlir::sync::SyncYieldOp::create(rewriter, yield.getLoc(),
+                                        yield.getOutput()
+                                            ? mlir::ValueRange{yield.getOutput()}
+                                            : mlir::ValueRange{});
+        rewriter.eraseOp(yield);
+      }
+      if (op->getNumResults() != 0)
+        rewriter.replaceOp(op, critical.getResults());
+      else
+        rewriter.eraseOp(op);
+      return mlir::success();
+    }
     // The verifier guarantees an exclusive cell here. The whole
     // read-modify-write becomes the guarded arm: raise the in-use flag for
     // the body so any reentrant access to the cell panics while its element

--- a/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
+++ b/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
@@ -1663,6 +1663,52 @@ public:
   }
 };
 
+// A read transaction over an rwlock cell: the body runs inside a read
+// critical section, sharing the lock with concurrent gets and other read
+// transactions. The element is cloned into the body — acquire and load, the
+// same door cell.get uses, safe under the shared lock because the
+// acquisition never writes the protected slot — and the yield carries only
+// the optional result out of the section.
+class ReussirCellRdlockOpRewritePattern
+    : public mlir::OpConversionPattern<ReussirCellRdlockOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReussirCellRdlockOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    CellAccess access = borrowCell(op.getCell(), op.getLoc(), rewriter);
+    mlir::Value lockView = getLockStorageView(access, op.getLoc(), rewriter);
+    auto critical = mlir::sync::SyncRwLockReadCriticalSectionOp::create(
+        rewriter, op.getLoc(), op->getResultTypes(), lockView);
+    {
+      mlir::OpBuilder::InsertionGuard guard(rewriter);
+      mlir::Block *criticalBody =
+          addCriticalSectionBody(critical, access, op.getLoc(), rewriter);
+      rewriter.setInsertionPointToStart(criticalBody);
+      mlir::Value slotRef =
+          getLockPayloadRef(criticalBody, access, op.getLoc(), rewriter);
+      mlir::Value value =
+          acquireThenLoadCellSlot(slotRef, op.getLoc(), rewriter);
+      mlir::Block &body = op.getBody().front();
+      auto yield = llvm::cast<ReussirScfYieldOp>(body.getTerminator());
+      rewriter.inlineBlockBefore(&body, criticalBody, criticalBody->end(),
+                                 mlir::ValueRange{value});
+      rewriter.setInsertionPoint(yield);
+      mlir::sync::SyncYieldOp::create(rewriter, yield.getLoc(),
+                                      yield.getValue()
+                                          ? mlir::ValueRange{yield.getValue()}
+                                          : mlir::ValueRange{});
+      rewriter.eraseOp(yield);
+    }
+    if (op->getNumResults() != 0)
+      rewriter.replaceOp(op, critical.getResults());
+    else
+      rewriter.eraseOp(op);
+    return mlir::success();
+  }
+};
+
 // LLVM's atomicrmw has no multiply flavor; direct multiply takes the same
 // retry loop as the region form. Every other direct kind is a straight-line
 // llvm.atomicrmw and stays high-level until the LLVM lowering.
@@ -1848,7 +1894,8 @@ struct ConvertToSTDPass
         ReussirNullableDispatchOp, ReussirRecordDispatchOp, ReussirScfYieldOp,
         ReussirClosureUniqifyOp, ReussirArrayWithUniqueViewOp,
         ReussirTokenEnsureOp, ReussirStrByteAtOp, ReussirStrSelectOp,
-        ReussirStrStartWithOp, ReussirCellCreateOp, ReussirCellInUseOp>();
+        ReussirStrStartWithOp, ReussirCellCreateOp, ReussirCellRdlockOp,
+        ReussirCellInUseOp>();
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {
@@ -1896,7 +1943,8 @@ void populateConvertToSTDConversionPatterns(mlir::RewritePatternSet &patterns) {
       ReussirStrByteAtOpRewritePattern, ReussirStrSelectOpRewritePattern,
       ReussirStrStartWithOpRewritePattern, ReussirCellCreateOpRewritePattern,
       ReussirCellGetOpRewritePattern, ReussirCellSetOpRewritePattern,
-      ReussirCellRmwOpRewritePattern, ReussirAtomicCellRmwOpRewritePattern,
+      ReussirCellRmwOpRewritePattern, ReussirCellRdlockOpRewritePattern,
+      ReussirAtomicCellRmwOpRewritePattern,
       ReussirCellInUseOpRewritePattern>(patterns.getContext());
 }
 

--- a/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
+++ b/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
@@ -1166,10 +1166,13 @@ static mlir::Value getMutexView(const CellAccess &access, mlir::Location loc,
   return getLockStorageView(access, loc, rewriter);
 }
 
-static mlir::Block *
-addMutexCriticalSectionBody(mlir::sync::SyncMutexCriticalSectionOp critical,
-                            const CellAccess &access, mlir::Location loc,
-                            mlir::PatternRewriter &rewriter) {
+// The single-block body of any lock critical section, entered with a
+// zero-ranked memref view of the protected payload.
+template <typename CriticalSectionOp>
+static mlir::Block *addCriticalSectionBody(CriticalSectionOp critical,
+                                           const CellAccess &access,
+                                           mlir::Location loc,
+                                           mlir::PatternRewriter &rewriter) {
   auto payloadViewType =
       mlir::MemRefType::get({}, access.cellType.getElementType());
   return rewriter.createBlock(&critical.getBody(), critical.getBody().begin(),
@@ -1198,15 +1201,6 @@ createCombiningCriticalSection(const CellAccess &access, mlir::Location loc,
       rewriter, loc, lockView, /*combine_limit=*/mlir::IntegerAttr{});
 }
 
-static mlir::Block *addCombiningCriticalSectionBody(
-    mlir::sync::SyncCombiningLockCriticalSectionOp critical,
-    const CellAccess &access, mlir::Location loc,
-    mlir::PatternRewriter &rewriter) {
-  auto payloadViewType =
-      mlir::MemRefType::get({}, access.cellType.getElementType());
-  return rewriter.createBlock(&critical.getBody(), critical.getBody().begin(),
-                              {payloadViewType}, {loc});
-}
 
 static mlir::Value acquireThenLoadCellSlot(mlir::Value slotRef,
                                            mlir::Location loc,
@@ -1347,7 +1341,7 @@ public:
           rewriter, op.getLoc(), op->getResultTypes(), mutexView);
       {
         mlir::OpBuilder::InsertionGuard guard(rewriter);
-        mlir::Block *body = addMutexCriticalSectionBody(critical, access,
+        mlir::Block *body = addCriticalSectionBody(critical, access,
                                                         op.getLoc(), rewriter);
         rewriter.setInsertionPointToStart(body);
         mlir::Value slotRef =
@@ -1369,7 +1363,7 @@ public:
           createCombiningCriticalSection(access, op.getLoc(), rewriter);
       {
         mlir::OpBuilder::InsertionGuard guard(rewriter);
-        mlir::Block *body = addCombiningCriticalSectionBody(
+        mlir::Block *body = addCriticalSectionBody(
             critical, access, op.getLoc(), rewriter);
         rewriter.setInsertionPointToStart(body);
         mlir::Value slotRef =
@@ -1383,6 +1377,27 @@ public:
       rewriter.replaceOp(op, mlir::memref::LoadOp::create(
                                  rewriter, op.getLoc(), out, mlir::ValueRange{})
                                  .getResult());
+      return mlir::success();
+    }
+    // A get only clones: the load and the acquisition (which bumps the
+    // element's own counts, never the protected slot) are safe under a shared
+    // read lock, so concurrent gets proceed in parallel.
+    if (access.cellType.getKind() == CellKind::rwlock) {
+      mlir::Value lockView = getLockStorageView(access, op.getLoc(), rewriter);
+      auto critical = mlir::sync::SyncRwLockReadCriticalSectionOp::create(
+          rewriter, op.getLoc(), op->getResultTypes(), lockView);
+      {
+        mlir::OpBuilder::InsertionGuard guard(rewriter);
+        mlir::Block *body =
+            addCriticalSectionBody(critical, access, op.getLoc(), rewriter);
+        rewriter.setInsertionPointToStart(body);
+        mlir::Value slotRef =
+            getLockPayloadRef(body, access, op.getLoc(), rewriter);
+        mlir::Value value =
+            acquireThenLoadCellSlot(slotRef, op.getLoc(), rewriter);
+        mlir::sync::SyncYieldOp::create(rewriter, op.getLoc(), value);
+      }
+      rewriter.replaceOp(op, critical.getResults());
       return mlir::success();
     }
     auto emitLoadAndAcquire = [&]() -> mlir::Value {
@@ -1422,7 +1437,7 @@ public:
           rewriter, op.getLoc(), op->getResultTypes(), mutexView);
       {
         mlir::OpBuilder::InsertionGuard guard(rewriter);
-        mlir::Block *body = addMutexCriticalSectionBody(critical, access,
+        mlir::Block *body = addCriticalSectionBody(critical, access,
                                                         op.getLoc(), rewriter);
         rewriter.setInsertionPointToStart(body);
         mlir::Value slotRef =
@@ -1438,8 +1453,26 @@ public:
           createCombiningCriticalSection(access, op.getLoc(), rewriter);
       {
         mlir::OpBuilder::InsertionGuard guard(rewriter);
-        mlir::Block *body = addCombiningCriticalSectionBody(
+        mlir::Block *body = addCriticalSectionBody(
             critical, access, op.getLoc(), rewriter);
+        rewriter.setInsertionPointToStart(body);
+        mlir::Value slotRef =
+            getLockPayloadRef(body, access, op.getLoc(), rewriter);
+        dropThenStoreCellSlot(slotRef, op.getValue(), op.getLoc(), rewriter);
+        mlir::sync::SyncYieldOp::create(rewriter, op.getLoc());
+      }
+      rewriter.eraseOp(op);
+      return mlir::success();
+    }
+    // A set mutates the protected slot, so it takes the rwlock exclusively.
+    if (access.cellType.getKind() == CellKind::rwlock) {
+      mlir::Value lockView = getLockStorageView(access, op.getLoc(), rewriter);
+      auto critical = mlir::sync::SyncRwLockWriteCriticalSectionOp::create(
+          rewriter, op.getLoc(), mlir::TypeRange{}, lockView);
+      {
+        mlir::OpBuilder::InsertionGuard guard(rewriter);
+        mlir::Block *body =
+            addCriticalSectionBody(critical, access, op.getLoc(), rewriter);
         rewriter.setInsertionPointToStart(body);
         mlir::Value slotRef =
             getLockPayloadRef(body, access, op.getLoc(), rewriter);
@@ -1489,7 +1522,7 @@ public:
           rewriter, op.getLoc(), op->getResultTypes(), mutexView);
       {
         mlir::OpBuilder::InsertionGuard guard(rewriter);
-        mlir::Block *criticalBody = addMutexCriticalSectionBody(
+        mlir::Block *criticalBody = addCriticalSectionBody(
             critical, access, op.getLoc(), rewriter);
         rewriter.setInsertionPointToStart(criticalBody);
         mlir::Value slotRef =
@@ -1529,7 +1562,7 @@ public:
           createCombiningCriticalSection(access, op.getLoc(), rewriter);
       {
         mlir::OpBuilder::InsertionGuard guard(rewriter);
-        mlir::Block *criticalBody = addCombiningCriticalSectionBody(
+        mlir::Block *criticalBody = addCriticalSectionBody(
             critical, access, op.getLoc(), rewriter);
         rewriter.setInsertionPointToStart(criticalBody);
         mlir::Value slotRef =

--- a/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
+++ b/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
@@ -1313,6 +1313,13 @@ public:
       rewriter.replaceOp(op, created.getRcPtr());
       return mlir::success();
     }
+    if (cellType.getKind() == CellKind::rwlock) {
+      mlir::Value lockView = getLockStorageView(access, op.getLoc(), rewriter);
+      mlir::sync::SyncRwLockInitOp::create(rewriter, op.getLoc(), lockView,
+                                           op.getValue());
+      rewriter.replaceOp(op, created.getRcPtr());
+      return mlir::success();
+    }
     mlir::Value slotRef = projectCellSlot(access, op.getLoc(), rewriter);
     ReussirRefStoreOp::create(rewriter, op.getLoc(), slotRef, op.getValue());
     // A fresh exclusive cell starts out not in use.

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -1218,13 +1218,9 @@ mlir::LogicalResult ReussirCellCreateOp::verify() {
   auto cellType = verifySharedCellOperand(getOperation(), rcType);
   if (mlir::failed(cellType))
     return mlir::failure();
-  // Mutex and flatlock creation have dedicated lowerings through
-  // `sync.mutex.init` / `sync.combining_lock.init`. Other lock kinds remain
-  // unavailable until their create operations are implemented.
-  if ((*cellType).getKind() != CellKind::mutex &&
-      (*cellType).getKind() != CellKind::flatlock &&
-      mlir::failed(rejectLockGuardedCell(getOperation(), *cellType)))
-    return mlir::failure();
+  // Every lock-guarded kind has a dedicated creation lowering through its
+  // `sync` init operation (`sync.mutex.init` / `sync.combining_lock.init` /
+  // `sync.rwlock.init`), so creation is never rejected on a lock kind.
   if (getValue().getType() != (*cellType).getElementType())
     return emitOpError("initial value type must match cell element type, got ")
            << getValue().getType() << " and " << (*cellType).getElementType();

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -120,8 +120,8 @@ static mlir::FailureOr<CellType> verifySharedCellOperand(mlir::Operation *op,
 // A cell operation without a dedicated lock-aware lowering is unsound on a
 // lock-guarded cell: its payload lives inside a `sync` primitive rather than at
 // the leading slot, and reaching it requires holding the lock. Create, get,
-// and set are handled separately through `sync` operations on every lock
-// kind, as is the region form of rmw on mutex and flatlock cells.
+// set, and the region form of rmw are handled separately through `sync`
+// operations on every lock kind.
 static mlir::LogicalResult rejectLockGuardedCell(mlir::Operation *op,
                                                  CellType cellType) {
   if (cellType.getLockGuarded())
@@ -1440,13 +1440,10 @@ mlir::LogicalResult ReussirCellRmwOp::verify() {
   auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
   if (mlir::failed(cellType))
     return mlir::failure();
-  // Mutex and flatlock read-modify-write have dedicated lowerings: the region
-  // runs as a critical section, borrowing the element RefCell-style with the
-  // held lock standing in for the exclusive cell's in-use flag.
-  if ((*cellType).getKind() != CellKind::mutex &&
-      (*cellType).getKind() != CellKind::flatlock &&
-      mlir::failed(rejectLockGuardedCell(getOperation(), *cellType)))
-    return mlir::failure();
+  // Every lock kind's read-modify-write has a dedicated lowering: the region
+  // runs as a critical section (a write one on an rwlock cell), borrowing the
+  // element RefCell-style with the held lock standing in for the exclusive
+  // cell's in-use flag.
   if (mlir::failed(verifyCellAtomicOrdering(
           getOperation(), *cellType, getOrdering(), CellAtomicAccess::Rmw)))
     return mlir::failure();
@@ -1461,14 +1458,15 @@ mlir::LogicalResult ReussirCellRmwOp::verify() {
     return emitOpError("region form requires a body");
 
   if (!(*cellType).getExclusive() && !(*cellType).getAtomic() &&
-      !(*cellType).getMutex() && !(*cellType).getFlatlock())
-    return emitOpError("read-modify-write requires an exclusive, atomic, "
-                       "mutex, or flatlock cell, got a plain cell");
+      !(*cellType).getLockGuarded())
+    return emitOpError("read-modify-write requires an exclusive, atomic, or "
+                       "lock-guarded cell, got a plain cell");
   if (!(*cellType).getAtomic() && direct)
     return emitOpError("direct atomic RMW form requires an atomic cell, got ")
-           << ((*cellType).getExclusive() ? "an exclusive cell"
-               : (*cellType).getMutex()  ? "a mutex cell"
-                                          : "a flatlock cell");
+           << ((*cellType).getExclusive()  ? "an exclusive cell"
+               : (*cellType).getMutex()    ? "a mutex cell"
+               : (*cellType).getFlatlock() ? "a flatlock cell"
+                                           : "an rwlock cell");
 
   mlir::Type elementType = (*cellType).getElementType();
   if (direct) {

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -119,9 +119,9 @@ static mlir::FailureOr<CellType> verifySharedCellOperand(mlir::Operation *op,
 
 // A cell operation without a dedicated lock-aware lowering is unsound on a
 // lock-guarded cell: its payload lives inside a `sync` primitive rather than at
-// the leading slot, and reaching it requires holding the lock. Mutex create,
-// get, set, and the region form of rmw are handled separately through `sync`
-// operations.
+// the leading slot, and reaching it requires holding the lock. Create, get,
+// and set are handled separately through `sync` operations on every lock
+// kind, as is the region form of rmw on mutex and flatlock cells.
 static mlir::LogicalResult rejectLockGuardedCell(mlir::Operation *op,
                                                  CellType cellType) {
   if (cellType.getLockGuarded())
@@ -1310,10 +1310,8 @@ mlir::LogicalResult ReussirCellGetOp::verify() {
   auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
   if (mlir::failed(cellType))
     return mlir::failure();
-  if ((*cellType).getKind() != CellKind::mutex &&
-      (*cellType).getKind() != CellKind::flatlock &&
-      mlir::failed(rejectLockGuardedCell(getOperation(), *cellType)))
-    return mlir::failure();
+  // Every lock-guarded kind has a dedicated get lowering: a mutex or flatlock
+  // critical section, or an rwlock read critical section.
   if (mlir::failed(verifyCellAtomicOrdering(
           getOperation(), *cellType, getOrdering(), CellAtomicAccess::Load)))
     return mlir::failure();
@@ -1327,10 +1325,8 @@ mlir::LogicalResult ReussirCellSetOp::verify() {
   auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
   if (mlir::failed(cellType))
     return mlir::failure();
-  if ((*cellType).getKind() != CellKind::mutex &&
-      (*cellType).getKind() != CellKind::flatlock &&
-      mlir::failed(rejectLockGuardedCell(getOperation(), *cellType)))
-    return mlir::failure();
+  // Every lock-guarded kind has a dedicated set lowering: a mutex or flatlock
+  // critical section, or an rwlock write critical section.
   if (mlir::failed(verifyCellAtomicOrdering(
           getOperation(), *cellType, getOrdering(), CellAtomicAccess::Store)))
     return mlir::failure();

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -1534,6 +1534,41 @@ mlir::LogicalResult ReussirCellRmwOp::verify() {
   return mlir::success();
 }
 
+mlir::LogicalResult ReussirCellRdlockOp::verify() {
+  auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
+  if (mlir::failed(cellType))
+    return mlir::failure();
+  // Only an rwlock cell has a shared read lock to take; every other lock
+  // kind reads through its exclusive critical section via get/rmw.
+  if (!(*cellType).getRwlock())
+    return emitOpError("read transaction requires an rwlock cell, got a cell "
+                       "of kind '")
+           << stringifyCellKind((*cellType).getKind()) << "'";
+
+  if (!llvm::hasSingleElement(getBody()))
+    return emitOpError("body must contain exactly one block");
+  mlir::Block &block = getBody().front();
+  if (block.getNumArguments() != 1)
+    return emitOpError("body must accept exactly one cell element argument");
+  if (block.getArgument(0).getType() != (*cellType).getElementType())
+    return emitOpError(
+               "body argument type must match cell element type, expected ")
+           << (*cellType).getElementType() << ", got "
+           << block.getArgument(0).getType();
+  if (block.empty() || !llvm::isa<ReussirScfYieldOp>(block.getTerminator()))
+    return emitOpError("body must terminate with reussir.scf.yield");
+
+  auto yield = llvm::cast<ReussirScfYieldOp>(block.getTerminator());
+  if (static_cast<bool>(getOutput()) != static_cast<bool>(yield.getValue()))
+    return emitOpError("body must yield exactly one optional output when the "
+                       "operation has a result");
+  if (getOutput() && getOutput().getType() != yield.getValue().getType())
+    return emitOpError(
+               "body output type must match operation result type, got ")
+           << yield.getValue().getType() << " and " << getOutput().getType();
+  return mlir::success();
+}
+
 mlir::LogicalResult ReussirCellInUseOp::verify() {
   auto cellType = verifySharedCellOperand(getOperation(), getCell().getType());
   if (mlir::failed(cellType))
@@ -2261,7 +2296,14 @@ mlir::LogicalResult ReussirScfYieldOp::verify() {
   mlir::Type yieldedType = getValue() ? getValue().getType() : mlir::Type{};
   mlir::Type expectedType = mlir::Type{};
   bool allowImplicitArrayResult = false;
-  if (auto nullableParent =
+  // The rdlock check looks at the immediate parent (not the nearest ancestor
+  // of a type): an rdlock body may itself sit inside a dispatch region, and
+  // this yield belongs to the rdlock.
+  if (auto rdlockParent = llvm::dyn_cast_if_present<ReussirCellRdlockOp>(
+          getOperation()->getParentOp()))
+    expectedType = rdlockParent.getOutput() ? rdlockParent.getOutput().getType()
+                                            : mlir::Type{};
+  else if (auto nullableParent =
           getOperation()->getParentOfType<ReussirNullableDispatchOp>())
     expectedType = nullableParent.getValue()
                        ? nullableParent.getValue().getType()

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -1084,11 +1084,9 @@ CellType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
 // to the element's alignment — the same layout LLVM derives for
 // `{element, i1}`.
 //
-// Lock-guarded cells with a lowered access path delegate to their `sync`
-// storage type's data-layout interface because token instantiation sizes the
-// RC allocation before the cell is converted to the sync type. Lock kinds
-// without lowered operations (rwlock, for now) remain unconstructable and
-// retain the element-only fallback.
+// Lock-guarded cells delegate to their `sync` storage type's data-layout
+// interface because token instantiation sizes the RC allocation before the
+// cell is converted to the sync type.
 
 mlir::Type lockGuardedStorageType(CellType type) {
   switch (type.getKind()) {
@@ -1098,6 +1096,9 @@ mlir::Type lockGuardedStorageType(CellType type) {
   case CellKind::flatlock:
     return mlir::sync::CombiningLockType::get(type.getContext(),
                                               type.getElementType());
+  case CellKind::rwlock:
+    return mlir::sync::RwLockType::get(type.getContext(),
+                                       type.getElementType());
   default:
     return {};
   }

--- a/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
@@ -244,10 +244,11 @@ llvm::LogicalResult runIncDecCancellation(mlir::func::FuncOp func) {
           setOp &&
           !isTriviallyCopyable(setOp.getCell().getType().getElementType()))
         break;
-      // A `reussir.cell.rmw` body is arbitrary nested code (it may drop the
-      // moved-out element or anything else) that this same-block scan never
-      // visits — treat the whole op as opaque.
-      if (llvm::isa<ReussirCellRmwOp>(next))
+      // A `reussir.cell.rmw` or `reussir.cell.rdlock` body is arbitrary
+      // nested code (it may drop the moved-out or cloned element or anything
+      // else) that this same-block scan never visits — treat the whole op as
+      // opaque.
+      if (llvm::isa<ReussirCellRmwOp, ReussirCellRdlockOp>(next))
         break;
       // Count-*observing* ops: `array.with_unique_view`, `closure.uniqify`
       // and a standalone `rc.is_unique` read `count == 1` to decide between

--- a/tests/integration/basic/failure/cell.mlir
+++ b/tests/integration/basic/failure/cell.mlir
@@ -75,7 +75,7 @@ module {
   }
 
   func.func @rmw_requires_exclusive(%cell: !rc_cell_i64) {
-    // expected-error @+1 {{read-modify-write requires an exclusive, atomic, mutex, or flatlock cell, got a plain cell}}
+    // expected-error @+1 {{read-modify-write requires an exclusive, atomic, or lock-guarded cell, got a plain cell}}
     reussir.cell.rmw(%cell : !rc_cell_i64) {
       ^bb0(%old: i64):
         reussir.cell.yield(%old : i64)

--- a/tests/integration/basic/failure/cell_rdlock.mlir
+++ b/tests/integration/basic/failure/cell_rdlock.mlir
@@ -1,0 +1,72 @@
+// RUN: %reussir-opt %s -verify-diagnostics -split-input-file
+
+// A read transaction shares the reader-writer lock; every other lock kind
+// only has an exclusive critical section, so rdlock rejects them.
+!mutex_cell = !reussir.rc<!reussir.cell<i64 mutex> atomic>
+
+func.func @rdlock_mutex(%cell: !mutex_cell) -> i64 {
+  // expected-error @+1 {{read transaction requires an rwlock cell, got a cell of kind 'mutex'}}
+  %v = reussir.cell.rdlock(%cell : !mutex_cell) -> i64 {
+    ^bb0(%current: i64):
+      reussir.scf.yield %current : i64
+  }
+  return %v : i64
+}
+
+// -----
+
+// Plain cells have no lock at all.
+!plain_cell = !reussir.rc<!reussir.cell<i64> shared>
+
+func.func @rdlock_plain(%cell: !plain_cell) -> i64 {
+  // expected-error @+1 {{read transaction requires an rwlock cell, got a cell of kind 'plain'}}
+  %v = reussir.cell.rdlock(%cell : !plain_cell) -> i64 {
+    ^bb0(%current: i64):
+      reussir.scf.yield %current : i64
+  }
+  return %v : i64
+}
+
+// -----
+
+// The body receives the cloned element, so its argument must match the cell
+// element type.
+!rwlock_cell = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+
+func.func @rdlock_bad_argument(%cell: !rwlock_cell) -> i64 {
+  // expected-error @+1 {{body argument type must match cell element type, expected 'i64', got 'i32'}}
+  %v = reussir.cell.rdlock(%cell : !rwlock_cell) -> i64 {
+    ^bb0(%current: i32):
+      %wide = arith.extsi %current : i32 to i64
+      reussir.scf.yield %wide : i64
+  }
+  return %v : i64
+}
+
+// -----
+
+// A transaction with a result must yield it.
+!rwlock_cell = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+
+func.func @rdlock_missing_yield_value(%cell: !rwlock_cell) -> i64 {
+  // expected-error @+1 {{body must yield exactly one optional output when the operation has a result}}
+  %v = reussir.cell.rdlock(%cell : !rwlock_cell) -> i64 {
+    ^bb0(%current: i64):
+      reussir.scf.yield
+  }
+  return %v : i64
+}
+
+// -----
+
+// The yielded value's type is the operation result type.
+!rwlock_cell = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+
+func.func @rdlock_yield_type_mismatch(%cell: !rwlock_cell) -> i32 {
+  // expected-error @+1 {{body output type must match operation result type, got 'i64' and 'i32'}}
+  %v = reussir.cell.rdlock(%cell : !rwlock_cell) -> i32 {
+    ^bb0(%current: i64):
+      reussir.scf.yield %current : i64
+  }
+  return %v : i32
+}

--- a/tests/integration/basic/failure/lock_cell_whole_access.mlir
+++ b/tests/integration/basic/failure/lock_cell_whole_access.mlir
@@ -1,25 +1,19 @@
 // RUN: %reussir-opt %s -verify-diagnostics -split-input-file
 
 // A lock-guarded cell keeps its payload inside a `sync` primitive, not at the
-// leading slot, so an operation needs a dedicated lock-aware lowering. Mutex
-// and flatlock create/get/set/rmw are supported; the remaining rwlock
-// operations stay rejected until their critical-section lowerings land.
+// leading slot, so an operation needs a dedicated lock-aware lowering.
+// Create/get/set are supported on every lock kind, and rmw on mutex and
+// flatlock cells; the rwlock rmw stays rejected until its critical-section
+// lowering lands.
 !rwlock_cell1 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
 
-func.func @get_rwlock(%cell: !rwlock_cell1) -> i64 {
+func.func @rmw_rwlock(%cell: !rwlock_cell1) -> i64 {
   // expected-error @+1 {{whole-element access is not supported on a cell of kind 'rwlock'; access it through a critical-section region}}
-  %v = reussir.cell.get(%cell : !rwlock_cell1) : i64
-  return %v : i64
-}
-
-// -----
-
-!rwlock_cell = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
-
-func.func @set_rwlock(%cell: !rwlock_cell, %value: i64) {
-  // expected-error @+1 {{whole-element access is not supported on a cell of kind 'rwlock'; access it through a critical-section region}}
-  reussir.cell.set(%value : i64, %cell : !rwlock_cell)
-  return
+  %old = reussir.cell.rmw(%cell : !rwlock_cell1) -> i64 {
+    ^bb0(%current: i64):
+      reussir.cell.yield(%current : i64) output(%current : i64)
+  }
+  return %old : i64
 }
 
 // -----

--- a/tests/integration/basic/failure/lock_cell_whole_access.mlir
+++ b/tests/integration/basic/failure/lock_cell_whole_access.mlir
@@ -2,8 +2,8 @@
 
 // A lock-guarded cell keeps its payload inside a `sync` primitive, not at the
 // leading slot, so an operation needs a dedicated lock-aware lowering. Mutex
-// create/get/set/rmw and flatlock create/get/set are supported; the other
-// lock operations remain unavailable.
+// and flatlock create/get/set/rmw are supported; the remaining rwlock
+// operations stay rejected until their critical-section lowerings land.
 !rwlock_cell1 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
 
 func.func @get_rwlock(%cell: !rwlock_cell1) -> i64 {
@@ -20,16 +20,6 @@ func.func @set_rwlock(%cell: !rwlock_cell, %value: i64) {
   // expected-error @+1 {{whole-element access is not supported on a cell of kind 'rwlock'; access it through a critical-section region}}
   reussir.cell.set(%value : i64, %cell : !rwlock_cell)
   return
-}
-
-// -----
-
-!rwlock_cell2 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
-
-func.func @create_rwlock(%value: i64) -> !rwlock_cell2 {
-  // expected-error @+1 {{whole-element access is not supported on a cell of kind 'rwlock'; access it through a critical-section region}}
-  %cell = reussir.cell.create value(%value : i64) : !rwlock_cell2
-  return %cell : !rwlock_cell2
 }
 
 // -----

--- a/tests/integration/basic/failure/lock_cell_whole_access.mlir
+++ b/tests/integration/basic/failure/lock_cell_whole_access.mlir
@@ -2,24 +2,11 @@
 
 // A lock-guarded cell keeps its payload inside a `sync` primitive, not at the
 // leading slot, so an operation needs a dedicated lock-aware lowering.
-// Create/get/set are supported on every lock kind, and rmw on mutex and
-// flatlock cells; the rwlock rmw stays rejected until its critical-section
-// lowering lands.
-!rwlock_cell1 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
-
-func.func @rmw_rwlock(%cell: !rwlock_cell1) -> i64 {
-  // expected-error @+1 {{whole-element access is not supported on a cell of kind 'rwlock'; access it through a critical-section region}}
-  %old = reussir.cell.rmw(%cell : !rwlock_cell1) -> i64 {
-    ^bb0(%current: i64):
-      reussir.cell.yield(%current : i64) output(%current : i64)
-  }
-  return %old : i64
-}
-
-// -----
-
-// The mutex exemption covers exactly create/get/set/rmw: a mutex cell has no
-// in-use flag to observe, so `cell.in_use` stays rejected.
+// Create/get/set and the region form of rmw are supported on every lock
+// kind.
+//
+// The lock exemption covers exactly create/get/set/rmw: a lock-guarded cell
+// has no in-use flag to observe, so `cell.in_use` stays rejected.
 !mutex_cell = !reussir.rc<!reussir.cell<i64 mutex> atomic>
 
 func.func @in_use_mutex(%cell: !mutex_cell) -> i1 {
@@ -48,6 +35,17 @@ func.func @direct_rmw_mutex(%delta: i64, %cell: !mutex_cell) -> i64 {
 func.func @direct_rmw_flatlock(%delta: i64, %cell: !flatlock_cell2) -> i64 {
   // expected-error @+1 {{direct atomic RMW form requires an atomic cell, got a flatlock cell}}
   %old = reussir.cell.rmw addi(%delta : i64, %cell : !flatlock_cell2) -> i64
+  return %old : i64
+}
+
+// -----
+
+// And on an rwlock cell: the region form takes the write lock instead.
+!rwlock_cell2 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+
+func.func @direct_rmw_rwlock(%delta: i64, %cell: !rwlock_cell2) -> i64 {
+  // expected-error @+1 {{direct atomic RMW form requires an atomic cell, got an rwlock cell}}
+  %old = reussir.cell.rmw addi(%delta : i64, %cell : !rwlock_cell2) -> i64
   return %old : i64
 }
 

--- a/tests/integration/basic/success/cell_rdlock.mlir
+++ b/tests/integration/basic/success/cell_rdlock.mlir
@@ -1,0 +1,39 @@
+// RUN: %reussir-opt %s | %reussir-opt | %FileCheck %s
+
+// `reussir.cell.rdlock` runs a read transaction over an rwlock cell: the body
+// receives a clone of the element, shares the read lock with concurrent gets
+// and other read transactions, and yields only the optional result. This test
+// pins down the assembly roundtrip of both forms.
+
+!inner = !reussir.rc<i64 atomic>
+!rwlock_i64 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+!rwlock_rc = !reussir.rc<!reussir.cell<!inner rwlock> atomic>
+
+module {
+  // CHECK-LABEL: func.func @rdlock_with_output
+  // CHECK: %{{.+}} = reussir.cell.rdlock(%{{.+}} : !reussir.rc<!reussir.cell<i64 rwlock> atomic>) -> i64 {
+  // CHECK: ^bb0(%[[CURRENT:.+]]: i64):
+  // CHECK: reussir.scf.yield %{{.+}} : i64
+  func.func @rdlock_with_output(%cell: !rwlock_i64) -> i64 {
+    %doubled = reussir.cell.rdlock(%cell : !rwlock_i64) -> i64 {
+      ^bb0(%current: i64):
+        %two = arith.constant 2 : i64
+        %result = arith.muli %current, %two : i64
+        reussir.scf.yield %result : i64
+    }
+    return %doubled : i64
+  }
+
+  // CHECK-LABEL: func.func @rdlock_no_output
+  // CHECK: reussir.cell.rdlock(%{{.+}} : !reussir.rc<!reussir.cell<!reussir.rc<i64 atomic> rwlock> atomic>) {
+  // CHECK: reussir.scf.yield
+  func.func private @consume(!inner) -> ()
+  func.func @rdlock_no_output(%cell: !rwlock_rc) {
+    reussir.cell.rdlock(%cell : !rwlock_rc) {
+      ^bb0(%current: !inner):
+        func.call @consume(%current) : (!inner) -> ()
+        reussir.scf.yield
+    }
+    return
+  }
+}

--- a/tests/integration/conversion/rwlock_cell_create.mlir
+++ b/tests/integration/conversion/rwlock_cell_create.mlir
@@ -1,0 +1,50 @@
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation))' | %FileCheck %s --check-prefix=TOKEN
+// RUN: %reussir-opt %s --reussir-convert-to-std | %FileCheck %s --check-prefix=STD
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-convert-to-std,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
+
+!inner = !reussir.rc<i64 atomic>
+!rwlock_i64 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+!rwlock_rc = !reussir.rc<!reussir.cell<!inner rwlock> atomic>
+
+module {
+  // The rwlock storage is `{{i32, i32} header, i64 payload}` — the raw
+  // header carries the two i32 words of the runtime's rwlock state machine.
+  // Together with the atomic RC count, its box requires 24 bytes at 8-byte
+  // alignment.
+  // TOKEN-LABEL: func.func @create_i64
+  // TOKEN: %[[TOKEN:.+]] = reussir.token.alloc : <align : 8, size : 24>
+  // TOKEN: reussir.cell.create value(%{{.+}} : i64) token(%[[TOKEN]] : !reussir.token<align : 8, size : 24>)
+  // STD-LABEL: func.func @create_i64
+  // STD: %[[CELL:.+]] = reussir.rc.create
+  // STD: %[[REF:.+]] = reussir.rc.borrow(%[[CELL]]
+  // STD: %[[VIEW:.+]] = reussir.ref.to_memref(%[[REF]] : !reussir.ref<!reussir.cell<i64 rwlock> atomic>) : memref<!sync.rwlock<i64>>
+  // STD: %[[RAW:.+]] = sync.rwlock.get_raw_rwlock %[[VIEW]]
+  // STD: sync.raw_rwlock.init %[[RAW]]
+  // STD: %[[PAYLOAD:.+]] = sync.rwlock.get_payload %[[VIEW]]
+  // STD: memref.store %{{.+}}, %[[PAYLOAD]][] : memref<i64>
+  // STD-NOT: reussir.cell.create
+  // LLVM-LABEL: define ptr @create_i64
+  // LLVM: store i32 0, ptr %{{.+}}
+  // LLVM: store i64 %{{.+}}, ptr %{{.+}}
+  func.func @create_i64(%value: i64) -> !rwlock_i64 {
+    %cell = reussir.cell.create value(%value : i64) : !rwlock_i64
+    return %cell : !rwlock_i64
+  }
+
+  // An RC-managed payload is moved into the protected slot without retaining
+  // it: ownership transfers from the argument to the newly created cell.
+  // TOKEN-LABEL: func.func @create_rc
+  // TOKEN: %[[TOKEN:.+]] = reussir.token.alloc : <align : 8, size : 24>
+  // TOKEN: reussir.cell.create value(%{{.+}} : !reussir.rc<i64 atomic>) token(%[[TOKEN]] : !reussir.token<align : 8, size : 24>)
+  // STD-LABEL: func.func @create_rc
+  // STD: reussir.ref.to_memref({{.*}}) : memref<!sync.rwlock<!reussir.rc<i64 atomic>>>
+  // STD: memref.store %{{.+}}, %{{.+}}[] : memref<!reussir.rc<i64 atomic>>
+  // STD-NOT: reussir.rc.inc
+  // LLVM-LABEL: define ptr @create_rc
+  // LLVM: store i32 0, ptr %{{.+}}
+  // LLVM: store ptr %{{.+}}, ptr %{{.+}}
+  func.func @create_rc(%value: !inner) -> !rwlock_rc {
+    %cell = reussir.cell.create value(%value : !inner) : !rwlock_rc
+    return %cell : !rwlock_rc
+  }
+}

--- a/tests/integration/conversion/rwlock_cell_drop.mlir
+++ b/tests/integration/conversion/rwlock_cell_drop.mlir
@@ -1,0 +1,47 @@
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion)' | %FileCheck %s --check-prefix=DROP
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion,reussir-convert-to-std,reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-convert-to-std,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
+
+!inner = !reussir.rc<i64 atomic>
+!rwlock_rc = !reussir.rc<!reussir.cell<!inner rwlock> atomic>
+
+module {
+  // Dropping the last reference to an rwlock cell releases the managed
+  // payload through the same door every mutation uses: a write critical
+  // section over the rwlock view, whose body loads the protected RC and
+  // decrements it — never a leading-slot projection, which would address the
+  // lock header.
+  // DROP-LABEL: func.func @rwlock_cell_drop
+  // DROP: reussir.rc.fetch_sub
+  // DROP-NOT: reussir.ref.project
+  // DROP: %[[VIEW:.+]] = reussir.ref.to_memref{{.*}} : memref<!sync.rwlock<!reussir.rc<i64 atomic>>>
+  // DROP: sync.rwlock.write_critical_section %[[VIEW]]
+  // DROP: ^bb0(%[[PAYLOAD:.+]]: memref<!reussir.rc<i64 atomic>>):
+  // DROP: %[[SLOT:.+]] = reussir.ref.from_memref(%[[PAYLOAD]]
+  // DROP: %[[INNER:.+]] = reussir.ref.load(%[[SLOT]]
+  // DROP: reussir.rc.dec(%[[INNER]] : !reussir.rc<i64 atomic>)
+  // DROP-NOT: reussir.ref.project
+
+  // Fully lowered: the box count drops first; on the last reference the
+  // state word of the two-word raw rwlock header is write-acquired (the
+  // whole writer mask compare-exchanged in), the payload pointer is loaded
+  // from rwlock field 1 — past the lock header — and its count is
+  // decremented under the lock. Both frees happen after the unlock, and the
+  // cell box dies through the rwlock-aware 24-byte layout.
+  // LLVM-LABEL: define void @rwlock_cell_drop(ptr
+  // LLVM: atomicrmw sub ptr %{{.+}}, i32 1
+  // LLVM: %[[CELL:.+]] = getelementptr { i32, { { i32, i32 }, ptr } }, ptr %{{.+}}, i32 0, i32 1
+  // LLVM: %[[HEADER:.+]] = getelementptr { { i32, i32 }, ptr }, ptr %[[CELL]], i32 0, i32 0
+  // LLVM: %[[STATE:.+]] = getelementptr { i32, i32 }, ptr %[[HEADER]], i32 0, i32 0
+  // LLVM: cmpxchg ptr %[[STATE]], i32 0, i32 1073741823
+  // LLVM: %[[SLOT:.+]] = getelementptr { { i32, i32 }, ptr }, ptr %[[CELL]], i32 0, i32 1
+  // LLVM: %[[INNER:.+]] = load ptr, ptr %[[SLOT]]
+  // LLVM: atomicrmw sub ptr %[[INNER]], i32 1
+  // LLVM: atomicrmw sub ptr %{{.+}}, i32 1073741823 release
+  // LLVM: call void @__reussir_deallocate(ptr %{{.+}}, i64 8, i64 24)
+  // LLVM: call void @__reussir_deallocate(ptr %{{.+}}, i64 8, i64 16)
+  func.func @rwlock_cell_drop(%cell: !rwlock_rc) {
+    %t = reussir.rc.dec (%cell : !rwlock_rc) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
+    reussir.token.free (%t : !reussir.nullable<!reussir.token<align: 8, size: 24>>)
+    return
+  }
+}

--- a/tests/integration/conversion/rwlock_cell_get_set.mlir
+++ b/tests/integration/conversion/rwlock_cell_get_set.mlir
@@ -1,0 +1,114 @@
+// RUN: %reussir-opt %s --reussir-convert-to-std | %FileCheck %s --check-prefix=STD
+// RUN: %reussir-opt %s --reussir-convert-to-std --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=MANAGE
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion,reussir-convert-to-std,reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-convert-to-std,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
+
+!inner = !reussir.rc<i64 atomic>
+!rwlock_i64 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+!rwlock_rc = !reussir.rc<!reussir.cell<!inner rwlock> atomic>
+
+module {
+  // A get takes the lock shared: the reader-count retry loop and the read
+  // slow path, never the write ones.
+  // STD-LABEL: func.func @get_i64
+  // STD: %[[VIEW:.+]] = reussir.ref.to_memref{{.*}} : memref<!sync.rwlock<i64>>
+  // STD: %[[RAW:.+]] = sync.rwlock.get_raw_rwlock %[[VIEW]]
+  // STD: scf.while
+  // STD: sync.raw_rwlock.load_state %[[RAW]]
+  // STD: sync.raw_rwlock.cmpxchg_state %[[RAW]]
+  // STD: func.call @mlir_sync_rwlock_read_lock_slow_path
+  // STD-NOT: write_lock
+  // STD: %[[PAYLOAD:.+]] = sync.rwlock.get_payload %[[VIEW]]
+  // STD: %[[SLOT:.+]] = reussir.ref.from_memref(%[[PAYLOAD]] : memref<i64>) : !reussir.ref<i64 field atomic>
+  // STD: reussir.ref.acquire(%[[SLOT]]
+  // STD-NEXT: %[[VALUE:.+]] = reussir.ref.load(%[[SLOT]]
+  // STD: sync.raw_rwlock.read_unlock_fast %[[RAW]]
+  // STD: func.call @mlir_sync_rwlock_unlock_slow_path
+  // STD: return %[[VALUE]]
+  // LLVM-LABEL: define i64 @get_i64
+  // LLVM: cmpxchg
+  // LLVM: load i64
+  // LLVM: atomicrmw sub ptr %{{.+}}, i32 1 release
+  // LLVM: ret i64
+  func.func @get_i64(%cell: !rwlock_i64) -> i64 {
+    %value = reussir.cell.get(%cell : !rwlock_i64) : i64
+    return %value : i64
+  }
+
+  // A set mutates the protected slot, so it takes the lock exclusively: the
+  // write acquisition compare-exchanges the whole writer mask in.
+  // STD-LABEL: func.func @set_i64
+  // STD: %[[VIEW:.+]] = reussir.ref.to_memref{{.*}} : memref<!sync.rwlock<i64>>
+  // STD: %[[RAW:.+]] = sync.rwlock.get_raw_rwlock %[[VIEW]]
+  // STD: scf.while
+  // STD: sync.raw_rwlock.load_state %[[RAW]]
+  // STD: sync.raw_rwlock.cmpxchg_state %[[RAW]]
+  // STD: func.call @mlir_sync_rwlock_write_lock_slow_path
+  // STD-NOT: read_lock
+  // STD: %[[PAYLOAD:.+]] = sync.rwlock.get_payload %[[VIEW]]
+  // STD: %[[SLOT:.+]] = reussir.ref.from_memref(%[[PAYLOAD]] : memref<i64>) : !reussir.ref<i64 field atomic>
+  // STD: reussir.ref.drop(%[[SLOT]]
+  // STD: reussir.ref.store(%[[SLOT]]
+  // STD: sync.raw_rwlock.write_unlock_fast %[[RAW]]
+  // STD: func.call @mlir_sync_rwlock_unlock_slow_path
+  // STD: return
+  // LLVM-LABEL: define void @set_i64
+  // LLVM: cmpxchg ptr %{{.+}}, i32 0, i32 1073741823
+  // LLVM: store i64
+  // LLVM: atomicrmw sub ptr %{{.+}}, i32 1073741823 release
+  // LLVM: ret void
+  func.func @set_i64(%value: i64, %cell: !rwlock_i64) {
+    reussir.cell.set(%value : i64, %cell : !rwlock_i64)
+    return
+  }
+
+  // Cloning an RC element under the read lock only bumps the element's own
+  // atomic count; the protected slot is never written, so concurrent readers
+  // are safe.
+  // STD-LABEL: func.func @get_rc
+  // STD: %[[VIEW:.+]] = reussir.ref.to_memref{{.*}} : memref<!sync.rwlock<!reussir.rc<i64 atomic>>>
+  // STD: func.call @mlir_sync_rwlock_read_lock_slow_path
+  // STD: %[[PAYLOAD:.+]] = sync.rwlock.get_payload %[[VIEW]]
+  // STD: %[[SLOT:.+]] = reussir.ref.from_memref(%[[PAYLOAD]] : memref<!reussir.rc<i64 atomic>>) : !reussir.ref<!reussir.rc<i64 atomic> field atomic>
+  // STD: %[[VALUE:.+]] = reussir.ref.load(%[[SLOT]]
+  // STD-NEXT: reussir.rc.inc(%[[VALUE]]
+  // STD: sync.raw_rwlock.read_unlock_fast
+  // STD: return %[[VALUE]]
+  // LLVM-LABEL: define ptr @get_rc
+  // LLVM: %[[VALUE:.+]] = load ptr
+  // LLVM: atomicrmw add ptr %{{.+}}, i32 1
+  // LLVM: atomicrmw sub ptr %{{.+}}, i32 1 release
+  // LLVM: ret ptr %[[VALUE]]
+  func.func @get_rc(%cell: !rwlock_rc) -> !inner {
+    %value = reussir.cell.get(%cell : !rwlock_rc) : !inner
+    return %value : !inner
+  }
+
+  // The old element is dropped and the caller-owned replacement moved in,
+  // all while holding the lock exclusively.
+  // MANAGE-LABEL: func.func @set_rc(
+  // MANAGE-SAME: %[[NEW:[a-zA-Z0-9_]+]]: !reussir.rc<i64 atomic>
+  // MANAGE-NOT: reussir.rc.inc
+  // MANAGE: %[[VIEW:.+]] = reussir.ref.to_memref{{.*}} : memref<!sync.rwlock<!reussir.rc<i64 atomic>>>
+  // MANAGE: func.call @mlir_sync_rwlock_write_lock_slow_path
+  // MANAGE: %[[PAYLOAD:.+]] = sync.rwlock.get_payload %[[VIEW]]
+  // MANAGE: %[[SLOT:.+]] = reussir.ref.from_memref(%[[PAYLOAD]] : memref<!reussir.rc<i64 atomic>>) : !reussir.ref<!reussir.rc<i64 atomic> field atomic>
+  // MANAGE: %[[OLD:.+]] = reussir.ref.load(%[[SLOT]]
+  // MANAGE-NEXT: %{{.+}} = reussir.rc.dec(%[[OLD]] : !reussir.rc<i64 atomic>)
+  // MANAGE-NOT: reussir.rc.inc
+  // MANAGE: reussir.ref.store(%[[SLOT]]{{.*}}) (%[[NEW]] : !reussir.rc<i64 atomic>)
+  // MANAGE: sync.raw_rwlock.write_unlock_fast
+  // MANAGE-NOT: reussir.rc.inc
+  // MANAGE: return
+  // LLVM-LABEL: define void @set_rc(
+  // LLVM-SAME: ptr %[[NEW:.+]], ptr
+  // LLVM: %[[OLD:.+]] = load ptr, ptr %[[SLOT:.+]], align 8
+  // LLVM: atomicrmw sub ptr %[[OLD]], i32 1
+  // LLVM: call void @__reussir_deallocate(ptr %[[OLD]], i64 8, i64 16)
+  // LLVM: store ptr %[[NEW]], ptr %[[SLOT]]
+  // LLVM: atomicrmw sub ptr %{{.+}}, i32 1073741823 release
+  // LLVM: ret void
+  func.func @set_rc(%value: !inner, %cell: !rwlock_rc) {
+    reussir.cell.set(%value : !inner, %cell : !rwlock_rc)
+    return
+  }
+}

--- a/tests/integration/conversion/rwlock_cell_omp_e2e.mlir
+++ b/tests/integration/conversion/rwlock_cell_omp_e2e.mlir
@@ -1,0 +1,76 @@
+// REQUIRES: openmp
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion,reussir-convert-to-std,reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-convert-to-std,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O2 -o %t.ll
+// RUN: %llc %t.ll -relocation-model=pic -filetype=obj -o %t.o
+// The futex slow paths ride inside reussir_rt (see mutex_cell_omp_e2e.mlir).
+// RUN: %cc %openmp_flags %t.o %S/rwlock_cell_omp_e2e_main.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// An rwlock cell under real reader/writer contention: an OpenMP driver
+// (rwlock_cell_omp_e2e_main.c) shares one rwlock-guarded i64 counter across
+// threads. Writer threads increment through the region-form rmw (a write
+// critical section); reader threads snapshot through `cell.rdlock` (a read
+// critical section) concurrently. A lost or torn update shows up as a wrong
+// final count; a broken read path shows up as a reader observing a value
+// outside the range of counts any prefix of increments could have produced,
+// or going backwards between two snapshots of the same thread.
+
+!rwlock_i64 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+
+// The real target layout (as `reussir-attach-native-target` emits it), so
+// `rc.dec`'s explicit token type is verified against the layout the box is
+// actually allocated with — parse-time verification runs before any pass,
+// and MLIR's default layout (i64 align 4) would reject the align-8 token.
+// The pipeline's attach-native-target pass overwrites these attributes with
+// the actual host's, so the sizes below stay honest on every LP64 target.
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"} {
+  func.func @rwlock_counter_create(%initial: i64) -> !rwlock_i64 {
+    %cell = reussir.cell.create value(%initial : i64) : !rwlock_i64
+    return %cell : !rwlock_i64
+  }
+
+  // Region-form rmw: add `delta` under the write lock and return the old
+  // value.
+  func.func @rwlock_counter_fetch_add(%cell: !rwlock_i64, %delta: i64) -> i64 {
+    %old = reussir.cell.rmw(%cell : !rwlock_i64) -> i64 {
+      ^bb0(%current: i64):
+        %next = arith.addi %current, %delta : i64
+        reussir.cell.yield(%next : i64) output(%current : i64)
+    }
+    return %old : i64
+  }
+
+  // A read transaction under the shared lock: the body sees the element and
+  // yields only its result. Returning `current * 2` (halved by the driver)
+  // keeps real work inside the section so the lock is held across it.
+  func.func @rwlock_counter_snapshot(%cell: !rwlock_i64) -> i64 {
+    %doubled = reussir.cell.rdlock(%cell : !rwlock_i64) -> i64 {
+      ^bb0(%current: i64):
+        %two = arith.constant 2 : i64
+        %scaled = arith.muli %current, %two : i64
+        reussir.scf.yield %scaled : i64
+    }
+    return %doubled : i64
+  }
+
+  // Whole-element get (read critical section) and set (write critical
+  // section).
+  func.func @rwlock_counter_get(%cell: !rwlock_i64) -> i64 {
+    %value = reussir.cell.get(%cell : !rwlock_i64) : i64
+    return %value : i64
+  }
+
+  func.func @rwlock_counter_set(%cell: !rwlock_i64, %value: i64) {
+    reussir.cell.set(%value : i64, %cell : !rwlock_i64)
+    return
+  }
+
+  // The box is `{i32 count, {{i32, i32} header, i64 payload}}`: 24 bytes at
+  // 8-byte alignment, the rwlock-aware layout token instantiation also
+  // computes.
+  func.func @rwlock_counter_drop(%cell: !rwlock_i64) {
+    %t = reussir.rc.dec (%cell : !rwlock_i64) : !reussir.nullable<!reussir.token<align: 8, size: 24>>
+    reussir.token.free (%t : !reussir.nullable<!reussir.token<align: 8, size: 24>>)
+    return
+  }
+}

--- a/tests/integration/conversion/rwlock_cell_omp_e2e_main.c
+++ b/tests/integration/conversion/rwlock_cell_omp_e2e_main.c
@@ -1,0 +1,78 @@
+/* OpenMP driver for the rwlock cell lowering (rwlock_cell_omp_e2e.mlir): one
+   rwlock-guarded i64 counter, writer threads incrementing it through the
+   region-form `cell.rmw` (a write critical section) while reader threads
+   snapshot it through `cell.rdlock` (a read critical section). Mutual
+   exclusion between writers is the first property under test: any lost or
+   torn update surfaces as a wrong final count. The read path is the second:
+   a snapshot taken under the shared lock must be a count some prefix of
+   increments produced — inside [0, total] and, per reader thread,
+   non-decreasing, since the counter only grows during the parallel phase.
+
+   The snapshot transaction returns the value doubled (the driver halves it)
+   so the multiply demonstrably runs inside the read section rather than
+   after it. */
+#include <omp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern void *rwlock_counter_create(int64_t);
+extern int64_t rwlock_counter_fetch_add(void *, int64_t);
+extern int64_t rwlock_counter_snapshot(void *);
+extern int64_t rwlock_counter_get(void *);
+extern void rwlock_counter_set(void *, int64_t);
+extern void rwlock_counter_drop(void *);
+
+int main(void) {
+  enum { WRITERS = 4, READERS = 4, ITERS = 20000 };
+  const int64_t total = (int64_t)WRITERS * ITERS;
+  void *cell = rwlock_counter_create(0);
+#pragma omp parallel num_threads(WRITERS + READERS)
+  {
+    int tid = omp_get_thread_num();
+    if (tid < WRITERS) {
+      for (int i = 0; i < ITERS; ++i) {
+        int64_t old = rwlock_counter_fetch_add(cell, 1);
+        if (old < 0 || old >= total) {
+          fprintf(stderr, "fetched old=%lld outside [0, %lld)\n",
+                  (long long)old, (long long)total);
+          abort();
+        }
+      }
+    } else {
+      int64_t last = 0;
+      for (int i = 0; i < ITERS; ++i) {
+        int64_t doubled = rwlock_counter_snapshot(cell);
+        if (doubled % 2 != 0) {
+          fprintf(stderr, "snapshot returned odd doubled value %lld\n",
+                  (long long)doubled);
+          abort();
+        }
+        int64_t seen = doubled / 2;
+        if (seen < last || seen > total) {
+          fprintf(stderr, "snapshot %lld regressed from %lld or exceeds %lld\n",
+                  (long long)seen, (long long)last, (long long)total);
+          abort();
+        }
+        last = seen;
+      }
+    }
+  }
+  /* The parallel region's join orders every increment before this read. */
+  int64_t count = rwlock_counter_get(cell);
+  if (count != total) {
+    fprintf(stderr, "count=%lld, want %lld\n", (long long)count,
+            (long long)total);
+    abort();
+  }
+  /* Whole-element set/get through the write and read sides of the lock. */
+  rwlock_counter_set(cell, -7);
+  if (rwlock_counter_get(cell) != -7) {
+    fprintf(stderr, "set/get roundtrip failed\n");
+    abort();
+  }
+  /* Release the creating reference; the box must die exactly here. */
+  rwlock_counter_drop(cell);
+  puts("all ok");
+  return 0;
+}

--- a/tests/integration/conversion/rwlock_cell_rdlock.mlir
+++ b/tests/integration/conversion/rwlock_cell_rdlock.mlir
@@ -1,0 +1,73 @@
+// RUN: %reussir-opt %s --reussir-convert-to-std | %FileCheck %s --check-prefix=STD
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion,reussir-convert-to-std,reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-convert-to-std,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
+
+!inner = !reussir.rc<i64 atomic>
+!rwlock_i64 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+!rwlock_rc = !reussir.rc<!reussir.cell<!inner rwlock> atomic>
+
+module {
+  // The whole transaction body runs inside the read critical section — after
+  // the shared acquisition, before the read unlock — and only the yielded
+  // result leaves the section. The element is cloned in like a get; nothing
+  // is stored back.
+  // STD-LABEL: func.func @read_i64
+  // STD: %[[VIEW:.+]] = reussir.ref.to_memref{{.*}} : memref<!sync.rwlock<i64>>
+  // STD: %[[RAW:.+]] = sync.rwlock.get_raw_rwlock %[[VIEW]]
+  // STD: func.call @mlir_sync_rwlock_read_lock_slow_path
+  // STD-NOT: write_lock
+  // STD: %[[PAYLOAD:.+]] = sync.rwlock.get_payload %[[VIEW]]
+  // STD: %[[SLOT:.+]] = reussir.ref.from_memref(%[[PAYLOAD]] : memref<i64>) : !reussir.ref<i64 field atomic>
+  // STD: reussir.ref.acquire(%[[SLOT]]
+  // STD-NEXT: %[[VALUE:.+]] = reussir.ref.load(%[[SLOT]]
+  // STD: %[[RESULT:.+]] = arith.muli %[[VALUE]]
+  // STD: sync.raw_rwlock.read_unlock_fast %[[RAW]]
+  // STD-NOT: reussir.ref.store
+  // STD-NOT: reussir.cell.rdlock
+  // STD: return %[[RESULT]]
+  // LLVM-LABEL: define i64 @read_i64
+  // LLVM: cmpxchg
+  // LLVM: %[[VALUE:.+]] = load i64
+  // LLVM: %[[RESULT:.+]] = mul i64 %[[VALUE]], 2
+  // LLVM: atomicrmw sub ptr %{{.+}}, i32 1 release
+  // LLVM-NOT: store i64
+  // LLVM: ret i64 %[[RESULT]]
+  func.func @read_i64(%cell: !rwlock_i64) -> i64 {
+    %doubled = reussir.cell.rdlock(%cell : !rwlock_i64) -> i64 {
+      ^bb0(%current: i64):
+        %two = arith.constant 2 : i64
+        %result = arith.muli %current, %two : i64
+        reussir.scf.yield %result : i64
+    }
+    return %doubled : i64
+  }
+
+  // An RC element is acquired into the body — the inc hits the element's own
+  // atomic count, never the protected slot, so concurrent read transactions
+  // are safe — and the body owns and consumes the clone. The result is
+  // optional; a resultless transaction erases cleanly.
+  // STD-LABEL: func.func @read_rc_no_output
+  // STD: func.call @mlir_sync_rwlock_read_lock_slow_path
+  // STD: %[[PAYLOAD:.+]] = sync.rwlock.get_payload
+  // STD: %[[SLOT:.+]] = reussir.ref.from_memref(%[[PAYLOAD]] : memref<!reussir.rc<i64 atomic>>) : !reussir.ref<!reussir.rc<i64 atomic> field atomic>
+  // STD: %[[VALUE:.+]] = reussir.ref.load(%[[SLOT]]
+  // STD-NEXT: reussir.rc.inc(%[[VALUE]]
+  // STD: call @consume(%[[VALUE]])
+  // STD: sync.raw_rwlock.read_unlock_fast
+  // STD-NOT: reussir.cell.rdlock
+  // STD: return
+  // LLVM-LABEL: define void @read_rc_no_output
+  // LLVM: %[[VALUE:.+]] = load ptr
+  // LLVM: atomicrmw add ptr %{{.+}}, i32 1
+  // LLVM: call void @consume(ptr %[[VALUE]])
+  // LLVM: atomicrmw sub ptr %{{.+}}, i32 1 release
+  // LLVM: ret void
+  func.func private @consume(!inner) -> ()
+  func.func @read_rc_no_output(%cell: !rwlock_rc) {
+    reussir.cell.rdlock(%cell : !rwlock_rc) {
+      ^bb0(%current: !inner):
+        func.call @consume(%current) : (!inner) -> ()
+        reussir.scf.yield
+    }
+    return
+  }
+}

--- a/tests/integration/conversion/rwlock_cell_rmw.mlir
+++ b/tests/integration/conversion/rwlock_cell_rmw.mlir
@@ -1,0 +1,91 @@
+// RUN: %reussir-opt %s --reussir-convert-to-std | %FileCheck %s --check-prefix=STD
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion,reussir-convert-to-std,reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-convert-to-std,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,canonicalize,cse)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
+
+!inner = !reussir.rc<i64 atomic>
+!rwlock_i64 = !reussir.rc<!reussir.cell<i64 rwlock> atomic>
+!rwlock_rc = !reussir.rc<!reussir.cell<!inner rwlock> atomic>
+
+module {
+  // The region form on an rwlock cell is a RefCell-style borrow under the
+  // WRITE lock: the replacement store mutates the protected slot, so the
+  // section excludes readers and writers alike. The element moves into the
+  // body and the yielded replacement is stored back before the unlock.
+  // STD-LABEL: func.func @rmw_addi
+  // STD: %[[VIEW:.+]] = reussir.ref.to_memref{{.*}} : memref<!sync.rwlock<i64>>
+  // STD: %[[RAW:.+]] = sync.rwlock.get_raw_rwlock %[[VIEW]]
+  // STD: sync.raw_rwlock.load_state %[[RAW]]
+  // STD: sync.raw_rwlock.cmpxchg_state %[[RAW]]
+  // STD: func.call @mlir_sync_rwlock_write_lock_slow_path
+  // STD-NOT: read_lock
+  // STD-NOT: reussir.expect
+  // STD-NOT: reussir.panic
+  // STD: %[[PAYLOAD:.+]] = sync.rwlock.get_payload %[[VIEW]]
+  // STD: %[[SLOT:.+]] = reussir.ref.from_memref(%[[PAYLOAD]] : memref<i64>) : !reussir.ref<i64 field atomic>
+  // STD: %[[OLD:.+]] = reussir.ref.load(%[[SLOT]]
+  // STD: %[[NEW:.+]] = arith.addi %[[OLD]]
+  // STD: reussir.ref.store(%[[SLOT]]{{.*}}) (%[[NEW]] : i64)
+  // STD: sync.raw_rwlock.write_unlock_fast %[[RAW]]
+  // STD-NOT: reussir.cell.rmw
+  // STD: return %[[OLD]]
+  // LLVM-LABEL: define i64 @rmw_addi
+  // LLVM: cmpxchg ptr %{{.+}}, i32 0, i32 1073741823
+  // LLVM: %[[OLD:.+]] = load i64
+  // LLVM: %[[NEXT:.+]] = add i64 %[[OLD]]
+  // LLVM: store i64 %[[NEXT]]
+  // LLVM: atomicrmw sub ptr %{{.+}}, i32 1073741823 release
+  // LLVM: ret i64 %[[OLD]]
+  func.func @rmw_addi(%delta: i64, %cell: !rwlock_i64) -> i64 {
+    %old = reussir.cell.rmw(%cell : !rwlock_i64) -> i64 {
+      ^bb0(%current: i64):
+        %next = arith.addi %current, %delta : i64
+        reussir.cell.yield(%next : i64) output(%current : i64)
+    }
+    return %old : i64
+  }
+
+  // A managed element moves through the body without any implicit retain or
+  // release: the old value's ownership transfers out as the output, the
+  // caller-owned replacement transfers in, and the only atomics left are the
+  // lock words themselves.
+  // STD-LABEL: func.func @rmw_swap
+  // STD: func.call @mlir_sync_rwlock_write_lock_slow_path
+  // STD-NOT: reussir.rc.inc
+  // STD-NOT: reussir.ref.acquire
+  // STD-NOT: reussir.ref.drop
+  // STD: %[[OLD:.+]] = reussir.ref.load
+  // STD-NOT: reussir.rc.inc
+  // STD-NOT: reussir.ref.drop
+  // STD: reussir.ref.store
+  // STD: sync.raw_rwlock.write_unlock_fast
+  // STD: return %[[OLD]]
+  // LLVM-LABEL: define ptr @rmw_swap
+  // LLVM-NOT: atomicrmw add
+  // LLVM-NOT: call void @__reussir_deallocate
+  // LLVM: %[[OLD:.+]] = load ptr
+  // LLVM: store ptr
+  // LLVM: ret ptr %[[OLD]]
+  func.func @rmw_swap(%new: !inner, %cell: !rwlock_rc) -> !inner {
+    %old = reussir.cell.rmw(%cell : !rwlock_rc) -> !inner {
+      ^bb0(%current: !inner):
+        reussir.cell.yield(%new : !inner) output(%current : !inner)
+    }
+    return %old : !inner
+  }
+
+  // The output is optional; a resultless read-modify-write erases cleanly.
+  // STD-LABEL: func.func @rmw_no_output
+  // STD: func.call @mlir_sync_rwlock_write_lock_slow_path
+  // STD: reussir.ref.store
+  // STD: sync.raw_rwlock.write_unlock_fast
+  // STD-NOT: reussir.cell.rmw
+  // STD: return
+  func.func @rmw_no_output(%cell: !rwlock_i64) {
+    reussir.cell.rmw(%cell : !rwlock_i64) {
+      ^bb0(%current: i64):
+        %one = arith.constant 1 : i64
+        %next = arith.addi %current, %one : i64
+        reussir.cell.yield(%next : i64)
+    }
+    return
+  }
+}


### PR DESCRIPTION
Completes the lock-guarded cell trio (#433 mutex, #434 flatlock) with the reader-writer kind, mirroring #434's commit structure, and adds one new operation for shared read transactions.

Rebased on main after #435 (libomp in the dev shell + mlir-sync pin bump) merged.

## Commits

- **give rwlock cells sync-backed storage and creation** — `!sync.rwlock<T>` (`{{i32, i32} header, T payload}`) routed through `lockGuardedStorageType` for layout and storage views; `cell.create` lowers to `sync.rwlock.init`.
- **lower rwlock cell get/set through read/write critical sections** — get clones under the shared read lock (the acquisition bumps the element's own atomic counts, never the protected slot); set drops the old value and stores the replacement under the write lock. The three identical per-kind critical-section body helpers folded into one template.
- **lower the region form of cell.rmw on rwlock cells** — the RefCell-style move-through borrow inside a `write_critical_section`; direct atomic form stays rejected.
- **add `reussir.cell.rdlock` for shared read transactions** — new region op, rwlock-only: the body runs inside a `read_critical_section` and receives a clone of the element (acquired like get, which is what makes it read-lock-safe); nothing is stored back, and the `reussir.scf.yield` terminator carries only the optional result. Joins `cell.rmw` as an opaque barrier in inc/dec cancellation and in the basic-ops illegal-op list.
- **release an rwlock cell payload through a critical section on drop** — drop glue takes the write side, uniform with set/rmw; the section is uncontended by construction (box count already zero).
- **add an OpenMP end-to-end test for rwlock cells** — 4 writer threads increment via rmw while 4 reader threads snapshot via `cell.rdlock` concurrently; checks the exact final count, per-reader monotonicity, snapshot range, a set/get roundtrip, and the 24-byte rwlock-aware drop. The module embeds the real target layout (as `attach-native-target` emits it) so the hand-written token verifies against the layout the box is allocated with.

## Verification

- Full integration suite: 374 passed, 8 unsupported, 0 failed; ctest 28/28.
- The OpenMP e2e runs under real reader/writer contention and passes (readers observe monotone, in-range snapshots while writers hammer the write lock).
- New failure tests pin the verifier surface: rdlock rejects non-rwlock kinds, argument/yield type mismatches, and missing yields; direct rmw stays atomic-only on rwlock cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786848251&installation_id=144622820&pr_number=436&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F436&signature=4ba72aada5cec716145a2a3e9288464b8ab884edbd1a17b86d9e0295c9bc231c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
