### PR TITLE
[frontend] explain arc-coloring mismatches in rustc-lifetime style

### DIFF
--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1171,6 +1171,66 @@ mod tests {
     }
 
     #[test]
+    fn arc_coloring_mismatch_explains_itself() {
+        // A mismatch that is *only* the arc coloring gets the reconciliation
+        // diagnostic instead of a bare "type mismatch" — on both sides of
+        // the confusion. Creation side: feeding a bare value where the
+        // atomic world demands an arc'd one names the SCC promotion and
+        // says how to fix it …
+        let creation = "enum List<T> { Nil, Cons(T, List<T>) }\n\
+                        fn f(x: i32) -> i32 { Arc<List<i32>>::Cons{x, List::Nil}; 0 }";
+        assert!(
+            has_error(
+                creation,
+                "cannot reconcile thread-safety: expected `Arc<List<i32>>`, found `List<i32>`"
+            ),
+            "{:#?}",
+            reports_of(creation)
+        );
+        assert!(
+            has_error(creation, "fields of the recursive group `List` are promoted to `Arc`"),
+            "{:#?}",
+            reports_of(creation)
+        );
+        assert!(
+            has_error(creation, "construct it as `Arc<List<i32>>::…` from the start"),
+            "{:#?}",
+            reports_of(creation)
+        );
+        // … and projection side: a field matched out of an arc'd box keeps
+        // the coloring, which the diagnostic explains rather than leaving
+        // the user wondering where the `Arc` came from.
+        let projection = "enum List<T> { Nil, Cons(T, List<T>) }\n\
+                          fn tail(l: Arc<List<i32>>) -> List<i32> {\n\
+                              match l { List::Cons(_, xs) => xs, List::Nil => List::Nil }\n\
+                          }";
+        assert!(
+            has_error(
+                projection,
+                "a value read out of an arc'd box keeps its `Arc` coloring"
+            ),
+            "{:#?}",
+            reports_of(projection)
+        );
+        // A non-recursive pair still reconciles, without the SCC note.
+        let flat = "struct Pair { a: i32 }\n\
+                    fn f(p: Pair) -> Arc<Pair> { p }";
+        assert!(
+            has_error(
+                flat,
+                "cannot reconcile thread-safety: expected `Arc<Pair>`, found `Pair`"
+            ),
+            "{:#?}",
+            reports_of(flat)
+        );
+        assert!(
+            !has_error(flat, "recursive group"),
+            "{:#?}",
+            reports_of(flat)
+        );
+    }
+
+    #[test]
     fn arc_mixes_explicit_and_promoted_members() {
         // A shared record can mix both member forms (§3.3): an explicit
         // `Arc<Inner>` member keeps its declared type everywhere — readable

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -115,6 +115,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         if self.infer.unify(expected, found).is_err() {
             let e = self.infer.resolve(expected);
             let f = self.infer.resolve(found);
+            if let Some(message) = self.arc_reconciliation_error(e, f) {
+                self.error(span, message);
+                return;
+            }
             self.error(
                 span,
                 format!(
@@ -146,6 +150,95 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 ),
             );
         }
+    }
+
+    /// The rich diagnostic for a mismatch that is *only* about the arc
+    /// coloring: `Arc<T>` against `T` (possibly under matching `Nullable`
+    /// wrappers). Plain "type mismatch" reads as noise here — the user either
+    /// fed a bare value where the atomic world demands an arc'd one (the
+    /// creation side) or is surprised that a field read through an `Arc` came
+    /// out arc'd (the projection side) — so explain the §3.3 rule the way
+    /// rustc explains lifetimes: what clashed, why the type is what it is,
+    /// and what to do about it. Returns `None` for any other mismatch.
+    fn arc_reconciliation_error(
+        &mut self,
+        expected: Ty<'tcx>,
+        found: Ty<'tcx>,
+    ) -> Option<String> {
+        // Peel matching `Nullable` wrappers: a promoted `Nullable<Arc<T>>`
+        // member mismatches a bare `Nullable<T>` the same way.
+        let (mut e, mut f) = (expected, found);
+        while let (TyKind::Nullable(ei), TyKind::Nullable(fi)) = (e.kind(), f.kind()) {
+            (e, f) = (*ei, *fi);
+        }
+        // Exactly one side is arc'd, and underneath they are the same type.
+        // Probe with a real unification so a still-unsolved hole on the bare
+        // side (`List<_>` against `Arc<List<i32>>`) is recognized — and
+        // solved, which also silences the "cannot infer" cascade the failed
+        // outer unification would otherwise leave behind.
+        let (inner, arc_is_expected) = match (e.kind(), f.kind()) {
+            (TyKind::Arc(inner), _) if self.infer.unify(*inner, f).is_ok() => (*inner, true),
+            (_, TyKind::Arc(inner)) if self.infer.unify(e, *inner).is_ok() => (*inner, false),
+            _ => return None,
+        };
+        let inner = self.infer.resolve(inner);
+        let shown = self.ty_display(inner);
+        // Re-resolve both sides: the probe above may have just solved holes
+        // the failed outer unification left behind (`List<_>` → `List<i32>`).
+        let (expected, found) = (self.infer.resolve(expected), self.infer.resolve(found));
+        let mut message = format!(
+            "cannot reconcile thread-safety: expected `{}`, found `{}`",
+            self.ty_display(expected),
+            self.ty_display(found),
+        );
+        // When the type is genuinely recursive, the arc'd side usually exists
+        // because of the SCC promotion — name the group and the rule.
+        if let TyKind::Record { def, .. } = *inner.kind()
+            && self.def_is_recursive(def)
+        {
+            let group = self.arc_recursive_group(def);
+            let mut names: Vec<&str> = group
+                .iter()
+                .filter_map(|d| self.records.get(d).map(|r| self.sym(r.name)))
+                .collect();
+            names.sort_unstable();
+            message.push_str(&format!(
+                "\nnote: fields of the recursive group `{}` are promoted to \
+                 `Arc` inside an arc'd box",
+                names.join("`, `"),
+            ));
+        }
+        if arc_is_expected {
+            message.push_str(&format!(
+                "\nnote: a plain value is never re-colored; construct it as \
+                 `Arc<{shown}>::…` from the start",
+            ));
+        } else {
+            message.push_str(
+                "\nnote: a value read out of an arc'd box keeps its `Arc` coloring",
+            );
+        }
+        Some(message)
+    }
+
+    /// Whether `def` sits on a genuine recursion: some chain of record member
+    /// references starting from its members returns to it. (Unlike
+    /// [`Elaborator::arc_recursive_group`], which always contains its root,
+    /// this distinguishes a recursive record from a plain one.)
+    fn def_is_recursive(&self, def: DefId) -> bool {
+        use crate::semi::traits::sync::SyncEnv;
+        let env = crate::semi::ty_eval::ElabSyncEnv { el: self };
+        let mut stack = env.member_record_defs(def).unwrap_or_default();
+        let mut seen = rustc_hash::FxHashSet::default();
+        while let Some(next) = stack.pop() {
+            if next == def {
+                return true;
+            }
+            if seen.insert(next) {
+                stack.extend(env.member_record_defs(next).unwrap_or_default());
+            }
+        }
+        false
     }
 
     /// The flexivity coloring at the head of `ty`, peeling a `Nullable` wrapper

--- a/crates/reussir-syntax/src/diagnostics.rs
+++ b/crates/reussir-syntax/src/diagnostics.rs
@@ -105,18 +105,25 @@ pub fn render(
         let start = start.min(len.saturating_sub(1));
         let end = end.clamp(start + 1, len.max(start + 1));
         let span = (diag.file, start as usize..end as usize);
-        // The message heads the report (a greppable summary line) and annotates
-        // the underlined span, so the caret line stands on its own.
-        Report::build(diag.severity.report_kind(), span.clone())
+        // The message's first line heads the report (a greppable summary
+        // line) and annotates the underlined span, so the caret line stands
+        // on its own; any further lines are rendered as notes below the
+        // snippet (a `note: ` prefix, if present, is dropped in favor of
+        // ariadne's own `Note:` heading) instead of bloating the label.
+        let mut lines = diag.message.lines();
+        let primary = lines.next().unwrap_or(diag.message);
+        let mut report = Report::build(diag.severity.report_kind(), span.clone())
             .with_config(Config::default().with_color(color))
-            .with_message(diag.message)
+            .with_message(primary)
             .with_label(
                 Label::new(span)
-                    .with_message(diag.message)
+                    .with_message(primary)
                     .with_color(diag.severity.color()),
-            )
-            .finish()
-            .write(cache, &mut out)?;
+            );
+        for note in lines {
+            report = report.with_note(note.strip_prefix("note: ").unwrap_or(note));
+        }
+        report.finish().write(cache, &mut out)?;
     }
     Ok(())
 }

--- a/tests/integration/frontend/arc_errors.rr
+++ b/tests/integration/frontend/arc_errors.rr
@@ -58,6 +58,22 @@ fn ctor_no_inner() -> i64 { Arc { value: 1 }; 0 }
 fn ctor_value_inner() -> i64 { Arc<Flat> { value: 1 }; 0 }
 
 // The arc coloring is part of the type: an arc'd constructor does not check
-// against the bare record.
-// CHECK-DAG: type mismatch
+// against the bare record, and the mismatch explains the coloring rather
+// than shrugging "type mismatch".
+// CHECK-DAG: cannot reconcile thread-safety: expected `Shared`, found `Arc<Shared>`
 fn ctor_is_colored() -> Shared { Arc<Shared> { value: 1 } }
+
+enum List<T> { Nil, Cons(T, List<T>) }
+// The recursive case names the strongly connected component and the §3.3
+// promotion, on both sides of the confusion: feeding a bare value into the
+// atomic world …
+// CHECK-DAG: cannot reconcile thread-safety: expected `Arc<List<i64>>`, found `List<i64>`
+// CHECK-DAG: fields of the recursive group `List` are promoted to `Arc`
+// CHECK-DAG: construct it as `Arc<List<i64>>::…` from the start
+fn bare_into_atomic() -> i64 { Arc<List<i64>>::Cons{1, List::Nil}; 0 }
+
+// … and being surprised that a projected field carries the coloring.
+// CHECK-DAG: a value read out of an arc'd box keeps its `Arc` coloring
+fn projected_is_arc(l: Arc<List<i64>>) -> List<i64> {
+    match l { List::Cons(_, xs) => xs, List::Nil => List::Nil }
+}


### PR DESCRIPTION
An `Arc<T>` vs `T` mismatch confuses on both sides of the coloring: at a **creation site** the user wonders why a plain value can't feed the arc'd constructor; at a **projection site** they wonder why the field they just read is suddenly an `Arc`. The generic "type mismatch: expected …, found …" answers neither.

Two commits:

1. **The diagnostic.** `expect` detects the coloring-only case — matching `Nullable` wrappers peeled, the bare side recognized through a real unification probe (which also solves its holes, silencing the "cannot infer the type of this expression" cascade the failed outer unification used to leave behind) — and explains it:

```
Error: cannot reconcile thread-safety: expected `Arc<List<i32>>`, found `List<i32>`
   ╭─[ arc_shape.rr:4:54 ]
   │
 4 │ fn creation(x: i32) -> i32 { Arc<List<i32>>::Cons{x, List::Nil}; 0 }
   │                                                      ────┬────
   │                                                          ╰────── cannot reconcile thread-safety: expected `Arc<List<i32>>`, found `List<i32>`
   │
   │ Note 1: fields of the recursive group `List` are promoted to `Arc` inside an arc'd box
   │
   │ Note 2: a plain value is never re-colored; construct it as `Arc<List<i32>>::…` from the start
───╯
```

   The recursive-group note appears only for genuinely recursive types (`def_is_recursive` — distinct from `arc_recursive_group`, whose root membership is unconditional); a flat `Arc<Pair>`/`Pair` clash reconciles without it. The closing note picks the side: *construct it from the start* when the arc'd type was expected, *a value read out of an arc'd box keeps its `Arc` coloring* when it was found. No design-doc citations in user-facing text.

2. **The renderer.** Multi-line messages previously repeated wholesale as the caret label; now the first line heads the report and labels the span, and further lines render through ariadne's note mechanism below the snippet — benefiting every multi-line diagnostic.

Covered by a semi unit test (both directions + flat case + note absence) and `arc_errors.rr` lit checks on the exact phrases. 290 core tests, 25 workspace suites, 381/389 lit (baseline), no new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4ihrGS9WQXXCw7k1VMdGC