### PR TITLE
[rene] initialize package manager crate: `rene build` loads and dumps the Nickel manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,10 +85,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -214,13 +232,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -319,6 +343,33 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "codespan"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583f52b0658b321b25fd6b209b6c76cf058f433071297de64e5980c3d9aad937"
+dependencies = [
+ "codespan-reporting",
+ "serde",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -730,6 +781,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -843,13 +900,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -860,8 +926,23 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -882,6 +963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +979,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -958,6 +1050,15 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json_scanner"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0a2dc336065c75719cffd3c6c929e0ec4ed85b92b8248a7bbd999acb0e419c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1138,7 +1239,16 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
 ]
 
 [[package]]
@@ -1158,12 +1268,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "logos-derive"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
- "logos-codegen",
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
 ]
 
 [[package]]
@@ -1186,6 +1319,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "malachite"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba00455c89cf785ef73a0dfc941ab3c21211963c86130c0bd48d7994b942707"
+dependencies = [
+ "malachite-base",
+ "malachite-float",
+ "malachite-nz",
+ "malachite-q",
+]
+
+[[package]]
 name = "malachite-base"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1343,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "malachite-float"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23982acc6f68aa384504a44d112f42fc82207035272f23485220a861e2cf1af"
+dependencies = [
+ "itertools 0.14.0",
+ "malachite-base",
+ "malachite-nz",
+ "malachite-q",
+ "serde",
+]
+
+[[package]]
 name = "malachite-nz"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,7 +1364,21 @@ dependencies = [
  "itertools 0.14.0",
  "libm",
  "malachite-base",
+ "serde",
  "wide",
+]
+
+[[package]]
+name = "malachite-q"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffcbeed95e34c0fcc3864ccd146e129cbbf7de1513d3afbcfb47c7674c82d94"
+dependencies = [
+ "itertools 0.14.0",
+ "libm",
+ "malachite-base",
+ "malachite-nz",
+ "serde",
 ]
 
 [[package]]
@@ -1216,6 +1388,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -1313,6 +1495,102 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nickel-lang"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5242161492409bbb82716f52e7af9c7d4ce8423d3b31d648fa818518c4d82295"
+dependencies = [
+ "codespan-reporting",
+ "indexmap",
+ "malachite",
+ "nickel-lang-core",
+ "nickel-lang-vector",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "toml",
+]
+
+[[package]]
+name = "nickel-lang-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692d8a2ba34c633bc37e704dc94f4ca33edaa8fbf6d08efdcadb81db333ccdb6"
+dependencies = [
+ "base64",
+ "bumpalo",
+ "codespan",
+ "codespan-reporting",
+ "colorchoice",
+ "indexmap",
+ "indoc",
+ "json_scanner",
+ "lalrpop",
+ "lalrpop-util",
+ "logos 0.16.1",
+ "malachite",
+ "malachite-q",
+ "md-5",
+ "nickel-lang-parser",
+ "nickel-lang-vector",
+ "once_cell",
+ "ouroboros",
+ "paste",
+ "pretty",
+ "regex",
+ "saphyr-parser",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha-1",
+ "sha2",
+ "simple-counter",
+ "smallvec",
+ "strip-ansi-escapes",
+ "strsim",
+ "toml",
+ "toml_edit 0.24.1+spec-1.1.0",
+ "typed-arena",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "nickel-lang-parser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7aaf73e60b66ef4fffc969b0e4e419a15a029525f9b53f2f5cc0ca41bbe17ff"
+dependencies = [
+ "bumpalo",
+ "codespan",
+ "codespan-reporting",
+ "indexmap",
+ "lalrpop",
+ "lalrpop-util",
+ "logos 0.16.1",
+ "malachite",
+ "nickel-lang-vector",
+ "ouroboros",
+ "pretty",
+ "regex",
+ "saphyr-parser",
+ "serde",
+ "serde_json",
+ "simple-counter",
+ "toml_edit 0.24.1+spec-1.1.0",
+ "typed-arena",
+]
+
+[[package]]
+name = "nickel-lang-vector"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f243832286908d8873add24a905d6732ffabd6cfb2bf74cb18d667e892e279"
+dependencies = [
+ "imbl-sized-chunks",
+ "serde",
+]
 
 [[package]]
 name = "nix"
@@ -1440,6 +1718,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89284d0c2af7b0eb5e814798aa07265413c8fd72009f7fc82ea25a81fb287ce9"
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "palc"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,7 +1758,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6ad802ed8080f568aa68b6fc6047f80264a6723efc0f11436f639b16a3c8bd0"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1724,6 +2026,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "pretty"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,7 +2052,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1749,6 +2062,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2002,6 +2328,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rene"
+version = "0.1.0"
+dependencies = [
+ "nickel-lang",
+ "palc",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "reussir-backend"
 version = "0.1.0"
 dependencies = [
@@ -2068,7 +2407,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lasso",
- "logos",
+ "logos 0.15.1",
  "malachite-base",
  "malachite-nz",
  "pprint",
@@ -2136,7 +2475,7 @@ dependencies = [
  "cstree",
  "lasso",
  "litrs",
- "logos",
+ "logos 0.15.1",
  "palc",
  "serde_json",
  "stacker",
@@ -2218,6 +2557,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr-parser"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
+dependencies = [
+ "arraydeque",
+ "hashlink",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,6 +2619,39 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -2346,6 +2728,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-counter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb57743b52ea059937169c0061d70298fe2df1d2c988b44caae79dd979d9b49"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2789,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,7 +2818,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2497,6 +2894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2667,6 +3073,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,14 +3107,27 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.24.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2693,8 +3136,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -2841,6 +3290,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,6 +3324,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "vtparse"
@@ -3075,6 +3539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,18 @@ members = [
     "crates/reussir-codegen",
     "crates/reussir-compiler",
     "crates/reussir-repl",
+    "crates/rene",
 ]
 # The backend crates (and reussir-codegen, which depends on them) link against
 # MLIR and the staged Reussir C API, so they are excluded from the default
 # `cargo build`; build them explicitly (e.g. `cargo build -p reussir-backend`
 # or `cargo build -p reussir-codegen`) with the CMake build wiring up the env.
-default-members = ["crates/reussir-rt", "crates/reussir-syntax", "crates/reussir-core"]
+default-members = [
+    "crates/reussir-rt",
+    "crates/reussir-syntax",
+    "crates/reussir-core",
+    "crates/rene",
+]
 
 [workspace.package]
 version = "0.1.0"
@@ -86,7 +92,11 @@ malachite-nz = "0.9"
 llvm-sys = "221"
 melior = "0.27"
 mlir-sys = "220"
+# The stable embedding interface to the Nickel configuration language; `rene`
+# evaluates package manifests (`rene.ncl`) with it.
+nickel-lang = "2.2"
 palc = "0.0.2"
+serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 stacker = "0.1.21"
 tracing = "0.1"

--- a/crates/rene/Cargo.toml
+++ b/crates/rene/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "rene"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Reussir package manager: builds packages described by a Nickel manifest"
+
+[lib]
+name = "rene"
+
+[[bin]]
+name = "rene"
+path = "src/main.rs"
+
+[dependencies]
+# Evaluates the `rene.ncl` manifest; the manifest is a full Nickel program
+# (imports, contracts, merging), not a static data file.
+nickel-lang.workspace = true
+palc.workspace = true
+serde.workspace = true
+# Re-render the evaluated manifest's JSON export pretty-printed for `build`'s
+# config dump.
+serde_json.workspace = true
+tracing.workspace = true
+# Install a subscriber so `-v`/`RUST_LOG` surface events (to stderr, never
+# stdout — the config dump owns stdout).
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+
+[dev-dependencies]
+# Auto-cleaned scratch directories for the manifest loading tests.
+tempfile = "3"

--- a/crates/rene/src/lib.rs
+++ b/crates/rene/src/lib.rs
@@ -1,0 +1,8 @@
+//! `rene`: the Reussir package manager.
+//!
+//! A package is a directory with a `rene.ncl` manifest — a Nickel program
+//! evaluating to the package description (name, dependencies, …). This first
+//! stage only locates and evaluates the manifest; driving `rrc`, dependency
+//! resolution, and project scaffolding come later.
+
+pub mod manifest;

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -1,0 +1,106 @@
+//! `rene`: the Reussir package manager driver.
+//!
+//! First stage: `rene build` locates the package manifest (`rene.ncl`),
+//! evaluates it, and dumps the resulting configuration. The actual build —
+//! resolving dependencies, detecting the Rust sysroot for polymorphic FFI,
+//! and driving `rrc` — comes in later stages.
+//!
+//! Exit 0 on success, 1 on a failed command, 2 on a usage error.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use palc::Parser;
+
+use rene::manifest;
+
+#[derive(Parser)]
+#[command(name = "rene", version)]
+struct Cli {
+    /// Verbose logging (DEBUG level; `RUST_LOG` takes precedence).
+    #[arg(short = 'v', long)]
+    verbose: bool,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(palc::Subcommand)]
+enum Command {
+    /// Build the current package. (Stub: evaluates and dumps the manifest.)
+    Build {
+        /// Path to the package manifest. Defaults to the nearest `rene.ncl`
+        /// at or above the current directory.
+        #[arg(long = "manifest-path")]
+        manifest_path: Option<PathBuf>,
+    },
+}
+
+fn main() -> ExitCode {
+    // Same convention as `rrc`: `palc` renders `--help` as a parse error, so
+    // route help back to stdout with exit 0 and keep real usage errors on
+    // stderr with exit 2.
+    let cli = match Cli::try_parse_from(std::env::args_os()) {
+        Ok(cli) => cli,
+        Err(err) => match err.try_into_help() {
+            Ok(help) => {
+                println!("{help}");
+                return ExitCode::SUCCESS;
+            }
+            Err(err) => {
+                eprintln!("{err}");
+                return ExitCode::from(2);
+            }
+        },
+    };
+    init_tracing(cli.verbose);
+    let result = match cli.command {
+        Command::Build { manifest_path } => build(manifest_path),
+    };
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            eprintln!("error: {message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Install a `tracing` subscriber writing to **stderr** (stdout belongs to the
+/// config dump). `RUST_LOG` wins if set; otherwise `-v` selects DEBUG and the
+/// default is quiet (WARN).
+fn init_tracing(verbose: bool) {
+    use tracing_subscriber::EnvFilter;
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(if verbose { "debug" } else { "warn" }));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
+}
+
+fn build(manifest_path: Option<PathBuf>) -> Result<(), String> {
+    let path = match manifest_path {
+        Some(path) => path,
+        None => {
+            let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+            manifest::locate(&cwd).ok_or_else(|| {
+                format!(
+                    "no `{}` found in `{}` or any parent directory",
+                    manifest::MANIFEST_FILE,
+                    cwd.display()
+                )
+            })?
+        }
+    };
+    let loaded = manifest::load(&path).map_err(|e| e.to_string())?;
+    tracing::debug!(
+        manifest = %loaded.path.display(),
+        package = %loaded.manifest.package.name,
+        dependencies = loaded.manifest.dependencies.len(),
+        "manifest loaded"
+    );
+    println!("TODO");
+    println!("{}", loaded.dump);
+    Ok(())
+}

--- a/crates/rene/src/manifest.rs
+++ b/crates/rene/src/manifest.rs
@@ -1,0 +1,231 @@
+//! Locating and evaluating the package manifest.
+//!
+//! The manifest is a Nickel *program*, not a data file: it may import other
+//! files, apply contracts, and merge records; `rene` sees only the fully
+//! evaluated result. Of that result only the fields in [`Manifest`] are
+//! interpreted today — everything else passes through to the dump untouched,
+//! so a manifest can carry fields for future `rene` stages (or for other
+//! tools) without being rejected.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use nickel_lang::{Context, ErrorFormat};
+use serde::Deserialize;
+
+/// The manifest file name a package directory is identified by.
+pub const MANIFEST_FILE: &str = "rene.ncl";
+
+/// The interpreted portion of an evaluated manifest.
+#[derive(Debug, Deserialize)]
+pub struct Manifest {
+    pub package: Package,
+    /// Dependencies by name. First stage: file-system paths only.
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, Dependency>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Package {
+    /// The package's name — becomes `rrc --package-name`, the first segment
+    /// of every item's module path.
+    pub name: String,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Dependency {
+    /// Directory of the dependency package, relative to the manifest's
+    /// directory unless absolute.
+    pub path: PathBuf,
+}
+
+/// A successfully loaded manifest.
+#[derive(Debug)]
+pub struct Loaded {
+    /// The manifest file the package was loaded from.
+    pub path: PathBuf,
+    pub manifest: Manifest,
+    /// The full evaluated configuration as pretty-printed JSON — including
+    /// fields [`Manifest`] does not interpret.
+    pub dump: String,
+}
+
+/// Why a manifest could not be loaded.
+#[derive(Debug)]
+pub enum ManifestError {
+    Io {
+        path: PathBuf,
+        error: std::io::Error,
+    },
+    /// Nickel evaluation failed; carries the rendered diagnostics.
+    Eval(String),
+    /// The evaluated configuration does not match the [`Manifest`] shape.
+    Schema(String),
+}
+
+impl std::fmt::Display for ManifestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ManifestError::Io { path, error } => {
+                write!(f, "cannot read `{}`: {error}", path.display())
+            }
+            ManifestError::Eval(diagnostics) => {
+                write!(f, "failed to evaluate the manifest\n{diagnostics}")
+            }
+            ManifestError::Schema(msg) => write!(f, "invalid manifest: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ManifestError {}
+
+/// Find the nearest `rene.ncl` at or above `start`, cargo-style, so `rene`
+/// works from any subdirectory of a package.
+pub fn locate(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .map(|dir| dir.join(MANIFEST_FILE))
+        .find(|candidate| candidate.is_file())
+}
+
+/// Evaluate the manifest at `path`.
+pub fn load(path: &Path) -> Result<Loaded, ManifestError> {
+    tracing::debug!(manifest = %path.display(), "evaluating manifest");
+    let source = std::fs::read_to_string(path).map_err(|error| ManifestError::Io {
+        path: path.to_owned(),
+        error,
+    })?;
+
+    // The source name is the real path, so `import` resolves relative to the
+    // manifest and diagnostics point at it; the parent directory is also an
+    // explicit import root as a fallback.
+    let mut ctx = Context::new().with_source_name(path.display().to_string());
+    if let Some(dir) = path.parent().filter(|d| !d.as_os_str().is_empty()) {
+        ctx = ctx.with_added_import_paths(vec![dir.as_os_str().to_owned()]);
+    }
+
+    // `for_export` honors `not_exported`, letting a manifest keep private
+    // helper fields out of the configuration it presents.
+    let expr = ctx
+        .eval_deep_for_export(&source)
+        .map_err(|e| ManifestError::Eval(render(&e)))?;
+    let json = ctx
+        .expr_to_json(&expr)
+        .map_err(|e| ManifestError::Eval(render(&e)))?;
+    let manifest: Manifest = expr
+        .to_serde()
+        .map_err(|e| ManifestError::Schema(e.to_string()))?;
+
+    // Nickel exports compact JSON; re-render pretty for the dump.
+    let dump = serde_json::from_str::<serde_json::Value>(&json)
+        .and_then(|v| serde_json::to_string_pretty(&v))
+        .unwrap_or(json);
+
+    Ok(Loaded {
+        path: path.to_owned(),
+        manifest,
+        dump,
+    })
+}
+
+/// Render a Nickel error's diagnostics as plain text (no ANSI: the result is
+/// embedded in a [`ManifestError`] and may end up in logs or test output).
+fn render(error: &nickel_lang::Error) -> String {
+    let mut out = Vec::new();
+    match error.format(&mut out, ErrorFormat::Text) {
+        Ok(()) => String::from_utf8_lossy(&out).trim_end().to_owned(),
+        Err(e) => format!("(diagnostics unavailable: {e})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_manifest(dir: &Path, text: &str) -> PathBuf {
+        let path = dir.join(MANIFEST_FILE);
+        std::fs::write(&path, text).unwrap();
+        path
+    }
+
+    #[test]
+    fn loads_a_minimal_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"{ package = { name = "hello", version = "0.1.0" } }"#,
+        );
+
+        let loaded = load(&path).unwrap();
+        assert_eq!(loaded.manifest.package.name, "hello");
+        assert_eq!(loaded.manifest.package.version.as_deref(), Some("0.1.0"));
+        assert!(loaded.manifest.dependencies.is_empty());
+        // The dump carries the evaluated config.
+        assert!(loaded.dump.contains("\"hello\""));
+    }
+
+    #[test]
+    fn manifest_is_a_program_with_path_dependencies() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Nickel evaluation (interpolation, merging) happens before `rene`
+        // reads the result, and unknown fields pass through untouched.
+        let path = write_manifest(
+            tmp.path(),
+            r#"
+            let base = "my" in
+            {
+              package = { name = "%{base}lib" },
+              dependencies.utils = { path = "../utils" },
+              future-field = { anything = [1, 2, 3] },
+            }
+            "#,
+        );
+
+        let loaded = load(&path).unwrap();
+        assert_eq!(loaded.manifest.package.name, "mylib");
+        assert_eq!(loaded.manifest.package.version, None);
+        assert_eq!(
+            loaded.manifest.dependencies["utils"].path,
+            PathBuf::from("../utils")
+        );
+        assert!(loaded.dump.contains("future-field"));
+    }
+
+    #[test]
+    fn locate_walks_up_from_a_subdirectory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_manifest(tmp.path(), r#"{ package = { name = "up" } }"#);
+        let sub = tmp.path().join("src").join("nested");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        assert_eq!(locate(&sub).as_deref(), Some(&*path));
+        assert_eq!(locate(tmp.path()).as_deref(), Some(&*path));
+    }
+
+    #[test]
+    fn evaluation_errors_carry_diagnostics() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A contract violation: `name` must be a string.
+        let path = write_manifest(
+            tmp.path(),
+            r#"{ package = { name | String = 42 } }"#,
+        );
+
+        match load(&path) {
+            Err(ManifestError::Eval(diag)) => assert!(diag.contains("contract")),
+            other => panic!("expected an evaluation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn schema_errors_name_the_problem() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_manifest(tmp.path(), r#"{ package = { version = "1" } }"#);
+
+        match load(&path) {
+            Err(ManifestError::Schema(_)) => {}
+            other => panic!("expected a schema error, got {other:?}"),
+        }
+    }
+}

--- a/crates/rene/tests/build_dump.rs
+++ b/crates/rene/tests/build_dump.rs
@@ -1,0 +1,62 @@
+//! End-to-end test of the `rene build` stub against the demo package in
+//! `tests/demo-pkg`: locate/evaluate the manifest, print `TODO`, dump the
+//! evaluated configuration.
+
+use std::path::Path;
+use std::process::Command;
+
+fn demo_manifest() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("demo-pkg")
+        .join("rene.ncl")
+}
+
+#[test]
+fn build_prints_todo_then_dumps_the_config() {
+    let out = Command::new(env!("CARGO_BIN_EXE_rene"))
+        .args(["build", "--manifest-path"])
+        .arg(demo_manifest())
+        .output()
+        .expect("failed to spawn rene");
+
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let mut lines = stdout.lines();
+    assert_eq!(lines.next(), Some("TODO"));
+
+    // The rest is the evaluated manifest as JSON.
+    let dump: serde_json::Value = serde_json::from_str(&lines.collect::<Vec<_>>().join("\n"))
+        .expect("dump is not valid JSON");
+    assert_eq!(dump["package"]["name"], "demo");
+    assert_eq!(dump["dependencies"]["utils"]["path"], "vendor/utils");
+}
+
+#[test]
+fn build_locates_the_manifest_from_a_subdirectory() {
+    let out = Command::new(env!("CARGO_BIN_EXE_rene"))
+        .arg("build")
+        .current_dir(demo_manifest().parent().unwrap().join("vendor"))
+        .output()
+        .expect("failed to spawn rene");
+
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    // `vendor/` has no manifest of its own; the walk-up finds the demo
+    // package's. (`vendor/utils/` does have one — from there, that one wins.)
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("\"demo\""), "stdout: {stdout}");
+}
+
+#[test]
+fn build_fails_cleanly_without_a_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_rene"))
+        .arg("build")
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to spawn rene");
+
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("rene.ncl"), "stderr: {stderr}");
+}

--- a/crates/rene/tests/demo-pkg/rene.ncl
+++ b/crates/rene/tests/demo-pkg/rene.ncl
@@ -1,0 +1,21 @@
+# A demo `rene` package manifest. The manifest is a Nickel program: bindings,
+# string interpolation, contracts, and imports all run before `rene` reads the
+# evaluated record. Try it from anywhere under this directory:
+#
+#     rene build
+#
+# NOTE: fields must not reference other record fields by bare name — Nickel
+# records are recursive, so `name = name` is infinite recursion; bind helpers
+# with `let` instead.
+let pkg_name = "demo" in
+{
+  package = {
+    name | String = pkg_name,
+    version = "0.1.0",
+  },
+  # First stage: dependencies are file-system paths, relative to this file.
+  # (Not resolved yet — recorded and dumped only.)
+  dependencies = {
+    utils = { path = "vendor/utils" },
+  },
+}

--- a/crates/rene/tests/demo-pkg/vendor/utils/rene.ncl
+++ b/crates/rene/tests/demo-pkg/vendor/utils/rene.ncl
@@ -1,0 +1,5 @@
+# The dependency package `demo` points at, so the demo stays coherent once
+# path dependencies are actually resolved.
+{
+  package = { name = "utils", version = "0.1.0" },
+}


### PR DESCRIPTION
First stage of the `rene` package manager (part of #451): the crate skeleton plus config loading, nothing more.

## What's here

- **`crates/rene`** — new workspace crate (lib `rene` + bin `rene`), added to `members` and `default-members` (no MLIR linkage).
- **`rene build`** — locates the nearest `rene.ncl` at or above the current directory (cargo-style walk-up, or `--manifest-path`), evaluates it, prints `TODO`, and dumps the evaluated configuration as pretty-printed JSON on stdout.
- **Manifest loading** (`src/manifest.rs`) — the manifest is a full Nickel *program* (imports, contracts, merging), evaluated with the stable `nickel-lang` 2.2 embedding crate. The typed `Manifest` reads `package.name`/`version` and file-system `dependencies.<name>.path` (matching the #451 bullets); unknown fields pass through to the dump untouched so the schema can grow without breaking manifests. Evaluation errors render full Nickel diagnostics with source snippets.
- **CLI conventions mirror `rrc`** — palc parser, help-to-stdout/exit-0 handling, exit codes 0/1/2, and the same tracing setup (`-v` → DEBUG, `RUST_LOG` wins, events to stderr so stdout stays a clean dump).

## Demo

`crates/rene/tests/demo-pkg/` is a runnable demo package (and the integration-test fixture):

```console
$ cd crates/rene/tests/demo-pkg
$ cargo run -p rene -- -v build
TODO
{
  "dependencies": { "utils": { "path": "vendor/utils" } },
  "package": { "name": "demo", "version": "0.1.0" }
}
```

## Tests

5 unit tests (minimal manifest, Nickel-program manifest with interpolation + passthrough fields, walk-up locate, evaluation diagnostics, schema errors) and 3 integration tests driving the built binary end to end (`TODO` + JSON dump, subdirectory locate, clean failure without a manifest). `cargo test -p rene`, `cargo clippy -p rene`, and the default-member `cargo build` are green.

## Next stages (not in this PR)

`rene new`/`init` scaffolding (VCS + gitignore), path-dependency resolution, Rust sysroot detection for polyffi, and driving `rrc --package-root/--package-name` from the loaded manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787460687&installation_model_id=426051&pr_number=455&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F455&signature=00aa4254f25fff6f8b7bcc20f46f05bf76850b3fc5f72eb96f24ba5a3d8e0c1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->