### PR TITLE
[frontend] rrc: root a package at the input file via --package-name

### DIFF
--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -165,8 +165,9 @@ impl Stage {
 #[derive(Parser)]
 #[command(name = "rrc", version)]
 struct Cli {
-    /// Input file (`-` reads Reussir source from stdin). Omitted in package
-    /// mode (`--package-root`/`--package-name`).
+    /// Input file (`-` reads Reussir source from stdin). With
+    /// `--package-name`, the input file is the package's crate root; omitted
+    /// with `--package-root`.
     input: Option<PathBuf>,
 
     /// Compile a whole package rooted at this directory: `lib.rr` is the
@@ -176,8 +177,10 @@ struct Cli {
     package_root: Option<PathBuf>,
 
     /// The package's name — the first segment of every item's module path
-    /// (and of its mangled symbols). `core` is reserved for the built-in core
-    /// package.
+    /// (and of its mangled symbols). With an input file, that file becomes
+    /// the package's crate root and its `mod` declarations discover sibling
+    /// files; without one, `--package-root` names the root directory. `core`
+    /// is reserved for the built-in core package.
     #[arg(long = "package-name")]
     package_name: Option<String>,
 
@@ -484,11 +487,39 @@ fn main() -> ExitCode {
     }
 }
 
+/// Where a package compilation's crate root comes from: `lib.rr` under a
+/// `--package-root` directory, or the input file itself when `--package-name`
+/// accompanies a positional input.
+enum PackageRoot {
+    Dir(PathBuf),
+    File(PathBuf),
+}
+
 fn run(cli: &Cli) -> Result<bool, String> {
-    let package = match (&cli.package_root, &cli.package_name) {
-        (Some(root), Some(name)) => Some((root.clone(), name.clone())),
-        (None, None) => None,
-        _ => return Err("--package-root and --package-name must be given together".into()),
+    let package = match (&cli.package_root, &cli.package_name, &cli.input) {
+        (Some(_), None, _) => return Err("--package-root requires --package-name".into()),
+        (Some(_), Some(_), Some(_)) => {
+            return Err("give either an input file or --package-root, not both".into());
+        }
+        (Some(root), Some(name), None) => Some((PackageRoot::Dir(root.clone()), name.clone())),
+        (None, Some(name), Some(input)) => {
+            // The crate root anchors `mod` discovery on disk, so it must be a
+            // real file.
+            if input.as_os_str() == "-" {
+                return Err(
+                    "--package-name roots the package at the input file; stdin has no \
+                     location for `mod` discovery"
+                        .into(),
+                );
+            }
+            Some((PackageRoot::File(input.clone()), name.clone()))
+        }
+        (None, Some(_), None) => {
+            return Err(
+                "--package-name needs a crate root: an input file or --package-root".into(),
+            );
+        }
+        (None, None, _) => None,
     };
     let target = resolve_target(cli)?;
     // Only the text dumps stream to stdout; `llvm-ir`/`asm`/`obj` go through the
@@ -535,19 +566,28 @@ fn run(cli: &Cli) -> Result<bool, String> {
         features: cli.target_features.clone(),
     };
 
-    // Package mode: discover the files from `lib.rr`'s `mod` declarations and
-    // elaborate the whole package as one translation unit.
+    // Package mode: discover the files from the crate root's `mod`
+    // declarations and elaborate the whole package as one translation unit.
     if let Some((root, pkg_name)) = package {
-        if cli.input.is_some() {
-            return Err(
-                "give either an input file or --package-root/--package-name, not both".into(),
-            );
-        }
         if cli.from.is_some_and(|f| f != Stage::Rr) {
             return Err("a package is always Reussir source; --from does not apply".into());
         }
+        if let PackageRoot::File(input) = &root {
+            // A rooted input also carries an extension; make a non-source one
+            // (`.hir`, `.mir`, …) fail like `--from` instead of parsing as source.
+            if resolve_input_stage(cli, input)? != Stage::Rr {
+                return Err(
+                    "a package is always Reussir source; the crate root must be a `.rr` file"
+                        .into(),
+                );
+            }
+        }
         let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
-        let pkg = match package::load_package(&root, &pkg_name, &interner) {
+        let loaded = match &root {
+            PackageRoot::Dir(dir) => package::load_package(dir, &pkg_name, &interner),
+            PackageRoot::File(file) => package::load_package_rooted(file, &pkg_name, &interner),
+        };
+        let pkg = match loaded {
             Ok(pkg) => pkg,
             Err(package::PackageError::Message(msg)) => return Err(msg),
             Err(package::PackageError::ParseErrors {

--- a/crates/reussir-compiler/src/package.rs
+++ b/crates/reussir-compiler/src/package.rs
@@ -1,13 +1,16 @@
-//! Package discovery: map a package root directory to its source files and
-//! module paths by following `mod` declarations from `lib.rr`.
+//! Package discovery: map a package's crate-root file to its source files and
+//! module paths by following `mod` declarations.
 //!
 //! The layout follows the reference frontend (Rust-flavoured):
 //!
-//! * `lib.rr` is the crate root, module path `[package]`.
-//! * A file's **location** determines its module path — `foo.rr` and
-//!   `foo/mod.rr` are `[package, foo]`, `foo/bar.rr` is `[package, foo, bar]`
-//!   — while `mod name;` declarations only drive *discovery*: a declaration
-//!   in file `F` looks for `dir(F)/name.rr`, then `dir(F)/name/mod.rr`.
+//! * The crate root is an explicit file — `lib.rr` under `--package-root`, or
+//!   the input file itself under `<input> --package-name` — with module path
+//!   `[package]` regardless of its name.
+//! * Every other file's **location** (relative to the crate root's directory)
+//!   determines its module path — `foo.rr` and `foo/mod.rr` are
+//!   `[package, foo]`, `foo/bar.rr` is `[package, foo, bar]` — while
+//!   `mod name;` declarations only drive *discovery*: a declaration in file
+//!   `F` looks for `dir(F)/name.rr`, then `dir(F)/name/mod.rr`.
 //! * Duplicate declarations and cycles are tolerated (each file is loaded
 //!   once, keyed by its canonical path); a declaration with no source file is
 //!   an error naming both candidates.
@@ -52,18 +55,13 @@ pub enum PackageError {
     },
 }
 
-/// Load the package rooted at `root` under `name`: read `lib.rr`, follow
-/// `mod` declarations transitively, and parse every file with `interner`.
+/// Load the package rooted at the directory `root` under `name`: `lib.rr` is
+/// the crate root; see [`load_package_rooted`].
 pub fn load_package(
     root: &Path,
     name: &str,
     interner: &Arc<MultiThreadedTokenInterner>,
 ) -> Result<PackageSource, PackageError> {
-    if name == "core" {
-        return Err(PackageError::Message(
-            "package name 'core' is reserved for the built-in core package".into(),
-        ));
-    }
     let root = root.canonicalize().map_err(|e| {
         PackageError::Message(format!("cannot open package root {}: {e}", root.display()))
     })?;
@@ -74,12 +72,40 @@ pub fn load_package(
             root.display()
         )));
     }
+    load_package_rooted(&lib, name, interner)
+}
+
+/// Load the package whose crate root is the file `root_file` under `name`:
+/// follow `mod` declarations transitively from it, and parse every file with
+/// `interner`. The crate root maps to module path `[name]` whatever the file
+/// is called; every other file's path derives from its location relative to
+/// the crate root's directory.
+pub fn load_package_rooted(
+    root_file: &Path,
+    name: &str,
+    interner: &Arc<MultiThreadedTokenInterner>,
+) -> Result<PackageSource, PackageError> {
+    if name == "core" {
+        return Err(PackageError::Message(
+            "package name 'core' is reserved for the built-in core package".into(),
+        ));
+    }
+    let root_file = root_file.canonicalize().map_err(|e| {
+        PackageError::Message(format!(
+            "cannot open package crate root {}: {e}",
+            root_file.display()
+        ))
+    })?;
+    let root = root_file
+        .parent()
+        .expect("a source file has a directory")
+        .to_owned();
 
     let mut cache = SourceCache::new();
     let mut files = Vec::new();
     let mut visited: HashSet<PathBuf> = HashSet::new();
     // Depth-first from the crate root, matching declaration order.
-    let mut work: Vec<PathBuf> = vec![lib];
+    let mut work: Vec<PathBuf> = vec![root_file.clone()];
 
     while let Some(path) = work.pop() {
         let canonical = path
@@ -128,7 +154,7 @@ pub fn load_package(
         children.reverse();
         work.extend(children);
 
-        let module = module_path(&root, &canonical, name);
+        let module = module_path(&root, &root_file, &canonical, name);
         files.push(PackageSourceFile {
             file,
             module,
@@ -153,10 +179,15 @@ fn mod_decls(parse: &Parse) -> Vec<String> {
         .collect()
 }
 
-/// A file's module path from its location under the package root:
-/// `lib.rr` → `[pkg]`, `foo.rr` and `foo/mod.rr` → `[pkg, foo]`,
-/// `foo/bar.rr` → `[pkg, foo, bar]`.
-fn module_path(root: &Path, file: &Path, pkg: &str) -> Vec<String> {
+/// A file's module path: the crate-root file itself is `[pkg]` whatever its
+/// name; any other file derives from its location under the crate root's
+/// directory — `foo.rr` and `foo/mod.rr` → `[pkg, foo]`, `foo/bar.rr` →
+/// `[pkg, foo, bar]`. All paths are canonical, so identity is plain equality.
+fn module_path(root: &Path, root_file: &Path, file: &Path, pkg: &str) -> Vec<String> {
+    let mut path = vec![pkg.to_owned()];
+    if file == root_file {
+        return path;
+    }
     let rel = file.strip_prefix(root).unwrap_or(file);
     let mut segs: Vec<String> = rel
         .with_extension("")
@@ -166,10 +197,6 @@ fn module_path(root: &Path, file: &Path, pkg: &str) -> Vec<String> {
     if segs.last().is_some_and(|s| s == "mod") {
         segs.pop();
     }
-    if segs.as_slice() == ["lib"] {
-        segs.clear();
-    }
-    let mut path = vec![pkg.to_owned()];
     path.extend(segs);
     path
 }
@@ -209,6 +236,43 @@ mod tests {
             ]
         );
         assert_eq!(pkg.files[0].file, FileId::ROOT);
+    }
+
+    #[test]
+    fn roots_a_package_at_an_arbitrary_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "main.rr", "mod util;\npub fn e() -> u64 { 0 }");
+        write(dir.path(), "util.rr", "pub fn o() -> u64 { 1 }");
+        let pkg = load_package_rooted(&dir.path().join("main.rr"), "app", &interner())
+            .unwrap_or_else(|_| panic!());
+        let modules: Vec<Vec<String>> = pkg.files.iter().map(|f| f.module.clone()).collect();
+        assert_eq!(
+            modules,
+            vec![
+                vec!["app".to_owned()],
+                vec!["app".to_owned(), "util".to_owned()],
+            ]
+        );
+        assert_eq!(pkg.files[0].file, FileId::ROOT);
+    }
+
+    #[test]
+    fn a_non_root_lib_file_keeps_its_own_module_path() {
+        // Only crate-root identity collapses a file to `[pkg]`; a discovered
+        // file that happens to be called `lib.rr` is an ordinary module.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "main.rr", "mod lib;\npub fn e() -> u64 { 0 }");
+        write(dir.path(), "lib.rr", "pub fn o() -> u64 { 1 }");
+        let pkg = load_package_rooted(&dir.path().join("main.rr"), "app", &interner())
+            .unwrap_or_else(|_| panic!());
+        let modules: Vec<Vec<String>> = pkg.files.iter().map(|f| f.module.clone()).collect();
+        assert_eq!(
+            modules,
+            vec![
+                vec!["app".to_owned()],
+                vec!["app".to_owned(), "lib".to_owned()],
+            ]
+        );
     }
 
     #[test]

--- a/tests/integration/frontend/module_basic.rr
+++ b/tests/integration/frontend/module_basic.rr
@@ -4,6 +4,10 @@
 
 // RUN: %rrc --package-root %S/module_basic --package-name mylib --emit hir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc --package-root %S/module_basic --package-name mylib -o %t.o --relocation-mode pic
+
+// Rooting the package at `lib.rr` directly (`<input> --package-name`) is the
+// same compilation: identical module paths, identical HIR.
+// RUN: %rrc %S/module_basic/lib.rr --package-name mylib --emit hir --no-source-locations -o - | %FileCheck %s
 // RUN: %cc %t.o %S/module_basic/driver.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
 

--- a/tests/integration/frontend/module_root_file.rr
+++ b/tests/integration/frontend/module_root_file.rr
@@ -1,0 +1,37 @@
+// `--package-name` with a positional input roots the package at that file:
+// the crate root is `main.rr` (any name works, no `lib.rr` required), its
+// `mod` declarations discover sibling files, and every item lands under the
+// package's module path instead of the anonymous top level.
+
+// RUN: %rrc %S/module_root_file/main.rr --package-name app --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %S/module_root_file/main.rr --package-name app -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/module_root_file/driver.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// CHECK: pub fn #app::entry(v0 (n): u64) -> u64 {
+// CHECK-NEXT: #app::util::add(v0 : u64, 10 : u64) : u64
+// CHECK: pub fn #app::util::add(v0 (a): u64, v1 (b): u64) -> u64 {
+
+// The crate root anchors `mod` discovery on disk, so stdin cannot be one; a
+// package is always Reussir source, so a non-`.rr` crate root is rejected up
+// front; and the remaining flag pairings each get a driver diagnostic.
+
+// RUN: %not %rrc - --package-name app -o %t2.o < %S/module_root_file/util.rr 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=STDIN
+// STDIN: stdin has no location for `mod` discovery
+
+// RUN: %not %rrc %t.no-such.hir --package-name app -o %t3.o 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NON-SOURCE
+// NON-SOURCE: a package is always Reussir source
+
+// RUN: %not %rrc --package-name app -o %t4.o 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NO-ROOT
+// NO-ROOT: --package-name needs a crate root
+
+// RUN: %not %rrc --package-root %S/module_root_file -o %t5.o 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NO-NAME
+// NO-NAME: --package-root requires --package-name
+
+// RUN: %not %rrc %S/module_root_file/main.rr --package-root %S/module_root_file \
+// RUN:   --package-name app -o %t6.o 2>&1 | %FileCheck %s --check-prefix=BOTH
+// BOTH: give either an input file or --package-root, not both

--- a/tests/integration/frontend/module_root_file/driver.c
+++ b/tests/integration/frontend/module_root_file/driver.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+extern uint64_t entry_ffi(uint64_t n);
+
+int main() {
+  if (entry_ffi(5) != 15)
+    abort();
+  if (entry_ffi(0) != 10)
+    abort();
+  return 0;
+}

--- a/tests/integration/frontend/module_root_file/lit.local.cfg
+++ b/tests/integration/frontend/module_root_file/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/module_root_file/main.rr
+++ b/tests/integration/frontend/module_root_file/main.rr
@@ -1,0 +1,7 @@
+mod util;
+
+pub fn entry(n: u64) -> u64 {
+    util::add(n, 10)
+}
+
+extern "C" trampoline "entry_ffi" = entry;

--- a/tests/integration/frontend/module_root_file/util.rr
+++ b/tests/integration/frontend/module_root_file/util.rr
@@ -1,0 +1,3 @@
+pub fn add(a: u64, b: u64) -> u64 {
+    a + b
+}


### PR DESCRIPTION
Second checkbox of #451 ("allow specify package name in rrc, so that package inner module are no longer top-level").

`rrc file.rr --package-name foo` now compiles a *package* whose crate root is the input file itself — no `lib.rr` layout required. The root file's `mod` declarations discover sibling files exactly as in `--package-root` mode, and every item elaborates under `foo::…` module paths (and v0 mangling) instead of the anonymous top level. This is the shape `rene` will drive: it resolves the package name/root and hands both to `rrc` in one flag.

- **Loader**: `load_package_rooted(root_file, name)` generalizes discovery to an arbitrary crate-root file; `load_package(root_dir, name)` is now the thin `lib.rr` wrapper. Module-path derivation switches from the special-cased name `lib` to crate-root *identity*: the root file is `[pkg]` whatever it is called, and a discovered file that happens to be named `lib.rr` keeps its own `[pkg, lib]` path (previously it would have collided with the root).
- **Driver**: the flag matrix is validated up front — `--package-root` requires `--package-name`; an input file plus `--package-root` is rejected; `--package-name` alone names no crate root; stdin (`-`) cannot root a package (`mod` discovery is path-based); a non-`.rr` crate root is rejected before parsing. Bare `rrc file.rr` (anonymous top level) is unchanged.

Testing:
- `package.rs` unit tests: rooted discovery at `main.rr`, and the non-root-`lib.rr` identity pin.
- New lit test `frontend/module_root_file.rr`: HIR paths (`#app::entry`, `#app::util::add`), an e2e C-driver run, and all five driver-diagnostic cases.
- `module_basic.rr` gains an equivalence RUN: rooting at `module_basic/lib.rr` via `--package-name` produces the same HIR as `--package-root` mode, pinned by the same FileCheck.
- Full lit suite (416 tests) and `cargo test -p reussir-compiler` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787460360&installation_model_id=426051&pr_number=454&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F454&signature=8c2bd22efdd18ffd144782a0c3c95ae4fd4bb3f5b5b8f097aacd50367b45f180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->