### PR TITLE
[frontend][mlir] polyffi: allow multiple libdirs

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -181,15 +181,17 @@ unsafe extern "C" {
     //==-- Standalone helpers --==//
 
     /// Monomorphizes and compiles polymorphic FFI operations in the module.
-    /// Returns true on success. `rust_path` and `lib_dir` name the rustc
-    /// executable and the Rust package search directory explicitly; pass empty
-    /// string refs to fall back to the `REUSSIR_RUSTC` / `REUSSIR_RUSTC_DEPS`
+    /// Returns true on success. `rust_path` and the `lib_dirs` array (of
+    /// `n_lib_dirs` entries) name the rustc executable and the Rust package
+    /// search directories explicitly; pass an empty string ref / an empty
+    /// array to fall back to the `REUSSIR_RUSTC` / `REUSSIR_RUSTC_DEPS`
     /// environment variables and the built-in probe list.
     pub fn reussirCompilePolymorphicFFI(
         module: MlirModule,
         optimized: bool,
         rust_path: MlirStringRef,
-        lib_dir: MlirStringRef,
+        lib_dirs: *const MlirStringRef,
+        n_lib_dirs: isize,
     ) -> bool;
 
     /// Gathers the LLVM bitcode modules attached to compiled operations into a

--- a/crates/reussir-backend/src/llvm.rs
+++ b/crates/reussir-backend/src/llvm.rs
@@ -35,9 +35,9 @@ use crate::pipeline::OptLevel;
 pub struct PolyffiPaths {
     /// The `rustc` executable used to compile textures.
     pub rust_path: Option<String>,
-    /// The directory searched for Rust packages (`rustc -L`) — `libreussir_rt`
-    /// and friends.
-    pub libdir: Option<String>,
+    /// The directories searched for Rust packages (one `rustc -L` each) —
+    /// `libreussir_rt` and friends.
+    pub libdirs: Vec<String>,
 }
 
 // Views an optional string as the borrowed MlirStringRef the C API takes; the
@@ -49,6 +49,19 @@ fn opt_string_ref(s: &Option<String>) -> sys::mlir_sys::MlirStringRef {
         data: s.as_ptr().cast(),
         length: s.len(),
     }
+}
+
+// Views a slice of strings as borrowed MlirStringRefs; the referents must
+// outlive every use of the result. An empty slice becomes an empty array,
+// which the C side treats as "fall back to discovery".
+fn string_refs(strings: &[String]) -> Vec<sys::mlir_sys::MlirStringRef> {
+    strings
+        .iter()
+        .map(|s| sys::mlir_sys::MlirStringRef {
+            data: s.as_ptr().cast(),
+            length: s.len(),
+        })
+        .collect()
 }
 
 /// Translates a lowered MLIR `module` to an LLVM IR module created in `context`.
@@ -124,7 +137,7 @@ impl LlvmLowering {
     /// Gathering erases the polyffi ops, so the lowering pipeline's own
     /// `CompilePolymorphicFFIPass` then sees nothing to do.
     ///
-    /// `paths` pins the rustc executable and package directory the texture
+    /// `paths` pins the rustc executable and package directories the texture
     /// compile uses; default it to keep the environment/probe discovery.
     pub fn prepare(
         module: &Module,
@@ -134,12 +147,14 @@ impl LlvmLowering {
     ) -> Result<Self, String> {
         let data_layout =
             CString::new(data_layout).map_err(|_| "data layout contains a NUL byte".to_string())?;
+        let libdirs = string_refs(&paths.libdirs);
         unsafe {
             if !sys::reussirCompilePolymorphicFFI(
                 module.to_raw(),
                 optimized,
                 opt_string_ref(&paths.rust_path),
-                opt_string_ref(&paths.libdir),
+                libdirs.as_ptr(),
+                libdirs.len() as isize,
             ) {
                 return Err("failed to compile polymorphic FFI".into());
             }

--- a/crates/reussir-backend/tests/polyffi_link.rs
+++ b/crates/reussir-backend/tests/polyffi_link.rs
@@ -42,7 +42,7 @@ fn polyffi_function_is_linked_in() {
     // passed explicitly through `PolyffiPaths` (rustc still resolves through
     // the environment/probe discovery).
     let paths = PolyffiPaths {
-        libdir: Some(env!("CARGO_MANIFEST_DIR").to_owned()),
+        libdirs: vec![env!("CARGO_MANIFEST_DIR").to_owned()],
         ..PolyffiPaths::default()
     };
 

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -225,11 +225,12 @@ struct Cli {
     polyffi_rust_path: Option<PathBuf>,
 
     /// Directory searched for the Rust packages polymorphic-FFI textures
-    /// link against (`rustc -L`) — `libreussir_rt` and friends. Takes
-    /// precedence over the `REUSSIR_RUSTC_DEPS` environment variable and the
-    /// built-in probe list.
+    /// link against (`rustc -L`) — `libreussir_rt` and friends. Repeatable;
+    /// each directory becomes its own `-L`. Takes precedence over the
+    /// `REUSSIR_RUSTC_DEPS` environment variable (itself a path-separated
+    /// list) and the built-in probe list.
     #[arg(long = "polyffi-libdir", value_name = "DIR")]
-    polyffi_libdir: Option<PathBuf>,
+    polyffi_libdir: Vec<PathBuf>,
 
     /// Let the token-reuse pass reuse tokens across function calls.
     #[arg(long = "reuse-across-call")]
@@ -691,17 +692,20 @@ fn polyffi_paths(cli: &Cli) -> Result<PolyffiPaths, String> {
         .as_deref()
         .map(resolve_rustc)
         .transpose()?;
-    let libdir = match cli.polyffi_libdir.as_deref() {
-        Some(dir) if !dir.is_dir() => {
-            return Err(format!(
-                "--polyffi-libdir `{}` is not a directory",
-                dir.display()
-            ));
-        }
-        Some(dir) => Some(dir.to_string_lossy().into_owned()),
-        None => None,
-    };
-    Ok(PolyffiPaths { rust_path, libdir })
+    let libdirs = cli
+        .polyffi_libdir
+        .iter()
+        .map(|dir| {
+            if !dir.is_dir() {
+                return Err(format!(
+                    "--polyffi-libdir `{}` is not a directory",
+                    dir.display()
+                ));
+            }
+            Ok(dir.to_string_lossy().into_owned())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(PolyffiPaths { rust_path, libdirs })
 }
 
 /// A bare `--polyffi-rust-path` name (no separator) searches `PATH`; anything

--- a/docs/design/polymorphic-ffi.md
+++ b/docs/design/polymorphic-ffi.md
@@ -142,10 +142,12 @@ possible extension; it was deliberately left out of v1.)
 The `reussir-compile-polymorphic-ffi` pass substitutes and compiles each
 texture with `rustc`. The driver flags `--polyffi-rust-path` (the `rustc`
 executable; a bare name resolves through `PATH`) and `--polyffi-libdir`
-(the package directory passed as `-L`, holding `libreussir_rt` and
-friends) pin the toolchain explicitly; they take precedence over the
-`REUSSIR_RUSTC` / `REUSSIR_RUSTC_DEPS` environment variables, which in
-turn beat the built-in probe list. The flags are the first step toward
+(a package directory passed as `-L`, holding `libreussir_rt` and
+friends; repeatable, each directory becoming its own `-L`) pin the
+toolchain explicitly; they take precedence over the `REUSSIR_RUSTC` /
+`REUSSIR_RUSTC_DEPS` environment variables (the latter a list separated
+by the platform's environment path separator), which in turn beat the
+built-in probe list. The flags are the first step toward
 building against a host `cargo`/`rustc` toolchain instead of shipping a
 full Rust sysroot alongside the compiler. `translateToModule` links the
 gathered bitcode into the final LLVM module. The JIT/REPL path does not

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -104,12 +104,15 @@ MlirPass reussirCreateReconcileUnrealizedCastsPass(void);
 //===----------------------------------------------------------------------===//
 
 // Monomorphizes and compiles polymorphic FFI operations in the module. Returns
-// true on success. `rustPath` and `libDir` name the rustc executable and the
-// Rust package search directory explicitly; pass empty string refs to fall
-// back to the REUSSIR_RUSTC / REUSSIR_RUSTC_DEPS environment variables and the
-// built-in probe list.
+// true on success. `rustPath` and the `libDirs` array (of `nLibDirs` entries)
+// name the rustc executable and the Rust package search directories
+// explicitly; pass an empty string ref / an empty array to fall back to the
+// REUSSIR_RUSTC / REUSSIR_RUSTC_DEPS environment variables and the built-in
+// probe list.
 bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized,
-                                  MlirStringRef rustPath, MlirStringRef libDir);
+                                  MlirStringRef rustPath,
+                                  const MlirStringRef *libDirs,
+                                  intptr_t nLibDirs);
 
 // Gathers the LLVM bitcode modules attached to compiled operations into a
 // single LLVM module owned by `context`. Returns NULL on failure; otherwise the

--- a/include/Reussir/Conversion/Passes.h
+++ b/include/Reussir/Conversion/Passes.h
@@ -36,15 +36,15 @@ namespace reussir {
 //
 // Compiles all uncompiled polymorphic FFI operations in the module by
 // monomorphizing their templates and compiling them to LLVM bitcode.
-// `rustPath` and `libDir`, when non-empty, name the `rustc` executable and the
-// package search directory explicitly (see `findRustCompiler` /
+// `rustPath` and `libDirs`, when non-empty, name the `rustc` executable and
+// the package search directories explicitly (see `findRustCompiler` /
 // `findRustCompilerDeps` for the fallback discovery).
 //
 //===----------------------------------------------------------------------===//
-mlir::LogicalResult compilePolymorphicFFI(mlir::ModuleOp moduleOp,
-                                          bool optimized = false,
-                                          llvm::StringRef rustPath = {},
-                                          llvm::StringRef libDir = {});
+mlir::LogicalResult
+compilePolymorphicFFI(mlir::ModuleOp moduleOp, bool optimized = false,
+                      llvm::StringRef rustPath = {},
+                      llvm::ArrayRef<llvm::StringRef> libDirs = {});
 
 //===----------------------------------------------------------------------===//
 // Variant debug-info fixup (post-translation)

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -245,11 +245,10 @@ def ReussirCompilePolymorphicFFIPass
                         /*default=*/"\"\"",
                         "explicit rustc executable used to compile FFI "
                         "templates (falls back to REUSSIR_RUSTC and probing)">,
-                 Option<"libDir", "libdir", "std::string",
-                        /*default=*/"\"\"",
-                        "directory searched for Rust packages when compiling "
-                        "FFI templates (falls back to REUSSIR_RUSTC_DEPS and "
-                        "probing)">,
+                 ListOption<"libDirs", "libdirs", "std::string",
+                        "directories searched for Rust packages when "
+                        "compiling FFI templates (falls back to "
+                        "REUSSIR_RUSTC_DEPS and probing)">,
   ];
   let dependentDialects = ["::reussir::ReussirDialect",
                            "::mlir::func::FuncDialect",

--- a/include/Reussir/RustCompiler.h
+++ b/include/Reussir/RustCompiler.h
@@ -16,10 +16,12 @@
 #pragma once
 #ifndef REUSSIR_RUSTCOMPILER_H
 #define REUSSIR_RUSTCOMPILER_H
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <memory>
+#include <string>
 
 namespace reussir {
 /// Locate the `rustc` used to compile FFI textures. A non-empty `preferred`
@@ -28,22 +30,25 @@ namespace reussir {
 /// then a list of conventional locations are probed. Empty when nothing is
 /// found.
 llvm::StringRef findRustCompiler(llvm::StringRef preferred = {});
-/// Locate the directory holding the Rust packages (`libreussir_rt` and
-/// friends) FFI textures link against (`rustc -L`). A non-empty `preferred`
-/// directory (an explicit `--polyffi-libdir`) is returned verbatim; otherwise
-/// the `REUSSIR_RUSTC_DEPS` environment variable and then conventional
-/// locations are probed. Empty when nothing is found.
-llvm::StringRef findRustCompilerDeps(llvm::StringRef preferred = {});
+/// Locate the directories holding the Rust packages (`libreussir_rt` and
+/// friends) FFI textures link against (one `rustc -L` each). Non-empty
+/// `preferred` directories (explicit `--polyffi-libdir` flags) are returned
+/// verbatim; otherwise the `REUSSIR_RUSTC_DEPS` environment variable (which
+/// may list several directories separated by the platform's environment path
+/// separator) and then conventional locations are probed. Empty when nothing
+/// is found.
+llvm::SmallVector<std::string>
+findRustCompilerDeps(llvm::ArrayRef<llvm::StringRef> preferred = {});
 std::unique_ptr<llvm::Module>
 compileRustSource(llvm::LLVMContext &context, llvm::StringRef sourceCode,
                   llvm::ArrayRef<llvm::StringRef> additionalArgs = {},
                   llvm::StringRef rustcPath = {},
-                  llvm::StringRef rustcDepsDir = {});
+                  llvm::ArrayRef<llvm::StringRef> rustcDepsDirs = {});
 std::unique_ptr<llvm::MemoryBuffer>
 compileRustSourceToBitcode(llvm::LLVMContext &context,
                            llvm::StringRef sourceCode,
                            llvm::ArrayRef<llvm::StringRef> additionalArgs = {},
                            llvm::StringRef rustcPath = {},
-                           llvm::StringRef rustcDepsDir = {});
+                           llvm::ArrayRef<llvm::StringRef> rustcDepsDirs = {});
 } // namespace reussir
 #endif // REUSSIR_RUSTCOMPILER_H

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -42,8 +42,8 @@
 #include <mlir/Transforms/Passes.h>
 
 #include "Reussir/Conversion/BasicOpsLowering.h"
-#include "Reussir/Conversion/Passes.h"
 #include "Reussir/Conversion/ConvertToSTD.h"
+#include "Reussir/Conversion/Passes.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/Transformation/Passes.h"
@@ -190,9 +190,14 @@ MlirPass reussirCreateReconcileUnrealizedCastsPass(void) {
 
 bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized,
                                   MlirStringRef rustPath,
-                                  MlirStringRef libDir) {
-  return succeeded(reussir::compilePolymorphicFFI(
-      unwrap(module), optimized, unwrap(rustPath), unwrap(libDir)));
+                                  const MlirStringRef *libDirs,
+                                  intptr_t nLibDirs) {
+  llvm::SmallVector<llvm::StringRef> dirs;
+  dirs.reserve(nLibDirs);
+  for (intptr_t i = 0; i < nLibDirs; ++i)
+    dirs.push_back(unwrap(libDirs[i]));
+  return succeeded(reussir::compilePolymorphicFFI(unwrap(module), optimized,
+                                                  unwrap(rustPath), dirs));
 }
 
 LLVMModuleRef reussirGatherCompiledModules(MlirModule module,

--- a/lib/Conversion/CompilePolymorphicFFI/CompilePolymorphicFFI.cpp
+++ b/lib/Conversion/CompilePolymorphicFFI/CompilePolymorphicFFI.cpp
@@ -190,10 +190,10 @@ static std::string monomorphize(mlir::ModuleOp moduleOp, ReussirPolyFFIOp op) {
 //===----------------------------------------------------------------------===//
 // CompilePolymorphicFFI Standalone Function
 //===----------------------------------------------------------------------===//
-mlir::LogicalResult compilePolymorphicFFI(mlir::ModuleOp moduleOp,
-                                          bool optimized,
-                                          llvm::StringRef rustPath,
-                                          llvm::StringRef libDir) {
+mlir::LogicalResult
+compilePolymorphicFFI(mlir::ModuleOp moduleOp, bool optimized,
+                      llvm::StringRef rustPath,
+                      llvm::ArrayRef<llvm::StringRef> libDirs) {
   llvm::LLVMContext context;
   llvm::SmallVector<ReussirPolyFFIOp> uncompiledOps;
   moduleOp.walk([&](ReussirPolyFFIOp op) {
@@ -208,7 +208,7 @@ mlir::LogicalResult compilePolymorphicFFI(mlir::ModuleOp moduleOp,
   for (ReussirPolyFFIOp op : uncompiledOps) {
     std::string monomorphized = monomorphize(moduleOp, op);
     std::unique_ptr<llvm::MemoryBuffer> bitcode = compileRustSourceToBitcode(
-        context, monomorphized, additionalArgs, rustPath, libDir);
+        context, monomorphized, additionalArgs, rustPath, libDirs);
     if (!bitcode)
       return mlir::failure();
     llvm::ArrayRef<char> buffer(bitcode->getBufferStart(),
@@ -240,8 +240,9 @@ public:
       ReussirCompilePolymorphicFFIPass>::ReussirCompilePolymorphicFFIPassBase;
 
   void runOnOperation() override {
-    if (failed(compilePolymorphicFFI(getOperation(), optimized, rustPath,
-                                     libDir)))
+    llvm::SmallVector<llvm::StringRef> dirs(libDirs.begin(), libDirs.end());
+    if (failed(
+            compilePolymorphicFFI(getOperation(), optimized, rustPath, dirs)))
       return signalPassFailure();
   }
 };

--- a/lib/RustCompiler/RustCompiler.cpp
+++ b/lib/RustCompiler/RustCompiler.cpp
@@ -85,30 +85,45 @@ llvm::StringRef findRustCompiler(llvm::StringRef preferred) {
   return "";
 }
 
-llvm::StringRef findRustCompilerDeps(llvm::StringRef preferred) {
-  // an explicit directory from the driver wins over the environment and the
+llvm::SmallVector<std::string>
+findRustCompilerDeps(llvm::ArrayRef<llvm::StringRef> preferred) {
+  // explicit directories from the driver win over the environment and the
   // probe
-  if (!preferred.empty())
-    return preferred;
-  // first check if REUSSIR_RUSTC_DEPS is set
-  if (const char *env_p = std::getenv("REUSSIR_RUSTC_DEPS"))
-    return env_p;
+  if (!preferred.empty()) {
+    llvm::SmallVector<std::string> dirs;
+    for (llvm::StringRef dir : preferred)
+      if (!dir.empty())
+        dirs.push_back(dir.str());
+    if (!dirs.empty())
+      return dirs;
+  }
+  // first check if REUSSIR_RUSTC_DEPS is set; it may list several directories
+  // separated by the platform's environment path separator
+  if (const char *env_p = std::getenv("REUSSIR_RUSTC_DEPS")) {
+    llvm::SmallVector<std::string> dirs;
+    llvm::SmallVector<llvm::StringRef> parts;
+    llvm::StringRef(env_p).split(parts, llvm::sys::EnvPathSeparator,
+                                 /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+    for (llvm::StringRef dir : parts)
+      dirs.push_back(dir.str());
+    if (!dirs.empty())
+      return dirs;
+  }
   for (const auto &path : RUSTC_DEPS_HINTS) {
     if (llvm::sys::fs::exists(path))
-      return llvm::sys::path::parent_path(path);
+      return {llvm::sys::path::parent_path(path).str()};
   }
-  return "";
+  return {};
 }
 
-std::unique_ptr<llvm::MemoryBuffer>
-compileRustSourceToBitcode(llvm::LLVMContext &context,
-                           llvm::StringRef sourceCode,
-                           llvm::ArrayRef<llvm::StringRef> additionalArgs,
-                           llvm::StringRef rustcPath,
-                           llvm::StringRef rustcDepsDir) {
+std::unique_ptr<llvm::MemoryBuffer> compileRustSourceToBitcode(
+    llvm::LLVMContext &context, llvm::StringRef sourceCode,
+    llvm::ArrayRef<llvm::StringRef> additionalArgs, llvm::StringRef rustcPath,
+    llvm::ArrayRef<llvm::StringRef> rustcDepsDirs) {
   rustcPath = findRustCompiler(rustcPath);
-  llvm::StringRef rustcDepsPath = findRustCompilerDeps(rustcDepsDir);
-  if (rustcPath.empty() || rustcDepsPath.empty()) {
+  llvm::SmallVector<std::string> rustcDepsPaths =
+      findRustCompilerDeps(rustcDepsDirs);
+  if (rustcPath.empty() || rustcDepsPaths.empty()) {
     llvm::SmallString<16> cwd;
     auto code = llvm::sys::fs::current_path(cwd);
     if (code) {
@@ -144,9 +159,13 @@ compileRustSourceToBitcode(llvm::LLVMContext &context,
   }
   // Prepare rustc command
   llvm::SmallVector<llvm::StringRef, 24> args = {
-      "rustc",        "-A",     "warnings",           srcFilePath,
-      "--crate-type", "cdylib", "--emit=llvm-bc",     "-L",
-      rustcDepsPath,  "-o",     resultBitcodeFilePath};
+      "rustc",          "-A",           "warnings",
+      srcFilePath,      "--crate-type", "cdylib",
+      "--emit=llvm-bc", "-o",           resultBitcodeFilePath};
+  for (const std::string &depsPath : rustcDepsPaths) {
+    args.push_back("-L");
+    args.push_back(depsPath);
+  }
   for (auto arg : additionalArgs)
     args.push_back(arg);
   // Execute rustc
@@ -183,9 +202,10 @@ compileRustSourceToBitcode(llvm::LLVMContext &context,
 std::unique_ptr<llvm::Module>
 compileRustSource(llvm::LLVMContext &context, llvm::StringRef sourceCode,
                   llvm::ArrayRef<llvm::StringRef> additionalArgs,
-                  llvm::StringRef rustcPath, llvm::StringRef rustcDepsDir) {
+                  llvm::StringRef rustcPath,
+                  llvm::ArrayRef<llvm::StringRef> rustcDepsDirs) {
   std::unique_ptr<llvm::MemoryBuffer> bitcode = compileRustSourceToBitcode(
-      context, sourceCode, additionalArgs, rustcPath, rustcDepsDir);
+      context, sourceCode, additionalArgs, rustcPath, rustcDepsDirs);
   if (!bitcode)
     return nullptr;
   auto moduleOrErr =

--- a/tests/integration/frontend/ffi_flags.rr
+++ b/tests/integration/frontend/ffi_flags.rr
@@ -1,6 +1,6 @@
 // UNSUPPORTED: darwin
 // The explicit polyffi toolchain flags: `--polyffi-rust-path` and
-// `--polyffi-libdir` pin the rustc executable and the package directory the
+// `--polyffi-libdir` pin the rustc executable and the package directories the
 // texture compile uses, taking precedence over the REUSSIR_RUSTC /
 // REUSSIR_RUSTC_DEPS environment (both unset here, so the flags are
 // load-bearing) and the probe list.
@@ -8,11 +8,18 @@
 // RUN: env -u REUSSIR_RUSTC -u REUSSIR_RUSTC_DEPS %rrc %s -o %t.o --relocation-mode pic \
 // RUN:   --polyffi-rust-path %rustc_path --polyffi-libdir %library_path
 
+// `--polyffi-libdir` is repeatable: every directory is searched (one
+// `rustc -L` each), so a package-free directory alongside the real one is
+// harmless — including listed first.
+// RUN: rm -rf %t.extra && mkdir -p %t.extra
+// RUN: env -u REUSSIR_RUSTC -u REUSSIR_RUSTC_DEPS %rrc %s -o %t.multi.o --relocation-mode pic \
+// RUN:   --polyffi-rust-path %rustc_path --polyffi-libdir %t.extra --polyffi-libdir %library_path
+
 // A missing rustc or a bogus package directory fails in the driver, before
-// the pipeline runs.
+// the pipeline runs — even when another directory in the list is fine.
 // RUN: %not %rrc %s -o %t2.o --polyffi-rust-path %t.no-such-rustc 2>&1 \
 // RUN:   | %FileCheck %s --check-prefix=NO-RUSTC
-// RUN: %not %rrc %s -o %t3.o --polyffi-libdir %t.no-such-dir 2>&1 \
+// RUN: %not %rrc %s -o %t3.o --polyffi-libdir %library_path --polyffi-libdir %t.no-such-dir 2>&1 \
 // RUN:   | %FileCheck %s --check-prefix=NO-LIBDIR
 
 // NO-RUSTC: --polyffi-rust-path

--- a/tests/unittest/cases/rustc_invoke.cpp
+++ b/tests/unittest/cases/rustc_invoke.cpp
@@ -28,19 +28,26 @@ TEST(RustCompilerTest, CompileSimpleSource) {
 }
 
 TEST(RustCompilerTest, ExplicitPathsOverrideDiscovery) {
-  // An explicit path short-circuits both the environment and the probe list.
+  // Explicit paths short-circuit both the environment and the probe list, and
+  // several package directories survive side by side.
   EXPECT_EQ(findRustCompiler("/explicit/bin/rustc"), "/explicit/bin/rustc");
-  EXPECT_EQ(findRustCompilerDeps("/explicit/lib"), "/explicit/lib");
+  llvm::SmallVector<std::string> explicitDeps =
+      findRustCompilerDeps({"/explicit/lib", "/explicit/other-lib"});
+  ASSERT_EQ(explicitDeps.size(), 2u);
+  EXPECT_EQ(explicitDeps[0], "/explicit/lib");
+  EXPECT_EQ(explicitDeps[1], "/explicit/other-lib");
 
-  // Feeding the discovered locations back as explicit arguments exercises the
-  // override path end to end.
+  // Feeding the discovered locations back as explicit arguments — alongside a
+  // second, package-free directory — exercises the override path end to end.
   llvm::StringRef rustc = findRustCompiler();
-  llvm::StringRef deps = findRustCompilerDeps();
+  llvm::SmallVector<std::string> deps = findRustCompilerDeps();
   ASSERT_FALSE(rustc.empty());
   ASSERT_FALSE(deps.empty());
+  llvm::SmallVector<llvm::StringRef> depDirs(deps.begin(), deps.end());
+  depDirs.push_back(".");
   llvm::LLVMContext context;
   std::unique_ptr<llvm::Module> m =
-      compileRustSource(context, EXAMPLE_SOURCE, {}, rustc, deps);
+      compileRustSource(context, EXAMPLE_SOURCE, {}, rustc, depDirs);
   ASSERT_NE(m, nullptr);
   EXPECT_NE(m->getFunction("__reussir_extern_Vec_f64_new"), nullptr);
 }


### PR DESCRIPTION
First checkbox of #451: `--polyffi-libdir` is now repeatable, so a polyffi build can search several Rust package directories (e.g. a `reussir_rt` sysroot plus project-level packages, ahead of the `rene` work).

- **Driver (`rrc`)**: `--polyffi-libdir DIR` accepts multiple occurrences; each directory is validated up front and becomes its own `rustc -L`.
- **Environment**: `REUSSIR_RUSTC_DEPS` may now hold several directories separated by the platform's environment path separator (`:` / `;`).
- **Plumbing**: `PolyffiPaths` carries `libdirs: Vec<String>`; `reussirCompilePolymorphicFFI` takes an array + count (following the `reussirCreateTransformPreloadLibraryPass` convention); the `reussir-compile-polymorphic-ffi` pass option becomes a `ListOption` (`libdirs=...`); `findRustCompilerDeps` returns the resolved directory list and `compileRustSource{,ToBitcode}` take `ArrayRef<StringRef>` deps dirs. Explicit dirs still beat the environment, which still beats the probe list.

Testing:
- `RustCompilerTest` extended: explicit multi-dir override round-trip, and a compile with a package-free directory alongside the discovered one.
- `frontend/ffi_flags.rr` extended: repeatable `--polyffi-libdir` (extra empty dir listed first) compiles; a bogus dir in a multi-dir list still fails in the driver.
- `polyffi_link.rs` updated to the `libdirs` field; full lit suite (415 tests) and ctest pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787456024&installation_model_id=426051&pr_number=453&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F453&signature=84dae6f18e70851647600b0d802bb5efc17fc81cc08d7bb793136744af06718d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->