### PR TITLE
[rene] declare targets and build profiles in rene.ncl; drive rrc to artifacts

### DIFF
--- a/crates/rene/src/compile.rs
+++ b/crates/rene/src/compile.rs
@@ -1,0 +1,302 @@
+//! Compiling the package's declared targets through `rrc`.
+//!
+//! One `rrc` invocation per (target, profile): the package rooted at
+//! `src/lib.rr`, the profile's knobs as flags, `--emit` from the target's
+//! kind, and the baked runtime's libdirs for polyffi and the link step.
+//! Artifacts land in `<build-dir>/<profile>/`, named per platform
+//! (`demo`/`demo.exe`, `libdemo.so`/`libdemo.dylib`/`demo.dll`,
+//! `libdemo.a`/`demo.lib`).
+//!
+//! Each product's build is recorded in the status database under
+//! [`tables::product_key`] with the fingerprint it was built from — the
+//! evaluated-config hash (which covers targets and profiles), the source
+//! graph's content digests, the toolchain, and the CLI overrides. A build
+//! whose fingerprint matches and whose artifact still exists reruns nothing.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::db::BuildDir;
+use crate::deps::{self, Prepared};
+use crate::manifest::{Loaded, Profile, TargetKind};
+use crate::rt::RtArtifacts;
+use crate::tables;
+
+/// What the CLI resolved for this build: the profile in force and the
+/// selection/override flags.
+pub struct Options {
+    /// The profile's name — the artifacts' directory under the build dir,
+    /// and half of each product's status key.
+    pub profile_name: String,
+    /// The resolved profile (built-in refined by the manifest's).
+    pub profile: Profile,
+    /// `--target` filters; empty means every declared target.
+    pub targets: Vec<String>,
+    /// `rene build --linker`, overriding the profile's.
+    pub linker: Option<PathBuf>,
+}
+
+/// A built (or reused) product.
+pub struct Product {
+    pub name: String,
+    pub path: PathBuf,
+}
+
+/// One product's recorded build (JSON under [`tables::product_key`]).
+#[derive(Serialize, Deserialize)]
+pub struct ProductRecord {
+    pub fingerprint: String,
+    pub path: PathBuf,
+}
+
+/// Build the selected targets, reusing whatever the record proves current.
+pub fn build(
+    dir: &BuildDir,
+    loaded: &Loaded,
+    sources: &Prepared,
+    rt: &RtArtifacts,
+    opts: &Options,
+) -> Result<Vec<Product>, String> {
+    let manifest = &loaded.manifest;
+    let selected: Vec<&str> = if opts.targets.is_empty() {
+        manifest.targets.keys().map(String::as_str).collect()
+    } else {
+        for name in &opts.targets {
+            if !manifest.targets.contains_key(name) {
+                return Err(format!(
+                    "no target named `{name}`: the manifest declares {}",
+                    manifest
+                        .targets
+                        .keys()
+                        .map(|t| format!("`{t}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+        opts.targets.iter().map(String::as_str).collect()
+    };
+
+    let out_dir = dir.root().join(&opts.profile_name);
+    std::fs::create_dir_all(&out_dir)
+        .map_err(|e| format!("cannot create `{}`: {e}", out_dir.display()))?;
+    let fingerprint = fingerprint(loaded, sources, rt, opts);
+
+    let mut products = Vec::with_capacity(selected.len());
+    for name in selected {
+        let kind = manifest.targets[name].kind;
+        let path = out_dir.join(artifact_file(
+            name,
+            kind,
+            opts.profile.target_triple.as_deref(),
+        ));
+        let key = tables::product_key(&opts.profile_name, name);
+        if product_is_current(dir, &key, &fingerprint, &path)? {
+            tracing::info!(target = name, "up to date");
+            products.push(Product {
+                name: name.to_owned(),
+                path,
+            });
+            continue;
+        }
+
+        tracing::info!(target = name, kind = kind.emit(), out = %path.display(), "compiling");
+        compile(loaded, rt, opts, kind, &path)?;
+
+        let record = ProductRecord {
+            fingerprint: fingerprint.clone(),
+            path: path.clone(),
+        };
+        let record = serde_json::to_string(&record).map_err(|e| e.to_string())?;
+        dir.set_status(&[(key.as_str(), record.as_str())])
+            .map_err(|e| e.to_string())?;
+        products.push(Product {
+            name: name.to_owned(),
+            path,
+        });
+    }
+    Ok(products)
+}
+
+/// One `rrc` run for one target.
+fn compile(
+    loaded: &Loaded,
+    rt: &RtArtifacts,
+    opts: &Options,
+    kind: TargetKind,
+    out: &Path,
+) -> Result<(), String> {
+    let rrc = deps::resolve_rrc();
+    let mut cmd = Command::new(&rrc);
+    cmd.arg("--package-root")
+        .arg(deps::source_root(loaded))
+        .arg("--package-name")
+        .arg(&loaded.manifest.package.name)
+        .arg("--emit")
+        .arg(kind.emit())
+        .arg("-o")
+        .arg(out);
+    for libdir in rt.libdirs() {
+        cmd.arg("--polyffi-libdir").arg(libdir);
+    }
+    // The toolchain that baked the runtime is the one the link step and the
+    // polyffi texture compiles must agree with.
+    cmd.env("REUSSIR_RUSTC", &rt.rustc);
+    profile_args(&mut cmd, &opts.profile, kind, opts.linker.as_deref());
+
+    // rrc's diagnostics stream straight through to the user.
+    let status = cmd
+        .status()
+        .map_err(|e| format!("cannot run `{}`: {e}", rrc.display()))?;
+    if !status.success() {
+        return Err(format!(
+            "compiling `{}` failed (see rrc's diagnostics above)",
+            out.display()
+        ));
+    }
+    Ok(())
+}
+
+/// The profile, spelled as `rrc` flags.
+fn profile_args(cmd: &mut Command, profile: &Profile, kind: TargetKind, linker: Option<&Path>) {
+    if let Some(opt) = &profile.opt {
+        cmd.arg("-O").arg(opt);
+    }
+    if profile.debug == Some(true) {
+        cmd.arg("-g");
+    }
+    if let Some(lto) = &profile.lto
+        && lto != "none"
+    {
+        cmd.arg("--lto").arg(lto);
+    }
+    // Every declared kind is a link product or archived into one; PIC is the
+    // working default, with the profile the override.
+    let reloc = profile.relocation_mode.as_deref().unwrap_or("pic");
+    cmd.arg("--relocation-mode").arg(reloc);
+    if let Some(units) = profile.codegen_units {
+        cmd.arg("--codegen-units").arg(units.to_string());
+    }
+    for sanitizer in &profile.sanitizers {
+        cmd.arg("--sanitizer").arg(sanitizer);
+    }
+    if let Some(encoding) = &profile.nullary_variant_encoding {
+        cmd.arg("--nullary-variant-encoding").arg(encoding);
+    }
+    if let Some(triple) = &profile.target_triple {
+        cmd.arg("--target-triple").arg(triple);
+    }
+    if let Some(cpu) = &profile.target_cpu {
+        cmd.arg("--target-cpu").arg(cpu);
+    }
+    if let Some(features) = &profile.target_features {
+        cmd.arg("--target-features").arg(features);
+    }
+    if profile.reuse_across_call == Some(true) {
+        cmd.arg("--reuse-across-call");
+    }
+    if profile.closure_wpd == Some(false) {
+        cmd.arg("--no-closure-wpd");
+    }
+    if profile.pack_record_members == Some(false) {
+        cmd.arg("--no-pack-record-members");
+    }
+    // The link-only knobs go to the linked kinds alone, so one profile can
+    // serve targets of every kind without tripping rrc's strictness.
+    if kind.is_linked() {
+        if let Some(linkage) = &profile.runtime_linkage {
+            cmd.arg("--runtime-linkage").arg(linkage);
+        }
+        if let Some(linker) = linker.or(profile.linker.as_deref()) {
+            cmd.arg("--linker").arg(linker);
+        }
+        for arg in &profile.link_args {
+            cmd.arg(format!("--link-arg={arg}"));
+        }
+    }
+    cmd.args(&profile.extra_flags);
+}
+
+/// Everything a product's freshness hangs on, digested: the evaluated
+/// manifest (targets and profiles included), the profile *name* (two names
+/// may resolve to equal knobs but build into different directories), every
+/// source file's content digest, the toolchain, and the CLI linker override.
+/// The source-graph paths are covered through the config hash + digests; the
+/// artifact's own existence is checked separately.
+fn fingerprint(loaded: &Loaded, sources: &Prepared, rt: &RtArtifacts, opts: &Options) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(deps::config_hash(&loaded.dump).as_bytes());
+    hasher.update(opts.profile_name.as_bytes());
+    for file in &sources.files {
+        hasher.update(file.path.as_bytes());
+        hasher.update(&file.record.hash);
+    }
+    hasher.update(rt.rustc_version.as_bytes());
+    hasher.update(rt.staticlib.display().to_string().as_bytes());
+    if let Some(linker) = &opts.linker {
+        hasher.update(linker.display().to_string().as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+/// Is the recorded build of this product still the one this build would do?
+fn product_is_current(
+    dir: &BuildDir,
+    key: &str,
+    fingerprint: &str,
+    path: &Path,
+) -> Result<bool, String> {
+    let Some(record) = dir.status(key).map_err(|e| e.to_string())? else {
+        return Ok(false);
+    };
+    let Ok(record) = serde_json::from_str::<ProductRecord>(&record) else {
+        // An older rene may have written a different shape; just rebuild.
+        return Ok(false);
+    };
+    Ok(record.fingerprint == fingerprint && record.path == path && path.is_file())
+}
+
+/// The artifact's file name for `name`, per the target platform — the
+/// profile's `target_triple` when set, the host otherwise.
+fn artifact_file(name: &str, kind: TargetKind, triple: Option<&str>) -> String {
+    let windows = triple.map_or(cfg!(windows), |t| t.contains("windows"));
+    let apple = triple.map_or(cfg!(target_vendor = "apple"), |t| t.contains("apple"));
+    match kind {
+        TargetKind::Executable if windows => format!("{name}.exe"),
+        TargetKind::Executable => name.to_owned(),
+        TargetKind::Dynlib if windows => format!("{name}.dll"),
+        TargetKind::Dynlib if apple => format!("lib{name}.dylib"),
+        TargetKind::Dynlib => format!("lib{name}.so"),
+        TargetKind::Staticlib if windows => format!("{name}.lib"),
+        TargetKind::Staticlib => format!("lib{name}.a"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artifact_names_follow_the_target_platform() {
+        let linux = Some("x86_64-unknown-linux-gnu");
+        let mac = Some("aarch64-apple-darwin");
+        let win = Some("x86_64-pc-windows-msvc");
+        for (kind, expect) in [
+            (TargetKind::Executable, ["demo", "demo", "demo.exe"]),
+            (
+                TargetKind::Dynlib,
+                ["libdemo.so", "libdemo.dylib", "demo.dll"],
+            ),
+            (
+                TargetKind::Staticlib,
+                ["libdemo.a", "libdemo.a", "demo.lib"],
+            ),
+        ] {
+            assert_eq!(artifact_file("demo", kind, linux), expect[0]);
+            assert_eq!(artifact_file("demo", kind, mac), expect[1]);
+            assert_eq!(artifact_file("demo", kind, win), expect[2]);
+        }
+    }
+}

--- a/crates/rene/src/deps.rs
+++ b/crates/rene/src/deps.rs
@@ -277,7 +277,7 @@ pub fn scan(root: &Path, package: &str) -> Result<Vec<SourceFile>, String> {
 
 /// The `rrc` executable: `REUSSIR_RRC` if set (the override rene's runtime
 /// bake uses for `cargo`/`rustc` too), else `rrc` through `PATH`.
-fn resolve_rrc() -> PathBuf {
+pub(crate) fn resolve_rrc() -> PathBuf {
     std::env::var_os("REUSSIR_RRC").map_or_else(|| PathBuf::from("rrc"), PathBuf::from)
 }
 

--- a/crates/rene/src/lib.rs
+++ b/crates/rene/src/lib.rs
@@ -4,11 +4,12 @@
 //! evaluating to the package description (name, dependencies, …) — and a
 //! `src/` tree whose `lib.rr` is the crate root. Builds run in a build
 //! directory (`reussir-build/` by default) whose status lives in a redb
-//! database: the baked bundled `reussir-rt` runtime ([`rt`]) and the
-//! package's source graph as `rrc --scan-deps` reported it ([`deps`]).
-//! Compiling the package itself, dependency resolution, and project
-//! scaffolding come later.
+//! database: the baked bundled `reussir-rt` runtime ([`rt`]), the package's
+//! source graph as `rrc --scan-deps` reported it ([`deps`]), and the built
+//! products of the manifest's declared targets ([`compile`]). Dependency
+//! resolution and project scaffolding come later.
 
+pub mod compile;
 pub mod db;
 pub mod deps;
 pub mod manifest;

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -4,10 +4,12 @@
 //! directory's lock (the status database), records the package's source graph
 //! (re-scanning it through `rrc --scan-deps` only when something moved), bakes
 //! the bundled `reussir-rt` runtime with the user's Rust toolchain if needed,
-//! and prints the library directories to pass to `rrc --polyffi-libdir`.
-//! `rene inspect` reports that source graph as JSON; `rene clean` deletes the
-//! build directory unless another instance holds it. Compiling the package
-//! itself comes in a later stage.
+//! and compiles the manifest's declared `targets` under the selected
+//! `--profile`, printing the artifact paths. A package declaring no targets
+//! stops after the bake and prints the library directories to pass to
+//! `rrc --polyffi-libdir` by hand. `rene inspect` reports the source graph as
+//! JSON; `rene clean` deletes the build directory unless another instance
+//! holds it.
 //!
 //! Progress goes to stderr via `tracing`; stdout carries only the final
 //! machine-readable listing. Exit 0 on success, 1 on a failed command, 2 on
@@ -19,7 +21,7 @@ use std::process::ExitCode;
 use palc::Parser;
 
 use rene::db::{self, BuildDir, CleanOutcome};
-use rene::{deps, manifest, rt};
+use rene::{compile, deps, manifest, rt};
 
 /// The default build directory name, next to the manifest.
 const BUILD_DIR: &str = "reussir-build";
@@ -57,11 +59,29 @@ enum Command {
 }
 
 /// Build the current package: bake the bundled reussir-rt runtime if needed,
-/// then print the library directories to pass to rrc.
+/// then compile the manifest's declared targets under the selected profile.
+/// A package declaring no targets stops after the bake and prints the
+/// library directories to pass to rrc by hand.
 #[derive(palc::Args)]
 struct BuildArgs {
     #[command(flatten)]
     location: Location,
+
+    /// The build profile: a built-in (`dev`, `release`) or one the manifest
+    /// declares under `profiles`. Artifacts land in
+    /// `<build-dir>/<profile>/`.
+    #[arg(long, default_value = "dev")]
+    profile: String,
+
+    /// Build only this declared target (repeatable). Default: all of them.
+    #[arg(long = "target")]
+    targets: Vec<String>,
+
+    /// The linker rrc's link step hands to rustc (`rrc --linker`),
+    /// overriding the profile's. Useful where rustc's own discovery resolves
+    /// the wrong tool.
+    #[arg(long)]
+    linker: Option<PathBuf>,
 }
 
 /// Delete the build directory, unless another rene is using it.
@@ -105,7 +125,7 @@ fn main() -> ExitCode {
     };
     init_tracing(cli.verbose);
     let result = match cli.command {
-        Command::Build(args) => build(&args.location),
+        Command::Build(args) => build(&args),
         Command::Clean(args) => clean(&args.location),
         Command::Inspect(args) => inspect(&args.location, args.frozen),
     };
@@ -161,14 +181,19 @@ fn locate_manifest(flag: &Option<PathBuf>) -> Result<PathBuf, String> {
     }
 }
 
-fn build(location: &Location) -> Result<(), String> {
+fn build(args: &BuildArgs) -> Result<(), String> {
+    let location = &args.location;
     let manifest_path = locate_manifest(&location.manifest_path)?;
     let loaded = manifest::load(&manifest_path).map_err(|e| e.to_string())?;
     tracing::info!(
         package = %loaded.manifest.package.name,
         manifest = %loaded.path.display(),
+        profile = %args.profile,
         "building"
     );
+    // Resolve the profile before any work: an unknown name is a usage
+    // problem, not something to discover after a runtime bake.
+    let profile = manifest::resolve_profile(&loaded.manifest, &args.profile)?;
 
     let root = resolve_build_dir(location)?;
     // Opening the status database takes the build directory's lock; hold it
@@ -178,18 +203,40 @@ fn build(location: &Location) -> Result<(), String> {
         return Err(pending_clean(&root));
     }
     // The source graph first: it is cheap, it fails fast on a broken package,
-    // and a build that finds nothing moved has nothing to do beyond reporting
-    // the (already baked) runtime.
+    // and a build that finds nothing moved skips straight to the freshness
+    // checks below.
     let sources = deps::prepare(&dir, &loaded)?;
     let artifacts = rt::prepare(&dir)?;
-    if !sources.rescanned() {
-        tracing::info!(files = sources.files.len(), "nothing to do");
+
+    // No declared targets: stop after the bake, reporting the libdirs for
+    // whoever drives rrc by hand — the pre-target workflow, kept working.
+    if loaded.manifest.targets.is_empty() {
+        if !sources.rescanned() {
+            tracing::info!(files = sources.files.len(), "nothing to do");
+        }
+        tracing::info!("no targets declared; pass these directories to `rrc --polyffi-libdir`:");
+        for libdir in artifacts.libdirs() {
+            println!("{}", libdir.display());
+        }
+        return Ok(());
     }
 
-    tracing::info!("TODO: compiling the package is not implemented yet");
-    tracing::info!("pass these directories to `rrc --polyffi-libdir`:");
-    for libdir in artifacts.libdirs() {
-        println!("{}", libdir.display());
+    let products = compile::build(
+        &dir,
+        &loaded,
+        &sources,
+        &artifacts,
+        &compile::Options {
+            profile_name: args.profile.clone(),
+            profile,
+            targets: args.targets.clone(),
+            linker: args.linker.clone(),
+        },
+    )?;
+    // Stdout carries the artifact listing, one path per target, in the
+    // order they were declared (or selected).
+    for product in &products {
+        println!("{}", product.path.display());
     }
     Ok(())
 }

--- a/crates/rene/src/manifest.rs
+++ b/crates/rene/src/manifest.rs
@@ -23,6 +23,16 @@ pub struct Manifest {
     /// Dependencies by name. First stage: file-system paths only.
     #[serde(default)]
     pub dependencies: BTreeMap<String, Dependency>,
+    /// The products `rene build` compiles, by name — the name becomes the
+    /// artifact's file stem (`demo` → `demo`/`demo.exe`, `libdemo.so`, …). A
+    /// package with no targets builds nothing; `build` still scans and bakes.
+    #[serde(default)]
+    pub targets: BTreeMap<String, Target>,
+    /// Named sets of build knobs, selected with `rene build --profile`. A
+    /// profile named like a built-in (`dev`, `release`) *refines* it: fields
+    /// it does not set keep the built-in's values.
+    #[serde(default)]
+    pub profiles: BTreeMap<String, Profile>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -38,6 +48,161 @@ pub struct Dependency {
     /// Directory of the dependency package, relative to the manifest's
     /// directory unless absolute.
     pub path: PathBuf,
+}
+
+/// What a target builds — the three link products `rrc` emits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TargetKind {
+    Executable,
+    Dynlib,
+    Staticlib,
+}
+
+impl TargetKind {
+    /// The `rrc --emit` value this kind compiles as.
+    pub fn emit(self) -> &'static str {
+        match self {
+            TargetKind::Executable => "executable",
+            TargetKind::Dynlib => "dynlib",
+            TargetKind::Staticlib => "staticlib",
+        }
+    }
+
+    /// Whether `rrc` finishes this kind with a link step — where the
+    /// link-only knobs (`runtime_linkage`, `linker`, `link_args`) apply.
+    pub fn is_linked(self) -> bool {
+        matches!(self, TargetKind::Executable | TargetKind::Dynlib)
+    }
+}
+
+/// A declared build product. Unknown fields are rejected: a typo here would
+/// otherwise silently change what gets built.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Target {
+    pub kind: TargetKind,
+}
+
+/// A named set of build knobs, mirroring `rrc`'s flags one for one — the
+/// values are passed through verbatim, so `rrc --help` is the reference for
+/// what each accepts, and an invalid one fails there with its diagnostic.
+/// Every field is optional; what a profile leaves unset falls back to the
+/// built-in it refines (see [`resolve_profile`]), then to `rrc`'s defaults.
+/// Unknown fields are rejected: a typo'd knob that silently vanished would
+/// change codegen without a trace.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Profile {
+    /// `rrc -O`: `none`, `default`, `aggressive`, or `size`.
+    pub opt: Option<String>,
+    /// `rrc -g`: emit DWARF debug info.
+    pub debug: Option<bool>,
+    /// `rrc --lto`: `none`, `thin`, or `fat`.
+    pub lto: Option<String>,
+    /// `rrc --relocation-mode`. Unset, `rene` passes `pic`: every declared
+    /// kind is a link product (or archived into one), and shared objects and
+    /// position-independent executables need it.
+    pub relocation_mode: Option<String>,
+    /// `rrc --codegen-units`.
+    pub codegen_units: Option<u32>,
+    /// `rrc --runtime-linkage` (linked targets): `static` or `dynamic`.
+    pub runtime_linkage: Option<String>,
+    /// `rrc --linker` (linked targets); `rene build --linker` overrides it.
+    pub linker: Option<PathBuf>,
+    /// `rrc --link-arg`, one per element (linked targets).
+    #[serde(default)]
+    pub link_args: Vec<String>,
+    /// `rrc --sanitizer`, one per element.
+    #[serde(default)]
+    pub sanitizers: Vec<String>,
+    /// `rrc --nullary-variant-encoding`.
+    pub nullary_variant_encoding: Option<String>,
+    /// `rrc --target-triple`.
+    pub target_triple: Option<String>,
+    /// `rrc --target-cpu`.
+    pub target_cpu: Option<String>,
+    /// `rrc --target-features`.
+    pub target_features: Option<String>,
+    /// `rrc --reuse-across-call` when true.
+    pub reuse_across_call: Option<bool>,
+    /// `rrc --no-closure-wpd` when false (the knob is spelled positively
+    /// here; unset leaves rrc's own default).
+    pub closure_wpd: Option<bool>,
+    /// `rrc --no-pack-record-members` when false (spelled positively here).
+    pub pack_record_members: Option<bool>,
+    /// Escape hatch: extra `rrc` arguments appended verbatim, for the knobs
+    /// this schema does not name (`--transform-script`, …).
+    #[serde(default)]
+    pub extra_flags: Vec<String>,
+}
+
+impl Profile {
+    /// This profile with `over`'s set fields winning; list fields
+    /// concatenate, this profile's elements first.
+    fn refined_by(mut self, over: &Profile) -> Profile {
+        macro_rules! take {
+            ($($field:ident),*) => {
+                $(if over.$field.is_some() {
+                    self.$field = over.$field.clone();
+                })*
+            };
+        }
+        take!(
+            opt,
+            debug,
+            lto,
+            relocation_mode,
+            codegen_units,
+            runtime_linkage,
+            linker,
+            nullary_variant_encoding,
+            target_triple,
+            target_cpu,
+            target_features,
+            reuse_across_call,
+            closure_wpd,
+            pack_record_members
+        );
+        self.link_args.extend(over.link_args.iter().cloned());
+        self.sanitizers.extend(over.sanitizers.iter().cloned());
+        self.extra_flags.extend(over.extra_flags.iter().cloned());
+        self
+    }
+}
+
+/// The built-in profile of that name, if any: `dev` (unoptimized, debug
+/// info — the default profile) and `release` (aggressive optimization).
+fn builtin_profile(name: &str) -> Option<Profile> {
+    match name {
+        "dev" => Some(Profile {
+            opt: Some("none".to_owned()),
+            debug: Some(true),
+            ..Profile::default()
+        }),
+        "release" => Some(Profile {
+            opt: Some("aggressive".to_owned()),
+            ..Profile::default()
+        }),
+        _ => None,
+    }
+}
+
+/// The profile `name` resolves to: the built-in of that name refined by the
+/// manifest's, either alone, and an error when the name is neither — an
+/// unknown profile silently meaning "all defaults" would be a typo trap.
+pub fn resolve_profile(manifest: &Manifest, name: &str) -> Result<Profile, String> {
+    let builtin = builtin_profile(name);
+    let declared = manifest.profiles.get(name);
+    match (builtin, declared) {
+        (Some(base), Some(over)) => Ok(base.refined_by(over)),
+        (Some(base), None) => Ok(base),
+        (None, Some(profile)) => Ok(profile.clone()),
+        (None, None) => Err(format!(
+            "no profile named `{name}`: the manifest declares none by that \
+             name and it is not a built-in (`dev`, `release`)"
+        )),
+    }
 }
 
 /// A successfully loaded manifest.
@@ -193,6 +358,94 @@ mod tests {
     }
 
     #[test]
+    fn targets_and_profiles_parse_from_the_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"
+            {
+              package = { name = "demo" },
+              targets = {
+                demo = { kind = 'executable },
+                shared = { kind = 'dynlib },
+                archive = { kind = 'staticlib },
+              },
+              profiles = {
+                release = { lto = "thin", codegen_units = 4, link_args = ["-lm"] },
+                asan = { sanitizers = ["address"], nullary_variant_encoding = "arch-independent" },
+              },
+            }
+            "#,
+        );
+
+        let loaded = load(&path).unwrap();
+        let m = &loaded.manifest;
+        assert_eq!(m.targets["demo"].kind, TargetKind::Executable);
+        assert_eq!(m.targets["shared"].kind, TargetKind::Dynlib);
+        assert_eq!(m.targets["archive"].kind, TargetKind::Staticlib);
+        assert_eq!(m.profiles["release"].lto.as_deref(), Some("thin"));
+        assert_eq!(m.profiles["release"].codegen_units, Some(4));
+        assert_eq!(m.profiles["release"].link_args, ["-lm"]);
+        assert_eq!(m.profiles["asan"].sanitizers, ["address"]);
+    }
+
+    /// A profile named like a built-in refines it: what it does not set keeps
+    /// the built-in's values. An undeclared, non-built-in name is an error.
+    #[test]
+    fn profiles_resolve_against_the_builtins() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"
+            {
+              package = { name = "demo" },
+              profiles = {
+                release = { lto = "thin" },
+                custom = { opt = "size" },
+              },
+            }
+            "#,
+        );
+        let manifest = load(&path).unwrap().manifest;
+
+        // Pure built-ins.
+        let dev = resolve_profile(&manifest, "dev").unwrap();
+        assert_eq!(dev.opt.as_deref(), Some("none"));
+        assert_eq!(dev.debug, Some(true));
+
+        // Refinement: the manifest's lto lands, the built-in's opt stays.
+        let release = resolve_profile(&manifest, "release").unwrap();
+        assert_eq!(release.opt.as_deref(), Some("aggressive"));
+        assert_eq!(release.lto.as_deref(), Some("thin"));
+
+        // A declared profile with no built-in stands alone.
+        let custom = resolve_profile(&manifest, "custom").unwrap();
+        assert_eq!(custom.opt.as_deref(), Some("size"));
+        assert_eq!(custom.debug, None);
+
+        let err = resolve_profile(&manifest, "bogus").unwrap_err();
+        assert!(err.contains("no profile named `bogus`"), "{err}");
+    }
+
+    /// A typo'd knob must be a schema error, not a silently ignored field —
+    /// it would change codegen without a trace.
+    #[test]
+    fn unknown_profile_and_target_fields_are_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        for manifest in [
+            r#"{ package = { name = "p" }, profiles = { dev = { optt = "none" } } }"#,
+            r#"{ package = { name = "p" }, targets = { t = { kind = 'executable, knid = 1 } } }"#,
+            r#"{ package = { name = "p" }, targets = { t = { kind = "exe" } } }"#,
+        ] {
+            let path = write_manifest(tmp.path(), manifest);
+            match load(&path) {
+                Err(ManifestError::Schema(_)) => {}
+                other => panic!("expected a schema error for {manifest}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn locate_walks_up_from_a_subdirectory() {
         let tmp = tempfile::tempdir().unwrap();
         let path = write_manifest(tmp.path(), r#"{ package = { name = "up" } }"#);
@@ -207,10 +460,7 @@ mod tests {
     fn evaluation_errors_carry_diagnostics() {
         let tmp = tempfile::tempdir().unwrap();
         // A contract violation: `name` must be a string.
-        let path = write_manifest(
-            tmp.path(),
-            r#"{ package = { name | String = 42 } }"#,
-        );
+        let path = write_manifest(tmp.path(), r#"{ package = { name | String = 42 } }"#);
 
         match load(&path) {
             Err(ManifestError::Eval(diag)) => assert!(diag.contains("contract")),

--- a/crates/rene/src/rt.rs
+++ b/crates/rene/src/rt.rs
@@ -40,7 +40,11 @@ pub fn unpack(dest: &Path) -> std::io::Result<()> {
 /// need. Stored as JSON under [`tables::RT_ARTIFACTS_KEY`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RtArtifacts {
-    /// `rustc --version` of the toolchain that baked the runtime.
+    /// The rustc that baked the runtime — also the one `rrc`'s link step and
+    /// polyffi texture compiles must use (`REUSSIR_RUSTC`), so the runtime
+    /// and everything linked against it agree on one toolchain.
+    pub rustc: PathBuf,
+    /// `rustc --version` of that toolchain.
     pub rustc_version: String,
     /// The toolchain's target libdir (`rustc --print target-libdir`) — the
     /// "detected rust lib" directory polyffi links the standard library from.
@@ -151,6 +155,7 @@ pub fn prepare(dir: &BuildDir) -> Result<RtArtifacts, String> {
         }
     };
     let artifacts = RtArtifacts {
+        rustc: toolchain.rustc,
         rustc_version: toolchain.version,
         rust_libdir: toolchain.rust_libdir,
         deps_dir,
@@ -201,7 +206,11 @@ fn fresh_bake(
 /// Returns the runtime's (rlib, staticlib).
 fn cargo_build(toolchain: &Toolchain, src_dir: &Path) -> Result<(PathBuf, PathBuf), String> {
     let mut child = Command::new(&toolchain.cargo)
-        .args(["build", "--release", "--message-format=json-render-diagnostics"])
+        .args([
+            "build",
+            "--release",
+            "--message-format=json-render-diagnostics",
+        ])
         .current_dir(src_dir)
         // Pin the rustc cargo delegates to, so the recorded version and
         // libdir describe the compiler that actually built the artifacts.
@@ -246,9 +255,7 @@ fn cargo_build(toolchain: &Toolchain, src_dir: &Path) -> Result<(PathBuf, PathBu
     }
     match (rlib, staticlib) {
         (Some(rlib), Some(staticlib)) => Ok((rlib, staticlib)),
-        _ => Err(
-            "cargo succeeded but did not report the runtime's rlib and staticlib".to_owned(),
-        ),
+        _ => Err("cargo succeeded but did not report the runtime's rlib and staticlib".to_owned()),
     }
 }
 

--- a/crates/rene/src/tables.rs
+++ b/crates/rene/src/tables.rs
@@ -45,6 +45,15 @@ pub const RT_SOURCE_HASH_KEY: &str = "rt.source-hash";
 /// toolchain identity plus the paths `build` reports to the user.
 pub const RT_ARTIFACTS_KEY: &str = "rt.artifacts";
 
+/// The status key of one built product's record, a JSON
+/// [`crate::compile::ProductRecord`]: the fingerprint it was built under and
+/// where the artifact landed. Records of targets that leave the manifest
+/// simply go stale in place — nothing reads them again, and a config change
+/// re-fingerprints the rest.
+pub fn product_key(profile: &str, target: &str) -> String {
+    format!("product.{profile}.{target}")
+}
+
 /// Teardown marker (JSON `true`), set by `clean` while it still holds the
 /// lock, right before it deletes the directory. A database carrying it is a
 /// directory whose deletion is in flight or was interrupted: `build` refuses

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -64,7 +64,11 @@ fn build_fails_cleanly_without_a_manifest() {
     let tmp = tempfile::tempdir().unwrap();
     let out = run(rene(&["build"]).current_dir(tmp.path()));
     assert_eq!(out.status.code(), Some(1));
-    assert!(stderr(&out).contains("rene.ncl"), "stderr: {}", stderr(&out));
+    assert!(
+        stderr(&out).contains("rene.ncl"),
+        "stderr: {}",
+        stderr(&out)
+    );
 }
 
 #[test]
@@ -183,18 +187,27 @@ impl Fakes {
              printf '{\"reason\":\"compiler-artifact\",\"target\":{\"name\":\"reussir-rt\"},\"filenames\":[\"%s\",\"%s\"]}\\n' \"$rlib\" \"$staticlib\"\n"
                 .to_owned(),
         );
-        // Stands in for `rrc --scan-deps`: counts invocations and reports the
-        // package root's `.rr` files as the source graph, crate root first —
-        // the same JSON shape rrc emits, so a file added to the package shows
-        // up in the next scan.
+        // Stands in for `rrc`. A `--scan-deps` invocation counts itself and
+        // reports the package root's `.rr` files as the source graph, crate
+        // root first — the same JSON shape rrc emits, so a file added to the
+        // package shows up in the next scan. Anything else is a compile:
+        // it logs the full argv (plus the REUSSIR_RUSTC rene handed it) and
+        // fabricates the `-o` artifact.
         let rrc = script(
             "fake-rrc",
-            "echo run >> \"$(dirname \"$0\")/rrc-runs\"\n\
-             root=\"\"; prev=\"\"\n\
+            "root=\"\"; out=\"\"; prev=\"\"; scan=no\n\
              for arg in \"$@\"; do\n\
                [ \"$prev\" = \"--package-root\" ] && root=\"$arg\"\n\
+               [ \"$prev\" = \"-o\" ] && out=\"$arg\"\n\
+               [ \"$arg\" = \"--scan-deps\" ] && scan=yes\n\
                prev=\"$arg\"\n\
              done\n\
+             if [ \"$scan\" = no ]; then\n\
+               echo \"$* rustc=$REUSSIR_RUSTC\" >> \"$(dirname \"$0\")/rrc-compiles\"\n\
+               echo compiled > \"$out\"\n\
+               exit 0\n\
+             fi\n\
+             echo run >> \"$(dirname \"$0\")/rrc-runs\"\n\
              printf '{\"package\":\"pkg\",\"files\":[{\"path\":\"%s\",\"module\":[\"pkg\"]}' \"$root/lib.rr\"\n\
              for f in \"$root\"/*.rr; do\n\
                case \"$f\" in */lib.rr) continue;; esac\n\
@@ -220,6 +233,14 @@ impl Fakes {
         match std::fs::read_to_string(self.dir.join(format!("{tool}-runs"))) {
             Ok(log) => log.lines().count(),
             Err(_) => 0,
+        }
+    }
+
+    /// The compile invocations the fake `rrc` served, one argv line each.
+    fn compiles(&self) -> Vec<String> {
+        match std::fs::read_to_string(self.dir.join("rrc-compiles")) {
+            Ok(log) => log.lines().map(str::to_owned).collect(),
+            Err(_) => Vec::new(),
         }
     }
 
@@ -356,7 +377,11 @@ fn build_rescans_the_whole_graph_when_a_source_changes() {
 
     let out = fakes.rene(&["build"], &manifest, &root);
     assert!(out.status.success(), "stderr: {}", stderr(&out));
-    assert_eq!(fakes.runs("rrc"), 2, "the changed package must be re-scanned");
+    assert_eq!(
+        fakes.runs("rrc"),
+        2,
+        "the changed package must be re-scanned"
+    );
 
     // The refreshed table is the new graph, `extra.rr` included (the record
     // is a set of files, reported in path order).
@@ -432,7 +457,11 @@ fn build_rescans_when_the_config_checksum_changes() {
     assert_ne!(before["config_hash"], after["config_hash"]);
 
     assert!(fakes.rene(&["build"], &manifest, &root).status.success());
-    assert_eq!(fakes.runs("rrc"), 2, "a changed config must force a re-scan");
+    assert_eq!(
+        fakes.runs("rrc"),
+        2,
+        "a changed config must force a re-scan"
+    );
     assert_eq!(
         frozen_report(&fakes, &manifest, &root)["state"],
         "up-to-date"
@@ -497,6 +526,151 @@ fn inspect_frozen_neither_scans_nor_creates_a_build_directory() {
     assert_eq!(report["files"].as_array().unwrap().len(), 0);
     assert_eq!(fakes.runs("rrc"), 0);
     assert!(!root.exists(), "--frozen created `{}`", root.display());
+}
+
+/// (Re)write the scratch package's manifest with targets of every kind and a
+/// `release` profile refining the built-in.
+#[cfg(unix)]
+fn write_targets_manifest(dir: &Path) -> PathBuf {
+    let path = dir.join("rene.ncl");
+    std::fs::write(
+        &path,
+        r#"
+        {
+          package = { name = "demo", version = "0.1.0" },
+          targets = {
+            demo = { kind = 'executable },
+            shared = { kind = 'dynlib },
+            archive = { kind = 'staticlib },
+          },
+          profiles = {
+            release = { lto = "thin", codegen_units = 2, link_args = ["-lm"] },
+          },
+        }
+        "#,
+    )
+    .unwrap();
+    path
+}
+
+/// The whole flag surface, through the fakes: every declared target compiles
+/// with the profile's knobs spelled as rrc flags, the link-only knobs go to
+/// the linked kinds alone, artifacts land under `<build-dir>/<profile>/`,
+/// and stdout lists them in declaration order.
+#[cfg(unix)]
+#[test]
+fn build_compiles_the_declared_targets_with_the_profile_knobs() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp = tmp_dir.path().canonicalize().unwrap();
+    let root = tmp.join("reussir-build");
+    package(&tmp, "demo");
+    let manifest = write_targets_manifest(&tmp);
+    let fakes = Fakes::new(&tmp);
+
+    let out = fakes.rene(&["build", "--profile", "release"], &manifest, &root);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    // Stdout lists the artifacts, BTreeMap (declaration-name) order.
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let release = root.join("release");
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        [
+            release.join("libarchive.a").display().to_string(),
+            release.join("demo").display().to_string(),
+            release.join("libshared.so").display().to_string(),
+        ]
+    );
+    for line in stdout.lines() {
+        assert!(Path::new(line).is_file(), "no artifact at {line}");
+    }
+
+    let compiles = fakes.compiles();
+    assert_eq!(compiles.len(), 3, "{compiles:#?}");
+    for line in &compiles {
+        // The package, the profile's codegen knobs (the built-in's opt
+        // refined by the manifest's lto/units), the PIC default, the baked
+        // libdirs, and the toolchain rene pinned for the child.
+        assert!(line.contains("--package-name demo"), "{line}");
+        assert!(line.contains("-O aggressive"), "{line}");
+        assert!(line.contains("--lto thin"), "{line}");
+        assert!(line.contains("--codegen-units 2"), "{line}");
+        assert!(line.contains("--relocation-mode pic"), "{line}");
+        assert!(line.contains("--polyffi-libdir"), "{line}");
+        assert!(
+            line.contains(&format!("rustc={}", fakes.rustc.display())),
+            "{line}"
+        );
+    }
+    let of_kind = |kind: &str| {
+        compiles
+            .iter()
+            .find(|l| l.contains(&format!("--emit {kind}")))
+            .unwrap_or_else(|| panic!("no {kind} compile in {compiles:#?}"))
+    };
+    // Link-only knobs reach the linked kinds and never the archive.
+    assert!(of_kind("executable").contains("--link-arg=-lm"));
+    assert!(of_kind("dynlib").contains("--link-arg=-lm"));
+    assert!(!of_kind("staticlib").contains("--link-arg"));
+
+    // A second build finds every product current: no new compiles, same
+    // listing.
+    let again = fakes.rene(&["build", "--profile", "release"], &manifest, &root);
+    assert!(again.status.success(), "stderr: {}", stderr(&again));
+    assert_eq!(String::from_utf8(again.stdout).unwrap(), stdout);
+    assert_eq!(fakes.compiles().len(), 3, "a fresh build re-compiled");
+
+    // A source edit re-fingerprints every product of the profile.
+    std::fs::write(
+        tmp.join("src/math.rr"),
+        "pub fn add(a: u64, b: u64) -> u64 { b + a }\n",
+    )
+    .unwrap();
+    let rebuilt = fakes.rene(&["build", "--profile", "release"], &manifest, &root);
+    assert!(rebuilt.status.success(), "stderr: {}", stderr(&rebuilt));
+    assert_eq!(fakes.compiles().len(), 6, "the edit must rebuild");
+}
+
+/// `--target` narrows the build; unknown target and profile names are
+/// refused with their names.
+#[cfg(unix)]
+#[test]
+fn build_selects_targets_and_refuses_unknown_names() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp = tmp_dir.path().canonicalize().unwrap();
+    let root = tmp.join("reussir-build");
+    package(&tmp, "demo");
+    let manifest = write_targets_manifest(&tmp);
+    let fakes = Fakes::new(&tmp);
+
+    let out = fakes.rene(&["build", "--target", "demo"], &manifest, &root);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        [root.join("dev").join("demo").display().to_string()]
+    );
+    let compiles = fakes.compiles();
+    assert_eq!(compiles.len(), 1, "{compiles:#?}");
+    // The dev built-in: unoptimized, debug info on.
+    assert!(compiles[0].contains("-O none"), "{}", compiles[0]);
+    assert!(compiles[0].contains("-g"), "{}", compiles[0]);
+
+    let out = fakes.rene(&["build", "--target", "bogus"], &manifest, &root);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr(&out).contains("no target named `bogus`"),
+        "stderr: {}",
+        stderr(&out)
+    );
+
+    let out = fakes.rene(&["build", "--profile", "bogus"], &manifest, &root);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr(&out).contains("no profile named `bogus`"),
+        "stderr: {}",
+        stderr(&out)
+    );
 }
 
 /// A package without a source root is a configuration error, named as such.

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -570,15 +570,22 @@ fn build_compiles_the_declared_targets_with_the_profile_knobs() {
     let out = fakes.rene(&["build", "--profile", "release"], &manifest, &root);
     assert!(out.status.success(), "stderr: {}", stderr(&out));
 
-    // Stdout lists the artifacts, BTreeMap (declaration-name) order.
+    // Stdout lists the artifacts, BTreeMap (declaration-name) order, named
+    // for the host platform (these tests are unix-only, so the split is
+    // Apple vs ELF).
     let stdout = String::from_utf8(out.stdout).unwrap();
     let release = root.join("release");
+    let dylib = if cfg!(target_vendor = "apple") {
+        "libshared.dylib"
+    } else {
+        "libshared.so"
+    };
     assert_eq!(
         stdout.lines().collect::<Vec<_>>(),
         [
             release.join("libarchive.a").display().to_string(),
             release.join("demo").display().to_string(),
-            release.join("libshared.so").display().to_string(),
+            release.join(dylib).display().to_string(),
         ]
     );
     for line in stdout.lines() {

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -274,6 +274,10 @@ def _probe_rustc_lto_link():
 if _probe_rustc_lto_link():
     config.available_features.add('rustc-lto-link')
 
+# Executables' platform suffix, for running artifacts whose name a tool
+# derived (`rene build`'s `<profile>/<target>`), not a RUN line's `-o`.
+config.substitutions.append((r'%exe_ext', '.exe' if sys.platform == 'win32' else ''))
+
 # TODO: should we support macos?
 if sys.platform == 'win32':
     config.available_features.add('windows')

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -1,0 +1,46 @@
+// UNSUPPORTED: windows
+// `rene build`, end to end: the manifest declares the targets, the profile
+// picks the knobs, and rene drives the real `rrc` — package scan, runtime
+// bake, compile, link — to a running executable. The runtime is baked with
+// the host toolchain inside the test's build directory: slow once, then
+// shared by every RUN line below through the one `--build-dir`.
+//
+// Windows-gated off for now: the bake runs cargo → rustc → link.exe inside
+// lit's environment, where rustc's linker discovery finds Git-for-Windows'
+// coreutils `link` (the very thing `rrc --linker` pins for the driver-level
+// links, which codegen/executable.rr covers on Windows). Teaching the bake
+// the same pinning is a follow-up.
+
+// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir > %t.listing
+// RUN: %FileCheck %s --check-prefix=LISTING < %t.listing
+
+// Stdout is the artifact listing: the one declared target, under the
+// default profile's directory.
+// LISTING: {{[/\\]}}dev{{[/\\]}}demo
+// LISTING-NOT: {{.}}
+
+// The built executable runs.
+// RUN: %t.bdir/dev/demo%exe_ext
+
+// An unchanged package rebuilds nothing — the product record and the source
+// graph both hold — and the listing is the same artifact.
+// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir 2>%t.fresh.log > %t.fresh.listing
+// RUN: %FileCheck %s --check-prefix=FRESH < %t.fresh.log
+// RUN: diff %t.listing %t.fresh.listing
+
+// FRESH: up to date
+
+// A profile builds into its own directory with its own knobs (`release`
+// here also refines the built-in with the manifest's `codegen_units = 2`,
+// exercising the multi-unit link under rene).
+// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --profile release | %FileCheck %s --check-prefix=RELEASE
+// RUN: %t.bdir/release/demo%exe_ext
+
+// RELEASE: {{[/\\]}}release{{[/\\]}}demo
+
+// An undeclared profile or target is refused by name, before any work.
+// RUN: %not %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --profile bogus 2>&1 | %FileCheck %s --check-prefix=NOPROFILE
+// RUN: %not %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --target bogus 2>&1 | %FileCheck %s --check-prefix=NOTARGET
+
+// NOPROFILE: no profile named `bogus`
+// NOTARGET: no target named `bogus`

--- a/tests/integration/rene/build/lit.local.cfg
+++ b/tests/integration/rene/build/lit.local.cfg
@@ -1,0 +1,2 @@
+# The package the build test compiles; not tests themselves.
+config.suffixes = []

--- a/tests/integration/rene/build/rene.ncl
+++ b/tests/integration/rene/build/rene.ncl
@@ -1,0 +1,15 @@
+# The package `rene build` compiles end to end: one executable target, and a
+# `release` profile refining the built-in (its aggressive optimization stays;
+# the unit count is the manifest's).
+{
+  package = {
+    name | String = "demo",
+    version = "0.1.0",
+  },
+  targets = {
+    demo = { kind = 'executable },
+  },
+  profiles = {
+    release = { codegen_units = 2 },
+  },
+}

--- a/tests/integration/rene/build/src/lib.rr
+++ b/tests/integration/rene/build/src/lib.rr
@@ -1,0 +1,6 @@
+mod math;
+
+#[main]
+pub fn entry() {
+    let doubled = math::twice(21);
+}

--- a/tests/integration/rene/build/src/math.rr
+++ b/tests/integration/rene/build/src/math.rr
@@ -1,0 +1,3 @@
+pub fn twice(n: u64) -> u64 {
+    n + n
+}


### PR DESCRIPTION
`rene build` stops at the TODO no longer: the manifest declares *what* to build (`targets`), a profile declares *how* (`profiles`), and rene drives `rrc` from the source graph and the baked runtime all the way to artifacts.

## Manifest schema

```nickel
{
  package = { name = "demo", version = "0.1.0" },
  targets = {
    demo = { kind = 'executable },
    shared = { kind = 'dynlib },
    archive = { kind = 'staticlib },
  },
  profiles = {
    release = { lto = "thin", codegen_units = 4, link_args = ["-lm"] },
  },
}
```

- **`targets`**: name → kind (Nickel enum tags). The name becomes the artifact's platform file name under `<build-dir>/<profile>/` (`demo`/`demo.exe`, `libshared.so`/`.dylib`/`shared.dll`, `libarchive.a`/`archive.lib`).
- **`profiles`**: rrc's knobs mirrored one for one — opt, debug, lto, relocation-mode, codegen-units, sanitizers, nullary-variant-encoding, target triple/cpu/features, the link-only runtime-linkage/linker/link-args, plus an `extra_flags` escape hatch. Values pass through verbatim (rrc stays the authority, invalid ones fail with its diagnostic); unknown *fields* are schema errors — a typo'd knob that silently vanished would change codegen without a trace.
- **Built-ins**: `dev` (unoptimized, `-g`; the default) and `release` (aggressive), refined cargo-style by a same-named manifest profile. An undeclared profile name is refused rather than meaning "all defaults".
- Link-only knobs reach only the linked kinds, so one profile serves targets of every kind; relocation defaults to `pic` (every declared kind is a link product or archived into one).

## Build driving

- `rene build [--profile NAME] [--target NAME]... [--linker PATH]`; stdout lists the artifact paths. A package declaring no targets keeps the pre-target behavior (scan, bake, print libdirs).
- Per-product freshness: each build records a fingerprint (evaluated config — targets/profiles included via the existing config hash — source digests, profile name, toolchain, CLI linker override); an unchanged package re-runs nothing, any drift rebuilds.
- The rrc children get `REUSSIR_RUSTC` pinned to the rustc that baked the runtime (now recorded in `RtArtifacts`), so the runtime and everything linked against it agree on one toolchain; the baked libdirs flow in as `--polyffi-libdir`.

## Tests

- **Manifest units**: schema parse, built-in refinement, unknown-name and unknown-field rejections.
- **CLI e2e (fake toolchain)**: the exact flag surface per kind (link knobs to linked kinds only, `-O aggressive --lto thin` refinement, PIC default, pinned `REUSSIR_RUSTC`), artifact listing order, the freshness no-op, and the edit-triggered rebuild; `--target` selection and both unknown-name refusals.
- **Lit e2e** (`tests/integration/rene/build.rr`): rene bakes the *real* runtime in the test's build dir and builds a real two-file package to a running executable under `dev` and `release`, checks the second build is a no-op, and both refusals. Windows-gated off for now: the bake's cargo→rustc link trips the same Git-coreutils-`link` discovery the driver-level links pin away via `--linker` (covered on Windows by codegen/executable.rr); teaching the bake that pinning is a follow-up.

Local verification: full lit suite 419 passed / 0 failed (9 environment-gated unsupported), all rene cargo tests, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787611957&installation_model_id=426051&pr_number=465&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F465&signature=a21321a9e90e3404da9b0305c8d59f61958eb4ffa636cf1178a407059c288ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->