### PR TITLE
[mlir][frontend] SCC promotion: whole-subtree atomicity, Arc on recursive types

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -111,6 +111,10 @@ enum Anchor<'c, 'b, 'tcx> {
         reference: Value<'c, 'b>,
         variant: &'tcx mir::VariantDef<'tcx>,
         cap: ReussirCapability,
+        /// The case reference's atomic kind, inherited from the dispatched
+        /// enum's box (whole-subtree rule) — arm-field projections derive
+        /// their link discipline from it.
+        atomic: bool,
         whole: Cursor<'c, 'b, 'tcx>,
     },
 }
@@ -174,11 +178,15 @@ enum Cursor<'c, 'b, 'tcx> {
     Value { val: Value<'c, 'b>, ty: Ty<'tcx> },
     /// A borrowed `!reussir.ref<…, cap>` into a record whose MIR type is `ty`.
     /// `cap` is the reference's capability, carried so a further projection out
-    /// of it picks the matching projected-reference capability.
+    /// of it picks the matching projected-reference capability. `atomic` is
+    /// the reference's atomic kind: the whole-subtree rule — interior
+    /// references of an atomically counted box stay in the atomic context,
+    /// and member links derive their refcount discipline from it.
     Ref {
         val: Value<'c, 'b>,
         ty: Ty<'tcx>,
         cap: ReussirCapability,
+        atomic: bool,
     },
 }
 
@@ -186,12 +194,14 @@ enum Cursor<'c, 'b, 'tcx> {
 /// the projected reference's element type and capability, and whether the
 /// projection is a pointer link to load (an `rc` member) rather than an inline
 /// sub-field to keep navigating by reference. See
-/// [`projected_member`](Lowerer::projected_member).
+/// [`projected_member`](Lowerer::projected_member). `atomic` carries the
+/// parent reference's atomic context into the projected reference.
 struct ProjectedMember<'c, 'tcx> {
     field_ty: Ty<'tcx>,
     elem_ty: Type<'c>,
     proj_cap: ReussirCapability,
     is_link: bool,
+    atomic: bool,
 }
 
 /// Per-program lowering state: the context to build in, the type arena, the
@@ -949,7 +959,9 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             block,
             dialect::rc_borrow(self.context, ref_ty, dst_val, loc).into(),
         );
-        let proj = self.projected_member(dst.ty, ReussirCapability::Flex, field)?;
+        // A `[field]` assignment target is regional; regional boxes are never
+        // atomic (design doc §6 — regions and threads do not mix).
+        let proj = self.projected_member(dst.ty, ReussirCapability::Flex, false, field)?;
         let field_ref_ty = self.tys.ref_type_with_cap(proj.elem_ty, proj.proj_cap);
         let index = IntegerAttribute::new(Type::index(self.context), i64::from(field));
         let field_ref = self.append(
@@ -1346,7 +1358,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         // (kept in each arm's `Case` anchor for a whole-value binding), and the
         // variant reference feeds the dispatch.
         let whole = self.resolve(block, env, root_idx, path)?;
-        let (variant_ref, enum_ty, cap) = self.resolve_variant_ref(block, whole)?;
+        let (variant_ref, enum_ty, cap, atomic) = self.resolve_variant_ref(block, whole)?;
         let variants = match self.tys.record_of(enum_ty).map(|r| r.layout) {
             Some(mir::RecordLayout::Variant(variants)) => variants,
             _ => return err("match scrutinee is not an enum"),
@@ -1379,6 +1391,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                         reference: arg,
                         variant,
                         cap,
+                        atomic,
                         whole,
                     },
                 ));
@@ -1839,25 +1852,32 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
     /// Turn an already-resolved enum [`Cursor`] into a `!reussir.ref` to its
     /// variant record, ready to feed `reussir.record.dispatch`: a boxed enum is
     /// borrowed, an inline `[value]` enum is spilled, and a value already reached
-    /// by reference is used as-is. Returns the reference, the enum's MIR type, and
-    /// the reference capability (which the arm payload references inherit).
+    /// by reference is used as-is. Returns the reference, the enum's MIR type,
+    /// the reference capability, and the reference's atomic kind (which the arm
+    /// payload references inherit).
     fn resolve_variant_ref<'b>(
         &self,
         block: &'b Block<'c>,
         cursor: Cursor<'c, 'b, 'tcx>,
-    ) -> Result<(Value<'c, 'b>, Ty<'tcx>, ReussirCapability)> {
+    ) -> Result<(Value<'c, 'b>, Ty<'tcx>, ReussirCapability, bool)> {
         let loc = self.loc();
         match cursor {
-            Cursor::Ref { val, ty, cap } => Ok((val, ty, cap)),
+            Cursor::Ref {
+                val,
+                ty,
+                cap,
+                atomic,
+            } => Ok((val, ty, cap, atomic)),
             Cursor::Value { val, ty } => {
                 let inner = self.tys.record_inner_of(ty)?;
+                let atomic = matches!(ty.kind(), TyKind::Arc(_));
                 if let Some(cap) = self.record_ref_cap(ty)? {
                     let ref_ty = self.tys.borrow_ref_type(ty, inner, cap);
                     let reference = self.append(
                         block,
                         dialect::rc_borrow(self.context, ref_ty, val, loc).into(),
                     );
-                    Ok((reference, ty, cap))
+                    Ok((reference, ty, cap, atomic))
                 } else {
                     // A spilled reference is always at `unspecified` capability
                     // (`reussir.ref.spilled` rejects anything else); the arm
@@ -1868,7 +1888,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                         block,
                         dialect::ref_spilled(self.context, ref_ty, val, loc).into(),
                     );
-                    Ok((reference, ty, cap))
+                    Ok((reference, ty, cap, false))
                 }
             }
         }
@@ -1912,6 +1932,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 reference,
                 variant,
                 cap,
+                atomic,
                 whole,
             } => {
                 // Naming the whole switched value (empty suffix): the case payload
@@ -1921,7 +1942,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     return Ok(whole);
                 };
                 let mut cursor =
-                    self.project_variant_field(block, reference, variant, cap, *first)?;
+                    self.project_variant_field(block, reference, variant, cap, atomic, *first)?;
                 for &idx in rest {
                     cursor = self.project_one(block, cursor, idx)?;
                 }
@@ -1940,6 +1961,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         case_ref: Value<'c, 'b>,
         variant: &'tcx mir::VariantDef<'tcx>,
         cap: ReussirCapability,
+        atomic: bool,
         idx: u32,
     ) -> Result<Cursor<'c, 'b, 'tcx>> {
         let loc = self.loc();
@@ -1947,8 +1969,10 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             .fields
             .get(idx as usize)
             .ok_or_else(|| LoweringError("variant field index out of range".into()))?;
-        let proj = self.projected_member_of(field_ty, false, cap)?;
-        let proj_ref_ty = self.tys.ref_type_with_cap(proj.elem_ty, proj.proj_cap);
+        let proj = self.projected_member_of(field_ty, false, cap, atomic)?;
+        let proj_ref_ty = self
+            .tys
+            .ref_type_in(proj.elem_ty, proj.proj_cap, proj.atomic);
         let index = IntegerAttribute::new(Type::index(self.context), i64::from(idx));
         let projected = self.append(
             block,
@@ -1968,6 +1992,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 val: projected,
                 ty: proj.field_ty,
                 cap: proj.proj_cap,
+                atomic: proj.atomic,
             })
         }
     }
@@ -2024,14 +2049,16 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 if let Some(cap) = self.record_ref_cap(ty)? {
                     // A boxed record value (shared or regional) is an rc pointer:
                     // borrow it at its capability to obtain a reference, then
-                    // project through that reference.
+                    // project through that reference. An arc'd box opens the
+                    // atomic context its interior inherits.
                     let inner = self.tys.record_inner_of(ty)?;
+                    let atomic = matches!(ty.kind(), TyKind::Arc(_));
                     let ref_ty = self.tys.borrow_ref_type(ty, inner, cap);
                     let borrowed = self.append(
                         block,
                         dialect::rc_borrow(self.context, ref_ty, val, loc).into(),
                     );
-                    self.project_ref(block, borrowed, ty, cap, idx)
+                    self.project_ref(block, borrowed, ty, cap, atomic, idx)
                 } else {
                     // An inline `[value]` record value: read the field out by value
                     // (an inline record has no `[field]` link members).
@@ -2047,7 +2074,12 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     })
                 }
             }
-            Cursor::Ref { val, ty, cap } => self.project_ref(block, val, ty, cap, idx),
+            Cursor::Ref {
+                val,
+                ty,
+                cap,
+                atomic,
+            } => self.project_ref(block, val, ty, cap, atomic, idx),
         }
     }
 
@@ -2061,11 +2093,14 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         reference: Value<'c, 'b>,
         record_ty: Ty<'tcx>,
         ref_cap: ReussirCapability,
+        ref_atomic: bool,
         idx: u32,
     ) -> Result<Cursor<'c, 'b, 'tcx>> {
         let loc = self.loc();
-        let proj = self.projected_member(record_ty, ref_cap, idx)?;
-        let proj_ref_ty = self.tys.ref_type_with_cap(proj.elem_ty, proj.proj_cap);
+        let proj = self.projected_member(record_ty, ref_cap, ref_atomic, idx)?;
+        let proj_ref_ty = self
+            .tys
+            .ref_type_in(proj.elem_ty, proj.proj_cap, proj.atomic);
         let index = IntegerAttribute::new(Type::index(self.context), i64::from(idx));
         let projected = self.append(
             block,
@@ -2085,6 +2120,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 val: projected,
                 ty: proj.field_ty,
                 cap: proj.proj_cap,
+                atomic: proj.atomic,
             })
         }
     }
@@ -2114,10 +2150,11 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         &self,
         record_ty: Ty<'tcx>,
         ref_cap: ReussirCapability,
+        ref_atomic: bool,
         idx: u32,
     ) -> Result<ProjectedMember<'c, 'tcx>> {
         let (field_ty, is_field) = self.field_at(record_ty, idx)?;
-        self.projected_member_of(field_ty, is_field, ref_cap)
+        self.projected_member_of(field_ty, is_field, ref_cap, ref_atomic)
     }
 
     /// The projection of a member given its MIR type and link flag directly, the
@@ -2130,6 +2167,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         field_ty: Ty<'tcx>,
         is_field: bool,
         ref_cap: ReussirCapability,
+        ref_atomic: bool,
     ) -> Result<ProjectedMember<'c, 'tcx>> {
         if is_field {
             // A mutable link: `nullable<rc<inner, flex|rigid>>`. Taken out of a
@@ -2155,14 +2193,37 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 elem_ty,
                 proj_cap,
                 is_link: true,
+                atomic: ref_atomic,
             })
-        } else if self.tys.is_shared_record(field_ty) {
+        } else if matches!(field_ty.kind(), TyKind::Arc(_)) {
+            // An explicit `Arc` member: the link's atomicity is *written* (the
+            // container cannot derive it — an atomic island in normal space).
             let inner = self.tys.record_inner_of(field_ty)?;
             Ok(ProjectedMember {
                 field_ty,
-                elem_ty: self.tys.rc_type(inner),
+                elem_ty: self.tys.rc_type_in(inner, true),
                 proj_cap: ref_cap,
                 is_link: true,
+                atomic: ref_atomic,
+            })
+        } else if self.tys.is_shared_record(field_ty) {
+            // A bare shared member: the link derives from the parent context
+            // (whole-subtree rule) — one declaration serves both colorings of
+            // a recursive spine, so under an atomic parent the loaded value is
+            // refined to its `Arc` coloring, mirroring the regional member's
+            // rigid refinement below.
+            let inner = self.tys.record_inner_of(field_ty)?;
+            let field_ty = if ref_atomic {
+                self.tcx.mk_arc(field_ty)
+            } else {
+                field_ty
+            };
+            Ok(ProjectedMember {
+                field_ty,
+                elem_ty: self.tys.rc_type_in(inner, ref_atomic),
+                proj_cap: ref_cap,
+                is_link: true,
+                atomic: ref_atomic,
             })
         } else if self.tys.is_regional_record(field_ty) {
             // A non-`[field]` regional member is a frozen link: the dialect
@@ -2182,15 +2243,34 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 elem_ty: self.tys.rc_type_with_cap(inner, ReussirCapability::Rigid),
                 proj_cap: ref_cap,
                 is_link: true,
+                atomic: ref_atomic,
             })
         } else if matches!(field_ty.kind(), TyKind::Cell { .. }) {
             // A cell member is stored as a bare payload type in the record
-            // declaration, but dialect projection materializes a shared rc link.
+            // declaration, but dialect projection materializes a shared rc link
+            // whose atomicity the cell kind itself decides.
             Ok(ProjectedMember {
                 field_ty,
                 elem_ty: self.tys.mlir_ty(field_ty)?,
                 proj_cap: ref_cap,
                 is_link: true,
+                atomic: ref_atomic,
+            })
+        } else if let TyKind::Nullable(elem) = *field_ty.kind()
+            && ref_atomic
+            && self.tys.is_shared_record(elem)
+            && !matches!(elem.kind(), TyKind::Arc(_))
+        {
+            // A nullable-wrapped bare shared link under an atomic parent: the
+            // whole-subtree rule floods through the wrapper — refine both the
+            // slot type and the loaded value's coloring.
+            let field_ty = self.tcx.mk_nullable(self.tcx.mk_arc(elem));
+            Ok(ProjectedMember {
+                field_ty,
+                elem_ty: self.tys.mlir_ty(field_ty)?,
+                proj_cap: ref_cap,
+                is_link: false,
+                atomic: ref_atomic,
             })
         } else {
             Ok(ProjectedMember {
@@ -2198,6 +2278,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 elem_ty: self.tys.mlir_ty(field_ty)?,
                 proj_cap: ref_cap,
                 is_link: false,
+                atomic: ref_atomic,
             })
         }
     }

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -1199,6 +1199,50 @@ transform [{
     }
 
     #[test]
+    fn lowers_explicit_arc_member_as_atomic_link() {
+        // An `Arc` member is the written form of the whole-subtree rule: the
+        // member slot in the record type spells `rc<…, atomic>`, and reading
+        // it out of a *bare* (normal) container hands out the atomic rc with
+        // no arc context involved.
+        let src = r#"
+            struct Inner { v: i64 }
+            struct Holder { h: Arc<Inner> }
+            pub fn get(x: Holder) -> Arc<Inner> { x.h }
+        "#;
+        let mlir = lower_source(src);
+        // The member type is the explicit atomic link inside the record body…
+        assert!(
+            mlir.contains("{!reussir.rc<!reussir.record<compound \"_RC5Inner\" {i64}> atomic>}"),
+            "{mlir}"
+        );
+        // …and the container itself stays a normal shared box.
+        assert!(!mlir.contains("\"_RC6Holder\"{{.*}} atomic"), "{mlir}");
+    }
+
+    #[test]
+    fn promoted_member_stays_bare_in_the_declaration() {
+        // The §3.3 spine: one record serves both colorings — the recursive
+        // member is declared bare (no `atomic` inside the record body), and
+        // the box's own atomic kind derives the interior discipline (atomic
+        // create, atomic borrow).
+        let src = r#"
+            enum List<T> { Nil, Cons(T, List<T>) }
+            pub fn make() -> Arc<List<i64>> {
+                Arc<List<i64>>::Cons{1, Arc<List<i64>>::Nil}
+            }
+        "#;
+        let mlir = lower_source(src);
+        // The Cons arm's tail member is the bare variant record, not an rc.
+        assert!(
+            mlir.contains("{i64, !reussir.record<variant \"_RIC4ListxE\">}"),
+            "{mlir}"
+        );
+        // The boxes create atomically and borrows inherit the context.
+        assert!(mlir.contains("reussir.rc.create"), "{mlir}");
+        assert!(mlir.contains("atomic>"), "{mlir}");
+    }
+
+    #[test]
     fn lowers_arc_to_an_atomic_rc_box() {
         // An arc'd value is the same shared record behind an atomically
         // counted box: the constructor creates `!reussir.rc<…, atomic>` and a

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -184,19 +184,23 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
     /// Lower a type as it appears *as a record member*. A managed member is named
     /// by its bare element type, never an `rc` pointer: the dialect boxes a member
     /// whose element capability is `shared`/`regional` to a pointer on its own (a
-    /// `!reussir.rc<…>` member is rejected — "use capability instead"). This holds
-    /// for a `shared`/`regional` record member (its inner record type), for a
-    /// closure, array, or cell member (its bare payload type). A scalar or
-    /// `[value]` record member is the same as [`mlir_ty`](Self::mlir_ty).
+    /// plain `!reussir.rc<…>` member is rejected — "use capability instead").
+    /// This holds for a `shared`/`regional` record member (its inner record
+    /// type), for a closure, array, or cell member (its bare payload type). A
+    /// scalar or `[value]` record member is the same as [`mlir_ty`](Self::mlir_ty).
+    ///
+    /// The one exception is an `Arc` member: its link's atomicity cannot be
+    /// derived from any capability (the container may be a normal, thread-local
+    /// box while the member's count is shared across threads), so it is spelled
+    /// as the explicit member type `rc<…, shared, atomic>` — the only rc member
+    /// form the dialect admits.
     fn member_ty(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
         match *ty.kind() {
+            TyKind::Arc(_) => self.mlir_ty(ty),
             TyKind::Record { .. } => self.record_inner_of(ty),
             TyKind::Closure { params, ret } => self.closure_inner(params, ret),
             TyKind::Array { .. } => self.array_inner_of(ty),
             TyKind::Cell { .. } => self.cell_inner_of(ty),
-            // Member capabilities have no atomic axis, so an arc member is
-            // rejected at elaboration; reaching here means a check was missed.
-            TyKind::Arc(_) => err("an `Arc` record member is not supported yet"),
             _ => self.mlir_ty(ty),
         }
     }
@@ -444,6 +448,18 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         rc(inner, cap, ReussirAtomicKind::Normal)
     }
 
+    /// A shared `rc` link at an explicit atomic context: the member-link type
+    /// derived under the whole-subtree rule (atomic parent → atomic link) or
+    /// for an explicit `Arc` member.
+    pub(super) fn rc_type_in(&self, inner: Type<'c>, atomic: bool) -> Type<'c> {
+        let kind = if atomic {
+            ReussirAtomicKind::Atomic
+        } else {
+            ReussirAtomicKind::Normal
+        };
+        rc(inner, ReussirCapability::Shared, kind)
+    }
+
     /// `!reussir.region` — the arena-allocator handle a `regional` function or a
     /// `region-run` body threads to its regional allocations.
     pub(super) fn region_type(&self) -> Type<'c> {
@@ -462,6 +478,23 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
     /// (region-local and mutable, or frozen).
     pub(super) fn ref_type_with_cap(&self, inner: Type<'c>, cap: ReussirCapability) -> Type<'c> {
         r#ref(inner, cap, ReussirAtomicKind::Normal)
+    }
+
+    /// `!reussir.ref<inner, cap>` at an explicit atomic context — projected
+    /// references inherit their parent reference's atomic kind (the
+    /// whole-subtree rule; the dialect verifier enforces it).
+    pub(super) fn ref_type_in(
+        &self,
+        inner: Type<'c>,
+        cap: ReussirCapability,
+        atomic: bool,
+    ) -> Type<'c> {
+        let kind = if atomic {
+            ReussirAtomicKind::Atomic
+        } else {
+            ReussirAtomicKind::Normal
+        };
+        r#ref(inner, cap, kind)
     }
 
     /// The `!reussir.ref` type for borrowing the payload of a managed box of

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -481,6 +481,21 @@ impl<'tcx> SyncEnv<'tcx> for MonoSyncEnv<'_, 'tcx> {
                 .collect(),
         })
     }
+
+    fn member_record_defs(&self, def: DefId) -> Option<Vec<DefId>> {
+        let rec = self.record_defs.get(&def)?;
+        let fields = rec.fields.as_ref()?;
+        let mut out = Vec::new();
+        let mut walk = |t: Ty<'tcx>| crate::semi::traits::sync::collect_record_defs(t, &mut out);
+        match fields {
+            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _)| walk(*t)),
+            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _)| walk(*t)),
+            RecordFields::Variants(vs) => vs
+                .iter()
+                .for_each(|v| v.fields.iter().for_each(|t| walk(*t))),
+        }
+        Some(out)
+    }
 }
 
 /// Mutable worklist + lowering state.
@@ -1803,21 +1818,30 @@ mod tests {
     #[test]
     fn arc_generic_rejects_non_sync_instantiation() {
         // The kind is admissible (a `[shared]` record) but the contents are
-        // not `Sync`: `Cons` holds a bare `List<T>` whose refcount is not
-        // atomic. Semi defers the generic inner; grounding it here is the
-        // backstop.
+        // not `Sync`: `S` holds a bare shared `Q` *outside its recursive
+        // group*, so §3.3 promotion does not apply and the plain box
+        // refutes. Semi defers the generic inner; grounding it here is the
+        // backstop. A recursive instantiation, by contrast, promotes and is
+        // accepted.
         let src = r#"
+            struct Q { x: i64 }
+            struct S { p: Q }
             enum List<T> { Nil, Cons(T, List<T>) }
             fn passthrough<T>(a: Arc<T>) -> Arc<T> { a }
-            extern "C" trampoline "bad_list" = passthrough<List<i32>>;
+            extern "C" trampoline "bad_s" = passthrough<S>;
+            extern "C" trampoline "ok_list" = passthrough<List<i32>>;
         "#;
         let reports = mono_reports(src);
         assert!(
             reports
                 .iter()
                 .any(|m| m.contains("grounds an `Arc` whose contents are not `Sync`")
-                    && m.contains("member `Cons.1`")),
+                    && m.contains("member `p`")),
             "{reports:#?}"
+        );
+        assert!(
+            !reports.iter().any(|m| m.contains("Cons")),
+            "the recursive instantiation must promote, not refute: {reports:#?}"
         );
     }
 
@@ -1830,10 +1854,11 @@ mod tests {
         // over fields is its only ground checkpoint, for both halves of the
         // check.
         let src = r#"
-            enum List<T> { Nil, Cons(T, List<T>) }
+            struct Q { x: i64 }
+            struct S { p: Q }
             struct Holder<T> { link: Nullable<Arc<T>> }
             fn keep<T>(h: Holder<T>) -> Holder<T> { h }
-            extern "C" trampoline "unsync_member" = keep<List<i64>>;
+            extern "C" trampoline "unsync_member" = keep<S>;
             extern "C" trampoline "non_box_member" = keep<i32>;
         "#;
         let reports = mono_reports(src);
@@ -1841,7 +1866,7 @@ mod tests {
             reports
                 .iter()
                 .any(|m| m.contains("grounds an `Arc` whose contents are not `Sync`")
-                    && m.contains("member `Cons.1`")),
+                    && m.contains("member `p`")),
             "{reports:#?}"
         );
         assert!(

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1075,12 +1075,20 @@ mod tests {
     }
 
     #[test]
-    fn rejects_arc_record_member() {
-        let src = "struct Pair { a: i32 }\nstruct Holder { p: Arc<Pair> }";
+    fn arc_record_members_are_allowed() {
+        // An `Arc` member spells its own atomic link (§3.3) — legal in
+        // shared and `[value]` records; a `[regional]` record still rejects
+        // it (regions and threads do not mix).
+        let ok = "struct Pair { a: i32 }\n\
+                  struct Holder { p: Arc<Pair> }\n\
+                  struct [value] VHolder { p: Arc<Pair> }";
+        assert!(reports_of(ok).is_empty(), "{:#?}", reports_of(ok));
+        let regional = "struct Pair { a: i32 }\n\
+                        struct [regional] R { v: i64, p: Arc<Pair> }";
         assert!(
-            has_error(src, "an `Arc` record member is not supported yet"),
+            has_error(regional, "an `Arc` member of a `[regional]` record"),
             "{:#?}",
-            reports_of(src)
+            reports_of(regional)
         );
     }
 
@@ -1129,28 +1137,66 @@ mod tests {
 
     #[test]
     fn rejects_arc_whose_member_is_a_bare_shared_record() {
-        // The stratified wf rule: the arc colors exactly one box, so every
-        // member must be `Sync` on its own — a bare `[shared]` member (its
-        // refcount is not atomic) refutes, and the witness names it.
-        let src = "enum List<T> { Nil, Cons(T, List<T>) }\n\
-                   fn f(l: Arc<List<i32>>) -> i32 { 0 }";
+        // The stratified wf rule: the arc colors exactly one box, so a bare
+        // `[shared]` member *outside the recursive group* refutes — it is
+        // not part of the spine the coloring floods, so it must already be
+        // `Sync` (an `Arc` member) on its own.
+        let src = "struct Q { x: i64 }\n\
+                   struct S { p: Q }\n\
+                   fn f(s: Arc<S>) -> i32 { 0 }";
         assert!(
             has_error(src, "every member of an `Arc` inner must be `Sync`"),
             "{:#?}",
             reports_of(src)
         );
         assert!(
-            has_error(src, "member `Cons.1` is a plain `[shared]` rc box"),
+            has_error(src, "member `p` is a plain `[shared]` rc box"),
             "{:#?}",
             reports_of(src)
         );
     }
 
     #[test]
+    fn arc_of_recursive_enum_is_wf_via_scc_promotion() {
+        // §3.3: Arc<List> selects the atomic instantiation of List's whole
+        // recursive group — the Cons tail promotes to Arc<List<T>>
+        // automatically, and the coinductive rule closes the cycle. Mutual
+        // recursion promotes the same way.
+        let src = "enum List<T> { Nil, Cons(T, List<T>) }\n\
+                   enum Tree { Leaf(i64), Node(Forest) }\n\
+                   enum Forest { None, More(Tree, Forest) }\n\
+                   fn f(l: Arc<List<i32>>) -> i32 { 0 }\n\
+                   fn g(t: Arc<Tree>) -> i32 { 0 }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn arc_ctor_and_match_use_promoted_field_types() {
+        // The closed colored world: the arc'd Cons demands an arc'd tail,
+        // and matching through the arc binds the tail at its promoted type.
+        let ok = "enum List<T> { Nil, Cons(T, List<T>) }\n\
+                  fn cons(x: i32, xs: Arc<List<i32>>) -> Arc<List<i32>> {\n\
+                      Arc<List<i32>>::Cons{x, xs}\n\
+                  }\n\
+                  fn tail(l: Arc<List<i32>>) -> Arc<List<i32>> {\n\
+                      match l {\n\
+                          List::Cons(_, xs) => xs,\n\
+                          List::Nil => Arc<List<i32>>::Nil\n\
+                      }\n\
+                  }";
+        assert!(reports_of(ok).is_empty(), "{:#?}", reports_of(ok));
+        // A bare tail cannot enter the atomic world implicitly.
+        let bad = "enum List<T> { Nil, Cons(T, List<T>) }\n\
+                   fn f(x: i32) -> i32 { Arc<List<i32>>::Cons{x, List::Nil}; 0 }";
+        assert!(!reports_of(bad).is_empty(), "{:#?}", reports_of(bad));
+    }
+
+    #[test]
     fn rejects_arc_wf_at_the_ctor_site() {
         // The coloring site checks too: no annotation is needed to trip it.
-        let src = "enum List<T> { Nil, Cons(T, List<T>) }\n\
-                   fn f() -> i32 { Arc<List<i32>>::Cons{1, List::Nil}; 0 }";
+        let src = "struct Q { x: i64 }\n\
+                   struct S { p: Q }\n\
+                   fn f() -> i32 { Arc<S> { p: Q { x: 1 } }; 0 }";
         assert!(
             has_error(src, "every member of an `Arc` inner must be `Sync`"),
             "{:#?}",
@@ -1170,8 +1216,8 @@ mod tests {
                 &interner;
             let mut elab = Elaborator::new(tcx, resolver);
             for src in [
-                "enum List<T> { Nil, Cons(T, List<T>) }",
-                "fn f(l: Arc<List<i32>>) -> i32 { 0 }",
+                "struct Q { x: i64 }\nstruct S { p: Q }",
+                "fn f(s: Arc<S>) -> i32 { 0 }",
             ] {
                 let parse = reussir_syntax::parse_with_interner(src, interner.clone());
                 assert!(parse.ok(), "{src}: {:#?}", parse.errors);

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1077,8 +1077,8 @@ mod tests {
     #[test]
     fn arc_record_members_are_allowed() {
         // An `Arc` member spells its own atomic link (§3.3) — legal in
-        // shared and `[value]` records; a `[regional]` record still rejects
-        // it (regions and threads do not mix).
+        // shared and `[value]` records; a `[regional]` record rejects it for
+        // now (not implemented — the §6 sync-regional design will decide).
         let ok = "struct Pair { a: i32 }\n\
                   struct Holder { p: Arc<Pair> }\n\
                   struct [value] VHolder { p: Arc<Pair> }";
@@ -1086,7 +1086,7 @@ mod tests {
         let regional = "struct Pair { a: i32 }\n\
                         struct [regional] R { v: i64, p: Arc<Pair> }";
         assert!(
-            has_error(regional, "an `Arc` member of a `[regional]` record"),
+            has_error(regional, "an `Arc` member of a `[regional]` record is not implemented yet"),
             "{:#?}",
             reports_of(regional)
         );
@@ -1168,6 +1168,62 @@ mod tests {
                    fn f(l: Arc<List<i32>>) -> i32 { 0 }\n\
                    fn g(t: Arc<Tree>) -> i32 { 0 }";
         assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn arc_mixes_explicit_and_promoted_members() {
+        // A shared record can mix both member forms (§3.3): an explicit
+        // `Arc<Inner>` member keeps its declared type everywhere — readable
+        // from a *bare* box too, no arc context needed — while the bare
+        // recursive children promote only under the arc'd box. The arc'd
+        // ctor demands the explicit member as declared and the recursive
+        // ones promoted.
+        let src = "struct Inner { v: i64 }\n\
+                   enum Tree { Leaf, Node(Arc<Inner>, Tree, Tree) }\n\
+                   fn node(h: Arc<Inner>, l: Arc<Tree>, r: Arc<Tree>) -> Arc<Tree> {\n\
+                       Arc<Tree>::Node{h, l, r}\n\
+                   }\n\
+                   fn header(t: Arc<Tree>) -> Arc<Inner> {\n\
+                       match t {\n\
+                           Tree::Node(h, _, _) => h,\n\
+                           Tree::Leaf => Arc<Inner> { v: 0 }\n\
+                       }\n\
+                   }\n\
+                   fn left(t: Arc<Tree>) -> Arc<Tree> {\n\
+                       match t {\n\
+                           Tree::Node(_, l, _) => l,\n\
+                           Tree::Leaf => Arc<Tree>::Leaf\n\
+                       }\n\
+                   }\n\
+                   fn bare_header(t: Tree) -> Arc<Inner> {\n\
+                       match t {\n\
+                           Tree::Node(h, _, _) => h,\n\
+                           Tree::Leaf => Arc<Inner> { v: 0 }\n\
+                       }\n\
+                   }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn value_intermediate_requires_explicit_arc_member() {
+        // A `[value]` record in the recursive group folds *outside* the
+        // promotion group: loaded out of the box by value, nothing carries
+        // its coloring, so a bare same-group link inside it refutes …
+        let bad = "struct [value] V { l: List }\n\
+                   enum List { Nil, Cons(V) }\n\
+                   fn f(l: Arc<List>) -> i32 { 0 }";
+        assert!(
+            has_error(bad, "every member of an `Arc` inner must be `Sync`"),
+            "{:#?}",
+            reports_of(bad)
+        );
+        // … and the expressible alternative is an explicit `Arc` member,
+        // which is `Sync` on its own (closed coinductively through the
+        // enclosing arc).
+        let good = "struct [value] W { l: Arc<List> }\n\
+                    enum List { Nil, Cons(W) }\n\
+                    fn f(l: Arc<List>) -> i32 { 0 }";
+        assert!(reports_of(good).is_empty(), "{:#?}", reports_of(good));
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1720,6 +1720,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// enum and variant index, instantiate generics to θ, check each payload argument
     /// against its instantiated type, and return the enum type `R`. Constructing a
     /// regional enum outside a region is a diagnostic.
+    #[allow(clippy::too_many_arguments)]
     fn infer_variant(
         &mut self,
         def: DefId,

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -895,9 +895,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         span: Option<Span>,
     ) -> Expr<'tcx> {
         let base = self.infer_expr(base);
-        let mut cur = self.peel_arc(base.ty);
+        let mut raw = self.infer.shallow_resolve(base.ty);
         let mut indices = Vec::new();
         for acc in accs {
+            // Reads see through the arc coloring, but the coloring is the
+            // atomic *context* of everything inside: a bare shared field read
+            // through an arc'd base comes out at its promoted (`Arc`) type —
+            // the §3.3 whole-subtree rule at the typing level.
+            let arced = matches!(raw.kind(), TyKind::Arc(_));
+            let cur = self.peel_arc(raw);
             let TyKind::Record { def, args, flex } = cur.kind() else {
                 let shown = self.infer.resolve(cur);
                 self.error(
@@ -911,9 +917,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 return self.poison(span);
             };
             indices.push(idx);
-            cur = self.infer.shallow_resolve(field_ty);
+            let field_ty = self.infer.shallow_resolve(field_ty);
+            raw = if arced {
+                let group = self.arc_recursive_group(*def);
+                self.arc_promote_member_ty(&group, field_ty)
+            } else {
+                field_ty
+            };
         }
-        self.mk_expr(ExprKind::Proj(Box::new(base), indices), cur, span)
+        self.mk_expr(ExprKind::Proj(Box::new(base), indices), raw, span)
     }
 
     /// Resolve an access on a record type to `(field index, field type, mutable)`.
@@ -1518,7 +1530,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 && matches!(self.records[&def].fields, Some(RecordFields::Variants(_)))
             {
                 self.record_use(enum_key);
-                return self.infer_variant(def, enum_key, path.basename, ty_args, args, span);
+                return self.infer_variant(def, enum_key, path.basename, ty_args, args, false, span);
             }
             let Some(def) = self.resolve_record_ref(path) else {
                 let hint = self.record_suggestion(enum_key);
@@ -1527,7 +1539,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 return self.poison(span);
             };
             self.record_use(path.basename);
-            return self.infer_struct_def(def, path.basename, ty_args, args, span);
+            return self.infer_struct_def(def, path.basename, ty_args, args, false, span);
         }
         // A bare struct constructor.
         self.infer_struct(path.basename, ty_args, args, span)
@@ -1580,8 +1592,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.record_use(ipath.basename);
         let iargs: Vec<Option<surface::Type>> = iargs.iter().cloned().map(Some).collect();
         let mut e = match variant {
-            None => self.infer_struct_def(def, ipath.basename, &iargs, args, span),
-            Some(v) => self.infer_variant(def, ipath.basename, v, &iargs, args, span),
+            None => self.infer_struct_def(def, ipath.basename, &iargs, args, true, span),
+            Some(v) => self.infer_variant(def, ipath.basename, v, &iargs, args, true, span),
         };
         // Wrap only a successfully built constructor; an error path stays the
         // poison it already is.
@@ -1645,7 +1657,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return self.poison(span);
         };
         self.record_use(name);
-        self.infer_struct_def(def, name, ty_args, args, span)
+        self.infer_struct_def(def, name, ty_args, args, false, span)
     }
 
     /// The resolved-def core of [`Self::infer_struct`] (shared with the
@@ -1656,6 +1668,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         name: TokenKey,
         ty_args: &[Option<surface::Type>],
         args: &[(Option<TokenKey>, surface::Expr)],
+        arc: bool,
         span: Option<Span>,
     ) -> Expr<'tcx> {
         let record = self.records[&def].clone();
@@ -1677,7 +1690,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
         }
         let inst = self.instantiate(&record.generics_as_decls(), ty_args, span);
-        let field_tys = self.field_types(&record.fields, &inst);
+        let mut field_tys = self.field_types(&record.fields, &inst);
+        if arc {
+            // The arc'd constructor is the coloring site: its atomic context
+            // flows into the fields (§3.3) — a bare same-group shared field
+            // is expected at its promoted `Arc` type, so the whole spine is
+            // built atomic from birth (the closed colored world).
+            let group = self.arc_recursive_group(def);
+            for (_, ty) in field_tys.iter_mut() {
+                *ty = self.arc_promote_member_ty(&group, *ty);
+            }
+        }
 
         let checked = self.check_ctor_args(name, args, &field_tys, span);
         let ty_args = self.inst_args(&record.generics_as_decls(), &inst);
@@ -1704,6 +1727,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         variant: TokenKey,
         ty_args: &[Option<surface::Type>],
         args: &[(Option<TokenKey>, surface::Expr)],
+        arc: bool,
         span: Option<Span>,
     ) -> Expr<'tcx> {
         let record = self.records[&def].clone();
@@ -1729,9 +1753,24 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
         let payload = variants[vidx].fields.clone();
         let inst = self.instantiate(&record.generics_as_decls(), ty_args, span);
+        // Under the arc'd constructor, the atomic context flows into the
+        // payload (§3.3): bare same-group shared fields are expected at their
+        // promoted `Arc` types — the spine is built atomic from birth.
+        let group = if arc {
+            self.arc_recursive_group(def)
+        } else {
+            rustc_hash::FxHashSet::default()
+        };
         let payload_tys: Vec<Ty<'tcx>> = payload
             .iter()
-            .map(|t| self.infer.instantiate_ty(*t, &inst))
+            .map(|t| {
+                let t = self.infer.instantiate_ty(*t, &inst);
+                if arc {
+                    self.arc_promote_member_ty(&group, t)
+                } else {
+                    t
+                }
+            })
             .collect();
 
         let mut checked = Vec::new();

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1148,7 +1148,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (name, ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
-                        self.reject_arc_member(fty, span);
+                        self.reject_arc_member(default_cap, fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -1161,7 +1161,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .map(|f| {
                         let (ty, mutable) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
-                        self.reject_arc_member(fty, span);
+                        self.reject_arc_member(default_cap, fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -1179,7 +1179,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                                 .iter()
                                 .map(|t| {
                                     let fty = self.eval_type(t);
-                                    self.reject_arc_member(fty, span);
+                                    self.reject_arc_member(default_cap, fty, span);
                                     fty
                                 })
                                 .collect(),
@@ -1379,12 +1379,16 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     /// Enforce that a `[field]` link's element is regional. The element (peeled
     /// from the `Nullable` link) must be a regional record: a concrete
-    /// Reject a record member whose slot is directly `Arc<…>`: the MLIR record
-    /// encoding names an rc-managed member by its capability and has no
-    /// per-member atomic axis yet, so an arc cannot sit inline in a record.
-    fn reject_arc_member(&mut self, fty: Ty<'tcx>, span: Option<Span>) {
-        if matches!(fty.kind(), TyKind::Arc(_)) {
-            self.error(span, "an `Arc` record member is not supported yet");
+    /// Reject an `Arc` member of a `[regional]` record: regions and threads
+    /// do not mix (design doc §6), and the region scanner has no atomic
+    /// member-link handling. Shared and `[value]` records may hold `Arc`
+    /// members — the member type spells its own atomic link (§3.3).
+    fn reject_arc_member(&mut self, record_cap: DefaultCap, fty: Ty<'tcx>, span: Option<Span>) {
+        if record_cap == DefaultCap::Regional && matches!(fty.kind(), TyKind::Arc(_)) {
+            self.error(
+                span,
+                "an `Arc` member of a `[regional]` record is not supported                  (regions and threads do not mix)",
+            );
         }
     }
 

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1379,15 +1379,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     /// Enforce that a `[field]` link's element is regional. The element (peeled
     /// from the `Nullable` link) must be a regional record: a concrete
-    /// Reject an `Arc` member of a `[regional]` record: regions and threads
-    /// do not mix (design doc §6), and the region scanner has no atomic
-    /// member-link handling. Shared and `[value]` records may hold `Arc`
-    /// members — the member type spells its own atomic link (§3.3).
+    /// Reject an `Arc` member of a `[regional]` record — **not implemented
+    /// for now**: nothing in the current machinery is known to break (the
+    /// region scanner only walks `[field]` links, and member release goes
+    /// through the ordinary drop glue at the written member type), but the
+    /// interaction with the deferred sync-regional design (§6 —
+    /// freeze/rigid release, region teardown) is deliberately left
+    /// undecided. Shared and `[value]` records may hold `Arc` members —
+    /// the member type spells its own atomic link (§3.3).
     fn reject_arc_member(&mut self, record_cap: DefaultCap, fty: Ty<'tcx>, span: Option<Span>) {
         if record_cap == DefaultCap::Regional && matches!(fty.kind(), TyKind::Arc(_)) {
             self.error(
                 span,
-                "an `Arc` member of a `[regional]` record is not supported                  (regions and threads do not mix)",
+                "an `Arc` member of a `[regional]` record is not implemented yet",
             );
         }
     }

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -316,7 +316,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         ty: Ty<'tcx>,
     ) -> Pat<'tcx> {
         // An `Arc<Enum<…>>` scrutinee dispatches on the inner enum's
-        // constructors; the pattern spelling is the plain one.
+        // constructors; the pattern spelling is the plain one. The coloring
+        // is the atomic context of everything inside, though: bare shared
+        // fields bind at their promoted (`Arc`) types (§3.3).
+        let arced = matches!(self.infer.shallow_resolve(ty).kind(), TyKind::Arc(_));
         let ty = self.peel_arc(ty);
         // The built-in nullable constructors, by the same qualifier convention
         // as [`Elaborator::infer_ctor`] on the expression side.
@@ -388,11 +391,21 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         );
         // Recurse into each declared field. Missing trailing fields (e.g. behind
         // a `..` ellipsis or an arity error) are treated as wildcards.
+        let group = if arced {
+            self.arc_recursive_group(enum_def)
+        } else {
+            rustc_hash::FxHashSet::default()
+        };
         let fields = payload
             .iter()
             .enumerate()
             .map(|(i, decl)| {
                 let field_ty = self.infer.instantiate_ty(*decl, &inst);
+                let field_ty = if arced {
+                    self.arc_promote_member_ty(&group, field_ty)
+                } else {
+                    field_ty
+                };
                 match ctor.args.get(i) {
                     Some(arg) => self.check_pat(&arg.kind, span, field_ty),
                     None => Pat::Wild,

--- a/crates/reussir-core/src/semi/traits/sync.rs
+++ b/crates/reussir-core/src/semi/traits/sync.rs
@@ -51,6 +51,83 @@ pub trait SyncEnv<'tcx> {
     /// (`name` / `.0` / `Variant.0`). `None` when the fields are not
     /// populated yet — the verdict blocks and the mono backstop re-checks.
     fn members(&self, def: DefId, args: &'tcx [Ty<'tcx>]) -> Option<Vec<(String, Ty<'tcx>)>>;
+
+    /// The defs of record heads referenced anywhere in `def`'s declared
+    /// member types (through nullables, value members, type arguments, …) —
+    /// the def-level reference graph the recursive-group (SCC) computation
+    /// walks. `None` when the fields are not populated yet.
+    fn member_record_defs(&self, def: DefId) -> Option<Vec<DefId>>;
+}
+
+/// Collect the def of every record head appearing anywhere in `ty`, for the
+/// [`SyncEnv::member_record_defs`] implementations: the def-level reference
+/// graph the recursive-group computation walks.
+pub fn collect_record_defs<'tcx>(ty: Ty<'tcx>, out: &mut Vec<DefId>) {
+    match *ty.kind() {
+        TyKind::Record { def, args, .. } => {
+            out.push(def);
+            for &arg in args {
+                collect_record_defs(arg, out);
+            }
+        }
+        TyKind::Arc(inner) | TyKind::Nullable(inner) => collect_record_defs(inner, out),
+        TyKind::Cell { elem, .. } | TyKind::Array { elem, .. } => collect_record_defs(elem, out),
+        TyKind::Closure { params, ret } => {
+            for &p in params {
+                collect_record_defs(p, out);
+            }
+            collect_record_defs(ret, out);
+        }
+        _ => {}
+    }
+}
+
+/// The recursive group of `root`: every def `D` such that `root` reaches `D`
+/// and `D` reaches `root` through the def-level member-reference graph
+/// (`root` itself included). §3.3's SCC promotion re-colors exactly these
+/// under an `Arc`. Type arguments are ignored at this level, so polymorphic
+/// recursion collapses onto its def. Returns `None` (blocked) when any
+/// reachable def's fields are not populated yet.
+pub fn recursive_group<'tcx>(
+    env: &dyn SyncEnv<'tcx>,
+    root: DefId,
+) -> Option<FxHashSet<DefId>> {
+    // Forward reachability from `root`.
+    let mut forward = FxHashSet::default();
+    let mut stack = vec![root];
+    while let Some(def) = stack.pop() {
+        if !forward.insert(def) {
+            continue;
+        }
+        for next in env.member_record_defs(def)? {
+            stack.push(next);
+        }
+    }
+    // Keep the defs that reach back: walk each candidate's forward set for
+    // `root`. Record graphs are small; quadratic is fine.
+    let mut group = FxHashSet::default();
+    for &candidate in &forward {
+        let mut seen = FxHashSet::default();
+        let mut stack = vec![candidate];
+        let mut reaches_root = false;
+        while let Some(def) = stack.pop() {
+            if def == root {
+                reaches_root = true;
+                break;
+            }
+            if !seen.insert(def) {
+                continue;
+            }
+            for next in env.member_record_defs(def)? {
+                stack.push(next);
+            }
+        }
+        if reaches_root {
+            group.insert(candidate);
+        }
+    }
+    group.insert(root);
+    Some(group)
 }
 
 /// Why a type is not `Sync`.
@@ -122,6 +199,7 @@ pub fn sync_verdict<'tcx>(env: &dyn SyncEnv<'tcx>, ty: Ty<'tcx>) -> SyncVerdict<
         env,
         on_path: FxHashSet::default(),
         path: Vec::new(),
+        group: FxHashSet::default(),
     };
     cx.check(ty)
 }
@@ -134,6 +212,7 @@ pub fn wf_arc<'tcx>(env: &dyn SyncEnv<'tcx>, inner: Ty<'tcx>) -> SyncVerdict<'tc
         env,
         on_path: FxHashSet::default(),
         path: Vec::new(),
+        group: FxHashSet::default(),
     };
     cx.on_path.insert(inner);
     cx.wf(inner)
@@ -145,6 +224,15 @@ struct Cx<'e, 'tcx> {
     /// a cycle and coinductively succeeds.
     on_path: FxHashSet<Ty<'tcx>>,
     path: Vec<String>,
+    /// The recursive group of the shared record whose members are currently
+    /// being folded under an `Arc` (§3.3): a bare shared member whose def is
+    /// in the group is checked *as its arc'd version* — the automatic SCC
+    /// promotion — instead of refuting as a plain box. Empty outside an arc'd
+    /// fold, and cleared while folding a `[value]` member's own members: a
+    /// value intermediate can escape the box by value, where nothing carries
+    /// the coloring, so its same-group links must be written as explicit
+    /// `Arc` members instead.
+    group: FxHashSet<DefId>,
 }
 
 impl<'tcx> Cx<'_, 'tcx> {
@@ -212,13 +300,32 @@ impl<'tcx> Cx<'_, 'tcx> {
             }
             TyKind::Record { def, args, .. } => match self.env.default_cap(def) {
                 None => SyncVerdict::Blocked,
+                // A bare shared member of the current arc'd recursive group
+                // promotes (§3.3): it is checked as its own `Arc`, and the
+                // coinductive guard closes the cycle. Outside the group the
+                // bare box refutes — shareability is carried by the coloring.
+                Some(DefaultCap::Shared) if self.group.contains(&def) => {
+                    if !self.on_path.insert(ty) {
+                        return SyncVerdict::Sync;
+                    }
+                    let verdict = self.wf(ty);
+                    self.on_path.remove(&ty);
+                    verdict
+                }
                 Some(DefaultCap::Shared) => self.refute(ty, NotSyncReason::NonAtomicBox),
                 Some(DefaultCap::Regional) => self.refute(ty, NotSyncReason::Regional),
                 // A `[value]` record is inline storage: `Sync` iff its
-                // members are.
+                // members are. Its fold runs *outside* the promotion group —
+                // a value intermediate can leave the box by value, where
+                // nothing carries the coloring.
                 Some(DefaultCap::Value) => match self.env.members(def, args) {
                     None => SyncVerdict::Blocked,
-                    Some(members) => self.fold(members),
+                    Some(members) => {
+                        let saved = std::mem::take(&mut self.group);
+                        let verdict = self.fold(members);
+                        self.group = saved;
+                        verdict
+                    }
                 },
             },
             TyKind::Arc(inner) => {
@@ -245,28 +352,48 @@ impl<'tcx> Cx<'_, 'tcx> {
             TyKind::Record { def, args, .. } => match self.env.default_cap(def) {
                 Some(DefaultCap::Shared) => match self.env.members(def, args) {
                     None => SyncVerdict::Blocked,
-                    Some(members) => self.fold(members),
+                    Some(members) => {
+                        // The members fold under this record's recursive
+                        // group: same-group bare shared links promote (§3.3).
+                        let Some(group) = recursive_group(self.env, def) else {
+                            return SyncVerdict::Blocked;
+                        };
+                        let saved = std::mem::replace(&mut self.group, group);
+                        let verdict = self.fold(members);
+                        self.group = saved;
+                        verdict
+                    }
                 },
                 None => SyncVerdict::Blocked,
                 // Value/regional inners: the kind gate's error.
                 Some(_) => SyncVerdict::Sync,
             },
+            // Array elements and closure arguments are not record-member
+            // positions, so the SCC promotion does not apply inside them —
+            // their fold runs outside any group.
             TyKind::Array { elem, .. } => {
+                let saved = std::mem::take(&mut self.group);
                 self.path.push("the array element".to_owned());
                 let verdict = self.check(elem);
                 self.path.pop();
+                self.group = saved;
                 verdict
             }
             // Argument types only: applied arguments become captures, so the
             // type-level bound covers every later partial application. The
             // creation-site check of *environment* captures lands with arc'd
             // closure construction.
-            TyKind::Closure { params, .. } => self.fold(
-                params
-                    .iter()
-                    .enumerate()
-                    .map(|(i, &p)| (format!("closure argument {i}"), p)),
-            ),
+            TyKind::Closure { params, .. } => {
+                let saved = std::mem::take(&mut self.group);
+                let verdict = self.fold(
+                    params
+                        .iter()
+                        .enumerate()
+                        .map(|(i, &p)| (format!("closure argument {i}"), p)),
+                );
+                self.group = saved;
+                verdict
+            }
             TyKind::Generic(_) | TyKind::Hole(_) | TyKind::Bottom => SyncVerdict::Blocked,
             // Everything else is the kind gate's error.
             _ => SyncVerdict::Sync,
@@ -295,6 +422,15 @@ mod tests {
         }
         fn members(&self, def: DefId, _args: &'tcx [Ty<'tcx>]) -> Option<Vec<(String, Ty<'tcx>)>> {
             self.records.get(&def).and_then(|(_, m)| m.clone())
+        }
+        fn member_record_defs(&self, def: DefId) -> Option<Vec<DefId>> {
+            let (_, members) = self.records.get(&def)?;
+            let members = members.as_ref()?;
+            let mut out = Vec::new();
+            for (_, ty) in members {
+                collect_record_defs(*ty, &mut out);
+            }
+            Some(out)
         }
     }
 

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -461,9 +461,65 @@ impl<'tcx> SyncEnv<'tcx> for ElabSyncEnv<'_, '_, 'tcx> {
                 .collect(),
         })
     }
+
+    fn member_record_defs(&self, def: DefId) -> Option<Vec<DefId>> {
+        let rec = self.el.records.get(&def)?;
+        let fields = rec.fields.as_ref()?;
+        let mut out = Vec::new();
+        let mut walk = |t: Ty<'tcx>| crate::semi::traits::sync::collect_record_defs(t, &mut out);
+        match fields {
+            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _)| walk(*t)),
+            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _)| walk(*t)),
+            RecordFields::Variants(vs) => vs
+                .iter()
+                .for_each(|v| v.fields.iter().for_each(|t| walk(*t))),
+        }
+        Some(out)
+    }
 }
 
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
+    /// The recursive group (SCC) of `def` over the record member-reference
+    /// graph — the defs whose bare shared links re-color under an `Arc` of
+    /// any group member (§3.3). Empty when fields are not populated yet (the
+    /// promotion then simply does not fire; mono re-derives it ground).
+    pub(crate) fn arc_recursive_group(&self, def: DefId) -> rustc_hash::FxHashSet<DefId> {
+        crate::semi::traits::sync::recursive_group(&ElabSyncEnv { el: self }, def)
+            .unwrap_or_default()
+    }
+
+    /// §3.3 SCC promotion of a member/field type read or written through an
+    /// arc'd box: a bare shared record head in `group` becomes its own `Arc`
+    /// (through a `Nullable` wrapper); everything else is untouched. This is
+    /// the typing half of the whole-subtree rule — representationally the
+    /// declaration stays bare and the box's atomic context derives the links.
+    pub(crate) fn arc_promote_member_ty(
+        &self,
+        group: &rustc_hash::FxHashSet<DefId>,
+        ty: Ty<'tcx>,
+    ) -> Ty<'tcx> {
+        match *ty.kind() {
+            TyKind::Record { def, .. }
+                if group.contains(&def)
+                    && self
+                        .records
+                        .get(&def)
+                        .is_some_and(|r| r.default_cap == DefaultCap::Shared) =>
+            {
+                self.tcx.mk_arc(ty)
+            }
+            TyKind::Nullable(inner) => {
+                let promoted = self.arc_promote_member_ty(group, inner);
+                if promoted == inner {
+                    ty
+                } else {
+                    self.tcx.mk_nullable(promoted)
+                }
+            }
+            _ => ty,
+        }
+    }
+
     /// Report an ill-formed `Arc<inner>` whose kind is admissible but whose
     /// contents are not `Sync`. Call only where records are complete (the
     /// post-populate sweep and body checking); a blocked verdict defers to

--- a/docs/design/thread-safety.md
+++ b/docs/design/thread-safety.md
@@ -170,9 +170,10 @@ member form the dialect admits, because the container's capability cannot
 derive it: the container may be a normal, thread-local box while the member's
 count is shared with other threads (its drop glue must decrement atomically
 even though the container's own count is plain). `Arc` members are legal in
-shared and `[value]` records; a `[regional]` record rejects them (§6 —
-regions and threads do not mix, and the region scanner has no atomic link
-handling).
+shared and `[value]` records; a `[regional]` record rejects them **for now
+(not implemented)** — nothing in the current machinery is known to break,
+but the interaction with the deferred sync-regional design (§6) is
+deliberately left undecided until that design is written down.
 
 ### 3.2 Arc closures: type-level WF plus a creation-site capture check
 

--- a/docs/design/thread-safety.md
+++ b/docs/design/thread-safety.md
@@ -159,17 +159,20 @@ Consequences:
    decrement on any thread is safe; every value a reader can clone out is
    `Sync`, so concurrent reads are safe.
 
-### 3.1 Reads through the coloring *(open: per-member atomic axis)*
+### 3.1 Reads through the coloring
 
 Projection and matching on `Arc<X>` see `X`'s members. A member that is itself
-an rc object must come out **with its own coloring** — i.e. the member was
-declared `Arc<Y>` and projects as `Arc<Y>`. This is why `Arc` record members
-are a prerequisite for `Arc` being useful on anything but leaf records, and
-they are currently rejected ("an `Arc` record member is not supported yet",
-`ctxt.rs::reject_arc_member`): the MLIR record encoding stores a per-member
-capability but no per-member atomic axis, so a member `Arc<Y>` cannot yet
-lower to `rc<Y, shared, atomic>` inside the record layout. Adding that axis is
-the main outstanding dialect work for this design.
+an rc object comes out **with its own coloring**: a declared `Arc<Y>` member
+projects as `Arc<Y>`, and a bare same-group member of an arc'd recursive
+record projects *promoted* (§3.3). Representationally, an `Arc<Y>` member
+lowers to the explicit member type `rc<Y, shared, atomic>` — the one rc
+member form the dialect admits, because the container's capability cannot
+derive it: the container may be a normal, thread-local box while the member's
+count is shared with other threads (its drop glue must decrement atomically
+even though the container's own count is plain). `Arc` members are legal in
+shared and `[value]` records; a `[regional]` record rejects them (§6 —
+regions and threads do not mix, and the region scanner has no atomic link
+handling).
 
 ### 3.2 Arc closures: type-level WF plus a creation-site capture check
 
@@ -260,15 +263,29 @@ committed here). The cost profile is the one already accepted in §1: an arc'd
 spine pays atomic refcounting from birth, where Koka would pay only after
 actual sharing.
 
-Representationally this refines the per-member atomic axis (§3.1, open
-item 2): member atomicity is **per record instance, derived from the
-instance's color**, not fixed per declaration. A `(def, args)` pair can exist
-at both colors; the two instances share layout offsets (the axis is metadata
-driving acquire/drop/scanner emission and borrow types) but differ in
-same-group member links and drop glue, and nullary constructors (`Nil`) need a
-per-color box. Until that axis lands, the frontend keeps rejecting
-`Arc<List<T>>` outright — accepting it early would lower an atomic head over a
-normal-spined payload, precisely the racy shape the rule exists to prevent.
+**Representation: the whole-subtree rule.** Atomicity needs *no* record
+encoding at all — no per-member flag array, no colored record instances, no
+dual mangling. The `Sync` discipline guarantees nothing nonatomic is ever
+stored inside an atomically counted box, so a member link's atomic kind is
+the **join of what the member type writes and what the parent context
+inherits**: the box's `rc<…, atomic>` floods its discipline down through
+`rc.borrow`/`ref.project` (interior references carry the parent's atomic
+kind), deriving every bare shared link, nullable wrapper, and value-record
+interior atomically — one `List` record type serves both colorings, and
+`Arc<X>` is `rc<X's own record, shared, atomic>` exactly as before. The only
+written atomicity is the `Arc` *island in normal space* (§3.1's explicit
+`rc<…, shared, atomic>` member type). Outlined drop/acquire glue forks per
+atomic kind (`drop_in_place_atomic…`), since the glue's body derives from
+its argument reference's kind.
+
+One consequence of context-carried coloring: a **`[value]` intermediate**
+containing a bare same-group link cannot promote — loaded out of the box by
+value, nothing would carry its coloring, so its drop glue would release the
+link at the wrong discipline. The checker therefore folds value-record
+members outside the promotion group; such shapes are expressed with an
+explicit `Arc` member inside the value record instead. (Variant *arms* are
+the enum's own members and promote normally — `Cons`'s tail is the canonical
+case.)
 
 ## 4. Cells
 
@@ -405,15 +422,15 @@ Not yet implemented (ordered roughly by dependency):
 1. **`Sync` auto trait** — retire the Phase-0 `Send` declaration, keep `Sync`
    as the single predicate, and add its structural propagation + member-path
    diagnostics.
-2. **Per-member atomic axis** in the MLIR record encoding, unlocking `Arc`
-   record members (§3.1) — without which `Arc` WF is only satisfiable by
-   records with no rc members. Scope refined by §3.3: the axis is derived
-   per record *instance* from its color (a `(def, args)` pair exists at up
-   to two colors), and the frontend's SCC-promotion rewrite in the `Sync`
-   checker ships together with it — the current outright rejection of
-   `Arc<List<T>>` must not be lifted before the colored lowering exists.
-3. **`Arc` lowering** (`reussir-codegen` currently errors: "`Arc` lowering is
-   not implemented yet").
+2. ~~Per-member atomic axis~~ — superseded and **implemented** as the §3.3
+   whole-subtree rule: no record encoding at all; interior references
+   inherit the box's atomic kind, `Arc` members are explicit
+   `rc<…, shared, atomic>` member types, `Arc<List<T>>` is accepted with the
+   whole spine atomic, and the SCC promotion ships in the `Sync` checker
+   (`semi/traits/sync.rs::recursive_group`).
+3. **`Arc` lowering** — implemented for records (atomic create, borrow,
+   projection, dispatch, atomic drop/acquire glue); arc'd arrays and
+   closures remain item 4.
 4. **Arc construction for arrays and closures** (annotations are accepted;
    constructors don't exist), including the §3.2 creation-site capture check.
 5. **Surface types for sync cells** (`Atomic<τ>`, `Mutex<τ>`, `Flatlock<τ>`,

--- a/include/Reussir/IR/ReussirOps.h
+++ b/include/Reussir/IR/ReussirOps.h
@@ -91,9 +91,13 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
 // drop operation. Returns the existing destructor if one is already present.
 //
 //===----------------------------------------------------------------------===//
-mlir::func::FuncOp createDtorIfNotExists(mlir::ModuleOp moduleOp,
-                                         RecordType type,
-                                         mlir::OpBuilder &builder);
+// `kind` is the atomic context the glue is dropped from: the glue's argument
+// reference carries it, and the expanded body derives member links from it
+// (whole-subtree rule), so each kind gets its own outlined symbol.
+mlir::func::FuncOp
+createDtorIfNotExists(mlir::ModuleOp moduleOp, RecordType type,
+                      mlir::OpBuilder &builder,
+                      AtomicKind kind = AtomicKind::normal);
 
 //===----------------------------------------------------------------------===//
 // emitOwnershipAcquisitionFuncIfNotExists
@@ -106,7 +110,8 @@ mlir::func::FuncOp createDtorIfNotExists(mlir::ModuleOp moduleOp,
 //
 //===----------------------------------------------------------------------===//
 mlir::func::FuncOp emitOwnershipAcquisitionFuncIfNotExists(
-    mlir::ModuleOp moduleOp, RecordType type, mlir::OpBuilder &builder);
+    mlir::ModuleOp moduleOp, RecordType type, mlir::OpBuilder &builder,
+    AtomicKind kind = AtomicKind::normal);
 
 //===----------------------------------------------------------------------===//
 

--- a/include/Reussir/IR/ReussirTypes.h
+++ b/include/Reussir/IR/ReussirTypes.h
@@ -42,7 +42,13 @@ bool isTriviallyCopyable(mlir::Type type);
 mlir::LogicalResult verifyAtomicElementType(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError, mlir::Type eleTy,
     llvm::StringRef what);
-mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap);
+// `parentAtomic` is the projecting rc/ref's atomic kind. Atomicity is a
+// whole-subtree property: a member link's atomic kind is the join of what
+// the member type writes and what the parent inherits down (an atomic parent
+// floods atomic through derived shared links, nullable wrappers, and value
+// records; an explicit atomic rc member stands on its own in normal space).
+mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap,
+                            AtomicKind parentAtomic = AtomicKind::normal);
 mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
                              bool isField, bool memBoxInternal = false);
 class CellType;

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -191,8 +191,14 @@ def ReussirRecordType
       // Position of logical member `index` in the packed physical order —
       // i.e. the GEP field index of that member in the converted LLVM struct.
       uint32_t getPhysicalMemberIndex(const mlir::DataLayout &dataLayout, uint32_t index) const;
-      ::mlir::FlatSymbolRefAttr getDtorName() const;
-      ::mlir::FlatSymbolRefAttr getAcquireName() const;
+      // Outlined drop/acquire glue symbols. The glue's body derives member
+      // links from its argument reference's atomic kind (the whole-subtree
+      // rule), so each kind gets its own symbol and the atomic variant names
+      // a distinct intrinsic path.
+      ::mlir::FlatSymbolRefAttr
+      getDtorName(AtomicKind kind = AtomicKind::normal) const;
+      ::mlir::FlatSymbolRefAttr
+      getAcquireName(AtomicKind kind = AtomicKind::normal) const;
       size_t emitScannerInstructions(
         llvm::SmallVectorImpl<int32_t> &buffer,
         const mlir::DataLayout &dataLayout, const scanner::EmitState &EmitState) const;

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -184,20 +184,23 @@ private:
     return mlir::success();
   }
 
+  // Member links and every projected/coerced reference inherit `refAtomic`,
+  // the dropped reference's atomic kind — the whole-subtree rule: inside an
+  // atomically counted box, every shared link is atomic.
   mlir::LogicalResult
   rewriteDropCompound(RecordType recordType, Capability refCap,
-                      ReussirRefDropOp op,
+                      AtomicKind refAtomic, ReussirRefDropOp op,
                       mlir::PatternRewriter &rewriter) const {
     assert(recordType.isCompound());
     for (auto [idx, memberTy, memberIsField] : llvm::enumerate(
              recordType.getMembers(), recordType.getMemberIsField())) {
       if (memberIsField)
         continue;
-      auto projectedTy = getProjectedType(memberTy, false, refCap);
+      auto projectedTy = getProjectedType(memberTy, false, refCap, refAtomic);
       if (isTriviallyCopyable(projectedTy))
         continue;
       RefType projectedRefTy =
-          RefType::get(op.getContext(), projectedTy, refCap);
+          RefType::get(op.getContext(), projectedTy, refCap, refAtomic);
       mlir::IntegerAttr index = rewriter.getIndexAttr(idx);
       mlir::Value projectedVal = ReussirRefProjectOp::create(
           rewriter, op.getLoc(), projectedRefTy, op.getRef(), index);
@@ -209,7 +212,7 @@ private:
 
   mlir::LogicalResult
   rewriteDropVariant(RecordType recordType, Capability refCap,
-                     ReussirRefDropOp op,
+                     AtomicKind refAtomic, ReussirRefDropOp op,
                      mlir::PatternRewriter &rewriter) const {
     assert(recordType.isVariant());
     llvm::SmallVector<mlir::Attribute> tagSets;
@@ -221,9 +224,10 @@ private:
         tagSets.size());
     for (auto [idx, memberTy, memberIsField] : llvm::enumerate(
              recordType.getMembers(), recordType.getMemberIsField())) {
-      auto projectedTy = getProjectedType(memberTy, memberIsField, refCap);
+      auto projectedTy =
+          getProjectedType(memberTy, memberIsField, refCap, refAtomic);
       RefType projectedRefTy =
-          RefType::get(op.getContext(), projectedTy, refCap);
+          RefType::get(op.getContext(), projectedTy, refCap, refAtomic);
       mlir::Block *block = rewriter.createBlock(
           &dispatcher.getRegions()[idx], dispatcher.getRegions()[idx].begin(),
           {projectedRefTy}, {op.getLoc()});
@@ -240,11 +244,12 @@ private:
 
   mlir::LogicalResult
   rewriteDropVariant(RecordType recordType, size_t tag, Capability refCap,
-                     ReussirRefDropOp op,
+                     AtomicKind refAtomic, ReussirRefDropOp op,
                      mlir::PatternRewriter &rewriter) const {
     assert(recordType.isVariant());
     auto targetType = recordType.getMembers()[tag];
-    auto targetRefType = rewriter.getType<RefType>(targetType, refCap);
+    auto targetRefType =
+        rewriter.getType<RefType>(targetType, refCap, refAtomic);
     auto targetRef =
         ReussirRecordCoerceOp::create(rewriter, op.getLoc(), targetRefType,
                                       rewriter.getIndexAttr(tag), op.getRef());
@@ -347,20 +352,23 @@ public:
         .Case<RecordType>([&](RecordType recordType) {
           if (shouldOutline(op, recordType)) {
             mlir::ModuleOp moduleOp = op->getParentOfType<mlir::ModuleOp>();
-            mlir::func::FuncOp dtor =
-                createDtorIfNotExists(moduleOp, recordType, rewriter);
+            mlir::func::FuncOp dtor = createDtorIfNotExists(
+                moduleOp, recordType, rewriter, refType.getAtomicKind());
             mlir::func::CallOp::create(rewriter, op.getLoc(), dtor,
                                        op.getRef());
             rewriter.eraseOp(op);
             return llvm::success();
           }
+          AtomicKind refAtomic = refType.getAtomicKind();
           if (recordType.isCompound())
-            return rewriteDropCompound(recordType, refCap, op, rewriter);
+            return rewriteDropCompound(recordType, refCap, refAtomic, op,
+                                       rewriter);
           if (op.getVariant())
             return rewriteDropVariant(recordType,
                                       op.getVariant()->getZExtValue(), refCap,
-                                      op, rewriter);
-          return rewriteDropVariant(recordType, refCap, op, rewriter);
+                                      refAtomic, op, rewriter);
+          return rewriteDropVariant(recordType, refCap, refAtomic, op,
+                                    rewriter);
         })
         .Case<NullableType>([&](NullableType nullableType) {
           return rewriteDropNullable(nullableType, op, rewriter);
@@ -410,21 +418,21 @@ public:
     if (auto recordType = llvm::dyn_cast<RecordType>(elementType)) {
       if (shouldOutline(op, recordType)) {
         mlir::ModuleOp moduleOp = op->getParentOfType<mlir::ModuleOp>();
-        mlir::func::FuncOp acquireFunc =
-            emitOwnershipAcquisitionFuncIfNotExists(moduleOp, recordType,
-                                                    rewriter);
+        mlir::func::FuncOp acquireFunc = emitOwnershipAcquisitionFuncIfNotExists(
+            moduleOp, recordType, rewriter, refType.getAtomicKind());
         mlir::func::CallOp::create(rewriter, op.getLoc(), acquireFunc,
                                    op.getRef());
         rewriter.eraseOp(op);
         return mlir::success();
       }
 
-      // For variant with known tag, coerce first then acquire
+      // For variant with known tag, coerce first then acquire; the coerced
+      // reference stays inside the same box and keeps its atomic context.
       if (recordType.isVariant() && op.getVariant()) {
         size_t tag = op.getVariant()->getZExtValue();
         auto targetType = recordType.getMembers()[tag];
-        auto targetRefType =
-            rewriter.getType<RefType>(targetType, refType.getCapability());
+        auto targetRefType = rewriter.getType<RefType>(
+            targetType, refType.getCapability(), refType.getAtomicKind());
         auto targetRef = ReussirRecordCoerceOp::create(
             rewriter, op.getLoc(), targetRefType, rewriter.getIndexAttr(tag),
             op.getRef());

--- a/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
+++ b/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
@@ -464,7 +464,8 @@ private:
       mlir::Type targetVariantType =
           getProjectedType(recordType.getMembers()[*singletonTag],
                            recordType.getMemberIsField()[*singletonTag],
-                           variantRef.getCapability());
+                           variantRef.getCapability(),
+                           variantRef.getAtomicKind());
       RefType coercedType =
           RefType::get(rewriter.getContext(), targetVariantType,
                        variantRef.getCapability(), variantRef.getAtomicKind());

--- a/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
+++ b/lib/Conversion/RcDecrementExpansion/RcDecrementExpansion.cpp
@@ -105,7 +105,8 @@ struct RcDecrementExpansionPattern
           if (bound.contains(static_cast<int64_t>(idx)) || memberIsField)
             continue;
           auto projectedTy = getProjectedType(memberTy, memberIsField,
-                                              Capability::unspecified);
+                                              Capability::unspecified,
+                                              type.getAtomicKind());
           if (isTriviallyCopyable(projectedTy))
             continue;
           // Unbound members release through `ref.drop` — the same route the

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -194,9 +194,13 @@ verifyRcCreateLikeSymbolUses(mlir::Operation *op, mlir::Value region,
   return mlir::success();
 }
 
+// `boxAtomic` is the atomic kind of the box being assembled: an atomic box
+// demands atomic member links (the whole-subtree rule — its ctor fields
+// must already be atomically counted where they are shared boxes).
 mlir::LogicalResult verifyCompoundFields(mlir::Operation *op,
                                          RecordType recordType,
-                                         mlir::ValueRange fields) {
+                                         mlir::ValueRange fields,
+                                         AtomicKind boxAtomic) {
   if (!recordType)
     return op->emitOpError("RC element type must be a record type");
   if (!recordType.getComplete())
@@ -207,14 +211,26 @@ mlir::LogicalResult verifyCompoundFields(mlir::Operation *op,
     return op->emitOpError("number of fields must match number of members");
   for (auto [field, member, memberCapability] : llvm::zip(
            fields, recordType.getMembers(), recordType.getMemberIsField())) {
-    mlir::Type projectedType =
-        reussir::getProjectedType(member, memberCapability, Capability::flex);
+    mlir::Type projectedType = reussir::getProjectedType(
+        member, memberCapability, Capability::flex, boxAtomic);
     if (projectedType != field.getType())
       return op->emitOpError("field type must match projected member type, ")
              << "field type: " << field.getType()
              << ", projected member type: " << projectedType;
   }
   return mlir::success();
+}
+
+// The standalone assemble ops do not know the atomic kind of the box their
+// record eventually lands in, so a shared-link field is accepted at either
+// kind here; the box-level `rc.create` verifiers pin the exact one.
+bool fieldMatchesEitherKind(mlir::Type member, bool isField,
+                            mlir::Type fieldTy) {
+  return fieldTy ==
+             reussir::getProjectedType(member, isField, Capability::flex) ||
+         fieldTy == reussir::getProjectedType(member, isField,
+                                              Capability::flex,
+                                              AtomicKind::atomic);
 }
 
 mlir::LogicalResult verifySkippedFields(mlir::Operation *op,
@@ -403,7 +419,8 @@ void ReussirRcDecOp::rematerializeBoundRetains(mlir::OpBuilder &builder) {
   for (int64_t idx : getBoundMembersAttr().asArrayRef()) {
     auto projectedTy = getProjectedType(payload.getMembers()[idx],
                                         payload.getMemberIsField()[idx],
-                                        Capability::unspecified);
+                                        Capability::unspecified,
+                                        rcType.getAtomicKind());
     auto projectedRefTy = builder.getType<RefType>(
         projectedTy, Capability::unspecified, rcType.getAtomicKind());
     mlir::Value slot =
@@ -698,7 +715,8 @@ ReussirRcCreateOp::verifySymbolUses(mlir::SymbolTableCollection &symbolTable) {
 //===----------------------------------------------------------------------===//
 mlir::LogicalResult ReussirRcCreateCompoundOp::verify() {
   RecordType recordType = getRecordType();
-  if (failed(verifyCompoundFields(getOperation(), recordType, getFields())))
+  if (failed(verifyCompoundFields(getOperation(), recordType, getFields(),
+                                  getRcPtr().getType().getAtomicKind())))
     return mlir::failure();
   if (failed(verifySkippedFields(getOperation(), getFields().size())))
     return mlir::failure();
@@ -806,7 +824,8 @@ mlir::LogicalResult ReussirRcCreateVariantOp::verify() {
 
   if (hasValue) {
     mlir::Type projectedType = reussir::getProjectedType(
-        targetVariantType, targetVariantIsField, Capability::flex);
+        targetVariantType, targetVariantIsField, Capability::flex,
+        getRcPtr().getType().getAtomicKind());
     if (projectedType != getValue().getType())
       return emitOpError("value type must match projected type, ")
              << "value type: " << getValue().getType()
@@ -820,7 +839,8 @@ mlir::LogicalResult ReussirRcCreateVariantOp::verify() {
     if (!compoundType || !compoundType.isCompound())
       return emitOpError("compound fields payload requires the selected "
                          "variant member to be a compound record");
-    if (failed(verifyCompoundFields(getOperation(), compoundType, getFields())))
+    if (failed(verifyCompoundFields(getOperation(), compoundType, getFields(),
+                                    getRcPtr().getType().getAtomicKind())))
       return mlir::failure();
     if (failed(verifyHoleFields(getOperation(), getFields().getTypes(),
                                 getHoles().getTypes())))
@@ -1018,13 +1038,14 @@ mlir::LogicalResult ReussirRecordCompoundOp::verify() {
   for (auto [field, member, memberCapability] :
        llvm::zip(getFields(), compoundType.getMembers(),
                  compoundType.getMemberIsField())) {
-    // Since this is assemble phase, assume flex ref capability.
-    mlir::Type projectedType =
-        reussir::getProjectedType(member, memberCapability, Capability::flex);
-    if (projectedType != field.getType())
+    // Since this is assemble phase, assume flex ref capability. The eventual
+    // box's atomic kind is unknown here, so either link kind is accepted.
+    if (!fieldMatchesEitherKind(member, memberCapability, field.getType()))
       return emitOpError("field type must match projected member type, ")
              << "field type: " << field.getType()
-             << ", projected member type: " << projectedType;
+             << ", projected member type: "
+             << reussir::getProjectedType(member, memberCapability,
+                                          Capability::flex);
   }
   return mlir::success();
 }
@@ -1045,12 +1066,16 @@ mlir::LogicalResult ReussirRecordVariantOp::verify() {
     return emitOpError("tag out of bounds");
   mlir::Type targetVariantType = variantType.getMembers()[tag];
   bool targetVariantIsIsField = variantType.getMemberIsField()[tag];
-  mlir::Type projectedType = reussir::getProjectedType(
-      targetVariantType, targetVariantIsIsField, Capability::flex);
-  if (projectedType != getValue().getType())
+  // The eventual box's atomic kind is unknown to the standalone assemble op,
+  // so either link kind is accepted; `rc.create` pins the exact one.
+  if (!fieldMatchesEitherKind(targetVariantType, targetVariantIsIsField,
+                              getValue().getType()))
     return emitOpError("value type must match projected type, ")
            << "value type: " << getValue().getType()
-           << ", projected type: " << projectedType;
+           << ", projected type: "
+           << reussir::getProjectedType(targetVariantType,
+                                        targetVariantIsIsField,
+                                        Capability::flex);
   if (targetVariantIsIsField)
     return emitOpError("TODO: check this is nested in a region operation");
   return mlir::success();
@@ -1110,10 +1135,11 @@ mlir::LogicalResult ReussirRecordCoerceOp::verify() {
     return emitOpError("tag out of bounds: ")
            << tag << " >= " << recordType.getMembers().size();
 
-  // Get the target variant element type at the specified tag position
+  // Get the target variant element type at the specified tag position; the
+  // arm inherits the scrutinee reference's atomic kind (whole-subtree rule).
   mlir::Type targetVariantElementType = getProjectedType(
       recordType.getMembers()[tag], recordType.getMemberIsField()[tag],
-      variantRefType.getCapability());
+      variantRefType.getCapability(), variantRefType.getAtomicKind());
 
   // Check that the output reference element type matches the target variant
   // element type
@@ -1662,15 +1688,24 @@ mlir::LogicalResult ReussirRefProjectOp::verify() {
   bool memberIsField = recordType.getMemberIsField()[index];
 
   // Calculate the expected projected type based on the member type, member
-  // capability, and reference capability
-  mlir::Type expectedProjectedType = reussir::getProjectedType(
-      memberType, memberIsField, refType.getCapability());
+  // capability, reference capability, and the reference's atomic kind (an
+  // atomic parent floods its discipline down — whole-subtree rule)
+  mlir::Type expectedProjectedType =
+      reussir::getProjectedType(memberType, memberIsField,
+                                refType.getCapability(),
+                                refType.getAtomicKind());
 
   // Check that the projected type matches the expected type
   if (expectedProjectedType != projectedType.getElementType())
     return emitOpError("projected type mismatch: expected ")
            << expectedProjectedType << ", got "
            << projectedType.getElementType();
+
+  // The projected reference stays inside the same box, so it keeps the
+  // parent reference's atomic context.
+  if (projectedType.getAtomicKind() != refType.getAtomicKind())
+    return emitOpError("projected reference must inherit the parent "
+                       "reference's atomic kind");
 
   // Check that the projected reference has the same capability as the
   // original reference. Or if the refType is flex, then the projected type
@@ -2050,7 +2085,8 @@ mlir::LogicalResult ReussirRecordDispatchOp::verify() {
       int64_t tag = tagSet[0];
       mlir::Type expectedType =
           getProjectedType(members[tag], recordType.getMemberIsField()[tag],
-                           variantRefType.getCapability());
+                           variantRefType.getCapability(),
+                           variantRefType.getAtomicKind());
       mlir::Type actualType = block.getArgument(0).getType();
 
       // The argument should be a reference to the member type
@@ -3042,17 +3078,22 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
           // The value is already a reference, so we can use it directly
 
           if (recordType.getKind() == RecordKind::compound) {
-            // For compound types, recursively apply to each field
+            // For compound types, recursively apply to each field. Member
+            // links and the projected references inherit the parent
+            // reference's atomic kind (whole-subtree rule).
             for (auto [i, actualMemberType, actualMemberCap] : llvm::enumerate(
                      recordType.getMembers(), recordType.getMemberIsField())) {
               auto projectedType = getProjectedType(
-                  actualMemberType, actualMemberCap, refType.getCapability());
+                  actualMemberType, actualMemberCap, refType.getCapability(),
+                  refType.getAtomicKind());
               if (isTriviallyCopyable(projectedType))
                 continue;
               auto fieldRef = ReussirRefProjectOp::create(
                   builder, loc,
-                  RefType::get(builder.getContext(), projectedType), value,
-                  builder.getIndexAttr(i));
+                  RefType::get(builder.getContext(), projectedType,
+                               Capability::unspecified,
+                               refType.getAtomicKind()),
+                  value, builder.getIndexAttr(i));
 
               if (emitOwnershipAcquisition(fieldRef, builder, loc).failed())
                 return mlir::failure();
@@ -3079,11 +3120,15 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
                                  recordType.getMemberIsField())) {
 
               auto projectedType = getProjectedType(
-                  actualVariantType, actualVariantCap, refType.getCapability());
+                  actualVariantType, actualVariantCap, refType.getCapability(),
+                  refType.getAtomicKind());
 
-              // Create a block for this variant region
+              // Create a block for this variant region; the arm reference
+              // inherits the scrutinee's atomic kind.
               RefType projectedRefTy =
-                  RefType::get(builder.getContext(), projectedType);
+                  RefType::get(builder.getContext(), projectedType,
+                               Capability::unspecified,
+                               refType.getAtomicKind());
               auto *block = builder.createBlock(
                   &dispatchOp.getRegions()[i],
                   dispatchOp.getRegions()[i].begin(), {projectedRefTy}, {loc});
@@ -3166,9 +3211,10 @@ void inheritSanitizerPassthrough(mlir::ModuleOp moduleOp,
 //===----------------------------------------------------------------------===//
 mlir::func::FuncOp createDtorIfNotExists(mlir::ModuleOp moduleOp,
                                          RecordType type,
-                                         mlir::OpBuilder &builder) {
+                                         mlir::OpBuilder &builder,
+                                         AtomicKind kind) {
   mlir::SymbolTable symTable(moduleOp);
-  auto dtorName = type.getDtorName();
+  auto dtorName = type.getDtorName(kind);
   if (!dtorName)
     llvm::report_fatal_error("only named record types have destructors");
   std::string funcName = dtorName.getValue().str();
@@ -3176,7 +3222,10 @@ mlir::func::FuncOp createDtorIfNotExists(mlir::ModuleOp moduleOp,
     return funcOp;
   mlir::OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(moduleOp.getBody());
-  RefType refType = builder.getType<RefType>(type);
+  // The argument reference carries the atomic context; the `ref.drop` below
+  // re-enters the expansion, which derives member links from it.
+  RefType refType =
+      builder.getType<RefType>(type, Capability::unspecified, kind);
   auto dtor =
       mlir::func::FuncOp::create(builder, builder.getUnknownLoc(), funcName,
                                  builder.getFunctionType({refType}, {}));
@@ -3205,9 +3254,10 @@ mlir::func::FuncOp createDtorIfNotExists(mlir::ModuleOp moduleOp,
 // emitOwnershipAcquisitionFuncIfNotExists
 //===----------------------------------------------------------------------===//
 mlir::func::FuncOp emitOwnershipAcquisitionFuncIfNotExists(
-    mlir::ModuleOp moduleOp, RecordType type, mlir::OpBuilder &builder) {
+    mlir::ModuleOp moduleOp, RecordType type, mlir::OpBuilder &builder,
+    AtomicKind kind) {
   mlir::SymbolTable symTable(moduleOp);
-  auto acquireName = type.getAcquireName();
+  auto acquireName = type.getAcquireName(kind);
   if (!acquireName)
     llvm::report_fatal_error(
         "only named record types have ownership acquisition functions");
@@ -3219,8 +3269,10 @@ mlir::func::FuncOp emitOwnershipAcquisitionFuncIfNotExists(
   mlir::OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(moduleOp.getBody());
 
-  // Construct RefType from RecordType
-  RefType refType = builder.getType<RefType>(type);
+  // Construct RefType from RecordType; the argument reference carries the
+  // atomic context the member walk derives links from.
+  RefType refType =
+      builder.getType<RefType>(type, Capability::unspecified, kind);
 
   auto funcOp =
       mlir::func::FuncOp::create(builder, builder.getUnknownLoc(), funcName,
@@ -3291,9 +3343,16 @@ mlir::LogicalResult ReussirRecordExtractOp::verify() {
   if (members.size() < indexVal)
     return emitOpError("index out of bounds");
   auto memberType = members[indexVal];
+  // An extract reads from a record *value*, whose enclosing box (if any) is
+  // not visible here — accept the member link at either atomic kind, like
+  // the standalone assemble ops.
   auto projectedType = getProjectedType(
       memberType, recordType.getMemberIsField()[indexVal], Capability::value);
-  if (projectedType != getField().getType())
+  auto atomicProjectedType = getProjectedType(
+      memberType, recordType.getMemberIsField()[indexVal], Capability::value,
+      AtomicKind::atomic);
+  if (projectedType != getField().getType() &&
+      atomicProjectedType != getField().getType())
     return emitOpError("projected type mismatch");
   return mlir::success();
 }

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -264,7 +264,9 @@ mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
          recordTy.getDefaultCapability() == Capability::regional)) ||
        llvm::isa<ArrayType, CellType>(rawMember)))
     member = ptrTy;
-  if (llvm::isa<ClosureType>(member))
+  // An explicit atomic rc member (thread-safety design §3.3) and a raw
+  // closure are always stored as pointers, box-internal or not.
+  if (llvm::isa<ClosureType, RcType>(member))
     member = ptrTy;
   return member;
 }
@@ -330,9 +332,26 @@ RecordType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
       return mlir::failure();
     }
 
-    if (llvm::isa<RcType>(member) || llvm::isa<RefType>(member)) {
+    if (auto rcMember = llvm::dyn_cast<RcType>(member)) {
+      // A member's *normal* shared link is derived from its capability, so a
+      // plain rc member stays banned. An **atomic** shared link cannot be
+      // derived — the member type carries a different refcount discipline
+      // than its nominal capability implies (an `Arc` member, or the
+      // same-group link of an arc'd recursive record, thread-safety design
+      // §3.3) — so it is spelled explicitly as the member type.
+      if (rcMember.getCapability() != Capability::shared ||
+          rcMember.getAtomicKind() != AtomicKind::atomic) {
+        emitError() << "rc members must be atomic shared links; a normal "
+                       "link is derived from the member's capability instead";
+        return mlir::failure();
+      }
+      if (isField) {
+        emitError() << "an atomic rc member cannot be a [field] link";
+        return mlir::failure();
+      }
+    } else if (llvm::isa<RefType>(member)) {
       emitError()
-          << "Members must not be Rc or Ref types, use capability instead";
+          << "Members must not be Ref types, use capability instead";
       return mlir::failure();
     }
 
@@ -562,22 +581,31 @@ reussir::Capability RecordType::getDefaultCapability() const {
 }
 bool RecordType::getFixed() const { return getImpl()->fixed; }
 
-::mlir::FlatSymbolRefAttr RecordType::getDtorName() const {
+::mlir::FlatSymbolRefAttr RecordType::getDtorName(AtomicKind kind) const {
   auto name = getName();
   if (!name)
     return nullptr;
-  auto prefix = llvm::Twine("_RINvNvC4core9intrinsic13drop_in_place");
+  // The glue derives member links from its argument reference's atomic kind,
+  // so each kind is a distinct intrinsic (the length prefix is the v0 length
+  // of the path segment).
+  auto prefix =
+      llvm::Twine(kind == AtomicKind::atomic
+                      ? "_RINvNvC4core9intrinsic20drop_in_place_atomic"
+                      : "_RINvNvC4core9intrinsic13drop_in_place");
   auto suffix = llvm::Twine("E");
   auto recordName = name.getValue();
   auto dtorName = (prefix + recordName.ltrim("_R") + suffix).str();
   return ::mlir::FlatSymbolRefAttr::get(getContext(), dtorName);
 }
 
-::mlir::FlatSymbolRefAttr RecordType::getAcquireName() const {
+::mlir::FlatSymbolRefAttr RecordType::getAcquireName(AtomicKind kind) const {
   auto name = getName();
   if (!name)
     return nullptr;
-  auto prefix = llvm::Twine("_RINvNvC4core9intrinsic16acquire_in_place");
+  auto prefix =
+      llvm::Twine(kind == AtomicKind::atomic
+                      ? "_RINvNvC4core9intrinsic23acquire_in_place_atomic"
+                      : "_RINvNvC4core9intrinsic16acquire_in_place");
   auto suffix = llvm::Twine("E");
   auto recordName = name.getValue();
   auto acquireName = (prefix + recordName.ltrim("_R") + suffix).str();
@@ -1447,7 +1475,17 @@ REUSSIR_POINTER_LIKE_DATA_LAYOUT_INTERFACE(ViewType)
 // is a rc pointer. Or it can be a rigid rc pointer if the field record is
 // regional.
 // Otherwise, we directly return the type.
-mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap) {
+//
+// Atomicity is a whole-subtree property (thread-safety design §3.3): the
+// `Sync` discipline guarantees nothing nonatomic is ever stored inside an
+// atomically counted box, so a member link's atomic kind is the *join* of
+// what the member type writes and what the parent context (`parentAtomic`,
+// the projecting rc/ref's atomic kind) inherits down. Derived shared links
+// and nullable-wrapped links flood atomic under an atomic parent; an
+// explicit atomic rc member (an `Arc` island inside a normal record) is
+// already written atomic and stands on its own.
+mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap,
+                            AtomicKind parentAtomic) {
   Capability targetCap =
       llvm::TypeSwitch<mlir::Type, Capability>(type)
           .Case<RecordType>([fieldCap](RecordType type) -> Capability {
@@ -1469,16 +1507,32 @@ mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap) {
   }
   if (targetCap == Capability::shared) {
     // An atomic scalar or lock-guarded cell member is managed by an atomic
-    // shared RC box (see `RcType::verify`); every other shared member keeps
-    // the default nonatomic refcount.
+    // shared RC box (see `RcType::verify`); an atomic parent floods its
+    // discipline down (the whole-subtree rule); every other shared member
+    // keeps the default nonatomic refcount.
     auto cellTy = llvm::dyn_cast<CellType>(type);
-    AtomicKind atomicKind = cellTy && cellTy.requiresAtomicSharedBox()
+    AtomicKind atomicKind = parentAtomic == AtomicKind::atomic ||
+                                    (cellTy && cellTy.requiresAtomicSharedBox())
                                 ? AtomicKind::atomic
                                 : AtomicKind::normal;
     return RcType::get(type.getContext(), type, Capability::shared, atomicKind);
   }
   if (targetCap == Capability::regional)
     return RcType::get(type.getContext(), type, Capability::rigid);
+  // A nullable-wrapped shared link is an explicit member type, but the
+  // whole-subtree rule still applies: under an atomic parent the wrapped
+  // link is atomic (the `Sync` rule made storing anything else illegal).
+  if (parentAtomic == AtomicKind::atomic) {
+    if (auto nullableTy = llvm::dyn_cast<NullableType>(type)) {
+      if (auto rcTy = llvm::dyn_cast<RcType>(nullableTy.getPtrTy());
+          rcTy && rcTy.getCapability() == Capability::shared &&
+          rcTy.getAtomicKind() == AtomicKind::normal)
+        return NullableType::get(
+            type.getContext(),
+            RcType::get(type.getContext(), rcTy.getElementType(),
+                        Capability::shared, AtomicKind::atomic));
+    }
+  }
   return type;
 }
 

--- a/tests/integration/conversion/record_dispatch_atomic.mlir
+++ b/tests/integration/conversion/record_dispatch_atomic.mlir
@@ -19,8 +19,11 @@ module {
     %result = reussir.record.dispatch(%opt_ref : !reussir.ref<!option shared atomic>) -> i32 {
       [0] -> {
         ^bb0(%some_ref : !reussir.ref<!option_some shared atomic>):
-          %field_ref = reussir.ref.project(%some_ref : !reussir.ref<!option_some shared atomic>) [0] : !reussir.ref<i32 shared>
-          %extracted = reussir.ref.load(%field_ref : !reussir.ref<i32 shared>) : i32
+          // The projected reference inherits the parent's atomic kind (the
+          // whole-subtree rule): interior references of an atomic box stay
+          // in the atomic context.
+          %field_ref = reussir.ref.project(%some_ref : !reussir.ref<!option_some shared atomic>) [0] : !reussir.ref<i32 shared atomic>
+          %extracted = reussir.ref.load(%field_ref : !reussir.ref<i32 shared atomic>) : i32
           reussir.scf.yield %extracted : i32
       }
       [1] -> {

--- a/tests/integration/conversion/record_member_atomic.mlir
+++ b/tests/integration/conversion/record_member_atomic.mlir
@@ -1,0 +1,73 @@
+// RUN: %reussir-opt %s --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=EXPAND
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1})' | %FileCheck %s --check-prefix=OUTLINE
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},reussir-convert-to-std,convert-scf-to-cf,convert-to-llvm)' | %reussir-translate --mlir-to-llvmir | %FileCheck %s --check-prefix=LLVM
+
+// The whole-subtree atomicity rule (thread-safety design §3.3). Two shapes:
+//
+// 1. An `Arc` island in normal space: `Pair` is a normal-context value
+//    holding one explicitly atomic rc member (an `Arc` member — the member
+//    type spells `rc<… atomic>` because the container cannot derive it) and
+//    one plain shared member. Acquire/drop of the pair must retain/release
+//    the two links at their own disciplines.
+//
+// 2. The arc'd recursive spine: dropping `rc<AList, …, atomic>` floods the
+//    atomic context down — the Cons tail member is *declared bare* (one
+//    record serves both colorings) but its link derives atomic from the
+//    parent box, and the outlined drop glue forks per atomic kind (its
+//    argument reference carries the context its body derives from).
+
+!inner = !reussir.record<compound "Inner" [shared] { i64 }>
+!pair = !reussir.record<compound "Pair" [value] { !reussir.rc<!inner atomic>, !inner }>
+
+!alist_ = !reussir.record<variant "AList" incomplete>
+!alist_nil = !reussir.record<compound "AList::Nil" [value] { }>
+!alist_cons = !reussir.record<compound "AList::Cons" [value] { i64, !alist_ }>
+!alist = !reussir.record<variant "AList" { !alist_nil, !alist_cons }>
+
+module @test attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>> } {
+  // The acquire glue loads each member link and bumps it at its own
+  // discipline: member 0 through the written atomic rc type, member 1
+  // through the derived normal link.
+  // EXPAND-LABEL: @acquire_pair
+  // EXPAND: reussir.ref.project{{.*}}[0]
+  // EXPAND: reussir.ref.load{{.*}} : !reussir.rc<!reussir.record<compound "Inner" {i64}> atomic>
+  // EXPAND: reussir.rc.inc(%{{[0-9a-z]+}} : !reussir.rc<!reussir.record<compound "Inner" {i64}> atomic>)
+  // EXPAND: reussir.ref.project{{.*}}[1]
+  // EXPAND: reussir.ref.load{{.*}} : !reussir.rc<!reussir.record<compound "Inner" {i64}>>
+  // EXPAND: reussir.rc.inc(%{{[0-9a-z]+}} : !reussir.rc<!reussir.record<compound "Inner" {i64}>>)
+
+  // LLVM-LABEL: @_RINvNvC4core9intrinsic16acquire_in_placePairE
+  // LLVM: atomicrmw add ptr %{{[0-9]+}}, i32 1 monotonic
+  func.func @acquire_pair(%ref : !reussir.ref<!pair>) {
+    reussir.ref.acquire (%ref : !reussir.ref<!pair>)
+    return
+  }
+
+  // Dropping the pair releases the atomic member through the acq_rel
+  // `atomicrmw sub` discipline and the plain member nonatomically.
+  // EXPAND-LABEL: @drop_pair
+  // EXPAND: reussir.rc.dec(%{{[0-9a-z]+}} : !reussir.rc<!reussir.record<compound "Inner" {i64}> atomic>)
+  // EXPAND: reussir.rc.dec(%{{[0-9a-z]+}} : !reussir.rc<!reussir.record<compound "Inner" {i64}>>)
+  func.func @drop_pair(%ref : !reussir.ref<!pair>) {
+    reussir.ref.drop (%ref : !reussir.ref<!pair>)
+    return
+  }
+
+  // The recursive spine outlines to a per-kind dtor: the atomic glue takes
+  // an *atomic* reference, dispatches, and releases the bare-declared Cons
+  // tail by calling itself — the whole spine shares one coloring.
+  // OUTLINE-LABEL: func.func private @_RINvNvC4core9intrinsic20drop_in_place_atomicAListE
+  // OUTLINE-SAME: !reussir.ref<!reussir.record<variant "AList" {{.*}}> atomic>
+  // OUTLINE: reussir.record.dispatch
+  // OUTLINE: func.call @_RINvNvC4core9intrinsic20drop_in_place_atomicAListE({{.*}} atomic>) -> ()
+  // OUTLINE-LABEL: @drop_alist
+  // OUTLINE: func.call @_RINvNvC4core9intrinsic20drop_in_place_atomicAListE
+
+  // LLVM-LABEL: @_RINvNvC4core9intrinsic20drop_in_place_atomicAListE
+  // LLVM: atomicrmw sub ptr %{{[0-9]+}}, i32 1 acq_rel
+  func.func @drop_alist(%rc : !reussir.rc<!alist atomic>) {
+    %t = reussir.rc.dec (%rc : !reussir.rc<!alist atomic>) : !reussir.nullable<!reussir.token<align: 8, size: ?>>
+    reussir.token.free (%t : !reussir.nullable<!reussir.token<align: 8, size: ?>>)
+    return
+  }
+}

--- a/tests/integration/frontend/arc.rr
+++ b/tests/integration/frontend/arc.rr
@@ -36,12 +36,37 @@ pub fn call_passthrough(a: Arc<Data>) -> Arc<Data> {
     passthrough(a)
 }
 
-// Scalar payloads only: a recursive enum (`Cons(T, List<T>)`) holds a bare
-// shared box, so its `Arc` is rejected by the structural `Sync` check until
-// the per-member atomic axis lands (design doc §3.3 SCC promotion).
 enum Opt<T> {
     None,
     Some(T)
+}
+
+// §3.3 SCC promotion: the recursive enum arcs as a whole spine. The
+// declaration stays bare — one record serves both colorings — while the
+// arc'd constructor demands an arc'd tail and the reads bind it promoted.
+enum List<T> {
+    Nil,
+    Cons(T, List<T>)
+}
+
+// HIR: pub fn #make_list() -> Arc<#List::<i64>>
+// HIR-NEXT: #List::<i64>#1(1 : i64, #List::<i64>#0() : Arc<#List::<i64>>) : Arc<#List::<i64>>
+// MIR-DAG: pub fn @_RC9make_list() -> Arc<List::<i64>>
+// The spine boxes are atomically counted from birth.
+// MLIR-DAG: reussir.rc.create value({{.+}}"_RIC4ListxE"{{.+}}) : !reussir.rc<!reussir.record<variant "_RIC4ListxE" {{.+}}> atomic>
+pub fn make_list() -> Arc<List<i64>> {
+    Arc<List<i64>>::Cons{1, Arc<List<i64>>::Nil}
+}
+
+// Matching through the coloring binds the tail at its promoted type.
+// HIR: pub fn #tail(v0 (l): Arc<#List::<i64>>) -> Arc<#List::<i64>>
+// HIR: match v0 : Arc<#List::<i64>> {
+// MIR-DAG: pub fn @_RC4tail(v0 (l): Arc<List::<i64>>) -> Arc<List::<i64>>
+pub fn tail(l: Arc<List<i64>>) -> Arc<List<i64>> {
+    match l {
+        List::Cons(_, xs) => xs,
+        List::Nil => Arc<List<i64>>::Nil
+    }
 }
 
 // The arc constructors are the inner record's own, at the arc'd type: the

--- a/tests/integration/frontend/arc_e2e.c
+++ b/tests/integration/frontend/arc_e2e.c
@@ -6,6 +6,7 @@ extern int64_t test_share_ffi(void);
 extern int64_t test_enum_ffi(void);
 extern int64_t test_nullable_ffi(void);
 extern int64_t test_generic_ffi(void);
+extern int64_t test_recursive_ffi(void);
 
 static int check(const char *name, int64_t got, int64_t want) {
   if (got == want)
@@ -21,5 +22,6 @@ int main(void) {
   failures += check("enum", test_enum_ffi(), 42);
   failures += check("nullable", test_nullable_ffi(), 11);
   failures += check("generic", test_generic_ffi(), 9);
+  failures += check("recursive", test_recursive_ffi(), 42);
   return failures ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/tests/integration/frontend/arc_e2e.c
+++ b/tests/integration/frontend/arc_e2e.c
@@ -7,6 +7,7 @@ extern int64_t test_enum_ffi(void);
 extern int64_t test_nullable_ffi(void);
 extern int64_t test_generic_ffi(void);
 extern int64_t test_recursive_ffi(void);
+extern int64_t test_tree_ffi(void);
 
 static int check(const char *name, int64_t got, int64_t want) {
   if (got == want)
@@ -23,5 +24,6 @@ int main(void) {
   failures += check("nullable", test_nullable_ffi(), 11);
   failures += check("generic", test_generic_ffi(), 9);
   failures += check("recursive", test_recursive_ffi(), 42);
+  failures += check("tree", test_tree_ffi(), 42);
   return failures ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/tests/integration/frontend/arc_e2e.rr
+++ b/tests/integration/frontend/arc_e2e.rr
@@ -1,9 +1,8 @@
 // End-to-end Arc semantics: the arc'd constructor allocates an atomically
 // counted box, sharing retains it atomically, and reads (projection and
-// matching) are the inner record's own. Enum payloads are scalars: the arc
-// colors exactly one box, so a member holding a bare shared box (a recursive
-// tail link) is rejected by the structural `Sync` check until the per-member
-// atomic axis lands (design doc §3.3 SCC promotion).
+// matching) are the inner record's own. A recursive enum arcs as a whole
+// spine (§3.3 SCC promotion): one declaration serves both colorings, and the
+// atomic context of the box derives every interior link.
 
 // RUN: %rrc %s -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/arc_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
@@ -52,6 +51,28 @@ pub fn test_nullable() -> i64 {
     }
 }
 extern "C" trampoline "test_nullable_ffi" = test_nullable;
+
+// The §3.3 recursive spine: the whole list is built atomic from `Nil` up
+// (the arc'd Cons demands an arc'd tail), and matching through the coloring
+// binds the tail at its promoted `Arc<List<i64>>` type — every spine link
+// retains/releases through the atomic discipline.
+enum List<T> {
+    Nil,
+    Cons(T, List<T>)
+}
+
+fn sum(l: Arc<List<i64>>) -> i64 {
+    match l {
+        List::Cons(x, xs) => x + sum(xs),
+        List::Nil => 0
+    }
+}
+
+pub fn test_recursive() -> i64 {
+    let l = Arc<List<i64>>::Cons{7, Arc<List<i64>>::Cons{35, Arc<List<i64>>::Nil}};
+    sum(l)
+}
+extern "C" trampoline "test_recursive_ffi" = test_recursive;
 
 fn id<T>(x: T) -> T { x }
 

--- a/tests/integration/frontend/arc_e2e.rr
+++ b/tests/integration/frontend/arc_e2e.rr
@@ -74,6 +74,31 @@ pub fn test_recursive() -> i64 {
 }
 extern "C" trampoline "test_recursive_ffi" = test_recursive;
 
+// A shared record mixing both member forms: an explicit `Arc<Data>` header
+// (its slot spells the atomic link — readable from bare and arc'd boxes
+// alike) and bare recursive children that promote under the arc'd box. The
+// whole tree retains/releases every link at its own discipline.
+enum Tree {
+    Leaf,
+    Node(Arc<Data>, Tree, Tree)
+}
+
+fn tree_sum(t: Arc<Tree>) -> i64 {
+    match t {
+        Tree::Node(h, l, r) => h.value + tree_sum(l) + tree_sum(r),
+        Tree::Leaf => 0
+    }
+}
+
+pub fn test_tree() -> i64 {
+    let l = Arc<Tree>::Node{Arc<Data> { value: 30 }, Arc<Tree>::Leaf, Arc<Tree>::Leaf};
+    let shared_header = Arc<Data> { value: 5 };
+    let r = Arc<Tree>::Node{shared_header, Arc<Tree>::Leaf, Arc<Tree>::Leaf};
+    let root = Arc<Tree>::Node{Arc<Data> { value: 7 }, l, r};
+    tree_sum(root)
+}
+extern "C" trampoline "test_tree_ffi" = test_tree;
+
 fn id<T>(x: T) -> T { x }
 
 // A generic instantiated at an arc'd type keeps the atomic discipline.

--- a/tests/integration/frontend/arc_errors.rr
+++ b/tests/integration/frontend/arc_errors.rr
@@ -26,11 +26,11 @@ struct [regional] Node { value: i64, next: [field] Node }
 fn regional_inner(a: Arc<Node>) -> i64 { 0 }
 
 // An `Arc` member is legal in shared/value records (its type spells the
-// atomic link), but not in a `[regional]` record: regions and threads do
-// not mix.
+// atomic link); a `[regional]` record rejects it for now — not implemented,
+// pending the §6 sync-regional design.
 struct [shared] Shared { value: i64 }
 struct Holder { a: Arc<Shared> }
-// CHECK-DAG: an `Arc` member of a `[regional]` record is not supported
+// CHECK-DAG: an `Arc` member of a `[regional]` record is not implemented yet
 struct [regional] RegionalHolder { v: i64, a: Arc<Shared> }
 
 // A mutable `[field]` link stores a regional record, never a shared box.

--- a/tests/integration/frontend/arc_errors.rr
+++ b/tests/integration/frontend/arc_errors.rr
@@ -25,11 +25,13 @@ struct [regional] Node { value: i64, next: [field] Node }
 // CHECK-DAG: `Arc` inner type `[regional] Node` is not a `[shared]` record, array, or closure (a `[regional]` record)
 fn regional_inner(a: Arc<Node>) -> i64 { 0 }
 
-// An arc cannot sit inline in a record member yet (the MLIR record encoding
-// has no per-member atomic axis).
+// An `Arc` member is legal in shared/value records (its type spells the
+// atomic link), but not in a `[regional]` record: regions and threads do
+// not mix.
 struct [shared] Shared { value: i64 }
-// CHECK-DAG: an `Arc` record member is not supported yet
 struct Holder { a: Arc<Shared> }
+// CHECK-DAG: an `Arc` member of a `[regional]` record is not supported
+struct [regional] RegionalHolder { v: i64, a: Arc<Shared> }
 
 // A mutable `[field]` link stores a regional record, never a shared box.
 // CHECK-DAG: a `[field]` link element must be a regional record
@@ -39,12 +41,14 @@ struct [regional] BadLink { value: [field] Arc<Shared> }
 // CHECK-DAG: `Arc` inner type `Arc<Shared>` is not a `[shared]` record, array, or closure (already an `Arc`)
 fn nested_inner(a: Arc<Arc<Shared>>) -> i64 { 0 }
 
-// The stratified wf rule: the arc colors exactly one box, so every member of
-// the inner must be `Sync` on its own — a recursive tail is a bare shared box
-// and refutes (until §3.3 SCC promotion lands with the per-member atomic axis).
-enum List<T> { Nil, Cons(T, List<T>) }
-// CHECK-DAG: `Arc<List<i64>>` is ill-formed: member `Cons.1` is a plain `[shared]` rc box whose refcount is not atomic; every member of an `Arc` inner must be `Sync`
-fn recursive_inner(l: Arc<List<i64>>) -> i64 { 0 }
+// The stratified wf rule: the arc colors exactly one box, so a bare shared
+// member *outside the recursive group* must be `Sync` on its own — §3.3 SCC
+// promotion covers only the arc'd spine itself (see arc.rr for the accepted
+// recursive shape).
+struct Outside { value: i64 }
+struct Carrier { o: Outside }
+// CHECK-DAG: `Arc<Carrier>` is ill-formed: member `o` is a plain `[shared]` rc box whose refcount is not atomic; every member of an `Arc` inner must be `Sync`
+fn non_group_member(c: Arc<Carrier>) -> i64 { 0 }
 
 // The arc constructors demand an explicit `[shared]` record inner.
 // CHECK-DAG: `Arc` construction takes exactly one explicit type argument


### PR DESCRIPTION
Implements #441's proposal (design doc §3.3): `Arc<List<T>>` and friends are now well-formed, typed, lowered, and running natively. Four commits, each self-contained and green (the one noted transient is called out in its message), meant to be read in order.

## The representation (evolved in discussion, final form)

Atomicity is a **whole-subtree property decided by the rc container** — the record encoding carries *nothing* (no per-member flag array, no record-level flag, no colored instances, no dual mangling). The `Sync` discipline guarantees nothing nonatomic is ever stored inside an atomically counted box, so a member link's atomic kind is the **join of what the member type writes and what the parent context inherits**:

- `rc<List, …, atomic>` floods its discipline down through `rc.borrow`/`ref.project`: interior references carry the parent's atomic kind, so every bare shared link, nullable wrapper, and value-record interior derives atomic. One `List` record serves both colorings; `Arc<X>` stays `rc<X's own record, shared, atomic>` (#427's transparency intact).
- The one *written* form is the `Arc` island in normal space (`FooBase { x: Arc<Y> }`): the container is thread-local but the member's count is shared with other threads, so its drop glue must decrement atomically — the member type spells `rc<Y, shared, atomic>`, the only rc member form the verifier admits.
- Outlined drop/acquire glue forks per atomic kind (`drop_in_place_atomic…`): the glue's argument reference carries the context its body derives from, and the recursive spine's atomic dtor calls itself at the atomic reference.

## Commit walk

1. **[mlir]** `getProjectedType` gains the parent atomic kind (join rule); `ref.project` results, dispatch arms, coerces, and the acquire/drop walks inherit it (revising #427's "projections stay plain"); `rc.create` pins an atomic box's ctor fields to atomic links while the standalone assemble ops accept either; RcCreateFusion refuses cross-kind token reuse; verifier admits exactly `rc<…, shared, atomic>` members. `record_member_atomic.mlir` pins both shapes down to `atomicrmw`.
2. **[codegen]** `Cursor`/`ProjectedMember` carry the atomic context; a bare shared member read under an atomic parent is refined to its `Arc` type (mirroring the regional→rigid refinement), so ownership ops emit the atomic discipline; `Arc` members lower as explicit atomic rc member types.
3. **[frontend]** The `Sync` checker computes the def-level recursive group and promotes bare same-group shared members under an `Arc` (coinduction closes the cycle); value-record members fold outside the group (a by-value intermediate can't carry the coloring — explicit `Arc` members express that shape); the arc'd ctor demands promoted field types (`Arc<List>::Cons` requires an `Arc<List>` tail — built atomic from birth, closed world), and projection/match bind promoted; `reject_arc_member` lifts to regional-only.
4. **[tests+docs]** Recursive `Arc<List>` positive at HIR/MIR/MLIR/native/sanitizer levels; the doc's §3.1/§3.3/open-items updated to this final scheme (superseding the per-instance `memberIsAtomic` text from #441).

## Verification

- 284 `reussir-core` tests, 25 workspace suites, 381/389 lit (8 unsupported = baseline), C++ unit tests 28/28.
- e2e: a three-node atomic list built from `Nil` up, matched through the coloring, summed natively; ASan+LSan gate holds the atomic retain/release balance.
- No new clippy warnings.

Follow-ups (unchanged roadmap): sync-cell surface types (PR 3), arc'd array/closure ctors + capture checks (PR 4); nested bare ctor literals under an `Arc` expectation could later absorb the coloring as ergonomic sugar (today the tail is spelled `Arc<List<i64>>::Nil` explicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4ihrGS9WQXXCw7k1VMdGC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787078459&installation_id=144622820&pr_number=443&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F443&signature=8ddfbe0a81fe70acd029962ccd0360ca398964056fcb9cfd6e18dc81698da336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->