### PR TITLE
[frontend] reject inline-recursive value records (infinite size)

### DIFF
--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -208,6 +208,15 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
     // layout unresolved.
     driver.close_records_over_fields(input.records, tcx);
 
+    // Reject inline-recursive record *instances* before resolving layouts: a
+    // `[value]` record stored inside itself through a chain of inline members
+    // has no finite layout (the LLVM conversion would recurse forever). Semi
+    // rejects the def-level cycles it can see; grounding can create new ones
+    // through generics (`[value] Wrap<T> { x: T }` instantiated at a value
+    // record that contains `Wrap` back), so the closed instance set is walked
+    // here with every member substituted.
+    driver.reject_infinite_value_recursion(tcx);
+
     // Resolve the discovered record instances to symbols. Collect the keys first
     // so the interner can be borrowed mutably while we map them.
     let record_keys: Vec<(DefId, &'tcx [Ty<'tcx>])> = driver.records.iter().copied().collect();
@@ -714,6 +723,110 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 // legal and semi's wf check blocks on the generic. This walk
                 // is its only ground checkpoint.
                 self.check_arc_inners(ground, record.span);
+            }
+        }
+    }
+
+    /// The instances stored *inline* in instance `(def, args)`'s layout:
+    /// ground member heads that are `[value]`-capability records. Pointers
+    /// (shared/regional records, `Arc`, `Nullable`, cells, arrays, closures)
+    /// break an inline chain.
+    fn inline_value_instances(
+        &self,
+        tcx: &'a TyCtxt<'tcx>,
+        def: DefId,
+        args: &'tcx [Ty<'tcx>],
+    ) -> Vec<(DefId, &'tcx [Ty<'tcx>])> {
+        let Some(record) = self.record_defs.get(&def) else {
+            return Vec::new();
+        };
+        let mut subst = Subst::default();
+        for ((_, gid), &ty) in record.ty_params.iter().zip(args.iter()) {
+            subst.insert(*gid, ty);
+        }
+        let field_tys: Vec<Ty<'tcx>> = match record.fields.as_ref() {
+            Some(RecordFields::Named(fields)) => fields.iter().map(|(_, ty, _)| *ty).collect(),
+            Some(RecordFields::Unnamed(fields)) => fields.iter().map(|(ty, _)| *ty).collect(),
+            Some(RecordFields::Variants(variants)) => variants
+                .iter()
+                .flat_map(|v| v.fields.iter().copied())
+                .collect(),
+            None => Vec::new(),
+        };
+        field_tys
+            .into_iter()
+            .filter_map(|t| match *subst_ty(tcx, t, &subst).kind() {
+                TyKind::Record { def, args, .. }
+                    if self
+                        .record_defs
+                        .get(&def)
+                        .is_some_and(|r| r.default_cap == DefaultCap::Value) =>
+                {
+                    Some((def, args))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The ground half of the infinite-size check (see semi's
+    /// `reject_infinite_value_recursion`): walk the closed record-instance
+    /// set and report any `[value]` instance stored inline within itself.
+    fn reject_infinite_value_recursion(&mut self, tcx: &'a TyCtxt<'tcx>) {
+        type Key<'tcx> = (DefId, &'tcx [Ty<'tcx>]);
+        // 1 = on the current DFS path, 2 = finished.
+        let mut color: FxHashMap<Key<'tcx>, u8> = FxHashMap::default();
+        let roots: Vec<Key<'tcx>> = self.records.iter().copied().collect();
+        for root in roots {
+            if color.contains_key(&root)
+                || !self
+                    .record_defs
+                    .get(&root.0)
+                    .is_some_and(|r| r.default_cap == DefaultCap::Value)
+            {
+                continue;
+            }
+            let mut stack: Vec<(Key<'tcx>, Vec<Key<'tcx>>)> =
+                vec![(root, self.inline_value_instances(tcx, root.0, root.1))];
+            color.insert(root, 1);
+            while let Some((_, succs)) = stack.last_mut() {
+                let Some(next) = succs.pop() else {
+                    let (done, _) = stack.pop().expect("non-empty stack");
+                    color.insert(done, 2);
+                    continue;
+                };
+                match color.get(&next) {
+                    Some(1) => {
+                        let cycle: Vec<String> = stack
+                            .iter()
+                            .map(|(k, _)| k.0)
+                            .skip_while(|&d| d != next.0)
+                            .map(|d| {
+                                self.resolver
+                                    .resolve(self.record_defs[&d].name)
+                                    .to_owned()
+                            })
+                            .collect();
+                        let span = self.record_defs[&next.0].span;
+                        self.error(
+                            span,
+                            format!(
+                                "this instantiation creates a recursive `[value]` \
+                                 record of infinite size: `{}` is stored inline \
+                                 within itself (through `{}`); break the cycle \
+                                 with a boxed link",
+                                cycle.first().cloned().unwrap_or_default(),
+                                cycle.join("` → `"),
+                            ),
+                        );
+                    }
+                    Some(_) => {}
+                    None => {
+                        let succs = self.inline_value_instances(tcx, next.0, next.1);
+                        color.insert(next, 1);
+                        stack.push((next, succs));
+                    }
+                }
             }
         }
     }
@@ -1735,6 +1848,26 @@ mod tests {
             reports
                 .iter()
                 .any(|m| m.contains("not a `[shared]` record, array, or closure")),
+            "{reports:#?}"
+        );
+    }
+
+    #[test]
+    fn ground_value_recursion_is_rejected_at_instantiation() {
+        // The def-level check cannot see a cycle closed through a generic:
+        // `Wrap<T>` stores `T` inline, and instantiating it at a record that
+        // contains `Wrap<A>` back closes the loop only once ground.
+        let src = r#"
+            struct [value] Wrap<T> { x: T }
+            struct [value] A { w: Wrap<A> }
+            fn f(a: A) -> i64 { 0 }
+            extern "C" trampoline "f_ffi" = f;
+        "#;
+        let reports = mono_reports(src);
+        assert!(
+            reports
+                .iter()
+                .any(|m| m.contains("recursive `[value]` record of infinite size")),
             "{reports:#?}"
         );
     }

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1085,6 +1085,38 @@ mod tests {
     }
 
     #[test]
+    fn rejects_infinite_value_recursion() {
+        // A `[value]` record stored inline within itself has no finite
+        // layout: mutual and self cycles are rejected at declaration.
+        let mutual = "struct [value] A { b: B }\nstruct [value] B { a: A }";
+        assert!(
+            has_error(mutual, "recursive `[value]` record has infinite size"),
+            "{:#?}",
+            reports_of(mutual)
+        );
+        let direct = "struct [value] A { a: A }";
+        assert!(
+            has_error(direct, "recursive `[value]` record has infinite size"),
+            "{:#?}",
+            reports_of(direct)
+        );
+    }
+
+    #[test]
+    fn boxed_links_break_value_recursion() {
+        // Any pointer member breaks the inline chain: a shared box makes
+        // the recursion finite. (A shared record holding a value chain is
+        // fine too — edges into a shared record are pointers, so it can
+        // never sit on an inline cycle.)
+        let src = "struct S { a: A }\n\
+                   struct [value] A { s: S }\n\
+                   struct Shared2 { v: i64 }\n\
+                   struct [value] C { s: Shared2 }\n\
+                   struct [value] D { c: C }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
     fn infers_arc_ctors() {
         // The struct and variant arc constructors type at `Arc<R>`.
         let src = "struct Pair { a: i32 }\n\

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -896,6 +896,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 def
             })
             .collect();
+        // Now that this batch's fields exist, reject inline-recursive record
+        // cycles: a `[value]` record stored inside a `[value]` record, around
+        // to itself, never crosses a box and has no finite layout. Forward
+        // references only resolve within a batch, so a new cycle is always
+        // rooted in this batch's defs.
+        self.reject_infinite_value_recursion(&record_defs);
         // Post-populate sweep: signatures and record members were evaluated
         // before fields existed, so their `Arc` nodes wf-check only now.
         // Restricted to this batch's items so a REPL re-run does not re-report
@@ -1271,6 +1277,104 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     fn field_ty(&mut self, ty: &surface::Type, mutable: bool) -> Ty<'tcx> {
         let t = self.eval_type(ty);
         if mutable { self.tcx.mk_nullable(t) } else { t }
+    }
+
+    /// The defs stored *inline* in `def`'s layout: direct member (or variant
+    /// arm field) heads that are `[value]`-capability records. Every other
+    /// member kind — shared/regional records, `Arc`, `Nullable`, cells,
+    /// arrays, closures — is a pointer and breaks an inline chain. Heads
+    /// only: a `[value]` head's *type arguments* can also be stored inline,
+    /// but which of them actually are is only known once the generic
+    /// grounds, so that half is checked at monomorphization.
+    fn inline_value_heads(&self, def: DefId) -> Vec<DefId> {
+        let Some(rec) = self.records.get(&def) else {
+            return Vec::new();
+        };
+        let member_tys: Vec<Ty<'tcx>> = match &rec.fields {
+            Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _)| *t).collect(),
+            Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _)| *t).collect(),
+            Some(RecordFields::Variants(vs)) => {
+                vs.iter().flat_map(|v| v.fields.iter().copied()).collect()
+            }
+            None => Vec::new(),
+        };
+        member_tys
+            .into_iter()
+            .filter_map(|t| match *t.kind() {
+                TyKind::Record { def, .. }
+                    if self
+                        .records
+                        .get(&def)
+                        .is_some_and(|r| r.default_cap == DefaultCap::Value) =>
+                {
+                    Some(def)
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Reject inline-recursive record cycles — a `[value]` record reachable
+    /// from itself purely through inline storage has no finite layout (the
+    /// LLVM conversion would recurse forever computing it). Only
+    /// `[value]`-capability records can participate: every edge *into* a
+    /// shared/regional record is a pointer, so a cycle is a cycle among
+    /// value defs. Reported once per back-edge, naming the cycle.
+    pub(super) fn reject_infinite_value_recursion(&mut self, batch: &[DefId]) {
+        // 1 = on the current DFS path, 2 = finished.
+        let mut color: FxHashMap<DefId, u8> = FxHashMap::default();
+        for &root in batch {
+            if color.contains_key(&root)
+                || !self
+                    .records
+                    .get(&root)
+                    .is_some_and(|r| r.default_cap == DefaultCap::Value)
+            {
+                continue;
+            }
+            let mut stack: Vec<(DefId, Vec<DefId>)> =
+                vec![(root, self.inline_value_heads(root))];
+            color.insert(root, 1);
+            while let Some((_, succs)) = stack.last_mut() {
+                let Some(next) = succs.pop() else {
+                    let (done, _) = stack.pop().expect("non-empty stack");
+                    color.insert(done, 2);
+                    continue;
+                };
+                match color.get(&next) {
+                    Some(1) => {
+                        // Back-edge: the cycle is the path suffix from `next`.
+                        let cycle: Vec<String> = stack
+                            .iter()
+                            .map(|(d, _)| d)
+                            .skip_while(|&&d| d != next)
+                            .map(|d| self.sym(self.records[d].name).to_owned())
+                            .collect();
+                        let (span, file) =
+                            (self.records[&next].span, self.records[&next].file);
+                        self.set_current_file(file);
+                        self.error(
+                            span,
+                            format!(
+                                "recursive `[value]` record has infinite size: \
+                                 `{}` is stored inline within itself (through `{}`); \
+                                 break the cycle with a boxed link (e.g. a \
+                                 `[shared]` record or `Arc`)",
+                                cycle.first().cloned().unwrap_or_default(),
+                                cycle.join("` → `"),
+                            ),
+                        );
+                    }
+                    Some(2) => {}
+                    None => {
+                        color.insert(next, 1);
+                        let succs = self.inline_value_heads(next);
+                        stack.push((next, succs));
+                    }
+                    Some(_) => {}
+                }
+            }
+        }
     }
 
     /// Enforce that a `[field]` link's element is regional. The element (peeled


### PR DESCRIPTION
Found while probing mutual-recursion support: `struct [value] A { b: B } / struct [value] B { a: A }` — an infinitely sized type — passed elaboration, emitted a cyclic value record, and crashed the LLVM type conversion with a stack overflow. Pre-existing (independent of #443).

Two checks, one shape:

- **Semi, post-populate, per batch**: DFS over the def-level graph whose nodes are `[value]`-capability records and whose edges are direct member (or variant arm field) heads of `[value]` capability — the inline containments. Every other member kind is a pointer and breaks the chain; edges *into* a shared record are pointers, so any cycle is a cycle among value defs. A back-edge reports the cycle by name with a fix hint. Self-cycles (`[value] A { a: A }`) included.
- **Mono, ground backstop, before layouts resolve**: the def-level check can't see a cycle closed through a generic (`[value] Wrap<T> { x: T }` instantiated at a record that contains `Wrap<A>` back), so the closed record-instance set is walked with every member substituted.

The original crash now reports:

```
Error: recursive `[value]` record has infinite size: `A` is stored inline
within itself (through `A` → `B`); break the cycle with a boxed link
(e.g. a `[shared]` record or `Arc`)
```

Guarded recursion (through shared boxes — `List`, `Tree`/`Forest` — or any pointer member) is untouched: 285 core tests, full lit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4ihrGS9WQXXCw7k1VMdGC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787082754&installation_id=144622820&pr_number=444&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F444&signature=21889d0fd25bc01340a576c6a40133138fc848fb61b4cc0d99b0e505afcb41de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->