### PR TITLE
[frontend] give the builtin type formers module homes under core::intrinsic, imported as a prelude

### DIFF
--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1652,19 +1652,30 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let expanded = self.expand_path(path);
         let path = expanded.as_ref().unwrap_or(path);
         let qualifier = path.segments.last().copied();
-        // The built-in nullable constructors.
-        if qualifier.map(|k| self.sym(k)) == Some("Nullable") {
+        // The built-in nullable constructors, canonically
+        // `core::intrinsic::nullable::Nullable::…` and prelude-imported as bare
+        // `Nullable::…`; a user record named `Nullable` shadows the bare form.
+        if qualifier.map(|k| self.sym(k)) == Some("Nullable")
+            && self.ctor_qualifier_prelude_applies(path, "nullable")
+        {
             return self.infer_nullable(self.sym(path.basename), args, span);
         }
-        // The built-in arc-coloring constructors (a root builtin, never
-        // module-qualified): `Arc<Inner>{…}` builds the `[shared]` struct
-        // `Inner` behind an atomically counted box, `Arc<Enum<…>>::Variant{…}`
-        // the enum flavor. `Arc<X>` is a specially colored version of `X`, so
-        // the constructor is the inner record's own, at the arc'd type.
-        if path.segments.is_empty() && self.sym(path.basename) == "Arc" {
+        // The built-in arc-coloring constructors, canonically
+        // `core::intrinsic::arc::Arc` and prelude-imported as bare `Arc`:
+        // `Arc<Inner>{…}` builds the `[shared]` struct `Inner` behind an
+        // atomically counted box, `Arc<Enum<…>>::Variant{…}` the enum flavor.
+        // `Arc<X>` is a specially colored version of `X`, so the constructor
+        // is the inner record's own, at the arc'd type. A user record named
+        // `Arc` shadows the bare form like any other prelude name.
+        if self.sym(path.basename) == "Arc"
+            && (path.segments.is_empty() && self.defs.resolve_record(path.basename).is_none()
+                || self.is_core_intrinsic_prefix(&path.segments, "arc"))
+        {
             return self.infer_arc_ctor(ty_args, None, args, span);
         }
-        if path.segments.len() == 1 && self.sym(path.segments[0]) == "Arc" {
+        if qualifier.map(|k| self.sym(k)) == Some("Arc")
+            && self.ctor_qualifier_prelude_applies(path, "arc")
+        {
             return self.infer_arc_ctor(ty_args, Some(path.basename), args, span);
         }
         if let Some(enum_key) = qualifier {

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -739,6 +739,37 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
     }
 
+    /// Whether `prefix` spells the canonical `core::intrinsic::<family>`
+    /// module of a prelude builtin. The package name `core` is reserved, so
+    /// the qualified spelling can never collide with user code.
+    pub(super) fn is_core_intrinsic_prefix(&self, prefix: &[TokenKey], family: &str) -> bool {
+        prefix.len() == 3
+            && self.sym(prefix[0]) == "core"
+            && self.sym(prefix[1]) == "intrinsic"
+            && self.sym(prefix[2]) == family
+    }
+
+    /// Whether a constructor path whose *qualifier* names a prelude builtin
+    /// (`Nullable::…`, `Arc::Variant`) targets that builtin: the canonical
+    /// `core::intrinsic::<family>::<Name>::…` spelling, or the prelude's
+    /// bare `<Name>::…` when no user record shadows the name (a shadowing
+    /// definition or import dispatches through ordinary enum resolution
+    /// instead).
+    pub(super) fn ctor_qualifier_prelude_applies(
+        &self,
+        path: &surface::Path,
+        family: &str,
+    ) -> bool {
+        let Some((_, prefix)) = path.segments.split_last() else {
+            return false;
+        };
+        if prefix.is_empty() {
+            self.resolve_ctor_qualifier(path).is_none()
+        } else {
+            self.is_core_intrinsic_prefix(prefix, family)
+        }
+    }
+
     /// Enter `def`'s declaration scope: reports attribute to `file`, and
     /// bare/relative references resolve against the item's own module (its
     /// qualified path minus the item name).
@@ -1339,16 +1370,6 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
         }
         let name = rec.name;
-        if matches!(self.sym(name), "Cell" | "RefCell" | "Arc") {
-            self.error(
-                span,
-                format!(
-                    "record name `{}` is reserved for the builtin type",
-                    self.sym(name)
-                ),
-            );
-            return None;
-        }
         let Some(def) = self.defs.declare_record(name) else {
             self.error(
                 span,

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -338,8 +338,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             None => ctor,
         };
         // The built-in nullable constructors, by the same qualifier convention
-        // as [`Elaborator::infer_ctor`] on the expression side.
-        if ctor.path.segments.last().map(|k| self.sym(*k)) == Some("Nullable") {
+        // as [`Elaborator::infer_ctor`] on the expression side: the canonical
+        // `core::intrinsic::nullable::Nullable::…`, or the prelude's bare
+        // `Nullable::…` when no user record shadows the name.
+        if ctor.path.segments.last().map(|k| self.sym(*k)) == Some("Nullable")
+            && self.ctor_qualifier_prelude_applies(&ctor.path, "nullable")
+        {
             return self.check_nullable_pat(ctor, span, ty);
         }
         let TyKind::Record { def, args, .. } = ty.kind() else {

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -103,13 +103,22 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let path = expanded.as_ref().unwrap_or(path);
         let key = path.basename;
 
-        // Built-in cell type constructors are roots and never
-        // module-qualified. `Cell<T>` is the plain get/set cell; `RefCell<T>`
-        // the exclusive flavor with guarded read-modify-write; `Atomic<T>`,
-        // `Mutex<T>`, `FlatLock<T>`, and `RwLock<T>` are the synchronization
-        // kinds (thread-safety design §4), each with its own element bound
-        // checked by [`Elaborator::report_cell_wf`].
-        if path.segments.is_empty()
+        // The prelude builtin type formers live in `core::intrinsic::cell`
+        // (the cell kinds — the synchronization kinds are just special
+        // cells) and `core::intrinsic::nullable` (`Nullable`); their bare
+        // names are default-imported as a prelude, so a bare spelling
+        // resolves here unless a user record of the same name shadows it —
+        // the same precedence a real import would have. The canonical
+        // qualified spelling always names the builtin (`core` is reserved).
+        let bare_unshadowed =
+            path.segments.is_empty() && self.defs.resolve_record(key).is_none();
+
+        // The cell type constructors: `Cell<T>` is the plain get/set cell;
+        // `RefCell<T>` the exclusive flavor with guarded read-modify-write;
+        // `Atomic<T>`, `Mutex<T>`, `FlatLock<T>`, and `RwLock<T>` are the
+        // synchronization kinds (thread-safety design §4), each with its own
+        // element bound checked by [`Elaborator::report_cell_wf`].
+        if (bare_unshadowed || self.is_core_intrinsic_prefix(&path.segments, "cell"))
             && let Some(kind) = crate::semi::ty::CellKind::parse(self.sym(key))
         {
             let name = kind.surface_name();
@@ -135,8 +144,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             };
         }
 
-        // The built-in nullable type (a root builtin: never module-qualified).
-        if path.segments.is_empty() && self.sym(key) == "Nullable" {
+        // The built-in nullable type, `core::intrinsic::nullable::Nullable`.
+        if (bare_unshadowed || self.is_core_intrinsic_prefix(&path.segments, "nullable"))
+            && self.sym(key) == "Nullable"
+        {
             return match args {
                 [inner] => {
                     let inner = self.eval_type(inner);
@@ -165,12 +176,13 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             };
         }
 
-        // The built-in atomic-rc coloring (a root builtin: never
-        // module-qualified). `Arc<X>` is the shared rc box `X` — a `[shared]`
-        // record, an array, or a closure — whose refcount is adjusted
-        // atomically, so the value may cross threads; everything but the rc
-        // discipline is `X`'s own.
-        if path.segments.is_empty() && self.sym(key) == "Arc" {
+        // The built-in atomic-rc coloring, `core::intrinsic::arc::Arc`.
+        // `Arc<X>` is the shared rc box `X` — a `[shared]` record, an array,
+        // or a closure — whose refcount is adjusted atomically, so the value
+        // may cross threads; everything but the rc discipline is `X`'s own.
+        if (bare_unshadowed || self.is_core_intrinsic_prefix(&path.segments, "arc"))
+            && self.sym(key) == "Arc"
+        {
             return match args {
                 [inner] => {
                     let inner = self.eval_type(inner);
@@ -203,6 +215,16 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     self.tcx.mk(TyKind::Bottom)
                 }
             };
+        }
+
+        // Nothing else under the reserved `core` package names a type.
+        if path.segments.first().map(|&k| self.sym(k)) == Some("core") {
+            let shown = self.path_display(path);
+            self.error(
+                Some(span),
+                format!("the built-in `core` package has no type `{shown}`"),
+            );
+            return self.tcx.mk(TyKind::Bottom);
         }
 
         // A user record, resolved to its def — bare in the current module, or

--- a/tests/integration/frontend/arc_errors.rr
+++ b/tests/integration/frontend/arc_errors.rr
@@ -1,11 +1,12 @@
 // RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
 
-// Arc is a root builtin type constructor.
+// Arc is a prelude builtin type constructor, canonically
+// `core::intrinsic::arc::Arc`; both spellings check their arity.
 // CHECK-DAG: `Arc` takes exactly one type argument
 fn missing_type(a: Arc) -> i64 { 0 }
 
-// CHECK-DAG: record name `Arc` is reserved for the builtin type
-struct Arc { value: i64 }
+// CHECK-DAG: `Arc` takes exactly one type argument
+fn missing_type_qualified(a: core::intrinsic::arc::Arc) -> i64 { 0 }
 
 // Only a shared rc box — a [shared] record, an array, or a closure — can be
 // arc-colored.

--- a/tests/integration/frontend/cell_errors.rr
+++ b/tests/integration/frontend/cell_errors.rr
@@ -2,18 +2,20 @@
 
 import core::intrinsic::cell;
 
-// Cell and RefCell are root builtin type constructors.
+// Cell and RefCell are prelude builtin type constructors, canonically
+// `core::intrinsic::cell::…`; both spellings check their arity.
 // CHECK-DAG: `Cell` takes exactly one type argument
 fn missing_type(c: Cell) -> i64 { 0 }
 
 // CHECK-DAG: `RefCell` takes exactly one type argument
 fn missing_ref_type(c: RefCell) -> i64 { 0 }
 
-// CHECK-DAG: record name `Cell` is reserved for the builtin type
-struct Cell { value: i64 }
+// CHECK-DAG: `Mutex` takes exactly one type argument
+fn missing_qualified(c: core::intrinsic::cell::Mutex) -> i64 { 0 }
 
-// CHECK-DAG: record name `RefCell` is reserved for the builtin type
-struct RefCell { value: i64 }
+// Nothing else under the reserved `core` package names a type.
+// CHECK-DAG: the built-in `core` package has no type `core::intrinsic::cell::Box`
+fn not_a_cell(c: core::intrinsic::cell::Box) -> i64 { 0 }
 
 // A mutable `[field]` link must still point at a regional record, not a Cell.
 // CHECK-DAG: a `[field]` link element must be a regional record

--- a/tests/integration/frontend/prelude_types.rr
+++ b/tests/integration/frontend/prelude_types.rr
@@ -1,0 +1,71 @@
+// The prelude builtin type formers and their canonical `core::intrinsic`
+// homes: `cell::{Cell, RefCell, Atomic, Mutex, FlatLock, RwLock}`,
+// `arc::Arc`, and `nullable::Nullable`. The bare names are default-imported
+// as a prelude; the canonical paths resolve directly and through `import`
+// aliases; and a user record of the same name shadows the bare prelude name
+// while the canonical path keeps naming the builtin.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s -o %t.o
+
+import core::intrinsic::cell;
+import core::intrinsic::cell::RefCell as XCell;
+import core::intrinsic::nullable::Nullable as Opt;
+import core::intrinsic::arc::Arc as SharedRc;
+
+struct [shared] Data { value: i64 }
+struct RcBox { value: i64 }
+
+// The canonical qualified spellings name the same types as the prelude.
+// CHECK: pub fn #qualified(v0 (c): Cell<i64>, v1 (r): RefCell<i64>) -> i64
+pub fn qualified(
+    c: core::intrinsic::cell::Cell<i64>,
+    r: core::intrinsic::cell::RefCell<i64>
+) -> i64 {
+    cell::get(c) + cell::get(r)
+}
+
+// An `import` alias of a canonical type path spells the builtin.
+// CHECK: pub fn #aliased(v0 (r): RefCell<i64>) -> Cell<i64>
+pub fn aliased(r: XCell<i64>) -> core::intrinsic::cell::Cell<i64> {
+    cell::alloc(cell::get(r))
+}
+
+// Arc, canonically `core::intrinsic::arc::Arc`, in type and ctor position.
+// CHECK: pub fn #arced() -> Arc<#Data>
+// CHECK: NonNull(#Data{42 : i64} : Arc<#Data>) : Nullable<Arc<#Data>>
+pub fn arced() -> core::intrinsic::arc::Arc<Data> {
+    let a = SharedRc<Data> { value: 21 };
+    let n = Opt::NonNull { SharedRc<Data> { value: 42 } };
+    match n {
+        Opt::NonNull(b) => b,
+        Opt::Null => a
+    }
+}
+
+// The qualified nullable spelling, in type and ctor position.
+// CHECK: pub fn #wrapped(v0 (v): i64) -> Nullable<#RcBox>
+pub fn wrapped(v: i64) -> core::intrinsic::nullable::Nullable<RcBox> {
+    core::intrinsic::nullable::Nullable::NonNull { RcBox { value: v } }
+}
+
+// A user record shadows the bare prelude name — the same precedence a real
+// import has — while the canonical path still names the builtin.
+struct [value] Mutex { value: i64 }
+
+// CHECK: pub fn #shadowed(v0 (m): #Mutex, v1 (b): Mutex<i64>) -> i64
+pub fn shadowed(m: Mutex, b: core::intrinsic::cell::Mutex<i64>) -> i64 {
+    m.value + cell::get(b)
+}
+
+// A user enum named `Nullable` shadows the prelude's constructors and
+// patterns, not just the type name.
+enum Nullable { A, B }
+
+// CHECK: pub fn #shadow_enum() -> i32
+pub fn shadow_enum() -> i32 {
+    match Nullable::A {
+        Nullable::A => 0,
+        Nullable::B => 1
+    }
+}


### PR DESCRIPTION
Part of #451 ("move Cells/NonNulls into `core::intrinsic` modules; but make them default imported as prelude").

## What changed

- **Canonical module homes** for the builtin type formers, resolvable in type, constructor, and pattern position:
  - `core::intrinsic::cell::{Cell, RefCell, Atomic, Mutex, FlatLock, RwLock}` (the sync kinds are just special cells, so they share the `cell` module)
  - `core::intrinsic::arc::Arc`
  - `core::intrinsic::nullable::Nullable` (including `…::Nullable::NonNull` / `…::Nullable::Null` constructors and patterns)
- **Import aliases of the canonical paths work** like any other import: `import core::intrinsic::cell::RefCell as XCell;`, `import core::intrinsic::nullable::Nullable as Opt;` then `Opt::NonNull{…}` / `match … { Opt::Null => … }`.
- **The bare names become a default prelude import** rather than hard root builtins: a user record of the same name now shadows the bare spelling (the same precedence a real import has), while the canonical path keeps naming the builtin. The `Cell`/`RefCell`/`Arc` record-name reservation is lifted accordingly.
- **Tightened constructor-qualifier dispatch**: previously *any* path ending in `Nullable` (e.g. `m::Nullable::X`) silently hit the builtin constructors; now only the bare-unshadowed or canonical spellings do, so a user enum named `Nullable` dispatches normally.
- Other paths under the reserved `core` package now report a dedicated `the built-in `core` package has no type …` diagnostic instead of the generic unknown-type error.

The `core::intrinsic::cell::*` *operations* (`alloc`/`get`/`set`/`rmw`/…) are untouched — they remain a single family dispatching on the operand's cell kind, as before.

## Testing

- New `tests/integration/frontend/prelude_types.rr` covers the qualified spellings, alias imports, and both struct- and enum-shadowing of prelude names.
- `cell_errors.rr` / `arc_errors.rr` updated for the lifted reservation and the new qualified/wrong-path diagnostics.
- Full lit suite passes (412 pass, 8 unsupported); `cargo test -p reussir-core` and clippy clean (no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787542540&installation_model_id=426051&pr_number=462&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F462&signature=515ce288ca95af117acefdd42334daf7f7715429585fd78599b427be740d1557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->