### PR TITLE
[frontend] rrc: --scan-deps lists the package source graph instead of compiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "reussir-codegen",
  "reussir-core",
  "reussir-syntax",
+ "serde_json",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/crates/reussir-compiler/Cargo.toml
+++ b/crates/reussir-compiler/Cargo.toml
@@ -31,6 +31,9 @@ reussir-codegen = { path = "../reussir-codegen" }
 reussir-core = { path = "../reussir-core" }
 reussir-syntax = { path = "../reussir-syntax" }
 palc.workspace = true
+# Encodes the `--scan-deps` source-graph listing (and lets the driver tests
+# parse it back).
+serde_json.workspace = true
 # The lowering and backend pipeline emit `tracing` events; install a subscriber
 # so `-v`/`RUST_LOG` surface them (to stderr, never stdout).
 tracing.workspace = true

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -181,11 +181,18 @@ struct Cli {
     #[arg(long = "package-name")]
     package_name: Option<String>,
 
+    /// Instead of compiling, list every file in the package's source graph —
+    /// `lib.rr` plus everything reachable through `mod` declarations — one
+    /// canonical path per line, in discovery order. Requires package mode;
+    /// the list goes to `-o` (stdout by default).
+    #[arg(long = "scan-deps")]
+    scan_deps: bool,
+
     /// Output file (`-` writes a text dump — `hir`/`mir`/`mlir`/`mlir-llvm` — to
     /// stdout). The target stage is inferred from its extension unless `--emit`
-    /// is given.
+    /// is given. Required except with `--scan-deps`.
     #[arg(short = 'o', long)]
-    output: PathBuf,
+    output: Option<PathBuf>,
 
     /// Stage to emit: `hir`, `mir`, `mlir`, `mlir-llvm`, `llvm-ir`, `asm`, or
     /// `obj`. Defaults to the output extension (else `obj`).
@@ -351,7 +358,7 @@ fn resolve_input_stage(cli: &Cli, input: &Path) -> Result<Stage, String> {
 fn resolve_target(cli: &Cli) -> Result<Stage, String> {
     let stage = cli
         .emit
-        .or_else(|| Stage::from_extension(&cli.output))
+        .or_else(|| cli.output.as_deref().and_then(Stage::from_extension))
         .unwrap_or(Stage::Obj);
     if stage == Stage::Rr {
         return Err("`rr` is the source input, not an emittable stage".into());
@@ -490,10 +497,20 @@ fn run(cli: &Cli) -> Result<bool, String> {
         (None, None) => None,
         _ => return Err("--package-root and --package-name must be given together".into()),
     };
+
+    // `--scan-deps` stops after discovery: list the package's source graph
+    // instead of compiling.
+    if cli.scan_deps {
+        return scan_deps(cli, package.as_ref());
+    }
+
+    let Some(output) = cli.output.as_deref() else {
+        return Err("no output file given; pass -o".into());
+    };
     let target = resolve_target(cli)?;
     // Only the text dumps stream to stdout; `llvm-ir`/`asm`/`obj` go through the
     // file-based LLVM emitter, so `-o -` would write a file literally named `-`.
-    if cli.output.as_os_str() == "-" && target.output_kind().is_some() {
+    if output.as_os_str() == "-" && target.output_kind().is_some() {
         return Err(format!(
             "cannot write `{target}` to stdout; give a file path with -o"
         ));
@@ -522,7 +539,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
                 .into(),
         );
     }
-    if cli.codegen_units > 1 && cli.output.as_os_str() == "-" {
+    if cli.codegen_units > 1 && output.as_os_str() == "-" {
         return Err(
             "--codegen-units > 1 writes one file per unit; give a file path with -o".into(),
         );
@@ -547,24 +564,10 @@ fn run(cli: &Cli) -> Result<bool, String> {
             return Err("a package is always Reussir source; --from does not apply".into());
         }
         let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
-        let pkg = match package::load_package(&root, &pkg_name, &interner) {
+        let pkg = match load_package_or_render(&root, &pkg_name, &interner) {
             Ok(pkg) => pkg,
-            Err(package::PackageError::Message(msg)) => return Err(msg),
-            Err(package::PackageError::ParseErrors {
-                cache,
-                file,
-                errors,
-            }) => {
-                let color = std::io::stderr().is_terminal();
-                let _ = diagnostics::render_errors(
-                    &cache,
-                    file,
-                    &errors,
-                    color,
-                    std::io::stderr().lock(),
-                );
-                return Ok(false);
-            }
+            Err(msg) if msg.is_empty() => return Ok(false),
+            Err(msg) => return Err(msg),
         };
         let name = pkg.cache.name(FileId::ROOT).to_owned();
         let context = reussir_backend::context();
@@ -581,7 +584,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
                     return Ok(false);
                 }
             };
-        return backend(cli, &context, produced, target, opt, reloc, &spec, &name);
+        return backend(cli, &context, produced, target, opt, reloc, &spec, &name, output);
     }
 
     let Some(input) = &cli.input else {
@@ -610,7 +613,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
             .ok_or_else(|| format!("cannot emit `{target}` from LLVM IR"))?;
         let machine = TargetMachine::new(&spec, opt, reloc)?;
         let finalized = parse_llvm_ir(&name, source)?;
-        emit_to_file(finalized, &machine, opt, kind, &cli.output)?;
+        emit_to_file(finalized, &machine, opt, kind, output)?;
         return Ok(true);
     }
 
@@ -634,7 +637,57 @@ fn run(cli: &Cli) -> Result<bool, String> {
             }
         },
     };
-    backend(cli, &context, produced, target, opt, reloc, &spec, &name)
+    backend(cli, &context, produced, target, opt, reloc, &spec, &name, output)
+}
+
+/// Discover and parse the package, rendering syntax errors through the same
+/// ariadne path as compile diagnostics.
+///
+/// An empty `Err` string signals diagnostics were already printed (a compile
+/// failure, exit 1) rather than a driver error (exit 2).
+fn load_package_or_render(
+    root: &Path,
+    name: &str,
+    interner: &std::sync::Arc<reussir_syntax::MultiThreadedTokenInterner>,
+) -> Result<package::PackageSource, String> {
+    match package::load_package(root, name, interner) {
+        Ok(pkg) => Ok(pkg),
+        Err(package::PackageError::Message(msg)) => Err(msg),
+        Err(package::PackageError::ParseErrors {
+            cache,
+            file,
+            errors,
+        }) => {
+            let color = std::io::stderr().is_terminal();
+            let _ = diagnostics::render_errors(&cache, file, &errors, color, std::io::stderr().lock());
+            Err(String::new())
+        }
+    }
+}
+
+/// `--scan-deps`: run package discovery — which parses every file to follow
+/// its `mod` declarations — and list the source graph instead of compiling,
+/// one canonical path per line in discovery order.
+fn scan_deps(cli: &Cli, package: Option<&(PathBuf, String)>) -> Result<bool, String> {
+    let Some((root, pkg_name)) = package else {
+        return Err("--scan-deps requires --package-root/--package-name".into());
+    };
+    if cli.input.is_some() {
+        return Err("give either an input file or --package-root/--package-name, not both".into());
+    }
+    let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+    let pkg = match load_package_or_render(root, pkg_name, &interner) {
+        Ok(pkg) => pkg,
+        Err(msg) if msg.is_empty() => return Ok(false),
+        Err(msg) => return Err(msg),
+    };
+    let mut list = String::new();
+    for file in &pkg.files {
+        list.push_str(pkg.cache.name(file.file));
+        list.push('\n');
+    }
+    write_text(cli.output.as_deref().unwrap_or(Path::new("-")), &list)?;
+    Ok(true)
 }
 
 /// The shared back leg from a produced text/module: write a text dump, or run
@@ -649,17 +702,18 @@ fn backend(
     reloc: RelocMode,
     spec: &TargetSpec,
     name: &str,
+    output: &Path,
 ) -> Result<bool, String> {
     let module = match produced {
         Produced::Text(text) => {
-            write_text(&cli.output, &text)?;
+            write_text(output, &text)?;
             return Ok(true);
         }
         // A partitioned build runs the whole back leg once per unit, writing
         // `<stem>.<i>.<ext>` siblings of `-o`.
         Produced::Units(units) => {
             for (index, module) in units.into_iter().enumerate() {
-                let out = unit_output(&cli.output, index);
+                let out = unit_output(output, index);
                 backend_module(cli, context, module, target, opt, reloc, spec, name, &out)?;
             }
             return Ok(true);
@@ -668,15 +722,7 @@ fn backend(
     };
 
     backend_module(
-        cli,
-        context,
-        module,
-        target,
-        opt,
-        reloc,
-        spec,
-        name,
-        &cli.output.clone(),
+        cli, context, module, target, opt, reloc, spec, name, output,
     )
 }
 

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -181,10 +181,11 @@ struct Cli {
     #[arg(long = "package-name")]
     package_name: Option<String>,
 
-    /// Instead of compiling, list every file in the package's source graph —
-    /// `lib.rr` plus everything reachable through `mod` declarations — one
-    /// canonical path per line, in discovery order. Requires package mode;
-    /// the list goes to `-o` (stdout by default).
+    /// Instead of compiling, describe the package's source graph — `lib.rr`
+    /// plus everything reachable through `mod` declarations — as JSON:
+    /// `{"package": …, "files": [{"path": …, "module": […]}]}`, with files in
+    /// discovery order and paths canonical. Requires package mode; the JSON
+    /// goes to `-o` (stdout by default).
     #[arg(long = "scan-deps")]
     scan_deps: bool,
 
@@ -666,8 +667,9 @@ fn load_package_or_render(
 }
 
 /// `--scan-deps`: run package discovery — which parses every file to follow
-/// its `mod` declarations — and list the source graph instead of compiling,
-/// one canonical path per line in discovery order.
+/// its `mod` declarations — and describe the source graph as JSON instead of
+/// compiling: the package name and, in discovery order, every file's
+/// canonical path and module path.
 fn scan_deps(cli: &Cli, package: Option<&(PathBuf, String)>) -> Result<bool, String> {
     let Some((root, pkg_name)) = package else {
         return Err("--scan-deps requires --package-root/--package-name".into());
@@ -681,12 +683,21 @@ fn scan_deps(cli: &Cli, package: Option<&(PathBuf, String)>) -> Result<bool, Str
         Err(msg) if msg.is_empty() => return Ok(false),
         Err(msg) => return Err(msg),
     };
-    let mut list = String::new();
-    for file in &pkg.files {
-        list.push_str(pkg.cache.name(file.file));
-        list.push('\n');
-    }
-    write_text(cli.output.as_deref().unwrap_or(Path::new("-")), &list)?;
+    let files: Vec<serde_json::Value> = pkg
+        .files
+        .iter()
+        .map(|file| {
+            serde_json::json!({
+                "path": pkg.cache.name(file.file),
+                "module": file.module,
+            })
+        })
+        .collect();
+    let graph = serde_json::json!({ "package": pkg_name, "files": files });
+    let mut text = serde_json::to_string_pretty(&graph)
+        .map_err(|e| format!("failed to encode the source graph: {e}"))?;
+    text.push('\n');
+    write_text(cli.output.as_deref().unwrap_or(Path::new("-")), &text)?;
     Ok(true)
 }
 

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -285,3 +285,89 @@ fn compiles_to_the_wasm_target() {
         &bytes[..bytes.len().min(8)]
     );
 }
+
+/// `--scan-deps` lists the package source graph — `lib.rr` plus everything
+/// reachable through `mod` declarations — as canonical paths in discovery
+/// order, without compiling anything.
+#[test]
+fn scan_deps_lists_the_package_source_graph() {
+    let dir = scratch("scan-deps");
+    let write = |rel: &str, content: &str| {
+        let path = dir.path().join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, content).unwrap();
+        path
+    };
+    let lib = write("lib.rr", "mod utils;\npub fn e() -> u64 { 0 }");
+    let utils = write("utils/mod.rr", "mod math;\npub fn o() -> u64 { 1 }");
+    let math = write("utils/math.rr", "pub fn d(x: u64) -> u64 { x }");
+
+    let output = rrc(&[
+        Path::new("--package-root"),
+        dir.path(),
+        Path::new("--package-name"),
+        Path::new("mypkg"),
+        Path::new("--scan-deps"),
+    ]);
+    assert!(
+        output.status.success(),
+        "scan-deps failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Discovery canonicalizes (macOS tempdirs sit behind /var -> /private/var);
+    // compare against the canonical form of each expected file.
+    let canonical = |path: &Path| {
+        path.canonicalize()
+            .expect("canonicalize expected path")
+            .display()
+            .to_string()
+    };
+    let stdout = String::from_utf8(output.stdout).expect("scan-deps stdout is utf-8");
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        [canonical(&lib), canonical(&utils), canonical(&math)],
+        "stdout:\n{stdout}"
+    );
+}
+
+/// `-o` redirects the `--scan-deps` listing into a file.
+#[test]
+fn scan_deps_writes_the_listing_to_the_output_file() {
+    let dir = scratch("scan-deps-o");
+    std::fs::write(dir.path().join("lib.rr"), "pub fn e() -> u64 { 0 }").unwrap();
+    let out = dir.path().join("deps.txt");
+    let output = rrc(&[
+        Path::new("--package-root"),
+        dir.path(),
+        Path::new("--package-name"),
+        Path::new("p"),
+        Path::new("--scan-deps"),
+        Path::new("-o"),
+        &out,
+    ]);
+    assert!(
+        output.status.success(),
+        "scan-deps failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stdout.is_empty(), "listing must go to -o, not stdout");
+    let listing = read(&out);
+    let expected = dir.path().join("lib.rr").canonicalize().unwrap();
+    assert_eq!(listing.trim(), expected.display().to_string());
+}
+
+/// Without package mode there is no source graph to scan.
+#[test]
+fn scan_deps_requires_package_mode() {
+    let (_dir, src) = source("scan-deps-nopkg");
+    let output = rrc(&[&src, Path::new("--scan-deps")]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected a usage error, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--package-root"), "stderr:\n{stderr}");
+}

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -286,9 +286,9 @@ fn compiles_to_the_wasm_target() {
     );
 }
 
-/// `--scan-deps` lists the package source graph — `lib.rr` plus everything
-/// reachable through `mod` declarations — as canonical paths in discovery
-/// order, without compiling anything.
+/// `--scan-deps` describes the package source graph — `lib.rr` plus
+/// everything reachable through `mod` declarations — as JSON with canonical
+/// paths and module paths in discovery order, without compiling anything.
 #[test]
 fn scan_deps_lists_the_package_source_graph() {
     let dir = scratch("scan-deps");
@@ -323,10 +323,18 @@ fn scan_deps_lists_the_package_source_graph() {
             .to_string()
     };
     let stdout = String::from_utf8(output.stdout).expect("scan-deps stdout is utf-8");
-    let lines: Vec<&str> = stdout.lines().collect();
+    let graph: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{stdout}"));
     assert_eq!(
-        lines,
-        [canonical(&lib), canonical(&utils), canonical(&math)],
+        graph,
+        serde_json::json!({
+            "package": "mypkg",
+            "files": [
+                { "path": canonical(&lib), "module": ["mypkg"] },
+                { "path": canonical(&utils), "module": ["mypkg", "utils"] },
+                { "path": canonical(&math), "module": ["mypkg", "utils", "math"] },
+            ],
+        }),
         "stdout:\n{stdout}"
     );
 }
@@ -352,9 +360,12 @@ fn scan_deps_writes_the_listing_to_the_output_file() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(output.stdout.is_empty(), "listing must go to -o, not stdout");
-    let listing = read(&out);
+    let graph: serde_json::Value = serde_json::from_str(&read(&out)).expect("bad JSON in -o file");
     let expected = dir.path().join("lib.rr").canonicalize().unwrap();
-    assert_eq!(listing.trim(), expected.display().to_string());
+    assert_eq!(
+        graph["files"][0]["path"],
+        serde_json::json!(expected.display().to_string())
+    );
 }
 
 /// Without package mode there is no source graph to scan.


### PR DESCRIPTION
Adds a build-tooling query to the driver: `rrc --package-root <dir> --package-name <name> --scan-deps` stops after package discovery and, instead of compiling, describes the package's source graph — `lib.rr` plus everything reachable through `mod` declarations — as JSON on `-o` (stdout by default), giving tools like `rene` a structured way to enumerate a package's inputs for staleness tracking:

```json
{
  "package": "demo",
  "files": [
    { "path": "/abs/pkg/lib.rr", "module": ["demo"] },
    { "path": "/abs/pkg/utils/mod.rr", "module": ["demo", "utils"] },
    { "path": "/abs/pkg/utils/math.rr", "module": ["demo", "utils", "math"] }
  ]
}
```

Files appear in discovery order with canonical paths; each entry carries the module path its location derives.

## Changes

- **`--scan-deps` flag** (package mode only): reuses `package::load_package`, so discovery semantics — DFS in declaration order, per-file dedup by canonical path, parse-error rendering — are exactly those of package-mode compilation. Parse errors render through the usual ariadne path and exit 1; missing package flags are a usage error (exit 2). The graph is encoded with serde_json (already a workspace dependency).
- **`-o` becomes `Option<PathBuf>`**: still effectively required for every compiling mode (a clear driver error replaces the parser's "required argument" one), optional for `--scan-deps` where stdout is the natural default. The resolved output path now threads through `backend`/`backend_module` instead of being re-read from the CLI struct.
- **Shared helper** `load_package_or_render`: the package loading + parse-error rendering previously inlined in package-mode compilation, now used by both callers.
- **Driver tests**: the JSON graph's content/order for a nested package, the `-o` redirect, and the package-mode requirement. Expected paths are compared canonicalized (macOS tempdirs sit behind the `/var -> /private/var` symlink).

## Verification

Built and tested locally against a conda-forge LLVM/MLIR 22.1.8 toolchain (the same LLVM the Windows CI uses): the full `rrc-test` target passes — 13/13 driver tests (including the three `--scan-deps` tests) plus the package-discovery unit tests — and a manual `rrc --package-root … --scan-deps` smoke run prints the JSON graph above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015to8AnNr9YhnzRfs7tjvEd