### PR TITLE
[frontend] rrc: executable and dynlib output modes

### DIFF
--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -19,9 +19,9 @@ use std::process::ExitCode;
 
 use palc::Parser;
 
+use reussir_backend::llvm::LtoMode;
 use reussir_backend::llvm::{LlvmLowering, PolyffiPaths};
 use reussir_backend::melior::ir::Module;
-use reussir_backend::llvm::LtoMode;
 use reussir_backend::pipeline::{self, Anchor, LoweringOptions, NullaryVariantEncoding, OptLevel};
 use reussir_codegen::lower::{
     CodegenUnit, LinkagePolicy, LoweringError, Sanitizer, lower_program, lower_unit,
@@ -66,15 +66,18 @@ enum Stage {
     Obj,
     /// A static library archiving the codegen units (`.a`/`.lib`).
     Staticlib,
-    /// A dynamic library (`.so`/`.dylib`/`.dll`). Not implemented yet.
+    /// A linked dynamic library (`.so`/`.dylib`/`.dll`) exporting the
+    /// program's `extern` trampolines.
     Dynlib,
-    /// A linked executable. Not implemented yet.
+    /// A linked executable (`.exe` on Windows), entered through the program's
+    /// `#[main]` function.
     Executable,
 }
 
 /// Whether the emitted code is packaged for link-time optimization, and how.
-/// Only a static library carries LTO today: its members become bitcode the
-/// linker optimizes across, instead of finished native objects.
+/// A static library's members become bitcode the consumer's linker optimizes
+/// across, instead of finished native objects; for the two linked targets the
+/// driver's own link step hands that bitcode to the linker.
 #[derive(Clone, Copy, PartialEq, Eq, palc::ValueEnum)]
 enum Lto {
     /// No LTO: each codegen unit is compiled to native code here.
@@ -84,6 +87,20 @@ enum Lto {
     Thin,
     /// Full ("fat") LTO: bitcode the linker merges into one module.
     Fat,
+}
+
+/// How a linked target (`--emit executable`/`dynlib`) carries the Reussir
+/// runtime.
+#[derive(Clone, Copy, PartialEq, Eq, palc::ValueEnum)]
+enum RuntimeLinkage {
+    /// Bundle the runtime's static archive into the product. Self-contained —
+    /// the result has no load-time dependency on a Reussir library — and the
+    /// default.
+    Static,
+    /// Link against the shared runtime library. One runtime per process no
+    /// matter how many Reussir products load into it, but the library must be
+    /// found at load time (rpath or the platform's search path).
+    Dynamic,
 }
 
 impl From<Lto> for LtoMode {
@@ -181,24 +198,32 @@ impl Stage {
             // stage. Dynamic libraries are named per platform.
             "a" | "lib" => Stage::Staticlib,
             "so" | "dylib" | "dll" => Stage::Dynlib,
+            "exe" => Stage::Executable,
             _ => return None,
         })
     }
 
-    /// The artifact each codegen unit is emitted as. For a static library
-    /// that is its *members*: finished objects normally, bitcode under LTO,
-    /// which the archive then collects.
+    /// The artifact each codegen unit is emitted as. For a static library and
+    /// the two linked targets that is their *intermediates*: finished objects
+    /// normally, bitcode under LTO — which the archive then collects, or the
+    /// link step hands to the linker.
     fn output_kind(self, lto: Lto) -> Option<OutputKind> {
         match self {
             Stage::LlvmIr => Some(OutputKind::LlvmIr),
             Stage::Asm => Some(OutputKind::Assembly),
             Stage::Obj => Some(OutputKind::Object),
-            Stage::Staticlib => Some(match lto {
+            Stage::Staticlib | Stage::Dynlib | Stage::Executable => Some(match lto {
                 Lto::None => OutputKind::Object,
                 packaged => OutputKind::Bitcode(packaged.into()),
             }),
             _ => None,
         }
+    }
+
+    /// Whether this stage is a linked product — the two targets the driver
+    /// finishes with a link step rather than a file emitter.
+    fn is_linked(self) -> bool {
+        matches!(self, Stage::Dynlib | Stage::Executable)
     }
 }
 
@@ -240,18 +265,39 @@ struct Cli {
     output: Option<PathBuf>,
 
     /// Stage to emit: `hir`, `mir`, `mlir`, `mlir-llvm`, `llvm-ir`, `asm`,
-    /// `obj`, or `staticlib`. Defaults to the output extension (else `obj`).
-    /// `dynlib` and `executable` are recognized but not implemented yet.
+    /// `obj`, `staticlib`, `dynlib`, or `executable`. Defaults to the output
+    /// extension (else `obj`).
     #[arg(short = 't', long = "emit")]
     emit: Option<Stage>,
 
-    /// Package a static library for link-time optimization: `none` (the
-    /// default) archives finished native objects, while `thin` and `fat`
-    /// archive LLVM bitcode built by the matching LTO pre-link pipeline, so
-    /// the linker optimizes across every codegen unit — and across this
-    /// library and its consumers. Applies to `--emit staticlib`.
+    /// Build with link-time optimization: `none` (the default) emits finished
+    /// native objects, while `thin` and `fat` emit LLVM bitcode built by the
+    /// matching LTO pre-link pipeline, so the linker optimizes across every
+    /// codegen unit. For `staticlib` the bitcode is archived for the
+    /// consumer's linker; for `dynlib` and `executable` the driver's own link
+    /// step hands it to the linker, which must carry the LTO plugin.
     #[arg(long = "lto", value_enum, default_value_t = Lto::None)]
     lto: Lto,
+
+    /// How a linked target carries the Reussir runtime: `static` (the
+    /// default) bundles the runtime archive into the product; `dynamic` links
+    /// the shared runtime library, which must then be found at load time.
+    /// Applies to `--emit executable` and `--emit dynlib`.
+    #[arg(long = "runtime-linkage", value_enum)]
+    runtime_linkage: Option<RuntimeLinkage>,
+
+    /// The linker rustc drives for the link step, passed as `-C linker=`.
+    /// Useful where rustc's own discovery resolves the wrong tool — a vcvars
+    /// shell whose PATH carries a coreutils `link` ahead of MSVC's. Applies
+    /// to `--emit executable` and `--emit dynlib`.
+    #[arg(long = "linker", value_name = "PATH")]
+    linker: Option<PathBuf>,
+
+    /// Extra argument for the link step, passed through as `-C link-arg=`
+    /// (repeatable; appended after the driver's own link inputs). Applies to
+    /// `--emit executable` and `--emit dynlib`.
+    #[arg(long = "link-arg", value_name = "ARG")]
+    link_arg: Vec<String>,
 
     /// Treat the input as this stage instead of inferring from its extension:
     /// `rr`, `hir`, `mir`, `mlir`, or `llvm-ir`.
@@ -494,11 +540,18 @@ fn write_text(path: &Path, text: &str) -> Result<(), String> {
 /// What the front (arena-scoped) leg produces: a text dump for `hir`/`mir`, or an
 /// MLIR module for `mlir` and anything past it. The module borrows the MLIR
 /// context, not the type arena, so it outlives the [`in_arena`] scope.
+/// The C-ABI export surface the front leg collected: the program's exported
+/// (non-import) trampoline symbols, `#[main]`'s `__reussir_main` among them.
+/// `None` when the input entered past MIR (`.mlir`/`.ll`), where the surface
+/// is no longer recorded — the link step then cannot name a dynamic library's
+/// exports, and skips the executable's entry-point pre-check.
+type ExportSurface = Option<Vec<String>>;
+
 enum Produced<'c> {
     Text(String),
-    Module(Module<'c>),
+    Module(Module<'c>, ExportSurface),
     /// One module per codegen unit (`--codegen-units` > 1), in unit order.
-    Units(Vec<Module<'c>>),
+    Units(Vec<Module<'c>>, ExportSurface),
 }
 
 /// Install a `tracing` subscriber writing to **stderr** (so it never corrupts a
@@ -590,24 +643,34 @@ fn run(cli: &Cli) -> Result<bool, String> {
         return Err("no output file given; pass -o".into());
     };
     let target = resolve_target(cli)?;
-    // Linking is not implemented; refuse the two stages that need a linker
-    // before doing any work, rather than compiling and then failing.
-    if matches!(target, Stage::Dynlib | Stage::Executable) {
+    if cli.lto != Lto::None && target != Stage::Staticlib && !target.is_linked() {
         return Err(format!(
-            "emitting `{target}` is not implemented yet: it needs a link step. \
-             Emit `obj` or `staticlib` and link with the C toolchain."
+            "--lto applies to `staticlib`, `dynlib`, and `executable`, not \
+             `{target}`: only a packaged or linked target consumes the \
+             bitcode it produces"
         ));
     }
-    if cli.lto != Lto::None && target != Stage::Staticlib {
-        return Err(format!(
-            "--lto applies to `--emit staticlib`, not `{target}`: only a \
-             static library carries the bitcode a link-time optimization \
-             consumes"
-        ));
+    // The link-step knobs mean nothing without a link step; refuse them up
+    // front rather than silently ignoring them.
+    if !target.is_linked() {
+        if cli.runtime_linkage.is_some() {
+            return Err(format!(
+                "--runtime-linkage applies to `executable` and `dynlib`, not `{target}`"
+            ));
+        }
+        if cli.linker.is_some() {
+            return Err(format!(
+                "--linker applies to `executable` and `dynlib`, not `{target}`"
+            ));
+        }
+        if !cli.link_arg.is_empty() {
+            return Err(format!(
+                "--link-arg applies to `executable` and `dynlib`, not `{target}`"
+            ));
+        }
     }
-    // Only the text dumps stream to stdout; `llvm-ir`/`asm`/`obj`/`staticlib`
-    // go through file-based emitters, so `-o -` would write a file literally
-    // named `-`.
+    // Only the text dumps stream to stdout; the file-emitting and linked
+    // targets would write a file literally named `-`.
     if output.as_os_str() == "-" && target.output_kind(cli.lto).is_some() {
         return Err(format!(
             "cannot write `{target}` to stdout; give a file path with -o"
@@ -687,7 +750,9 @@ fn run(cli: &Cli) -> Result<bool, String> {
                     return Ok(false);
                 }
             };
-        return backend(cli, &context, produced, target, opt, reloc, &spec, &name, output);
+        return backend(
+            cli, &context, produced, target, opt, reloc, &spec, &name, output,
+        );
     }
 
     let Some(input) = &cli.input else {
@@ -708,6 +773,16 @@ fn run(cli: &Cli) -> Result<bool, String> {
             "--codegen-units applies while lowering to MLIR; a `{input_stage}` input is already a single unit"
         ));
     }
+    // A dynamic library's exports are the trampolines the *frontend* records;
+    // a backend-stage input no longer carries them, and exporting every
+    // external symbol instead would leak the cross-unit linkage surface.
+    if target == Stage::Dynlib && matches!(input_stage, Stage::Mlir | Stage::LlvmIr) {
+        return Err(format!(
+            "cannot emit `dynlib` from a `{input_stage}` input: the export surface \
+             (the program's trampolines) is only recorded up to `mir`; resume from \
+             source, `hir`, or `mir`"
+        ));
+    }
     // A `.ll` input skips the whole MLIR front: parse the IR and run the LLVM
     // backend straight to the requested artifact.
     if input_stage == Stage::LlvmIr {
@@ -716,11 +791,15 @@ fn run(cli: &Cli) -> Result<bool, String> {
             .ok_or_else(|| format!("cannot emit `{target}` from LLVM IR"))?;
         let machine = TargetMachine::new(&spec, opt, reloc)?;
         let finalized = parse_llvm_ir(&name, source)?;
-        // One module, so a static library here archives a single member.
-        if target == Stage::Staticlib {
-            let mut lib = StaticLib::new(output, cli.lto)?;
+        // One module, so a static library here archives a single member, and
+        // an executable links a single object.
+        if target == Stage::Staticlib || target.is_linked() {
+            let mut lib = ScratchMembers::new(output, cli.lto)?;
             emit_to_file(finalized, &machine, opt, kind, &lib.next_member())?;
-            return lib.finish(output, machine.triple()).map(|()| true);
+            if target == Stage::Staticlib {
+                return lib.finish(output, machine.triple()).map(|()| true);
+            }
+            return link_product(cli, target, machine.triple(), None, &lib, output).map(|()| true);
         }
         emit_to_file(finalized, &machine, opt, kind, output)?;
         return Ok(true);
@@ -734,7 +813,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
     // input parses directly; source/`.hir`/`.mir` run the frontend in the arena.
     let produced = match input_stage {
         Stage::Mlir => Module::parse(&context, source)
-            .map(Produced::Module)
+            .map(|module| Produced::Module(module, None))
             .ok_or_else(|| format!("{name}: failed to parse MLIR module"))?,
         _ => match in_arena(|tcx| frontend(&context, tcx, input_stage, target, &sources, cli)) {
             Ok(produced) => produced,
@@ -746,7 +825,9 @@ fn run(cli: &Cli) -> Result<bool, String> {
             }
         },
     };
-    backend(cli, &context, produced, target, opt, reloc, &spec, &name, output)
+    backend(
+        cli, &context, produced, target, opt, reloc, &spec, &name, output,
+    )
 }
 
 /// Discover and parse the package from its crate root — `lib.rr` under a
@@ -773,7 +854,8 @@ fn load_package_or_render(
             errors,
         }) => {
             let color = std::io::stderr().is_terminal();
-            let _ = diagnostics::render_errors(&cache, file, &errors, color, std::io::stderr().lock());
+            let _ =
+                diagnostics::render_errors(&cache, file, &errors, color, std::io::stderr().lock());
             Err(String::new())
         }
     }
@@ -829,28 +911,42 @@ fn backend(
     name: &str,
     output: &Path,
 ) -> Result<bool, String> {
-    let (modules, partitioned) = match produced {
+    let (modules, partitioned, exports) = match produced {
         Produced::Text(text) => {
             write_text(output, &text)?;
             return Ok(true);
         }
-        Produced::Units(units) => (units, true),
-        Produced::Module(module) => (vec![module], false),
+        Produced::Units(units, exports) => (units, true, exports),
+        Produced::Module(module, exports) => (vec![module], false, exports),
     };
 
-    // A static library is the one target whose units do not each become a
-    // user-visible file: every unit is emitted into a scratch directory and
-    // the archive is the deliverable. This is also where `--codegen-units`
-    // stops being observable to the consumer — N units or one, the library
-    // exposes the same symbols.
-    if target == Stage::Staticlib {
-        let mut lib = StaticLib::new(output, cli.lto)?;
+    // A static library and the linked targets are the ones whose units do not
+    // each become a user-visible file: every unit is emitted into a scratch
+    // directory, and the archive — or the linked product — is the
+    // deliverable. This is also where `--codegen-units` stops being
+    // observable to the consumer — N units or one, the result exposes the
+    // same symbols.
+    if target == Stage::Staticlib || target.is_linked() {
+        let mut lib = ScratchMembers::new(output, cli.lto)?;
         for module in modules {
             let member = lib.next_member();
-            backend_module(cli, context, module, target, opt, reloc, spec, name, &member)?;
+            backend_module(
+                cli, context, module, target, opt, reloc, spec, name, &member,
+            )?;
         }
         let machine = TargetMachine::new(spec, opt, reloc)?;
-        return lib.finish(output, machine.triple()).map(|()| true);
+        if target == Stage::Staticlib {
+            return lib.finish(output, machine.triple()).map(|()| true);
+        }
+        return link_product(
+            cli,
+            target,
+            machine.triple(),
+            exports.as_deref(),
+            &lib,
+            output,
+        )
+        .map(|()| true);
     }
 
     // Otherwise each unit writes its own artifact: `<stem>.<i>.<ext>`
@@ -866,36 +962,42 @@ fn backend(
     Ok(true)
 }
 
-/// The members a static library will archive, in a scratch directory that
-/// lives until the archive is written.
+/// The per-unit intermediates a packaged or linked target consumes — archive
+/// members or link inputs — in a scratch directory that lives until the
+/// deliverable is written.
 ///
 /// The members are intermediates, not artifacts: naming them after the
-/// library (`libfoo.0.o`) keeps the archive's member names — and so linker
+/// product (`libfoo.0.o`) keeps the archive's member names — and so linker
 /// diagnostics — meaningful, while the directory's removal on drop keeps
 /// them out of the user's output directory.
-struct StaticLib {
+struct ScratchMembers {
     dir: tempfile::TempDir,
     stem: String,
     extension: &'static str,
     members: Vec<PathBuf>,
 }
 
-impl StaticLib {
+impl ScratchMembers {
     fn new(output: &Path, lto: Lto) -> Result<Self, String> {
         let dir = tempfile::Builder::new()
-            .prefix("rrc-staticlib-")
+            .prefix("rrc-scratch-")
             .tempdir()
             .map_err(|e| format!("cannot create a scratch directory: {e}"))?;
         let stem = output
             .file_stem()
             .map(|s| s.to_string_lossy().into_owned())
             .unwrap_or_else(|| "lib".to_owned());
-        Ok(StaticLib {
+        Ok(ScratchMembers {
             dir,
             stem,
             extension: if lto == Lto::None { "o" } else { "bc" },
             members: Vec::new(),
         })
+    }
+
+    /// The scratch directory itself, for the link step's generated sources.
+    fn dir(&self) -> &Path {
+        self.dir.path()
     }
 
     /// Reserve and return the path of the next member.
@@ -914,6 +1016,255 @@ impl StaticLib {
     fn finish(self, output: &Path, triple: &str) -> Result<(), String> {
         write_archive(output, &self.members, triple)
     }
+}
+
+/// The launcher a Reussir executable is built around, embedded at compile
+/// time: a real Rust `bin` whose `main` calls `__reussir_main`, so rustc
+/// emits the C entry that runs `lang_start` and the program starts under the
+/// full Rust runtime. See the file's own docs for why nothing less will do.
+const LAUNCHER_SOURCE: &str = include_str!("../../reussir-rt/launcher/main.rs");
+
+/// Link `--emit executable`/`dynlib`: compile the embedded launcher (or an
+/// empty cdylib shim) with rustc, handing it the program's objects, the
+/// runtime, and the platform's system libraries — the link line
+/// `tests/integration/frontend/main_attribute.rr` used to spell by hand.
+///
+/// rustc rather than a C toolchain because the launcher *is* Rust — that is
+/// how the program gets the real Rust runtime — and because rustc already
+/// knows each target's linker and system-library baseline.
+fn link_product(
+    cli: &Cli,
+    target: Stage,
+    triple: &str,
+    exports: Option<&[String]>,
+    scratch: &ScratchMembers,
+    output: &Path,
+) -> Result<(), String> {
+    let msvc = triple.contains("-windows") && triple.contains("msvc");
+    let apple = triple.contains("-apple");
+
+    // An executable needs the entry point; say so up front when the frontend
+    // recorded the surface, rather than as a linker's undefined-symbol error.
+    // (`None` — a backend-stage input — leaves the check to the linker.)
+    let main_symbol = reussir_core::semi::Elaborator::MAIN_SYMBOL;
+    if target == Stage::Executable
+        && let Some(exports) = exports
+        && !exports.iter().any(|e| e == main_symbol)
+    {
+        return Err(format!(
+            "an executable needs an entry point: no function is marked `#[main]` \
+             (and no trampoline exports `{main_symbol}`)"
+        ));
+    }
+
+    let rustc = resolve_link_rustc(cli)?;
+    let libdirs = runtime_libdirs(cli)?;
+    let linkage = cli.runtime_linkage.unwrap_or(RuntimeLinkage::Static);
+
+    let mut cmd = std::process::Command::new(&rustc);
+    cmd.arg("--edition").arg("2024");
+    match target {
+        Stage::Executable => {
+            let launcher = scratch.dir().join("launcher.rs");
+            std::fs::write(&launcher, LAUNCHER_SOURCE)
+                .map_err(|e| format!("cannot write the launcher source: {e}"))?;
+            cmd.arg(launcher);
+        }
+        Stage::Dynlib => {
+            // The shim gives rustc a crate to build the shared library
+            // around; every symbol of substance arrives through the link
+            // inputs below.
+            let shim = scratch.dir().join("shim.rs");
+            std::fs::write(&shim, "")
+                .map_err(|e| format!("cannot write the cdylib shim source: {e}"))?;
+            cmd.arg(shim).arg("--crate-type").arg("cdylib");
+        }
+        _ => unreachable!("link_product only links executable/dynlib"),
+    }
+    cmd.arg("-o").arg(output);
+    if let Some(linker) = &cli.linker {
+        if !linker.is_file() {
+            return Err(format!("--linker `{}` does not exist", linker.display()));
+        }
+        cmd.arg(format!("-Clinker={}", linker.display()));
+    }
+    for member in &scratch.members {
+        cmd.arg(format!("-Clink-arg={}", member.display()));
+    }
+
+    // The runtime. The static archive is named by *path*, not `-l static=`:
+    // rustc lowers the latter to a bare `-l` on ELF and Mach-O, and the
+    // linker then prefers a shared library sitting in the same directory
+    // (see main_attribute.rr's history for the load-time failure that buys).
+    match linkage {
+        RuntimeLinkage::Static => {
+            let archive = if msvc {
+                "reussir_rt.lib"
+            } else {
+                "libreussir_rt.a"
+            };
+            cmd.arg(format!(
+                "-Clink-arg={}",
+                find_in_libdirs(&libdirs, archive)?.display()
+            ));
+            // What the archive's own code needs beyond what rustc links
+            // anyway — invisible to rustc inside a *native* archive. (The
+            // shared runtime records its own dependencies.)
+            let sys_libs: &[&str] = if apple {
+                &["framework=Security", "framework=CoreFoundation"]
+            } else if msvc {
+                &["ntdll", "ws2_32", "advapi32", "bcrypt", "userenv"]
+            } else {
+                &[]
+            };
+            for lib in sys_libs {
+                cmd.arg("-l").arg(lib);
+            }
+        }
+        RuntimeLinkage::Dynamic => {
+            if msvc {
+                // The DLL is linked through its import library, whose
+                // `reussir_rt.dll.lib` name `-l dylib=` would not find (it
+                // would find the *static* `reussir_rt.lib` instead).
+                cmd.arg(format!(
+                    "-Clink-arg={}",
+                    find_in_libdirs(&libdirs, "reussir_rt.dll.lib")?.display()
+                ));
+            } else {
+                let shared = if apple {
+                    "libreussir_rt.dylib"
+                } else {
+                    "libreussir_rt.so"
+                };
+                // Presence check only — the link itself goes through `-L`/`-l`
+                // so the product records the library's soname, not a path.
+                find_in_libdirs(&libdirs, shared)?;
+                for dir in &libdirs {
+                    cmd.arg("-L").arg(dir);
+                }
+                cmd.arg("-l").arg("dylib=reussir_rt");
+            }
+        }
+    }
+
+    // A dynamic library's exports: rustc's cdylib machinery localizes
+    // everything the *crate* does not export — which is everything here, the
+    // shim being empty — so the trampoline surface is spelled to the linker
+    // directly, in each platform's dialect.
+    if target == Stage::Dynlib {
+        let Some(exports) = exports else {
+            unreachable!("dynlib from a backend-stage input is refused up front");
+        };
+        if msvc {
+            // COFF exports nothing by default; /EXPORT also grows the
+            // import library the consumer links.
+            for export in exports {
+                cmd.arg(format!("-Clink-arg=/EXPORT:{export}"));
+            }
+        } else if apple {
+            // ld64 takes the union of every -exported_symbols_list given.
+            let list = scratch.dir().join("exports.list");
+            let text: String = exports.iter().map(|e| format!("_{e}\n")).collect();
+            std::fs::write(&list, text)
+                .map_err(|e| format!("cannot write the export list: {e}"))?;
+            cmd.arg(format!(
+                "-Clink-arg=-Wl,-exported_symbols_list,{}",
+                list.display()
+            ));
+        } else if !exports.is_empty() {
+            // A second version script unions with the `local: *` one rustc
+            // passes (lld semantics — rustc's default linker on ELF).
+            let script = scratch.dir().join("exports.ver");
+            let mut text = String::from("{ global:\n");
+            for export in exports {
+                text.push_str("  ");
+                text.push_str(export);
+                text.push_str(";\n");
+            }
+            text.push_str("};\n");
+            std::fs::write(&script, text)
+                .map_err(|e| format!("cannot write the export version script: {e}"))?;
+            cmd.arg(format!(
+                "-Clink-arg=-Wl,--version-script={}",
+                script.display()
+            ));
+        }
+    }
+
+    for arg in &cli.link_arg {
+        cmd.arg(format!("-Clink-arg={arg}"));
+    }
+
+    // rustc's diagnostics stream straight through to stderr.
+    let status = cmd
+        .status()
+        .map_err(|e| format!("cannot run `{rustc}` for the link step: {e}"))?;
+    if !status.success() {
+        return Err(format!(
+            "linking `{}` failed: `{rustc}` exited with {status}",
+            output.display()
+        ));
+    }
+    Ok(())
+}
+
+/// The rustc driving the link step: `--polyffi-rust-path`, then the
+/// `REUSSIR_RUSTC` environment variable, then `rustc` on `PATH` — the same
+/// order the polyffi texture compiles resolve in.
+fn resolve_link_rustc(cli: &Cli) -> Result<String, String> {
+    if let Some(path) = &cli.polyffi_rust_path {
+        return resolve_rustc(path);
+    }
+    if let Some(env) = std::env::var_os("REUSSIR_RUSTC") {
+        let path = PathBuf::from(&env);
+        if !path.is_file() {
+            return Err(format!("REUSSIR_RUSTC `{}` does not exist", path.display()));
+        }
+        return Ok(path.to_string_lossy().into_owned());
+    }
+    resolve_rustc(Path::new("rustc")).map_err(|_| {
+        "cannot find `rustc` for the link step: pass --polyffi-rust-path or set \
+         REUSSIR_RUSTC"
+            .to_owned()
+    })
+}
+
+/// The directories searched for the runtime library: `--polyffi-libdir`, then
+/// the path-separated `REUSSIR_RUSTC_DEPS` environment variable.
+fn runtime_libdirs(cli: &Cli) -> Result<Vec<PathBuf>, String> {
+    if !cli.polyffi_libdir.is_empty() {
+        return Ok(cli.polyffi_libdir.clone());
+    }
+    if let Some(env) = std::env::var_os("REUSSIR_RUSTC_DEPS") {
+        let dirs: Vec<PathBuf> = std::env::split_paths(&env).collect();
+        if !dirs.is_empty() {
+            return Ok(dirs);
+        }
+    }
+    Err(
+        "cannot locate the Reussir runtime for the link step: pass --polyffi-libdir \
+         or set REUSSIR_RUSTC_DEPS"
+            .to_owned(),
+    )
+}
+
+/// The first libdir containing `name`, or an error naming everywhere it
+/// looked.
+fn find_in_libdirs(libdirs: &[PathBuf], name: &str) -> Result<PathBuf, String> {
+    for dir in libdirs {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err(format!(
+        "cannot find `{name}` in {}",
+        libdirs
+            .iter()
+            .map(|d| format!("`{}`", d.display()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
 }
 
 /// The back leg for one module, writing to `output` (per-unit paths in a
@@ -1047,7 +1398,7 @@ fn backend_module(
         .map_err(|e| format!("{name}: {e}"))?;
     let kind = target
         .output_kind(cli.lto)
-        .expect("llvm-ir/asm/obj/staticlib target past the mlir-llvm stage");
+        .expect("file-emitting or linked target past the mlir-llvm stage");
     emit_to_file(finalized, &machine, opt, kind, output)?;
     Ok(true)
 }
@@ -1357,6 +1708,15 @@ fn finish_mir<'c, 'tcx>(
     }
     // Names feed variable/function debug info; only meaningful with `-g`.
     let names = cli.debug.then_some(resolver);
+    // The link step's view of the program: its exported trampolines — the
+    // dynamic library's export surface, and where `#[main]`'s
+    // `__reussir_main` shows up for the executable's entry-point check.
+    let exports: Vec<String> = program
+        .trampolines
+        .iter()
+        .filter(|t| !t.import)
+        .map(|t| program.symbol(t.export).to_owned())
+        .collect();
     // AOT linkage: internal / linkonce_odr definitions per the policy; the
     // trampolines and pub functions stay the object's external ABI surface.
     let linkage = LinkagePolicy::aot_for_triple(cli.target_triple.as_deref());
@@ -1384,12 +1744,12 @@ fn finish_mir<'c, 'tcx>(
             )?;
             units.push(module);
         }
-        return Ok(Produced::Units(units));
+        return Ok(Produced::Units(units, Some(exports)));
     }
     let module = lower_or_render(
         lower_program(context, tcx, program, sources, names, linkage, &sanitizers),
         sources,
         name,
     )?;
-    Ok(Produced::Module(module))
+    Ok(Produced::Module(module, Some(exports)))
 }

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -1177,14 +1177,18 @@ fn link_product(
             // second script outright ("anonymous version tag cannot be
             // combined with other version tags"), and bfd is what `cc` picks
             // on the Linux targets where lld is not yet rustc's default
-            // (aarch64). Pin the toolchain's own bundled rust-lld for this
-            // link — the same linker the x86_64 default resolves to.
+            // (aarch64). Steer this link to the toolchain's bundled rust-lld
+            // — the same linker the x86_64 default resolves to — through the
+            // stable `cc` arguments rustc's own switch expands to, since the
+            // rustc driving the link need not be a nightly (`rene` hands rrc
+            // whatever toolchain its environment resolves, and the opt-in
+            // `-Clink-self-contained=+linker` is nightly-gated). A rustc
+            // shipped without the component falls back to a system lld.
             if triple.contains("-linux") {
-                cmd.arg("-Clinker-features=+lld");
-                // `+linker` (opting *in* to the bundled lld) is still
-                // nightly-gated; the workspace pins a nightly toolchain.
-                cmd.arg("-Zunstable-options");
-                cmd.arg("-Clink-self-contained=+linker");
+                if let Some(gcc_ld) = bundled_lld_dir(&rustc) {
+                    cmd.arg(format!("-Clink-arg=-B{}", gcc_ld.display()));
+                }
+                cmd.arg("-Clink-arg=-fuse-ld=lld");
             }
             let script = scratch.dir().join("exports.ver");
             let mut text = String::from("{ global:\n");
@@ -1218,6 +1222,22 @@ fn link_product(
         ));
     }
     Ok(())
+}
+
+/// The directory of the toolchain's bundled rust-lld shims (`gcc-ld`, next
+/// to the target libdir), asked of the rustc driving the link. `None` when
+/// that distribution ships no rust-lld component.
+fn bundled_lld_dir(rustc: &str) -> Option<PathBuf> {
+    let out = std::process::Command::new(rustc)
+        .args(["--print", "target-libdir"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let libdir = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
+    let dir = libdir.parent()?.join("bin").join("gcc-ld");
+    dir.is_dir().then_some(dir)
 }
 
 /// The rustc driving the link step: `--polyffi-rust-path`, then the

--- a/crates/reussir-compiler/src/main.rs
+++ b/crates/reussir-compiler/src/main.rs
@@ -1173,7 +1173,19 @@ fn link_product(
             ));
         } else if !exports.is_empty() {
             // A second version script unions with the `local: *` one rustc
-            // passes (lld semantics — rustc's default linker on ELF).
+            // passes. That union semantics is lld's: GNU bfd rejects the
+            // second script outright ("anonymous version tag cannot be
+            // combined with other version tags"), and bfd is what `cc` picks
+            // on the Linux targets where lld is not yet rustc's default
+            // (aarch64). Pin the toolchain's own bundled rust-lld for this
+            // link — the same linker the x86_64 default resolves to.
+            if triple.contains("-linux") {
+                cmd.arg("-Clinker-features=+lld");
+                // `+linker` (opting *in* to the bundled lld) is still
+                // nightly-gated; the workspace pins a nightly toolchain.
+                cmd.arg("-Zunstable-options");
+                cmd.arg("-Clink-self-contained=+linker");
+            }
             let script = scratch.dir().join("exports.ver");
             let mut text = String::from("{ global:\n");
             for export in exports {

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -378,7 +378,10 @@ fn scan_deps_writes_the_listing_to_the_output_file() {
         "scan-deps failed:\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(output.stdout.is_empty(), "listing must go to -o, not stdout");
+    assert!(
+        output.stdout.is_empty(),
+        "listing must go to -o, not stdout"
+    );
     let graph: serde_json::Value = serde_json::from_str(&read(&out)).expect("bad JSON in -o file");
     let expected = dir.path().join("lib.rr").canonicalize().unwrap();
     assert_eq!(
@@ -534,50 +537,85 @@ fn a_static_library_is_reproducible() {
     assert_eq!(first, second, "two identical builds differ");
 }
 
-/// The link-requiring targets are recognized — by `--emit` and by the output
-/// extension — and refused before any compilation happens.
-#[test]
-fn refuses_the_targets_that_need_a_linker() {
-    let (dir, src) = source("link-products");
-
-    for (args, expected) in [
-        (vec!["--emit", "executable"], "executable"),
-        (vec!["--emit", "dynlib"], "dynlib"),
-    ] {
-        let out = dir.path().join("out.bin");
-        let mut argv: Vec<&Path> = vec![&src, Path::new("-o"), &out];
-        argv.extend(args.iter().map(Path::new));
-        let output = rrc(&argv);
-        assert_eq!(
-            output.status.code(),
-            Some(2),
-            "expected a usage error for {expected}"
-        );
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(
-            stderr.contains(expected) && stderr.contains("not implemented yet"),
-            "stderr:\n{stderr}"
-        );
-        assert!(!out.exists(), "{expected} produced a file anyway");
-    }
-
-    // A shared-library extension names the same unimplemented stage.
-    let out = dir.path().join("libprog.so");
-    let output = rrc(&[&src, Path::new("-o"), &out]);
-    assert_eq!(output.status.code(), Some(2));
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("dynlib"),
-        "a `.so` output should resolve to the dynlib stage"
-    );
+/// Like [`rrc`], with the toolchain environment scrubbed, so assertions
+/// about a *missing* toolchain hold no matter what the developer's shell
+/// exports. (The lit suite covers the links that succeed; these tests cover
+/// the driver's own diagnostics, which must not depend on one.)
+fn rrc_without_toolchain(args: &[&Path]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rrc"))
+        .args(args)
+        .env_remove("REUSSIR_RUSTC")
+        .env_remove("REUSSIR_RUSTC_DEPS")
+        .output()
+        .expect("spawn rrc")
 }
 
-/// `--lto` describes how a *library* is packed; it is meaningless for the
-/// other targets, and says so rather than silently doing nothing.
+/// The link step's driver-level diagnostics, all raised before any linker
+/// runs.
 #[test]
-fn rejects_lto_without_a_static_library() {
+fn link_step_driver_diagnostics() {
+    let (dir, src) = source("link-products");
+
+    // `PROGRAM` has no `#[main]`, so there is no entry point to link an
+    // executable around; refused before rustc or the runtime is even looked
+    // up, which is why this needs no toolchain.
+    let out = dir.path().join("prog.exe");
+    let output = rrc(&[
+        &src,
+        Path::new("-o"),
+        &out,
+        Path::new("--emit"),
+        Path::new("executable"),
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("an executable needs an entry point"),
+        "stderr:\n{stderr}"
+    );
+    assert!(!out.exists(), "the refused link produced a file anyway");
+
+    // A shared-library extension resolves to the dynlib stage: the driver
+    // heads for its link step (and, with the toolchain scrubbed, fails
+    // looking for it) instead of emitting the default object.
+    let out = dir.path().join("libprog.so");
+    let output = rrc_without_toolchain(&[&src, Path::new("-o"), &out]);
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("for the link step"), "stderr:\n{stderr}");
+    assert!(!out.exists(), "the failed link produced a file anyway");
+
+    // The link knobs mean nothing without a link step.
+    for (knob, name) in [
+        ("--link-arg=-lm", "--link-arg"),
+        ("--runtime-linkage=static", "--runtime-linkage"),
+        ("--linker=rustc", "--linker"),
+    ] {
+        let out = dir.path().join("prog.o");
+        let output = rrc(&[&src, Path::new("-o"), &out, Path::new(knob)]);
+        assert_eq!(output.status.code(), Some(2), "{name} with an object");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(name) && stderr.contains("applies to `executable` and `dynlib`"),
+            "stderr:\n{stderr}"
+        );
+    }
+}
+
+/// `--lto` describes how a packaged or linked product is built; it is
+/// meaningless for the plain emission targets, and says so rather than
+/// silently doing nothing.
+#[test]
+fn rejects_lto_without_a_packaged_or_linked_target() {
     let (dir, src) = source("lto-misuse");
     let out = dir.path().join("prog.o");
-    let output = rrc(&[&src, Path::new("-o"), &out, Path::new("--lto"), Path::new("fat")]);
+    let output = rrc(&[
+        &src,
+        Path::new("-o"),
+        &out,
+        Path::new("--lto"),
+        Path::new("fat"),
+    ]);
     assert_eq!(output.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("--lto applies to"), "stderr:\n{stderr}");

--- a/tests/integration/codegen/dynlib.rr
+++ b/tests/integration/codegen/dynlib.rr
@@ -3,7 +3,8 @@
 // program's `extern` trampolines. rustc's cdylib machinery localizes every
 // symbol the (empty) shim crate does not export — which is everything — so
 // the driver spells the trampolines to the linker itself: a second version
-// script on ELF (lld unions it with rustc's `local: *` one), an
+// script on ELF — union semantics lld has and GNU bfd rejects, so the link
+// pins the toolchain's bundled rust-lld on Linux — and an
 // `-exported_symbols_list` on Mach-O. That localization is also what keeps
 // the cross-unit linkage surface (`_RC…` symbols made external for
 // `--codegen-units`) out of the dynamic table.

--- a/tests/integration/codegen/dynlib.rr
+++ b/tests/integration/codegen/dynlib.rr
@@ -1,0 +1,43 @@
+// UNSUPPORTED: windows
+// `rrc --emit dynlib`: a shared library whose export surface is exactly the
+// program's `extern` trampolines. rustc's cdylib machinery localizes every
+// symbol the (empty) shim crate does not export — which is everything — so
+// the driver spells the trampolines to the linker itself: a second version
+// script on ELF (lld unions it with rustc's `local: *` one), an
+// `-exported_symbols_list` on Mach-O. That localization is also what keeps
+// the cross-unit linkage surface (`_RC…` symbols made external for
+// `--codegen-units`) out of the dynamic table.
+//
+// Windows spells exports as `/EXPORT:` and consumes the library through an
+// import library; dynlib_windows.rr covers it.
+
+// RUN: %rrc %S/staticlib/lib.rr -o %t.so --emit dynlib --relocation-mode pic --codegen-units 2 %rrc_linker
+
+// The trampolines are exported…
+// RUN: %llvm-nm --defined-only --extern-only %t.so | %FileCheck %s --check-prefix=EXPORTS
+// EXPORTS-DAG: fib_ffi
+// EXPORTS-DAG: twice_ffi
+
+// …and the mangled Reussir internals — external in the objects so the two
+// codegen units can call each other — are not.
+// RUN: %llvm-nm --defined-only --extern-only %t.so | %FileCheck %s --check-prefix=HIDDEN
+// HIDDEN-NOT: _RC
+
+// The C driver links against the library by path and runs; a miscompiled or
+// unresolved trampoline fails here.
+// RUN: %cc %S/staticlib/driver.c %t.so -o %t.exe
+// RUN: %t.exe | %FileCheck %s --check-prefix=EXEC
+// EXEC: fib=55 twice=42
+
+// A `#[main]` in a dynamic library is not a contradiction: `__reussir_main`
+// is an ordinary trampoline, exported like any other, for a host that wants
+// to dlopen the program and run it.
+// RUN: %rrc %S/../frontend/main_attribute.rr -o %t.main.so --emit dynlib --relocation-mode pic %rrc_linker
+// RUN: %llvm-nm --defined-only --extern-only %t.main.so | %FileCheck %s --check-prefix=MAIN
+// MAIN: __reussir_main
+
+// The exports come from the frontend's trampoline records, which a
+// backend-stage input no longer carries; refused up front.
+// RUN: %rrc %S/staticlib/lib.rr --emit llvm-ir --relocation-mode pic -o %t.ll
+// RUN: %not %rrc %t.ll -o %t.ll.so --emit dynlib 2>&1 | %FileCheck %s --check-prefix=BACKEND
+// BACKEND: cannot emit `dynlib` from a `llvm-ir` input

--- a/tests/integration/codegen/dynlib_windows.rr
+++ b/tests/integration/codegen/dynlib_windows.rr
@@ -1,0 +1,12 @@
+// REQUIRES: windows
+// `rrc --emit dynlib` on Windows: the exports are spelled as `/EXPORT:`
+// (COFF exports nothing by default), which also makes link.exe grow the
+// import library a consumer links against. The explicit `/IMPLIB:` pins that
+// library's path for the test; the DLL itself is found at run time because
+// it sits in the same directory as the test executable.
+
+// RUN: %rrc %S/staticlib/lib.rr -o %t.dll --emit dynlib --relocation-mode pic --codegen-units 2 --link-arg=/IMPLIB:%t.lib %rrc_linker
+// RUN: %cc %S/staticlib/driver.c %t.lib -o %t.exe
+// RUN: %t.exe | %FileCheck %s
+
+// CHECK: fib=55 twice=42

--- a/tests/integration/codegen/executable.rr
+++ b/tests/integration/codegen/executable.rr
@@ -1,0 +1,66 @@
+// `rrc --emit executable`: the driver finishes the stage chain with a link
+// step — the program's objects, the embedded Rust launcher
+// (crates/reussir-rt/launcher/main.rs, so the program starts under the full
+// Rust runtime), and the runtime's static archive, named by path so no
+// same-named shared library can be picked in its place. rustc drives the
+// link because the launcher *is* Rust, and because rustc already knows each
+// target's linker and system-library baseline. `%rrc_linker` pins MSVC's
+// link.exe on Windows CI and is empty elsewhere.
+//
+// frontend/main_attribute.rr covers the `#[main]` attribute itself and the
+// resumed stage chain; this suite covers the link step.
+
+// RUN: %rrc %s -o %t.exe --emit executable --relocation-mode pic %rrc_linker
+// RUN: %t.exe
+
+// `--codegen-units` stays invisible: the units are linked, not left as
+// `<stem>.<i>.o` siblings, and cross-unit calls resolve inside the link.
+// RUN: %rrc %s -o %t.4.exe --emit executable --relocation-mode pic --codegen-units 4 %rrc_linker
+// RUN: %t.4.exe
+
+// A `.exe` output extension infers the target like any other stage's
+// extension does.
+// RUN: %rrc %s -o %t.inferred.exe --relocation-mode pic %rrc_linker
+// RUN: %t.inferred.exe
+
+// An LLVM-IR input resumes straight into the link — the backend fast path
+// emits the one object and links it the same way.
+// RUN: %rrc %s --emit llvm-ir --relocation-mode pic -o %t.ll
+// RUN: %rrc %t.ll -o %t.ll.exe --emit executable %rrc_linker
+// RUN: %t.ll.exe
+
+// Without a `#[main]` there is nothing to enter: refused before any linker
+// runs, as a driver diagnostic rather than an undefined-symbol error.
+// RUN: %not %rrc %S/staticlib/lib.rr -o %t.nomain.exe --emit executable 2>&1 | %FileCheck %s --check-prefix=NOMAIN
+
+// NOMAIN: an executable needs an entry point
+
+// The link-step knobs mean nothing without a link step; refused up front
+// rather than silently ignored.
+// RUN: %not %rrc %s -o %t.o --link-arg=-lm 2>&1 | %FileCheck %s --check-prefix=LINKARG
+// RUN: %not %rrc %s -o %t.o --runtime-linkage static 2>&1 | %FileCheck %s --check-prefix=RTLINK
+// RUN: %not %rrc %s -o %t.o --linker %rrc 2>&1 | %FileCheck %s --check-prefix=LINKER
+
+// LINKARG: --link-arg applies to `executable` and `dynlib`
+// RTLINK: --runtime-linkage applies to `executable` and `dynlib`
+// LINKER: --linker applies to `executable` and `dynlib`
+
+// Two functions calling across the file, so a partitioned build has
+// something to resolve between units.
+fn fib(n: u64) -> u64 {
+    if n <= 1 {
+        n
+    } else {
+        fib(n - 1) + fib(n - 2)
+    }
+}
+
+fn twice(n: u64) -> u64 {
+    n + n
+}
+
+#[main]
+pub fn entry() {
+    let f = fib(10);
+    let t = twice(f);
+}

--- a/tests/integration/codegen/executable_dynamic_rt.rr
+++ b/tests/integration/codegen/executable_dynamic_rt.rr
@@ -1,0 +1,22 @@
+// REQUIRES: linux
+// `--runtime-linkage dynamic`: the executable records the shared runtime
+// library (by soname, through `-L`/`-l`, not by path) instead of bundling
+// the static archive. Finding it at load time is the deployment's problem,
+// not the driver's — here an rpath supplied through `--link-arg` points at
+// the build tree. Linux-gated: the mechanism is identical on macOS, but the
+// cargo-built dylib's install name bakes the cargo target directory's path,
+// which is a runtime-packaging question this test has no business settling;
+// Windows consumes the DLL through its import library (see
+// dynlib_windows.rr for that side of the toolchain).
+
+// RUN: %rrc %s -o %t.exe --emit executable --relocation-mode pic --runtime-linkage dynamic --link-arg=-Wl,-rpath,%library_path
+// RUN: %t.exe
+
+fn twice(n: u64) -> u64 {
+    n + n
+}
+
+#[main]
+pub fn entry() {
+    let doubled = twice(21);
+}

--- a/tests/integration/codegen/executable_lto.rr
+++ b/tests/integration/codegen/executable_lto.rr
@@ -1,0 +1,39 @@
+// REQUIRES: rustc-lto-link
+// `--lto` through the driver's own link: the codegen units are emitted as
+// bitcode by the matching LTO pre-link pipeline and handed to the linker
+// rustc drives, which optimizes across them. Gated on a probe (lit.cfg.py)
+// that runs this exact pipeline: the linker must consume *this* LLVM's
+// bitcode, which rust-lld does where it is rustc's default, and a system
+// linker without a matching-version LTO plugin does not.
+
+// RUN: %rrc %s -o %t.thin.exe --emit executable --relocation-mode pic --codegen-units 2 --lto thin %rrc_linker
+// RUN: %t.thin.exe
+
+// RUN: %rrc %s -o %t.fat.exe --emit executable --relocation-mode pic --codegen-units 2 --lto fat %rrc_linker
+// RUN: %t.fat.exe
+
+// The dynamic library takes the same path; its exports survive the LTO's
+// internalization because the export list reaches the same linker.
+// RUN: %rrc %S/staticlib/lib.rr -o %t.thin.so --emit dynlib --relocation-mode pic --codegen-units 2 --lto thin %rrc_linker
+// RUN: %cc %S/staticlib/driver.c %t.thin.so -o %t.drv.exe
+// RUN: %t.drv.exe | %FileCheck %s --check-prefix=EXEC
+
+// EXEC: fib=55 twice=42
+
+fn fib(n: u64) -> u64 {
+    if n <= 1 {
+        n
+    } else {
+        fib(n - 1) + fib(n - 2)
+    }
+}
+
+fn twice(n: u64) -> u64 {
+    n + n
+}
+
+#[main]
+pub fn entry() {
+    let f = fib(10);
+    let t = twice(f);
+}

--- a/tests/integration/codegen/staticlib.rr
+++ b/tests/integration/codegen/staticlib.rr
@@ -46,11 +46,3 @@
 // RUN: %not %rrc %S/staticlib/lib.rr -o - --emit staticlib 2>&1 | %FileCheck %s --check-prefix=STDOUT
 
 // STDOUT: cannot write `staticlib` to stdout
-
-// The two link-requiring targets are recognized, and refused up front rather
-// than after compiling.
-// RUN: %not %rrc %S/staticlib/lib.rr -o %t.exe --emit executable 2>&1 | %FileCheck %s --check-prefix=EXE
-// RUN: %not %rrc %S/staticlib/lib.rr -o %t.dylib --emit dynlib 2>&1 | %FileCheck %s --check-prefix=DYN
-
-// EXE: emitting `executable` is not implemented yet
-// DYN: emitting `dynlib` is not implemented yet

--- a/tests/integration/codegen/staticlib_lto.rr
+++ b/tests/integration/codegen/staticlib_lto.rr
@@ -65,8 +65,8 @@
 
 // NATIVE: target triple = "arm64-apple-darwin24.6.0"
 
-// `--lto` is about how a library is packed; it has nothing to say about the
-// other emission targets.
-// RUN: %not %rrc %S/staticlib/lib.rr -o %t.o --lto thin 2>&1 | %FileCheck %s --check-prefix=ONLY-STATICLIB
+// `--lto` is about how a packaged or linked product is built; it has nothing
+// to say about the plain emission targets.
+// RUN: %not %rrc %S/staticlib/lib.rr -o %t.o --lto thin 2>&1 | %FileCheck %s --check-prefix=ONLY-PACKAGED
 
-// ONLY-STATICLIB: --lto applies to `--emit staticlib`
+// ONLY-PACKAGED: --lto applies to `staticlib`, `dynlib`, and `executable`

--- a/tests/integration/frontend/main_attribute.rr
+++ b/tests/integration/frontend/main_attribute.rr
@@ -2,32 +2,18 @@
 // symbol `__reussir_main`, through the same trampoline path an explicit
 // `extern "C" trampoline` takes.
 //
-// An executable is then built *around* it: the launcher
-// (crates/reussir-rt/launcher/main.rs) is a real Rust `main`, so rustc emits
-// the C entry that runs `lang_start` and the program starts under the full
-// Rust runtime. Here the link is spelled out by hand; the driver will do it
-// once it learns to emit executables.
-//
-// The runtime is linked *statically*. A Rust dylib re-exports the std it was
-// built against, so linking one only works when the launcher was compiled by
-// the very same rustc; where they disagree, the mismatch surfaces as a
-// missing std symbol at load time rather than at link time. The static
-// archive carries no such dependency — but it must be named by path
-// (%launcher_rt_archive), not `-l static=reussir_rt`: rustc lowers the
-// latter to a bare `-lreussir_rt` on ELF and Mach-O, and the linker then
-// takes the dylib sitting in the same directory, dylib problem and all.
-// With the object and the archive both explicit link inputs the executable
-// is self-contained, so it needs no rpath either. `%launcher_sys_libs` is
-// what the archive's own code needs beyond what rustc links anyway (the
-// CoreFoundation/Security frameworks on macOS, a few system libraries on
-// Windows), which rustc cannot infer from a *native* archive. And
-// `%launcher_linker` pins the MSVC link.exe on Windows, where rustc's own
-// discovery under a vcvars environment finds Git-for-Windows' coreutils
-// `link` on PATH instead; elsewhere it is empty.
+// An executable is then built *around* it: `--emit executable` has the
+// driver compile the launcher (crates/reussir-rt/launcher/main.rs) — a real
+// Rust `main`, so rustc emits the C entry that runs `lang_start` and the
+// program starts under the full Rust runtime — and link it with the
+// program's objects and the runtime's static archive. The link line this
+// file once spelled by hand lives in the driver now; codegen/executable.rr
+// covers the link step's own behavior. (`%rrc_linker` pins the MSVC link.exe
+// on Windows, where rustc's own discovery under a vcvars environment finds
+// Git-for-Windows' coreutils `link` on PATH instead; elsewhere it is empty.)
 
 // RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
-// RUN: %rrc %s -o %t.o --relocation-mode pic
-// RUN: %rustc_path --edition 2024 %S/../../../crates/reussir-rt/launcher/main.rs -o %t.exe %launcher_linker -C link-arg=%t.o -C link-arg=%launcher_rt_archive %launcher_sys_libs
+// RUN: %rrc %s -o %t.exe --emit executable --relocation-mode pic %rrc_linker
 // RUN: %t.exe
 
 // The attribute lowers to an ordinary C-ABI export of the marked function.
@@ -50,8 +36,7 @@
 // RESUMED: extern "C" trampoline "__reussir_main" =
 
 // …and resuming all the way to a running executable gives the same program.
-// RUN: %rrc %t.a.hir -o %t.resumed.o --relocation-mode pic
-// RUN: %rustc_path --edition 2024 %S/../../../crates/reussir-rt/launcher/main.rs -o %t.resumed.exe %launcher_linker -C link-arg=%t.resumed.o -C link-arg=%launcher_rt_archive %launcher_sys_libs
+// RUN: %rrc %t.a.hir -o %t.resumed.exe --emit executable --relocation-mode pic %rrc_linker
 // RUN: %t.resumed.exe
 
 // One entry point per program…

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -166,30 +166,20 @@ if _lto_link_flags:
     config.available_features.add('lto-link')
     config.substitutions.append((r'%lto_link_flags', _lto_link_flags))
 config.substitutions.append((r'%rpath_flag', sh_path(config.rpath_flag)))
-# The main-attribute suite links a Reussir object and the runtime into an
-# executable with the staged rustc. The runtime must be its *static* archive,
-# and the archive must be named by path: rustc lowers `-l static=reussir_rt`
-# to a bare `-lreussir_rt` on ELF and Mach-O, and the linker then prefers the
-# shared library sitting in the same directory — on macOS the executable ends
-# up importing even std symbols from libreussir_rt.dylib and dies at load
-# time when its std does not match the launcher's.
-_launcher_rt_archive = (
-    'reussir_rt.lib' if sys.platform == 'win32' else 'libreussir_rt.a')
-config.substitutions.append((r'%launcher_rt_archive',
-                             sh_path(os.path.join(config.library_path,
-                                                  _launcher_rt_archive))))
-# What the archive's own code needs beyond what rustc links anyway — spelled
-# as rustc `-l` flags. rustc cannot see inside a native archive: on macOS the
-# frameworks its crates use must be named by hand. COFF objects carry
-# embedded defaultlib directives for some of their imports but not all of
-# the runtime's, so the Windows list stays explicit too; ELF needs nothing.
-if sys.platform == 'darwin':
-    _launcher_sys_libs = '-l framework=Security -l framework=CoreFoundation'
-elif sys.platform == 'win32':
-    _launcher_sys_libs = '-l ntdll -l ws2_32 -l advapi32 -l bcrypt -l userenv'
-else:
-    _launcher_sys_libs = ''
-config.substitutions.append((r'%launcher_sys_libs', _launcher_sys_libs))
+# The MSVC linker `rrc`'s link step should drive, as a driver flag, resolved
+# at configure time (see tests/integration/CMakeLists.txt): left to its own
+# discovery under a vcvars environment, rustc degrades to a bare PATH scan
+# for `link.exe` and finds Git-for-Windows' coreutils /usr/bin/link instead.
+# The path contains spaces (Program Files), so the substitution carries its
+# own quoting. Empty — no vcvars at configure, or not Windows — means rustc's
+# registry-based discovery, which is right on a plain dev box.
+#
+# Appended before `%rrc`, which is its prefix: lit applies substitutions in
+# list order, and the later `%rrc` would otherwise rewrite this one's name.
+_rrc_linker = ''
+if sys.platform == 'win32' and config.msvc_linker_path:
+    _rrc_linker = '--linker "%s"' % sh_path(config.msvc_linker_path)
+config.substitutions.append((r'%rrc_linker', _rrc_linker))
 config.substitutions.append((r'%rrc', sh_path(config.reussir_rrc_path)))
 # The package manager. It shells out to `rrc` for the source-graph scan, so
 # point it at the staged driver rather than whatever `rrc` a PATH lookup finds.
@@ -215,18 +205,6 @@ config.substitutions.append((r'%reussir_rt_lsan', sh_path(config.reussir_rt_lsan
 config.substitutions.append((r'%reussir_rt_msan', sh_path(config.reussir_rt_msan_path)))
 config.substitutions.append((r'%reussir_rt_tsan', sh_path(config.reussir_rt_tsan_path)))
 
-# The MSVC linker the launcher link hands to rustc via `-C linker=`,
-# resolved at configure time (see tests/integration/CMakeLists.txt): left to
-# its own discovery under a vcvars environment, rustc degrades to a bare
-# PATH scan for `link.exe` and finds Git-for-Windows' coreutils
-# /usr/bin/link instead. The path contains spaces (Program Files), so the
-# substitution carries its own quoting. Empty — no vcvars at configure —
-# means rustc's registry-based discovery, which is right on a plain dev box.
-_launcher_linker = ''
-if sys.platform == 'win32' and config.msvc_linker_path:
-    _launcher_linker = '-C "linker=%s"' % sh_path(config.msvc_linker_path)
-config.substitutions.append((r'%launcher_linker', _launcher_linker))
-
 # link.exe itself resolves the CRT and system import libraries through the
 # vcvars LIB variable; carry it (and its companions) across lit's
 # environment scrubbing.
@@ -238,6 +216,49 @@ if sys.platform == 'win32':
                  'LIB', 'INCLUDE', 'LIBPATH'):
         if _var in os.environ:
             config.environment[_var] = os.environ[_var]
+
+# `rrc --emit executable --lto …` needs the linker *rustc* drives to consume
+# this LLVM's bitcode: rust-lld does on the targets where it is rustc's
+# default, but a system linker without a matching-version LTO plugin (an old
+# ld64, MSVC's link.exe, aarch64-linux's bfd) fails on the first member.
+# Probe with the real pipeline; failing leaves `rustc-lto-link` off and the
+# LTO link tests unsupported rather than broken.
+def _probe_rustc_lto_link():
+    import subprocess
+    import tempfile
+    rrc = sh_path(config.reussir_rrc_path)
+    if not rrc or not os.path.exists(rrc):
+        return False
+    env = dict(os.environ)
+    for var in ('REUSSIR_RUSTC', 'REUSSIR_RUSTC_DEPS'):
+        if var in config.environment:
+            env[var] = config.environment[var]
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+        src = os.path.join(tmp, 'probe.rr')
+        exe = os.path.join(tmp, 'probe.exe')
+        with open(src, 'w') as f:
+            f.write('fn twice(n: u64) -> u64 { n + n }\n'
+                    '#[main]\n'
+                    'pub fn entry() {\n'
+                    '    let doubled = twice(21);\n'
+                    '}\n')
+        cmd = [rrc, src, '-o', exe, '--emit', 'executable',
+               '--relocation-mode', 'pic', '--lto', 'thin']
+        if sys.platform == 'win32' and config.msvc_linker_path:
+            cmd += ['--linker', config.msvc_linker_path]
+        try:
+            if subprocess.run(cmd, env=env, capture_output=True,
+                              timeout=300).returncode != 0:
+                return False
+            if subprocess.run([exe], capture_output=True,
+                              timeout=60).returncode != 0:
+                return False
+        except Exception:
+            return False
+    return True
+
+if _probe_rustc_lto_link():
+    config.available_features.add('rustc-lto-link')
 
 # TODO: should we support macos?
 if sys.platform == 'win32':


### PR DESCRIPTION
The two link-product stages stop being refusals: `rrc --emit executable` and `--emit dynlib` finish the stage chain with a link step of the driver's own — the one `frontend/main_attribute.rr` has been spelling by hand.

## How

- **rustc drives the link.** The executable's launcher *is* Rust (that is how a program starts under the full Rust runtime — `lang_start`, panic hook, stack guard), and rustc already knows each target's linker and system-library baseline. The launcher source is embedded in the driver; a dynlib builds around an empty cdylib shim instead.
- **The runtime archive is named by path**, never `-l static=` (which lowers to a bare `-l` and lets the linker take the dylib sitting beside the archive — the #461 macOS failure). `--runtime-linkage dynamic` trades the bundle for a soname reference against the shared runtime; on MSVC that means the `reussir_rt.dll.lib` import library by path, since `-l dylib=` would find the same-named *static* `reussir_rt.lib`.
- **A dynlib exports exactly the program's extern trampolines**, `#[main]`'s `__reussir_main` among them. rustc's cdylib machinery localizes everything the shim crate does not export, so the driver spells the surface to the linker per platform: a second version script on ELF (lld unions it with rustc's `local: *`), `-exported_symbols_list` on Mach-O, `/EXPORT:` on COFF — which is also what makes link.exe produce the import library at all. The localization is a feature: the cross-unit `_RC…` linkage surface of `--codegen-units` stays out of the dynamic table.
- **The export surface travels from the frontend's trampoline records** (`mir::Program::trampolines`), which also lets an executable refuse a `#[main]`-less program as a driver diagnostic instead of an undefined-symbol error. A backend-stage input (`.mlir`/`.ll`) no longer carries the surface, so `dynlib` from one is refused up front, while `executable` — which needs no export list — resumes from `.ll` straight into the link.
- **`--lto thin|fat` extends to the linked targets**: units are emitted as bitcode by the existing pre-link pipelines and the linker rustc drives optimizes across them. Whether that linker consumes this LLVM's bitcode is a host property (rust-lld does; an old ld64 or MSVC link.exe does not), so lit probes the real pipeline once and gates the LTO link tests on a `rustc-lto-link` feature.
- **New knobs** — `--runtime-linkage`, `--linker` (the MSVC pinning duty, replacing the hand-rolled `-C linker=`), `--link-arg` (pass-through) — are refused with any non-link target rather than silently ignored.

## Tests

- `codegen/executable.rr` — link and run, `--codegen-units 4`, `.exe` extension inference, `.ll` resume, the no-`#[main]` refusal, and the knob refusals.
- `codegen/dynlib.rr` — export surface (trampolines in, `_RC…` internals out), C consumer by path, `#[main]`-in-dynlib export, backend-input refusal. `codegen/dynlib_windows.rr` — the import-library flow.
- `codegen/executable_lto.rr` — thin/fat executables and a thin-LTO dynlib, gated on the probe. `codegen/executable_dynamic_rt.rr` — dynamic runtime linkage with an rpath.
- `frontend/main_attribute.rr` collapses to plain `--emit executable` invocations (resumed-from-HIR included); the `%launcher_*` lit substitutions collapse into `%rrc_linker`.
- Driver cargo tests updated: the old "not implemented" assertions become the new driver-level diagnostics, toolchain-scrubbed where they assert its absence.

Local verification (linux x86_64): full lit suite 418/418 passing (9 environment-gated unsupported), all 18 driver cargo tests, plus manual checks — static exe has no `libreussir_rt`/`libstd` runtime deps, dynamic exe records `libreussir_rt.so`, dynlib exports exactly the two trampolines, LTO thin/fat link and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787608238&installation_model_id=426051&pr_number=464&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F464&signature=0720935d0a8bd8cb8aff339b76c81bddd970b568bee4b92a989ce6ad84a9f1a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->