### PR TITLE
[frontend][mlir] rrc: explicit polyffi toolchain flags

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -181,8 +181,16 @@ unsafe extern "C" {
     //==-- Standalone helpers --==//
 
     /// Monomorphizes and compiles polymorphic FFI operations in the module.
-    /// Returns true on success.
-    pub fn reussirCompilePolymorphicFFI(module: MlirModule, optimized: bool) -> bool;
+    /// Returns true on success. `rust_path` and `lib_dir` name the rustc
+    /// executable and the Rust package search directory explicitly; pass empty
+    /// string refs to fall back to the `REUSSIR_RUSTC` / `REUSSIR_RUSTC_DEPS`
+    /// environment variables and the built-in probe list.
+    pub fn reussirCompilePolymorphicFFI(
+        module: MlirModule,
+        optimized: bool,
+        rust_path: MlirStringRef,
+        lib_dir: MlirStringRef,
+    ) -> bool;
 
     /// Gathers the LLVM bitcode modules attached to compiled operations into a
     /// single LLVM module owned by `context`. Returns null on failure; otherwise

--- a/crates/reussir-backend/src/llvm.rs
+++ b/crates/reussir-backend/src/llvm.rs
@@ -28,6 +28,29 @@ use reussir_backend_sys as sys;
 
 use crate::pipeline::OptLevel;
 
+/// Explicit locations for the polymorphic-FFI texture compile. Empty fields
+/// fall back to the `REUSSIR_RUSTC` / `REUSSIR_RUSTC_DEPS` environment
+/// variables and the built-in probe list (see `RustCompiler.cpp`).
+#[derive(Clone, Debug, Default)]
+pub struct PolyffiPaths {
+    /// The `rustc` executable used to compile textures.
+    pub rust_path: Option<String>,
+    /// The directory searched for Rust packages (`rustc -L`) — `libreussir_rt`
+    /// and friends.
+    pub libdir: Option<String>,
+}
+
+// Views an optional string as the borrowed MlirStringRef the C API takes; the
+// referent must outlive every use of the result. `None` becomes an empty ref,
+// which the C side treats as "fall back to discovery".
+fn opt_string_ref(s: &Option<String>) -> sys::mlir_sys::MlirStringRef {
+    let s = s.as_deref().unwrap_or("");
+    sys::mlir_sys::MlirStringRef {
+        data: s.as_ptr().cast(),
+        length: s.len(),
+    }
+}
+
 /// Translates a lowered MLIR `module` to an LLVM IR module created in `context`.
 ///
 /// The returned module is owned alongside `context`. Returns an error if MLIR
@@ -100,11 +123,24 @@ impl LlvmLowering {
     ///
     /// Gathering erases the polyffi ops, so the lowering pipeline's own
     /// `CompilePolymorphicFFIPass` then sees nothing to do.
-    pub fn prepare(module: &Module, data_layout: &str, optimized: bool) -> Result<Self, String> {
+    ///
+    /// `paths` pins the rustc executable and package directory the texture
+    /// compile uses; default it to keep the environment/probe discovery.
+    pub fn prepare(
+        module: &Module,
+        data_layout: &str,
+        optimized: bool,
+        paths: &PolyffiPaths,
+    ) -> Result<Self, String> {
         let data_layout =
             CString::new(data_layout).map_err(|_| "data layout contains a NUL byte".to_string())?;
         unsafe {
-            if !sys::reussirCompilePolymorphicFFI(module.to_raw(), optimized) {
+            if !sys::reussirCompilePolymorphicFFI(
+                module.to_raw(),
+                optimized,
+                opt_string_ref(&paths.rust_path),
+                opt_string_ref(&paths.libdir),
+            ) {
                 return Err("failed to compile polymorphic FFI".into());
             }
             let context = LLVMContextCreate();

--- a/crates/reussir-backend/tests/polyffi_link.rs
+++ b/crates/reussir-backend/tests/polyffi_link.rs
@@ -16,7 +16,7 @@
 use std::ffi::CString;
 
 use reussir_backend::context;
-use reussir_backend::llvm::LlvmLowering;
+use reussir_backend::llvm::{LlvmLowering, PolyffiPaths};
 use reussir_backend::melior::ir::Module;
 use reussir_backend::pipeline::{LoweringOptions, run_lowering_pipeline};
 
@@ -37,19 +37,22 @@ module {
 #[test]
 #[ignore = "requires rustc + a REUSSIR_RUSTC_DEPS directory for the polyffi bitcode compile"]
 fn polyffi_function_is_linked_in() {
-    // The Rust-compiler helper requires a non-empty deps directory even when the
-    // template pulls in no external crates; any existing directory will do.
-    if std::env::var_os("REUSSIR_RUSTC_DEPS").is_none() {
-        unsafe { std::env::set_var("REUSSIR_RUSTC_DEPS", env!("CARGO_MANIFEST_DIR")) };
-    }
+    // The Rust-compiler helper requires a non-empty package directory even when
+    // the template pulls in no external crates; any existing directory will do,
+    // passed explicitly through `PolyffiPaths` (rustc still resolves through
+    // the environment/probe discovery).
+    let paths = PolyffiPaths {
+        libdir: Some(env!("CARGO_MANIFEST_DIR").to_owned()),
+        ..PolyffiPaths::default()
+    };
 
     let context = context();
     let mut module = Module::parse(&context, MODULE).expect("polyffi module parses");
 
     // Gather (compiles the template + collects its bitcode) must run before the
     // lowering pipeline erases the polyffi op; the link happens in `finish`.
-    let prepared =
-        LlvmLowering::prepare(&module, "", false).expect("polyffi compile + gather succeeds");
+    let prepared = LlvmLowering::prepare(&module, "", false, &paths)
+        .expect("polyffi compile + gather succeeds");
     run_lowering_pipeline(&context, &mut module, &LoweringOptions::default())
         .expect("lowering pipeline succeeds");
     let finalized = prepared.finish(&module).expect("translate + link succeeds");

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -19,7 +19,7 @@ use std::process::ExitCode;
 
 use palc::Parser;
 
-use reussir_backend::llvm::LlvmLowering;
+use reussir_backend::llvm::{LlvmLowering, PolyffiPaths};
 use reussir_backend::melior::ir::Module;
 use reussir_backend::pipeline::{self, Anchor, LoweringOptions, NullaryVariantEncoding, OptLevel};
 use reussir_codegen::lower::{
@@ -714,8 +714,13 @@ fn backend_module(
         ..LoweringOptions::default()
     };
     let optimize_ffi = !matches!(opt, OptLevel::None);
-    let prepared = LlvmLowering::prepare(&module, machine.data_layout(), optimize_ffi)
-        .map_err(|e| format!("{name}: {e}"))?;
+    let prepared = LlvmLowering::prepare(
+        &module,
+        machine.data_layout(),
+        optimize_ffi,
+        &PolyffiPaths::default(),
+    )
+    .map_err(|e| format!("{name}: {e}"))?;
     pipeline::run_lowering_pipeline(context, &mut module, &options)
         .map_err(|e| format!("lowering pipeline failed: {e:?}"))?;
 

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -217,6 +217,20 @@ struct Cli {
     #[arg(long = "target-features")]
     target_features: Option<String>,
 
+    /// `rustc` used to compile polymorphic-FFI textures. A bare name resolves
+    /// through `PATH` (the host-toolchain workflow: `--polyffi-rust-path
+    /// rustc`); takes precedence over the `REUSSIR_RUSTC` environment
+    /// variable and the built-in probe list.
+    #[arg(long = "polyffi-rust-path", value_name = "PATH")]
+    polyffi_rust_path: Option<PathBuf>,
+
+    /// Directory searched for the Rust packages polymorphic-FFI textures
+    /// link against (`rustc -L`) — `libreussir_rt` and friends. Takes
+    /// precedence over the `REUSSIR_RUSTC_DEPS` environment variable and the
+    /// built-in probe list.
+    #[arg(long = "polyffi-libdir", value_name = "DIR")]
+    polyffi_libdir: Option<PathBuf>,
+
     /// Let the token-reuse pass reuse tokens across function calls.
     #[arg(long = "reuse-across-call")]
     reuse_across_call: bool,
@@ -668,6 +682,62 @@ fn backend(
 /// The back leg for one module, writing to `output` (per-unit paths in a
 /// partitioned build; `-o` itself otherwise).
 #[allow(clippy::too_many_arguments)]
+/// Resolve the explicit polyffi toolchain locations from the command line.
+/// Both are validated here so a typo fails with a clear driver diagnostic
+/// instead of a texture-compile error deep in the pipeline.
+fn polyffi_paths(cli: &Cli) -> Result<PolyffiPaths, String> {
+    let rust_path = cli
+        .polyffi_rust_path
+        .as_deref()
+        .map(resolve_rustc)
+        .transpose()?;
+    let libdir = match cli.polyffi_libdir.as_deref() {
+        Some(dir) if !dir.is_dir() => {
+            return Err(format!(
+                "--polyffi-libdir `{}` is not a directory",
+                dir.display()
+            ));
+        }
+        Some(dir) => Some(dir.to_string_lossy().into_owned()),
+        None => None,
+    };
+    Ok(PolyffiPaths { rust_path, libdir })
+}
+
+/// A bare `--polyffi-rust-path` name (no separator) searches `PATH`; anything
+/// else is used as given. Either way the executable must exist.
+fn resolve_rustc(path: &Path) -> Result<String, String> {
+    let is_bare = path.components().count() == 1 && !path.is_absolute();
+    if is_bare && !path.exists() {
+        let name = path.as_os_str().to_owned();
+        let found = std::env::var_os("PATH").and_then(|paths| {
+            std::env::split_paths(&paths).find_map(|dir| {
+                let candidate = dir.join(&name);
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+                if cfg!(windows) {
+                    let with_exe = dir.join(format!("{}.exe", name.to_string_lossy()));
+                    if with_exe.is_file() {
+                        return Some(with_exe);
+                    }
+                }
+                None
+            })
+        });
+        if let Some(found) = found {
+            return Ok(found.to_string_lossy().into_owned());
+        }
+    }
+    if !path.is_file() {
+        return Err(format!(
+            "--polyffi-rust-path `{}` does not exist",
+            path.display()
+        ));
+    }
+    Ok(path.to_string_lossy().into_owned())
+}
+
 fn backend_module(
     cli: &Cli,
     context: &reussir_backend::melior::Context,
@@ -718,7 +788,7 @@ fn backend_module(
         &module,
         machine.data_layout(),
         optimize_ffi,
-        &PolyffiPaths::default(),
+        &polyffi_paths(cli)?,
     )
     .map_err(|e| format!("{name}: {e}"))?;
     pipeline::run_lowering_pipeline(context, &mut module, &options)

--- a/docs/design/polymorphic-ffi.md
+++ b/docs/design/polymorphic-ffi.md
@@ -140,8 +140,14 @@ possible extension; it was deliberately left out of v1.)
 ## Pipeline and toolchain
 
 The `reussir-compile-polymorphic-ffi` pass substitutes and compiles each
-texture with the `rustc` located via `REUSSIR_RUSTC` (deps —
-`libreussir_rt` — via `REUSSIR_RUSTC_DEPS`); `translateToModule` links the
+texture with `rustc`. The driver flags `--polyffi-rust-path` (the `rustc`
+executable; a bare name resolves through `PATH`) and `--polyffi-libdir`
+(the package directory passed as `-L`, holding `libreussir_rt` and
+friends) pin the toolchain explicitly; they take precedence over the
+`REUSSIR_RUSTC` / `REUSSIR_RUSTC_DEPS` environment variables, which in
+turn beat the built-in probe list. The flags are the first step toward
+building against a host `cargo`/`rustc` toolchain instead of shipping a
+full Rust sysroot alongside the compiler. `translateToModule` links the
 gathered bitcode into the final LLVM module. The JIT/REPL path does not
 gather polyffi modules yet and rejects programs containing them.
 

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -104,8 +104,12 @@ MlirPass reussirCreateReconcileUnrealizedCastsPass(void);
 //===----------------------------------------------------------------------===//
 
 // Monomorphizes and compiles polymorphic FFI operations in the module. Returns
-// true on success.
-bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized);
+// true on success. `rustPath` and `libDir` name the rustc executable and the
+// Rust package search directory explicitly; pass empty string refs to fall
+// back to the REUSSIR_RUSTC / REUSSIR_RUSTC_DEPS environment variables and the
+// built-in probe list.
+bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized,
+                                  MlirStringRef rustPath, MlirStringRef libDir);
 
 // Gathers the LLVM bitcode modules attached to compiled operations into a
 // single LLVM module owned by `context`. Returns NULL on failure; otherwise the

--- a/include/Reussir/Conversion/Passes.h
+++ b/include/Reussir/Conversion/Passes.h
@@ -36,10 +36,15 @@ namespace reussir {
 //
 // Compiles all uncompiled polymorphic FFI operations in the module by
 // monomorphizing their templates and compiling them to LLVM bitcode.
+// `rustPath` and `libDir`, when non-empty, name the `rustc` executable and the
+// package search directory explicitly (see `findRustCompiler` /
+// `findRustCompilerDeps` for the fallback discovery).
 //
 //===----------------------------------------------------------------------===//
 mlir::LogicalResult compilePolymorphicFFI(mlir::ModuleOp moduleOp,
-                                          bool optimized = false);
+                                          bool optimized = false,
+                                          llvm::StringRef rustPath = {},
+                                          llvm::StringRef libDir = {});
 
 //===----------------------------------------------------------------------===//
 // Variant debug-info fixup (post-translation)

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -241,6 +241,15 @@ def ReussirCompilePolymorphicFFIPass
   }];
   let options = [Option<"optimized", "optimized", "bool", /*default=*/"false",
                         "enable optimizations when compiling FFI templates">,
+                 Option<"rustPath", "rust-path", "std::string",
+                        /*default=*/"\"\"",
+                        "explicit rustc executable used to compile FFI "
+                        "templates (falls back to REUSSIR_RUSTC and probing)">,
+                 Option<"libDir", "libdir", "std::string",
+                        /*default=*/"\"\"",
+                        "directory searched for Rust packages when compiling "
+                        "FFI templates (falls back to REUSSIR_RUSTC_DEPS and "
+                        "probing)">,
   ];
   let dependentDialects = ["::reussir::ReussirDialect",
                            "::mlir::func::FuncDialect",

--- a/include/Reussir/RustCompiler.h
+++ b/include/Reussir/RustCompiler.h
@@ -22,14 +22,28 @@
 #include <memory>
 
 namespace reussir {
-llvm::StringRef findRustCompiler();
-llvm::StringRef findRustCompilerDeps();
+/// Locate the `rustc` used to compile FFI textures. A non-empty `preferred`
+/// path (an explicit `--polyffi-rust-path` threaded down from the driver) is
+/// returned verbatim; otherwise the `REUSSIR_RUSTC` environment variable and
+/// then a list of conventional locations are probed. Empty when nothing is
+/// found.
+llvm::StringRef findRustCompiler(llvm::StringRef preferred = {});
+/// Locate the directory holding the Rust packages (`libreussir_rt` and
+/// friends) FFI textures link against (`rustc -L`). A non-empty `preferred`
+/// directory (an explicit `--polyffi-libdir`) is returned verbatim; otherwise
+/// the `REUSSIR_RUSTC_DEPS` environment variable and then conventional
+/// locations are probed. Empty when nothing is found.
+llvm::StringRef findRustCompilerDeps(llvm::StringRef preferred = {});
 std::unique_ptr<llvm::Module>
 compileRustSource(llvm::LLVMContext &context, llvm::StringRef sourceCode,
-                  llvm::ArrayRef<llvm::StringRef> additionalArgs = {});
+                  llvm::ArrayRef<llvm::StringRef> additionalArgs = {},
+                  llvm::StringRef rustcPath = {},
+                  llvm::StringRef rustcDepsDir = {});
 std::unique_ptr<llvm::MemoryBuffer>
 compileRustSourceToBitcode(llvm::LLVMContext &context,
                            llvm::StringRef sourceCode,
-                           llvm::ArrayRef<llvm::StringRef> additionalArgs = {});
+                           llvm::ArrayRef<llvm::StringRef> additionalArgs = {},
+                           llvm::StringRef rustcPath = {},
+                           llvm::StringRef rustcDepsDir = {});
 } // namespace reussir
 #endif // REUSSIR_RUSTCOMPILER_H

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -188,8 +188,11 @@ MlirPass reussirCreateReconcileUnrealizedCastsPass(void) {
 // Standalone helpers
 //===----------------------------------------------------------------------===//
 
-bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized) {
-  return succeeded(reussir::compilePolymorphicFFI(unwrap(module), optimized));
+bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized,
+                                  MlirStringRef rustPath,
+                                  MlirStringRef libDir) {
+  return succeeded(reussir::compilePolymorphicFFI(
+      unwrap(module), optimized, unwrap(rustPath), unwrap(libDir)));
 }
 
 LLVMModuleRef reussirGatherCompiledModules(MlirModule module,

--- a/lib/Conversion/CompilePolymorphicFFI/CompilePolymorphicFFI.cpp
+++ b/lib/Conversion/CompilePolymorphicFFI/CompilePolymorphicFFI.cpp
@@ -191,7 +191,9 @@ static std::string monomorphize(mlir::ModuleOp moduleOp, ReussirPolyFFIOp op) {
 // CompilePolymorphicFFI Standalone Function
 //===----------------------------------------------------------------------===//
 mlir::LogicalResult compilePolymorphicFFI(mlir::ModuleOp moduleOp,
-                                          bool optimized) {
+                                          bool optimized,
+                                          llvm::StringRef rustPath,
+                                          llvm::StringRef libDir) {
   llvm::LLVMContext context;
   llvm::SmallVector<ReussirPolyFFIOp> uncompiledOps;
   moduleOp.walk([&](ReussirPolyFFIOp op) {
@@ -205,8 +207,8 @@ mlir::LogicalResult compilePolymorphicFFI(mlir::ModuleOp moduleOp,
 
   for (ReussirPolyFFIOp op : uncompiledOps) {
     std::string monomorphized = monomorphize(moduleOp, op);
-    std::unique_ptr<llvm::MemoryBuffer> bitcode =
-        compileRustSourceToBitcode(context, monomorphized, additionalArgs);
+    std::unique_ptr<llvm::MemoryBuffer> bitcode = compileRustSourceToBitcode(
+        context, monomorphized, additionalArgs, rustPath, libDir);
     if (!bitcode)
       return mlir::failure();
     llvm::ArrayRef<char> buffer(bitcode->getBufferStart(),
@@ -238,7 +240,8 @@ public:
       ReussirCompilePolymorphicFFIPass>::ReussirCompilePolymorphicFFIPassBase;
 
   void runOnOperation() override {
-    if (failed(compilePolymorphicFFI(getOperation(), optimized)))
+    if (failed(compilePolymorphicFFI(getOperation(), optimized, rustPath,
+                                     libDir)))
       return signalPassFailure();
   }
 };

--- a/lib/RustCompiler/RustCompiler.cpp
+++ b/lib/RustCompiler/RustCompiler.cpp
@@ -69,7 +69,10 @@ constexpr std::array<llvm::StringRef, 14> RUSTC_DEPS_HINTS = {
 };
 } // namespace
 
-llvm::StringRef findRustCompiler() {
+llvm::StringRef findRustCompiler(llvm::StringRef preferred) {
+  // an explicit path from the driver wins over the environment and the probe
+  if (!preferred.empty())
+    return preferred;
   // first check if REUSSIR_RUSTC is set
   if (const char *env_p = std::getenv("REUSSIR_RUSTC"))
     return env_p;
@@ -82,7 +85,11 @@ llvm::StringRef findRustCompiler() {
   return "";
 }
 
-llvm::StringRef findRustCompilerDeps() {
+llvm::StringRef findRustCompilerDeps(llvm::StringRef preferred) {
+  // an explicit directory from the driver wins over the environment and the
+  // probe
+  if (!preferred.empty())
+    return preferred;
   // first check if REUSSIR_RUSTC_DEPS is set
   if (const char *env_p = std::getenv("REUSSIR_RUSTC_DEPS"))
     return env_p;
@@ -96,9 +103,11 @@ llvm::StringRef findRustCompilerDeps() {
 std::unique_ptr<llvm::MemoryBuffer>
 compileRustSourceToBitcode(llvm::LLVMContext &context,
                            llvm::StringRef sourceCode,
-                           llvm::ArrayRef<llvm::StringRef> additionalArgs) {
-  llvm::StringRef rustcPath = findRustCompiler();
-  llvm::StringRef rustcDepsPath = findRustCompilerDeps();
+                           llvm::ArrayRef<llvm::StringRef> additionalArgs,
+                           llvm::StringRef rustcPath,
+                           llvm::StringRef rustcDepsDir) {
+  rustcPath = findRustCompiler(rustcPath);
+  llvm::StringRef rustcDepsPath = findRustCompilerDeps(rustcDepsDir);
   if (rustcPath.empty() || rustcDepsPath.empty()) {
     llvm::SmallString<16> cwd;
     auto code = llvm::sys::fs::current_path(cwd);
@@ -173,9 +182,10 @@ compileRustSourceToBitcode(llvm::LLVMContext &context,
 
 std::unique_ptr<llvm::Module>
 compileRustSource(llvm::LLVMContext &context, llvm::StringRef sourceCode,
-                  llvm::ArrayRef<llvm::StringRef> additionalArgs) {
-  std::unique_ptr<llvm::MemoryBuffer> bitcode =
-      compileRustSourceToBitcode(context, sourceCode, additionalArgs);
+                  llvm::ArrayRef<llvm::StringRef> additionalArgs,
+                  llvm::StringRef rustcPath, llvm::StringRef rustcDepsDir) {
+  std::unique_ptr<llvm::MemoryBuffer> bitcode = compileRustSourceToBitcode(
+      context, sourceCode, additionalArgs, rustcPath, rustcDepsDir);
   if (!bitcode)
     return nullptr;
   auto moduleOrErr =

--- a/tests/integration/frontend/ffi_flags.rr
+++ b/tests/integration/frontend/ffi_flags.rr
@@ -1,0 +1,38 @@
+// UNSUPPORTED: darwin
+// The explicit polyffi toolchain flags: `--polyffi-rust-path` and
+// `--polyffi-libdir` pin the rustc executable and the package directory the
+// texture compile uses, taking precedence over the REUSSIR_RUSTC /
+// REUSSIR_RUSTC_DEPS environment (both unset here, so the flags are
+// load-bearing) and the probe list.
+
+// RUN: env -u REUSSIR_RUSTC -u REUSSIR_RUSTC_DEPS %rrc %s -o %t.o --relocation-mode pic \
+// RUN:   --polyffi-rust-path %rustc_path --polyffi-libdir %library_path
+
+// A missing rustc or a bogus package directory fails in the driver, before
+// the pipeline runs.
+// RUN: %not %rrc %s -o %t2.o --polyffi-rust-path %t.no-such-rustc 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NO-RUSTC
+// RUN: %not %rrc %s -o %t3.o --polyffi-libdir %t.no-such-dir 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NO-LIBDIR
+
+// NO-RUSTC: --polyffi-rust-path
+// NO-RUSTC-SAME: does not exist
+// NO-LIBDIR: --polyffi-libdir
+// NO-LIBDIR-SAME: is not a directory
+
+extern "rust" [{
+    use reussir_rt::collections::vec::Vec as RVec;
+}];
+
+#[ffi(rust = "::reussir_rt::collections::vec::Vec")]
+pub struct Vec<T>;
+
+#[ffi(import)]
+pub fn new<T>() -> Vec<T> [{ RVec::new() }];
+
+#[ffi(import)]
+pub fn push<T>(v: Vec<T>, x: T) -> Vec<T> [{ RVec::push(v, x) }];
+
+pub fn build() -> Vec<f64> {
+    push(new<f64>(), 1.5)
+}

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -54,6 +54,10 @@ config.substitutions.append((r'%linkage_check_prefixes', linkage_check_prefixes)
 config.substitutions.append((r'%not', sh_path(config.not_path)))
 config.substitutions.append((r'%opt', sh_path(config.opt_path)))
 config.substitutions.append((r'%library_path', sh_path(config.library_path)))
+# The rustc the build provisioned for polyffi texture compiles — the same
+# value REUSSIR_RUSTC is set to; exposed so tests can exercise the explicit
+# --polyffi-rust-path/--polyffi-libdir flags without the environment.
+config.substitutions.append((r'%rustc_path', sh_path(config.environment['REUSSIR_RUSTC'])))
 config.substitutions.append((r'%llc', sh_path(config.llc_path)))
 config.substitutions.append((r'%extra_sys_libs', sh_path(config.extra_sys_libs)))
 config.substitutions.append((r'%lli', sh_path(config.lli_path)))

--- a/tests/unittest/cases/rustc_invoke.cpp
+++ b/tests/unittest/cases/rustc_invoke.cpp
@@ -26,4 +26,22 @@ TEST(RustCompilerTest, CompileSimpleSource) {
   EXPECT_NE(m->getFunction("__reussir_extern_Vec_f64_push"), nullptr);
   EXPECT_NE(m->getFunction("__reussir_extern_Vec_f64_drop"), nullptr);
 }
+
+TEST(RustCompilerTest, ExplicitPathsOverrideDiscovery) {
+  // An explicit path short-circuits both the environment and the probe list.
+  EXPECT_EQ(findRustCompiler("/explicit/bin/rustc"), "/explicit/bin/rustc");
+  EXPECT_EQ(findRustCompilerDeps("/explicit/lib"), "/explicit/lib");
+
+  // Feeding the discovered locations back as explicit arguments exercises the
+  // override path end to end.
+  llvm::StringRef rustc = findRustCompiler();
+  llvm::StringRef deps = findRustCompilerDeps();
+  ASSERT_FALSE(rustc.empty());
+  ASSERT_FALSE(deps.empty());
+  llvm::LLVMContext context;
+  std::unique_ptr<llvm::Module> m =
+      compileRustSource(context, EXAMPLE_SOURCE, {}, rustc, deps);
+  ASSERT_NE(m, nullptr);
+  EXPECT_NE(m->getFunction("__reussir_extern_Vec_f64_new"), nullptr);
+}
 } // namespace reussir


### PR DESCRIPTION
First step toward building polymorphic-FFI textures with a **host** `cargo`/`rustc` toolchain instead of shipping a full Rust sysroot: `rrc` gains

- `--polyffi-rust-path <PATH>` — the `rustc` used to compile FFI textures. A bare name (`--polyffi-rust-path rustc`) resolves through `PATH`.
- `--polyffi-libdir <DIR>` — the directory searched for the Rust packages textures link against (`rustc -L`), i.e. `libreussir_rt` and friends.

Precedence: explicit flag → `REUSSIR_RUSTC` / `REUSSIR_RUSTC_DEPS` environment → built-in probe list. Both flags are validated in the driver, so a typo fails with a clear diagnostic instead of a texture-compile error deep in the pipeline.

Plumbing, one layer per commit (~60 LOC each):
1. `RustCompiler.{h,cpp}` + the standalone `compilePolymorphicFFI` helper accept explicit overrides; the `reussir-compile-polymorphic-ffi` pass grows matching `rust-path`/`libdir` options (usable from `reussir-opt`); unit-test coverage for the override path.
2. The C API (`reussirCompilePolymorphicFFI`) and `LlvmLowering::prepare` thread a new `PolyffiPaths` through (the ignored backend link test now uses it instead of mutating the environment).
3. The `rrc` flags, `PATH` resolution, and driver-side validation.
4. lit coverage: compiles an FFI program with both env vars **unset** and only the flags provided, plus the two failure diagnostics (new `%rustc_path` substitution).
5. Design-doc update.

Tested with the conda LLVM 22 env: unit tests, `check` (401 pass; the only failure is the pre-existing `cells_sync_parallel.rr` LSan report from conda-forge's libomp internals, unrelated), and the new `ffi_flags.rr` lit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9NppfLXpEhQHKV22ERUgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9NppfLXpEhQHKV22ERUgv)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787410495&installation_model_id=426051&pr_number=449&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F449&signature=4e778ae482c8bfda2680c36f1488d114fa1cf7ba6f4a908939c3f46e5a2dfcda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->