### PR TITLE
[frontend] sync-cell surface: Atomic, Mutex, FlatLock, RwLock + core::cell::rdlock

### DIFF
--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -359,6 +359,25 @@ pub fn cell_rmw<'c>(
     builder.build().expect("valid reussir.cell.rmw")
 }
 
+/// `reussir.cell.rdlock(%cell) (-> R)? { body }` — run a read transaction
+/// over an rwlock cell: the body receives a clone of the element (loaded and
+/// acquired under the shared read lock), must consume it, and terminates
+/// with `reussir.scf.yield` carrying the optional result.
+pub fn cell_rdlock<'c>(
+    cell: Value<'c, '_>,
+    result_type: Option<Type<'c>>,
+    body: Region<'c>,
+    location: Location<'c>,
+) -> Operation<'c> {
+    let mut builder = OperationBuilder::new("reussir.cell.rdlock", location)
+        .add_operands(&[cell])
+        .add_regions([body]);
+    if let Some(result_type) = result_type {
+        builder = builder.add_results(&[result_type]);
+    }
+    builder.build().expect("valid reussir.cell.rdlock")
+}
+
 /// `reussir.cell.yield(%replacement : T)` — terminate a cell RMW body.
 pub fn cell_yield<'c>(
     replacement: Value<'c, '_>,

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -2840,7 +2840,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 if !matches!(
                     *base.ty.kind(),
                     TyKind::Cell {
-                        exclusive: true,
+                        kind: reussir_core::semi::ty::CellKind::Exclusive,
                         ..
                     }
                 ) {
@@ -2868,7 +2868,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     .ok_or_else(|| LoweringError("cell update closure produced no value".into()))?;
                 let TyKind::Cell {
                     elem,
-                    exclusive: true,
+                    kind: reussir_core::semi::ty::CellKind::Exclusive,
                 } = *base.ty.kind()
                 else {
                     return err("cell RMW operand is not an exclusive cell");

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -2866,13 +2866,12 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 let closure = self
                     .expr(block, env, kernel)?
                     .ok_or_else(|| LoweringError("cell update closure produced no value".into()))?;
-                let TyKind::Cell {
-                    elem,
-                    kind: reussir_core::semi::ty::CellKind::Exclusive,
-                } = *base.ty.kind()
-                else {
-                    return err("cell RMW operand is not an exclusive cell");
+                let TyKind::Cell { elem, kind } = *base.ty.kind() else {
+                    return err("cell RMW operand is not a cell");
                 };
+                if kind == reussir_core::semi::ty::CellKind::Plain {
+                    return err("cell RMW is not supported on a plain cell");
+                }
                 let elem_ty = self.tys.mlir_ty(elem)?;
                 let body = Block::new(&[(elem_ty, loc)]);
                 let current = body
@@ -2894,6 +2893,50 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 // paid only for the eval above.
                 block.append_operation(dialect::rc_dec(self.context, closure, loc).into());
                 Ok(None)
+            }
+            CellFn::Rdlock => {
+                // A read transaction over an rwlock cell: the body receives a
+                // *clone* of the element (loaded and acquired under the
+                // shared read lock) and consumes it through the reader
+                // closure; the reader's result leaves through the region
+                // yield as the operation's result.
+                let base = &args[0];
+                let cell = self
+                    .expr(block, env, base)?
+                    .ok_or_else(|| LoweringError("cell operand produced no value".into()))?;
+                self.remember_temp(env, base, cell);
+                let kernel = &args[1];
+                let closure = self
+                    .expr(block, env, kernel)?
+                    .ok_or_else(|| LoweringError("cell reader closure produced no value".into()))?;
+                let TyKind::Cell { elem, .. } = *base.ty.kind() else {
+                    return err("cell rdlock operand is not a cell");
+                };
+                let elem_ty = self.tys.mlir_ty(elem)?;
+                let body = Block::new(&[(elem_ty, loc)]);
+                let current = body
+                    .argument(0)
+                    .expect("cell rdlock body takes the cloned element")
+                    .into();
+                body.append_operation(dialect::rc_inc(self.context, closure, loc).into());
+                let output = self.call_kernel(&body, closure, kernel.ty, &[current])?;
+                body.append_operation(builders::scf_yield(output, loc));
+                let region = Region::new();
+                region.append_block(body);
+                let result_ty = if is_unit(e.ty) {
+                    None
+                } else {
+                    Some(self.tys.mlir_ty(e.ty)?)
+                };
+                let op = builders::cell_rdlock(cell, result_ty, region, loc);
+                let result = if result_ty.is_some() {
+                    Some(self.append(block, op))
+                } else {
+                    block.append_operation(op);
+                    None
+                };
+                block.append_operation(dialect::rc_dec(self.context, closure, loc).into());
+                Ok(result)
             }
         }
     }

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -2869,8 +2869,12 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 let TyKind::Cell { elem, kind } = *base.ty.kind() else {
                     return err("cell RMW operand is not a cell");
                 };
-                if kind == reussir_core::semi::ty::CellKind::Plain {
-                    return err("cell RMW is not supported on a plain cell");
+                if matches!(
+                    kind,
+                    reussir_core::semi::ty::CellKind::Plain
+                        | reussir_core::semi::ty::CellKind::Atomic
+                ) {
+                    return err("cell RMW is not supported on this cell kind");
                 }
                 let elem_ty = self.tys.mlir_ty(elem)?;
                 let body = Block::new(&[(elem_ty, loc)]);

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -152,8 +152,13 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             // payload (`!reussir.rc<!reussir.array<dims x elem>>`); see #344.
             TyKind::Array { .. } => Ok(self.rc_type(self.array_inner_of(ty)?)),
             // A cell is one shared rc box around its payload container. Unlike
-            // arrays, its element may itself be a managed type.
-            TyKind::Cell { .. } => Ok(self.rc_type(self.cell_inner_of(ty)?)),
+            // arrays, its element may itself be a managed type. A sync-kind
+            // cell is born in an *atomically counted* box — the dialect
+            // requires it (`CellType::requiresAtomicSharedBox`), and it is
+            // what makes the cell `Sync` with no `Arc` involved.
+            TyKind::Cell { kind, .. } => {
+                Ok(self.rc_type_in(self.cell_inner_of(ty)?, kind.is_sync()))
+            }
             // The arc coloring: the same shared payload behind a box whose
             // refcount is adjusted with atomic operations. Of the shared rc
             // boxes an `Arc` may color (a `[shared]` record, an array, or a

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -27,9 +27,9 @@ use std::cell::RefCell;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use reussir_backend::dialect::ty::{
-    ReussirAtomicKind, ReussirCapability, ReussirLifeScope, ReussirRecordKind, array, cell,
-    closure, nullable, rc, record_complete_in_place, record_incomplete, record_is_complete, r#ref,
-    region, str as str_type,
+    ReussirAtomicKind, ReussirCapability, ReussirCellKind, ReussirLifeScope, ReussirRecordKind,
+    array, cell_with_kind, closure, nullable, rc, record_complete_in_place, record_incomplete,
+    record_is_complete, r#ref, region, str as str_type,
 };
 use reussir_backend::melior::Context;
 use reussir_backend::melior::ir::Type;
@@ -170,11 +170,15 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
                         ReussirAtomicKind::Atomic,
                     ))
                 } else if matches!(inner.kind(), TyKind::Array { .. } | TyKind::Closure { .. }) {
-                    err("arc'd arrays and closures do not lower yet: only a `[shared]` \
-                         record inner is implemented")
+                    err(
+                        "arc'd arrays and closures do not lower yet: only a `[shared]` \
+                         record inner is implemented",
+                    )
                 } else {
-                    err("`Arc` requires a shared rc box inner (a `[shared]` record, an \
-                         array, or a closure)")
+                    err(
+                        "`Arc` requires a shared rc box inner (a `[shared]` record, an \
+                         array, or a closure)",
+                    )
                 }
             }
             _ => scalar_ty(self.context, ty),
@@ -430,10 +434,10 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
     /// element uses full type lowering because cells may recursively own
     /// managed values.
     pub(super) fn cell_inner_of(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
-        let TyKind::Cell { elem, exclusive } = *ty.kind() else {
+        let TyKind::Cell { elem, kind } = *ty.kind() else {
             return err("cell payload requested for a non-cell type");
         };
-        Ok(cell(self.mlir_ty(elem)?, exclusive))
+        Ok(cell_with_kind(self.mlir_ty(elem)?, backend_cell_kind(kind)))
     }
 
     /// `!reussir.rc<inner, shared>` — the pointer type for a heap-allocated,
@@ -523,6 +527,20 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             ReussirCapability::Unspecified,
             ReussirAtomicKind::Normal,
         )
+    }
+}
+
+/// The dialect's cell kind for the semi `CellKind`: the two lattices
+/// mirror each other one to one.
+pub(super) fn backend_cell_kind(kind: reussir_core::semi::ty::CellKind) -> ReussirCellKind {
+    use reussir_core::semi::ty::CellKind as K;
+    match kind {
+        K::Plain => ReussirCellKind::Plain,
+        K::Exclusive => ReussirCellKind::Exclusive,
+        K::Atomic => ReussirCellKind::Atomic,
+        K::Mutex => ReussirCellKind::Mutex,
+        K::Flatlock => ReussirCellKind::Flatlock,
+        K::Rwlock => ReussirCellKind::Rwlock,
     }
 }
 

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -145,12 +145,12 @@ impl<'a> Mangler<'a> {
                 // to its inner type.
                 self.path_with_args_segs(out, &["Nullable"], &[inner]);
             }
-            TyKind::Cell { elem, exclusive } => {
-                // `Cell<T>`/`RefCell<T>` are root built-in type constructors,
+            TyKind::Cell { elem, kind } => {
+                // The cell surface constructors (`Cell<T>`, `RefCell<T>`,
+                // `Mutex<T>`, …) are root built-in type constructors,
                 // represented as synthetic one-segment records in the ABI
                 // spelling.
-                let name = if exclusive { "RefCell" } else { "Cell" };
-                self.path_with_args_segs(out, &[name], &[elem]);
+                self.path_with_args_segs(out, &[kind.surface_name()], &[elem]);
             }
             TyKind::Arc(inner) => {
                 // `Arc<X>` is a root built-in type constructor too: a synthetic
@@ -345,9 +345,10 @@ mod tests {
             let nul = tcx.mk_nullable(tcx.mk_int(IntTy::Signed(32)));
             assert_eq!(m.mangle_ty(nul), "_RIC8NullablelE");
             // `Cell<i32>` → `IC4CelllE`; `RefCell<i32>` → `IC7RefCelllE`.
-            let cell = tcx.mk_cell(tcx.mk_int(IntTy::Signed(32)), false);
+            let cell = tcx.mk_cell(tcx.mk_int(IntTy::Signed(32)), crate::semi::ty::CellKind::Plain);
             assert_eq!(m.mangle_ty(cell), "_RIC4CelllE");
-            let refcell = tcx.mk_cell(tcx.mk_int(IntTy::Signed(32)), true);
+            let refcell =
+                tcx.mk_cell(tcx.mk_int(IntTy::Signed(32)), crate::semi::ty::CellKind::Exclusive);
             assert_eq!(m.mangle_ty(refcell), "_RIC7RefCelllE");
             // `Arc<i32>` → `IC3ArclE` (a synthetic root record, like the
             // others; a real inner is always a `[shared]` record).

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -345,10 +345,15 @@ mod tests {
             let nul = tcx.mk_nullable(tcx.mk_int(IntTy::Signed(32)));
             assert_eq!(m.mangle_ty(nul), "_RIC8NullablelE");
             // `Cell<i32>` → `IC4CelllE`; `RefCell<i32>` → `IC7RefCelllE`.
-            let cell = tcx.mk_cell(tcx.mk_int(IntTy::Signed(32)), crate::semi::ty::CellKind::Plain);
+            let cell = tcx.mk_cell(
+                tcx.mk_int(IntTy::Signed(32)),
+                crate::semi::ty::CellKind::Plain,
+            );
             assert_eq!(m.mangle_ty(cell), "_RIC4CelllE");
-            let refcell =
-                tcx.mk_cell(tcx.mk_int(IntTy::Signed(32)), crate::semi::ty::CellKind::Exclusive);
+            let refcell = tcx.mk_cell(
+                tcx.mk_int(IntTy::Signed(32)),
+                crate::semi::ty::CellKind::Exclusive,
+            );
             assert_eq!(m.mangle_ty(refcell), "_RIC7RefCelllE");
             // `Arc<i32>` → `IC3ArclE` (a synthetic root record, like the
             // others; a real inner is always a `[shared]` record).

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -269,9 +269,9 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let inner = self.ty(inner);
                 self.tcx.mk_nullable(inner)
             }
-            raw::Ty::Cell { inner, exclusive } => {
+            raw::Ty::Cell { inner, kind } => {
                 let inner = self.ty(inner);
-                self.tcx.mk_cell(inner, *exclusive)
+                self.tcx.mk_cell(inner, *kind)
             }
             raw::Ty::Arc(inner) => {
                 let inner = self.ty(inner);

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -7,6 +7,7 @@
 use std::borrow::Cow;
 
 use crate::full::mir::raw as raw;
+use crate::semi::ty::CellKind;
 use crate::ir_lex::{LexError, Token, unescape_debug_str};
 use crate::literal::{FloatLit, Integer};
 
@@ -123,8 +124,12 @@ Ty: raw::Ty = {
     "(" ")" => raw::Ty::Unit,
     "!" => raw::Ty::Bottom,
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
-    "Cell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: false },
-    "RefCell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: true },
+    "Cell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Plain },
+    "RefCell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Exclusive },
+    "Atomic" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Atomic },
+    "Mutex" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Mutex },
+    "FlatLock" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Flatlock },
+    "RwLock" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Rwlock },
     "Arc" "<" <t:Ty> ">" => raw::Ty::Arc(Box::new(t)),
     <cap:Cap> <path:TyPathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
@@ -355,6 +360,10 @@ extern {
         "Nullable" => Token::Nullable,
         "Cell" => Token::Cell,
         "RefCell" => Token::RefCell,
+        "Atomic" => Token::AtomicCell,
+        "Mutex" => Token::MutexCell,
+        "FlatLock" => Token::FlatLockCell,
+        "RwLock" => Token::RwLockCell,
         "Arc" => Token::Arc,
         "NonNull" => Token::NonNull,
         "Null" => Token::Null,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -264,8 +264,8 @@ impl Render<'_> {
             TyKind::Unit => text("()"),
             TyKind::Bottom => text("!"),
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
-            TyKind::Cell { elem, exclusive } => {
-                text(if exclusive { "RefCell<" } else { "Cell<" }) + self.ty(elem) + text(">")
+            TyKind::Cell { elem, kind } => {
+                text(kind.surface_name()) + text("<") + self.ty(elem) + text(">")
             }
             TyKind::Arc(inner) => text("Arc<") + self.ty(inner) + text(">"),
             TyKind::Array { elem, dims } => {

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -209,7 +209,7 @@ pub enum Ty {
     Nullable(Box<Ty>),
     Cell {
         inner: Box<Ty>,
-        exclusive: bool,
+        kind: crate::semi::ty::CellKind,
     },
     Arc(Box<Ty>),
     /// `[cap] path<args>` — a regional/value record type.

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -816,11 +816,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                             .iter()
                             .map(|(k, _)| k.0)
                             .skip_while(|&d| d != next.0)
-                            .map(|d| {
-                                self.resolver
-                                    .resolve(self.record_defs[&d].name)
-                                    .to_owned()
-                            })
+                            .map(|d| self.resolver.resolve(self.record_defs[&d].name).to_owned())
                             .collect();
                         let span = self.record_defs[&next.0].span;
                         self.error(
@@ -1833,10 +1829,10 @@ mod tests {
         "#;
         let reports = mono_reports(src);
         assert!(
-            reports
-                .iter()
-                .any(|m| m.contains("grounds an `Arc` whose contents are not `Sync`")
-                    && m.contains("member `p`")),
+            reports.iter().any(
+                |m| m.contains("grounds an `Arc` whose contents are not `Sync`")
+                    && m.contains("member `p`")
+            ),
             "{reports:#?}"
         );
         assert!(
@@ -1863,10 +1859,10 @@ mod tests {
         "#;
         let reports = mono_reports(src);
         assert!(
-            reports
-                .iter()
-                .any(|m| m.contains("grounds an `Arc` whose contents are not `Sync`")
-                    && m.contains("member `p`")),
+            reports.iter().any(
+                |m| m.contains("grounds an `Arc` whose contents are not `Sync`")
+                    && m.contains("member `p`")
+            ),
             "{reports:#?}"
         );
         assert!(

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -658,7 +658,69 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 self.check_arc_inners(ret, span);
             }
             TyKind::Nullable(inner) => self.check_arc_inners(inner, span),
-            TyKind::Cell { elem: inner, .. } => self.check_arc_inners(inner, span),
+            TyKind::Cell { elem: inner, kind } => {
+                // The ground half of the cell element bounds (see semi's
+                // `report_cell_wf`): a generic element defers to this point.
+                use crate::semi::ty::CellKind;
+                use crate::semi::ty_eval::{
+                    atomic_cell_element_rejection, lock_cell_slot_rejection,
+                };
+                match kind {
+                    CellKind::Plain | CellKind::Exclusive => {}
+                    CellKind::Atomic => {
+                        if let Some(what) = atomic_cell_element_rejection(inner)
+                            && self.reported_arcs.insert(ty)
+                        {
+                            self.error(
+                                span,
+                                format!(
+                                    "this instantiation grounds an `Atomic` cell \
+                                     whose element is {what}"
+                                ),
+                            );
+                        }
+                    }
+                    CellKind::Mutex | CellKind::Flatlock | CellKind::Rwlock => {
+                        let slot = lock_cell_slot_rejection(
+                            |def| self.record_defs.get(&def).map(|r| r.default_cap),
+                            inner,
+                        );
+                        if let Some(what) = slot {
+                            if self.reported_arcs.insert(ty) {
+                                self.error(
+                                    span,
+                                    format!(
+                                        "this instantiation grounds a `{}` cell \
+                                         whose element is {what}",
+                                        kind.surface_name()
+                                    ),
+                                );
+                            }
+                        } else {
+                            let env = MonoSyncEnv {
+                                tcx: self.tcx,
+                                record_defs: self.record_defs,
+                                resolver: self.resolver,
+                            };
+                            if let SyncVerdict::NotSync(w) =
+                                crate::semi::traits::sync::sync_verdict(&env, inner)
+                                && self.reported_arcs.insert(ty)
+                            {
+                                self.error(
+                                    span,
+                                    format!(
+                                        "this instantiation grounds a `{}` cell whose \
+                                         element is not `Sync`: {}",
+                                        kind.surface_name(),
+                                        w.describe()
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+                self.check_arc_inners(inner, span);
+            }
             TyKind::Array { elem, .. } => self.check_arc_inners(elem, span),
             _ => {}
         }
@@ -1891,6 +1953,37 @@ mod tests {
                 .any(|m| m.contains("recursive `[value]` record of infinite size")),
             "{reports:#?}"
         );
+    }
+
+    #[test]
+    fn ground_cell_element_bounds_are_rechecked() {
+        // Semi defers a generic cell element; grounding is where the bounds
+        // land: a bare shared record fails the lock kinds' Sync bound, a
+        // record fails Atomic's primitive bound, while Sync instantiations
+        // pass.
+        let src = r#"
+            struct Pair { a: i32 }
+            fn hold<T>(m: Mutex<T>) -> Mutex<T> { m }
+            fn count<T>(a: Atomic<T>) -> Atomic<T> { a }
+            extern "C" trampoline "bad_mutex" = hold<Pair>;
+            extern "C" trampoline "ok_mutex" = hold<i64>;
+            extern "C" trampoline "bad_atomic" = count<Pair>;
+            extern "C" trampoline "ok_atomic" = count<i64>;
+        "#;
+        let reports = mono_reports(src);
+        assert!(
+            reports
+                .iter()
+                .any(|m| m.contains("grounds a `Mutex` cell whose element is not `Sync`")),
+            "{reports:#?}"
+        );
+        assert!(
+            reports
+                .iter()
+                .any(|m| m.contains("grounds an `Atomic` cell whose element is")),
+            "{reports:#?}"
+        );
+        assert_eq!(reports.len(), 2, "{reports:#?}");
     }
 
     #[test]

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -23,6 +23,7 @@ use crate::full::mir::{
     self, ClosureExpr, DecisionTree, Expr, ExprKind, Function, Param, SwitchCases,
 };
 use crate::semi::hir::{ExprId, VarId};
+use crate::semi::ty::CellKind;
 use crate::semi::ty::{DefId, Flexivity, IntTy, Ty, TyCtxt};
 use crate::surface::Visibility;
 use crate::with_tcx;
@@ -306,7 +307,14 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
     }
 
     fn cell_ty(&self, elem: Ty<'tcx>, exclusive: bool) -> Ty<'tcx> {
-        self.tcx.mk_cell(elem, exclusive)
+        self.tcx.mk_cell(
+            elem,
+            if exclusive {
+                CellKind::Exclusive
+            } else {
+                CellKind::Plain
+            },
+        )
     }
 
     fn cell_op(
@@ -1051,9 +1059,12 @@ fn is_rr_classification() {
             "frozen rigid value is a managed object ⇒ rc"
         );
         assert!(rr.is_rr(tcx.mk_nullable(rc)), "nullable rc is RR");
-        assert!(rr.is_rr(tcx.mk_cell(i64t, false)), "a cell is always RR");
         assert!(
-            rr.is_rr(tcx.mk_cell(i64t, true)),
+            rr.is_rr(tcx.mk_cell(i64t, CellKind::Plain)),
+            "a cell is always RR"
+        );
+        assert!(
+            rr.is_rr(tcx.mk_cell(i64t, CellKind::Exclusive)),
             "an exclusive cell is always RR"
         );
         assert!(

--- a/crates/reussir-core/src/full/subst.rs
+++ b/crates/reussir-core/src/full/subst.rs
@@ -35,7 +35,7 @@ pub fn subst_ty<'tcx>(tcx: &TyCtxt<'tcx>, ty: Ty<'tcx>, subst: &Subst<'tcx>) -> 
             tcx.mk_closure(&params, subst_ty(tcx, ret, subst))
         }
         TyKind::Nullable(inner) => tcx.mk_nullable(subst_ty(tcx, inner, subst)),
-        TyKind::Cell { elem, exclusive } => tcx.mk_cell(subst_ty(tcx, elem, subst), exclusive),
+        TyKind::Cell { elem, kind } => tcx.mk_cell(subst_ty(tcx, elem, subst), kind),
         TyKind::Arc(inner) => tcx.mk_arc(subst_ty(tcx, inner, subst)),
         TyKind::Array { elem, dims } => tcx.mk_array(subst_ty(tcx, elem, subst), dims),
         TyKind::Int(_)

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -172,12 +172,13 @@ pub enum ArrayFn {
 
 /// A built-in operation on a shared mutable [`Cell`](crate::semi::ty::TyKind::Cell),
 /// spelled `core::intrinsic::cell::<fn>` and dispatched on the operand's
-/// cell flavor. A plain `Cell` supports only whole-element
-/// `alloc`/`get`/`set`; an exclusive `RefCell` additionally supports the
-/// guarded `rmw` and the `in_use` observation of its guard flag. The
-/// operation itself does not record the flavor — operand and result types
-/// carry it, the checker enforces it, and the dialect verifier re-checks
-/// it after lowering.
+/// cell kind. `alloc`/`get`/`set` work on every kind; `rmw` on every kind
+/// but a plain `Cell` (the exclusive in-use region, an atomic CAS-retry, or
+/// a lock's critical section); `in_use` observes the exclusive guard flag;
+/// `rdlock` runs a read transaction over an `RwLock` cell. The operation
+/// itself does not record the kind — operand and result types carry it, the
+/// checker enforces the matrix, and the dialect verifier re-checks it after
+/// lowering.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum CellFn {
     /// `alloc(value)`: move `value` into a fresh cell.
@@ -187,11 +188,14 @@ pub enum CellFn {
     /// `set(cell, value)`: replace and drop the old value.
     Set,
     /// `rmw(cell, update)`: move the value through `update` and store its
-    /// result. Exclusive cells (`RefCell`) only.
+    /// result. Every kind but a plain `Cell`.
     Rmw,
     /// `in_use(cell)`: whether the element is currently moved out into an
     /// active `rmw` updater. Exclusive cells (`RefCell`) only.
     InUse,
+    /// `rdlock(cell, reader)`: run `reader` over a clone of the element
+    /// inside the shared read lock. `RwLock` cells only.
+    Rdlock,
 }
 
 impl CellFn {
@@ -203,6 +207,7 @@ impl CellFn {
             "set" => Some(CellFn::Set),
             "rmw" => Some(CellFn::Rmw),
             "in_use" => Some(CellFn::InUse),
+            "rdlock" => Some(CellFn::Rdlock),
             _ => None,
         }
     }
@@ -215,14 +220,34 @@ impl CellFn {
             CellFn::Set => "set",
             CellFn::Rmw => "rmw",
             CellFn::InUse => "in_use",
+            CellFn::Rdlock => "rdlock",
         }
     }
 
-    /// Whether this operation exists only on an exclusive cell (`RefCell`).
-    /// The checker rejects these on a plain `Cell` operand, and lowering
-    /// re-derives the flavor from the monomorphized operand type.
-    pub fn requires_exclusive(self) -> bool {
-        matches!(self, CellFn::Rmw | CellFn::InUse)
+    /// Whether this operation is available on a cell of `kind` — the §4.2
+    /// access matrix. Lowering re-derives the kind from the monomorphized
+    /// operand type; the dialect verifier re-checks after lowering.
+    pub fn supported_on(self, kind: crate::semi::ty::CellKind) -> bool {
+        use crate::semi::ty::CellKind;
+        match self {
+            CellFn::Alloc | CellFn::Get | CellFn::Set => true,
+            CellFn::Rmw => kind != CellKind::Plain,
+            CellFn::InUse => kind == CellKind::Exclusive,
+            CellFn::Rdlock => kind == CellKind::Rwlock,
+        }
+    }
+
+    /// Which operands support this operation, for diagnostics.
+    pub fn requirement(self) -> &'static str {
+        match self {
+            CellFn::Alloc | CellFn::Get | CellFn::Set => "any cell",
+            CellFn::Rmw => {
+                "an exclusive or synchronized cell (`RefCell`, `Atomic`, \
+                 `Mutex`, `FlatLock`, or `RwLock`)"
+            }
+            CellFn::InUse => "an exclusive cell (`RefCell`)",
+            CellFn::Rdlock => "an `RwLock` cell",
+        }
     }
 }
 

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -188,7 +188,9 @@ pub enum CellFn {
     /// `set(cell, value)`: replace and drop the old value.
     Set,
     /// `rmw(cell, update)`: move the value through `update` and store its
-    /// result. Every kind but a plain `Cell`.
+    /// result. Every kind but a plain `Cell` and an `Atomic` cell (the
+    /// atomic CAS-retry region must be effect-free, which a closure call is
+    /// not; dedicated atomic arithmetic intrinsics are future work).
     Rmw,
     /// `in_use(cell)`: whether the element is currently moved out into an
     /// active `rmw` updater. Exclusive cells (`RefCell`) only.
@@ -231,7 +233,7 @@ impl CellFn {
         use crate::semi::ty::CellKind;
         match self {
             CellFn::Alloc | CellFn::Get | CellFn::Set => true,
-            CellFn::Rmw => kind != CellKind::Plain,
+            CellFn::Rmw => kind != CellKind::Plain && kind != CellKind::Atomic,
             CellFn::InUse => kind == CellKind::Exclusive,
             CellFn::Rdlock => kind == CellKind::Rwlock,
         }
@@ -242,8 +244,8 @@ impl CellFn {
         match self {
             CellFn::Alloc | CellFn::Get | CellFn::Set => "any cell",
             CellFn::Rmw => {
-                "an exclusive or synchronized cell (`RefCell`, `Atomic`, \
-                 `Mutex`, `FlatLock`, or `RwLock`)"
+                "an exclusive or lock-guarded cell (`RefCell`, `Mutex`, \
+                 `FlatLock`, or `RwLock`)"
             }
             CellFn::InUse => "an exclusive cell (`RefCell`)",
             CellFn::Rdlock => "an `RwLock` cell",

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -90,6 +90,14 @@ pub enum Token<'a> {
     Cell,
     #[token("RefCell")]
     RefCell,
+    #[token("Atomic")]
+    AtomicCell,
+    #[token("Mutex")]
+    MutexCell,
+    #[token("FlatLock")]
+    FlatLockCell,
+    #[token("RwLock")]
+    RwLockCell,
     #[token("Arc")]
     Arc,
     #[token("NonNull")]

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1086,7 +1086,10 @@ mod tests {
         let regional = "struct Pair { a: i32 }\n\
                         struct [regional] R { v: i64, p: Arc<Pair> }";
         assert!(
-            has_error(regional, "an `Arc` member of a `[regional]` record is not implemented yet"),
+            has_error(
+                regional,
+                "an `Arc` member of a `[regional]` record is not implemented yet"
+            ),
             "{:#?}",
             reports_of(regional)
         );
@@ -1188,12 +1191,18 @@ mod tests {
             reports_of(creation)
         );
         assert!(
-            has_error(creation, "fields of the recursive group `List` are promoted to `Arc`"),
+            has_error(
+                creation,
+                "fields of the recursive group `List` are promoted to `Arc`"
+            ),
             "{:#?}",
             reports_of(creation)
         );
         assert!(
-            has_error(creation, "construct it as `Arc<List<i32>>::…` from the start"),
+            has_error(
+                creation,
+                "construct it as `Arc<List<i32>>::…` from the start"
+            ),
             "{:#?}",
             reports_of(creation)
         );

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1141,6 +1141,25 @@ mod tests {
     }
 
     #[test]
+    fn atomic_rmw_is_gated() {
+        // The atomic CAS-retry region must be effect-free, which a closure
+        // call is not — rmw on an Atomic cell is rejected at the checker
+        // until dedicated atomic arithmetic intrinsics exist.
+        let src = "fn f(a: Atomic<i64>) -> i64 {\n\
+                       core::intrinsic::cell::rmw(a, |x| x + 1);\n\
+                       core::intrinsic::cell::get(a)\n\
+                   }";
+        assert!(
+            has_error(
+                src,
+                "`core::intrinsic::cell::rmw` is not supported on `Atomic<i64>`"
+            ),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
     fn sync_cell_element_bounds() {
         // Atomic demands an arithmetic primitive …
         let bad_atomic = "struct Pair { a: i32 }\nfn f(a: Atomic<Pair>) -> i32 { 0 }";

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1128,6 +1128,51 @@ mod tests {
     }
 
     #[test]
+    fn sync_cell_surface_types() {
+        // The four sync kinds are surface type constructors with per-kind
+        // element bounds. Well-formed shapes elaborate cleanly, including
+        // the composition direction: an Arc'd record with a sync-cell
+        // member is interior mutability behind an arc.
+        let ok = "struct Pair { a: i32 }\n\
+                  struct Counter { hits: Atomic<i64>, guard: Mutex<i64> }\n\
+                  fn f(m: Mutex<i64>, a: Atomic<f64>, l: FlatLock<i64>, r: RwLock<Arc<Pair>>) -> i32 { 0 }\n\
+                  fn g(c: Arc<Counter>) -> i32 { 0 }";
+        assert!(reports_of(ok).is_empty(), "{:#?}", reports_of(ok));
+    }
+
+    #[test]
+    fn sync_cell_element_bounds() {
+        // Atomic demands an arithmetic primitive …
+        let bad_atomic = "struct Pair { a: i32 }\nfn f(a: Atomic<Pair>) -> i32 { 0 }";
+        assert!(
+            has_error(bad_atomic, "`Atomic<Pair>` is ill-formed"),
+            "{:#?}",
+            reports_of(bad_atomic)
+        );
+        // … the lock kinds demand a Sync element (Mutex<Arc> yes,
+        // Mutex<bare shared> no) …
+        let bad_mutex = "struct Pair { a: i32 }\nfn f(m: Mutex<Pair>) -> i32 { 0 }";
+        assert!(
+            has_error(
+                bad_mutex,
+                "the element of a lock-guarded cell must be `Sync`"
+            ),
+            "{:#?}",
+            reports_of(bad_mutex)
+        );
+        // … and a pointer-or-primitive slot shape.
+        let bad_slot = "struct [value] V { a: i32 }\nfn f(r: RwLock<V>) -> i32 { 0 }";
+        assert!(
+            has_error(
+                bad_slot,
+                "`RwLock<V>` is ill-formed: the element is a `[value]` record"
+            ),
+            "{:#?}",
+            reports_of(bad_slot)
+        );
+    }
+
+    #[test]
     fn infers_arc_ctors() {
         // The struct and variant arc constructors type at `Arc<R>`.
         let src = "struct Pair { a: i32 }\n\

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1320,6 +1320,34 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     span,
                 )
             }
+            CellFn::Rdlock => {
+                // `rdlock(cell, reader)`: the reader runs over a *clone* of
+                // the element inside the shared read lock — `reader : T -> ρ`
+                // for a fresh `ρ`, which is the operation's result. The clone
+                // is consumed by the reader like any owned argument.
+                let [cell, reader] = fc.args.as_slice() else {
+                    self.error(
+                        span,
+                        format!("`core::intrinsic::cell::{name}` expects two arguments"),
+                    );
+                    return self.poison(span);
+                };
+                let cell = self.infer_expr(cell);
+                let Some(elem) = self.cell_element(cell.ty, func, &name, span) else {
+                    return self.poison(span);
+                };
+                let result = self.infer.new_hole_ty();
+                let expected = self.tcx.mk_closure(&[elem], result);
+                let reader = self.check_expr(reader, expected);
+                self.mk_expr(
+                    ExprKind::Intrinsic {
+                        op,
+                        args: vec![cell, reader],
+                    },
+                    result,
+                    span,
+                )
+            }
         }
     }
 
@@ -1334,14 +1362,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     ) -> Option<Ty<'tcx>> {
         let resolved = self.infer.shallow_resolve(ty);
         if let TyKind::Cell { elem, kind } = *resolved.kind() {
-            if func.requires_exclusive() && kind != CellKind::Exclusive {
+            if !func.supported_on(kind) {
                 let shown = self.infer.resolve(resolved);
                 self.error(
                     span,
                     format!(
-                        "`core::intrinsic::cell::{method}` requires an exclusive cell, found \
-                         `{}`; use a `RefCell`",
-                        self.ty_display(shown)
+                        "`core::intrinsic::cell::{method}` is not supported on `{}`; \
+                         it requires {}",
+                        self.ty_display(shown),
+                        func.requirement()
                     ),
                 );
                 return None;

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -4,6 +4,7 @@ use reussir_syntax::kind::TokenKey;
 
 use crate::semi::infer::Instantiation;
 use crate::semi::traits::{Obligation, TraitId, TraitRef};
+use crate::semi::ty::CellKind;
 use crate::semi::ty::{DefId, Flexivity, GenericId, Ty, TyKind};
 use crate::surface::{self, BinOp, Const, Span, UnaryOp};
 
@@ -160,11 +161,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// out arc'd (the projection side) — so explain the §3.3 rule the way
     /// rustc explains lifetimes: what clashed, why the type is what it is,
     /// and what to do about it. Returns `None` for any other mismatch.
-    fn arc_reconciliation_error(
-        &mut self,
-        expected: Ty<'tcx>,
-        found: Ty<'tcx>,
-    ) -> Option<String> {
+    fn arc_reconciliation_error(&mut self, expected: Ty<'tcx>, found: Ty<'tcx>) -> Option<String> {
         // Peel matching `Nullable` wrappers: a promoted `Nullable<Arc<T>>`
         // member mismatches a bare `Nullable<T>` the same way.
         let (mut e, mut f) = (expected, found);
@@ -214,9 +211,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                  `Arc<{shown}>::…` from the start",
             ));
         } else {
-            message.push_str(
-                "\nnote: a value read out of an arc'd box keeps its `Arc` coloring",
-            );
+            message.push_str("\nnote: a value read out of an arc'd box keeps its `Arc` coloring");
         }
         Some(message)
     }
@@ -1261,7 +1256,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     }
                     None => self.infer_expr(value),
                 };
-                let result = result.unwrap_or_else(|| self.tcx.mk_cell(value.ty, false));
+                let result = result.unwrap_or_else(|| self.tcx.mk_cell(value.ty, CellKind::Plain));
                 self.mk_expr(
                     ExprKind::Intrinsic {
                         op,
@@ -1338,8 +1333,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         span: Option<Span>,
     ) -> Option<Ty<'tcx>> {
         let resolved = self.infer.shallow_resolve(ty);
-        if let TyKind::Cell { elem, exclusive } = *resolved.kind() {
-            if func.requires_exclusive() && !exclusive {
+        if let TyKind::Cell { elem, kind } = *resolved.kind() {
+            if func.requires_exclusive() && kind != CellKind::Exclusive {
                 let shown = self.infer.resolve(resolved);
                 self.error(
                     span,
@@ -1623,7 +1618,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 && matches!(self.records[&def].fields, Some(RecordFields::Variants(_)))
             {
                 self.record_use(enum_key);
-                return self.infer_variant(def, enum_key, path.basename, ty_args, args, false, span);
+                return self.infer_variant(
+                    def,
+                    enum_key,
+                    path.basename,
+                    ty_args,
+                    args,
+                    false,
+                    span,
+                );
             }
             let Some(def) = self.resolve_record_ref(path) else {
                 let hint = self.record_suggestion(enum_key);

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -457,8 +457,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.push_ty_display(out, inner);
                 out.push('>');
             }
-            TyKind::Cell { elem, exclusive } => {
-                out.push_str(if exclusive { "RefCell<" } else { "Cell<" });
+            TyKind::Cell { elem, kind } => {
+                out.push_str(kind.surface_name());
+                out.push('<');
                 self.push_ty_display(out, elem);
                 out.push('>');
             }
@@ -1332,8 +1333,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             {
                 continue;
             }
-            let mut stack: Vec<(DefId, Vec<DefId>)> =
-                vec![(root, self.inline_value_heads(root))];
+            let mut stack: Vec<(DefId, Vec<DefId>)> = vec![(root, self.inline_value_heads(root))];
             color.insert(root, 1);
             while let Some((_, succs)) = stack.last_mut() {
                 let Some(next) = succs.pop() else {
@@ -1350,8 +1350,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                             .skip_while(|&&d| d != next)
                             .map(|d| self.sym(self.records[d].name).to_owned())
                             .collect();
-                        let (span, file) =
-                            (self.records[&next].span, self.records[&next].file);
+                        let (span, file) = (self.records[&next].span, self.records[&next].file);
                         self.set_current_file(file);
                         self.error(
                             span,

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -317,9 +317,9 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let inner = self.ty(inner);
                 self.tcx.mk_nullable(inner)
             }
-            raw::Ty::Cell { inner, exclusive } => {
+            raw::Ty::Cell { inner, kind } => {
                 let inner = self.ty(inner);
-                self.tcx.mk_cell(inner, *exclusive)
+                self.tcx.mk_cell(inner, *kind)
             }
             raw::Ty::Arc(inner) => {
                 let inner = self.ty(inner);

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 use crate::ir_lex::{LexError, Token, unescape_debug_str};
 use crate::literal::{FloatLit, Integer};
 use crate::semi::hir::raw as raw;
+use crate::semi::ty::CellKind;
 
 grammar<'input>;
 
@@ -180,8 +181,12 @@ Ty: raw::Ty = {
     "!" => raw::Ty::Bottom,
     <g:"generic"> => raw::Ty::Generic(g),
     "Nullable" "<" <t:Ty> ">" => raw::Ty::Nullable(Box::new(t)),
-    "Cell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: false },
-    "RefCell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), exclusive: true },
+    "Cell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Plain },
+    "RefCell" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Exclusive },
+    "Atomic" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Atomic },
+    "Mutex" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Mutex },
+    "FlatLock" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Flatlock },
+    "RwLock" "<" <t:Ty> ">" => raw::Ty::Cell { inner: Box::new(t), kind: CellKind::Rwlock },
     "Arc" "<" <t:Ty> ">" => raw::Ty::Arc(Box::new(t)),
     <cap:Cap> "#" <path:PathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
@@ -389,6 +394,10 @@ extern {
         "Nullable" => Token::Nullable,
         "Cell" => Token::Cell,
         "RefCell" => Token::RefCell,
+        "Atomic" => Token::AtomicCell,
+        "Mutex" => Token::MutexCell,
+        "FlatLock" => Token::FlatLockCell,
+        "RwLock" => Token::RwLockCell,
         "Arc" => Token::Arc,
         "NonNull" => Token::NonNull,
         "Null" => Token::Null,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -316,8 +316,8 @@ impl<'a> Printer<'a> {
             TyKind::Generic(g) => text(format!("${}", g.0)),
             TyKind::Hole(_) => unreachable!("a fully elaborated HIR carries no inference holes"),
             TyKind::Nullable(inner) => text("Nullable<") + self.ty(inner) + text(">"),
-            TyKind::Cell { elem, exclusive } => {
-                text(if exclusive { "RefCell<" } else { "Cell<" }) + self.ty(elem) + text(">")
+            TyKind::Cell { elem, kind } => {
+                text(kind.surface_name()) + text("<") + self.ty(elem) + text(">")
             }
             TyKind::Arc(inner) => text("Arc<") + self.ty(inner) + text(">"),
             TyKind::Array { elem, dims } => {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -177,7 +177,7 @@ pub enum Ty {
     Nullable(Box<Ty>),
     Cell {
         inner: Box<Ty>,
-        exclusive: bool,
+        kind: crate::semi::ty::CellKind,
     },
     Arc(Box<Ty>),
     Record {

--- a/crates/reussir-core/src/semi/infer.rs
+++ b/crates/reussir-core/src/semi/infer.rs
@@ -217,9 +217,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let elem = self.resolve(*elem);
                 self.tcx.mk_array(elem, dims)
             }
-            TyKind::Cell { elem, exclusive } => {
+            TyKind::Cell { elem, kind } => {
                 let elem = self.resolve(*elem);
-                self.tcx.mk_cell(elem, *exclusive)
+                self.tcx.mk_cell(elem, *kind)
             }
             _ => ty,
         }
@@ -308,16 +308,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify(*x, *y),
             (TyKind::Arc(x), TyKind::Arc(y)) => self.unify(*x, *y),
-            (
-                TyKind::Cell {
-                    elem: x,
-                    exclusive: e1,
-                },
-                TyKind::Cell {
-                    elem: y,
-                    exclusive: e2,
-                },
-            ) if e1 == e2 => self.unify(*x, *y),
+            (TyKind::Cell { elem: x, kind: e1 }, TyKind::Cell { elem: y, kind: e2 })
+                if e1 == e2 =>
+            {
+                self.unify(*x, *y)
+            }
             (TyKind::Array { elem: e1, dims: d1 }, TyKind::Array { elem: e2, dims: d2 })
                 if d1 == d2 =>
             {
@@ -525,16 +520,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             (TyKind::Nullable(x), TyKind::Nullable(y)) => self.unify_instantiated(*x, inst, *y),
             (TyKind::Arc(x), TyKind::Arc(y)) => self.unify_instantiated(*x, inst, *y),
-            (
-                TyKind::Cell {
-                    elem: x,
-                    exclusive: e1,
-                },
-                TyKind::Cell {
-                    elem: y,
-                    exclusive: e2,
-                },
-            ) if e1 == e2 => self.unify_instantiated(*x, inst, *y),
+            (TyKind::Cell { elem: x, kind: e1 }, TyKind::Cell { elem: y, kind: e2 })
+                if e1 == e2 =>
+            {
+                self.unify_instantiated(*x, inst, *y)
+            }
             (TyKind::Array { elem: e1, dims: d1 }, TyKind::Array { elem: e2, dims: d2 })
                 if d1 == d2 =>
             {
@@ -601,9 +591,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let elem = self.materialize(*elem, inst);
                 self.tcx.mk_array(elem, dims)
             }
-            TyKind::Cell { elem, exclusive } => {
+            TyKind::Cell { elem, kind } => {
                 let elem = self.materialize(*elem, inst);
-                self.tcx.mk_cell(elem, *exclusive)
+                self.tcx.mk_cell(elem, *kind)
             }
             _ => template,
         }

--- a/crates/reussir-core/src/semi/traits/sync.rs
+++ b/crates/reussir-core/src/semi/traits/sync.rs
@@ -88,10 +88,7 @@ pub fn collect_record_defs<'tcx>(ty: Ty<'tcx>, out: &mut Vec<DefId>) {
 /// under an `Arc`. Type arguments are ignored at this level, so polymorphic
 /// recursion collapses onto its def. Returns `None` (blocked) when any
 /// reachable def's fields are not populated yet.
-pub fn recursive_group<'tcx>(
-    env: &dyn SyncEnv<'tcx>,
-    root: DefId,
-) -> Option<FxHashSet<DefId>> {
+pub fn recursive_group<'tcx>(env: &dyn SyncEnv<'tcx>, root: DefId) -> Option<FxHashSet<DefId>> {
     // Forward reachability from `root`.
     let mut forward = FxHashSet::default();
     let mut stack = vec![root];
@@ -147,9 +144,7 @@ pub enum NotSyncReason {
 impl NotSyncReason {
     pub fn describe(self) -> &'static str {
         match self {
-            NotSyncReason::NonAtomicBox => {
-                "a plain `[shared]` rc box whose refcount is not atomic"
-            }
+            NotSyncReason::NonAtomicBox => "a plain `[shared]` rc box whose refcount is not atomic",
             NotSyncReason::Regional => "a regional object",
             NotSyncReason::PlainCell => "a plain `Cell`, which is unsynchronized",
             NotSyncReason::ExclusiveCell => "a `RefCell`, whose in-use guard is not atomic",
@@ -246,10 +241,7 @@ impl<'tcx> Cx<'_, 'tcx> {
 
     /// Fold a labeled member list: the first definite failure wins; a block
     /// only surfaces when nothing fails outright.
-    fn fold(
-        &mut self,
-        members: impl IntoIterator<Item = (String, Ty<'tcx>)>,
-    ) -> SyncVerdict<'tcx> {
+    fn fold(&mut self, members: impl IntoIterator<Item = (String, Ty<'tcx>)>) -> SyncVerdict<'tcx> {
         let mut blocked = false;
         for (label, ty) in members {
             self.path.push(label);
@@ -284,9 +276,11 @@ impl<'tcx> Cx<'_, 'tcx> {
             | TyKind::Bottom => SyncVerdict::Sync,
             TyKind::Generic(_) | TyKind::Hole(_) => SyncVerdict::Blocked,
             TyKind::Nullable(inner) => self.check(inner),
-            TyKind::Cell { exclusive, .. } => self.refute(
+            // Sync-kind cells gain their `Sync` verdict in the next commit;
+            // until then every kind conservatively refutes.
+            TyKind::Cell { kind, .. } => self.refute(
                 ty,
-                if exclusive {
+                if kind == crate::semi::ty::CellKind::Exclusive {
                     NotSyncReason::ExclusiveCell
                 } else {
                     NotSyncReason::PlainCell
@@ -405,7 +399,7 @@ impl<'tcx> Cx<'_, 'tcx> {
 mod tests {
     use super::*;
     use crate::semi::ctxt::DefaultCap;
-    use crate::semi::ty::{Flexivity, IntTy, Ty, TyCtxt};
+    use crate::semi::ty::{CellKind, Flexivity, IntTy, Ty, TyCtxt};
     use crate::with_tcx;
     use rustc_hash::FxHashMap;
 
@@ -483,10 +477,8 @@ mod tests {
                 (DefaultCap::Value, Some(vec![("leaf".into(), leaf)])),
             );
             let mid = rec(tcx, 2);
-            env.records.insert(
-                DefId(3),
-                (DefaultCap::Value, Some(vec![("m".into(), mid)])),
-            );
+            env.records
+                .insert(DefId(3), (DefaultCap::Value, Some(vec![("m".into(), mid)])));
             let SyncVerdict::NotSync(w) = sync_verdict(&env, rec(tcx, 3)) else {
                 panic!("expected NotSync");
             };
@@ -560,7 +552,7 @@ mod tests {
                 DefId(0),
                 (
                     DefaultCap::Shared,
-                    Some(vec![("c".into(), tcx.mk_cell(i32t, false))]),
+                    Some(vec![("c".into(), tcx.mk_cell(i32t, CellKind::Plain))]),
                 ),
             );
             let SyncVerdict::NotSync(w) = wf_arc(&env, rec(tcx, 0)) else {
@@ -569,7 +561,7 @@ mod tests {
             assert_eq!(w.reason, NotSyncReason::PlainCell);
             assert_eq!(w.path, vec!["c".to_owned()]);
             assert!(matches!(
-                sync_verdict(&env, tcx.mk_cell(i32t, true)),
+                sync_verdict(&env, tcx.mk_cell(i32t, CellKind::Exclusive)),
                 SyncVerdict::NotSync(Witness {
                     reason: NotSyncReason::ExclusiveCell,
                     ..

--- a/crates/reussir-core/src/semi/traits/sync.rs
+++ b/crates/reussir-core/src/semi/traits/sync.rs
@@ -276,16 +276,29 @@ impl<'tcx> Cx<'_, 'tcx> {
             | TyKind::Bottom => SyncVerdict::Sync,
             TyKind::Generic(_) | TyKind::Hole(_) => SyncVerdict::Blocked,
             TyKind::Nullable(inner) => self.check(inner),
-            // Sync-kind cells gain their `Sync` verdict in the next commit;
-            // until then every kind conservatively refutes.
-            TyKind::Cell { kind, .. } => self.refute(
-                ty,
-                if kind == crate::semi::ty::CellKind::Exclusive {
-                    NotSyncReason::ExclusiveCell
-                } else {
-                    NotSyncReason::PlainCell
-                },
-            ),
+            // The cell verdict follows the kind lattice (thread-safety
+            // design §4): a plain/exclusive cell is unsynchronized and
+            // refutes; an atomic cell is `Sync` outright (its element is an
+            // arithmetic scalar by formation); a lock-guarded cell is `Sync`
+            // exactly when its element is — the lock protects the stored
+            // slot, but clones of the element leave the critical section and
+            // are used concurrently, so the element must carry its own
+            // thread safety.
+            TyKind::Cell { elem, kind } => {
+                use crate::semi::ty::CellKind;
+                match kind {
+                    CellKind::Plain => self.refute(ty, NotSyncReason::PlainCell),
+                    CellKind::Exclusive => self.refute(ty, NotSyncReason::ExclusiveCell),
+                    CellKind::Atomic => SyncVerdict::Sync,
+                    CellKind::Mutex | CellKind::Flatlock | CellKind::Rwlock => {
+                        self.path
+                            .push(format!("the `{}` element", kind.surface_name()));
+                        let verdict = self.check(elem);
+                        self.path.pop();
+                        verdict
+                    }
+                }
+            }
             // Bare shared rc boxes: never `Sync`, regardless of contents —
             // shareability is carried by the box coloring (`Arc`), not the
             // nominal type.
@@ -567,6 +580,56 @@ mod tests {
                     ..
                 })
             ));
+        });
+    }
+
+    #[test]
+    fn sync_cells_are_sync_with_sync_elements() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut env = TestEnv::default();
+            let i32t = tcx.mk_int(IntTy::Signed(32));
+            // Atomic cells and lock cells over Sync elements are Sync — the
+            // sanctioned primitive for sharing mutable state, no Arc needed.
+            for kind in [
+                CellKind::Atomic,
+                CellKind::Mutex,
+                CellKind::Flatlock,
+                CellKind::Rwlock,
+            ] {
+                assert!(
+                    matches!(
+                        sync_verdict(&env, tcx.mk_cell(i32t, kind)),
+                        SyncVerdict::Sync
+                    ),
+                    "{kind:?}"
+                );
+            }
+            // A lock cell over a bare shared record refutes through the
+            // element: the lock guards the slot, not the element's counts
+            // (Mutex<Rc>-analog no, Mutex<Arc> yes).
+            env.records
+                .insert(DefId(0), (DefaultCap::Shared, Some(vec![])));
+            let bare = rec(tcx, 0);
+            let SyncVerdict::NotSync(w) = sync_verdict(&env, tcx.mk_cell(bare, CellKind::Mutex))
+            else {
+                panic!("expected NotSync");
+            };
+            assert_eq!(w.path, vec!["the `Mutex` element".to_owned()]);
+            assert_eq!(w.reason, NotSyncReason::NonAtomicBox);
+            assert!(matches!(
+                sync_verdict(&env, tcx.mk_cell(tcx.mk_arc(bare), CellKind::Mutex)),
+                SyncVerdict::Sync
+            ));
+            // The composition direction: an Arc'd record holding a sync-cell
+            // member is well-formed — interior mutability behind an arc.
+            env.records.insert(
+                DefId(1),
+                (
+                    DefaultCap::Shared,
+                    Some(vec![("m".into(), tcx.mk_cell(i32t, CellKind::Mutex))]),
+                ),
+            );
+            assert!(matches!(wf_arc(&env, rec(tcx, 1)), SyncVerdict::Sync));
         });
     }
 

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -116,6 +116,77 @@ pub enum FpTy {
     Float8,
 }
 
+/// The synchronization discipline of a [`TyKind::Cell`], mirroring the
+/// dialect's `CellKind` lattice (thread-safety design §4). The kind decides
+/// whether the cell's box is atomically counted, whether the cell is `Sync`,
+/// which element types it admits, and which `core::intrinsic::cell`
+/// operations apply.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum CellKind {
+    /// Surface `Cell<T>`: whole-element `get`/`set`, no synchronization.
+    Plain,
+    /// Surface `RefCell<T>`: adds the guarded `rmw` move-out region and the
+    /// `in_use` flag observation.
+    Exclusive,
+    /// Surface `Atomic<T>`: an inline atomic arithmetic scalar; accesses are
+    /// atomic loads/stores/rmw.
+    Atomic,
+    /// Surface `Mutex<T>`: accesses run inside a mutex critical section.
+    Mutex,
+    /// Surface `FlatLock<T>`: accesses run inside a flat-combining lock
+    /// critical section (the body may execute on the combining thread).
+    Flatlock,
+    /// Surface `RwLock<T>`: reads (`get`/`rdlock`) share the read lock,
+    /// writes (`set`/`rmw`) take it exclusively.
+    Rwlock,
+}
+
+impl CellKind {
+    /// The surface type-constructor name, also used by the textual IR.
+    pub fn surface_name(self) -> &'static str {
+        match self {
+            CellKind::Plain => "Cell",
+            CellKind::Exclusive => "RefCell",
+            CellKind::Atomic => "Atomic",
+            CellKind::Mutex => "Mutex",
+            CellKind::Flatlock => "FlatLock",
+            CellKind::Rwlock => "RwLock",
+        }
+    }
+
+    /// Parse a surface / textual-IR type-constructor name.
+    pub fn parse(name: &str) -> Option<CellKind> {
+        match name {
+            "Cell" => Some(CellKind::Plain),
+            "RefCell" => Some(CellKind::Exclusive),
+            "Atomic" => Some(CellKind::Atomic),
+            "Mutex" => Some(CellKind::Mutex),
+            "FlatLock" => Some(CellKind::Flatlock),
+            "RwLock" => Some(CellKind::Rwlock),
+            _ => None,
+        }
+    }
+
+    /// Whether the cell is a synchronization primitive: born in an atomic
+    /// shared box and `Sync` by itself (given its element bound).
+    pub fn is_sync(self) -> bool {
+        matches!(
+            self,
+            CellKind::Atomic | CellKind::Mutex | CellKind::Flatlock | CellKind::Rwlock
+        )
+    }
+
+    /// Whether accesses are guarded by a lock. Lock-guarded cells require a
+    /// `Sync` element: the lock only protects the stored slot, while clones
+    /// of the element leave the critical section and are used concurrently.
+    pub fn is_lock(self) -> bool {
+        matches!(
+            self,
+            CellKind::Mutex | CellKind::Flatlock | CellKind::Rwlock
+        )
+    }
+}
+
 /// The structure of a type. Compound variants hold interned children
 /// (`Ty<'tcx>` and arena slices), so `TyKind` is `Copy` and its derived
 /// `Eq`/`Hash` bottom out in pointer comparison — exactly the hash-cons key.
@@ -147,13 +218,12 @@ pub enum TyKind<'tcx> {
         dims: &'tcx [u64],
     },
     /// A shared mutable cell. The cell box is always reference-counted; `T`
-    /// may itself contain reference-counted ownership. An `exclusive` cell is
-    /// the surface `RefCell<T>`: it additionally supports in-place
-    /// read-modify-write, guarded at runtime by an in-use flag while the
-    /// element is moved out through the updater.
+    /// may itself contain reference-counted ownership. The [`CellKind`]
+    /// mirrors the dialect's lattice and decides both the synchronization
+    /// discipline and which `core::intrinsic::cell` operations apply.
     Cell {
         elem: Ty<'tcx>,
-        exclusive: bool,
+        kind: CellKind,
     },
     Nullable(Ty<'tcx>),
     /// An atomically reference-counted coloring of a `[shared]` record:
@@ -281,8 +351,8 @@ impl<'tcx> TyCtxt<'tcx> {
         self.mk(TyKind::Array { elem, dims })
     }
 
-    pub fn mk_cell(&self, elem: Ty<'tcx>, exclusive: bool) -> Ty<'tcx> {
-        self.mk(TyKind::Cell { elem, exclusive })
+    pub fn mk_cell(&self, elem: Ty<'tcx>, kind: CellKind) -> Ty<'tcx> {
+        self.mk(TyKind::Cell { elem, kind })
     }
 
     pub fn mk_nullable(&self, inner: Ty<'tcx>) -> Ty<'tcx> {

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -100,12 +100,16 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // `Cell<T>` is the plain get/set cell; `RefCell<T>` is the exclusive
         // flavor that additionally supports guarded read-modify-write.
         if path.segments.is_empty() && matches!(self.sym(key), "Cell" | "RefCell") {
-            let exclusive = self.sym(key) == "RefCell";
-            let name = if exclusive { "RefCell" } else { "Cell" };
+            let kind = if self.sym(key) == "RefCell" {
+                crate::semi::ty::CellKind::Exclusive
+            } else {
+                crate::semi::ty::CellKind::Plain
+            };
+            let name = kind.surface_name();
             return match args {
                 [inner] => {
                     let inner = self.eval_type(inner);
-                    self.tcx.mk_cell(inner, exclusive)
+                    self.tcx.mk_cell(inner, kind)
                 }
                 _ => {
                     self.error(

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -96,19 +96,26 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return self.tcx.mk_generic(generic);
         }
 
-        // Built-in type constructors are roots and never module-qualified.
-        // `Cell<T>` is the plain get/set cell; `RefCell<T>` is the exclusive
-        // flavor that additionally supports guarded read-modify-write.
-        if path.segments.is_empty() && matches!(self.sym(key), "Cell" | "RefCell") {
-            let kind = if self.sym(key) == "RefCell" {
-                crate::semi::ty::CellKind::Exclusive
-            } else {
-                crate::semi::ty::CellKind::Plain
-            };
+        // Built-in cell type constructors are roots and never
+        // module-qualified. `Cell<T>` is the plain get/set cell; `RefCell<T>`
+        // the exclusive flavor with guarded read-modify-write; `Atomic<T>`,
+        // `Mutex<T>`, `FlatLock<T>`, and `RwLock<T>` are the synchronization
+        // kinds (thread-safety design §4), each with its own element bound
+        // checked by [`Elaborator::report_cell_wf`].
+        if path.segments.is_empty()
+            && let Some(kind) = crate::semi::ty::CellKind::parse(self.sym(key))
+        {
             let name = kind.surface_name();
             return match args {
                 [inner] => {
                     let inner = self.eval_type(inner);
+                    if self.records_complete {
+                        // Same staging as `Arc` wf: the lock kinds' `Sync`
+                        // element bound needs record members, so annotation
+                        // sites evaluated before fields populate are
+                        // re-checked by the post-populate sweep.
+                        self.report_cell_wf(inner, kind, Some(span));
+                    }
                     self.tcx.mk_cell(inner, kind)
                 }
                 _ => {
@@ -379,6 +386,51 @@ pub(crate) fn is_plain_scalar_or_deferred(t: Ty<'_>) -> bool {
 /// `ty_eval` (a concrete annotation) and monomorphization (the deferred half:
 /// a generic inner is first grounded by an instantiation, e.g. a trampoline's
 /// explicit type arguments).
+/// Why `t` cannot be the element of an `Atomic` cell, or `None` when it can
+/// (or when it is a generic/hole, deferred to the monomorphization
+/// backstop): the dialect stores the element as an inline atomic scalar, so
+/// only integer and floating-point primitives qualify (every supported fp
+/// width is a power of two).
+pub fn atomic_cell_element_rejection(t: Ty<'_>) -> Option<&'static str> {
+    match *t.kind() {
+        TyKind::Int(IntTy::Signed(w) | IntTy::Unsigned(w)) => {
+            if w.is_power_of_two() && w >= 8 {
+                None
+            } else {
+                Some("an integer whose width is not a power of two of at least 8 bits")
+            }
+        }
+        TyKind::Fp(_) => None,
+        TyKind::Generic(_) | TyKind::Hole(_) | TyKind::Bottom => None,
+        TyKind::Bool => Some("`bool` (use an 8-bit integer)"),
+        TyKind::Char => Some("`char` (use a 32-bit integer)"),
+        _ => Some("not an integer or floating-point primitive"),
+    }
+}
+
+/// Why `t` cannot sit in a lock-guarded cell's slot, or `None` when it can
+/// (or when the answer waits for monomorphization): the slot is a memref
+/// element, so it stores a primitive or an rc pointer — inline aggregates
+/// and nullable wrappers do not qualify. (The `Sync` element bound is
+/// checked separately; this is only the storage-shape half.)
+pub fn lock_cell_slot_rejection<'tcx>(
+    cap_of: impl FnOnce(DefId) -> Option<DefaultCap>,
+    t: Ty<'tcx>,
+) -> Option<&'static str> {
+    match *t.kind() {
+        TyKind::Record { def, .. } => match cap_of(def) {
+            Some(DefaultCap::Value) => {
+                Some("a `[value]` record, which is stored inline rather than as a pointer")
+            }
+            _ => None,
+        },
+        TyKind::Nullable(_) => Some("a nullable, whose null case has no pointer to store"),
+        TyKind::Str => Some("a `str`"),
+        TyKind::Unit => Some("the unit type"),
+        _ => None,
+    }
+}
+
 pub fn arc_inner_rejection<'tcx>(
     cap_of: impl FnOnce(DefId) -> Option<DefaultCap>,
     t: Ty<'tcx>,
@@ -528,6 +580,65 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// contents are not `Sync`. Call only where records are complete (the
     /// post-populate sweep and body checking); a blocked verdict defers to
     /// the monomorphization backstop.
+    /// Report an ill-formed cell type per its kind's element bound
+    /// (thread-safety design §4.2). `Atomic` demands an integer or
+    /// floating-point primitive; the lock-guarded kinds demand a
+    /// pointer-or-primitive slot shape and a `Sync` element. Concrete
+    /// violations report here; generic elements defer to the
+    /// monomorphization backstop. Plain and exclusive cells have no bound.
+    pub(crate) fn report_cell_wf(
+        &mut self,
+        elem: Ty<'tcx>,
+        kind: crate::semi::ty::CellKind,
+        span: Option<surface::Span>,
+    ) {
+        use crate::semi::traits::sync::sync_verdict;
+        use crate::semi::ty::CellKind;
+        match kind {
+            CellKind::Plain | CellKind::Exclusive => {}
+            CellKind::Atomic => {
+                if let Some(what) = atomic_cell_element_rejection(elem) {
+                    self.error(
+                        span,
+                        format!(
+                            "`Atomic<{}>` is ill-formed: the element is {what}",
+                            self.ty_display(elem)
+                        ),
+                    );
+                }
+            }
+            CellKind::Mutex | CellKind::Flatlock | CellKind::Rwlock => {
+                let name = kind.surface_name();
+                if let Some(what) = lock_cell_slot_rejection(
+                    |def| self.records.get(&def).map(|r| r.default_cap),
+                    elem,
+                ) {
+                    self.error(
+                        span,
+                        format!(
+                            "`{name}<{}>` is ill-formed: the element is {what}",
+                            self.ty_display(elem)
+                        ),
+                    );
+                    return;
+                }
+                if let SyncVerdict::NotSync(w) = sync_verdict(&ElabSyncEnv { el: self }, elem) {
+                    self.error(
+                        span,
+                        format!(
+                            "`{name}<{}>` is ill-formed: {}; the element of a \
+                             lock-guarded cell must be `Sync` — the lock protects \
+                             the stored slot, while clones of the element leave \
+                             the critical section",
+                            self.ty_display(elem),
+                            w.describe()
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
     pub(crate) fn report_arc_wf(&mut self, inner: Ty<'tcx>, span: Option<surface::Span>) {
         if self.arc_inner_rejection(inner).is_some() {
             // The kind gate owns this error at its own site.
@@ -568,7 +679,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.sweep_arc_wf(ret, span);
             }
             TyKind::Nullable(inner) => self.sweep_arc_wf(inner, span),
-            TyKind::Cell { elem, .. } => self.sweep_arc_wf(elem, span),
+            TyKind::Cell { elem, kind } => {
+                self.report_cell_wf(elem, kind, span);
+                self.sweep_arc_wf(elem, span);
+            }
             TyKind::Array { elem, .. } => self.sweep_arc_wf(elem, span),
             _ => {}
         }

--- a/crates/reussir-repl/src/reflect.rs
+++ b/crates/reussir-repl/src/reflect.rs
@@ -470,8 +470,10 @@ impl<'tcx> Walker<'_, 'tcx> {
                 }
                 TyKind::Unit => out.push_str("()"),
                 TyKind::Closure { .. } => out.push_str("<closure>"),
-                TyKind::Cell { exclusive, .. } => {
-                    out.push_str(if exclusive { "<refcell>" } else { "<cell>" })
+                TyKind::Cell { kind, .. } => {
+                    out.push('<');
+                    out.push_str(&kind.surface_name().to_lowercase());
+                    out.push('>');
                 }
                 TyKind::Nullable(inner) => {
                     let ptr = addr.cast::<*const u8>().read_unaligned();

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -630,9 +630,12 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
             TyKind::Nullable(inner) => {
                 format!("Nullable<{}>", Self::render_ty_with(elab, inner))
             }
-            TyKind::Cell { elem, exclusive } => {
-                let name = if exclusive { "RefCell" } else { "Cell" };
-                format!("{name}<{}>", Self::render_ty_with(elab, elem))
+            TyKind::Cell { elem, kind } => {
+                format!(
+                    "{}<{}>",
+                    kind.surface_name(),
+                    Self::render_ty_with(elab, elem)
+                )
             }
             TyKind::Arc(inner) => {
                 format!("Arc<{}>", Self::render_ty_with(elab, inner))

--- a/docs/design/thread-safety.md
+++ b/docs/design/thread-safety.md
@@ -434,9 +434,13 @@ Not yet implemented (ordered roughly by dependency):
    closures remain item 4.
 4. **Arc construction for arrays and closures** (annotations are accepted;
    constructors don't exist), including the §3.2 creation-site capture check.
-5. **Surface types for sync cells** (`Atomic<τ>`, `Mutex<τ>`, `Flatlock<τ>`,
-   `Rwlock<τ>`) with the §4.2 element bounds enforced in the frontend, not
-   just the dialect verifier.
+5. ~~Surface types for sync cells~~ — **implemented**: `Atomic<τ>`,
+   `Mutex<τ>`, `FlatLock<τ>`, `RwLock<τ>` with the §4.2 element bounds
+   enforced at annotation/sweep/mono, the `core::intrinsic::cell` matrix
+   over every kind, and `rdlock` read transactions. One narrowing: surface
+   `rmw` is rejected on `Atomic` cells (the CAS-retry region must be
+   effect-free, which a closure call is not) — dedicated atomic arithmetic
+   intrinsics (`fetch_add`, …) are follow-up work.
 6. *(later)* escape hatches — an unsafe "assert Sync" for FFI types and an
    opt-out poison for structurally-Sync but thread-affine types (Rust
    `unsafe impl` / `MutexGuard` precedents); a linear closure kind (§3.2);

--- a/tests/integration/frontend/cell_errors.rr
+++ b/tests/integration/frontend/cell_errors.rr
@@ -22,12 +22,12 @@ fn unknown(c: Cell<i64>) -> i64 { core::intrinsic::cell::swap(c) }
 
 // Read-modify-write and the guard flag dispatch on the operand and demand
 // the exclusive flavor.
-// CHECK: `core::intrinsic::cell::rmw` requires an exclusive cell, found `Cell<i64>`; use a `RefCell`
+// CHECK: `core::intrinsic::cell::rmw` is not supported on `Cell<i64>`; it requires an exclusive or synchronized cell
 fn plain_rmw(c: Cell<i64>) -> unit {
     core::intrinsic::cell::rmw(c, |x| x)
 }
 
-// CHECK: `core::intrinsic::cell::in_use` requires an exclusive cell, found `Cell<i64>`; use a `RefCell`
+// CHECK: `core::intrinsic::cell::in_use` is not supported on `Cell<i64>`; it requires an exclusive cell (`RefCell`)
 fn plain_in_use(c: Cell<i64>) -> bool { core::intrinsic::cell::in_use(c) }
 
 // CHECK: `core::intrinsic::cell::get` expects a cell as its first argument, found `i64`

--- a/tests/integration/frontend/cell_errors.rr
+++ b/tests/integration/frontend/cell_errors.rr
@@ -22,7 +22,7 @@ fn unknown(c: Cell<i64>) -> i64 { core::intrinsic::cell::swap(c) }
 
 // Read-modify-write and the guard flag dispatch on the operand and demand
 // the exclusive flavor.
-// CHECK: `core::intrinsic::cell::rmw` is not supported on `Cell<i64>`; it requires an exclusive or synchronized cell
+// CHECK: `core::intrinsic::cell::rmw` is not supported on `Cell<i64>`; it requires an exclusive or lock-guarded cell
 fn plain_rmw(c: Cell<i64>) -> unit {
     core::intrinsic::cell::rmw(c, |x| x)
 }

--- a/tests/integration/frontend/cells_sync.rr
+++ b/tests/integration/frontend/cells_sync.rr
@@ -1,0 +1,56 @@
+// The sync-cell surface (thread-safety design §4): Atomic / Mutex /
+// FlatLock / RwLock are surface type constructors whose boxes are born
+// atomically counted, and the `core::intrinsic::cell` namespace dispatches
+// on the kind — including the RwLock-only `rdlock` read transaction.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
+// RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %rrc %s --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=MLIR
+
+struct [shared] Data {
+    value: i64
+}
+
+// The four kinds round-trip both textual IRs and lower to kind-tagged cells
+// inside atomic shared boxes.
+// HIR: pub fn #make_mutex() -> Mutex<i64>
+// MIR-DAG: pub fn @_RC10make_mutex() -> Mutex<i64>
+// MLIR-DAG: !reussir.rc<!reussir.cell<i64 mutex> atomic>
+pub fn make_mutex() -> Mutex<i64> {
+    core::intrinsic::cell::alloc<Mutex<i64>>(0)
+}
+
+// HIR: pub fn #make_atomic() -> Atomic<i64>
+// MLIR-DAG: !reussir.rc<!reussir.cell<i64 atomic> atomic>
+pub fn make_atomic() -> Atomic<i64> {
+    core::intrinsic::cell::alloc<Atomic<i64>>(0)
+}
+
+// HIR: pub fn #make_flatlock() -> FlatLock<i64>
+// MLIR-DAG: !reussir.rc<!reussir.cell<i64 flatlock> atomic>
+pub fn make_flatlock() -> FlatLock<i64> {
+    core::intrinsic::cell::alloc<FlatLock<i64>>(0)
+}
+
+// A lock cell over an Arc'd element: the Mutex<Arc> composition.
+// HIR: pub fn #make_rwlock(v0 (d): Arc<#Data>) -> RwLock<Arc<#Data>>
+// MLIR-DAG: !reussir.rc<!reussir.cell<!reussir.rc<!reussir.record<compound "_RC4Data" {i64}> atomic> rwlock> atomic>
+pub fn make_rwlock(d: Arc<Data>) -> RwLock<Arc<Data>> {
+    core::intrinsic::cell::alloc<RwLock<Arc<Data>>>(d)
+}
+
+// get/set/rmw dispatch on the kind; rmw's update runs inside the mutex
+// critical section.
+// MLIR-DAG: reussir.cell.rmw
+pub fn bump(m: Mutex<i64>) -> i64 {
+    core::intrinsic::cell::rmw(m, |x| x + 1);
+    core::intrinsic::cell::get(m)
+}
+
+// The read transaction: the reader receives a clone of the element under
+// the shared read lock and its result leaves through the region yield.
+// HIR: pub fn #peek(v0 (r): RwLock<Arc<#Data>>) -> i64
+// MLIR-DAG: reussir.cell.rdlock
+pub fn peek(r: RwLock<Arc<Data>>) -> i64 {
+    core::intrinsic::cell::rdlock(r, |d| d.value)
+}

--- a/tests/integration/frontend/cells_sync_e2e.c
+++ b/tests/integration/frontend/cells_sync_e2e.c
@@ -1,0 +1,25 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int64_t test_mutex_ffi(void);
+extern int64_t test_atomic_ffi(void);
+extern int64_t test_flatlock_ffi(void);
+extern int64_t test_rwlock_ffi(void);
+
+static int check(const char *name, int64_t got, int64_t want) {
+  if (got == want)
+    return 0;
+  fprintf(stderr, "%s: got %lld, want %lld\n", name, (long long)got,
+          (long long)want);
+  return 1;
+}
+
+int main(void) {
+  int failures = 0;
+  failures += check("mutex", test_mutex_ffi(), 42);
+  failures += check("atomic", test_atomic_ffi(), 42);
+  failures += check("flatlock", test_flatlock_ffi(), 33);
+  failures += check("rwlock", test_rwlock_ffi(), 42);
+  return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/cells_sync_e2e.rr
+++ b/tests/integration/frontend/cells_sync_e2e.rr
@@ -1,0 +1,48 @@
+// End-to-end sync-cell semantics, single-threaded: each kind's box is
+// atomically counted from birth, get/set/rmw dispatch on the kind, and
+// rdlock runs its reader over a clone under the shared read lock. (The
+// multi-threaded disciplines are exercised by the conversion-level omp e2e
+// tests; this pins the frontend wiring and the refcount balance.)
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/cells_sync_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/cells_sync_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+struct [shared] Data {
+    value: i64
+}
+
+pub fn test_mutex() -> i64 {
+    let m = core::intrinsic::cell::alloc<Mutex<i64>>(40);
+    core::intrinsic::cell::rmw(m, |x| x + 1);
+    core::intrinsic::cell::rmw(m, |x| x + 1);
+    core::intrinsic::cell::get(m)
+}
+extern "C" trampoline "test_mutex_ffi" = test_mutex;
+
+pub fn test_atomic() -> i64 {
+    let a = core::intrinsic::cell::alloc<Atomic<i64>>(5);
+    core::intrinsic::cell::set(a, 42);
+    core::intrinsic::cell::get(a)
+}
+extern "C" trampoline "test_atomic_ffi" = test_atomic;
+
+pub fn test_flatlock() -> i64 {
+    let f = core::intrinsic::cell::alloc<FlatLock<i64>>(3);
+    core::intrinsic::cell::set(f, 33);
+    core::intrinsic::cell::get(f)
+}
+extern "C" trampoline "test_flatlock_ffi" = test_flatlock;
+
+// The Mutex<Arc> composition end to end: an arc'd element clones out of the
+// read transaction with its atomic count balanced.
+pub fn test_rwlock() -> i64 {
+    let r = core::intrinsic::cell::alloc<RwLock<Arc<Data>>>(Arc<Data> { value: 11 });
+    let first = core::intrinsic::cell::rdlock(r, |d| d.value);
+    core::intrinsic::cell::set(r, Arc<Data> { value: 31 });
+    first + core::intrinsic::cell::rdlock(r, |d| d.value)
+}
+extern "C" trampoline "test_rwlock_ffi" = test_rwlock;

--- a/tests/integration/frontend/cells_sync_parallel_e2e.c
+++ b/tests/integration/frontend/cells_sync_parallel_e2e.c
@@ -1,0 +1,62 @@
+#include <omp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* The exported C-ABI trampolines follow reussir's own convention, not the
+   platform aggregate ABI: a struct result is returned through a leading
+   sret pointer, and a multi-field argument list is passed as one pointer to
+   a packed argument struct. A single scalar argument with a scalar result
+   is passed and returned directly. */
+struct worker_args {
+  void *stats;
+  int64_t tid;
+  int64_t stride;
+  int64_t upto;
+};
+struct dup_arg {
+  void *s;
+};
+struct pair {
+  void *keep;
+  void *extra;
+};
+
+extern void *make_stats_ffi(void);
+extern void dup_ffi(struct pair *out, struct dup_arg *in);
+extern int64_t worker_ffi(struct worker_args *);
+extern int64_t grand_total_ffi(void *);
+
+enum { THREADS = 4, KEYS = 4000 };
+
+int main(void) {
+  void *stats = make_stats_ffi(); /* one owned reference */
+  /* Split it into THREADS worker handles plus one for the final fold, each
+     an owned reference consumed exactly once — no leak, no over-release. */
+  void *handles[THREADS];
+  for (int i = 0; i < THREADS; ++i) {
+    struct dup_arg in = {stats};
+    struct pair out;
+    dup_ffi(&out, &in);
+    handles[i] = out.extra;
+    stats = out.keep;
+  }
+
+  omp_set_num_threads(THREADS);
+#pragma omp parallel
+  {
+    int tid = omp_get_thread_num();
+    struct worker_args a = {handles[tid], tid, THREADS, KEYS};
+    worker_ffi(&a); /* consumes handles[tid] */
+  }
+
+  int64_t got = grand_total_ffi(stats); /* consumes the last reference */
+  int64_t want = (int64_t)KEYS * (KEYS - 1) / 2;
+  if (got != want) {
+    fprintf(stderr, "grand total: got %lld, want %lld\n", (long long)got,
+            (long long)want);
+    return EXIT_FAILURE;
+  }
+  printf("parallel shared map: %lld\n", (long long)got);
+  return EXIT_SUCCESS;
+}

--- a/tests/integration/frontend/cells_sync_parallel_e2e.rr
+++ b/tests/integration/frontend/cells_sync_parallel_e2e.rr
@@ -1,0 +1,91 @@
+// REQUIRES: openmp
+// The capability showcase for the thread-safety design, driven by real OS
+// threads: a persistent map shared across OpenMP threads through a
+// `Mutex<Arc<Map>>`, each thread committing pure path-copying inserts over
+// a strided slice of the keyspace, with the final fold proving no update
+// was lost and no count was torn. The worker body is exported over the C
+// ABI: multi-argument trampolines take a pointer to a packed argument
+// struct, and arguments are owned, so the driver splits its one reference
+// into N + 1 with `dup` (threading `keep` forward) — one per worker plus one
+// for the final fold, each consumed exactly once.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %openmp_flags %t.o %S/cells_sync_parallel_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %openmp_flags %t.opt.o %S/cells_sync_parallel_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+enum Map {
+    Tip,
+    Node(i64, i64, Map, Map)
+}
+
+// Path-copying insert in the colored world: untouched subtrees are shared,
+// and a uniquely held path is updated in place by Perceus reuse.
+fn insert(m: Arc<Map>, k: i64, v: i64) -> Arc<Map> {
+    match m {
+        Map::Tip => Arc<Map>::Node{k, v, Arc<Map>::Tip, Arc<Map>::Tip},
+        Map::Node(nk, nv, l, r) => {
+            if k < nk {
+                Arc<Map>::Node{nk, nv, insert(l, k, v), r}
+            } else {
+                if k > nk {
+                    Arc<Map>::Node{nk, nv, l, insert(r, k, v)}
+                } else {
+                    Arc<Map>::Node{nk, v, l, r}
+                }
+            }
+        }
+    }
+}
+
+fn total(m: Arc<Map>) -> i64 {
+    match m {
+        Map::Tip => 0,
+        Map::Node(_, nv, l, r) => nv + total(l) + total(r)
+    }
+}
+
+pub fn make_stats() -> Mutex<Arc<Map>> {
+    core::intrinsic::cell::alloc<Mutex<Arc<Map>>>(Arc<Map>::Tip)
+}
+extern "C" trampoline "make_stats_ffi" = make_stats;
+
+// Split one owned handle into two: the ctor references `s` twice, so the
+// returned pair holds two live references. Both fields carry the same
+// atomically counted cell — a `[value]` struct, so the pair is returned by
+// value (two pointers, no heap box) and the C driver consumes each handle
+// exactly once. Threading `keep` forward turns one reference into N + 1 with
+// no leak and no over-release.
+struct [value] Pair {
+    keep: Mutex<Arc<Map>>,
+    extra: Mutex<Arc<Map>>
+}
+
+pub fn dup(s: Mutex<Arc<Map>>) -> Pair {
+    Pair { keep: s, extra: s }
+}
+extern "C" trampoline "dup_ffi" = dup;
+
+// One worker's whole job: commit a strided slice of the keyspace, each
+// commit a short critical section running the pure insert.
+fn loop_insert(stats: Mutex<Arc<Map>>, k: i64, stride: i64, upto: i64) -> i64 {
+    if k < upto {
+        core::intrinsic::cell::rmw(stats, |m| insert(m, k, k));
+        loop_insert(stats, k + stride, stride, upto)
+    } else {
+        0
+    }
+}
+
+pub fn worker(stats: Mutex<Arc<Map>>, tid: i64, stride: i64, upto: i64) -> i64 {
+    loop_insert(stats, tid, stride, upto)
+}
+extern "C" trampoline "worker_ffi" = worker;
+
+// The final fold over a snapshot, consuming the last reference.
+pub fn grand_total(stats: Mutex<Arc<Map>>) -> i64 {
+    total(core::intrinsic::cell::get(stats))
+}
+extern "C" trampoline "grand_total_ffi" = grand_total;

--- a/tests/integration/sanitizer/e2e/cells_sync.rr
+++ b/tests/integration/sanitizer/e2e/cells_sync.rr
@@ -1,0 +1,14 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/cells_sync_e2e.rr: refcount balance on the
+// sync-cell boxes and the arc'd elements cloned out of the rwlock read
+// transaction — a missed decrement leaks, a doubled one double-frees.
+
+// RUN: %rrc %S/../../frontend/cells_sync_e2e.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/cells_sync_e2e.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/cells_sync_e2e.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/cells_sync_e2e.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe

--- a/tests/integration/sanitizer/e2e/cells_sync_parallel.rr
+++ b/tests/integration/sanitizer/e2e/cells_sync_parallel.rr
@@ -1,0 +1,16 @@
+// REQUIRES: asan
+// REQUIRES: openmp
+// ASan+LSan over the parallel shared-map showcase: four OpenMP threads
+// hammer a `Mutex<Arc<Map>>` with pure path-copying inserts, and the driver
+// splits its reference exactly N+1 ways. A torn count would leak or
+// double-free; a lost update would fail the total.
+
+// RUN: %rrc %S/../../frontend/cells_sync_parallel_e2e.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %openmp_flags %t.none.o %S/../../frontend/cells_sync_parallel_e2e.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/cells_sync_parallel_e2e.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call --sanitizer address --nullary-variant-encoding arch-independent
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %openmp_flags %t.aggr.o %S/../../frontend/cells_sync_parallel_e2e.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe


### PR DESCRIPTION
PR 3 of the thread-safety roadmap (design doc §4): the sync cell kinds get surface types, the `core::intrinsic::cell` API generalizes over the whole kind lattice with the new `rdlock` read transaction, and the `Sync` auto trait learns the cell verdicts. Five commits, in review order:

1. **`[frontend]` cell kind axis** — mechanical, behavior-preserving: `TyKind::Cell`'s `exclusive: bool` becomes a six-way `CellKind` mirroring the dialect lattice, threaded through unification, display, textual-IR print/parse (new lexer tokens + grammar rules), v0 mangling, and codegen's kind-taking cell constructor. Only `Cell`/`RefCell` remain constructible here.

2. **`[frontend]` Sync verdict** — plain/exclusive refute as before; `Atomic` is `Sync` outright; a lock-guarded cell is `Sync` exactly when its element is (the lock protects the slot while clones of the element leave the critical section — Mutex<Arc> yes, Mutex<bare shared> no, reported with the witness path ``the `Mutex` element is …``). Both composition directions verified: a sync cell alone, and `Arc<X>` with a sync-cell member.

3. **`[frontend]` surface types + element bounds** — `Atomic<T>` (arithmetic primitive, power-of-two width), `Mutex/FlatLock/RwLock<T>` (pointer-or-primitive slot shape + `Sync` element), enforced with the same three-site staging as Arc wf: annotation once records complete, post-populate sweep, mono ground backstop for generic elements (`hold<Pair>` reports, `hold<i64>` passes).

4. **`[frontend]` the API + rdlock** — one `supported_on` matrix (alloc/get/set everywhere; rmw everywhere but plain `Cell` and `Atomic`; in_use exclusive-only; rdlock RwLock-only) with per-op requirement text; `core::intrinsic::cell::rdlock(cell, reader)` types `reader : T -> ρ` and returns ρ, lowering to `reussir.cell.rdlock` — the reader runs over a clone of the element inside the shared read lock, concurrent with other readers. Ownership needed no changes (the generic borrow-cell/consume-rest rule covers it).

5. **`[tests+docs]`** — type-level lit (the four kinds' HIR/MIR/MLIR spellings, `cell.rmw`/`cell.rdlock` emission), a native e2e (+ ASan/LSan gate): mutex counter through rmw critical sections, atomic set/get, flatlock, and an `RwLock<Arc<Data>>` whose read transactions clone the arc'd element out with the balance held across a `set`. **The lit test caught a real bug**: codegen emitted sync-cell boxes with *normal* refcounts — precisely the unsound shape §4 forbids — fixed in the cell lowering (sync kinds are born in atomic boxes).

One deliberate narrowing, called out in the doc: surface `rmw` on `Atomic` is rejected — the dialect's atomic rmw is a CAS-retry region that must be effect-free, and a closure call is not. Dedicated atomic arithmetic intrinsics (`fetch_add`, …) are the right follow-up surface.

Verification: 295 core tests, 25 workspace suites, 384/392 lit (baseline unsupported only), no new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4ihrGS9WQXXCw7k1VMdGC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787093289&installation_id=144622820&pr_number=446&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F446&signature=3287cf0ef578cc081c1300383c50df967c8ec92460cd06ba8833781b1dd01a11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->