### PR TITLE
[llvm] Linear recurrence strength reduction: recursion linearization + Kitamasa exponentiation

### DIFF
--- a/crates/reussir-backend-sys/build.rs
+++ b/crates/reussir-backend-sys/build.rs
@@ -53,6 +53,7 @@ const REUSSIR_ARCHIVES: &[&str] = &[
     "MLIRSyncConvertSyncToLLVM",
     // The custom LLVM passes run by the JIT codegen helper (Jit.cpp).
     "ReussirLLVMAllocationSimplicationPass",
+    "ReussirLLVMLinearRecurrencePass",
 ];
 
 // TPDE static archives (and TPDE's own vendored dependencies: spdlog plus the

--- a/docs/design/linear-recurrence.md
+++ b/docs/design/linear-recurrence.md
@@ -129,20 +129,27 @@ skipped.
 
 ## Pipeline placement
 
-Both `runNPMOptimization` (bridge) and `reussirRunBackendLLVMPipeline`
-(rrc/JIT) bracket the default pipeline at the speed-oriented levels
-(default/aggressive):
+`registerLinearRecurrencePipelines` hooks both passes into the default
+pipeline's extension points; both `runNPMOptimization` (bridge) and
+`reussirRunBackendLLVMPipeline` (rrc/JIT) register it at the
+speed-oriented levels (default/aggressive):
 
-```
-mem2reg → recursion-linearization → default<O2/O3>
-        → loop-simplify → matexp → instcombine → simplifycfg
-```
+- **Pipeline start**: `mem2reg → recursion-linearization`. Linearization
+  must run before the inliner tears the recursive shape apart.
+- **Vectorizer start**: `loop-simplify → matexp → early-cse → instcombine`.
+  This point is load-bearing in both directions. The loops are already
+  canonicalized (rotated, indvar-simplified) — exactly what the inlined
+  `step` helper of a linear recurrence collapses into — but the vectorizers
+  have not run yet: placed *after* the whole pipeline instead, SLP
+  vectorizes wider recurrence windows (order >= 4) into vector PHIs the
+  affine matcher cannot see, and the rewrite silently never fires. And
+  because the rewrite runs *inside* the pipeline, the emitted kernel gets
+  the full late pipeline (instcombine, vectorizers, unrolling) on top of
+  the immediate EarlyCSE, which folds the schoolbook squaring's commutative
+  duplicate products (b_i*b_j vs b_j*b_i).
 
-Linearization must run *before* the inliner tears the recursive shape apart;
-matrix exponentiation wants the rotated, indvar-simplified single-block
-loops the default pipeline produces — which is exactly what the inlined
-`step` helper of a linear recurrence collapses into, closing the
-recursion → loop → log-time chain.
+The `reussir-llvm-opt` flag `--linear-recurrence-pipeline=<level>` runs
+this exact configuration, which is what the end-to-end lit tests use.
 
 ## Limits and future work
 

--- a/docs/design/linear-recurrence.md
+++ b/docs/design/linear-recurrence.md
@@ -90,22 +90,42 @@ their updates must stay affine. PHIs outside the closure — typically an exit
 counter of a different width — die with the loop. Add/sub/mul-by-constant
 and shl-by-constant are the recognized affine operations.
 
-### Rewrite
+### Rewrite (Kitamasa)
 
-With the augmented companion matrix `A = [[M, c], [0, 1]]`, the final state
-is `A^btc * s_0`. The pass emits a square-and-multiply loop over the bits of
-the materialized backedge-taken count (`O(K^3 log n)` ring operations for
-`K = |state| + 1`, capped at `K <= 7`), then rebuilds each live-out from the
-final state vector and deletes the original loop.
+With the augmented companion matrix `A = [[M, c], [0, 1]]` of dimension `D`,
+the final state is `A^btc * s_0`. Rather than exponentiating the matrix
+(`O(D^3)` per squaring), the pass works in the quotient ring
+`(Z/2^N)[z] / chi_A(z)`:
+
+1. `chi_A`, the characteristic polynomial of the compile-time constant `A`,
+   is computed at compile time by division-free cofactor expansion mod 2^N
+   (memoized on column subsets); it is monic by construction, so reduction
+   mod `chi_A` needs no division either.
+2. The emitted loop computes `p(z) = z^btc mod chi_A` by square-and-multiply
+   over the exponent's bits — each step is a degree-`< D` polynomial
+   multiply plus monic reduction, `O(D^2)` ring operations, with only `2D`
+   loop-carried coefficients instead of `2D^2` matrix entries.
+3. By Cayley–Hamilton (a polynomial identity over Z, hence valid in any
+   commutative ring including Z/2^N), `A^btc s_0 = p(A) s_0 =
+   sum_i p_i (A^i s_0)`. The Krylov vectors `A^i s_0` for `i < D` are
+   emitted once as straight-line code with the (typically sparse, 0/±1)
+   constant matrix entries folded away.
+
+Total: `O(D^2 log n)` emitted ring operations — the FFT-free Kitamasa
+bound. The FFT variant (`O(D log D log n)`) only wins for `D` in the dozens,
+far beyond the `D <= 7` cap here, so plain schoolbook polynomial
+multiplication is the right choice. Each live-out is then rebuilt from the
+final state vector and the original loop is deleted.
 
 ### Soundness
 
-Z/2^N is a commutative ring, so matrix exponentiation is bit-exact for
-wrapping arithmetic; `nsw`/`nuw` flags on the original operations only
-license *removing* poison, so dropping them in the emitted code is a
-refinement. If the backedge-taken count SCEV relied on no-wrap reasoning,
-the original loop already had the corresponding UB on the offending inputs.
-Loops whose exact trip count SCEV cannot compute are skipped.
+Z/2^N is a commutative ring, so both the polynomial arithmetic and
+Cayley–Hamilton are bit-exact for wrapping arithmetic; `nsw`/`nuw` flags on
+the original operations only license *removing* poison, so dropping them in
+the emitted code is a refinement. If the backedge-taken count SCEV relied on
+no-wrap reasoning, the original loop already had the corresponding UB on the
+offending inputs. Loops whose exact trip count SCEV cannot compute are
+skipped.
 
 ## Pipeline placement
 

--- a/docs/design/linear-recurrence.md
+++ b/docs/design/linear-recurrence.md
@@ -1,0 +1,143 @@
+# Linear Recurrence Strength Reduction
+
+Two LLVM-IR passes (`lib/LLVMPass/LinearRecurrence`) recognize
+linear-recurrence computation in recursive and loop form and successively
+strength-reduce it: exponential call trees become linear loops, and linear
+affine loops become logarithmic-time matrix exponentiation. The flagship
+consequence is that the naive doubly-recursive `fibonacci` compiles into an
+O(log n) kernel at the default optimization level, but both passes are
+general compiler transforms with precise applicability conditions rather than
+a `fib` pattern-match.
+
+## Pass 1: `reussir-recursion-linearization`
+
+### Shape
+
+A directly self-recursive function
+
+```
+f(x, c...) = combine(x, c..., f(x - d_1, c...), ..., f(x - d_k, c...))
+```
+
+where the `d_i` are constant positive offsets, every non-induction argument
+is passed through unchanged, and `combine` — everything else the body does —
+is an arbitrary side-effect-free, speculatable computation. No linearity is
+required at this stage: modular sums, saturating/min/max combinations, and
+floating-point recurrences all qualify, because the rewrite never
+reassociates the user's arithmetic.
+
+### Rewrite
+
+The body is outlined into a private `alwaysinline` helper
+`step(x, c..., y_1, ..., y_k)` in which the recursive call with offset `d`
+is replaced by the parameter `y_d`. The function itself becomes a
+dynamic-programming loop over a sliding window of the last `k` results:
+
+```
+f(x, c...):
+  if (x < C)  return step(x, c..., poison...)        // call-free region
+  w_j = step(C - j, c..., poison...)   for j = 1..k  // seeds, also < C
+  for (v = C; ; ++v):
+    cur = step(v, c..., w_1, ..., w_k)
+    if (v == x) return cur
+    w_1 = cur; w_j = w_{j-1}
+```
+
+`C` is the *recursion floor*: a constant lower bound of `x` at every
+recursive call site, derived by intersecting `ConstantRange`s from dominating
+`icmp x, constant` branch edges. The floor's lattice (signed or unsigned)
+follows the predicates the source itself used, so signed base guards keep
+negative inputs on the direct base path.
+
+### Soundness
+
+- **`x < C` implies the body is call-free.** Every call site is dominated by
+  conditions placing `x` in a range whose minimum is at least `C`
+  (contrapositive of the range computation). On those paths the `y`
+  parameters are dead, so passing `poison` is safe; branch conditions cannot
+  depend on a `y` value without a recursive call having executed first.
+- **Seeds stay below the floor.** `C - k` is required not to wrap past the
+  lattice minimum, so each seed evaluates the call-free region.
+- **The window is exact.** By induction, at `v` the window holds
+  `f(v-1) .. f(v-k)`; `step(v, ...)` therefore computes `f(v)` whether it
+  takes a base or a recursive path.
+- **Extra evaluation points cannot trap.** The loop visits every `v` in
+  `[C, x]` even where the original call tree skipped points, so every
+  instruction must be speculatable: the matcher whitelists effect-free
+  instructions, requires an acyclic body CFG, and only admits division by
+  provably benign constants.
+- **Termination is structural.** The original recursion descends by at least
+  1 per call under the same floor, so it terminates for exactly the same
+  inputs; eliminating duplicated evaluations of a pure, terminating
+  computation needs no `willreturn` attributes.
+
+## Pass 2: `reussir-linear-recurrence-matexp`
+
+### Shape
+
+A single-block loop with a preheader, one exit, an exact
+ScalarEvolution backedge-taken count, no side effects, whose loop-carried
+integer state evolves as an affine map with compile-time constant
+coefficients:
+
+```
+s_{i+1} = M * s_i + c      // all arithmetic wrapping, i.e. in Z/2^N
+```
+
+Every value used outside the loop must be an affine combination of the
+header PHIs of one common integer type, and the closure of those PHIs under
+their updates must stay affine. PHIs outside the closure — typically an exit
+counter of a different width — die with the loop. Add/sub/mul-by-constant
+and shl-by-constant are the recognized affine operations.
+
+### Rewrite
+
+With the augmented companion matrix `A = [[M, c], [0, 1]]`, the final state
+is `A^btc * s_0`. The pass emits a square-and-multiply loop over the bits of
+the materialized backedge-taken count (`O(K^3 log n)` ring operations for
+`K = |state| + 1`, capped at `K <= 7`), then rebuilds each live-out from the
+final state vector and deletes the original loop.
+
+### Soundness
+
+Z/2^N is a commutative ring, so matrix exponentiation is bit-exact for
+wrapping arithmetic; `nsw`/`nuw` flags on the original operations only
+license *removing* poison, so dropping them in the emitted code is a
+refinement. If the backedge-taken count SCEV relied on no-wrap reasoning,
+the original loop already had the corresponding UB on the offending inputs.
+Loops whose exact trip count SCEV cannot compute are skipped.
+
+## Pipeline placement
+
+Both `runNPMOptimization` (bridge) and `reussirRunBackendLLVMPipeline`
+(rrc/JIT) bracket the default pipeline at the speed-oriented levels
+(default/aggressive):
+
+```
+mem2reg → recursion-linearization → default<O2/O3>
+        → loop-simplify → matexp → instcombine → simplifycfg
+```
+
+Linearization must run *before* the inliner tears the recursive shape apart;
+matrix exponentiation wants the rotated, indvar-simplified single-block
+loops the default pipeline produces — which is exactly what the inlined
+`step` helper of a linear recurrence collapses into, closing the
+recursion → loop → log-time chain.
+
+## Limits and future work
+
+- Mutual recursion, multi-dimensional induction (`f(x-1, y+2)`), and
+  non-constant descent such as `f(x / 2)` are out of scope (the latter is
+  the divide-and-conquer class, a different transform).
+- The matexp pass models Z/2^N only. An explicit-modulus recognizer
+  (`urem` by a loop-invariant modulus at each step) and other semirings
+  (min/max-plus) would slot into the same affine framework but need widened
+  multiplies or a semiring-parameterized emitter.
+- No runtime break-even guard is emitted: for tiny trip counts the
+  exponentiation kernel does more work than the scalar loop it replaced.
+
+Testing lives in `tests/integration/llvmpass/*.ll` (structure via FileCheck,
+semantics via `lli`, including a naive-recursive `fib(10^15)` that only the
+logarithmic path can answer) and
+`tests/integration/frontend/naive_fib_linear_recurrence.rr` for the full
+Reussir pipeline.

--- a/include/Reussir/LLVMPass/LinearRecurrence.h
+++ b/include/Reussir/LLVMPass/LinearRecurrence.h
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linear-recurrence oriented LLVM passes.
+///
+/// `RecursionLinearizationPass` rewrites pure, directly self-recursive
+/// functions whose recursion argument decreases by constant offsets (the
+/// `f(x) = combine(f(x - d_1), ..., f(x - d_k))` shape, with an arbitrary
+/// side-effect-free `combine`) into a dynamic-programming loop over a sliding
+/// window of the last `k` results, turning exponential call trees into linear
+/// loops.
+///
+/// `LinearRecurrenceMatExpPass` recognizes single-block loops whose
+/// loop-carried state evolves as an affine map over Z/2^N (constant
+/// coefficients, wrapping integer arithmetic) and replaces the loop with
+/// square-and-multiply exponentiation of the companion matrix, turning linear
+/// loops into logarithmic-time computations.
+///
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <llvm/IR/PassManager.h>
+
+namespace reussir::llvmpass {
+
+class RecursionLinearizationPass
+    : public llvm::PassInfoMixin<RecursionLinearizationPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module,
+                              llvm::ModuleAnalysisManager &mam);
+};
+
+class LinearRecurrenceMatExpPass
+    : public llvm::PassInfoMixin<LinearRecurrenceMatExpPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Function &function,
+                              llvm::FunctionAnalysisManager &fam);
+};
+
+} // namespace reussir::llvmpass

--- a/include/Reussir/LLVMPass/LinearRecurrence.h
+++ b/include/Reussir/LLVMPass/LinearRecurrence.h
@@ -30,6 +30,10 @@
 
 #include <llvm/IR/PassManager.h>
 
+namespace llvm {
+class PassBuilder;
+} // namespace llvm
+
 namespace reussir::llvmpass {
 
 class RecursionLinearizationPass
@@ -45,5 +49,23 @@ public:
   llvm::PreservedAnalyses run(llvm::Function &function,
                               llvm::FunctionAnalysisManager &fam);
 };
+
+/// Hooks both passes into the extension points of a PassBuilder-driven
+/// default pipeline: recursion linearization (preceded by mem2reg) at
+/// pipeline start — before the inliner tears the recursive shape apart —
+/// and the Kitamasa rewrite at vectorizer start, after loop canonicalization
+/// (rotation, indvar simplification) but *before* the vectorizers.
+///
+/// The placement inside the pipeline matters twice over: running after the
+/// whole pipeline instead would let SLP vectorize wider recurrence windows
+/// (k >= 4) into vector PHIs the affine matcher cannot see, and would leave
+/// the emitted kernel without the late pipeline's cleanups. At vectorizer
+/// start the rewrite sees canonical scalar loops, an EarlyCSE pass right
+/// after it folds the schoolbook squaring's commutative duplicate products,
+/// and the remaining late pipeline (instcombine, vectorizers, unrolling)
+/// then optimizes the emitted kernel like any other code.
+///
+/// Call before `buildPerModuleDefaultPipeline`.
+void registerLinearRecurrencePipelines(llvm::PassBuilder &passBuilder);
 
 } // namespace reussir::llvmpass

--- a/lib/Bridge/Bridge.cppm
+++ b/lib/Bridge/Bridge.cppm
@@ -38,13 +38,9 @@ module;
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/IPO/FunctionAttrs.h>
 #include <llvm/Transforms/IPO/Inliner.h>
-#include <llvm/Transforms/InstCombine/InstCombine.h>
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/ADCE.h>
-#include <llvm/Transforms/Scalar/SimplifyCFG.h>
 #include <llvm/Transforms/Utils.h>
-#include <llvm/Transforms/Utils/LoopSimplify.h>
-#include <llvm/Transforms/Utils/Mem2Reg.h>
 #include <mlir/Conversion/ConvertToLLVM/ToLLVMPass.h>
 #include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
 #include <mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h>
@@ -254,29 +250,16 @@ void runNPMOptimization(llvm::Module &llvmModule, ReussirOptOption opt) {
   // Create the default optimization pipeline for the specified level.
   llvm::ModulePassManager mpm;
   mpm.addPass(reussir::llvmpass::RuntimeFunctionAttributorPass());
-  // Linear-recurrence strength reduction brackets the default pipeline: the
-  // recursion linearization must see the recursive shape before the inliner
-  // rewrites it, and the matrix-exponentiation pass wants the canonicalized
-  // (rotated, indvar-simplified) loops the default pipeline leaves behind.
-  // Only speed-oriented levels opt in — the exponentiation kernel trades
-  // code size for time.
-  bool linearRecurrence =
-      opt == REUSSIR_OPT_DEFAULT || opt == REUSSIR_OPT_AGGRESSIVE;
-  if (linearRecurrence) {
-    llvm::FunctionPassManager cleanup;
-    cleanup.addPass(llvm::PromotePass());
-    mpm.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(cleanup)));
-    mpm.addPass(reussir::llvmpass::RecursionLinearizationPass());
-  }
+  // Linear-recurrence strength reduction hooks into the default pipeline's
+  // extension points: recursion linearization at pipeline start (before the
+  // inliner tears the recursive shape apart) and the Kitamasa rewrite at
+  // vectorizer start (canonicalized loops, but before SLP can fold wider
+  // recurrence windows into vector PHIs the matcher cannot see). Only
+  // speed-oriented levels opt in — the exponentiation kernel trades code
+  // size for time.
+  if (opt == REUSSIR_OPT_DEFAULT || opt == REUSSIR_OPT_AGGRESSIVE)
+    reussir::llvmpass::registerLinearRecurrencePipelines(pb);
   mpm.addPass(pb.buildPerModuleDefaultPipeline(optLevel));
-  if (linearRecurrence) {
-    llvm::FunctionPassManager matexp;
-    matexp.addPass(llvm::LoopSimplifyPass());
-    matexp.addPass(reussir::llvmpass::LinearRecurrenceMatExpPass());
-    matexp.addPass(llvm::InstCombinePass());
-    matexp.addPass(llvm::SimplifyCFGPass());
-    mpm.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(matexp)));
-  }
   mpm.addPass(reussir::llvmpass::AllocationSimplicationPass());
 
   // Run the optimization

--- a/lib/Bridge/Bridge.cppm
+++ b/lib/Bridge/Bridge.cppm
@@ -38,9 +38,13 @@ module;
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/IPO/FunctionAttrs.h>
 #include <llvm/Transforms/IPO/Inliner.h>
+#include <llvm/Transforms/InstCombine/InstCombine.h>
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/ADCE.h>
+#include <llvm/Transforms/Scalar/SimplifyCFG.h>
 #include <llvm/Transforms/Utils.h>
+#include <llvm/Transforms/Utils/LoopSimplify.h>
+#include <llvm/Transforms/Utils/Mem2Reg.h>
 #include <mlir/Conversion/ConvertToLLVM/ToLLVMPass.h>
 #include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
 #include <mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h>
@@ -88,6 +92,7 @@ module;
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/LLVMPass/AllocationSimplication.h"
+#include "Reussir/LLVMPass/LinearRecurrence.h"
 #include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"
 #include "Reussir/Transformation/Passes.h"
 
@@ -249,7 +254,29 @@ void runNPMOptimization(llvm::Module &llvmModule, ReussirOptOption opt) {
   // Create the default optimization pipeline for the specified level.
   llvm::ModulePassManager mpm;
   mpm.addPass(reussir::llvmpass::RuntimeFunctionAttributorPass());
+  // Linear-recurrence strength reduction brackets the default pipeline: the
+  // recursion linearization must see the recursive shape before the inliner
+  // rewrites it, and the matrix-exponentiation pass wants the canonicalized
+  // (rotated, indvar-simplified) loops the default pipeline leaves behind.
+  // Only speed-oriented levels opt in — the exponentiation kernel trades
+  // code size for time.
+  bool linearRecurrence =
+      opt == REUSSIR_OPT_DEFAULT || opt == REUSSIR_OPT_AGGRESSIVE;
+  if (linearRecurrence) {
+    llvm::FunctionPassManager cleanup;
+    cleanup.addPass(llvm::PromotePass());
+    mpm.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(cleanup)));
+    mpm.addPass(reussir::llvmpass::RecursionLinearizationPass());
+  }
   mpm.addPass(pb.buildPerModuleDefaultPipeline(optLevel));
+  if (linearRecurrence) {
+    llvm::FunctionPassManager matexp;
+    matexp.addPass(llvm::LoopSimplifyPass());
+    matexp.addPass(reussir::llvmpass::LinearRecurrenceMatExpPass());
+    matexp.addPass(llvm::InstCombinePass());
+    matexp.addPass(llvm::SimplifyCFGPass());
+    mpm.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(matexp)));
+  }
   mpm.addPass(reussir::llvmpass::AllocationSimplicationPass());
 
   // Run the optimization

--- a/lib/Bridge/CMakeLists.txt
+++ b/lib/Bridge/CMakeLists.txt
@@ -38,6 +38,7 @@ add_mlir_library(MLIRReussirBridge
     MLIRReussirConversion
     MLIRReussirTransformation
     ReussirLLVMAllocationSimplicationPass
+    ReussirLLVMLinearRecurrencePass
     spdlog::spdlog
     ${TPDE_LINK_LIB}
 )

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library(ReussirCAPI STATIC Dialects.cpp Passes.cpp Types.cpp Attrs.cpp Jit.c
 # these as usage requirements gives ReussirCAPI their headers/defines and orders
 # the build; the archives themselves are pulled onto the final Rust link line by
 # reussir-backend-sys (see its build.rs).
-target_link_libraries(ReussirCAPI PRIVATE ReussirLLVMAllocationSimplicationPass)
+target_link_libraries(ReussirCAPI PRIVATE ReussirLLVMAllocationSimplicationPass
+                                          ReussirLLVMLinearRecurrencePass)
 if(REUSSIR_HAS_TPDE)
   target_compile_definitions(ReussirCAPI PRIVATE REUSSIR_HAS_TPDE)
   target_link_libraries(ReussirCAPI PRIVATE tpde_llvm)

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -30,7 +30,13 @@
 #include <llvm/Transforms/IPO/LowerTypeTests.h>
 #include <llvm/Transforms/IPO/WholeProgramDevirt.h>
 
+#include <llvm/Transforms/InstCombine/InstCombine.h>
+#include <llvm/Transforms/Scalar/SimplifyCFG.h>
+#include <llvm/Transforms/Utils/LoopSimplify.h>
+#include <llvm/Transforms/Utils/Mem2Reg.h>
+
 #include "Reussir/LLVMPass/AllocationSimplication.h"
+#include "Reussir/LLVMPass/LinearRecurrence.h"
 #include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"
 
 #ifdef REUSSIR_HAS_TPDE
@@ -142,7 +148,30 @@ void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt,
   mpm.addPass(llvm::LowerTypeTestsPass(
       /*ExportSummary=*/nullptr, /*ImportSummary=*/nullptr,
       llvm::lowertypetests::DropTestKind::Assume));
+  // Linear-recurrence strength reduction brackets the default pipeline: the
+  // recursion linearization must see the recursive shape before the inliner
+  // rewrites it, and the matrix-exponentiation pass wants the canonicalized
+  // (rotated, indvar-simplified) loops the default pipeline leaves behind.
+  // Only speed-oriented levels opt in — the exponentiation kernel trades
+  // code size for time.
+  bool linearRecurrence =
+      opt == ReussirJitOptDefault || opt == ReussirJitOptAggressive;
+  if (linearRecurrence) {
+    llvm::FunctionPassManager cleanup;
+    cleanup.addPass(llvm::PromotePass());
+    mpm.addPass(
+        llvm::createModuleToFunctionPassAdaptor(std::move(cleanup)));
+    mpm.addPass(reussir::llvmpass::RecursionLinearizationPass());
+  }
   mpm.addPass(pb.buildPerModuleDefaultPipeline(level));
+  if (linearRecurrence) {
+    llvm::FunctionPassManager matexp;
+    matexp.addPass(llvm::LoopSimplifyPass());
+    matexp.addPass(reussir::llvmpass::LinearRecurrenceMatExpPass());
+    matexp.addPass(llvm::InstCombinePass());
+    matexp.addPass(llvm::SimplifyCFGPass());
+    mpm.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(matexp)));
+  }
   mpm.addPass(reussir::llvmpass::AllocationSimplicationPass());
   mpm.run(m, mam);
 }

--- a/lib/CAPI/Jit.cpp
+++ b/lib/CAPI/Jit.cpp
@@ -30,11 +30,6 @@
 #include <llvm/Transforms/IPO/LowerTypeTests.h>
 #include <llvm/Transforms/IPO/WholeProgramDevirt.h>
 
-#include <llvm/Transforms/InstCombine/InstCombine.h>
-#include <llvm/Transforms/Scalar/SimplifyCFG.h>
-#include <llvm/Transforms/Utils/LoopSimplify.h>
-#include <llvm/Transforms/Utils/Mem2Reg.h>
-
 #include "Reussir/LLVMPass/AllocationSimplication.h"
 #include "Reussir/LLVMPass/LinearRecurrence.h"
 #include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"
@@ -148,30 +143,16 @@ void reussirRunBackendLLVMPipeline(LLVMModuleRef module, ReussirJitOptLevel opt,
   mpm.addPass(llvm::LowerTypeTestsPass(
       /*ExportSummary=*/nullptr, /*ImportSummary=*/nullptr,
       llvm::lowertypetests::DropTestKind::Assume));
-  // Linear-recurrence strength reduction brackets the default pipeline: the
-  // recursion linearization must see the recursive shape before the inliner
-  // rewrites it, and the matrix-exponentiation pass wants the canonicalized
-  // (rotated, indvar-simplified) loops the default pipeline leaves behind.
-  // Only speed-oriented levels opt in — the exponentiation kernel trades
-  // code size for time.
-  bool linearRecurrence =
-      opt == ReussirJitOptDefault || opt == ReussirJitOptAggressive;
-  if (linearRecurrence) {
-    llvm::FunctionPassManager cleanup;
-    cleanup.addPass(llvm::PromotePass());
-    mpm.addPass(
-        llvm::createModuleToFunctionPassAdaptor(std::move(cleanup)));
-    mpm.addPass(reussir::llvmpass::RecursionLinearizationPass());
-  }
+  // Linear-recurrence strength reduction hooks into the default pipeline's
+  // extension points: recursion linearization at pipeline start (before the
+  // inliner tears the recursive shape apart) and the Kitamasa rewrite at
+  // vectorizer start (canonicalized loops, but before SLP can fold wider
+  // recurrence windows into vector PHIs the matcher cannot see). Only
+  // speed-oriented levels opt in — the exponentiation kernel trades code
+  // size for time.
+  if (opt == ReussirJitOptDefault || opt == ReussirJitOptAggressive)
+    reussir::llvmpass::registerLinearRecurrencePipelines(pb);
   mpm.addPass(pb.buildPerModuleDefaultPipeline(level));
-  if (linearRecurrence) {
-    llvm::FunctionPassManager matexp;
-    matexp.addPass(llvm::LoopSimplifyPass());
-    matexp.addPass(reussir::llvmpass::LinearRecurrenceMatExpPass());
-    matexp.addPass(llvm::InstCombinePass());
-    matexp.addPass(llvm::SimplifyCFGPass());
-    mpm.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(matexp)));
-  }
   mpm.addPass(reussir::llvmpass::AllocationSimplicationPass());
   mpm.run(m, mam);
 }

--- a/lib/LLVMPass/CMakeLists.txt
+++ b/lib/LLVMPass/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(AllocationSimplication)
+add_subdirectory(LinearRecurrence)
 

--- a/lib/LLVMPass/LinearRecurrence/CMakeLists.txt
+++ b/lib/LLVMPass/LinearRecurrence/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(ReussirLLVMLinearRecurrencePass STATIC
+  RecursionLinearization.cpp
+  LinearRecurrenceMatExp.cpp
+)
+
+set_target_properties(ReussirLLVMLinearRecurrencePass PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+)

--- a/lib/LLVMPass/LinearRecurrence/CMakeLists.txt
+++ b/lib/LLVMPass/LinearRecurrence/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ReussirLLVMLinearRecurrencePass STATIC
   RecursionLinearization.cpp
   LinearRecurrenceMatExp.cpp
+  LinearRecurrencePipeline.cpp
 )
 
 set_target_properties(ReussirLLVMLinearRecurrencePass PROPERTIES

--- a/lib/LLVMPass/LinearRecurrence/LinearRecurrenceMatExp.cpp
+++ b/lib/LLVMPass/LinearRecurrence/LinearRecurrenceMatExp.cpp
@@ -1,0 +1,512 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements loop-to-matrix-exponentiation strength reduction for
+/// linear recurrences over machine integers.
+///
+/// A single-block loop whose loop-carried integer state evolves as an affine
+/// map with compile-time constant coefficients,
+///
+///   s_{i+1} = M * s_i + c        (all arithmetic wrapping, i.e. in Z/2^N)
+///
+/// computes `s_n = A^n * s_0` for the augmented companion matrix
+/// `A = [[M, c], [0, 1]]`. Because Z/2^N is a commutative ring, `A^n` can be
+/// evaluated with square-and-multiply in O(K^3 log n) ring operations, so the
+/// pass replaces the loop (O(n) iterations) with an O(log n) exponentiation
+/// loop over the bits of the backedge-taken count.
+///
+/// Recognition requirements:
+///   - the loop is a single block with a preheader and one exit;
+///   - ScalarEvolution can compute the exact backedge-taken count;
+///   - no instruction in the loop has side effects;
+///   - every value used outside the loop is an affine combination (constant
+///     coefficients) of the header PHIs of one common integer type, and the
+///     closure of those PHIs under their update expressions stays affine.
+///
+/// Header PHIs outside that closure (e.g. an exit-condition induction
+/// variable of a different width) simply die with the loop. Wrapping
+/// semantics make the rewrite bit-exact; `nsw`/`nuw` flags on the original
+/// arithmetic only license the removal of poison, so dropping them in the
+/// emitted code is a sound refinement.
+///
+/// The recursion linearization pass feeds this one: linear self-recursions
+/// become single-block affine loops after inlining and simplification, and
+/// this pass then reduces them to logarithmic time — `fib(n)` in O(log n)
+/// from a naive doubly-recursive definition.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/LLVMPass/LinearRecurrence.h"
+
+#include <optional>
+
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SetVector.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/Analysis/LoopInfo.h>
+#include <llvm/Analysis/ScalarEvolution.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Dominators.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/Transforms/Utils/ScalarEvolutionExpander.h>
+
+namespace reussir::llvmpass {
+namespace {
+
+using namespace llvm;
+
+/// Maximum number of state PHIs (excluding the augmentation row). The emitted
+/// exponentiation body is O(K^3) instructions for K = state + 1.
+constexpr unsigned kMaxStateSize = 6;
+/// Cap on expression-walk depth during affine decomposition.
+constexpr unsigned kMaxDecomposeDepth = 512;
+
+/// An affine expression `sum coeff_i * phi_i + constant` over the header
+/// PHIs, with all arithmetic in Z/2^N.
+struct AffineExpr {
+  DenseMap<PHINode *, APInt> coeffs;
+  APInt constant;
+};
+
+/// Decomposes in-loop values into affine expressions over the header PHIs of
+/// a single integer type. Results are cached; failure is cached as nullopt.
+class AffineDecomposer {
+public:
+  AffineDecomposer(BasicBlock *header, IntegerType *type)
+      : header(header), type(type), bits(type->getBitWidth()) {}
+
+  std::optional<AffineExpr> decompose(Value *value, unsigned depth = 0) {
+    auto cached = cache.find(value);
+    if (cached != cache.end())
+      return cached->second;
+    std::optional<AffineExpr> result = decomposeImpl(value, depth);
+    cache.try_emplace(value, result);
+    return result;
+  }
+
+private:
+  std::optional<AffineExpr> decomposeImpl(Value *value, unsigned depth) {
+    if (depth > kMaxDecomposeDepth)
+      return std::nullopt;
+    if (value->getType() != type)
+      return std::nullopt;
+    if (auto *ci = dyn_cast<ConstantInt>(value)) {
+      AffineExpr expr;
+      expr.constant = ci->getValue();
+      return expr;
+    }
+    if (auto *phi = dyn_cast<PHINode>(value)) {
+      if (phi->getParent() != header)
+        return std::nullopt;
+      AffineExpr expr;
+      expr.constant = APInt::getZero(bits);
+      expr.coeffs.try_emplace(phi, APInt(bits, 1));
+      return expr;
+    }
+    auto *inst = dyn_cast<Instruction>(value);
+    if (!inst || inst->getParent() != header)
+      return std::nullopt;
+    auto *bin = dyn_cast<BinaryOperator>(inst);
+    if (!bin)
+      return std::nullopt;
+    switch (bin->getOpcode()) {
+    case Instruction::Add:
+    case Instruction::Sub: {
+      auto lhs = decompose(bin->getOperand(0), depth + 1);
+      auto rhs = decompose(bin->getOperand(1), depth + 1);
+      if (!lhs || !rhs)
+        return std::nullopt;
+      bool negate = bin->getOpcode() == Instruction::Sub;
+      AffineExpr expr = *lhs;
+      expr.constant += negate ? -rhs->constant : rhs->constant;
+      for (const auto &[phi, coeff] : rhs->coeffs) {
+        APInt addend = negate ? -coeff : coeff;
+        auto [it, inserted] = expr.coeffs.try_emplace(phi, addend);
+        if (!inserted)
+          it->second += addend;
+      }
+      return expr;
+    }
+    case Instruction::Mul: {
+      auto lhs = decompose(bin->getOperand(0), depth + 1);
+      auto rhs = decompose(bin->getOperand(1), depth + 1);
+      if (!lhs || !rhs)
+        return std::nullopt;
+      // One side must be a pure constant to stay affine.
+      const AffineExpr *scalar = lhs->coeffs.empty() ? &*lhs : nullptr;
+      const AffineExpr *vector = scalar ? &*rhs : &*lhs;
+      if (!scalar) {
+        if (!rhs->coeffs.empty())
+          return std::nullopt;
+        scalar = &*rhs;
+      }
+      return scale(*vector, scalar->constant);
+    }
+    case Instruction::Shl: {
+      auto *shamt = dyn_cast<ConstantInt>(bin->getOperand(1));
+      if (!shamt || shamt->getValue().uge(bits))
+        return std::nullopt;
+      auto lhs = decompose(bin->getOperand(0), depth + 1);
+      if (!lhs)
+        return std::nullopt;
+      APInt factor = APInt(bits, 1).shl(shamt->getValue());
+      return scale(*lhs, factor);
+    }
+    default:
+      return std::nullopt;
+    }
+  }
+
+  static AffineExpr scale(const AffineExpr &expr, const APInt &factor) {
+    AffineExpr result;
+    result.constant = expr.constant * factor;
+    for (const auto &[phi, coeff] : expr.coeffs)
+      result.coeffs.try_emplace(phi, coeff * factor);
+    return result;
+  }
+
+  BasicBlock *header;
+  IntegerType *type;
+  unsigned bits;
+  DenseMap<Value *, std::optional<AffineExpr>> cache;
+};
+
+struct LoopCandidate {
+  Loop *loop = nullptr;
+  BasicBlock *header = nullptr;
+  BasicBlock *preheader = nullptr;
+  BasicBlock *exitBlock = nullptr;
+  IntegerType *type = nullptr;
+  /// Ordered state PHIs; row i of the matrix updates state[i].
+  SmallVector<PHINode *, 4> state;
+  SmallVector<AffineExpr, 4> updates;
+  const SCEV *backedgeCount = nullptr;
+  /// Materialized backedge-taken count (filled in during expansion).
+  Value *exponent = nullptr;
+  bool needsAugment = false;
+};
+
+std::optional<LoopCandidate> analyzeLoop(Loop *loop, ScalarEvolution &se) {
+  if (loop->getNumBlocks() != 1)
+    return std::nullopt;
+  BasicBlock *header = loop->getHeader();
+  BasicBlock *preheader = loop->getLoopPreheader();
+  if (!preheader || !isa<BranchInst>(preheader->getTerminator()))
+    return std::nullopt;
+  auto *latchBranch = dyn_cast<BranchInst>(header->getTerminator());
+  if (!latchBranch || !latchBranch->isConditional())
+    return std::nullopt;
+  BasicBlock *succ0 = latchBranch->getSuccessor(0);
+  BasicBlock *succ1 = latchBranch->getSuccessor(1);
+  if ((succ0 == header) == (succ1 == header))
+    return std::nullopt;
+  BasicBlock *exitBlock = succ0 == header ? succ1 : succ0;
+
+  const SCEV *backedgeCount = se.getBackedgeTakenCount(loop);
+  if (isa<SCEVCouldNotCompute>(backedgeCount) ||
+      !backedgeCount->getType()->isIntegerTy())
+    return std::nullopt;
+
+  for (Instruction &inst : *header)
+    if (inst.mayHaveSideEffects())
+      return std::nullopt;
+
+  // Gather in-loop values used outside the loop; each must be affine over
+  // header PHIs of one shared integer type.
+  SmallVector<Instruction *, 4> liveOuts;
+  for (Instruction &inst : *header)
+    for (User *user : inst.users())
+      if (cast<Instruction>(user)->getParent() != header) {
+        liveOuts.push_back(&inst);
+        break;
+      }
+  if (liveOuts.empty())
+    return std::nullopt; // Dead loop; leave it to DCE.
+
+  auto *type = dyn_cast<IntegerType>(liveOuts.front()->getType());
+  if (!type)
+    return std::nullopt;
+  AffineDecomposer decomposer(header, type);
+
+  SetVector<PHINode *> statePhis;
+  SmallVector<AffineExpr, 4> liveOutExprs;
+  for (Instruction *liveOut : liveOuts) {
+    auto expr = decomposer.decompose(liveOut);
+    if (!expr)
+      return std::nullopt;
+    for (const auto &[phi, coeff] : expr->coeffs)
+      statePhis.insert(phi);
+  }
+  // Close the state set under the update expressions.
+  SmallVector<AffineExpr, 4> updates;
+  for (unsigned i = 0; i < statePhis.size(); ++i) {
+    PHINode *phi = statePhis[i];
+    auto update = decomposer.decompose(phi->getIncomingValueForBlock(header));
+    if (!update)
+      return std::nullopt;
+    for (const auto &[usedPhi, coeff] : update->coeffs)
+      statePhis.insert(usedPhi);
+    updates.push_back(std::move(*update));
+  }
+  if (statePhis.size() > kMaxStateSize)
+    return std::nullopt;
+
+  LoopCandidate candidate;
+  candidate.loop = loop;
+  candidate.header = header;
+  candidate.preheader = preheader;
+  candidate.exitBlock = exitBlock;
+  candidate.type = type;
+  candidate.state.assign(statePhis.begin(), statePhis.end());
+  candidate.updates = std::move(updates);
+  candidate.backedgeCount = backedgeCount;
+  for (const AffineExpr &update : candidate.updates)
+    if (!update.constant.isZero())
+      candidate.needsAugment = true;
+  return candidate;
+}
+
+/// Emits `out = lhs * rhs` for row-major K x K matrices of SSA values.
+SmallVector<Value *, 16> emitMatMul(IRBuilder<> &builder,
+                                    ArrayRef<Value *> lhs,
+                                    ArrayRef<Value *> rhs, unsigned dim) {
+  SmallVector<Value *, 16> out(dim * dim);
+  for (unsigned i = 0; i < dim; ++i)
+    for (unsigned j = 0; j < dim; ++j) {
+      Value *acc = nullptr;
+      for (unsigned l = 0; l < dim; ++l) {
+        Value *prod =
+            builder.CreateMul(lhs[i * dim + l], rhs[l * dim + j]);
+        acc = acc ? builder.CreateAdd(acc, prod) : prod;
+      }
+      out[i * dim + j] = acc;
+    }
+  return out;
+}
+
+/// Emits `coeff * value` folding the trivial coefficients.
+Value *emitScaled(IRBuilder<> &builder, const APInt &coeff, Value *value,
+                  IntegerType *type) {
+  if (coeff.isZero())
+    return nullptr;
+  if (coeff.isOne())
+    return value;
+  return builder.CreateMul(ConstantInt::get(type, coeff), value);
+}
+
+Value *emitAffine(IRBuilder<> &builder, const AffineExpr &expr,
+                  ArrayRef<PHINode *> state, ArrayRef<Value *> stateValues,
+                  IntegerType *type) {
+  Value *acc = nullptr;
+  for (unsigned i = 0; i < state.size(); ++i) {
+    auto it = expr.coeffs.find(state[i]);
+    if (it == expr.coeffs.end())
+      continue;
+    Value *term = emitScaled(builder, it->second, stateValues[i], type);
+    if (!term)
+      continue;
+    acc = acc ? builder.CreateAdd(acc, term) : term;
+  }
+  if (!expr.constant.isZero() || !acc) {
+    Constant *c = ConstantInt::get(type, expr.constant);
+    acc = acc ? builder.CreateAdd(acc, c) : static_cast<Value *>(c);
+  }
+  return acc;
+}
+
+/// Rewrites one candidate loop into a square-and-multiply exponentiation of
+/// its augmented companion matrix. Returns false (leaving the function
+/// untouched) if new live-outs appeared since analysis that are not affine —
+/// e.g. uses introduced by expanding another candidate's trip count.
+bool rewriteLoop(LoopCandidate &candidate) {
+  BasicBlock *header = candidate.header;
+  BasicBlock *preheader = candidate.preheader;
+  BasicBlock *exitBlock = candidate.exitBlock;
+  IntegerType *type = candidate.type;
+  Function *function = header->getParent();
+  LLVMContext &ctx = function->getContext();
+  unsigned stateSize = candidate.state.size();
+  unsigned dim = stateSize + (candidate.needsAugment ? 1 : 0);
+
+  // Re-collect live-outs: expansion of other candidates' trip counts may
+  // have added uses of header values since analysis ran.
+  AffineDecomposer decomposer(header, type);
+  SmallVector<std::pair<Instruction *, AffineExpr>, 4> liveOuts;
+  for (Instruction &inst : *header) {
+    bool usedOutside = false;
+    for (User *user : inst.users())
+      if (cast<Instruction>(user)->getParent() != header) {
+        usedOutside = true;
+        break;
+      }
+    if (!usedOutside)
+      continue;
+    auto expr = decomposer.decompose(&inst);
+    if (!expr)
+      return false;
+    for (const auto &[phi, coeff] : expr->coeffs)
+      if (!llvm::is_contained(candidate.state, phi))
+        return false;
+    liveOuts.emplace_back(&inst, std::move(*expr));
+  }
+
+  // Companion matrix (row-major, row i updates state[i]; optional trailing
+  // augmentation row [0 ... 0 1] carrying the affine constants).
+  SmallVector<Constant *, 16> companion(dim * dim);
+  SmallVector<Constant *, 16> identity(dim * dim);
+  for (unsigned i = 0; i < dim; ++i)
+    for (unsigned j = 0; j < dim; ++j) {
+      identity[i * dim + j] =
+          ConstantInt::get(type, i == j ? 1 : 0);
+      APInt entry = APInt::getZero(type->getBitWidth());
+      if (i < stateSize) {
+        if (j < stateSize) {
+          auto it = candidate.updates[i].coeffs.find(candidate.state[j]);
+          if (it != candidate.updates[i].coeffs.end())
+            entry = it->second;
+        } else {
+          entry = candidate.updates[i].constant;
+        }
+      } else if (j == dim - 1) {
+        entry = APInt(type->getBitWidth(), 1);
+      }
+      companion[i * dim + j] = ConstantInt::get(type, entry);
+    }
+
+  BasicBlock *check =
+      BasicBlock::Create(ctx, "reussir.matexp.check", function, exitBlock);
+  BasicBlock *body =
+      BasicBlock::Create(ctx, "reussir.matexp.body", function, exitBlock);
+  BasicBlock *done =
+      BasicBlock::Create(ctx, "reussir.matexp.done", function, exitBlock);
+
+  auto *preBranch = cast<BranchInst>(preheader->getTerminator());
+  preBranch->setSuccessor(0, check);
+
+  Value *exponent = candidate.exponent;
+  auto *exponentTy = cast<IntegerType>(exponent->getType());
+
+  // check: while (e != 0)
+  IRBuilder<> builder(check);
+  PHINode *ePhi = builder.CreatePHI(exponentTy, 2, "reussir.matexp.e");
+  SmallVector<PHINode *, 16> accPhis(dim * dim);
+  SmallVector<PHINode *, 16> basePhis(dim * dim);
+  for (unsigned i = 0; i < dim * dim; ++i)
+    accPhis[i] = builder.CreatePHI(type, 2, "reussir.matexp.acc");
+  for (unsigned i = 0; i < dim * dim; ++i)
+    basePhis[i] = builder.CreatePHI(type, 2, "reussir.matexp.base");
+  Value *eIsZero =
+      builder.CreateICmpEQ(ePhi, ConstantInt::get(exponentTy, 0));
+  builder.CreateCondBr(eIsZero, done, body);
+
+  // body: if (e & 1) acc *= base; base *= base; e >>= 1
+  builder.SetInsertPoint(body);
+  Value *odd = builder.CreateTrunc(ePhi, Type::getInt1Ty(ctx),
+                                   "reussir.matexp.odd");
+  SmallVector<Value *, 16> accValues(accPhis.begin(), accPhis.end());
+  SmallVector<Value *, 16> baseValues(basePhis.begin(), basePhis.end());
+  SmallVector<Value *, 16> accTimesBase =
+      emitMatMul(builder, accValues, baseValues, dim);
+  SmallVector<Value *, 16> accNext(dim * dim);
+  for (unsigned i = 0; i < dim * dim; ++i)
+    accNext[i] = builder.CreateSelect(odd, accTimesBase[i], accPhis[i]);
+  SmallVector<Value *, 16> baseNext =
+      emitMatMul(builder, baseValues, baseValues, dim);
+  Value *eNext =
+      builder.CreateLShr(ePhi, ConstantInt::get(exponentTy, 1));
+  builder.CreateBr(check);
+
+  ePhi->addIncoming(exponent, preheader);
+  ePhi->addIncoming(eNext, body);
+  for (unsigned i = 0; i < dim * dim; ++i) {
+    accPhis[i]->addIncoming(identity[i], preheader);
+    accPhis[i]->addIncoming(accNext[i], body);
+    basePhis[i]->addIncoming(companion[i], preheader);
+    basePhis[i]->addIncoming(baseNext[i], body);
+  }
+
+  // done: final = acc * s_0, then rebuild the live-outs from it.
+  builder.SetInsertPoint(done);
+  SmallVector<Value *, 8> initial(dim);
+  for (unsigned j = 0; j < stateSize; ++j)
+    initial[j] = candidate.state[j]->getIncomingValueForBlock(preheader);
+  if (candidate.needsAugment)
+    initial[dim - 1] = ConstantInt::get(type, 1);
+  SmallVector<Value *, 8> finalState(stateSize);
+  for (unsigned i = 0; i < stateSize; ++i) {
+    Value *acc = nullptr;
+    for (unsigned j = 0; j < dim; ++j) {
+      Value *term = builder.CreateMul(accPhis[i * dim + j], initial[j]);
+      acc = acc ? builder.CreateAdd(acc, term) : term;
+    }
+    finalState[i] = acc;
+  }
+  for (auto &[inst, expr] : liveOuts) {
+    Value *replacement =
+        emitAffine(builder, expr, candidate.state, finalState, type);
+    inst->replaceUsesWithIf(replacement, [&](Use &use) {
+      return cast<Instruction>(use.getUser())->getParent() != header;
+    });
+  }
+  builder.CreateBr(exitBlock);
+  exitBlock->replacePhiUsesWith(header, done);
+
+  header->dropAllReferences();
+  header->eraseFromParent();
+  return true;
+}
+
+} // namespace
+
+llvm::PreservedAnalyses
+LinearRecurrenceMatExpPass::run(llvm::Function &function,
+                                llvm::FunctionAnalysisManager &fam) {
+  using namespace llvm;
+  auto &loopInfo = fam.getResult<LoopAnalysis>(function);
+  auto &se = fam.getResult<ScalarEvolutionAnalysis>(function);
+
+  // Phase 1: analysis over the intact IR.
+  SmallVector<LoopCandidate, 4> candidates;
+  for (Loop *loop : loopInfo.getLoopsInPreorder())
+    if (auto candidate = analyzeLoop(loop, se))
+      candidates.push_back(std::move(*candidate));
+  if (candidates.empty())
+    return llvm::PreservedAnalyses::all();
+
+  // Phase 2: materialize every trip count while ScalarEvolution still
+  // matches the IR.
+  const llvm::DataLayout &dataLayout = function.getParent()->getDataLayout();
+  SCEVExpander expander(se, dataLayout, "reussir.matexp");
+  SmallVector<LoopCandidate, 4> expandable;
+  for (LoopCandidate &candidate : candidates) {
+    llvm::Instruction *insertion = candidate.preheader->getTerminator();
+    if (!expander.isSafeToExpandAt(candidate.backedgeCount, insertion))
+      continue;
+    candidate.exponent = expander.expandCodeFor(
+        candidate.backedgeCount, candidate.backedgeCount->getType(),
+        insertion);
+    expandable.push_back(std::move(candidate));
+  }
+
+  // Phase 3: structural rewrites (no analysis use past this point). Even if
+  // every rewrite backs out, materialized trip counts already changed the IR.
+  bool changed = !expandable.empty();
+  for (LoopCandidate &candidate : expandable)
+    changed |= rewriteLoop(candidate);
+  return changed ? llvm::PreservedAnalyses::none()
+                 : llvm::PreservedAnalyses::all();
+}
+
+} // namespace reussir::llvmpass

--- a/lib/LLVMPass/LinearRecurrence/LinearRecurrenceMatExp.cpp
+++ b/lib/LLVMPass/LinearRecurrence/LinearRecurrenceMatExp.cpp
@@ -9,8 +9,8 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file implements loop-to-matrix-exponentiation strength reduction for
-/// linear recurrences over machine integers.
+/// This file implements loop-to-logarithmic strength reduction for linear
+/// recurrences over machine integers, via the Kitamasa method.
 ///
 /// A single-block loop whose loop-carried integer state evolves as an affine
 /// map with compile-time constant coefficients,
@@ -18,10 +18,23 @@
 ///   s_{i+1} = M * s_i + c        (all arithmetic wrapping, i.e. in Z/2^N)
 ///
 /// computes `s_n = A^n * s_0` for the augmented companion matrix
-/// `A = [[M, c], [0, 1]]`. Because Z/2^N is a commutative ring, `A^n` can be
-/// evaluated with square-and-multiply in O(K^3 log n) ring operations, so the
-/// pass replaces the loop (O(n) iterations) with an O(log n) exponentiation
-/// loop over the bits of the backedge-taken count.
+/// `A = [[M, c], [0, 1]]` of dimension D. Rather than exponentiating the
+/// matrix directly (O(D^3) per squaring), the pass evaluates `z^n mod
+/// chi_A(z)` in the quotient ring (Z/2^N)[z]/chi_A by square-and-multiply —
+/// O(D^2) ring operations per squaring — and then combines the resulting
+/// polynomial `p` with the Krylov vectors of the initial state:
+///
+///   A^n s_0 = p(A) s_0 = sum_i p_i (A^i s_0)     (Cayley–Hamilton)
+///
+/// Cayley–Hamilton is a polynomial identity over Z, so it holds in any
+/// commutative ring, including Z/2^N; the characteristic polynomial is
+/// computed at compile time by division-free cofactor expansion mod 2^N and
+/// is monic by construction, so the reductions need no division either. The
+/// Krylov vectors `A^i s_0` for `i < D` are emitted once as straight-line
+/// code, with the (typically very sparse, 0/±1) constant matrix entries
+/// folded away. Overall: O(D^2 log n) emitted ring operations, the
+/// FFT-free Kitamasa bound — an FFT-based O(D log D log n) variant only
+/// wins for D far beyond the size cap here.
 ///
 /// Recognition requirements:
 ///   - the loop is a single block with a preheader and one exit;
@@ -48,18 +61,23 @@
 
 #include <optional>
 
+#include <cassert>
+
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SetVector.h>
+#include <llvm/ADT/bit.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Analysis/ScalarEvolution.h>
+#include <llvm/Config/llvm-config.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Dominators.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Transforms/Utils/ScalarEvolutionExpander.h>
 
 namespace reussir::llvmpass {
@@ -68,7 +86,7 @@ namespace {
 using namespace llvm;
 
 /// Maximum number of state PHIs (excluding the augmentation row). The emitted
-/// exponentiation body is O(K^3) instructions for K = state + 1.
+/// exponentiation body is O(D^2) instructions for D = state + 1.
 constexpr unsigned kMaxStateSize = 6;
 /// Cap on expression-walk depth during affine decomposition.
 constexpr unsigned kMaxDecomposeDepth = 512;
@@ -79,6 +97,9 @@ struct AffineExpr {
   DenseMap<PHINode *, APInt> coeffs;
   APInt constant;
 };
+
+/// A polynomial over Z/2^N, coefficients low degree first.
+using Poly = SmallVector<APInt, 8>;
 
 /// Decomposes in-loop values into affine expressions over the header PHIs of
 /// a single integer type. Results are cached; failure is cached as nullopt.
@@ -189,7 +210,7 @@ struct LoopCandidate {
   BasicBlock *preheader = nullptr;
   BasicBlock *exitBlock = nullptr;
   IntegerType *type = nullptr;
-  /// Ordered state PHIs; row i of the matrix updates state[i].
+  /// Ordered state PHIs; row i of the companion matrix updates state[i].
   SmallVector<PHINode *, 4> state;
   SmallVector<AffineExpr, 4> updates;
   const SCEV *backedgeCount = nullptr;
@@ -241,7 +262,6 @@ std::optional<LoopCandidate> analyzeLoop(Loop *loop, ScalarEvolution &se) {
   AffineDecomposer decomposer(header, type);
 
   SetVector<PHINode *> statePhis;
-  SmallVector<AffineExpr, 4> liveOutExprs;
   for (Instruction *liveOut : liveOuts) {
     auto expr = decomposer.decompose(liveOut);
     if (!expr)
@@ -278,32 +298,82 @@ std::optional<LoopCandidate> analyzeLoop(Loop *loop, ScalarEvolution &se) {
   return candidate;
 }
 
-/// Emits `out = lhs * rhs` for row-major K x K matrices of SSA values.
-SmallVector<Value *, 16> emitMatMul(IRBuilder<> &builder,
-                                    ArrayRef<Value *> lhs,
-                                    ArrayRef<Value *> rhs, unsigned dim) {
-  SmallVector<Value *, 16> out(dim * dim);
-  for (unsigned i = 0; i < dim; ++i)
-    for (unsigned j = 0; j < dim; ++j) {
-      Value *acc = nullptr;
-      for (unsigned l = 0; l < dim; ++l) {
-        Value *prod =
-            builder.CreateMul(lhs[i * dim + l], rhs[l * dim + j]);
-        acc = acc ? builder.CreateAdd(acc, prod) : prod;
-      }
-      out[i * dim + j] = acc;
-    }
+//===----------------------------------------------------------------------===//
+// Compile-time polynomial arithmetic over Z/2^N
+//===----------------------------------------------------------------------===//
+
+Poly polyMul(const Poly &lhs, const Poly &rhs, unsigned bits) {
+  Poly out(lhs.size() + rhs.size() - 1, APInt::getZero(bits));
+  for (unsigned i = 0; i < lhs.size(); ++i)
+    for (unsigned j = 0; j < rhs.size(); ++j)
+      out[i + j] += lhs[i] * rhs[j];
   return out;
 }
 
-/// Emits `coeff * value` folding the trivial coefficients.
+void polyAddInPlace(Poly &lhs, const Poly &rhs, bool negate, unsigned bits) {
+  if (lhs.size() < rhs.size())
+    lhs.resize(rhs.size(), APInt::getZero(bits));
+  for (unsigned i = 0; i < rhs.size(); ++i)
+    lhs[i] += negate ? -rhs[i] : rhs[i];
+}
+
+/// Characteristic polynomial `det(zI - A) mod 2^N` of the row-major
+/// `dim x dim` matrix, by cofactor expansion memoized on the column subset —
+/// division-free, so valid over Z/2^N; monic of degree `dim` by construction.
+Poly charPoly(ArrayRef<APInt> matrix, unsigned dim, unsigned bits) {
+  DenseMap<uint32_t, Poly> memo;
+  // det over rows [row..dim) and the columns in `mask`, where
+  // row = dim - popcount(mask).
+  auto det = [&](auto &&self, uint32_t mask) -> Poly {
+    if (mask == 0)
+      return Poly{APInt(bits, 1)};
+    auto cached = memo.find(mask);
+    if (cached != memo.end())
+      return cached->second;
+    unsigned row = dim - llvm::popcount(mask);
+    Poly result{APInt::getZero(bits)};
+    bool negate = false;
+    for (unsigned col = 0; col < dim; ++col) {
+      if (!(mask & (1U << col)))
+        continue;
+      // Entry (zI - A)[row][col]: degree <= 1.
+      Poly entry{-matrix[size_t(row) * dim + col]};
+      if (row == col)
+        entry.push_back(APInt(bits, 1));
+      Poly sub = self(self, mask & ~(1U << col));
+      polyAddInPlace(result, polyMul(entry, sub, bits), negate, bits);
+      negate = !negate;
+    }
+    memo.try_emplace(mask, result);
+    return result;
+  };
+  Poly chi = det(det, (1U << dim) - 1);
+  chi.resize(dim + 1, APInt::getZero(bits));
+  assert(chi[dim].isOne() && "characteristic polynomial must be monic");
+  return chi;
+}
+
+//===----------------------------------------------------------------------===//
+// IR emission helpers
+//===----------------------------------------------------------------------===//
+
+/// Emits `coeff * value` folding the trivial coefficients (0, 1, -1).
 Value *emitScaled(IRBuilder<> &builder, const APInt &coeff, Value *value,
                   IntegerType *type) {
   if (coeff.isZero())
     return nullptr;
   if (coeff.isOne())
     return value;
+  if (coeff.isAllOnes())
+    return builder.CreateNeg(value);
   return builder.CreateMul(ConstantInt::get(type, coeff), value);
+}
+
+/// Emits `acc + term`, treating null as zero.
+Value *emitAccumulate(IRBuilder<> &builder, Value *acc, Value *term) {
+  if (!term)
+    return acc;
+  return acc ? builder.CreateAdd(acc, term) : term;
 }
 
 Value *emitAffine(IRBuilder<> &builder, const AffineExpr &expr,
@@ -314,10 +384,8 @@ Value *emitAffine(IRBuilder<> &builder, const AffineExpr &expr,
     auto it = expr.coeffs.find(state[i]);
     if (it == expr.coeffs.end())
       continue;
-    Value *term = emitScaled(builder, it->second, stateValues[i], type);
-    if (!term)
-      continue;
-    acc = acc ? builder.CreateAdd(acc, term) : term;
+    acc = emitAccumulate(builder, acc,
+                         emitScaled(builder, it->second, stateValues[i], type));
   }
   if (!expr.constant.isZero() || !acc) {
     Constant *c = ConstantInt::get(type, expr.constant);
@@ -326,10 +394,40 @@ Value *emitAffine(IRBuilder<> &builder, const AffineExpr &expr,
   return acc;
 }
 
-/// Rewrites one candidate loop into a square-and-multiply exponentiation of
-/// its augmented companion matrix. Returns false (leaving the function
-/// untouched) if new live-outs appeared since analysis that are not affine —
-/// e.g. uses introduced by expanding another candidate's trip count.
+/// Emits `lhs * rhs mod chi` for polynomials of degree < D given as SSA
+/// coefficient vectors, `chi` monic of degree D: O(D^2) ring operations.
+SmallVector<Value *, 8> emitPolyModMul(IRBuilder<> &builder,
+                                       ArrayRef<Value *> lhs,
+                                       ArrayRef<Value *> rhs, const Poly &chi,
+                                       IntegerType *type) {
+  unsigned dim = lhs.size();
+  // Full product, degree <= 2D-2.
+  SmallVector<Value *, 16> prod(2 * size_t(dim) - 1, nullptr);
+  for (unsigned i = 0; i < dim; ++i)
+    for (unsigned j = 0; j < dim; ++j)
+      prod[i + j] = emitAccumulate(builder, prod[i + j],
+                                   builder.CreateMul(lhs[i], rhs[j]));
+  // Reduce top-down: z^k = z^(k-D) z^D = -sum_j chi_j z^(k-D+j) (mod chi).
+  for (unsigned k = 2 * dim - 2; k >= dim; --k) {
+    Value *top = prod[k];
+    for (unsigned j = 0; j < dim; ++j) {
+      Value *term = emitScaled(builder, chi[j], top, type);
+      if (!term)
+        continue;
+      unsigned at = k - dim + j;
+      prod[at] = prod[at] ? builder.CreateSub(prod[at], term)
+                          : builder.CreateNeg(term);
+    }
+  }
+  prod.truncate(dim);
+  return prod;
+}
+
+/// Rewrites one candidate loop into Kitamasa exponentiation: `z^btc mod
+/// chi_A` by square-and-multiply, then `A^btc s_0 = sum_i p_i (A^i s_0)`.
+/// Returns false (leaving the function untouched) if new live-outs appeared
+/// since analysis that are not affine — e.g. uses introduced by expanding
+/// another candidate's trip count.
 bool rewriteLoop(LoopCandidate &candidate) {
   BasicBlock *header = candidate.header;
   BasicBlock *preheader = candidate.preheader;
@@ -337,6 +435,7 @@ bool rewriteLoop(LoopCandidate &candidate) {
   IntegerType *type = candidate.type;
   Function *function = header->getParent();
   LLVMContext &ctx = function->getContext();
+  unsigned bits = type->getBitWidth();
   unsigned stateSize = candidate.state.size();
   unsigned dim = stateSize + (candidate.needsAugment ? 1 : 0);
 
@@ -363,27 +462,21 @@ bool rewriteLoop(LoopCandidate &candidate) {
   }
 
   // Companion matrix (row-major, row i updates state[i]; optional trailing
-  // augmentation row [0 ... 0 1] carrying the affine constants).
-  SmallVector<Constant *, 16> companion(dim * dim);
-  SmallVector<Constant *, 16> identity(dim * dim);
-  for (unsigned i = 0; i < dim; ++i)
-    for (unsigned j = 0; j < dim; ++j) {
-      identity[i * dim + j] =
-          ConstantInt::get(type, i == j ? 1 : 0);
-      APInt entry = APInt::getZero(type->getBitWidth());
-      if (i < stateSize) {
-        if (j < stateSize) {
-          auto it = candidate.updates[i].coeffs.find(candidate.state[j]);
-          if (it != candidate.updates[i].coeffs.end())
-            entry = it->second;
-        } else {
-          entry = candidate.updates[i].constant;
-        }
-      } else if (j == dim - 1) {
-        entry = APInt(type->getBitWidth(), 1);
-      }
-      companion[i * dim + j] = ConstantInt::get(type, entry);
+  // augmentation row [0 ... 0 1] carrying the affine constants) and its
+  // characteristic polynomial.
+  SmallVector<APInt, 16> companion(size_t(dim) * dim, APInt::getZero(bits));
+  for (unsigned i = 0; i < stateSize; ++i) {
+    for (unsigned j = 0; j < stateSize; ++j) {
+      auto it = candidate.updates[i].coeffs.find(candidate.state[j]);
+      if (it != candidate.updates[i].coeffs.end())
+        companion[size_t(i) * dim + j] = it->second;
     }
+    if (candidate.needsAugment)
+      companion[size_t(i) * dim + (dim - 1)] = candidate.updates[i].constant;
+  }
+  if (candidate.needsAugment)
+    companion[size_t(dim - 1) * dim + (dim - 1)] = APInt(bits, 1);
+  Poly chi = charPoly(companion, dim, bits);
 
   BasicBlock *check =
       BasicBlock::Create(ctx, "reussir.matexp.check", function, exitBlock);
@@ -398,61 +491,85 @@ bool rewriteLoop(LoopCandidate &candidate) {
   Value *exponent = candidate.exponent;
   auto *exponentTy = cast<IntegerType>(exponent->getType());
 
-  // check: while (e != 0)
+  // check: while (e != 0). acc/base are polynomials of degree < D in
+  // (Z/2^N)[z]/chi; acc starts at 1, base at `z mod chi`.
   IRBuilder<> builder(check);
   PHINode *ePhi = builder.CreatePHI(exponentTy, 2, "reussir.matexp.e");
-  SmallVector<PHINode *, 16> accPhis(dim * dim);
-  SmallVector<PHINode *, 16> basePhis(dim * dim);
-  for (unsigned i = 0; i < dim * dim; ++i)
+  SmallVector<PHINode *, 8> accPhis(dim);
+  SmallVector<PHINode *, 8> basePhis(dim);
+  for (unsigned i = 0; i < dim; ++i)
     accPhis[i] = builder.CreatePHI(type, 2, "reussir.matexp.acc");
-  for (unsigned i = 0; i < dim * dim; ++i)
+  for (unsigned i = 0; i < dim; ++i)
     basePhis[i] = builder.CreatePHI(type, 2, "reussir.matexp.base");
-  Value *eIsZero =
-      builder.CreateICmpEQ(ePhi, ConstantInt::get(exponentTy, 0));
+  Value *eIsZero = builder.CreateICmpEQ(ePhi, ConstantInt::get(exponentTy, 0));
   builder.CreateCondBr(eIsZero, done, body);
 
-  // body: if (e & 1) acc *= base; base *= base; e >>= 1
+  // body: if (e & 1) acc = acc*base mod chi; base = base^2 mod chi; e >>= 1
   builder.SetInsertPoint(body);
   Value *odd = builder.CreateTrunc(ePhi, Type::getInt1Ty(ctx),
                                    "reussir.matexp.odd");
-  SmallVector<Value *, 16> accValues(accPhis.begin(), accPhis.end());
-  SmallVector<Value *, 16> baseValues(basePhis.begin(), basePhis.end());
-  SmallVector<Value *, 16> accTimesBase =
-      emitMatMul(builder, accValues, baseValues, dim);
-  SmallVector<Value *, 16> accNext(dim * dim);
-  for (unsigned i = 0; i < dim * dim; ++i)
+  SmallVector<Value *, 8> accValues(accPhis.begin(), accPhis.end());
+  SmallVector<Value *, 8> baseValues(basePhis.begin(), basePhis.end());
+  SmallVector<Value *, 8> accTimesBase =
+      emitPolyModMul(builder, accValues, baseValues, chi, type);
+  SmallVector<Value *, 8> accNext(dim);
+  for (unsigned i = 0; i < dim; ++i)
     accNext[i] = builder.CreateSelect(odd, accTimesBase[i], accPhis[i]);
-  SmallVector<Value *, 16> baseNext =
-      emitMatMul(builder, baseValues, baseValues, dim);
-  Value *eNext =
-      builder.CreateLShr(ePhi, ConstantInt::get(exponentTy, 1));
+  SmallVector<Value *, 8> baseNext =
+      emitPolyModMul(builder, baseValues, baseValues, chi, type);
+  Value *eNext = builder.CreateLShr(ePhi, ConstantInt::get(exponentTy, 1));
   builder.CreateBr(check);
 
+  // Initial polynomials: acc = 1; base = z mod chi (which is -chi_0 when
+  // D == 1, else just z).
+  SmallVector<Constant *, 8> accInit(dim), baseInit(dim);
+  for (unsigned i = 0; i < dim; ++i) {
+    accInit[i] = ConstantInt::get(type, i == 0 ? 1 : 0);
+    APInt baseCoeff = APInt::getZero(bits);
+    if (dim == 1)
+      baseCoeff = -chi[0];
+    else if (i == 1)
+      baseCoeff = APInt(bits, 1);
+    baseInit[i] = ConstantInt::get(type, baseCoeff);
+  }
   ePhi->addIncoming(exponent, preheader);
   ePhi->addIncoming(eNext, body);
-  for (unsigned i = 0; i < dim * dim; ++i) {
-    accPhis[i]->addIncoming(identity[i], preheader);
+  for (unsigned i = 0; i < dim; ++i) {
+    accPhis[i]->addIncoming(accInit[i], preheader);
     accPhis[i]->addIncoming(accNext[i], body);
-    basePhis[i]->addIncoming(companion[i], preheader);
+    basePhis[i]->addIncoming(baseInit[i], preheader);
     basePhis[i]->addIncoming(baseNext[i], body);
   }
 
-  // done: final = acc * s_0, then rebuild the live-outs from it.
+  // done: s_n = sum_i p_i * (A^i s_0). The Krylov vectors A^i s_0 are
+  // straight-line constant-matrix/vector products, with the (typically
+  // sparse, 0/±1) companion entries folded away.
   builder.SetInsertPoint(done);
-  SmallVector<Value *, 8> initial(dim);
+  SmallVector<Value *, 8> krylov(dim);
   for (unsigned j = 0; j < stateSize; ++j)
-    initial[j] = candidate.state[j]->getIncomingValueForBlock(preheader);
+    krylov[j] = candidate.state[j]->getIncomingValueForBlock(preheader);
   if (candidate.needsAugment)
-    initial[dim - 1] = ConstantInt::get(type, 1);
-  SmallVector<Value *, 8> finalState(stateSize);
-  for (unsigned i = 0; i < stateSize; ++i) {
-    Value *acc = nullptr;
-    for (unsigned j = 0; j < dim; ++j) {
-      Value *term = builder.CreateMul(accPhis[i * dim + j], initial[j]);
-      acc = acc ? builder.CreateAdd(acc, term) : term;
+    krylov[dim - 1] = ConstantInt::get(type, 1);
+  SmallVector<Value *, 8> result(dim, nullptr);
+  for (unsigned i = 0; i < dim; ++i) {
+    for (unsigned r = 0; r < dim; ++r)
+      result[r] = emitAccumulate(
+          builder, result[r], builder.CreateMul(accPhis[i], krylov[r]));
+    if (i + 1 == dim)
+      break;
+    SmallVector<Value *, 8> next(dim, nullptr);
+    for (unsigned r = 0; r < dim; ++r) {
+      for (unsigned c = 0; c < dim; ++c)
+        next[r] = emitAccumulate(
+            builder, next[r],
+            emitScaled(builder, companion[size_t(r) * dim + c], krylov[c], type));
+      if (!next[r])
+        next[r] = ConstantInt::get(type, 0);
     }
-    finalState[i] = acc;
+    krylov = std::move(next);
   }
+  SmallVector<Value *, 8> finalState(result.begin(),
+                                     result.begin() + stateSize);
   for (auto &[inst, expr] : liveOuts) {
     Value *replacement =
         emitAffine(builder, expr, candidate.state, finalState, type);
@@ -487,8 +604,12 @@ LinearRecurrenceMatExpPass::run(llvm::Function &function,
 
   // Phase 2: materialize every trip count while ScalarEvolution still
   // matches the IR.
-  const llvm::DataLayout &dataLayout = function.getParent()->getDataLayout();
-  SCEVExpander expander(se, dataLayout, "reussir.matexp");
+#if LLVM_VERSION_MAJOR >= 22
+  SCEVExpander expander(se, "reussir.matexp");
+#else
+  SCEVExpander expander(se, function.getParent()->getDataLayout(),
+                        "reussir.matexp");
+#endif
   SmallVector<LoopCandidate, 4> expandable;
   for (LoopCandidate &candidate : candidates) {
     llvm::Instruction *insertion = candidate.preheader->getTerminator();

--- a/lib/LLVMPass/LinearRecurrence/LinearRecurrencePipeline.cpp
+++ b/lib/LLVMPass/LinearRecurrence/LinearRecurrencePipeline.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Extension-point wiring for the linear-recurrence passes (see the header
+/// for the placement rationale).
+///
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/LLVMPass/LinearRecurrence.h"
+
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Transforms/Scalar/EarlyCSE.h>
+#include <llvm/Transforms/InstCombine/InstCombine.h>
+#include <llvm/Transforms/Utils/LoopSimplify.h>
+#include <llvm/Transforms/Utils/Mem2Reg.h>
+
+namespace reussir::llvmpass {
+
+void registerLinearRecurrencePipelines(llvm::PassBuilder &passBuilder) {
+  passBuilder.registerPipelineStartEPCallback(
+      [](llvm::ModulePassManager &mpm, llvm::OptimizationLevel) {
+        // The matcher requires SSA scalars (no allocas/loads); promote
+        // memory first in case the frontend emitted stack slots.
+        mpm.addPass(
+            llvm::createModuleToFunctionPassAdaptor(llvm::PromotePass()));
+        mpm.addPass(RecursionLinearizationPass());
+      });
+  passBuilder.registerVectorizerStartEPCallback(
+      [](llvm::FunctionPassManager &fpm, llvm::OptimizationLevel) {
+        fpm.addPass(llvm::LoopSimplifyPass());
+        fpm.addPass(LinearRecurrenceMatExpPass());
+        // The schoolbook polynomial squaring emits commutative duplicate
+        // products (b_i*b_j and b_j*b_i); EarlyCSE folds them before the
+        // late pipeline takes over.
+        fpm.addPass(llvm::EarlyCSEPass());
+        fpm.addPass(llvm::InstCombinePass());
+      });
+}
+
+} // namespace reussir::llvmpass

--- a/lib/LLVMPass/LinearRecurrence/RecursionLinearization.cpp
+++ b/lib/LLVMPass/LinearRecurrence/RecursionLinearization.cpp
@@ -1,0 +1,512 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements recursion linearization: rewriting pure, directly
+/// self-recursive functions of the shape
+///
+///   f(x, c...) = combine(x, c..., f(x - d_1, c...), ..., f(x - d_k, c...))
+///
+/// into a dynamic-programming loop over a sliding window of the last
+/// `k = max d_i` results. `combine` may be any side-effect-free, speculatable
+/// computation (so modular sums, min/max-plus combinations, and other
+/// generalized recurrences are all covered), and the base cases may be any
+/// call-free paths guarded by comparisons of `x` against constants.
+///
+/// The transformation is semantics-preserving without any linearity
+/// assumption, because it never reassociates the user's arithmetic. It
+/// outlines the original body into a `step` helper in which each recursive
+/// call `f(x - d, c...)` is replaced by an extra parameter `y_d`, then
+/// rewrites `f` as
+///
+///   f(x, c...):
+///     if (x < C)  return step(x, c..., poison...)      // call-free region
+///     w_j = step(C - j, c..., poison...)  for j = 1..k // seeds, also < C
+///     for (v = C; ; ++v) {
+///       cur = step(v, c..., w_1, ..., w_k)
+///       if (v == x) return cur
+///       shift window: w_1 = cur, w_j = w_{j-1}
+///     }
+///
+/// where `C` is a proven lower bound of `x` at every recursive call site
+/// (derived from dominating comparisons against constants). Whenever `x < C`
+/// no recursive call executes in the original body, so on those paths the
+/// window parameters of `step` are dead and may be poison; whenever `x >= C`
+/// the window carries exactly `f(v-1), ..., f(v-k)`, so `step` computes
+/// `f(v)`. Every instruction is required to be speculatable because the loop
+/// evaluates `f` at points the original call tree may have skipped.
+///
+/// The helper is marked `alwaysinline`; after the standard pipeline inlines
+/// and simplifies it, first-order *linear* recurrences surface as single-block
+/// affine loops that `LinearRecurrenceMatExpPass` can further rewrite into
+/// logarithmic-time matrix exponentiation.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Reussir/LLVMPass/LinearRecurrence.h"
+
+#include <optional>
+
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/SmallPtrSet.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/Twine.h>
+#include <llvm/Analysis/CFG.h>
+#include <llvm/Analysis/ValueTracking.h>
+#include <llvm/IR/Argument.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/ConstantRange.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DebugInfo.h>
+#include <llvm/IR/Dominators.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Transforms/Utils/Cloning.h>
+#include <llvm/Transforms/Utils/ValueMapper.h>
+
+namespace reussir::llvmpass {
+namespace {
+
+/// Largest recursion depth window (max `d_i`) we are willing to carry.
+constexpr uint64_t kMaxWindow = 16;
+/// Narrow induction integers interact badly with the window arithmetic below
+/// (e.g. `floor - window` wrapping through the whole domain), so require a
+/// reasonable width.
+constexpr unsigned kMinInductionBits = 8;
+
+struct SelfCall {
+  llvm::CallInst *call;
+  /// Positive decrement of the induction argument: the call is
+  /// `f(..., x - offset, ...)`.
+  uint64_t offset;
+};
+
+struct RecursionShape {
+  unsigned inductionIndex = 0;
+  /// Window size `k = max offset`.
+  uint64_t window = 0;
+  /// Lower bound `C` of the induction argument at every recursive call.
+  llvm::APInt floor;
+  /// Lattice in which `floor` is a lower bound (and in which the rewritten
+  /// entry guard compares).
+  bool isSigned = false;
+  llvm::SmallVector<SelfCall, 4> calls;
+};
+
+/// Matches `v == x - d` for a positive constant `d`, accepting both the
+/// `sub x, d` and the canonical `add x, -d` spellings.
+std::optional<llvm::APInt> matchDecrement(llvm::Value *value,
+                                          llvm::Argument *induction) {
+  auto *bin = llvm::dyn_cast<llvm::BinaryOperator>(value);
+  if (!bin)
+    return std::nullopt;
+  llvm::Value *lhs = bin->getOperand(0);
+  llvm::Value *rhs = bin->getOperand(1);
+  if (bin->getOpcode() == llvm::Instruction::Add) {
+    if (lhs != induction)
+      std::swap(lhs, rhs);
+    if (lhs != induction)
+      return std::nullopt;
+    if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(rhs))
+      return -ci->getValue();
+    return std::nullopt;
+  }
+  if (bin->getOpcode() == llvm::Instruction::Sub) {
+    if (lhs != induction)
+      return std::nullopt;
+    if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(rhs))
+      return ci->getValue();
+  }
+  return std::nullopt;
+}
+
+/// Whether `inst` is admissible inside a linearizable body: side-effect free,
+/// non-trapping for *arbitrary* inputs (the rewritten loop evaluates the body
+/// at points the original call tree may never have reached), and free of
+/// memory access. Recursive calls are validated separately and passed in via
+/// `selfCalls`.
+bool isAllowedInstruction(llvm::Instruction &inst,
+                          const llvm::SmallPtrSetImpl<llvm::CallInst *> &selfCalls) {
+  using namespace llvm;
+  if (isa<PHINode>(inst) || isa<SelectInst>(inst) || isa<CmpInst>(inst) ||
+      isa<CastInst>(inst) || isa<FreezeInst>(inst) ||
+      isa<ExtractValueInst>(inst) || isa<InsertValueInst>(inst) ||
+      isa<ExtractElementInst>(inst) || isa<InsertElementInst>(inst) ||
+      isa<ShuffleVectorInst>(inst) || isa<UnaryOperator>(inst) ||
+      isa<BranchInst>(inst) || isa<ReturnInst>(inst))
+    return true;
+  if (auto *bin = dyn_cast<BinaryOperator>(&inst)) {
+    switch (bin->getOpcode()) {
+    case Instruction::UDiv:
+    case Instruction::URem:
+    case Instruction::SDiv:
+    case Instruction::SRem: {
+      // Division traps on a zero divisor (and signed division on
+      // INT_MIN / -1), which would be genuine UB introduced at the extra
+      // evaluation points; only constant, provably benign divisors pass.
+      auto *divisor = dyn_cast<ConstantInt>(bin->getOperand(1));
+      if (!divisor || divisor->isZero())
+        return false;
+      bool isSignedDiv = bin->getOpcode() == Instruction::SDiv ||
+                         bin->getOpcode() == Instruction::SRem;
+      return !(isSignedDiv && divisor->isMinusOne());
+    }
+    default:
+      return true;
+    }
+  }
+  if (auto *call = dyn_cast<CallInst>(&inst)) {
+    if (selfCalls.contains(call))
+      return true;
+    // Speculatable, effect-free intrinsics (smax, ctpop, fshl, ...) are fine;
+    // anything else (including any non-intrinsic call) is rejected.
+    if (auto *intrinsic = dyn_cast<IntrinsicInst>(call))
+      return !intrinsic->mayHaveSideEffects() &&
+             !intrinsic->mayReadFromMemory() &&
+             isSafeToSpeculativelyExecute(intrinsic);
+    return false;
+  }
+  return false;
+}
+
+/// Computes the recursion floor `C`: a constant such that every recursive
+/// call site is dominated by comparisons proving `x >= C` (in the returned
+/// signedness lattice), hence `x < C` implies the body is call-free.
+std::optional<std::pair<llvm::APInt, bool>>
+computeFloor(llvm::Function &function, llvm::Argument *induction,
+             llvm::ArrayRef<SelfCall> calls, llvm::DominatorTree &domTree,
+             uint64_t window) {
+  using namespace llvm;
+  unsigned bits = induction->getType()->getIntegerBitWidth();
+  bool sawSigned = false;
+  bool sawUnsigned = false;
+  SmallVector<ConstantRange, 4> ranges;
+
+  for (const SelfCall &selfCall : calls) {
+    ConstantRange range = ConstantRange::getFull(bits);
+    BasicBlock *callBlock = selfCall.call->getParent();
+    for (BasicBlock &block : function) {
+      auto *branch = dyn_cast<BranchInst>(block.getTerminator());
+      if (!branch || !branch->isConditional() ||
+          branch->getSuccessor(0) == branch->getSuccessor(1))
+        continue;
+      auto *cmp = dyn_cast<ICmpInst>(branch->getCondition());
+      if (!cmp)
+        continue;
+      Value *lhs = cmp->getOperand(0);
+      Value *rhs = cmp->getOperand(1);
+      ICmpInst::Predicate pred = cmp->getPredicate();
+      if (lhs != induction) {
+        std::swap(lhs, rhs);
+        pred = ICmpInst::getSwappedPredicate(pred);
+      }
+      if (lhs != induction)
+        continue;
+      auto *bound = dyn_cast<ConstantInt>(rhs);
+      if (!bound)
+        continue;
+      for (unsigned succIdx : {0U, 1U}) {
+        BasicBlockEdge edge(&block, branch->getSuccessor(succIdx));
+        if (!domTree.dominates(edge, callBlock))
+          continue;
+        ICmpInst::Predicate edgePred =
+            succIdx == 0 ? pred : ICmpInst::getInversePredicate(pred);
+        range = range.intersectWith(
+            ConstantRange::makeAllowedICmpRegion(edgePred, bound->getValue()));
+        if (ICmpInst::isSigned(edgePred))
+          sawSigned = true;
+        if (ICmpInst::isUnsigned(edgePred))
+          sawUnsigned = true;
+      }
+    }
+    // A full range means the call is unguarded; an empty range means it is
+    // dominated by contradictory conditions (unreachable) — be conservative
+    // in both cases.
+    if (range.isFullSet() || range.isEmptySet())
+      return std::nullopt;
+    ranges.push_back(range);
+  }
+
+  auto tryLattice =
+      [&](bool isSigned) -> std::optional<std::pair<llvm::APInt, bool>> {
+    APInt floor = isSigned ? APInt::getSignedMaxValue(bits)
+                           : APInt::getMaxValue(bits);
+    for (const ConstantRange &range : ranges) {
+      APInt low = isSigned ? range.getSignedMin() : range.getUnsignedMin();
+      if (isSigned ? low.slt(floor) : low.ult(floor))
+        floor = low;
+    }
+    // The seeds evaluate `step` at `C - 1 .. C - window`; require that these
+    // stay above the lattice minimum so the guard `x < C` covers them and no
+    // wrap-around occurs.
+    APInt latticeMin = isSigned ? APInt::getSignedMinValue(bits)
+                                : APInt::getZero(bits);
+    APInt slack = latticeMin + window;
+    bool inBounds = isSigned ? floor.sge(slack) : floor.uge(slack);
+    if (!inBounds)
+      return std::nullopt;
+    return std::make_pair(floor, isSigned);
+  };
+
+  // Prefer the lattice the source's own guards speak: a signed-guarded
+  // recursion linearized with an unsigned floor would still be correct, but
+  // negative inputs would walk the whole unsigned domain instead of taking
+  // the base path directly.
+  bool signedFirst = sawSigned && !sawUnsigned;
+  if (auto result = tryLattice(signedFirst))
+    return result;
+  return tryLattice(!signedFirst);
+}
+
+std::optional<RecursionShape> matchRecursion(llvm::Function &function,
+                                             llvm::DominatorTree &domTree) {
+  using namespace llvm;
+  if (function.isDeclaration() || function.isVarArg() ||
+      function.hasFnAttribute(Attribute::OptimizeNone))
+    return std::nullopt;
+  Type *retTy = function.getReturnType();
+  if (retTy->isVoidTy() || retTy->isTokenTy() || !retTy->isFirstClassType())
+    return std::nullopt;
+
+  // The loop below evaluates the body at every point from the floor up to
+  // the query, so internal loops (whose termination at unevaluated points is
+  // unknown) are not admissible.
+  SmallVector<std::pair<const BasicBlock *, const BasicBlock *>, 8> backedges;
+  FindFunctionBackedges(function, backedges);
+  if (!backedges.empty())
+    return std::nullopt;
+
+  // Collect direct self-calls.
+  SmallVector<CallInst *, 4> selfCallInsts;
+  for (BasicBlock &block : function)
+    for (Instruction &inst : block)
+      if (auto *call = dyn_cast<CallInst>(&inst))
+        if (call->getCalledFunction() == &function)
+          selfCallInsts.push_back(call);
+  if (selfCallInsts.empty())
+    return std::nullopt;
+
+  // Exactly one argument position may vary across recursive calls: the
+  // induction argument. All other arguments must be passed through untouched
+  // so the recursion is a one-dimensional sequence.
+  std::optional<unsigned> inductionIndex;
+  for (CallInst *call : selfCallInsts) {
+    if (call->arg_size() != function.arg_size() || call->hasOperandBundles() ||
+        call->getFunctionType() != function.getFunctionType())
+      return std::nullopt;
+    std::optional<unsigned> varying;
+    for (unsigned i = 0; i < call->arg_size(); ++i) {
+      if (call->getArgOperand(i) == function.getArg(i))
+        continue;
+      if (varying)
+        return std::nullopt;
+      varying = i;
+    }
+    if (!varying)
+      return std::nullopt; // `f(x) = ... f(x) ...` never makes progress.
+    if (inductionIndex && *inductionIndex != *varying)
+      return std::nullopt;
+    inductionIndex = *varying;
+  }
+
+  auto *inductionTy =
+      dyn_cast<IntegerType>(function.getArg(*inductionIndex)->getType());
+  if (!inductionTy || inductionTy->getBitWidth() < kMinInductionBits)
+    return std::nullopt;
+  Argument *induction = function.getArg(*inductionIndex);
+
+  RecursionShape shape;
+  shape.inductionIndex = *inductionIndex;
+  for (CallInst *call : selfCallInsts) {
+    std::optional<APInt> offset =
+        matchDecrement(call->getArgOperand(*inductionIndex), induction);
+    if (!offset || offset->isZero() || offset->ugt(kMaxWindow))
+      return std::nullopt;
+    uint64_t d = offset->getZExtValue();
+    shape.calls.push_back({call, d});
+    shape.window = std::max(shape.window, d);
+  }
+
+  SmallPtrSet<CallInst *, 4> selfCallSet(selfCallInsts.begin(),
+                                         selfCallInsts.end());
+  for (BasicBlock &block : function)
+    for (Instruction &inst : block)
+      if (!isAllowedInstruction(inst, selfCallSet))
+        return std::nullopt;
+
+  auto floor = computeFloor(function, induction, shape.calls, domTree,
+                            shape.window);
+  if (!floor)
+    return std::nullopt;
+  shape.floor = floor->first;
+  shape.isSigned = floor->second;
+  return shape;
+}
+
+/// Outlines the body of `function` into a private `step` helper whose extra
+/// trailing parameters stand in for the recursive results, then rebuilds
+/// `function` as the guarded dynamic-programming loop described in the file
+/// header.
+void rewriteFunction(llvm::Function &function, const RecursionShape &shape) {
+  using namespace llvm;
+  Module &module = *function.getParent();
+  LLVMContext &ctx = function.getContext();
+  Type *retTy = function.getReturnType();
+  auto *inductionTy =
+      cast<IntegerType>(function.getArg(shape.inductionIndex)->getType());
+  uint64_t window = shape.window;
+
+  // Build the step helper by cloning the body and substituting the window
+  // parameters for the recursive calls.
+  SmallVector<Type *, 8> paramTys(function.getFunctionType()->params().begin(),
+                                  function.getFunctionType()->params().end());
+  for (uint64_t i = 0; i < window; ++i)
+    paramTys.push_back(retTy);
+  auto *stepTy = FunctionType::get(retTy, paramTys, /*isVarArg=*/false);
+  Function *step =
+      Function::Create(stepTy, GlobalValue::PrivateLinkage,
+                       function.getName() + ".reussir.step", &module);
+  ValueToValueMapTy valueMap;
+  for (unsigned i = 0; i < function.arg_size(); ++i) {
+    valueMap[function.getArg(i)] = step->getArg(i);
+    step->getArg(i)->setName(function.getArg(i)->getName());
+  }
+  for (uint64_t j = 1; j <= window; ++j)
+    step->getArg(function.arg_size() + j - 1)->setName("prev" + Twine(j));
+  SmallVector<ReturnInst *, 4> returns;
+  CloneFunctionInto(step, &function, valueMap,
+                    CloneFunctionChangeType::LocalChangesOnly, returns);
+  // copyAttributesFrom inside the clone reproduces the original's visibility
+  // and dso_local flag; a private helper must be dso_local with default
+  // visibility.
+  step->setVisibility(GlobalValue::DefaultVisibility);
+  step->setDSOLocal(true);
+  // The helper is an internal implementation detail; detach it from the
+  // original's debug identity rather than carrying a duplicated subprogram.
+  step->setSubprogram(nullptr);
+  stripDebugInfo(*step);
+  for (const SelfCall &selfCall : shape.calls) {
+    auto *cloned = cast<CallInst>(valueMap[selfCall.call]);
+    Argument *replacement =
+        step->getArg(function.arg_size() + selfCall.offset - 1);
+    cloned->replaceAllUsesWith(replacement);
+    cloned->eraseFromParent();
+  }
+  step->removeFnAttr(Attribute::NoInline);
+  step->addFnAttr(Attribute::AlwaysInline);
+  step->addFnAttr(Attribute::NoUnwind);
+
+  // Rebuild `function` from scratch.
+  for (BasicBlock &block : function)
+    block.dropAllReferences();
+  while (!function.empty())
+    function.begin()->eraseFromParent();
+
+  BasicBlock *entry = BasicBlock::Create(ctx, "entry", &function);
+  BasicBlock *baseBlock = BasicBlock::Create(ctx, "reussir.base", &function);
+  BasicBlock *seedBlock = BasicBlock::Create(ctx, "reussir.seed", &function);
+  BasicBlock *loopBlock = BasicBlock::Create(ctx, "reussir.dp.loop", &function);
+  BasicBlock *exitBlock = BasicBlock::Create(ctx, "reussir.dp.exit", &function);
+
+  Argument *induction = function.getArg(shape.inductionIndex);
+  Value *poison = PoisonValue::get(retTy);
+  auto makeArgs = [&](Value *inductionValue, ArrayRef<Value *> windowValues) {
+    SmallVector<Value *, 8> args;
+    for (unsigned i = 0; i < function.arg_size(); ++i)
+      args.push_back(i == shape.inductionIndex
+                         ? inductionValue
+                         : static_cast<Value *>(function.getArg(i)));
+    for (uint64_t j = 0; j < window; ++j)
+      args.push_back(j < windowValues.size() ? windowValues[j] : poison);
+    return args;
+  };
+
+  IRBuilder<> builder(entry);
+  Constant *floorC = ConstantInt::get(inductionTy, shape.floor);
+  Value *isBase = builder.CreateICmp(
+      shape.isSigned ? ICmpInst::ICMP_SLT : ICmpInst::ICMP_ULT, induction,
+      floorC, "reussir.isbase");
+  builder.CreateCondBr(isBase, baseBlock, seedBlock);
+
+  // Below the floor the body is call-free, so the window is dead.
+  builder.SetInsertPoint(baseBlock);
+  CallInst *baseResult =
+      builder.CreateCall(step, makeArgs(induction, {}), "reussir.basecase");
+  builder.CreateRet(baseResult);
+
+  // Seed the window with f(C-1) .. f(C-k); all of these are below the floor
+  // as well.
+  builder.SetInsertPoint(seedBlock);
+  SmallVector<Value *, 8> seeds;
+  for (uint64_t j = 1; j <= window; ++j) {
+    Constant *seedPoint =
+        ConstantInt::get(inductionTy, shape.floor - APInt(inductionTy->getBitWidth(), j));
+    seeds.push_back(builder.CreateCall(step, makeArgs(seedPoint, {}),
+                                       "reussir.seed" + Twine(j)));
+  }
+  builder.CreateBr(loopBlock);
+
+  // Walk v from C to x, maintaining w_j = f(v - j).
+  builder.SetInsertPoint(loopBlock);
+  PHINode *iv = builder.CreatePHI(inductionTy, 2, "reussir.iv");
+  SmallVector<PHINode *, 8> windowPhis;
+  for (uint64_t j = 1; j <= window; ++j)
+    windowPhis.push_back(
+        builder.CreatePHI(retTy, 2, "reussir.w" + Twine(j)));
+  SmallVector<Value *, 8> windowValues(windowPhis.begin(), windowPhis.end());
+  CallInst *current =
+      builder.CreateCall(step, makeArgs(iv, windowValues), "reussir.cur");
+  Value *ivNext = builder.CreateAdd(iv, ConstantInt::get(inductionTy, 1),
+                                    "reussir.iv.next");
+  Value *done = builder.CreateICmpEQ(iv, induction, "reussir.done");
+  builder.CreateCondBr(done, exitBlock, loopBlock);
+  iv->addIncoming(floorC, seedBlock);
+  iv->addIncoming(ivNext, loopBlock);
+  for (uint64_t j = 0; j < window; ++j) {
+    windowPhis[j]->addIncoming(seeds[j], seedBlock);
+    windowPhis[j]->addIncoming(j == 0 ? static_cast<Value *>(current)
+                                      : windowPhis[j - 1],
+                               loopBlock);
+  }
+
+  builder.SetInsertPoint(exitBlock);
+  builder.CreateRet(current);
+}
+
+} // namespace
+
+llvm::PreservedAnalyses
+RecursionLinearizationPass::run(llvm::Module &module,
+                                llvm::ModuleAnalysisManager &mam) {
+  using namespace llvm;
+  auto &fam =
+      mam.getResult<FunctionAnalysisManagerModuleProxy>(module).getManager();
+  bool changed = false;
+  // Snapshot: rewriting appends the outlined helpers to the module.
+  SmallVector<Function *, 16> functions;
+  for (Function &function : module)
+    functions.push_back(&function);
+  for (Function *function : functions) {
+    if (function->isDeclaration())
+      continue;
+    auto &domTree = fam.getResult<DominatorTreeAnalysis>(*function);
+    if (auto shape = matchRecursion(*function, domTree)) {
+      rewriteFunction(*function, *shape);
+      changed = true;
+    }
+  }
+  return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}
+
+} // namespace reussir::llvmpass

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -178,7 +178,8 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter)
 # builds after the runtime, not concurrently, and enables the repl-rs suite.
 add_custom_target(check
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/lit "${CMAKE_CURRENT_BINARY_DIR}" -v
-  DEPENDS reussir-opt reussir-rt reussir-translate reussir-syntax rrc rrepl)
+  DEPENDS reussir-opt reussir-rt reussir-translate reussir-llvm-opt
+          reussir-syntax rrc rrepl)
 
 if(REUSSIR_SANITIZED_RUNTIME_TARGETS)
   add_custom_target(check-sanitizer

--- a/tests/integration/frontend/naive_fib_linear_recurrence.c
+++ b/tests/integration/frontend/naive_fib_linear_recurrence.c
@@ -1,0 +1,28 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+extern uint64_t naive_fibonacci_ffi(uint64_t n);
+
+int main() {
+  if (naive_fibonacci_ffi(0) != 0)
+    abort();
+  if (naive_fibonacci_ffi(1) != 1)
+    abort();
+  if (naive_fibonacci_ffi(2) != 1)
+    abort();
+  if (naive_fibonacci_ffi(10) != 55)
+    abort();
+  // Unreachable for the exponential recursion within any reasonable time.
+  if (naive_fibonacci_ffi(90) != 2880067194370816120ULL)
+    abort();
+  // Wraps mod 2^64; still bit-exact after the rewrites.
+  if (naive_fibonacci_ffi(200) != 17323038258947941269ULL)
+    abort();
+  // Far beyond the exponential call tree; instant via matrix exponentiation
+  // and still bounded (a few seconds) if only the linearized loop fired, so
+  // the test cannot hang CI. The O(log n) guarantee itself is pinned by the
+  // llvmpass/linear_recurrence_full_e2e.ll test.
+  if (naive_fibonacci_ffi(1000000000ULL) != 3311503426941990459ULL)
+    abort();
+  return 0;
+}

--- a/tests/integration/frontend/naive_fib_linear_recurrence.rr
+++ b/tests/integration/frontend/naive_fib_linear_recurrence.rr
@@ -1,0 +1,25 @@
+// RUN: %rrc %s --emit llvm-ir -o %t.ll
+// RUN: %FileCheck %s < %t.ll
+// RUN: %rrc %s -o %t.o
+// RUN: %cc %t.o %S/naive_fib_linear_recurrence.c -o %t.exe
+// RUN: %t.exe
+
+// The backend linear-recurrence passes (recursion linearization + matrix
+// exponentiation) must rewrite the naive doubly-recursive fibonacci at the
+// default optimization level: the optimized IR may not contain a
+// self-recursive call anymore, and the driver exercises arguments far beyond
+// what the exponential call tree could ever answer (values mod 2^64).
+
+// CHECK-LABEL: define{{.*}} @_RC9fibonacci(
+// CHECK-NOT: call{{.*}} @_RC9fibonacci(
+// CHECK: {{^[}]$}}
+
+pub fn fibonacci(n: u64) -> u64 {
+    if n <= 1 {
+        n
+    } else {
+        fibonacci(n - 1) + fibonacci(n - 2)
+    }
+}
+
+extern "C" trampoline "naive_fibonacci_ffi" = fibonacci;

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -5,7 +5,7 @@ import sys
 config.name = 'Reussir'
 config.test_format = lit.formats.ShTest(True)
 
-config.suffixes = ['.mlir', '.rr', '.repl']
+config.suffixes = ['.mlir', '.rr', '.repl', '.ll']
 # `Inputs/` directories hold companion files (transform scripts, C drivers)
 # referenced by tests via %S; they are not tests themselves.
 config.excludes = ['Inputs']
@@ -40,6 +40,8 @@ config.substitutions.append((r'%reussir-opt',
                              bin_tool('reussir-opt')))
 config.substitutions.append((r'%reussir-translate',
                              bin_tool('reussir-translate')))
+config.substitutions.append((r'%reussir-llvm-opt',
+                             bin_tool('reussir-llvm-opt')))
 
 # Add C compiler substitution using CMake's C compiler
 config.substitutions.append((r'%cc', append_flags(config.cc_path, config.cc_runtime_flags)))

--- a/tests/integration/llvmpass/linear_recurrence_full_e2e.ll
+++ b/tests/integration/llvmpass/linear_recurrence_full_e2e.ll
@@ -1,0 +1,35 @@
+; RUN: %reussir-llvm-opt --passes='reussir-recursion-linearization,default<O2>,function(loop-simplify,reussir-linear-recurrence-matexp,instcombine,simplifycfg)' %s -o %t.ll
+; RUN: %FileCheck %s < %t.ll
+; RUN: %lli %t.ll
+
+; The full chain, mirroring the production pipeline placement: recursion
+; linearization before the default pipeline, matrix exponentiation after it.
+; The naive doubly-recursive fibonacci is asked for fib(10^15) mod 2^64 —
+; unreachable both for the exponential recursion (~2^(10^15) calls) and for a
+; linear-time loop (~10^15 iterations); only the O(log n) matrix
+; exponentiation path can answer within the test timeout.
+
+; CHECK-LABEL: define{{.*}} i64 @fib(i64 %n)
+; CHECK-NOT:     call
+; CHECK:         lshr
+define i64 @fib(i64 %n) {
+entry:
+  %cmp = icmp ult i64 %n, 2
+  br i1 %cmp, label %base, label %rec
+base:
+  ret i64 %n
+rec:
+  %n1 = add i64 %n, -1
+  %f1 = call i64 @fib(i64 %n1)
+  %n2 = add i64 %n, -2
+  %f2 = call i64 @fib(i64 %n2)
+  %s = add i64 %f1, %f2
+  ret i64 %s
+}
+
+define i32 @main() {
+  %r = call i64 @fib(i64 1000000000000000)
+  %ok = icmp eq i64 %r, 17845758328335168059
+  %ret = select i1 %ok, i32 0, i32 1
+  ret i32 %ret
+}

--- a/tests/integration/llvmpass/linear_recurrence_full_e2e.ll
+++ b/tests/integration/llvmpass/linear_recurrence_full_e2e.ll
@@ -1,13 +1,13 @@
-; RUN: %reussir-llvm-opt --passes='reussir-recursion-linearization,default<O2>,function(loop-simplify,reussir-linear-recurrence-matexp,instcombine,simplifycfg)' %s -o %t.ll
+; RUN: %reussir-llvm-opt --linear-recurrence-pipeline=O2 %s -o %t.ll
 ; RUN: %FileCheck %s < %t.ll
 ; RUN: %lli %t.ll
 
-; The full chain, mirroring the production pipeline placement: recursion
-; linearization before the default pipeline, matrix exponentiation after it.
-; The naive doubly-recursive fibonacci is asked for fib(10^15) mod 2^64 —
-; unreachable both for the exponential recursion (~2^(10^15) calls) and for a
-; linear-time loop (~10^15 iterations); only the O(log n) matrix
-; exponentiation path can answer within the test timeout.
+; The full chain with the exact production pipeline: recursion linearization
+; at pipeline start, Kitamasa exponentiation at the vectorizer-start
+; extension point. The naive doubly-recursive fibonacci is asked for
+; fib(10^15) mod 2^64 — unreachable both for the exponential recursion
+; (~2^(10^15) calls) and for a linear-time loop (~10^15 iterations); only
+; the O(log n) exponentiation path can answer within the test timeout.
 
 ; CHECK-LABEL: define{{.*}} i64 @fib(i64 %n)
 ; CHECK-NOT:     call

--- a/tests/integration/llvmpass/linear_recurrence_matexp.ll
+++ b/tests/integration/llvmpass/linear_recurrence_matexp.ll
@@ -1,0 +1,80 @@
+; RUN: %reussir-llvm-opt --passes='function(loop-simplify,reussir-linear-recurrence-matexp)' %s -o - | %FileCheck %s
+
+; A rotated fib loop (i32 counter, i64 data) must be strength-reduced into a
+; square-and-multiply exponentiation loop over the exponent's bits. The i32
+; exit counter is not part of the affine state and simply dies with the loop.
+
+; CHECK-LABEL: define i64 @fib_loop(i64 %n)
+; CHECK:       reussir.matexp.check:
+; CHECK:         %reussir.matexp.e = phi i32
+; CHECK:         phi i64
+; CHECK:       reussir.matexp.body:
+; CHECK:         trunc i32 %reussir.matexp.e to i1
+; CHECK:         mul i64
+; CHECK:         lshr i32 %reussir.matexp.e, 1
+; CHECK:       reussir.matexp.done:
+define i64 @fib_loop(i64 %n) {
+entry:
+  %small = icmp ult i64 %n, 2
+  br i1 %small, label %ret_n, label %ph
+ret_n:
+  ret i64 %n
+ph:
+  %count = trunc i64 %n to i32
+  br label %loop
+loop:
+  %i = phi i32 [ 2, %ph ], [ %inext, %loop ]
+  %a = phi i64 [ 0, %ph ], [ %b, %loop ]
+  %b = phi i64 [ 1, %ph ], [ %next, %loop ]
+  %next = add i64 %a, %b
+  %inext = add i32 %i, 1
+  %done = icmp eq i32 %i, %count
+  br i1 %done, label %exit, label %loop
+exit:
+  ret i64 %next
+}
+
+; A linear congruential generator: one state cell plus the augmentation row
+; carrying the additive constant.
+
+; CHECK-LABEL: define i64 @lcg(i64 %seed, i64 %rounds)
+; CHECK:       reussir.matexp.check:
+; CHECK:       reussir.matexp.done:
+define i64 @lcg(i64 %seed, i64 %rounds) {
+entry:
+  %zero = icmp eq i64 %rounds, 0
+  br i1 %zero, label %ret0, label %ph
+ret0:
+  ret i64 %seed
+ph:
+  br label %loop
+loop:
+  %i = phi i64 [ 0, %ph ], [ %inext, %loop ]
+  %x = phi i64 [ %seed, %ph ], [ %xnext, %loop ]
+  %scaled = mul i64 %x, 6364136223846793005
+  %xnext = add i64 %scaled, 1442695040888963407
+  %inext = add i64 %i, 1
+  %done = icmp eq i64 %inext, %rounds
+  br i1 %done, label %exit, label %loop
+exit:
+  ret i64 %xnext
+}
+
+; A quadratic update is not an affine map; the loop must remain untouched.
+
+; CHECK-LABEL: define i64 @quad(i64 %n)
+; CHECK-NOT:   reussir.matexp
+; CHECK:         %xnext = mul i64 %x, %x
+define i64 @quad(i64 %n) {
+entry:
+  br label %loop
+loop:
+  %i = phi i64 [ 0, %entry ], [ %inext, %loop ]
+  %x = phi i64 [ 3, %entry ], [ %xnext, %loop ]
+  %xnext = mul i64 %x, %x
+  %inext = add i64 %i, 1
+  %done = icmp eq i64 %inext, %n
+  br i1 %done, label %exit, label %loop
+exit:
+  ret i64 %xnext
+}

--- a/tests/integration/llvmpass/linear_recurrence_matexp_exec.ll
+++ b/tests/integration/llvmpass/linear_recurrence_matexp_exec.ll
@@ -1,0 +1,93 @@
+; RUN: %lli %s
+; RUN: %reussir-llvm-opt --passes='function(loop-simplify,reussir-linear-recurrence-matexp)' %s -o %t.ll
+; RUN: %lli %t.ll
+
+; The same module must compute identical results before and after the
+; matrix-exponentiation rewrite (values fixed mod 2^64; distinct exit codes
+; identify the failing case). `main`'s own control flow contains calls, so it
+; is never a candidate itself.
+
+define i64 @fib_loop(i64 %n) {
+entry:
+  %small = icmp ult i64 %n, 2
+  br i1 %small, label %ret_n, label %ph
+ret_n:
+  ret i64 %n
+ph:
+  %count = trunc i64 %n to i32
+  br label %loop
+loop:
+  %i = phi i32 [ 2, %ph ], [ %inext, %loop ]
+  %a = phi i64 [ 0, %ph ], [ %b, %loop ]
+  %b = phi i64 [ 1, %ph ], [ %next, %loop ]
+  %next = add i64 %a, %b
+  %inext = add i32 %i, 1
+  %done = icmp eq i32 %i, %count
+  br i1 %done, label %exit, label %loop
+exit:
+  ret i64 %next
+}
+
+define i64 @lcg(i64 %seed, i64 %rounds) {
+entry:
+  %zero = icmp eq i64 %rounds, 0
+  br i1 %zero, label %ret0, label %ph
+ret0:
+  ret i64 %seed
+ph:
+  br label %loop
+loop:
+  %i = phi i64 [ 0, %ph ], [ %inext, %loop ]
+  %x = phi i64 [ %seed, %ph ], [ %xnext, %loop ]
+  %scaled = mul i64 %x, 6364136223846793005
+  %xnext = add i64 %scaled, 1442695040888963407
+  %inext = add i64 %i, 1
+  %done = icmp eq i64 %inext, %rounds
+  br i1 %done, label %exit, label %loop
+exit:
+  ret i64 %xnext
+}
+
+define i64 @quad(i64 %n) {
+entry:
+  br label %loop
+loop:
+  %i = phi i64 [ 0, %entry ], [ %inext, %loop ]
+  %x = phi i64 [ 3, %entry ], [ %xnext, %loop ]
+  %xnext = mul i64 %x, %x
+  %inext = add i64 %i, 1
+  %done = icmp eq i64 %inext, %n
+  br i1 %done, label %exit, label %loop
+exit:
+  ret i64 %xnext
+}
+
+define i32 @check(i64 %got, i64 %want, i32 %code) {
+  %ok = icmp eq i64 %got, %want
+  %r = select i1 %ok, i32 0, i32 %code
+  ret i32 %r
+}
+
+define i32 @main() {
+  %f2 = call i64 @fib_loop(i64 2)
+  %c0 = call i32 @check(i64 %f2, i64 1, i32 1)
+  %f3 = call i64 @fib_loop(i64 3)
+  %c1 = call i32 @check(i64 %f3, i64 2, i32 2)
+  %f90 = call i64 @fib_loop(i64 90)
+  %c2 = call i32 @check(i64 %f90, i64 2880067194370816120, i32 3)
+  %f1000 = call i64 @fib_loop(i64 1000)
+  %c3 = call i32 @check(i64 %f1000, i64 817770325994397771, i32 4)
+  %l = call i64 @lcg(i64 42, i64 1000000)
+  %c4 = call i32 @check(i64 %l, i64 16854984035281278314, i32 5)
+  %l0 = call i64 @lcg(i64 7, i64 0)
+  %c5 = call i32 @check(i64 %l0, i64 7, i32 6)
+  %q = call i64 @quad(i64 3)
+  %c6 = call i32 @check(i64 %q, i64 6561, i32 7)
+  %a = or i32 %c0, %c1
+  %b = or i32 %a, %c2
+  %c = or i32 %b, %c3
+  %d = or i32 %c, %c4
+  %e = or i32 %d, %c5
+  %f = or i32 %e, %c6
+  ret i32 %f
+}

--- a/tests/integration/llvmpass/linear_recurrence_order4_e2e.ll
+++ b/tests/integration/llvmpass/linear_recurrence_order4_e2e.ll
@@ -1,0 +1,68 @@
+; RUN: %reussir-llvm-opt --linear-recurrence-pipeline=O2 %s -o %t.ll
+; RUN: %FileCheck %s < %t.ll
+; RUN: %lli %t.ll
+
+; Wider-window regression test (order 4, dense coefficients, inhomogeneous
+; constant; companion dimension D = 5 with the augmentation row). Placement
+; matters here: run *after* the whole default pipeline, the rewrite never
+; fires because SLP vectorizes the k=4 sliding window into vector PHIs the
+; affine matcher cannot see. At the vectorizer-start extension point the
+; loop is still scalar, and EarlyCSE right after the rewrite folds the
+; schoolbook squaring's commutative duplicate products.
+;
+; quart(10^14) mod 2^64 is unreachable for both the exponential recursion
+; and the linear loop; only the O(log n) path answers within the timeout.
+
+; CHECK-LABEL: define{{.*}} i64 @quart(i64 %n)
+; CHECK-NOT:     call
+; CHECK:         reussir.matexp
+; CHECK:         lshr
+define i64 @quart(i64 %n) {
+entry:
+  %cmp = icmp ult i64 %n, 4
+  br i1 %cmp, label %base, label %rec
+base:
+  ret i64 %n
+rec:
+  %n1 = add i64 %n, -1
+  %f1 = call i64 @quart(i64 %n1)
+  %t1 = mul i64 %f1, 3
+  %n2 = add i64 %n, -2
+  %f2 = call i64 @quart(i64 %n2)
+  %t2 = mul i64 %f2, 5
+  %n3 = add i64 %n, -3
+  %f3 = call i64 @quart(i64 %n3)
+  %t3 = mul i64 %f3, 7
+  %n4 = add i64 %n, -4
+  %f4 = call i64 @quart(i64 %n4)
+  %t4 = mul i64 %f4, 11
+  %s1 = add i64 %t1, %t2
+  %s2 = add i64 %s1, %t3
+  %s3 = add i64 %s2, %t4
+  %s = add i64 %s3, 13
+  ret i64 %s
+}
+
+define i32 @check(i64 %got, i64 %want, i32 %code) {
+  %ok = icmp eq i64 %got, %want
+  %r = select i1 %ok, i32 0, i32 %code
+  ret i32 %r
+}
+
+define i32 @main() {
+  %q3 = call i64 @quart(i64 3)
+  %c0 = call i32 @check(i64 %q3, i64 3, i32 1)
+  %q4 = call i64 @quart(i64 4)
+  %c1 = call i32 @check(i64 %q4, i64 39, i32 2)
+  %q5 = call i64 @quart(i64 5)
+  %c2 = call i32 @check(i64 %q5, i64 170, i32 3)
+  %q100k = call i64 @quart(i64 100000)
+  %c3 = call i32 @check(i64 %q100k, i64 14715427454508611264, i32 4)
+  %qhuge = call i64 @quart(i64 100000000000000)
+  %c4 = call i32 @check(i64 %qhuge, i64 735566407347175424, i32 5)
+  %a = or i32 %c0, %c1
+  %b = or i32 %a, %c2
+  %c = or i32 %b, %c3
+  %d = or i32 %c, %c4
+  ret i32 %d
+}

--- a/tests/integration/llvmpass/linear_recurrence_order6_e2e.ll
+++ b/tests/integration/llvmpass/linear_recurrence_order6_e2e.ll
@@ -1,0 +1,81 @@
+; RUN: %reussir-llvm-opt --linear-recurrence-pipeline=O2 %s -o %t.ll
+; RUN: %FileCheck %s < %t.ll
+; RUN: %lli %t.ll
+
+; Order-6 recurrence with dense coefficients and an inhomogeneous constant:
+; state size 6 is exactly the Kitamasa cap (kMaxStateSize), and the
+; augmentation row brings the companion dimension to the maximal D = 7.
+;   f(n) = n+1                                            for n < 6
+;   f(n) = 2f(n-1) + 3f(n-2) + 5f(n-3) + 7f(n-4)
+;        + 11f(n-5) + 13f(n-6) + 17                       for n >= 6
+; sext(10^13) is unreachable for the exponential recursion and out of
+; timeout range for a linear loop; only the O(log n) path answers.
+
+; CHECK-LABEL: define{{.*}} i64 @sext(i64 %n)
+; CHECK-NOT:     call
+; CHECK:         reussir.matexp
+; CHECK:         lshr
+define i64 @sext(i64 %n) {
+entry:
+  %small = icmp ult i64 %n, 6
+  br i1 %small, label %base, label %rec
+base:
+  %succ = add i64 %n, 1
+  ret i64 %succ
+rec:
+  %n1 = add i64 %n, -1
+  %f1 = call i64 @sext(i64 %n1)
+  %t1 = shl i64 %f1, 1
+  %n2 = add i64 %n, -2
+  %f2 = call i64 @sext(i64 %n2)
+  %t2 = mul i64 %f2, 3
+  %n3 = add i64 %n, -3
+  %f3 = call i64 @sext(i64 %n3)
+  %t3 = mul i64 %f3, 5
+  %n4 = add i64 %n, -4
+  %f4 = call i64 @sext(i64 %n4)
+  %t4 = mul i64 %f4, 7
+  %n5 = add i64 %n, -5
+  %f5 = call i64 @sext(i64 %n5)
+  %t5 = mul i64 %f5, 11
+  %n6 = add i64 %n, -6
+  %f6 = call i64 @sext(i64 %n6)
+  %t6 = mul i64 %f6, 13
+  %s1 = add i64 %t1, %t2
+  %s2 = add i64 %s1, %t3
+  %s3 = add i64 %s2, %t4
+  %s4 = add i64 %s3, %t5
+  %s5 = add i64 %s4, %t6
+  %s = add i64 %s5, 17
+  ret i64 %s
+}
+
+define i32 @check(i64 %got, i64 %want, i32 %code) {
+  %ok = icmp eq i64 %got, %want
+  %r = select i1 %ok, i32 0, i32 %code
+  ret i32 %r
+}
+
+define i32 @main() {
+  %f0 = call i64 @sext(i64 0)
+  %c0 = call i32 @check(i64 %f0, i64 1, i32 1)
+  %f5 = call i64 @sext(i64 5)
+  %c1 = call i32 @check(i64 %f5, i64 6, i32 2)
+  %f6 = call i64 @sext(i64 6)
+  %c2 = call i32 @check(i64 %f6, i64 120, i32 3)
+  %f7 = call i64 @sext(i64 7)
+  %c3 = call i32 @check(i64 %f7, i64 387, i32 4)
+  %f8 = call i64 @sext(i64 8)
+  %c4 = call i32 @check(i64 %f8, i64 1299, i32 5)
+  %f2000 = call i64 @sext(i64 2000)
+  %c5 = call i32 @check(i64 %f2000, i64 10227571276236485390, i32 6)
+  %fhuge = call i64 @sext(i64 10000000000000)
+  %c6 = call i32 @check(i64 %fhuge, i64 5994342898092240063, i32 7)
+  %a0 = or i32 %c0, %c1
+  %a1 = or i32 %a0, %c2
+  %a2 = or i32 %a1, %c3
+  %a3 = or i32 %a2, %c4
+  %a4 = or i32 %a3, %c5
+  %a5 = or i32 %a4, %c6
+  ret i32 %a5
+}

--- a/tests/integration/llvmpass/recursion_linearization.ll
+++ b/tests/integration/llvmpass/recursion_linearization.ll
@@ -1,0 +1,90 @@
+; RUN: %reussir-llvm-opt --passes=reussir-recursion-linearization %s -o - | %FileCheck %s
+
+; Naive doubly-recursive fibonacci must be rewritten into the guarded
+; dynamic-programming loop calling the outlined step helper, with no
+; self-recursive call left behind.
+
+; CHECK-LABEL: define i64 @fib(i64 %n)
+; CHECK:         icmp ult i64 %n, 2
+; CHECK:         call i64 @fib.reussir.step(i64 %n, i64 poison, i64 poison)
+; CHECK:         call i64 @fib.reussir.step(i64 1, i64 poison, i64 poison)
+; CHECK:         call i64 @fib.reussir.step(i64 0, i64 poison, i64 poison)
+; CHECK:       reussir.dp.loop:
+; CHECK:         %[[IV:.*]] = phi i64 [ 2, %reussir.seed ]
+; CHECK:         call i64 @fib.reussir.step(i64 %[[IV]], i64 %reussir.w1, i64 %reussir.w2)
+; CHECK-NOT:     call i64 @fib(
+define i64 @fib(i64 %n) {
+entry:
+  %cmp = icmp ult i64 %n, 2
+  br i1 %cmp, label %base, label %rec
+base:
+  ret i64 %n
+rec:
+  %n1 = add i64 %n, -1
+  %f1 = call i64 @fib(i64 %n1)
+  %n2 = add i64 %n, -2
+  %f2 = call i64 @fib(i64 %n2)
+  %s = add i64 %f1, %f2
+  ret i64 %s
+}
+
+@sink = global i64 0
+
+define void @escape(i64 %v) {
+  store volatile i64 %v, ptr @sink
+  ret void
+}
+
+; A side-effecting body must stay recursive.
+
+; CHECK-LABEL: define i64 @bad_effect(i64 %n)
+; CHECK:         call i64 @bad_effect(
+define i64 @bad_effect(i64 %n) {
+entry:
+  %cmp = icmp ult i64 %n, 2
+  br i1 %cmp, label %base, label %rec
+base:
+  ret i64 %n
+rec:
+  call void @escape(i64 %n)
+  %n1 = add i64 %n, -1
+  %f1 = call i64 @bad_effect(i64 %n1)
+  ret i64 %f1
+}
+
+; Non-constant descent (divide and conquer) is out of scope and must stay
+; recursive.
+
+; CHECK-LABEL: define i64 @bad_halving(i64 %n)
+; CHECK:         call i64 @bad_halving(
+define i64 @bad_halving(i64 %n) {
+entry:
+  %cmp = icmp ult i64 %n, 2
+  br i1 %cmp, label %base, label %rec
+base:
+  ret i64 %n
+rec:
+  %h = lshr i64 %n, 1
+  %f1 = call i64 @bad_halving(i64 %h)
+  %s = add i64 %f1, 1
+  ret i64 %s
+}
+
+; Without a dominating comparison bounding the induction argument there is no
+; provable recursion floor; the function must stay recursive.
+
+; CHECK-LABEL: define i64 @bad_unguarded(i64 %n)
+; CHECK:         call i64 @bad_unguarded(
+define i64 @bad_unguarded(i64 %n) {
+entry:
+  %n1 = add i64 %n, -1
+  %f1 = call i64 @bad_unguarded(i64 %n1)
+  ret i64 %f1
+}
+
+; The outlined helper keeps the base-case dispatch but replaces the recursive
+; calls with the window parameters.
+
+; CHECK-LABEL: define private i64 @fib.reussir.step(i64 %n, i64 %prev1, i64 %prev2)
+; CHECK-NOT:     call
+; CHECK:         add i64 %prev1, %prev2

--- a/tests/integration/llvmpass/recursion_linearization_exec.ll
+++ b/tests/integration/llvmpass/recursion_linearization_exec.ll
@@ -1,0 +1,140 @@
+; RUN: %reussir-llvm-opt --passes=reussir-recursion-linearization %s -o %t.ll
+; RUN: %lli %t.ll
+
+; End-to-end execution of linearized recurrences. Every `check` returns a
+; distinct nonzero exit code on mismatch, so a failure identifies the broken
+; case. Large arguments (fib(200), gen(40)) would be unreachable for the
+; original exponential recursions; expected values are computed mod 2^64.
+
+; Naive doubly-recursive fib (unsigned guard).
+define i64 @fib(i64 %n) {
+entry:
+  %cmp = icmp ult i64 %n, 2
+  br i1 %cmp, label %base, label %rec
+base:
+  ret i64 %n
+rec:
+  %n1 = add i64 %n, -1
+  %f1 = call i64 @fib(i64 %n1)
+  %n2 = add i64 %n, -2
+  %f2 = call i64 @fib(i64 %n2)
+  %s = add i64 %f1, %f2
+  ret i64 %s
+}
+
+; Signed-guard variant: f(n) = n for n < 2, including negative inputs.
+define i64 @fib_signed(i64 %n) {
+entry:
+  %cmp = icmp slt i64 %n, 2
+  br i1 %cmp, label %base, label %rec
+base:
+  ret i64 %n
+rec:
+  %n1 = sub i64 %n, 1
+  %f1 = call i64 @fib_signed(i64 %n1)
+  %n2 = sub i64 %n, 2
+  %f2 = call i64 @fib_signed(i64 %n2)
+  %s = add i64 %f1, %f2
+  ret i64 %s
+}
+
+; Order-3 recurrence with coefficients and an inhomogeneous constant:
+; g(n) = 3 g(n-1) + 2 g(n-3) + 7, g(0)=1, g(1)=2, g(2)=3.
+define i64 @gen(i64 %n) {
+entry:
+  %c0 = icmp eq i64 %n, 0
+  br i1 %c0, label %r0, label %n0
+r0:
+  ret i64 1
+n0:
+  %c1 = icmp eq i64 %n, 1
+  br i1 %c1, label %r1, label %n1b
+r1:
+  ret i64 2
+n1b:
+  %c2 = icmp eq i64 %n, 2
+  br i1 %c2, label %r2, label %rec
+r2:
+  ret i64 3
+rec:
+  %m1 = add i64 %n, -1
+  %g1 = call i64 @gen(i64 %m1)
+  %t1 = mul i64 %g1, 3
+  %m3 = add i64 %n, -3
+  %g3 = call i64 @gen(i64 %m3)
+  %t3 = shl i64 %g3, 1
+  %s0 = add i64 %t1, %t3
+  %s = add i64 %s0, 7
+  ret i64 %s
+}
+
+; Generalized (nonlinear) combine — a max-plus recurrence:
+; h(n) = max(h(n-1)+2, h(n-2)+3), h(0)=0, h(1)=1.
+define i64 @maxplus(i64 %n) {
+entry:
+  %cmp = icmp ult i64 %n, 2
+  br i1 %cmp, label %base, label %rec
+base:
+  ret i64 %n
+rec:
+  %n1 = add i64 %n, -1
+  %h1 = call i64 @maxplus(i64 %n1)
+  %a = add i64 %h1, 2
+  %n2 = add i64 %n, -2
+  %h2 = call i64 @maxplus(i64 %n2)
+  %b = add i64 %h2, 3
+  %cmp2 = icmp sgt i64 %a, %b
+  %m = select i1 %cmp2, i64 %a, i64 %b
+  ret i64 %m
+}
+
+define i32 @check(i64 %got, i64 %want, i32 %code) {
+  %ok = icmp eq i64 %got, %want
+  %r = select i1 %ok, i32 0, i32 %code
+  ret i32 %r
+}
+
+define i32 @main() {
+  %f0 = call i64 @fib(i64 0)
+  %c0 = call i32 @check(i64 %f0, i64 0, i32 1)
+  %f1 = call i64 @fib(i64 1)
+  %c1 = call i32 @check(i64 %f1, i64 1, i32 2)
+  %f2 = call i64 @fib(i64 2)
+  %c2 = call i32 @check(i64 %f2, i64 1, i32 3)
+  %f3 = call i64 @fib(i64 3)
+  %c3 = call i32 @check(i64 %f3, i64 2, i32 4)
+  %f90 = call i64 @fib(i64 90)
+  %c4 = call i32 @check(i64 %f90, i64 2880067194370816120, i32 5)
+  %f100 = call i64 @fib(i64 100)
+  %c5 = call i32 @check(i64 %f100, i64 3736710778780434371, i32 6)
+  %f200 = call i64 @fib(i64 200)
+  %c6 = call i32 @check(i64 %f200, i64 17323038258947941269, i32 7)
+  %fs = call i64 @fib_signed(i64 -5)
+  %c7 = call i32 @check(i64 %fs, i64 -5, i32 8)
+  %fs30 = call i64 @fib_signed(i64 30)
+  %c8 = call i32 @check(i64 %fs30, i64 832040, i32 9)
+  %g2 = call i64 @gen(i64 2)
+  %c9 = call i32 @check(i64 %g2, i64 3, i32 10)
+  %g3 = call i64 @gen(i64 3)
+  %c10 = call i32 @check(i64 %g3, i64 18, i32 11)
+  %g40 = call i64 @gen(i64 40)
+  %c11 = call i32 @check(i64 %g40, i64 3616619083927076757, i32 12)
+  %h1 = call i64 @maxplus(i64 1)
+  %c12 = call i32 @check(i64 %h1, i64 1, i32 13)
+  %h10 = call i64 @maxplus(i64 10)
+  %c13 = call i32 @check(i64 %h10, i64 19, i32 14)
+  %a = or i32 %c0, %c1
+  %b = or i32 %a, %c2
+  %c = or i32 %b, %c3
+  %d = or i32 %c, %c4
+  %e = or i32 %d, %c5
+  %f = or i32 %e, %c6
+  %g = or i32 %f, %c7
+  %h = or i32 %g, %c8
+  %i = or i32 %h, %c9
+  %j = or i32 %i, %c10
+  %k = or i32 %j, %c11
+  %l = or i32 %k, %c12
+  %m = or i32 %l, %c13
+  ret i32 %m
+}

--- a/tests/integration/llvmpass/recursion_linearization_wide_window.ll
+++ b/tests/integration/llvmpass/recursion_linearization_wide_window.ll
@@ -1,0 +1,131 @@
+; RUN: %reussir-llvm-opt --passes=reussir-recursion-linearization %s -o %t.lin.ll
+; RUN: %FileCheck %s --check-prefix=LIN < %t.lin.ll
+; RUN: %lli %t.lin.ll
+; RUN: %reussir-llvm-opt --linear-recurrence-pipeline=O2 %s -o %t.prod.ll
+; RUN: %FileCheck %s --check-prefix=PROD < %t.prod.ll
+; RUN: %lli %t.prod.ll
+
+; Medium-width window (order 8) with three heterogeneous base-case branches
+; behind mixed eq/ult guards, each returning a different expression:
+;   f(0) = 7 ; f(1) = 3 ; f(n) = 2n+1 for n < 8
+;   f(n) = f(n-1) + 2f(n-2) + 3f(n-3) + f(n-4) + 2f(n-5) + 3f(n-6)
+;        + f(n-7) + 2f(n-8) + 5                 for n >= 8
+;
+; The recursion floor analysis must land on C = 8 from the guard chain, and
+; linearization must carry the full 8-wide sliding window. Through the
+; production pipeline the state (8 PHIs) exceeds the Kitamasa cap
+; (kMaxStateSize = 6), so the loop must stay a linear scalar (or
+; SLP-vectorized) loop — no exponentiation kernel may be emitted for it.
+
+; The linearized form must carry the full 8-wide window.
+; LIN-LABEL: define i64 @wide(i64 %n)
+; LIN-NOT:     call i64 @wide(
+; LIN:         %reussir.w8 = phi i64
+; LIN:         call i64 @wide.reussir.step(
+
+; PROD-LABEL: define{{.*}} i64 @wide(i64 %n)
+; PROD-NOT:     call
+; PROD-NOT:     reussir.matexp
+define i64 @wide(i64 %n) {
+entry:
+  %is0 = icmp eq i64 %n, 0
+  br i1 %is0, label %ret0, label %chk1
+ret0:
+  ret i64 7
+chk1:
+  %is1 = icmp eq i64 %n, 1
+  br i1 %is1, label %ret1, label %chksmall
+ret1:
+  ret i64 3
+chksmall:
+  %small = icmp ult i64 %n, 8
+  br i1 %small, label %retsmall, label %rec
+retsmall:
+  %dbl = shl i64 %n, 1
+  %odd = add i64 %dbl, 1
+  ret i64 %odd
+rec:
+  %n1 = add i64 %n, -1
+  %f1 = call i64 @wide(i64 %n1)
+  %n2 = add i64 %n, -2
+  %f2 = call i64 @wide(i64 %n2)
+  %t2 = shl i64 %f2, 1
+  %n3 = add i64 %n, -3
+  %f3 = call i64 @wide(i64 %n3)
+  %t3 = mul i64 %f3, 3
+  %n4 = add i64 %n, -4
+  %f4 = call i64 @wide(i64 %n4)
+  %n5 = add i64 %n, -5
+  %f5 = call i64 @wide(i64 %n5)
+  %t5 = shl i64 %f5, 1
+  %n6 = add i64 %n, -6
+  %f6 = call i64 @wide(i64 %n6)
+  %t6 = mul i64 %f6, 3
+  %n7 = add i64 %n, -7
+  %f7 = call i64 @wide(i64 %n7)
+  %n8 = add i64 %n, -8
+  %f8 = call i64 @wide(i64 %n8)
+  %t8 = shl i64 %f8, 1
+  %s1 = add i64 %f1, %t2
+  %s2 = add i64 %s1, %t3
+  %s3 = add i64 %s2, %f4
+  %s4 = add i64 %s3, %t5
+  %s5 = add i64 %s4, %t6
+  %s6 = add i64 %s5, %f7
+  %s7 = add i64 %s6, %t8
+  %s = add i64 %s7, 5
+  ret i64 %s
+}
+
+; Descending by more than the window cap (kMaxWindow = 16) must not be
+; linearized by the pass. (The production pipeline's own tail-recursion
+; elimination may still turn this accumulator-free single call into a loop —
+; that is plain LLVM behavior, so the check is on the pass-only output.)
+
+; LIN-LABEL: define i64 @bad_beyond_window(i64 %n)
+; LIN:         call i64 @bad_beyond_window(
+define i64 @bad_beyond_window(i64 %n) {
+entry:
+  %cmp = icmp ult i64 %n, 17
+  br i1 %cmp, label %base, label %rec
+base:
+  ret i64 %n
+rec:
+  %n17 = add i64 %n, -17
+  %f = call i64 @bad_beyond_window(i64 %n17)
+  %s = add i64 %f, 1
+  ret i64 %s
+}
+
+define i32 @check(i64 %got, i64 %want, i32 %code) {
+  %ok = icmp eq i64 %got, %want
+  %r = select i1 %ok, i32 0, i32 %code
+  ret i32 %r
+}
+
+define i32 @main() {
+  %w0 = call i64 @wide(i64 0)
+  %c0 = call i32 @check(i64 %w0, i64 7, i32 1)
+  %w1 = call i64 @wide(i64 1)
+  %c1 = call i32 @check(i64 %w1, i64 3, i32 2)
+  %w5 = call i64 @wide(i64 5)
+  %c2 = call i32 @check(i64 %w5, i64 11, i32 3)
+  %w7 = call i64 @wide(i64 7)
+  %c3 = call i32 @check(i64 %w7, i64 15, i32 4)
+  %w8 = call i64 @wide(i64 8)
+  %c4 = call i32 @check(i64 %w8, i64 134, i32 5)
+  %w9 = call i64 @wide(i64 9)
+  %c5 = call i32 @check(i64 %w9, i64 269, i32 6)
+  %wbig = call i64 @wide(i64 100000)
+  %c6 = call i32 @check(i64 %wbig, i64 16362317766162041378, i32 7)
+  %b = call i64 @bad_beyond_window(i64 40)
+  %c7 = call i32 @check(i64 %b, i64 8, i32 8)
+  %a0 = or i32 %c0, %c1
+  %a1 = or i32 %a0, %c2
+  %a2 = or i32 %a1, %c3
+  %a3 = or i32 %a2, %c4
+  %a4 = or i32 %a3, %c5
+  %a5 = or i32 %a4, %c6
+  %a6 = or i32 %a5, %c7
+  ret i32 %a6
+}

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(reussir-opt)
 add_subdirectory(reussir-translate)
+add_subdirectory(reussir-llvm-opt)

--- a/tool/reussir-llvm-opt/CMakeLists.txt
+++ b/tool/reussir-llvm-opt/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(LLVM_LINK_COMPONENTS
+  Core
+  IRReader
+  Passes
+  Support
+)
+
+add_llvm_executable(reussir-llvm-opt
+  main.cpp
+)
+
+target_link_libraries(reussir-llvm-opt
+  PRIVATE
+    ReussirLLVMAllocationSimplicationPass
+    ReussirLLVMLinearRecurrencePass
+)

--- a/tool/reussir-llvm-opt/main.cpp
+++ b/tool/reussir-llvm-opt/main.cpp
@@ -16,6 +16,8 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include <optional>
+
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Verifier.h>
@@ -43,6 +45,26 @@ llvm::cl::opt<std::string>
     passPipeline("passes",
                  llvm::cl::desc("Textual pass pipeline (same syntax as opt)"),
                  llvm::cl::init(""));
+llvm::cl::opt<std::string> linearRecurrencePipeline(
+    "linear-recurrence-pipeline",
+    llvm::cl::desc("Run the production default pipeline (O1/O2/O3/Os/Oz) "
+                   "with the linear-recurrence passes registered at its "
+                   "extension points, exactly as the Reussir backend does"),
+    llvm::cl::init(""));
+
+std::optional<llvm::OptimizationLevel> parseLevel(llvm::StringRef level) {
+  if (level == "O1")
+    return llvm::OptimizationLevel::O1;
+  if (level == "O2")
+    return llvm::OptimizationLevel::O2;
+  if (level == "O3")
+    return llvm::OptimizationLevel::O3;
+  if (level == "Os")
+    return llvm::OptimizationLevel::Os;
+  if (level == "Oz")
+    return llvm::OptimizationLevel::Oz;
+  return std::nullopt;
+}
 } // namespace
 
 int main(int argc, char **argv) {
@@ -98,8 +120,24 @@ int main(int argc, char **argv) {
       });
 
   llvm::ModulePassManager mpm;
-  if (llvm::Error error =
-          passBuilder.parsePassPipeline(mpm, passPipeline)) {
+  if (!linearRecurrencePipeline.empty()) {
+    if (!passPipeline.empty()) {
+      llvm::errs() << argv[0]
+                   << ": --passes and --linear-recurrence-pipeline are "
+                      "mutually exclusive\n";
+      return 1;
+    }
+    std::optional<llvm::OptimizationLevel> level =
+        parseLevel(linearRecurrencePipeline);
+    if (!level) {
+      llvm::errs() << argv[0] << ": invalid optimization level '"
+                   << linearRecurrencePipeline << "'\n";
+      return 1;
+    }
+    reussir::llvmpass::registerLinearRecurrencePipelines(passBuilder);
+    mpm.addPass(passBuilder.buildPerModuleDefaultPipeline(*level));
+  } else if (llvm::Error error =
+                 passBuilder.parsePassPipeline(mpm, passPipeline)) {
     llvm::errs() << argv[0] << ": " << llvm::toString(std::move(error))
                  << "\n";
     return 1;

--- a/tool/reussir-llvm-opt/main.cpp
+++ b/tool/reussir-llvm-opt/main.cpp
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements a minimal `opt`-style driver over LLVM IR that
+/// registers the Reussir LLVM passes with the new pass manager, so lit tests
+/// can exercise them by name (alone or inside standard pipelines) without
+/// relying on an external `opt` binary carrying our passes.
+///
+//===----------------------------------------------------------------------===//
+
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/InitLLVM.h>
+#include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/ToolOutputFile.h>
+
+#include "Reussir/LLVMPass/AllocationSimplication.h"
+#include "Reussir/LLVMPass/LinearRecurrence.h"
+#include "Reussir/LLVMPass/RuntimeFunctionAttributor.h"
+
+namespace {
+llvm::cl::opt<std::string> inputFilename(llvm::cl::Positional,
+                                         llvm::cl::desc("<input file>"),
+                                         llvm::cl::init("-"));
+llvm::cl::opt<std::string> outputFilename("o",
+                                          llvm::cl::desc("Output filename"),
+                                          llvm::cl::value_desc("filename"),
+                                          llvm::cl::init("-"));
+llvm::cl::opt<std::string>
+    passPipeline("passes",
+                 llvm::cl::desc("Textual pass pipeline (same syntax as opt)"),
+                 llvm::cl::init(""));
+} // namespace
+
+int main(int argc, char **argv) {
+  llvm::InitLLVM initLLVM(argc, argv);
+  llvm::cl::ParseCommandLineOptions(argc, argv,
+                                    "Reussir LLVM pass driver\n");
+
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic diagnostic;
+  std::unique_ptr<llvm::Module> module =
+      llvm::parseIRFile(inputFilename, diagnostic, context);
+  if (!module) {
+    diagnostic.print(argv[0], llvm::errs());
+    return 1;
+  }
+
+  llvm::PassBuilder passBuilder;
+  llvm::LoopAnalysisManager lam;
+  llvm::FunctionAnalysisManager fam;
+  llvm::CGSCCAnalysisManager cgam;
+  llvm::ModuleAnalysisManager mam;
+  passBuilder.registerModuleAnalyses(mam);
+  passBuilder.registerCGSCCAnalyses(cgam);
+  passBuilder.registerFunctionAnalyses(fam);
+  passBuilder.registerLoopAnalyses(lam);
+  passBuilder.crossRegisterProxies(lam, fam, cgam, mam);
+
+  passBuilder.registerPipelineParsingCallback(
+      [](llvm::StringRef name, llvm::ModulePassManager &mpm,
+         llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+        if (name == "reussir-recursion-linearization") {
+          mpm.addPass(reussir::llvmpass::RecursionLinearizationPass());
+          return true;
+        }
+        if (name == "reussir-allocation-simplication") {
+          mpm.addPass(reussir::llvmpass::AllocationSimplicationPass());
+          return true;
+        }
+        if (name == "reussir-runtime-function-attributor") {
+          mpm.addPass(reussir::llvmpass::RuntimeFunctionAttributorPass());
+          return true;
+        }
+        return false;
+      });
+  passBuilder.registerPipelineParsingCallback(
+      [](llvm::StringRef name, llvm::FunctionPassManager &fpm,
+         llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+        if (name == "reussir-linear-recurrence-matexp") {
+          fpm.addPass(reussir::llvmpass::LinearRecurrenceMatExpPass());
+          return true;
+        }
+        return false;
+      });
+
+  llvm::ModulePassManager mpm;
+  if (llvm::Error error =
+          passBuilder.parsePassPipeline(mpm, passPipeline)) {
+    llvm::errs() << argv[0] << ": " << llvm::toString(std::move(error))
+                 << "\n";
+    return 1;
+  }
+  mpm.run(*module, mam);
+
+  if (llvm::verifyModule(*module, &llvm::errs())) {
+    llvm::errs() << argv[0] << ": module verification failed\n";
+    return 1;
+  }
+
+  std::error_code errorCode;
+  llvm::ToolOutputFile output(outputFilename, errorCode,
+                              llvm::sys::fs::OF_Text);
+  if (errorCode) {
+    llvm::errs() << argv[0] << ": " << errorCode.message() << "\n";
+    return 1;
+  }
+  module->print(output.os(), nullptr);
+  output.keep();
+  return 0;
+}


### PR DESCRIPTION
## Summary

Two new LLVM-IR passes (`lib/LLVMPass/LinearRecurrence`) detect linear-recurrence computation in **recursive** and **loop** form and successively strength-reduce it — exponential call trees → linear loops → logarithmic-time exponentiation. The flagship consequence: the naive doubly-recursive `fibonacci` compiles to an O(log n) kernel at the default optimization level (`fib(10^15) mod 2^64` answers in microseconds from the textbook definition), but both passes are general transforms with precise applicability conditions, not a `fib` pattern-match.

### `reussir-recursion-linearization` (module pass)

Rewrites pure, directly self-recursive `f(x, c...) = combine(f(x-d_1, c...), ..., f(x-d_k, c...))` into a dynamic-programming loop over a sliding window of the last `k` results, via an outlined `alwaysinline` step helper whose window parameters stand in for the recursive calls.

- `combine` may be **any** side-effect-free, speculatable computation — modular sums, min/max-plus, FP — because the rewrite never reassociates the user's arithmetic.
- A constant *recursion floor* `C` is proven from dominating `icmp x, const` branch edges (`ConstantRange` intersection); `x < C` provably takes a call-free path, which covers base cases and makes `poison` window seeds sound. The floor's signedness lattice follows the source's own guards.
- Every instruction must be speculatable (the DP loop evaluates points the original call tree may skip): acyclic body CFG, whitelisted opcodes, division only by provably benign constants.

### `reussir-linear-recurrence-matexp` (function pass, Kitamasa method)

Recognizes single-block loops (preheader, single exit, exact SCEV backedge-taken count, no side effects) whose loop-carried integer state evolves as a constant-coefficient affine map over Z/2^N — `s' = M·s + c`, i.e. `s_n = A^n s_0` for the augmented companion matrix `A = [[M, c], [0, 1]]` of dimension D — and replaces the loop with **FFT-free Kitamasa exponentiation**, O(D² log n) instead of O(D³ log n) matrix powering:

1. `χ_A`, the characteristic polynomial of the compile-time constant `A`, is computed at compile time by **division-free cofactor expansion mod 2^N** (memoized on column subsets); monic by construction, so reduction needs no division either.
2. The emitted loop computes `z^btc mod χ_A` by square-and-multiply — each step a degree-<D polynomial multiply + monic reduction, **O(D²) ring ops with 2D loop-carried coefficients** instead of 2D² matrix entries. For fib (D=2) the loop body is 7 multiplies (spill-free on x86-64); at D=5 it is 40 multiplies per iteration (schoolbook 50 minus 10 commutative duplicates folded by EarlyCSE) vs 250 for matrix squaring.
3. By **Cayley–Hamilton** (a polynomial identity over Z, hence valid in any commutative ring incl. Z/2^N), `A^btc s_0 = Σ p_i (A^i s_0)`; the Krylov vectors are emitted once as straight-line code with the (typically sparse, 0/±1) companion entries folded away.

An FFT variant (D log D per step) only wins for D in the dozens, far beyond the `D ≤ 7` cap, so schoolbook polynomial multiplication is the right choice. Bit-exact under wrapping semantics; dropping `nsw`/`nuw` only removes poison (sound refinement). Live-outs must be affine over the header PHIs of one integer type; PHIs outside the affine closure (e.g. a different-width exit counter) die with the loop.

### Pipeline placement (extension points)

`registerLinearRecurrencePipelines()` hooks both passes into the default pipeline's extension points; the bridge and rrc/JIT pipelines register it at default/aggressive levels, and `reussir-llvm-opt --linear-recurrence-pipeline=<level>` runs the identical configuration from lit:

- **Pipeline start**: `mem2reg → recursion-linearization` — before the inliner tears the recursive shape apart.
- **Vectorizer start**: `loop-simplify → kitamasa → early-cse → instcombine` — loops are canonicalized (rotated, indvar-simplified) but **before SLP**, which otherwise vectorizes order ≥ 4 recurrence windows into vector PHIs the affine matcher cannot see (the rewrite would silently never fire); and because the rewrite runs inside the pipeline, the emitted kernel still gets the full late pipeline on top of the immediate EarlyCSE.

## Tests

- `tests/integration/llvmpass/*.ll` — structure via FileCheck and semantics via `%lli`:
  - `recursion_linearization{,_exec}.ll`: fib (unsigned + signed guards, negative inputs), an order-3 recurrence with coefficients and an inhomogeneous constant (`3g(n-1)+2g(n-3)+7`), a max-plus (nonlinear-combine) recurrence, and negatives (side effects, `f(n/2)` descent, unguarded recursion) that must stay recursive.
  - `linear_recurrence_matexp{,_exec}.ll`: rotated fib loop with a mixed-width (i32) counter, an LCG (augmentation row), a quadratic-update negative; exec test runs the same module before/after the rewrite.
  - `linear_recurrence_full_e2e.ll`: production pipeline on naive recursive fib, executing `fib(10^15) mod 2^64` — only the O(log n) path answers in time.
  - `linear_recurrence_order4_e2e.ll`: order-4 dense recurrence (D=5) pinning the vectorizer-preemption regression, executing `quart(10^14) mod 2^64`.
- `tests/integration/frontend/naive_fib_linear_recurrence.rr` + C driver — full Reussir pipeline on textbook fib: FileCheck that the optimized IR has no self-recursive call, plus execution up to `fib(10^9) mod 2^64`.
- Unit-test note: the repo's existing LLVM passes have no gtest coverage and are exercised via lit; these passes follow that convention — lit is also how LLVM itself tests passes, including execution-level checks here via `lli`.

Design notes: `docs/design/linear-recurrence.md` (shape, soundness argument, limits/future work: mutual recursion, `f(x/2)` divide-and-conquer class, explicit-modulus and other semirings, runtime break-even guard).

## Validation

The container's egress policy blocks apt.llvm.org and conda channels (LLVM 22), so the full CMake build could not run locally. Instead, both passes and the tool were compiled standalone against LLVM 18 (version-guarded where 22 changed APIs, e.g. the `SCEVExpander` constructor; sources also compile clean under `-Wextra -Wall -Werror -pedantic`), and every `.ll` test's RUN lines were replayed with that build (FileCheck + lli, all passing; `fib(10^15)` in ~22 ms, `quart(10^14)` at D=5 in ~160 ms; generated x86-64 inspected via llc). CI's LLVM 22 build is the authoritative check; the `.rr` test exercises the pipeline wiring that could not be run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bvc4SdPdoQufAZe6y3e1Gk