### PR TITLE
[ci] test rene on push/PR: clippy, fast suite, and the host-toolchain bake

### DIFF
--- a/.github/workflows/rene-test.yml
+++ b/.github/workflows/rene-test.yml
@@ -1,0 +1,66 @@
+name: Rene Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'crates/rene/**'
+      # rene's build script bundles the reussir-rt source tree (and the
+      # workspace manifest/lock it rewrites against) into the binary, so
+      # changes there change what the tests bake.
+      - 'crates/reussir-rt/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/rene-test.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'crates/rene/**'
+      - 'crates/reussir-rt/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/rene-test.yml'
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test (rene)
+    strategy:
+      fail-fast: false
+      matrix:
+        # rene is a plain Rust crate (no LLVM/MLIR build), so testing it on
+        # every platform users run it on is cheap. Windows is left out for
+        # now: the fake-toolchain CLI test is unix-only (#[cfg(unix)] shell
+        # scripts), which would leave Windows covering almost nothing.
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly-2026-02-15
+          components: clippy
+
+      - name: Clippy
+        run: cargo clippy -p rene --all-targets -- -D warnings
+
+      # The fast suite: manifest loading, build-dir locking, the clean
+      # protocol, and the bake driven through fake cargo/rustc scripts.
+      - name: Run tests
+        run: cargo test -p rene
+
+      # The real thing, ignored by default because it is slow and
+      # network-dependent: unpack the bundled runtime and bake reussir-rt
+      # with the host toolchain (crates.io + the pinned mlir-sync git rev).
+      - name: Run host-toolchain bake test
+        run: cargo test -p rene --test cli -- --ignored

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -111,13 +111,17 @@ fn clean_errors_out_when_the_db_is_in_use() {
 fn build_bakes_the_runtime_and_prints_the_libdirs() {
     use std::os::unix::fs::PermissionsExt;
 
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path().join("reussir-build");
-    let libdir = tmp.path().join("fake-rust-libdir");
+    let tmp_dir = tempfile::tempdir().unwrap();
+    // Canonicalized: macOS tempdirs sit behind the `/var -> /private/var`
+    // symlink, and the deps line rene prints comes from cargo's artifact
+    // report, whose paths the fake cargo roots at the resolved `$PWD`.
+    let tmp = tmp_dir.path().canonicalize().unwrap();
+    let root = tmp.join("reussir-build");
+    let libdir = tmp.join("fake-rust-libdir");
     std::fs::create_dir_all(&libdir).unwrap();
 
     let script = |name: &str, body: String| -> PathBuf {
-        let path = tmp.path().join(name);
+        let path = tmp.join(name);
         std::fs::write(&path, format!("#!/bin/sh\n{body}")).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
         path
@@ -181,7 +185,7 @@ fn build_bakes_the_runtime_and_prints_the_libdirs() {
     let out = build(&root);
     assert!(out.status.success(), "stderr: {}", stderr(&out));
     assert_eq!(String::from_utf8(out.stdout).unwrap(), stdout);
-    let runs = std::fs::read_to_string(tmp.path().join("cargo-runs")).unwrap();
+    let runs = std::fs::read_to_string(tmp.join("cargo-runs")).unwrap();
     assert_eq!(runs.lines().count(), 1, "the second build re-ran cargo");
 }
 


### PR DESCRIPTION
Adds `.github/workflows/rene-test.yml`, a CI pipeline for the `rene` package manager crate (follow-up to #455/#456).

## What it runs

Each matrix job, on the workspace's pinned `nightly-2026-02-15`:

1. `cargo clippy -p rene --all-targets -- -D warnings` — the crate is clippy-clean today, so warnings are denied from the start.
2. `cargo test -p rene` — the fast suite: manifest loading, build-dir locking, the clean protocol, and the bake driven through fake `cargo`/`rustc` scripts.
3. `cargo test -p rene --test cli -- --ignored` — the end-to-end test that unpacks the bundled runtime and really bakes `reussir-rt` with the host toolchain (crates.io + the pinned mlir-sync git rev), which is exactly the network-dependent path a CI runner can exercise.

All three were verified passing locally on the pinned toolchain.

## Shape

- **Path-filtered** (mirroring `miri-reussir-rt.yml`): `crates/rene/**`, plus the build-script inputs that change what the tests bake — `crates/reussir-rt/**` (the bundled source) and the workspace `Cargo.toml`/`Cargo.lock` (rewritten/shipped by `build.rs`) — and the workflow file itself.
- **Matrix**: `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15` — rene is a plain Rust crate (no LLVM/MLIR build), so covering the platforms users run it on is cheap. Windows is left out for now: the fake-toolchain CLI test is `#[cfg(unix)]` (shell scripts), which would leave a Windows job covering almost nothing.
- `actions-rust-lang/setup-rust-toolchain@v1` provides cargo caching out of the box, same as the other workflows.

A deliberate omission: no `cargo fmt --check`. The crate's current (merged) code deviates from rustfmt's output in ~10 places, and no other workflow in the repo enforces fmt — adding the gate would need a reformat commit first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015to8AnNr9YhnzRfs7tjvEd

---
_Generated by [Claude Code](https://claude.ai/code/session_015to8AnNr9YhnzRfs7tjvEd)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787497823&installation_model_id=426051&pr_number=457&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F457&signature=be5293aa570dfe5c2730017f03c32b662cd0758dbf02f112e8cde02137df72c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->