### PR TITLE
[misc] migrate source license headers to LLVM style

### DIFF
--- a/include/Reussir-c/Attrs.h
+++ b/include/Reussir-c/Attrs.h
@@ -1,16 +1,19 @@
-//===-- Attrs.h - Reussir dialect attribute C API --------------*- C -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// C API constructors for the Reussir debug-info attributes. These attributes
-// describe a value's debug type / variable so the debug-info conversion pass
-// can emit LLVM DI; they use custom storage that the generic MLIR C API cannot
-// build, so the code generator constructs them through these entry points.
-//
+///
+/// \file
+/// C API constructors for the Reussir debug-info attributes. These attributes
+/// describe a value's debug type / variable so the debug-info conversion pass
+/// can emit LLVM DI; they use custom storage that the generic MLIR C API cannot
+/// build, so the code generator constructs them through these entry points.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_C_ATTRS_H

--- a/include/Reussir-c/Dialects.h
+++ b/include/Reussir-c/Dialects.h
@@ -1,15 +1,18 @@
-//===-- Dialects.h - Reussir dialect C API ---------------------*- C -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// C API entry points for the Reussir dialect. These let Rust bindings built on
-// the MLIR C API (mlir-sys / melior) register and load the out-of-tree Reussir
-// dialect alongside the upstream dialects it depends on.
-//
+///
+/// \file
+/// C API entry points for the Reussir dialect. These let Rust bindings built on
+/// the MLIR C API (mlir-sys / melior) register and load the out-of-tree Reussir
+/// dialect alongside the upstream dialects it depends on.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_C_DIALECTS_H

--- a/include/Reussir-c/Jit.h
+++ b/include/Reussir-c/Jit.h
@@ -1,17 +1,20 @@
-//===-- Jit.h - Reussir JIT codegen C API ----------------------*- C -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// LLVM-side codegen helpers for the Rust ORC JIT (reussir-jit). These are the
-// pieces that cannot be expressed through the LLVM-C ORC API the Rust engine is
-// built on: the Reussir custom LLVM optimization pipeline (which runs C++
-// passes) and TPDE object compilation. They operate on opaque `LLVMModuleRef`
-// values so the Rust side can keep driving the ORC session through llvm-sys.
-//
+///
+/// \file
+/// LLVM-side codegen helpers for the Rust ORC JIT (reussir-jit). These are the
+/// pieces that cannot be expressed through the LLVM-C ORC API used by the Rust
+/// engine: the Reussir custom LLVM optimization pipeline (which runs C++
+/// passes) and TPDE object compilation. They operate on opaque `LLVMModuleRef`
+/// values so the Rust side can keep driving the ORC session through llvm-sys.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_C_JIT_H

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -1,16 +1,19 @@
-//===-- Passes.h - Reussir backend pipeline C API --------------*- C -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// C API for assembling the Reussir lowering pipeline from Rust. Each Reussir
-// (and required upstream) pass is exposed as an MlirPass factory so the Rust
-// backend can build the pipeline step by step with melior's pass manager, plus
-// the standalone helpers the pipeline depends on.
-//
+///
+/// \file
+/// C API for assembling the Reussir lowering pipeline from Rust. Each Reussir
+/// (and required upstream) pass is exposed as an MlirPass factory so the Rust
+/// backend can build the pipeline step by step with melior's pass manager, plus
+/// the standalone helpers the pipeline depends on.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_C_PASSES_H

--- a/include/Reussir-c/Types.h
+++ b/include/Reussir-c/Types.h
@@ -1,17 +1,20 @@
-//===-- Types.h - Reussir dialect type C API -------------------*- C -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// C API constructors for the Reussir dialect types. The dialect types use
-// custom printers/parsers, so the generic MLIR C API cannot build them; these
-// entry points wrap each type's C++ `get` builder so the Rust bindings
-// (mlir-sys / melior) can construct Reussir types directly rather than by
-// round-tripping through textual MLIR.
-//
+///
+/// \file
+/// C API constructors for the Reussir dialect types. The dialect types use
+/// custom printers/parsers, so the generic MLIR C API cannot build them; these
+/// entry points wrap each type's C++ `get` builder so the Rust bindings
+/// (mlir-sys / melior) can construct Reussir types directly rather than by
+/// round-tripping through textual MLIR.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_C_TYPES_H

--- a/include/Reussir/Analysis/AliasAnalysis.h
+++ b/include/Reussir/Analysis/AliasAnalysis.h
@@ -1,9 +1,16 @@
-//===-- AliasAnalysis.h - Reussir alias analysis header ---------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file declares the Reussir alias analysis.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Bridge.h
+++ b/include/Reussir/Bridge.h
@@ -1,13 +1,16 @@
-//===-- Bridge.h - Reussir backend bridge -----------------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the bridge between rust frontend and C++ backend.
-//
+///
+/// \file
+/// This file implements the bridge between rust frontend and C++ backend.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Conversion/AcquireDropExpansion.h
+++ b/include/Reussir/Conversion/AcquireDropExpansion.h
@@ -1,14 +1,17 @@
-//===-- AcquireDropExpansion.h - Reussir acquire/drop expansion -*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides expansion patterns for Reussir acquire and drop
-// operations.
-//
+///
+/// \file
+/// This header file provides expansion patterns for Reussir acquire and drop
+/// operations.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Conversion/AttachNativeTarget.h
+++ b/include/Reussir/Conversion/AttachNativeTarget.h
@@ -1,9 +1,16 @@
-//===-- AttachNativeTarget.h - Attach native target pass --------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file declares the pass that attaches native target information.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_CONVERSION_ATTACHNATIVETARGET_H

--- a/include/Reussir/Conversion/AttachRegionVtables.h
+++ b/include/Reussir/Conversion/AttachRegionVtables.h
@@ -1,14 +1,19 @@
-//===-- RegionPatterns.h (legacy header) - deprecated  --*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides lowering patterns for attaching vtables to regions.
-//
+///
+/// \file
+/// This header file provides lowering patterns for attaching vtables to
+/// regions.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_CONVERSION_ATTACHREGIONVTABLES_H
 #define REUSSIR_CONVERSION_ATTACHREGIONVTABLES_H

--- a/include/Reussir/Conversion/BasicOpsLowering.h
+++ b/include/Reussir/Conversion/BasicOpsLowering.h
@@ -1,14 +1,18 @@
-//===-- BasicOpsLowering.h - Reussir basic ops lowering --------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides lowering patterns for basic Reussir operations.
-//
+///
+/// \file
+/// This header file provides lowering patterns for basic Reussir operations.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_CONVERSION_BASICOPSLOWERING_H
 #define REUSSIR_CONVERSION_BASICOPSLOWERING_H

--- a/include/Reussir/Conversion/Blake3Symbol.h
+++ b/include/Reussir/Conversion/Blake3Symbol.h
@@ -1,23 +1,27 @@
-//===-- Blake3Symbol.h - BLAKE3-hashed symbol mangling ---------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// Content-addressed symbol names for lowering-generated globals (panic
-// messages, string prefixes, string dispatchers): a Rust-v0-style identifier
-// `_RNvC<len(ns)><ns><len(digits)>[_]<digits>` whose digits are the base-62
-// encoding of the payload's 256-bit BLAKE3 digest.
-//
-// The digest-to-number convention matches the Rust frontend's `StringToken`
-// (`reussir-core`'s `utils::string` + `utils::b62`): each 8-byte chunk of the
-// digest is combined little-endian into a word, word 0 is the most
-// significant, and the alphabet is `0-9a-zA-Z`. Both sides therefore derive
-// identical digits from the same payload, on any host.
-//
+///
+/// \file
+/// Content-addressed symbol names for lowering-generated globals (panic
+/// messages, string prefixes, string dispatchers): a Rust-v0-style identifier
+/// `_RNvC<len(ns)><ns><len(digits)>[_]<digits>` whose digits are the base-62
+/// encoding of the payload's 256-bit BLAKE3 digest.
+///
+/// The digest-to-number convention matches the Rust frontend's `StringToken`
+/// (`reussir-core`'s `utils::string` + `utils::b62`): each 8-byte chunk of the
+/// digest is combined little-endian into a word, word 0 is the most
+/// significant, and the alphabet is `0-9a-zA-Z`. Both sides therefore derive
+/// identical digits from the same payload, on any host.
+///
 //===----------------------------------------------------------------------===//
+
 #ifndef REUSSIR_CONVERSION_BLAKE3SYMBOL_H
 #define REUSSIR_CONVERSION_BLAKE3SYMBOL_H
 

--- a/include/Reussir/Conversion/CABISignatureConversion.h
+++ b/include/Reussir/Conversion/CABISignatureConversion.h
@@ -1,14 +1,17 @@
-//===-- CABISignatureConversion.h - C ABI signature conversion -*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header defines helpers for evaluating C ABI-facing trampoline
-// signatures from internal LLVM-level function types.
-//
+///
+/// \file
+/// This header defines helpers for evaluating C ABI-facing trampoline
+/// signatures from internal LLVM-level function types.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Conversion/ClosureOutlining.h
+++ b/include/Reussir/Conversion/ClosureOutlining.h
@@ -1,13 +1,16 @@
-//===-- ClosureOutlining.h - Reussir closure outlining -------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides the ClosureOutlining pass declaration.
-//
+///
+/// \file
+/// This header file provides the ClosureOutlining pass declaration.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Conversion/ClosureWpd.h
+++ b/include/Reussir/Conversion/ClosureWpd.h
@@ -1,32 +1,36 @@
-//===-- ClosureWpd.h - closure whole-program devirt type ids ---*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// Type identifiers for whole-program devirtualization (WPD) of closures.
-//
-// `closure.apply`/`closure.uniqify`/`closure.clone` never change a closure's
-// vtable — only the static type (one fewer leading parameter) and the cursor
-// — so the RETURN type is the one component of the static type that every
-// value backed by the same vtable agrees on. It is also the only thing the
-// slot ABIs depend on (`evaluate` is `fn(rc<box>) -> c` reading all arguments
-// from the payload; `drop`/`clone` are signature-free). Each closure vtable
-// therefore carries exactly one type id, keyed by its return type, and each
-// indirect slot call site asserts the id of its operand's return type: the
-// minimal scheme under which every vtable observable at a tested site carries
-// the tested id, which is all `WholeProgramDevirt` requires.
-//
-// The id embeds the base-62 BLAKE3 digest of the return type's canonical
-// textual form (the `Blake3Symbol.h` convention), so identical return types
-// produce identical ids in any module. Ids are metadata strings, never
-// symbols, so no mangling scheme applies.
-//
-// See docs/design/closure-wpd.md for the full design.
-//
+///
+/// \file
+/// Type identifiers for whole-program devirtualization (WPD) of closures.
+///
+/// `closure.apply`/`closure.uniqify`/`closure.clone` never change a closure's
+/// vtable — only the static type (one fewer leading parameter) and the cursor
+/// — so the RETURN type is the one component of the static type that every
+/// value backed by the same vtable agrees on. It is also the only thing the
+/// slot ABIs depend on (`evaluate` is `fn(rc<box>) -> c` reading all arguments
+/// from the payload; `drop`/`clone` are signature-free). Each closure vtable
+/// therefore carries exactly one type id, keyed by its return type, and each
+/// indirect slot call site asserts the id of its operand's return type: the
+/// minimal scheme under which every vtable observable at a tested site carries
+/// the tested id, which is all `WholeProgramDevirt` requires.
+///
+/// The id embeds the base-62 BLAKE3 digest of the return type's canonical
+/// textual form (the `Blake3Symbol.h` convention), so identical return types
+/// produce identical ids in any module. Ids are metadata strings, never
+/// symbols, so no mangling scheme applies.
+///
+/// See docs/design/closure-wpd.md for the full design.
+///
 //===----------------------------------------------------------------------===//
+
 #ifndef REUSSIR_CONVERSION_CLOSUREWPD_H
 #define REUSSIR_CONVERSION_CLOSUREWPD_H
 

--- a/include/Reussir/Conversion/ConvertToSTD.h
+++ b/include/Reussir/Conversion/ConvertToSTD.h
@@ -1,15 +1,19 @@
-//===-- ConvertToSTD.h - Reussir standard conversion ------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides patterns that lower high-level Reussir operations
-// to standard MLIR dialects.
-//
+///
+/// \file
+/// This header file provides patterns that lower high-level Reussir operations
+/// to standard MLIR dialects.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_CONVERSION_CONVERTTOSTD_H
 #define REUSSIR_CONVERSION_CONVERTTOSTD_H

--- a/include/Reussir/Conversion/Passes.h
+++ b/include/Reussir/Conversion/Passes.h
@@ -1,15 +1,19 @@
-//===-- Passes.h - Reussir conversion passes --------------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides the definitions for conversion passes used in the
-// Reussir dialect.
-//
+///
+/// \file
+/// This header file provides the definitions for conversion passes used in the
+/// Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_CONVERSION_PASSES_H
 #define REUSSIR_CONVERSION_PASSES_H

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -1,15 +1,19 @@
-//===-- Passes.td - Conversion pass definition file --------*- tablegen -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines the lowering and conversion passes for the Reussir
-// dialect.
-//
+///
+/// \file
+/// This file defines the lowering and conversion passes for the Reussir
+/// dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #ifndef REUSSIR_CONVERSION_PASSES_TD
 #define REUSSIR_CONVERSION_PASSES_TD
 

--- a/include/Reussir/Conversion/RcDecrementExpansion.h
+++ b/include/Reussir/Conversion/RcDecrementExpansion.h
@@ -1,14 +1,17 @@
-//===-- RcDecrementExpansion.h - Reussir rc decrement expansion -*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides expansion patterns for Reussir rc decrement
-// operations.
-//
+///
+/// \file
+/// This header file provides expansion patterns for Reussir rc decrement
+/// operations.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Conversion/RegionPatterns.h
+++ b/include/Reussir/Conversion/RegionPatterns.h
@@ -1,14 +1,18 @@
-//===-- RegionPatterns.h - Reussir region-related patterns --*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides lowering/cleanup patterns related to region ops.
-//
+///
+/// \file
+/// This header file provides lowering/cleanup patterns related to region ops.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_CONVERSION_REGIONPATTERNS_H
 #define REUSSIR_CONVERSION_REGIONPATTERNS_H

--- a/include/Reussir/Conversion/TypeConverter.h
+++ b/include/Reussir/Conversion/TypeConverter.h
@@ -1,14 +1,18 @@
-//===-- TypeConverter.h - Reussir type conversion utilities ---*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides type conversion utilities for the Reussir dialect.
-//
+///
+/// \file
+/// This header file provides type conversion utilities for the Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_CONVERSION_TYPECONVERTER_H
 #define REUSSIR_CONVERSION_TYPECONVERTER_H

--- a/include/Reussir/IR/ReussirAttrs.h
+++ b/include/Reussir/IR/ReussirAttrs.h
@@ -1,15 +1,19 @@
-//===-- ReussirAttrs.h - Reussir dialect operations -------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides the definitions for the attributes used in the
-// Reussir dialect.
-//
+///
+/// \file
+/// This header file provides the definitions for the attributes used in the
+/// Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_IR_REUSSIRATTRS_H
 #define REUSSIR_IR_REUSSIRATTRS_H

--- a/include/Reussir/IR/ReussirAttrs.td
+++ b/include/Reussir/IR/ReussirAttrs.td
@@ -1,13 +1,16 @@
-//===-- ReussirAttrs.td - Reussir dialect attributes -------*- tablegen -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines the Reussir dialect attributes.
-//
+///
+/// \file
+/// This file defines the Reussir dialect attributes.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_IR_REUSSIRATTRS_TD

--- a/include/Reussir/IR/ReussirDialect.h
+++ b/include/Reussir/IR/ReussirDialect.h
@@ -1,14 +1,18 @@
-//===-- ReussirDialect.h - Reussir dialect definition ----------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file defines the Reussir dialect and its core functionality.
-//
+///
+/// \file
+/// This header file defines the Reussir dialect and its core functionality.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_IR_REUSSIRDIALECT_H
 #define REUSSIR_IR_REUSSIRDIALECT_H

--- a/include/Reussir/IR/ReussirDialect.td
+++ b/include/Reussir/IR/ReussirDialect.td
@@ -1,14 +1,17 @@
-//===-- ReussirDialect.td - Reussir dialect definition -----*- tablegen -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines the Reussir dialect. This is to be used as a common
-// tablegen header that provides common dialect references.
-//
+///
+/// \file
+/// This file defines the Reussir dialect. This is to be used as a common
+/// tablegen header that provides common dialect references.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_IR_REUSSIRDIALECT_TD

--- a/include/Reussir/IR/ReussirEnumAttrs.h
+++ b/include/Reussir/IR/ReussirEnumAttrs.h
@@ -1,15 +1,19 @@
-//===-- ReussirEnumAttrs.h - Reussir enum attributes -----------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides the definitions for enum attributes used in the
-// Reussir dialect.
-//
+///
+/// \file
+/// This header file provides the definitions for enum attributes used in the
+/// Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_IR_REUSSIRENUMATTRS_H
 #define REUSSIR_IR_REUSSIRENUMATTRS_H

--- a/include/Reussir/IR/ReussirInterfaces.h
+++ b/include/Reussir/IR/ReussirInterfaces.h
@@ -1,13 +1,16 @@
-//===-- ReussirInterfaces.h - Reussir Interfaces ---------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file declares the interfaces for the Reussir dialect.
-//
+///
+/// \file
+/// This file declares the interfaces for the Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_IR_REUSSIRINTERFACES_H

--- a/include/Reussir/IR/ReussirInterfaces.td
+++ b/include/Reussir/IR/ReussirInterfaces.td
@@ -1,13 +1,16 @@
-//===-- ReussirInterfaces.td - Reussir Interfaces ----------*- tablegen -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines the interfaces for the Reussir dialect.
-//
+///
+/// \file
+/// This file defines the interfaces for the Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_IR_REUSSIRINTERFACES_TD

--- a/include/Reussir/IR/ReussirOps.h
+++ b/include/Reussir/IR/ReussirOps.h
@@ -1,15 +1,19 @@
-//===-- ReussirOps.h - Reussir dialect operations ---------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides the definitions for operations used in the Reussir
-// dialect.
-//
+///
+/// \file
+/// This header file provides the definitions for operations used in the Reussir
+/// dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_IR_REUSSIROPS_H
 #define REUSSIR_IR_REUSSIROPS_H

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1,13 +1,16 @@
-//===-- ReussirOps.td - Reussir dialect operations ---------*- tablegen -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines the Reussir dialect operations.
-//
+///
+/// \file
+/// This file defines the Reussir dialect operations.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_IR_REUSSIROPS_TD

--- a/include/Reussir/IR/ReussirTypeDetails.h
+++ b/include/Reussir/IR/ReussirTypeDetails.h
@@ -1,15 +1,19 @@
-//===-- ReussirTypeDetails.h - Reussir type details impl --------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the types used in the Reussir dialect (internal
-// details).
-//
+///
+/// \file
+/// This file implements the types used in the Reussir dialect (internal
+/// details).
+///
 //===----------------------------------------------------------------------===//
+
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/Hashing.h>
 #include <llvm/Support/TypeSize.h>

--- a/include/Reussir/IR/ReussirTypes.h
+++ b/include/Reussir/IR/ReussirTypes.h
@@ -1,15 +1,19 @@
-//===-- ReussirTypes.h - Reussir dialect types ------------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides the definitions for types used in the Reussir
-// dialect.
-//
+///
+/// \file
+/// This header file provides the definitions for types used in the Reussir
+/// dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #include <mlir/IR/Builders.h>
 #ifndef REUSSIR_IR_REUSSIRTYPES_H

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -1,14 +1,16 @@
-//===-- ReussirTypes.td - Reussir dialect types -------------*- tablegen
-//-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines the Reussir dialect types.
-//
+///
+/// \file
+/// This file defines the Reussir dialect types.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_IR_REUSSIRTYPES_TD

--- a/include/Reussir/LLVMPass/AllocationSimplication.h
+++ b/include/Reussir/LLVMPass/AllocationSimplication.h
@@ -1,14 +1,17 @@
-//===- AllocationSimplication.h - Reussir LLVM allocation pass -*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This pass simplifies runtime allocation/deallocation calls when pointer
-// operands are compile-time null.
-//
+///
+/// \file
+/// This pass simplifies runtime allocation/deallocation calls when pointer
+/// operands are compile-time null.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/LLVMPass/RuntimeFunctionAttributor.h
+++ b/include/Reussir/LLVMPass/RuntimeFunctionAttributor.h
@@ -1,14 +1,17 @@
-//===- RuntimeFunctionAttributor.h - Reussir runtime attrib pass *- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This pass applies canonical LLVM function attributes to Reussir runtime
-// allocation/deallocation entry points.
-//
+///
+/// \file
+/// This pass applies canonical LLVM function attributes to Reussir runtime
+/// allocation/deallocation entry points.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/RustCompiler.h
+++ b/include/Reussir/RustCompiler.h
@@ -1,3 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file declares helpers for locating and invoking the Rust compiler.
+///
+//===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_RUSTCOMPILER_H
 #define REUSSIR_RUSTCOMPILER_H

--- a/include/Reussir/Support/AllocatorBinModel.h
+++ b/include/Reussir/Support/AllocatorBinModel.h
@@ -1,9 +1,16 @@
-//===-- AllocatorBinModel.h - default allocator size-class map -*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
-// SPDX-License-Identifier: Apache-2.0 With LLVM Exceptions OR MIT
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines the default allocator size-class model.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Support/Immer.h
+++ b/include/Reussir/Support/Immer.h
@@ -1,3 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines aliases for unsynchronized Immer collections.
+///
+//===----------------------------------------------------------------------===//
+
 #pragma once
 
 #ifndef REUSSIR_SUPPORT_IMMER_H

--- a/include/Reussir/Transformation/IncDecCancellation.h
+++ b/include/Reussir/Transformation/IncDecCancellation.h
@@ -1,14 +1,17 @@
-//===-- IncDecCancellation.h - Reussir inc/dec cancellation -*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides patterns for canceling adjacent increment and
-// decrement operations in Reussir.
-//
+///
+/// \file
+/// This header file provides patterns for canceling adjacent increment and
+/// decrement operations in Reussir.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Transformation/InferVariantTag.h
+++ b/include/Reussir/Transformation/InferVariantTag.h
@@ -1,14 +1,17 @@
-//===-- InferVariantTag.h - Reussir variant tag inference -*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides patterns for inferring variant tags in Reussir
-// drop and acquire operations.
-//
+///
+/// \file
+/// This header file provides patterns for inferring variant tags in Reussir
+/// drop and acquire operations.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Transformation/InvariantGroupAnalysis.h
+++ b/include/Reussir/Transformation/InvariantGroupAnalysis.h
@@ -1,14 +1,17 @@
-//===-- InvariantGroupAnalysis.h - Invariant group analysis -*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file declares the invariant group analysis pass for Reussir
-// ref.load operations.
-//
+///
+/// \file
+/// This header file declares the invariant group analysis pass for Reussir
+/// ref.load operations.
+///
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/include/Reussir/Transformation/Passes.h
+++ b/include/Reussir/Transformation/Passes.h
@@ -1,15 +1,19 @@
-//===-- Passes.h - Reussir transformation passes --------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides the definitions for transformation passes used in
-// the Reussir dialect.
-//
+///
+/// \file
+/// This header file provides the definitions for transformation passes used in
+/// the Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_TRANSFORMATION_PASSES_H
 #define REUSSIR_TRANSFORMATION_PASSES_H

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -1,15 +1,19 @@
-//===-- Passes.td - Transformation pass definition file ----*- tablegen -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines the transformation and analysis passes for the Reussir
-// dialect.
-//
+///
+/// \file
+/// This file defines the transformation and analysis passes for the Reussir
+/// dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #ifndef REUSSIR_TRANSFORMATION_PASSES_TD
 #define REUSSIR_TRANSFORMATION_PASSES_TD
 

--- a/include/Reussir/Transformation/SpecialPointerTag.h
+++ b/include/Reussir/Transformation/SpecialPointerTag.h
@@ -1,9 +1,17 @@
-//===-- SpecialPointerTag.h - Nullary variants as immediates ----*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
-// SPDX-License-Identifier: Apache-2.0 With LLVM Exceptions OR MIT
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file declares support for encoding nullary variants as immediate
+/// pointers.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef REUSSIR_TRANSFORMATION_SPECIALPOINTERTAG_H

--- a/include/Reussir/Transformation/TokenReuse.h
+++ b/include/Reussir/Transformation/TokenReuse.h
@@ -1,14 +1,18 @@
-//===-- TokenReuse.h - Reussir token reuse pass ----------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This header file provides the definition for the token reuse pass.
-//
+///
+/// \file
+/// This header file provides the definition for the token reuse pass.
+///
 //===----------------------------------------------------------------------===//
+
 #pragma once
 #ifndef REUSSIR_TRANSFORMATION_TOKENREUSE_H
 #define REUSSIR_TRANSFORMATION_TOKENREUSE_H

--- a/lib/Analysis/AliasAnalysis.cpp
+++ b/lib/Analysis/AliasAnalysis.cpp
@@ -1,9 +1,16 @@
-//===-- AliasAnalysis.cpp - Reussir alias analysis impl ---------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir alias analysis.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Analysis/AliasAnalysis.h"

--- a/lib/Bridge/Bridge.cppm
+++ b/lib/Bridge/Bridge.cppm
@@ -1,13 +1,18 @@
-//===-- Bridge.cppm - Reussir backend bridge --------------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the bridge between frontend and backend.
+///
+/// \file
+/// This file implements the bridge between frontend and backend.
+///
 //===----------------------------------------------------------------------===//
+
 module;
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ADT/Twine.h>

--- a/lib/Bridge/JITEngine.cppm
+++ b/lib/Bridge/JITEngine.cppm
@@ -1,13 +1,18 @@
-//===-- JITEngine.cppm - Reussir JIT engine ---------------------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the JIT engine for Reussir.
+///
+/// \file
+/// This file implements the JIT engine for Reussir.
+///
 //===----------------------------------------------------------------------===//
+
 module;
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ExecutionEngine/Orc/AbsoluteSymbols.h>

--- a/lib/Bridge/Logging.cppm
+++ b/lib/Bridge/Logging.cppm
@@ -1,3 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir logging bridge module.
+///
+//===----------------------------------------------------------------------===//
+
 module;
 #include "Reussir/Bridge.h"
 #include <memory>

--- a/lib/CAPI/Attrs.cpp
+++ b/lib/CAPI/Attrs.cpp
@@ -1,9 +1,16 @@
-//===-- Attrs.cpp - Reussir dialect attribute C API -----------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir attribute C API.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir-c/Attrs.h"

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -1,9 +1,16 @@
-//===-- Dialects.cpp - Reussir dialect C API ------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir dialect C API.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir-c/Dialects.h"

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -1,9 +1,16 @@
-//===-- Jit.cpp - Reussir JIT codegen C API -------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir JIT code generation C API.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir-c/Jit.h"

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -1,9 +1,16 @@
-//===-- Passes.cpp - Reussir backend pipeline C API ----------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir backend pipeline C API.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir-c/Passes.h"

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -1,9 +1,16 @@
-//===-- Types.cpp - Reussir dialect type C API ----------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir type C API.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir-c/Types.h"

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -1,10 +1,16 @@
-//===-- AcquireDropExpansion.cpp - Reussir acquire/drop expansion -*- C++
-//-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements Reussir acquire and drop expansion.
+///
 //===----------------------------------------------------------------------===//
 
 #include <algorithm>

--- a/lib/Conversion/AttachNativeTarget/AttachNativeTarget.cpp
+++ b/lib/Conversion/AttachNativeTarget/AttachNativeTarget.cpp
@@ -1,9 +1,16 @@
-//===-- AttachNativeTarget.cpp - Attach native target pass ------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the pass that attaches native target information.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/AttachNativeTarget.h"

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -1,9 +1,16 @@
-//===-- BasicOpsLowering.cpp - Reussir basic ops lowering impl --*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements lowering for basic Reussir operations.
+///
 //===----------------------------------------------------------------------===//
 
 #include <llvm/ADT/ArrayRef.h>

--- a/lib/Conversion/BasicOpsLowering/CABISignatureConversion.cpp
+++ b/lib/Conversion/BasicOpsLowering/CABISignatureConversion.cpp
@@ -1,10 +1,16 @@
-//===-- CABISignatureConversion.cpp - C ABI signature conversion -*- C++
-//-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements C ABI signature conversion.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/CABISignatureConversion.h"

--- a/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
+++ b/lib/Conversion/BasicOpsLowering/DbgInfoConversion.cpp
@@ -1,14 +1,16 @@
-
-//===-- DbgInfoConversion.cpp - Reussir debug info conversion ---*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements lowering of Reussir debug info attributes to LLVM DI.
-//
+///
+/// \file
+/// This file implements lowering of Reussir debug info attributes to LLVM DI.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/BasicOpsLowering.h"

--- a/lib/Conversion/BasicOpsLowering/VariantDebugInfo.cpp
+++ b/lib/Conversion/BasicOpsLowering/VariantDebugInfo.cpp
@@ -1,26 +1,30 @@
-//===-- VariantDebugInfo.cpp - variant_part DWARF fixup ---------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// MLIR's `DICompositeTypeAttr` has no discriminator field, so the debug-info
-// conversion can only describe an enum as a `{ tag, payload-union }` struct: a
-// debugger then shows every case overlapping and leaves the user to read the
-// tag. This post-translation pass rewrites that struct into a real DWARF
-// `DW_TAG_variant_part` — a discriminant member plus one `DW_TAG_variant` per
-// case carrying its `DW_AT_discr_value` — which gdb uses to display only the
-// live case.
-//
-// It runs on the translated `llvm::Module` because the `discriminator` operand
-// (and the per-case discriminant constant) exist only at the LLVM-DI level,
-// not in MLIR's attribute. The composite is rewritten *in place*: every Reussir
-// composite is a `distinct` node, so mutating its `elements` operand preserves
-// node identity — a recursive payload that points back at the enum, and every
-// variable whose type is the enum, see the variant_part with no further work.
-//
+///
+/// \file
+/// MLIR's `DICompositeTypeAttr` has no discriminator field, so the debug-info
+/// conversion can only describe an enum as a `{ tag, payload-union }` struct: a
+/// debugger then shows every case overlapping and leaves the user to read the
+/// tag. This post-translation pass rewrites that struct into a real DWARF
+/// `DW_TAG_variant_part` — a discriminant member plus one `DW_TAG_variant` per
+/// case carrying its `DW_AT_discr_value` — which gdb uses to display only the
+/// live case.
+///
+/// It runs on the translated `llvm::Module` because the `discriminator` operand
+/// (and the per-case discriminant constant) exist only at the LLVM-DI level,
+/// not in MLIR's attribute. The composite is rewritten *in place*: every
+/// Reussir composite is a `distinct` node, so mutating its `elements` operand
+/// preserves node identity — a recursive payload that points back at the enum,
+/// and every variable whose type is the enum, see the variant_part with no
+/// further work.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/Passes.h"

--- a/lib/Conversion/ClosureOutlining/ClosureOutlining.cpp
+++ b/lib/Conversion/ClosureOutlining/ClosureOutlining.cpp
@@ -1,9 +1,16 @@
-//===-- ClosureOutlining.cpp ------------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir closure outlining pass.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/ClosureOutlining.h"

--- a/lib/Conversion/CompilePolymorphicFFI/CompilePolymorphicFFI.cpp
+++ b/lib/Conversion/CompilePolymorphicFFI/CompilePolymorphicFFI.cpp
@@ -1,16 +1,18 @@
-//===-- CompilePolymorphicFFI.cpp - Compile polymorphic FFI pass --*- C++
-//-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the CompilePolymorphicFFI pass which compiles
-// polymorphic FFI template into concrete LLVM bitcode and embeds them into the
-// module.
-//
+///
+/// \file
+/// This file implements the CompilePolymorphicFFI pass which compiles
+/// polymorphic FFI template into concrete LLVM bitcode and embeds them into the
+/// module.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/Passes.h"

--- a/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
+++ b/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
@@ -1,9 +1,17 @@
-//===-- ConvertToSTD.cpp - Reussir standard conversion impl -----*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements conversion from Reussir operations to standard
+/// dialects.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/ConvertToSTD.h"

--- a/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
+++ b/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
@@ -1,9 +1,16 @@
-//===-- RcDecrementExpansion.cpp -------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements Reussir reference-count decrement expansion.
+///
 //===----------------------------------------------------------------------===//
 
 #include <algorithm>

--- a/lib/Conversion/RegionPatterns/RegionPatterns.cpp
+++ b/lib/Conversion/RegionPatterns/RegionPatterns.cpp
@@ -1,9 +1,16 @@
-//===-- RegionPatterns.cpp - Reussir region-related patterns -*-C++-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements Reussir region-related lowering patterns.
+///
 //===----------------------------------------------------------------------===//
 
 #include <llvm/Support/Casting.h>

--- a/lib/Conversion/TokenInstantiation/TokenInstantiation.cpp
+++ b/lib/Conversion/TokenInstantiation/TokenInstantiation.cpp
@@ -1,16 +1,18 @@
-//===-- TokenInstantiation.cpp - Token instantiation pass ---------*- C++
-//-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the TokenInstantiation pass which inserts token
-// allocation operations for TokenAcceptor operations that do not have a token
-// assigned.
-//
+///
+/// \file
+/// This file implements the TokenInstantiation pass which inserts token
+/// allocation operations for TokenAcceptor operations that do not have a token
+/// assigned.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirDialect.h"

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -1,9 +1,16 @@
-//===-- TypeConverter.cpp - Reussir type converter impl ---------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements Reussir type conversion utilities.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Conversion/TypeConverter.h"

--- a/lib/IR/ReussirAttrs.cpp
+++ b/lib/IR/ReussirAttrs.cpp
@@ -1,14 +1,18 @@
-//===-- ReussirAttrs.cpp - Reussir attributes implementation ----*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the attributes used in the Reussir dialect.
-//
+///
+/// \file
+/// This file implements the attributes used in the Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #include "Reussir/IR/ReussirAttrs.h"
 #include "Reussir/IR/ReussirDialect.h"
 

--- a/lib/IR/ReussirDialect.cpp
+++ b/lib/IR/ReussirDialect.cpp
@@ -1,13 +1,16 @@
-//===-- ReussirDialect.cpp - Reussir dialect implementation -----*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the Reussir dialect and its core functionality.
-//
+///
+/// \file
+/// This file implements the Reussir dialect and its core functionality.
+///
 //===----------------------------------------------------------------------===//
 
 // The dependent-dialect loading generated into the dialect constructor

--- a/lib/IR/ReussirEnumAttrs.cpp
+++ b/lib/IR/ReussirEnumAttrs.cpp
@@ -1,13 +1,16 @@
-//===-- ReussirEnumAttrs.cpp - Reussir enum attributes impl -----*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the enum attributes used in the Reussir dialect.
-//
+///
+/// \file
+/// This file implements the enum attributes used in the Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirEnumAttrs.h"

--- a/lib/IR/ReussirInterfaces.cpp
+++ b/lib/IR/ReussirInterfaces.cpp
@@ -1,13 +1,16 @@
-//===-- ReussirInterfaces.cpp - Reussir Interfaces -------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the interfaces for the Reussir dialect.
-//
+///
+/// \file
+/// This file implements the interfaces for the Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirInterfaces.h"

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -1,14 +1,18 @@
-//===-- ReussirOps.cpp - Reussir operations implementation ------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the operations used in the Reussir dialect.
-//
+///
+/// \file
+/// This file implements the operations used in the Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
+
 #include <array>
 #include <optional>
 

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -1,13 +1,16 @@
-//===-- ReussirTypes.cpp - Reussir types implementation ---------*- c++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements the types used in the Reussir dialect.
-//
+///
+/// \file
+/// This file implements the types used in the Reussir dialect.
+///
 //===----------------------------------------------------------------------===//
 
 #include <algorithm>

--- a/lib/IR/ReussirTypesScanner.cpp
+++ b/lib/IR/ReussirTypesScanner.cpp
@@ -1,14 +1,16 @@
-//===-- ReussirTypesScanner.cpp - Scanner instructions for types -*- c++
-//-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// This file implements scanner instruction emission for Reussir types.
-//
+///
+/// \file
+/// This file implements scanner instruction emission for Reussir types.
+///
 //===----------------------------------------------------------------------===//
 
 #include <cassert>

--- a/lib/LLVMPass/AllocationSimplication/AllocationSimplication.cpp
+++ b/lib/LLVMPass/AllocationSimplication/AllocationSimplication.cpp
@@ -1,9 +1,16 @@
-//===- AllocationSimplication.cpp - Reussir LLVM allocation pass ---------===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir LLVM allocation simplification pass.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/LLVMPass/AllocationSimplication.h"

--- a/lib/LLVMPass/AllocationSimplication/RuntimeFunctionAttributor.cpp
+++ b/lib/LLVMPass/AllocationSimplication/RuntimeFunctionAttributor.cpp
@@ -1,9 +1,16 @@
-//===- RuntimeFunctionAttributor.cpp - Reussir runtime attrib pass ------===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements attribution of Reussir runtime functions.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"

--- a/lib/RustCompiler/RustCompiler.cpp
+++ b/lib/RustCompiler/RustCompiler.cpp
@@ -1,3 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements helpers for locating and invoking the Rust compiler.
+///
+//===----------------------------------------------------------------------===//
+
 #include "Reussir/RustCompiler.h"
 #include <array>
 #include <llvm/ADT/STLExtras.h>

--- a/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
+++ b/lib/Transformation/ClosureBetaReduction/ClosureBetaReduction.cpp
@@ -1,71 +1,74 @@
-//===-- ClosureBetaReduction.cpp - Reussir closure beta reduction -*-C++-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// Beta-reduce closure application chains. Runs right after the inliner (so
-// cross-function create→eval pairs are visible) and before token
-// instantiation / closure outlining (so `closure.create` bodies are still
-// inline regions and carry no materialized token yet).
-//
-// Three one-step local patterns under the greedy driver; their fixpoint
-// walks each eval's chain without any hand-driven recursion:
-//
-//  * FOLD: `eval(apply(a, x), pack)` with a single-use apply becomes
-//    `eval(x, [a] ++ pack)` — the argument prepends, so the pack stays in
-//    application order. Dominance is free (def-use edge), and ownership is
-//    untouched: the fused eval consumes closure and pack exactly as the
-//    apply chain did.
-//
-//  * STRIP: a single-use `closure.uniqify` under a fused eval is erased
-//    when it is a provable runtime no-op — its operand is a single-use
-//    `closure.apply` or `closure.create`, i.e. a value that is unique by
-//    construction (a fresh box, or an in-place application to a value the
-//    chain's genuine guard already made unique). The bottom-most uniqify,
-//    whose operand is anything else, never matches: it stays in the IR as
-//    the fused eval's operand — the fused form carries `apply`'s contract
-//    (uniqueness is the producer's obligation) and never re-establishes it.
-//
-//  * INLINE: `eval(create{body}, pack)` over a single-use inlined create is
-//    a visible beta redex: the body block is spliced in front of the eval
-//    with the pack substituted for its parameters (legal anywhere — the
-//    region is IsolatedFromAbove), and the chain, the create, and its dead
-//    `token.alloc` are erased. Evals spliced out of the body are re-queued
-//    by the driver, which is what makes the reduction recursive.
-//
-//  * STRUCTURALINLINE: a redex carried into a supported structured region,
-//    in its general frontend shape —
-//
-//      %c = create {body}; (uniqify; apply cap)*     // capture binding
-//      structural* {                                 // LoopLike or cell.rmw
-//        rc.inc %c; (uniqify; apply x_i)*; eval(...) // per-execution chain
-//      }
-//      rc.dec %c
-//
-//    The body is spliced into the innermost region at the eval and the closure
-//    box vanishes: its create / per-execution inc+chain / trailing dec traffic
-//    is self-contained (a fresh box nothing else can observe), so erasing all
-//    of it is count-neutral. The per-execution uniqify is a *genuine* guard —
-//    the carried box is shared, so it clones every execution — but the clone
-//    is itself a fresh box the chain consumes whole: cloning inc'd the stored
-//    captures out
-//    and the eval consumed them, a wash the fused form reproduces. Capture
-//    counts are preserved, not reasoned about: each rc-typed capture bound
-//    *outside* the structure gains a per-execution `rc.inc` at the splice
-//    point (the inlined body consumes its capture parameters each execution)
-//    and one `rc.dec` where the box's dec stood (the box's drop used to
-//    release the ref the apply consumed). Captures bound *inside* the
-//    structure were consumed once per execution before and still are — they
-//    just take their seat in the substitution pack.
-//
-// Fused evals that bottom out anywhere else survive the pass; the SCF-ops
-// lowering re-expands them into unchecked applies + plain eval, so the net
-// effect of FOLD+STRIP on a chain the inliner merged is the removal of its
-// intermediate uniqueness checks.
-//
+///
+/// \file
+/// Beta-reduce closure application chains. Runs right after the inliner (so
+/// cross-function create→eval pairs are visible) and before token
+/// instantiation / closure outlining (so `closure.create` bodies are still
+/// inline regions and carry no materialized token yet).
+///
+/// Three one-step local patterns under the greedy driver; their fixpoint
+/// walks each eval's chain without any hand-driven recursion:
+///
+///  * FOLD: `eval(apply(a, x), pack)` with a single-use apply becomes
+///    `eval(x, [a] ++ pack)` — the argument prepends, so the pack stays in
+///    application order. Dominance is free (def-use edge), and ownership is
+///    untouched: the fused eval consumes closure and pack exactly as the
+///    apply chain did.
+///
+///  * STRIP: a single-use `closure.uniqify` under a fused eval is erased
+///    when it is a provable runtime no-op — its operand is a single-use
+///    `closure.apply` or `closure.create`, i.e. a value that is unique by
+///    construction (a fresh box, or an in-place application to a value the
+///    chain's genuine guard already made unique). The bottom-most uniqify,
+///    whose operand is anything else, never matches: it stays in the IR as
+///    the fused eval's operand — the fused form carries `apply`'s contract
+///    (uniqueness is the producer's obligation) and never re-establishes it.
+///
+///  * INLINE: `eval(create{body}, pack)` over a single-use inlined create is
+///    a visible beta redex: the body block is spliced in front of the eval
+///    with the pack substituted for its parameters (legal anywhere — the
+///    region is IsolatedFromAbove), and the chain, the create, and its dead
+///    `token.alloc` are erased. Evals spliced out of the body are re-queued
+///    by the driver, which is what makes the reduction recursive.
+///
+///  * STRUCTURALINLINE: a redex carried into a supported structured region,
+///    in its general frontend shape —
+///
+///      %c = create {body}; (uniqify; apply cap)*     // capture binding
+///      structural* {                                 // LoopLike or cell.rmw
+///        rc.inc %c; (uniqify; apply x_i)*; eval(...) // per-execution chain
+///      }
+///      rc.dec %c
+///
+///    The body is spliced into the innermost region at the eval and the closure
+///    box vanishes: its create / per-execution inc+chain / trailing dec traffic
+///    is self-contained (a fresh box nothing else can observe), so erasing all
+///    of it is count-neutral. The per-execution uniqify is a *genuine* guard —
+///    the carried box is shared, so it clones every execution — but the clone
+///    is itself a fresh box the chain consumes whole: cloning inc'd the stored
+///    captures out
+///    and the eval consumed them, a wash the fused form reproduces. Capture
+///    counts are preserved, not reasoned about: each rc-typed capture bound
+///    *outside* the structure gains a per-execution `rc.inc` at the splice
+///    point (the inlined body consumes its capture parameters each execution)
+///    and one `rc.dec` where the box's dec stood (the box's drop used to
+///    release the ref the apply consumed). Captures bound *inside* the
+///    structure were consumed once per execution before and still are — they
+///    just take their seat in the substitution pack.
+///
+/// Fused evals that bottom out anywhere else survive the pass; the SCF-ops
+/// lowering re-expands them into unchecked applies + plain eval, so the net
+/// effect of FOLD+STRIP on a chain the inliner merged is the removal of its
+/// intermediate uniqueness checks.
+///
 //===----------------------------------------------------------------------===//
 
 #include <llvm/ADT/STLExtras.h>

--- a/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
+++ b/lib/Transformation/IncDecCancellation/IncDecCancellation.cpp
@@ -1,9 +1,16 @@
-//===-- IncDecCancellation.cpp ----------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir increment/decrement cancellation pass.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Transformation/IncDecCancellation.h"

--- a/lib/Transformation/InferVariantTag/InferVariantTag.cpp
+++ b/lib/Transformation/InferVariantTag/InferVariantTag.cpp
@@ -1,10 +1,16 @@
-//===-- InferVariantTag.cpp - Reussir variant tag inference impl -*- C++
-//-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements Reussir variant tag inference.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Transformation/InferVariantTag.h"

--- a/lib/Transformation/InvariantGroupAnalysis/InvariantGroupAnalysis.cpp
+++ b/lib/Transformation/InvariantGroupAnalysis/InvariantGroupAnalysis.cpp
@@ -1,10 +1,16 @@
-//===-- InvariantGroupAnalysis.cpp - Invariant group analysis ----*- C++
-//-*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir invariant group analysis.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Transformation/InvariantGroupAnalysis.h"

--- a/lib/Transformation/RcCreateFusion/RcCreateFusion.cpp
+++ b/lib/Transformation/RcCreateFusion/RcCreateFusion.cpp
@@ -1,9 +1,16 @@
-//===-- RcCreateFusion.cpp - Reussir rc.create fusion -----------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements fusion of Reussir rc.create operations.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirDialect.h"

--- a/lib/Transformation/RcCreateSink/RcCreateSink.cpp
+++ b/lib/Transformation/RcCreateSink/RcCreateSink.cpp
@@ -1,9 +1,16 @@
-//===-- RcCreateSink.cpp - Reussir rc.create sinking -----------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements sinking of Reussir rc.create operations.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirDialect.h"

--- a/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
+++ b/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
@@ -1,59 +1,62 @@
-//===-- RcDispatchFusion.cpp ------------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// Fuses a pattern match's consumption of its scrutinee into a *destructuring*
-// decrement (Koka's `dropn_reuse` shape).
-//
-// The frontend lowers `match v { Ctor(a, b, ..) => .. }` into a borrowing
-// dispatch whose taken arm retains every bound member and then decrements the
-// scrutinee:
-//
-//   %ref = reussir.rc.borrow %v
-//   reussir.record.dispatch(%ref) {
-//     [k] -> ^arm(%payload):
-//       %a = ref.load(ref.project %payload [i])
-//       rc.inc %a                      // retain the binding
-//       ...
-//       rc.dec %v                      // release the box (transitive glue)
-//   }
-//
-// The retain/release pair over each bound member is pure count traffic on the
-// hot unique path: the box dies and its slots could simply transfer. This
-// pass erases the bound retains and tags the decrement with the arm's tag and
-// the bound member indices; `reussir-rc-decrement-expansion` then expands it
-// shallowly — unique: release only *unbound* rc members and take the box as a
-// token; shared: retain the bound members and drop the count. A preceding
-// increment cancels against the destructuring decrement in
-// `reussir-inc-dec-cancellation` by rematerializing the bound retains
-// (borrow semantics), which is what turns inlined read-only predicates like
-// rbtree's `is_red` into pure tag reads.
-//
-// The same consumption shape appears without a pattern match: a
-// rebuild-style update of a compound box reads its fields, retains the ones
-// it keeps, and releases the box —
-//
-//   %front = ref.load(ref.project(rc.borrow %q, 1))
-//   rc.inc %front                    // keeps the front list
-//   %state = ref.load(ref.project(rc.borrow %q, 2))
-//   ref.acquire (ref.spilled %state) // keeps the [value] state's children
-//   ...
-//   rc.dec %q
-//   ... build the updated box from the loaded fields ...
-//
-// (functional-queue's snoc/uncons over its Hood-Melville Queue). On the hot
-// unique path every one of those retains is answered by the release of the
-// same member inside the whole-record drop — pure count traffic, and for a
-// [value] member a whole tag-switch of child increments each way. The
-// second walk below fuses these into a *tagless* destructuring decrement
-// whose bound members index the compound record itself: unique — the kept
-// members transfer, only unkept managed members release; shared — the
-// retains rematerialize (see `rematerializeBoundRetains`).
-//
+///
+/// \file
+/// Fuses a pattern match's consumption of its scrutinee into a *destructuring*
+/// decrement (Koka's `dropn_reuse` shape).
+///
+/// The frontend lowers `match v { Ctor(a, b, ..) => .. }` into a borrowing
+/// dispatch whose taken arm retains every bound member and then decrements the
+/// scrutinee:
+///
+///   %ref = reussir.rc.borrow %v
+///   reussir.record.dispatch(%ref) {
+///     [k] -> ^arm(%payload):
+///       %a = ref.load(ref.project %payload [i])
+///       rc.inc %a                      // retain the binding
+///       ...
+///       rc.dec %v                      // release the box (transitive glue)
+///   }
+///
+/// The retain/release pair over each bound member is pure count traffic on the
+/// hot unique path: the box dies and its slots could simply transfer. This
+/// pass erases the bound retains and tags the decrement with the arm's tag and
+/// the bound member indices; `reussir-rc-decrement-expansion` then expands it
+/// shallowly — unique: release only *unbound* rc members and take the box as a
+/// token; shared: retain the bound members and drop the count. A preceding
+/// increment cancels against the destructuring decrement in
+/// `reussir-inc-dec-cancellation` by rematerializing the bound retains
+/// (borrow semantics), which is what turns inlined read-only predicates like
+/// rbtree's `is_red` into pure tag reads.
+///
+/// The same consumption shape appears without a pattern match: a
+/// rebuild-style update of a compound box reads its fields, retains the ones
+/// it keeps, and releases the box —
+///
+///   %front = ref.load(ref.project(rc.borrow %q, 1))
+///   rc.inc %front                    // keeps the front list
+///   %state = ref.load(ref.project(rc.borrow %q, 2))
+///   ref.acquire (ref.spilled %state) // keeps the [value] state's children
+///   ...
+///   rc.dec %q
+///   ... build the updated box from the loaded fields ...
+///
+/// (functional-queue's snoc/uncons over its Hood-Melville Queue). On the hot
+/// unique path every one of those retains is answered by the release of the
+/// same member inside the whole-record drop — pure count traffic, and for a
+/// [value] member a whole tag-switch of child increments each way. The
+/// second walk below fuses these into a *tagless* destructuring decrement
+/// whose bound members index the compound record itself: unique — the kept
+/// members transfer, only unkept managed members release; shared — the
+/// retains rematerialize (see `rematerializeBoundRetains`).
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirDialect.h"

--- a/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
+++ b/lib/Transformation/SpecialPointerTag/SpecialPointerTag.cpp
@@ -1,9 +1,16 @@
-//===-- SpecialPointerTag.cpp - Nullary variants as immediates --*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
-// SPDX-License-Identifier: Apache-2.0 With LLVM Exceptions OR MIT
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements encoding nullary variants as immediate pointers.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Transformation/SpecialPointerTag.h"

--- a/lib/Transformation/TRMCRecursionAnalysis/TRMCRecursionAnalysis.cpp
+++ b/lib/Transformation/TRMCRecursionAnalysis/TRMCRecursionAnalysis.cpp
@@ -1,29 +1,32 @@
-//===-- TRMCRecursionAnalysis.cpp -------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// Tail recursion modulo constructors via first-class constructor contexts.
-//
-// A self-recursive function returning an rc-boxed value is split into a thin
-// wrapper and a `.trmc` helper that threads a `!reussir.cctx` accumulator —
-// the partially built result with one unfilled hole. Every return-position
-// leaf of the helper is rewritten into exactly one of three shapes:
-//
-//   A. a constructor whose field is a direct self-call: allocate the
-//      constructor with a hole, `cctx.extend` the context with it, and
-//      tail-call the helper — the constructor chain becomes a loop;
-//   B. a plain self tail call: thread the context through unchanged;
-//   C. anything else: `cctx.apply` the context to the finished value.
-//
-// Because every leaf has a sound rewrite, eligibility is purely per-site: a
-// non-constructor arm (say, a rebalancing wrapper call around the recursion)
-// no longer disables the constructor arms next to it — it simply takes the
-// apply fallback, exactly like Koka's ctail compilation.
-//
+///
+/// \file
+/// Tail recursion modulo constructors via first-class constructor contexts.
+///
+/// A self-recursive function returning an rc-boxed value is split into a thin
+/// wrapper and a `.trmc` helper that threads a `!reussir.cctx` accumulator —
+/// the partially built result with one unfilled hole. Every return-position
+/// leaf of the helper is rewritten into exactly one of three shapes:
+///
+///   A. a constructor whose field is a direct self-call: allocate the
+///      constructor with a hole, `cctx.extend` the context with it, and
+///      tail-call the helper — the constructor chain becomes a loop;
+///   B. a plain self tail call: thread the context through unchanged;
+///   C. anything else: `cctx.apply` the context to the finished value.
+///
+/// Because every leaf has a sound rewrite, eligibility is purely per-site: a
+/// non-constructor arm (say, a rebalancing wrapper call around the recursion)
+/// no longer disables the constructor arms next to it — it simply takes the
+/// apply fallback, exactly like Koka's ctail compilation.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirDialect.h"

--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -1,9 +1,16 @@
-//===-- TokenReuse.cpp - Reussir token reuse pass impl ----------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
-// SPDX-License-Identifier: Apache-2.0 With LLVM Exceptions OR MIT
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir token reuse pass.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/Transformation/TokenReuse.h"

--- a/lib/Transformation/UniqueCarryingRecursionAnalysis/UniqueCarryingRecursionAnalysis.cpp
+++ b/lib/Transformation/UniqueCarryingRecursionAnalysis/UniqueCarryingRecursionAnalysis.cpp
@@ -1,86 +1,89 @@
-//===-- UniqueCarryingRecursionAnalysis.cpp ---------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //===----------------------------------------------------------------------===//
-//
-// Uniqueness-carrying analysis and `.unique` specialization.
-//
-// # The claim
-//
-// A function *carries uniqueness* when every rc-typed result it returns is,
-// on every path, either **fresh** (produced by an `rc.create*` whose count
-// is initialized to 1 and never shared afterwards) or **carried** (one of
-// the function's own rc arguments, passed through unshared). The payoff:
-// at a call site where every carried argument is *itself* proven unique,
-// the results are unique too — so a directly self-recursive carrying
-// function can run a specialized `.unique` clone that asserts argument
-// uniqueness at entry (`rc.assume_unique`, an `llvm.assume(count == 1)`
-// after lowering), letting the reuse machinery take unique fast paths
-// through the whole recursion.
-//
-// # Provenance lattice
-//
-// Per rc value: `Unknown` (bottom) or a pair `{fresh, carriedArgs}` meaning
-// "on some path this is a fresh create / argument i". Join is the pointwise
-// union: the value is unique iff every contributor is, so a joined value is
-// proven unique under an assumption set exactly when *all* its carried bits
-// are assumed (freshness needs no assumption). `Unknown` is absorbing in
-// proofs (never unique) and the identity of the join.
-//
-// # Sharing discipline (the part provenance alone cannot see)
-//
-// Freshness at the definition does not survive sharing: a created value
-// that is also retained elsewhere (`rc.inc`, a second consuming user)
-// reaches the recursive call with count > 1, and asserting uniqueness on
-// it would be undefined behavior. Provenance is therefore *disqualified*
-// (demoted to `Unknown`) when the value has any retaining user, or more
-// than one consuming user. Forwarding terminators (`scf.yield`,
-// `reussir.scf.yield`, `func.return`) and read-only observers (`rc.borrow`,
-// `rc.fetch`, `rc.is_unique`, `rc.assume_unique`) do not count: forwards
-// sit on mutually exclusive paths (their sharing is checked at the level of
-// the forwarded result), and reads do not retain. This is conservative —
-// consuming uses on mutually exclusive paths are also rejected — but it is
-// what makes the entry assumption sound without a path-sensitive count
-// analysis. The frontend's ownership discipline guarantees any genuine
-// sharing materializes as an explicit `rc.inc`, which this check sees.
-//
-// # Control flow
-//
-// Region results are traced only through operations whose results are
-// *exhaustively* defined by their regions' yields: `scf.if`,
-// `scf.index_switch`, `scf.execute_region`, and `reussir.record.dispatch`.
-// Loop-carrying ops (`scf.for`, `scf.while`) are deliberately Unknown:
-// their results may come from the *init* operands on a zero-trip count, a
-// path the yield-only join would miss. `reussir.array.with_unique_view` is
-// fresh only in its implicit-result form (an empty yield returns the
-// uniquified array itself, count 1 by construction); an explicit yield is
-// traced like any other forward.
-//
-// # Fixpoint
-//
-// Function summaries start at bottom and are recomputed from the previous
-// round until stable — a Kleene iteration of a monotone map (joins only
-// accumulate bits, bounded by the argument count), so it terminates at the
-// least fixpoint. Optimism about recursion is sound coinductively: any
-// value a terminating execution actually returns is produced by a finite
-// chain of creates/argument passes, which some iteration covers.
-//
-// # Specialization
-//
-// For each carrying, directly self-recursive function, the set of provable
-// assumption vectors is closed off: starting from the empty assumption,
-// each self call contributes the argument subset it can prove, and each
-// discovered subset is re-run (the clone bodies are copies of the base, so
-// walking the base under the subset's assumptions is equivalent). Each
-// subset gets one clone (`f.unique` when it is the only one, else
-// `f.unique_<bits>`), marked private/internal and tagged
-// `reussir.unique_clone`; debug info is stripped (the clone has no distinct
-// source location). Reruns are idempotent: self calls are reset to the base
-// symbol before re-deciding, and existing clones are found by the marker.
-//
+///
+/// \file
+/// Uniqueness-carrying analysis and `.unique` specialization.
+///
+/// # The claim
+///
+/// A function *carries uniqueness* when every rc-typed result it returns is,
+/// on every path, either **fresh** (produced by an `rc.create*` whose count
+/// is initialized to 1 and never shared afterwards) or **carried** (one of
+/// the function's own rc arguments, passed through unshared). The payoff:
+/// at a call site where every carried argument is *itself* proven unique,
+/// the results are unique too — so a directly self-recursive carrying
+/// function can run a specialized `.unique` clone that asserts argument
+/// uniqueness at entry (`rc.assume_unique`, an `llvm.assume(count == 1)`
+/// after lowering), letting the reuse machinery take unique fast paths
+/// through the whole recursion.
+///
+/// # Provenance lattice
+///
+/// Per rc value: `Unknown` (bottom) or a pair `{fresh, carriedArgs}` meaning
+/// "on some path this is a fresh create / argument i". Join is the pointwise
+/// union: the value is unique iff every contributor is, so a joined value is
+/// proven unique under an assumption set exactly when *all* its carried bits
+/// are assumed (freshness needs no assumption). `Unknown` is absorbing in
+/// proofs (never unique) and the identity of the join.
+///
+/// # Sharing discipline (the part provenance alone cannot see)
+///
+/// Freshness at the definition does not survive sharing: a created value
+/// that is also retained elsewhere (`rc.inc`, a second consuming user)
+/// reaches the recursive call with count > 1, and asserting uniqueness on
+/// it would be undefined behavior. Provenance is therefore *disqualified*
+/// (demoted to `Unknown`) when the value has any retaining user, or more
+/// than one consuming user. Forwarding terminators (`scf.yield`,
+/// `reussir.scf.yield`, `func.return`) and read-only observers (`rc.borrow`,
+/// `rc.fetch`, `rc.is_unique`, `rc.assume_unique`) do not count: forwards
+/// sit on mutually exclusive paths (their sharing is checked at the level of
+/// the forwarded result), and reads do not retain. This is conservative —
+/// consuming uses on mutually exclusive paths are also rejected — but it is
+/// what makes the entry assumption sound without a path-sensitive count
+/// analysis. The frontend's ownership discipline guarantees any genuine
+/// sharing materializes as an explicit `rc.inc`, which this check sees.
+///
+/// # Control flow
+///
+/// Region results are traced only through operations whose results are
+/// *exhaustively* defined by their regions' yields: `scf.if`,
+/// `scf.index_switch`, `scf.execute_region`, and `reussir.record.dispatch`.
+/// Loop-carrying ops (`scf.for`, `scf.while`) are deliberately Unknown:
+/// their results may come from the *init* operands on a zero-trip count, a
+/// path the yield-only join would miss. `reussir.array.with_unique_view` is
+/// fresh only in its implicit-result form (an empty yield returns the
+/// uniquified array itself, count 1 by construction); an explicit yield is
+/// traced like any other forward.
+///
+/// # Fixpoint
+///
+/// Function summaries start at bottom and are recomputed from the previous
+/// round until stable — a Kleene iteration of a monotone map (joins only
+/// accumulate bits, bounded by the argument count), so it terminates at the
+/// least fixpoint. Optimism about recursion is sound coinductively: any
+/// value a terminating execution actually returns is produced by a finite
+/// chain of creates/argument passes, which some iteration covers.
+///
+/// # Specialization
+///
+/// For each carrying, directly self-recursive function, the set of provable
+/// assumption vectors is closed off: starting from the empty assumption,
+/// each self call contributes the argument subset it can prove, and each
+/// discovered subset is re-run (the clone bodies are copies of the base, so
+/// walking the base under the subset's assumptions is equivalent). Each
+/// subset gets one clone (`f.unique` when it is the only one, else
+/// `f.unique_<bits>`), marked private/internal and tagged
+/// `reussir.unique_clone`; debug info is stripped (the clone has no distinct
+/// source location). Reruns are idempotent: self calls are reset to the base
+/// symbol before re-deciding, and existing clones are found by the marker.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirDialect.h"

--- a/tool/reussir-opt/main.cpp
+++ b/tool/reussir-opt/main.cpp
@@ -1,9 +1,16 @@
-//===-- main.cpp - Reussir optimization driver main -------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir optimization driver.
+///
 //===----------------------------------------------------------------------===//
 
 #include <mlir/Conversion/ConvertToLLVM/ToLLVMPass.h>

--- a/tool/reussir-translate/main.cpp
+++ b/tool/reussir-translate/main.cpp
@@ -1,9 +1,16 @@
-//===-- main.cpp - Reussir translation driver main --------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the Reussir project, dual licensed under the Apache License v2.0 or
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
 // the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir translation driver.
+///
 //===----------------------------------------------------------------------===//
 
 #include "Reussir/IR/ReussirDialect.h"


### PR DESCRIPTION
## Summary

- replace legacy filename banners with the separator-first LLVM-style layout
- preserve Reussir's Apache-2.0-or-MIT terms while adding the canonical license link
- add `\file` documentation blocks to all 90 production C/C++/module/TableGen files
- add the same header to four production files that previously had none

The migration changes comments only; a content-equivalence audit confirmed that executable declarations and definitions are unchanged.

## Testing

- `ctest --test-dir build --output-on-failure` (28/28 passed)
- `ninja -C build rrc-test`
- `ninja -C build reussir-backend-test`
- `ninja -C build reussir-codegen-test`
- `ninja -C build check` (359 passed, 29 unsupported, 0 failed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787073832&installation_id=144622820&pr_number=442&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F442&signature=17fa97a8b4e69b8b7774bfd344c21bbe29391a35d35fdda2c4621098ef169851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->