### PR TITLE
[frontend] structural Sync: coinductive checker + Arc member well-formedness

### DIFF
--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -776,7 +776,7 @@ mod tests {
         roundtrip(
             r#"
             struct Data { value: i64 }
-            enum List<T> { Nil, Cons(T, List<T>) }
+            enum Opt<T> { None, Some(T) }
             fn generic<T>(a: T) -> T { a }
             pub fn use_arc(a: Arc<Data>) -> Arc<Data> {
                 generic(a)
@@ -787,16 +787,16 @@ mod tests {
             pub fn make(v: i64) -> Arc<Data> {
                 Arc<Data> { value: v }
             }
-            pub fn make_list() -> Arc<List<i64>> {
-                Arc<List<i64>>::Cons{1, List::Nil}
+            pub fn make_some() -> Arc<Opt<i64>> {
+                Arc<Opt<i64>>::Some{1}
             }
             pub fn read(a: Arc<Data>) -> i64 {
                 a.value
             }
-            pub fn head(l: Arc<List<i64>>) -> i64 {
-                match l {
-                    List::Cons(x, _) => x,
-                    List::Nil => 0
+            pub fn get(o: Arc<Opt<i64>>) -> i64 {
+                match o {
+                    Opt::Some(x) => x,
+                    Opt::None => 0
                 }
             }
             "#,

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -65,6 +65,7 @@ use crate::semi::ctxt::{
 };
 use crate::semi::hir::{self, DecisionTree, Expr, ExprKind, Function, SwitchCases};
 use crate::semi::resolve::DefTable;
+use crate::semi::traits::sync::{SyncEnv, SyncVerdict, wf_arc};
 use crate::semi::ty::{DefId, Flexivity, Ty, TyCtxt, TyKind};
 use crate::semi::ty::{FpTy, IntTy};
 use crate::semi::ty_eval::arc_inner_rejection;
@@ -121,6 +122,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
 
     let mut driver = Driver {
         tcx,
+        resolver: input.resolver,
         mangler: Mangler::new(input.defs, input.resolver),
         symbols: Rodeo::default(),
         queue: VecDeque::new(),
@@ -422,9 +424,61 @@ fn is_regional_arg(ty: Ty<'_>) -> bool {
     )
 }
 
+/// [`SyncEnv`] over ground mono state: capabilities and members from the
+/// elaborated record table, member types grounded with [`subst_ty`]. Every
+/// type here is ground, so — unlike the semi-side env — nothing blocks on
+/// incomplete fields or generics.
+struct MonoSyncEnv<'a, 'tcx> {
+    tcx: &'a TyCtxt<'tcx>,
+    record_defs: &'a FxHashMap<DefId, Record<'tcx>>,
+    resolver: &'a dyn Resolver<TokenKey>,
+}
+
+impl<'tcx> SyncEnv<'tcx> for MonoSyncEnv<'_, 'tcx> {
+    fn default_cap(&self, def: DefId) -> Option<DefaultCap> {
+        self.record_defs.get(&def).map(|r| r.default_cap)
+    }
+
+    fn members(&self, def: DefId, args: &'tcx [Ty<'tcx>]) -> Option<Vec<(String, Ty<'tcx>)>> {
+        let rec = self.record_defs.get(&def)?;
+        let fields = rec.fields.as_ref()?;
+        let subst: Subst<'tcx> = rec
+            .ty_params
+            .iter()
+            .map(|(_, g)| *g)
+            .zip(args.iter().copied())
+            .collect();
+        let ground = |t: Ty<'tcx>| subst_ty(self.tcx, t, &subst);
+        Some(match fields {
+            RecordFields::Named(fs) => fs
+                .iter()
+                .map(|(n, t, _)| (self.resolver.resolve(*n).to_owned(), ground(*t)))
+                .collect(),
+            RecordFields::Unnamed(fs) => fs
+                .iter()
+                .enumerate()
+                .map(|(i, (t, _))| (i.to_string(), ground(*t)))
+                .collect(),
+            RecordFields::Variants(vs) => vs
+                .iter()
+                .flat_map(|v| {
+                    let vname = self.resolver.resolve(v.name);
+                    v.fields
+                        .iter()
+                        .enumerate()
+                        .map(move |(i, t)| (format!("{vname}.{i}"), *t))
+                })
+                .map(|(label, t)| (label, ground(t)))
+                .collect(),
+        })
+    }
+}
+
 /// Mutable worklist + lowering state.
 struct Driver<'a, 'tcx> {
     tcx: &'a TyCtxt<'tcx>,
+    /// Symbol resolution for diagnostics (member labels in `Sync` witnesses).
+    resolver: &'a dyn Resolver<TokenKey>,
     mangler: Mangler<'a>,
     /// Interner for every mangled symbol; moved into the final `mir::Program`.
     symbols: Rodeo,
@@ -532,16 +586,39 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                     |def| self.record_defs.get(&def).map(|r| r.default_cap),
                     inner,
                 );
-                if let Some(kind) = rejection
-                    && self.reported_arcs.insert(ty)
-                {
-                    self.error(
-                        span,
-                        format!(
-                            "this instantiation grounds an `Arc` inner type that is not a \
-                             `[shared]` record, array, or closure ({kind})"
-                        ),
-                    );
+                if let Some(kind) = rejection {
+                    if self.reported_arcs.insert(ty) {
+                        self.error(
+                            span,
+                            format!(
+                                "this instantiation grounds an `Arc` inner type that is not a \
+                                 `[shared]` record, array, or closure ({kind})"
+                            ),
+                        );
+                    }
+                } else {
+                    // The kind is admissible; the ground backstop for the
+                    // structural half: every member must be `Sync`. Semi
+                    // checks concrete annotations/ctors eagerly but defers
+                    // anything a generic blocks — instantiation is where
+                    // those ground.
+                    let env = MonoSyncEnv {
+                        tcx: self.tcx,
+                        record_defs: self.record_defs,
+                        resolver: self.resolver,
+                    };
+                    if let SyncVerdict::NotSync(w) = wf_arc(&env, inner)
+                        && self.reported_arcs.insert(ty)
+                    {
+                        self.error(
+                            span,
+                            format!(
+                                "this instantiation grounds an `Arc` whose contents are not \
+                                 `Sync`: {}",
+                                w.describe()
+                            ),
+                        );
+                    }
                 }
                 self.check_arc_inners(inner, span);
             }
@@ -1599,6 +1676,27 @@ mod tests {
                 "grounds an `Arc` inner type that is not a `[shared]` record, \
                  array, or closure (a cell)"
             )),
+            "{reports:#?}"
+        );
+    }
+
+    #[test]
+    fn arc_generic_rejects_non_sync_instantiation() {
+        // The kind is admissible (a `[shared]` record) but the contents are
+        // not `Sync`: `Cons` holds a bare `List<T>` whose refcount is not
+        // atomic. Semi defers the generic inner; grounding it here is the
+        // backstop.
+        let src = r#"
+            enum List<T> { Nil, Cons(T, List<T>) }
+            fn passthrough<T>(a: Arc<T>) -> Arc<T> { a }
+            extern "C" trampoline "bad_list" = passthrough<List<i32>>;
+        "#;
+        let reports = mono_reports(src);
+        assert!(
+            reports
+                .iter()
+                .any(|m| m.contains("grounds an `Arc` whose contents are not `Sync`")
+                    && m.contains("member `Cons.1`")),
             "{reports:#?}"
         );
     }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -707,6 +707,13 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             for field_ty in field_tys {
                 let ground = subst_ty(tcx, field_ty, &subst);
                 self.discover_records(ground, &mut worklist);
+                // The member position is where an `Arc` can ground without
+                // ever appearing in a signature or expression type: a direct
+                // `Arc` slot is rejected at declaration, but one behind a
+                // `Nullable`/`Cell` wrapper (`next: Nullable<Arc<T>>`) is
+                // legal and semi's wf check blocks on the generic. This walk
+                // is its only ground checkpoint.
+                self.check_arc_inners(ground, record.span);
             }
         }
     }
@@ -1697,6 +1704,37 @@ mod tests {
                 .iter()
                 .any(|m| m.contains("grounds an `Arc` whose contents are not `Sync`")
                     && m.contains("member `Cons.1`")),
+            "{reports:#?}"
+        );
+    }
+
+    #[test]
+    fn arc_behind_a_generic_member_is_checked_at_instantiation() {
+        // A member-position `Arc` can ground without ever appearing in a
+        // signature or expression type: `link: Nullable<Arc<T>>` is a legal
+        // member (only a *direct* `Arc` slot is rejected at declaration) and
+        // semi's wf check blocks on the generic — closing the record set
+        // over fields is its only ground checkpoint, for both halves of the
+        // check.
+        let src = r#"
+            enum List<T> { Nil, Cons(T, List<T>) }
+            struct Holder<T> { link: Nullable<Arc<T>> }
+            fn keep<T>(h: Holder<T>) -> Holder<T> { h }
+            extern "C" trampoline "unsync_member" = keep<List<i64>>;
+            extern "C" trampoline "non_box_member" = keep<i32>;
+        "#;
+        let reports = mono_reports(src);
+        assert!(
+            reports
+                .iter()
+                .any(|m| m.contains("grounds an `Arc` whose contents are not `Sync`")
+                    && m.contains("member `Cons.1`")),
+            "{reports:#?}"
+        );
+        assert!(
+            reports
+                .iter()
+                .any(|m| m.contains("not a `[shared]` record, array, or closure")),
             "{reports:#?}"
         );
     }

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1127,6 +1127,37 @@ mod tests {
     }
 
     #[test]
+    fn later_batch_arc_wf_reports_once() {
+        // A second `run` batch (the REPL shape) scans its signatures while
+        // the flag left by the previous batch's completed sweep would still
+        // be set; the annotation-site check must stay silent until this
+        // batch's own sweep, or the error doubles.
+        with_tcx(|tcx| {
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let resolver: &dyn reussir_syntax::kind::Resolver<reussir_syntax::kind::TokenKey> =
+                &interner;
+            let mut elab = Elaborator::new(tcx, resolver);
+            for src in [
+                "enum List<T> { Nil, Cons(T, List<T>) }",
+                "fn f(l: Arc<List<i32>>) -> i32 { 0 }",
+            ] {
+                let parse = reussir_syntax::parse_with_interner(src, interner.clone());
+                assert!(parse.ok(), "{src}: {:#?}", parse.errors);
+                elab.run(&surface::program(&parse.root));
+            }
+            let arc_errors = elab
+                .reports
+                .iter()
+                .filter(|r| {
+                    r.message
+                        .contains("every member of an `Arc` inner must be `Sync`")
+                })
+                .count();
+            assert_eq!(arc_errors, 1, "{:#?}", elab.reports);
+        });
+    }
+
+    #[test]
     fn arc_wf_witness_names_a_nested_member_path() {
         // The `!Sync` leaf sits two levels down, through a `[value]` record;
         // the diagnostic walks the path instead of blaming the root.

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1088,11 +1088,68 @@ mod tests {
     fn infers_arc_ctors() {
         // The struct and variant arc constructors type at `Arc<R>`.
         let src = "struct Pair { a: i32 }\n\
-                   enum List<T> { Nil, Cons(T, List<T>) }\n\
+                   enum Opt<T> { None, Some(T) }\n\
                    fn f(v: i32) -> Arc<Pair> { Arc<Pair> { a: v } }\n\
-                   fn g() -> Arc<List<i32>> { Arc<List<i32>>::Cons{1, List::Nil} }\n\
-                   fn h() -> Arc<List<i32>> { Arc<List<i32>>::Nil }";
+                   fn g() -> Arc<Opt<i32>> { Arc<Opt<i32>>::Some{1} }\n\
+                   fn h() -> Arc<Opt<i32>> { Arc<Opt<i32>>::None }";
         assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn rejects_arc_whose_member_is_a_bare_shared_record() {
+        // The stratified wf rule: the arc colors exactly one box, so every
+        // member must be `Sync` on its own — a bare `[shared]` member (its
+        // refcount is not atomic) refutes, and the witness names it.
+        let src = "enum List<T> { Nil, Cons(T, List<T>) }\n\
+                   fn f(l: Arc<List<i32>>) -> i32 { 0 }";
+        assert!(
+            has_error(src, "every member of an `Arc` inner must be `Sync`"),
+            "{:#?}",
+            reports_of(src)
+        );
+        assert!(
+            has_error(src, "member `Cons.1` is a plain `[shared]` rc box"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_arc_wf_at_the_ctor_site() {
+        // The coloring site checks too: no annotation is needed to trip it.
+        let src = "enum List<T> { Nil, Cons(T, List<T>) }\n\
+                   fn f() -> i32 { Arc<List<i32>>::Cons{1, List::Nil}; 0 }";
+        assert!(
+            has_error(src, "every member of an `Arc` inner must be `Sync`"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn arc_wf_witness_names_a_nested_member_path() {
+        // The `!Sync` leaf sits two levels down, through a `[value]` record;
+        // the diagnostic walks the path instead of blaming the root.
+        let src = "struct Leaf { x: i32 }\n\
+                   struct [value] Mid { leaf: Leaf }\n\
+                   struct Top { m: Mid }\n\
+                   fn f(t: Arc<Top>) -> i32 { 0 }";
+        assert!(
+            has_error(src, "member `m.leaf` is a plain `[shared]` rc box"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_arc_whose_member_is_a_cell() {
+        let src = "struct Counter { c: Cell<i32> }\n\
+                   fn f(x: Arc<Counter>) -> i32 { 0 }";
+        assert!(
+            has_error(src, "member `c` is a plain `Cell`"),
+            "{:#?}",
+            reports_of(src)
+        );
     }
 
     #[test]
@@ -1134,13 +1191,10 @@ mod tests {
         // Projection and matching see through the arc coloring; the bound
         // fields carry their declared (plain) types.
         let src = "struct Pair { a: i32, b: i32 }\n\
-                   enum List<T> { Nil, Cons(T, List<T>) }\n\
+                   enum Opt<T> { None, Some(T) }\n\
                    fn f(p: Arc<Pair>) -> i32 { p.a + p.b }\n\
-                   fn g(l: Arc<List<i32>>) -> i32 {\n\
-                       match l { List::Cons(x, xs) => x + len(xs), List::Nil => 0 }\n\
-                   }\n\
-                   fn len<T>(l: List<T>) -> i32 {\n\
-                       match l { List::Cons(_, xs) => 1 + len(xs), List::Nil => 0 }\n\
+                   fn g(o: Arc<Opt<i32>>) -> i32 {\n\
+                       match o { Opt::Some(x) => x, Opt::None => 0 }\n\
                    }";
         assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
     }

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1586,6 +1586,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // Wrap only a successfully built constructor; an error path stays the
         // poison it already is.
         if matches!(e.ty.kind(), TyKind::Record { .. }) {
+            // The coloring site: the arc's contents must be `Sync`. (Ctors
+            // run during body checking, after record fields populate; a
+            // generic-blocked verdict defers to the mono backstop.)
+            self.report_arc_wf(e.ty, span);
             e.ty = self.tcx.mk_arc(e.ty);
         }
         e

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -294,6 +294,14 @@ pub struct Elaborator<'a, 'tcx> {
     /// ([`Elaborator::set_current_file`]); the check passes restore it per item
     /// from the item's own declaration file.
     pub current_file: FileId,
+    /// Whether record fields are populated for the current [`run_files`]
+    /// batch. `Arc` well-formedness needs member types (the structural `Sync`
+    /// check), so annotation-site checks fire only once this is set; types
+    /// evaluated earlier (signatures, record members) are re-checked by the
+    /// post-populate sweep ([`Elaborator::sweep_arc_wf`]).
+    ///
+    /// [`run_files`]: Elaborator::run_files
+    pub(super) records_complete: bool,
 
     // ----- per-function working state (reset by `enter_function`) -----
     pub infer: InferCtxt<'a, 'tcx>,
@@ -357,6 +365,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             elaborated: Vec::new(),
             reports: Vec::new(),
             current_file: FileId::ROOT,
+            records_complete: false,
             infer: InferCtxt::new(tcx),
             vars: VarEnv::default(),
             generic_names: FxHashMap::default(),
@@ -873,13 +882,59 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .zip(&function_defs)
             .filter_map(|((_, _, _, anchor), def)| if *anchor { *def } else { None })
             .for_each(|def| self.transform_anchors.push(def));
-        records
+        // Field types evaluated during population may reference records whose
+        // own fields are not populated yet, so `Arc` wf checks (which need
+        // member types for the structural `Sync` half) stay silent until the
+        // sweep below.
+        self.records_complete = false;
+        let record_defs: Vec<DefId> = records
             .iter()
             .zip(record_defs)
             .filter_map(|((rec, _, _), def)| Some((rec, def?)))
-            .for_each(|(rec, def)| {
+            .map(|(rec, def)| {
                 self.populate_record(rec, def);
-            });
+                def
+            })
+            .collect();
+        // Post-populate sweep: signatures and record members were evaluated
+        // before fields existed, so their `Arc` nodes wf-check only now.
+        // Restricted to this batch's items so a REPL re-run does not re-report
+        // earlier ones. Body annotations check inline during `check_function`.
+        for def in record_defs {
+            let Some(rec) = self.records.get(&def) else {
+                continue;
+            };
+            let (span, file) = (rec.span, rec.file);
+            let member_tys: Vec<Ty<'tcx>> = match &rec.fields {
+                Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _)| *t).collect(),
+                Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _)| *t).collect(),
+                Some(RecordFields::Variants(vs)) => {
+                    vs.iter().flat_map(|v| v.fields.iter().copied()).collect()
+                }
+                None => Vec::new(),
+            };
+            self.set_current_file(file);
+            for t in member_tys {
+                self.sweep_arc_wf(t, span);
+            }
+        }
+        for def in function_defs.iter().flatten() {
+            let Some(proto) = self.functions.get(def) else {
+                continue;
+            };
+            let (span, file) = (proto.span, proto.file);
+            let tys: Vec<Ty<'tcx>> = proto
+                .params
+                .iter()
+                .map(|(_, t)| *t)
+                .chain([proto.return_ty])
+                .collect();
+            self.set_current_file(file);
+            for t in tys {
+                self.sweep_arc_wf(t, span);
+            }
+        }
+        self.records_complete = true;
         functions
             .iter()
             .zip(function_defs)

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -806,6 +806,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// the owning item's file/module scope), and collect trampoline roots per
     /// file.
     fn run_files(&mut self, files: &[(FileId, Vec<TokenKey>, &surface::Program)]) {
+        // This batch's record fields are not populated yet, so `Arc` wf
+        // checks (which need member types for the structural `Sync` half)
+        // stay silent from the very first scan — a previous batch may have
+        // left the flag set — until the post-populate sweep re-checks.
+        self.records_complete = false;
         // Project each item once — `kind()` re-walks the node and is not
         // memoized — then run the passes over the typed collections, each item
         // tagged with its file/module scope.
@@ -882,11 +887,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .zip(&function_defs)
             .filter_map(|((_, _, _, anchor), def)| if *anchor { *def } else { None })
             .for_each(|def| self.transform_anchors.push(def));
-        // Field types evaluated during population may reference records whose
-        // own fields are not populated yet, so `Arc` wf checks (which need
-        // member types for the structural `Sync` half) stay silent until the
-        // sweep below.
-        self.records_complete = false;
         let record_defs: Vec<DefId> = records
             .iter()
             .zip(record_defs)

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -240,6 +240,27 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 if ty_has_hole(self_ty) {
                     return Discharge::Defer;
                 }
+                // `Sync` is the structural thread-safety auto trait: answered
+                // by the checker over the type's shape, never by impl search
+                // (docs/design/thread-safety.md §2.2).
+                if tref.trait_id == self.builtins.sync {
+                    use crate::semi::traits::sync::{SyncVerdict, sync_verdict};
+                    use crate::semi::ty_eval::ElabSyncEnv;
+                    return match sync_verdict(&ElabSyncEnv { el: self }, self_ty) {
+                        SyncVerdict::Sync => Discharge::Solved,
+                        SyncVerdict::NotSync(w) => Discharge::Failed(format!(
+                            "`{}` is not `Sync`: {}",
+                            self.ty_display(self_ty),
+                            w.describe()
+                        )),
+                        // The verdict depends on a generic nested under a
+                        // constructor: everything grounds at monomorphization
+                        // (where the `Arc` wf backstop re-checks), so be
+                        // optimistic here rather than reporting a spurious
+                        // ambiguity.
+                        SyncVerdict::Blocked => Discharge::Solved,
+                    };
+                }
                 let goal = Obligation::Trait(TraitRef {
                     trait_id: tref.trait_id,
                     args: vec![self_ty],

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -831,7 +831,7 @@ mod tests {
         roundtrip(
             r#"
             struct Data { value: i64 }
-            enum List<T> { Nil, Cons(T, List<T>) }
+            enum Opt<T> { None, Some(T) }
             pub fn use_arc(a: Arc<Data>) -> Arc<Data> {
                 a
             }
@@ -844,19 +844,19 @@ mod tests {
             pub fn make(v: i64) -> Arc<Data> {
                 Arc<Data> { value: v }
             }
-            pub fn make_list() -> Arc<List<i64>> {
-                Arc<List<i64>>::Cons{1, List::Nil}
+            pub fn make_some() -> Arc<Opt<i64>> {
+                Arc<Opt<i64>>::Some{1}
             }
-            pub fn make_nil() -> Arc<List<i64>> {
-                Arc<List<i64>>::Nil
+            pub fn make_none() -> Arc<Opt<i64>> {
+                Arc<Opt<i64>>::None
             }
             pub fn read(a: Arc<Data>) -> i64 {
                 a.value
             }
-            pub fn head(l: Arc<List<i64>>) -> i64 {
-                match l {
-                    List::Cons(x, _) => x,
-                    List::Nil => 0
+            pub fn get(o: Arc<Opt<i64>>) -> i64 {
+                match o {
+                    Opt::Some(x) => x,
+                    Opt::None => 0
                 }
             }
             "#,

--- a/crates/reussir-core/src/semi/traits.rs
+++ b/crates/reussir-core/src/semi/traits.rs
@@ -13,6 +13,7 @@
 pub mod builtins;
 pub mod db;
 pub mod def;
+pub mod sync;
 
 pub use db::{SelectError, TraitDb};
 pub use def::{AssocTyDef, ImplDef, MethodSig, TraitDef};

--- a/crates/reussir-core/src/semi/traits/builtins.rs
+++ b/crates/reussir-core/src/semi/traits/builtins.rs
@@ -14,9 +14,9 @@
 //! reached from any thread, concurrently. It subsumes both of Rust's `Send`
 //! and `Sync` — duplicable rc handles make transfer-without-sharing
 //! unprovable, so the two predicates collapse (see
-//! `docs/design/thread-safety.md`). Phase 0 only declares it and gives the
-//! leaves (primitive scalars) `Sync` impls; structural auto-trait propagation
-//! (a record is `Sync` iff its members are) lands in Phase 1+.
+//! `docs/design/thread-safety.md`). It is declared here for name resolution
+//! and bound syntax only: ground `Sync` goals are answered *structurally* by
+//! [`crate::semi::traits::sync`], never by impl search, so it has no impls.
 
 use crate::semi::ty::{FpTy, GenericId, IntTy, Ty, TyCtxt};
 
@@ -111,17 +111,6 @@ impl Builtins {
         for &ty in &fps {
             implement(floating_point, ty, db);
         }
-        // Primitive scalars are the `Sync` leaves.
-        let scalars = ints.iter().chain(&fps).copied().chain([
-            tcx.mk_bool(),
-            tcx.mk_str(),
-            tcx.mk_char(),
-            tcx.mk_unit(),
-        ]);
-        for ty in scalars {
-            implement(sync, ty, db);
-        }
-
         Builtins {
             num,
             integral,

--- a/crates/reussir-core/src/semi/traits/db.rs
+++ b/crates/reussir-core/src/semi/traits/db.rs
@@ -181,21 +181,8 @@ mod tests {
         });
     }
 
-    #[test]
-    fn primitive_scalars_are_sync() {
-        with_tcx(|tcx: &TyCtxt| {
-            let mut db = TraitDb::new();
-            let b = Builtins::register(&mut db, tcx);
-            for ty in [
-                tcx.mk_int(IntTy::Unsigned(64)),
-                tcx.mk_bool(),
-                tcx.mk_str(),
-                tcx.mk_char(),
-            ] {
-                assert!(db.select(&needs(b.sync, ty)).is_ok());
-            }
-        });
-    }
+    // `Sync` has no impls: ground goals are answered structurally by
+    // `traits::sync` (see its tests), so nothing here selects it.
 
     #[test]
     fn transitive_super_traits_build_a_full_evidence_chain() {

--- a/crates/reussir-core/src/semi/traits/sync.rs
+++ b/crates/reussir-core/src/semi/traits/sync.rs
@@ -1,0 +1,458 @@
+//! Structural `Sync`: the single thread-safety auto trait.
+//!
+//! `Sync(τ)` holds when a value of type `τ` may be reached — aliased, read,
+//! cloned, stored, dropped — from any thread concurrently. It subsumes both of
+//! Rust's `Send` and `Sync` (duplicable rc handles collapse transfer into
+//! sharing); the rules live in `docs/design/thread-safety.md` §2.2 and this
+//! module is their implementation.
+//!
+//! The check is **structural** (an auto trait: derived, never written by the
+//! user) and **coinductive**: re-encountering an `Arc` inner that is already
+//! on the current checking path is success, so recursive arc'd structures
+//! (`Arc<Node>` lists/trees) are well-formed — a genuine violation always
+//! surfaces at a finite unfolding on some non-cyclic path.
+//!
+//! Two queries are exposed:
+//!
+//! - [`sync_verdict`]: is `τ` `Sync`? A bare `[shared]` record never is — its
+//!   own box count is not atomic — no matter what its members are.
+//! - [`wf_arc`]: is `Arc<X>` well-formed? The stratified rule: the arc
+//!   supplies atomicity for exactly the one box it wraps, so every *member*
+//!   of `X` (element for arrays, argument type for closures) must already be
+//!   `Sync` on its own. This runs *after* the kind gate
+//!   ([`crate::semi::ty_eval::arc_inner_rejection`]) has admitted `X` as a
+//!   shared rc box.
+//!
+//! A failed check carries a [`Witness`]: the member path to the offending
+//! leaf and the reason, so diagnostics can say *which* member broke the type
+//! instead of shrugging at the root.
+//!
+//! Record lookup is abstracted behind [`SyncEnv`] because the two callers
+//! substitute differently: the elaborator instantiates member types with
+//! [`crate::semi::infer::InferCtxt::instantiate_ty`], monomorphization with
+//! [`crate::full::subst::subst_ty`]. An env may also answer "not known yet"
+//! (unresolved def, fields not populated) — the verdict is then [`Blocked`]
+//! and the caller defers to the monomorphization backstop, where every type
+//! is ground and every record complete.
+//!
+//! [`Blocked`]: SyncVerdict::Blocked
+
+use rustc_hash::FxHashSet;
+
+use crate::semi::ty::{DefId, Ty, TyKind};
+
+/// Record information the checker needs, provided by each phase.
+pub trait SyncEnv<'tcx> {
+    /// The record's declared capability; `None` when the def is unknown
+    /// (error recovery) — the verdict blocks.
+    fn default_cap(&self, def: DefId) -> Option<crate::semi::ctxt::DefaultCap>;
+
+    /// The record's members instantiated at `args`, labeled for diagnostics
+    /// (`name` / `.0` / `Variant.0`). `None` when the fields are not
+    /// populated yet — the verdict blocks and the mono backstop re-checks.
+    fn members(&self, def: DefId, args: &'tcx [Ty<'tcx>]) -> Option<Vec<(String, Ty<'tcx>)>>;
+}
+
+/// Why a type is not `Sync`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotSyncReason {
+    /// A bare shared rc box (record, array, or closure): its refcount is not
+    /// atomic, so two threads bumping it race.
+    NonAtomicBox,
+    /// A regional object; regions and threads do not mix (for now).
+    Regional,
+    /// A plain `Cell`: whole-element stores with no synchronization.
+    PlainCell,
+    /// A `RefCell`: the in-use guard flag is not atomic.
+    ExclusiveCell,
+}
+
+impl NotSyncReason {
+    pub fn describe(self) -> &'static str {
+        match self {
+            NotSyncReason::NonAtomicBox => {
+                "a plain `[shared]` rc box whose refcount is not atomic"
+            }
+            NotSyncReason::Regional => "a regional object",
+            NotSyncReason::PlainCell => "a plain `Cell`, which is unsynchronized",
+            NotSyncReason::ExclusiveCell => "a `RefCell`, whose in-use guard is not atomic",
+        }
+    }
+}
+
+/// The member path to a `!Sync` leaf, for diagnostics.
+#[derive(Clone, Debug)]
+pub struct Witness<'tcx> {
+    /// Member labels from the checked root down to the leaf, e.g.
+    /// `["next", "Cons.1"]`. Empty when the root itself is the leaf.
+    pub path: Vec<String>,
+    /// The offending type.
+    pub leaf: Ty<'tcx>,
+    pub reason: NotSyncReason,
+}
+
+impl Witness<'_> {
+    /// Render as a diagnostic fragment: `` member `a.b` is <reason> `` (or
+    /// `it is <reason>` for the root).
+    pub fn describe(&self) -> String {
+        if self.path.is_empty() {
+            format!("it is {}", self.reason.describe())
+        } else {
+            format!(
+                "member `{}` is {}",
+                self.path.join("."),
+                self.reason.describe()
+            )
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum SyncVerdict<'tcx> {
+    Sync,
+    NotSync(Witness<'tcx>),
+    /// The answer depends on a generic, a hole, or a not-yet-known record —
+    /// defer; monomorphization re-checks every ground instantiation.
+    Blocked,
+}
+
+/// Is `τ` `Sync`?
+pub fn sync_verdict<'tcx>(env: &dyn SyncEnv<'tcx>, ty: Ty<'tcx>) -> SyncVerdict<'tcx> {
+    let mut cx = Cx {
+        env,
+        on_path: FxHashSet::default(),
+        path: Vec::new(),
+    };
+    cx.check(ty)
+}
+
+/// Is `Arc<inner>` well-formed — every member of `inner` `Sync`? Run after
+/// the kind gate has admitted `inner` as a shared rc box; inners the gate
+/// rejects report there and yield `Sync` here to avoid double diagnostics.
+pub fn wf_arc<'tcx>(env: &dyn SyncEnv<'tcx>, inner: Ty<'tcx>) -> SyncVerdict<'tcx> {
+    let mut cx = Cx {
+        env,
+        on_path: FxHashSet::default(),
+        path: Vec::new(),
+    };
+    cx.on_path.insert(inner);
+    cx.wf(inner)
+}
+
+struct Cx<'e, 'tcx> {
+    env: &'e dyn SyncEnv<'tcx>,
+    /// Arc inners currently being wf-checked on this path: a re-encounter is
+    /// a cycle and coinductively succeeds.
+    on_path: FxHashSet<Ty<'tcx>>,
+    path: Vec<String>,
+}
+
+impl<'tcx> Cx<'_, 'tcx> {
+    fn refute(&self, leaf: Ty<'tcx>, reason: NotSyncReason) -> SyncVerdict<'tcx> {
+        SyncVerdict::NotSync(Witness {
+            path: self.path.clone(),
+            leaf,
+            reason,
+        })
+    }
+
+    /// Fold a labeled member list: the first definite failure wins; a block
+    /// only surfaces when nothing fails outright.
+    fn fold(
+        &mut self,
+        members: impl IntoIterator<Item = (String, Ty<'tcx>)>,
+    ) -> SyncVerdict<'tcx> {
+        let mut blocked = false;
+        for (label, ty) in members {
+            self.path.push(label);
+            let verdict = self.check(ty);
+            self.path.pop();
+            match verdict {
+                SyncVerdict::Sync => {}
+                SyncVerdict::Blocked => blocked = true,
+                refuted @ SyncVerdict::NotSync(_) => return refuted,
+            }
+        }
+        if blocked {
+            SyncVerdict::Blocked
+        } else {
+            SyncVerdict::Sync
+        }
+    }
+
+    fn check(&mut self, ty: Ty<'tcx>) -> SyncVerdict<'tcx> {
+        use crate::semi::ctxt::DefaultCap;
+        match *ty.kind() {
+            TyKind::Int(_)
+            | TyKind::Fp(_)
+            | TyKind::Bool
+            | TyKind::Char
+            | TyKind::Unit
+            // `str` values are immutable byte references; the frontend type
+            // does not carry a lifescope (yet), so global and local strs are
+            // not distinguished here — see the design doc's str caveat.
+            | TyKind::Str
+            // Error recovery: don't cascade.
+            | TyKind::Bottom => SyncVerdict::Sync,
+            TyKind::Generic(_) | TyKind::Hole(_) => SyncVerdict::Blocked,
+            TyKind::Nullable(inner) => self.check(inner),
+            TyKind::Cell { exclusive, .. } => self.refute(
+                ty,
+                if exclusive {
+                    NotSyncReason::ExclusiveCell
+                } else {
+                    NotSyncReason::PlainCell
+                },
+            ),
+            // Bare shared rc boxes: never `Sync`, regardless of contents —
+            // shareability is carried by the box coloring (`Arc`), not the
+            // nominal type.
+            TyKind::Array { .. } | TyKind::Closure { .. } => {
+                self.refute(ty, NotSyncReason::NonAtomicBox)
+            }
+            TyKind::Record { def, args, .. } => match self.env.default_cap(def) {
+                None => SyncVerdict::Blocked,
+                Some(DefaultCap::Shared) => self.refute(ty, NotSyncReason::NonAtomicBox),
+                Some(DefaultCap::Regional) => self.refute(ty, NotSyncReason::Regional),
+                // A `[value]` record is inline storage: `Sync` iff its
+                // members are.
+                Some(DefaultCap::Value) => match self.env.members(def, args) {
+                    None => SyncVerdict::Blocked,
+                    Some(members) => self.fold(members),
+                },
+            },
+            TyKind::Arc(inner) => {
+                // Coinduction: an arc inner already being checked on this
+                // path is a cycle — assume it holds; a real violation shows
+                // up at a finite unfolding elsewhere.
+                if !self.on_path.insert(inner) {
+                    return SyncVerdict::Sync;
+                }
+                let verdict = self.wf(inner);
+                self.on_path.remove(&inner);
+                verdict
+            }
+        }
+    }
+
+    /// The `Arc` member rule. Anything the kind gate rejects as an arc inner
+    /// (scalars, cells, value/regional records, nested arcs, nullables) is
+    /// reported by the gate at its own site; here those yield `Sync` so one
+    /// error is emitted, not two.
+    fn wf(&mut self, inner: Ty<'tcx>) -> SyncVerdict<'tcx> {
+        use crate::semi::ctxt::DefaultCap;
+        match *inner.kind() {
+            TyKind::Record { def, args, .. } => match self.env.default_cap(def) {
+                Some(DefaultCap::Shared) => match self.env.members(def, args) {
+                    None => SyncVerdict::Blocked,
+                    Some(members) => self.fold(members),
+                },
+                None => SyncVerdict::Blocked,
+                // Value/regional inners: the kind gate's error.
+                Some(_) => SyncVerdict::Sync,
+            },
+            TyKind::Array { elem, .. } => {
+                self.path.push("the array element".to_owned());
+                let verdict = self.check(elem);
+                self.path.pop();
+                verdict
+            }
+            // Argument types only: applied arguments become captures, so the
+            // type-level bound covers every later partial application. The
+            // creation-site check of *environment* captures lands with arc'd
+            // closure construction.
+            TyKind::Closure { params, .. } => self.fold(
+                params
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &p)| (format!("closure argument {i}"), p)),
+            ),
+            TyKind::Generic(_) | TyKind::Hole(_) | TyKind::Bottom => SyncVerdict::Blocked,
+            // Everything else is the kind gate's error.
+            _ => SyncVerdict::Sync,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::semi::ctxt::DefaultCap;
+    use crate::semi::ty::{Flexivity, IntTy, Ty, TyCtxt};
+    use crate::with_tcx;
+    use rustc_hash::FxHashMap;
+
+    /// A synthetic record table: `def ↦ (cap, members)`. Members are stored
+    /// pre-instantiated (the tests use no generics).
+    #[derive(Default)]
+    struct TestEnv<'tcx> {
+        records: FxHashMap<DefId, (DefaultCap, Option<Vec<(String, Ty<'tcx>)>>)>,
+    }
+
+    impl<'tcx> SyncEnv<'tcx> for TestEnv<'tcx> {
+        fn default_cap(&self, def: DefId) -> Option<DefaultCap> {
+            self.records.get(&def).map(|(cap, _)| *cap)
+        }
+        fn members(&self, def: DefId, _args: &'tcx [Ty<'tcx>]) -> Option<Vec<(String, Ty<'tcx>)>> {
+            self.records.get(&def).and_then(|(_, m)| m.clone())
+        }
+    }
+
+    fn rec<'tcx>(tcx: &TyCtxt<'tcx>, def: u32) -> Ty<'tcx> {
+        tcx.mk_record(DefId(def), &[], Flexivity::Irrelevant)
+    }
+
+    #[test]
+    fn scalars_are_sync() {
+        with_tcx(|tcx: &TyCtxt| {
+            let env = TestEnv::default();
+            for ty in [tcx.mk_int(IntTy::Unsigned(64)), tcx.mk_bool(), tcx.mk_str()] {
+                assert!(matches!(sync_verdict(&env, ty), SyncVerdict::Sync));
+            }
+        });
+    }
+
+    #[test]
+    fn bare_shared_record_is_never_sync() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut env = TestEnv::default();
+            // Even with all-Sync members: shareability is the box coloring's.
+            env.records.insert(
+                DefId(0),
+                (
+                    DefaultCap::Shared,
+                    Some(vec![("a".into(), tcx.mk_int(IntTy::Signed(32)))]),
+                ),
+            );
+            let verdict = sync_verdict(&env, rec(tcx, 0));
+            let SyncVerdict::NotSync(w) = verdict else {
+                panic!("expected NotSync, got {verdict:?}");
+            };
+            assert_eq!(w.reason, NotSyncReason::NonAtomicBox);
+            assert!(w.path.is_empty());
+        });
+    }
+
+    #[test]
+    fn value_record_folds_members_with_path() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut env = TestEnv::default();
+            // [value] Mid { leaf: Leaf }, [shared] Leaf {} — the witness
+            // names the nested member path.
+            env.records
+                .insert(DefId(1), (DefaultCap::Shared, Some(vec![])));
+            let leaf = rec(tcx, 1);
+            env.records.insert(
+                DefId(2),
+                (DefaultCap::Value, Some(vec![("leaf".into(), leaf)])),
+            );
+            let mid = rec(tcx, 2);
+            env.records.insert(
+                DefId(3),
+                (DefaultCap::Value, Some(vec![("m".into(), mid)])),
+            );
+            let SyncVerdict::NotSync(w) = sync_verdict(&env, rec(tcx, 3)) else {
+                panic!("expected NotSync");
+            };
+            assert_eq!(w.path, vec!["m".to_owned(), "leaf".to_owned()]);
+            assert_eq!(w.reason, NotSyncReason::NonAtomicBox);
+        });
+    }
+
+    #[test]
+    fn arc_wf_requires_sync_members() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut env = TestEnv::default();
+            // [shared] Pair { a: i32 } — Arc<Pair> is WF and Sync.
+            env.records.insert(
+                DefId(0),
+                (
+                    DefaultCap::Shared,
+                    Some(vec![("a".into(), tcx.mk_int(IntTy::Signed(32)))]),
+                ),
+            );
+            let pair = rec(tcx, 0);
+            assert!(matches!(wf_arc(&env, pair), SyncVerdict::Sync));
+            assert!(matches!(
+                sync_verdict(&env, tcx.mk_arc(pair)),
+                SyncVerdict::Sync
+            ));
+
+            // [shared] Holder { p: Pair } — a bare shared member refutes.
+            env.records.insert(
+                DefId(1),
+                (DefaultCap::Shared, Some(vec![("p".into(), pair)])),
+            );
+            let SyncVerdict::NotSync(w) = wf_arc(&env, rec(tcx, 1)) else {
+                panic!("expected NotSync");
+            };
+            assert_eq!(w.path, vec!["p".to_owned()]);
+        });
+    }
+
+    #[test]
+    fn recursive_arc_is_coinductively_wf() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut env = TestEnv::default();
+            // [shared] Node { v: i64, next: Nullable<Arc<Node>> } — checking
+            // wf_arc(Node) re-encounters Arc<Node>; the cycle succeeds.
+            let node = rec(tcx, 0);
+            env.records.insert(
+                DefId(0),
+                (
+                    DefaultCap::Shared,
+                    Some(vec![
+                        ("v".into(), tcx.mk_int(IntTy::Signed(64))),
+                        ("next".into(), tcx.mk_nullable(tcx.mk_arc(node))),
+                    ]),
+                ),
+            );
+            assert!(matches!(wf_arc(&env, node), SyncVerdict::Sync));
+            assert!(matches!(
+                sync_verdict(&env, tcx.mk_arc(node)),
+                SyncVerdict::Sync
+            ));
+        });
+    }
+
+    #[test]
+    fn cells_refute_with_their_kind() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut env = TestEnv::default();
+            let i32t = tcx.mk_int(IntTy::Signed(32));
+            env.records.insert(
+                DefId(0),
+                (
+                    DefaultCap::Shared,
+                    Some(vec![("c".into(), tcx.mk_cell(i32t, false))]),
+                ),
+            );
+            let SyncVerdict::NotSync(w) = wf_arc(&env, rec(tcx, 0)) else {
+                panic!("expected NotSync");
+            };
+            assert_eq!(w.reason, NotSyncReason::PlainCell);
+            assert_eq!(w.path, vec!["c".to_owned()]);
+            assert!(matches!(
+                sync_verdict(&env, tcx.mk_cell(i32t, true)),
+                SyncVerdict::NotSync(Witness {
+                    reason: NotSyncReason::ExclusiveCell,
+                    ..
+                })
+            ));
+        });
+    }
+
+    #[test]
+    fn incomplete_records_block() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut env = TestEnv::default();
+            env.records.insert(DefId(0), (DefaultCap::Shared, None));
+            assert!(matches!(wf_arc(&env, rec(tcx, 0)), SyncVerdict::Blocked));
+            // Unknown def: also blocked (error recovery).
+            assert!(matches!(
+                sync_verdict(&env, rec(tcx, 9)),
+                SyncVerdict::Blocked
+            ));
+        });
+    }
+}

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -39,10 +39,12 @@
 //! binding. Generics are left uncolored — their modality is resolved at
 //! monomorphization.
 
+use crate::semi::infer::Instantiation;
+use crate::semi::traits::sync::{SyncEnv, SyncVerdict, wf_arc};
 use crate::semi::ty::{DefId, Flexivity, FpTy, IntTy, Ty, TyKind};
 use crate::surface::{self, FpType, IntegralType, TypeKind};
 
-use super::ctxt::{DefaultCap, Elaborator};
+use super::ctxt::{DefaultCap, Elaborator, RecordFields};
 
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Evaluate a surface type, coloring concrete regional records as
@@ -168,6 +170,13 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                                 self.ty_display(inner)
                             ),
                         );
+                    } else if self.records_complete {
+                        // Body-position annotations run after record fields
+                        // populate, so the member (`Sync`) half of the wf
+                        // check answers here. Signature and member positions
+                        // evaluate earlier and blocked — the post-populate
+                        // sweep re-checks them.
+                        self.report_arc_wf(inner, Some(span));
                     }
                     self.tcx.mk_arc(inner)
                 }
@@ -402,4 +411,106 @@ fn is_concretely_non_pointer(t: Ty<'_>) -> bool {
             | TyKind::Unit
             | TyKind::Nullable(_)
     )
+}
+
+//===------------------------------------------------------------------===//
+// Structural `Sync` over the elaborator's tables
+//===------------------------------------------------------------------===//
+
+/// [`SyncEnv`] over the elaborator: record capabilities from the collected
+/// table, member types instantiated through the inference context.
+pub(crate) struct ElabSyncEnv<'e, 'a, 'tcx> {
+    pub el: &'e Elaborator<'a, 'tcx>,
+}
+
+impl<'tcx> SyncEnv<'tcx> for ElabSyncEnv<'_, '_, 'tcx> {
+    fn default_cap(&self, def: DefId) -> Option<DefaultCap> {
+        self.el.records.get(&def).map(|r| r.default_cap)
+    }
+
+    fn members(&self, def: DefId, args: &'tcx [Ty<'tcx>]) -> Option<Vec<(String, Ty<'tcx>)>> {
+        let rec = self.el.records.get(&def)?;
+        let fields = rec.fields.as_ref()?;
+        let inst = Instantiation::from_pairs(
+            rec.ty_params
+                .iter()
+                .map(|(_, g)| *g)
+                .zip(args.iter().copied()),
+        );
+        let subst = |t: Ty<'tcx>| self.el.infer.instantiate_ty(t, &inst);
+        Some(match fields {
+            RecordFields::Named(fs) => fs
+                .iter()
+                .map(|(n, t, _)| (self.el.sym(*n).to_owned(), subst(*t)))
+                .collect(),
+            RecordFields::Unnamed(fs) => fs
+                .iter()
+                .enumerate()
+                .map(|(i, (t, _))| (i.to_string(), subst(*t)))
+                .collect(),
+            RecordFields::Variants(vs) => vs
+                .iter()
+                .flat_map(|v| {
+                    let vname = self.el.sym(v.name);
+                    v.fields
+                        .iter()
+                        .enumerate()
+                        .map(move |(i, t)| (format!("{vname}.{i}"), *t))
+                })
+                .map(|(label, t)| (label, subst(t)))
+                .collect(),
+        })
+    }
+}
+
+impl<'a, 'tcx> Elaborator<'a, 'tcx> {
+    /// Report an ill-formed `Arc<inner>` whose kind is admissible but whose
+    /// contents are not `Sync`. Call only where records are complete (the
+    /// post-populate sweep and body checking); a blocked verdict defers to
+    /// the monomorphization backstop.
+    pub(crate) fn report_arc_wf(&mut self, inner: Ty<'tcx>, span: Option<surface::Span>) {
+        if self.arc_inner_rejection(inner).is_some() {
+            // The kind gate owns this error at its own site.
+            return;
+        }
+        if let SyncVerdict::NotSync(w) = wf_arc(&ElabSyncEnv { el: self }, inner) {
+            self.error(
+                span,
+                format!(
+                    "`Arc<{}>` is ill-formed: {}; every member of an `Arc` inner must be `Sync`",
+                    self.ty_display(inner),
+                    w.describe()
+                ),
+            );
+        }
+    }
+
+    /// Walk a signature or member type and wf-check every `Arc` node inside
+    /// it. Function prototypes are scanned before record fields populate, so
+    /// their annotation-site checks blocked; the post-populate sweep re-runs
+    /// them through this walker (mono's `check_arc_inners` is the ground
+    /// backstop for what still blocks here, e.g. generic inners).
+    pub(crate) fn sweep_arc_wf(&mut self, ty: Ty<'tcx>, span: Option<surface::Span>) {
+        match *ty.kind() {
+            TyKind::Arc(inner) => {
+                self.report_arc_wf(inner, span);
+                self.sweep_arc_wf(inner, span);
+            }
+            TyKind::Record { args, .. } => {
+                for &arg in args {
+                    self.sweep_arc_wf(arg, span);
+                }
+            }
+            TyKind::Closure { params, ret } => {
+                for &p in params {
+                    self.sweep_arc_wf(p, span);
+                }
+                self.sweep_arc_wf(ret, span);
+            }
+            TyKind::Nullable(inner) => self.sweep_arc_wf(inner, span),
+            TyKind::Cell { elem, .. } => self.sweep_arc_wf(elem, span),
+            TyKind::Array { elem, .. } => self.sweep_arc_wf(elem, span),
+            _ => {}
+        }
+    }
 }

--- a/tests/integration/frontend/arc.rr
+++ b/tests/integration/frontend/arc.rr
@@ -36,9 +36,12 @@ pub fn call_passthrough(a: Arc<Data>) -> Arc<Data> {
     passthrough(a)
 }
 
-enum List<T> {
-    Nil,
-    Cons(T, List<T>)
+// Scalar payloads only: a recursive enum (`Cons(T, List<T>)`) holds a bare
+// shared box, so its `Arc` is rejected by the structural `Sync` check until
+// the per-member atomic axis lands (design doc §3.3 SCC promotion).
+enum Opt<T> {
+    None,
+    Some(T)
 }
 
 // The arc constructors are the inner record's own, at the arc'd type: the
@@ -52,11 +55,11 @@ pub fn make(v: i64) -> Arc<Data> {
     Arc<Data> { value: v }
 }
 
-// HIR: pub fn #make_list() -> Arc<#List::<i64>>
-// HIR-NEXT: #List::<i64>#1(1 : i64, #List::<i64>#0() : #List::<i64>) : Arc<#List::<i64>>
-// MIR-DAG: pub fn @_RC9make_list() -> Arc<List::<i64>>
-pub fn make_list() -> Arc<List<i64>> {
-    Arc<List<i64>>::Cons{1, List::Nil}
+// HIR: pub fn #make_opt() -> Arc<#Opt::<i64>>
+// HIR-NEXT: #Opt::<i64>#1(1 : i64) : Arc<#Opt::<i64>>
+// MIR-DAG: pub fn @_RC8make_opt() -> Arc<Opt::<i64>>
+pub fn make_opt() -> Arc<Opt<i64>> {
+    Arc<Opt<i64>>::Some{1}
 }
 
 // The lowering: an arc'd value is `!reussir.rc<…, atomic>`, constructed
@@ -88,13 +91,13 @@ pub fn read(a: Arc<Data>) -> i64 {
     a.value
 }
 
-// HIR: pub fn #head(v0 (l): Arc<#List::<i64>>) -> i64
-// HIR-NEXT: match v0 : Arc<#List::<i64>> {
-// MIR-DAG: pub fn @_RC4head(v0 (l): Arc<List::<i64>>) -> i64
-// MIR-DAG: match v0 : Arc<List::<i64>> {
-pub fn head(l: Arc<List<i64>>) -> i64 {
+// HIR: pub fn #head(v0 (l): Arc<#Opt::<i64>>) -> i64
+// HIR-NEXT: match v0 : Arc<#Opt::<i64>> {
+// MIR-DAG: pub fn @_RC4head(v0 (l): Arc<Opt::<i64>>) -> i64
+// MIR-DAG: match v0 : Arc<Opt::<i64>> {
+pub fn head(l: Arc<Opt<i64>>) -> i64 {
     match l {
-        List::Cons(x, _) => x,
-        List::Nil => 0
+        Opt::Some(x) => x,
+        Opt::None => 0
     }
 }

--- a/tests/integration/frontend/arc_e2e.rr
+++ b/tests/integration/frontend/arc_e2e.rr
@@ -1,7 +1,9 @@
 // End-to-end Arc semantics: the arc'd constructor allocates an atomically
-// counted box, sharing retains it atomically, reads (projection and
-// matching) are the inner record's own, and the arc colors only the outer
-// box — enum payload links stay plain shared values.
+// counted box, sharing retains it atomically, and reads (projection and
+// matching) are the inner record's own. Enum payloads are scalars: the arc
+// colors exactly one box, so a member holding a bare shared box (a recursive
+// tail link) is rejected by the structural `Sync` check until the per-member
+// atomic axis lands (design doc §3.3 SCC promotion).
 
 // RUN: %rrc %s -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/arc_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
@@ -14,9 +16,9 @@ struct [shared] Data {
     value: i64
 }
 
-enum List<T> {
-    Nil,
-    Cons(T, List<T>)
+enum Opt<T> {
+    None,
+    Some(T)
 }
 
 fn read_twice(a: Arc<Data>, b: Arc<Data>) -> i64 {
@@ -30,19 +32,13 @@ pub fn test_share() -> i64 {
 }
 extern "C" trampoline "test_share_ffi" = test_share;
 
-// The arc colors only the outer box: the tail links are plain shared lists.
-fn sum(l: List<i64>) -> i64 {
-    match l {
-        List::Cons(x, xs) => x + sum(xs),
-        List::Nil => 0
-    }
-}
-
+// An arc'd enum: the variant constructor is the inner enum's own, matching
+// peels the coloring, and drop releases the tagged payload atomically.
 pub fn test_enum() -> i64 {
-    let l = Arc<List<i64>>::Cons{7, List::Cons{35, List::Nil}};
+    let l = Arc<Opt<i64>>::Some{42};
     match l {
-        List::Cons(x, xs) => x + sum(xs),
-        List::Nil => 0
+        Opt::Some(x) => x,
+        Opt::None => 0
     }
 }
 extern "C" trampoline "test_enum_ffi" = test_enum;

--- a/tests/integration/frontend/arc_errors.rr
+++ b/tests/integration/frontend/arc_errors.rr
@@ -39,6 +39,13 @@ struct [regional] BadLink { value: [field] Arc<Shared> }
 // CHECK-DAG: `Arc` inner type `Arc<Shared>` is not a `[shared]` record, array, or closure (already an `Arc`)
 fn nested_inner(a: Arc<Arc<Shared>>) -> i64 { 0 }
 
+// The stratified wf rule: the arc colors exactly one box, so every member of
+// the inner must be `Sync` on its own — a recursive tail is a bare shared box
+// and refutes (until §3.3 SCC promotion lands with the per-member atomic axis).
+enum List<T> { Nil, Cons(T, List<T>) }
+// CHECK-DAG: `Arc<List<i64>>` is ill-formed: member `Cons.1` is a plain `[shared]` rc box whose refcount is not atomic; every member of an `Arc` inner must be `Sync`
+fn recursive_inner(l: Arc<List<i64>>) -> i64 { 0 }
+
 // The arc constructors demand an explicit `[shared]` record inner.
 // CHECK-DAG: `Arc` construction takes exactly one explicit type argument
 fn ctor_no_inner() -> i64 { Arc { value: 1 }; 0 }

--- a/tests/integration/sanitizer/e2e/arc.rr
+++ b/tests/integration/sanitizer/e2e/arc.rr
@@ -1,6 +1,6 @@
 // REQUIRES: asan
 // ASan+LSan gate over frontend/arc_e2e.rr: atomic retain/release balance on
-// the arc'd boxes (sharing, enum payload links, nullable wrapping, generic
+// the arc'd boxes (sharing, enum payloads, nullable wrapping, generic
 // instantiation) — a missed atomic decrement leaks, a doubled one
 // double-frees.
 


### PR DESCRIPTION
PR 1 of the thread-safety implementation stack (design: #438, discussed and ratified; stacked on #439). Implements open item 1 of `docs/design/thread-safety.md`: `Sync` becomes a real structural auto trait, and `Arc` gains the stratified member rule.

## The checker (`semi/traits/sync.rs`)

- `sync_verdict(τ)` — is a value of `τ` safe to reach from any thread? Scalars yes; bare `[shared]` records / arrays / closures **never** (their box refcount is not atomic, regardless of members — shareability is the box coloring's, not the nominal type's); `[value]` records fold over members; plain/exclusive cells no; regional no; `Nullable` transparent.
- `wf_arc(inner)` — the stratified Arc rule: the arc supplies atomicity for exactly the one box it wraps, so every member (array element, closure **argument type** — covering later partial applies) must be `Sync` on its own. Runs after the existing kind gate, so each failure reports exactly once.
- **Coinductive**: an `Arc` inner re-encountered on the current checking path succeeds, so recursive arc'd structures (`Arc<Node>` lists/trees) are well-formed once Arc members land; a genuine violation always surfaces at a finite unfolding.
- **Witness paths**: failures name the offending member chain — ``member `m.leaf` is a plain `[shared]` rc box whose refcount is not atomic`` — not just the root type.
- Record lookup sits behind a `SyncEnv` trait: the elaborator instantiates member types through the inference context; mono grounds them with `subst_ty`. Unknown defs, unpopulated fields, and generics yield `Blocked` → deferred.

## Enforcement points

| site | when |
|---|---|
| body-position `Arc<…>` annotations & the `Arc` ctor | inline, during body checking |
| function signatures & record member types | post-populate sweep in `run_files` (they evaluate before record fields exist; a `records_complete` flag prevents double-reporting, and the sweep is batch-scoped so REPL re-runs don't re-report) |
| generic-blocked verdicts | mono backstop: `check_arc_inners` re-checks every ground instantiation |
| `τ: Sync` obligations | fulfill routes ground goals to the checker; the trait keeps its declaration for name resolution but loses its scalar impls — one source of truth |

## Behavioral tightening (as designed)

Until the per-member atomic axis lands (PR 2), `Arc<X>` is satisfiable only when `X` has no rc members: `Arc<List<i32>>` with a bare `List` tail is now **rejected**, closing the deep-atomicity hole #426 deliberately left open (destructuring an arc'd list bound the tail at a normal refcount). Existing tests that used it move to scalar-payload enums; nothing lowerable breaks (`Arc` codegen is still unimplemented).

New tests: witness paths (nested through `[value]` records), ctor-site rejection, cell members, coinductive recursion + incomplete-record blocking (unit), and the mono trampoline-grounding backstop. `cargo test -p reussir-core`: 280 passed. Clippy: no new warnings. Workspace checks clean.

Next in the stack: **PR 2** — `memberIsAtomic` axis on the MLIR `RecordType` + lifting `reject_arc_member`; **PR 3** — sync-cell surface types with `Sync(τ)` element bounds; **PR 4** — arc'd array/closure construction + creation-site capture checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4ihrGS9WQXXCw7k1VMdGC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786987844&installation_id=144622820&pr_number=440&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F440&signature=18c99d6f72572dc56a7374155366e98193c6025222fa58000259c8fbb91fe587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->