### PR TITLE
[rene] pin the linker through the runtime bake; un-gate the Windows e2e

### DIFF
--- a/.github/workflows/rene-test.yml
+++ b/.github/workflows/rene-test.yml
@@ -34,10 +34,13 @@ jobs:
       fail-fast: false
       matrix:
         # rene is a plain Rust crate (no LLVM/MLIR build), so testing it on
-        # every platform users run it on is cheap. Windows is left out for
-        # now: the fake-toolchain CLI test is unix-only (#[cfg(unix)] shell
-        # scripts), which would leave Windows covering almost nothing.
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15]
+        # every platform users run it on is cheap. On Windows the
+        # fake-toolchain CLI tests sit out (#[cfg(unix)] shell scripts), but
+        # the crate must build and its unit and locking tests hold there —
+        # and the real Windows e2e (rene/build.rr, driving the bake and the
+        # rrc links with the pinned MSVC linker) runs under the MSVC full
+        # pipeline, not here.
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
 
     runs-on: ${{ matrix.os }}
 

--- a/crates/rene/build.rs
+++ b/crates/rene/build.rs
@@ -20,7 +20,10 @@ fn main() {
     let workspace_toml = workspace_dir.join("Cargo.toml");
     let workspace_lock = workspace_dir.join("Cargo.lock");
 
-    println!("cargo::rerun-if-changed={}", rt_dir.join("Cargo.toml").display());
+    println!(
+        "cargo::rerun-if-changed={}",
+        rt_dir.join("Cargo.toml").display()
+    );
     println!("cargo::rerun-if-changed={}", rt_dir.join("src").display());
     println!("cargo::rerun-if-changed={}", workspace_toml.display());
     println!("cargo::rerun-if-changed={}", workspace_lock.display());
@@ -91,7 +94,10 @@ fn standalone_manifest(crate_toml: &Path, workspace_toml: &Path) -> String {
         }
     }
 
-    if let Some(deps) = doc.get_mut("dependencies").and_then(Item::as_table_like_mut) {
+    if let Some(deps) = doc
+        .get_mut("dependencies")
+        .and_then(Item::as_table_like_mut)
+    {
         let names: Vec<String> = deps.iter().map(|(k, _)| k.to_owned()).collect();
         for name in names {
             let spec = deps.get(&name).unwrap();

--- a/crates/rene/src/db.rs
+++ b/crates/rene/src/db.rs
@@ -57,9 +57,8 @@ impl std::error::Error for DbError {}
 impl BuildDir {
     /// Create/open the build directory rooted at `root` and take its lock.
     pub fn open(root: &Path) -> Result<Self, DbError> {
-        std::fs::create_dir_all(root).map_err(|e| {
-            DbError::Other(format!("cannot create `{}`: {e}", root.display()))
-        })?;
+        std::fs::create_dir_all(root)
+            .map_err(|e| DbError::Other(format!("cannot create `{}`: {e}", root.display())))?;
         let path = root.join(DB_FILE);
         let db = Database::create(&path).map_err(|e| match e {
             DatabaseError::DatabaseAlreadyOpen => DbError::InUse(path.clone()),
@@ -219,9 +218,8 @@ pub fn clean(root: &Path) -> Result<CleanOutcome, DbError> {
             Err(e) => tracing::warn!("ignoring unreadable `{}`: {e}", path.display()),
         }
     }
-    std::fs::remove_dir_all(root).map_err(|e| {
-        DbError::Other(format!("cannot remove `{}`: {e}", root.display()))
-    })?;
+    std::fs::remove_dir_all(root)
+        .map_err(|e| DbError::Other(format!("cannot remove `{}`: {e}", root.display())))?;
     Ok(CleanOutcome::Removed)
 }
 
@@ -244,10 +242,7 @@ mod tests {
     fn the_database_lock_is_exclusive() {
         let tmp = tempfile::tempdir().unwrap();
         let held = BuildDir::open(tmp.path()).unwrap();
-        assert!(matches!(
-            BuildDir::open(tmp.path()),
-            Err(DbError::InUse(_))
-        ));
+        assert!(matches!(BuildDir::open(tmp.path()), Err(DbError::InUse(_))));
         drop(held);
         BuildDir::open(tmp.path()).unwrap();
     }

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -206,7 +206,10 @@ fn build(args: &BuildArgs) -> Result<(), String> {
     // and a build that finds nothing moved skips straight to the freshness
     // checks below.
     let sources = deps::prepare(&dir, &loaded)?;
-    let artifacts = rt::prepare(&dir)?;
+    // The bake links the runtime dylib with the same linker pinning the
+    // driver-level links get: the CLI override first, then the profile's.
+    let bake_linker = args.linker.clone().or_else(|| profile.linker.clone());
+    let artifacts = rt::prepare(&dir, bake_linker.as_deref())?;
 
     // No declared targets: stop after the bake, reporting the libdirs for
     // whoever drives rrc by hand — the pre-target workflow, kept working.

--- a/crates/rene/src/rt.rs
+++ b/crates/rene/src/rt.rs
@@ -70,6 +70,9 @@ struct Toolchain {
     cargo: PathBuf,
     rustc: PathBuf,
     version: String,
+    /// The host triple `rustc -vV` reports — the target the bake builds for,
+    /// and so the key of cargo's target-specific configuration.
+    host: String,
     rust_libdir: PathBuf,
 }
 
@@ -86,12 +89,29 @@ impl Toolchain {
         };
         let cargo = pick("REUSSIR_CARGO", "CARGO", "cargo");
         let rustc = pick("REUSSIR_RUSTC", "RUSTC", "rustc");
-        let version = capture(&rustc, &["--version"])?;
+        let verbose_version = capture(&rustc, &["-vV"])?;
+        let version = verbose_version
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_owned();
+        let host = verbose_version
+            .lines()
+            .find_map(|line| line.strip_prefix("host: "))
+            .ok_or_else(|| {
+                format!(
+                    "`{} -vV` reported no `host:` line:\n{verbose_version}",
+                    rustc.display()
+                )
+            })?
+            .trim()
+            .to_owned();
         let rust_libdir = PathBuf::from(capture(&rustc, &["--print", "target-libdir"])?);
         Ok(Toolchain {
             cargo,
             rustc,
             version,
+            host,
             rust_libdir,
         })
     }
@@ -117,7 +137,14 @@ fn capture(program: &Path, args: &[&str]) -> Result<String, String> {
 /// the bundle and toolchain are unchanged. The caller holds the build
 /// directory's lock (it *is* the open [`BuildDir`]), so no other instance can
 /// race the extract/build/record sequence.
-pub fn prepare(dir: &BuildDir) -> Result<RtArtifacts, String> {
+///
+/// `linker`, when given, is pinned for the bake's own links (the runtime
+/// dylib) — the same pinning `rrc --linker` gives the driver-level links,
+/// needed where rustc's discovery resolves the wrong tool (a vcvars shell
+/// whose PATH carries a coreutils `link` ahead of MSVC's). It is not part of
+/// the bake's freshness: whichever working linker linked the runtime, the
+/// artifacts are equivalent.
+pub fn prepare(dir: &BuildDir, linker: Option<&Path>) -> Result<RtArtifacts, String> {
     let toolchain = Toolchain::resolve()?;
     let hash = bundle_hash();
 
@@ -141,7 +168,7 @@ pub fn prepare(dir: &BuildDir) -> Result<RtArtifacts, String> {
         rustc = %toolchain.version,
         "building reussir-rt (once per toolchain or runtime change)"
     );
-    let (rlib, staticlib) = cargo_build(&toolchain, &src_dir)?;
+    let (rlib, staticlib) = cargo_build(&toolchain, &src_dir, linker)?;
 
     // Cargo may report the uplifted rlib (`target/release/lib….rlib`) rather
     // than the hashed copy in `deps/`; polyffi's `rustc -L` needs `deps/`,
@@ -204,17 +231,32 @@ fn fresh_bake(
 /// Run `cargo build --release` in `src_dir`, following the JSON message
 /// stream for progress and artifact locations (no directory guessing).
 /// Returns the runtime's (rlib, staticlib).
-fn cargo_build(toolchain: &Toolchain, src_dir: &Path) -> Result<(PathBuf, PathBuf), String> {
-    let mut child = Command::new(&toolchain.cargo)
-        .args([
-            "build",
-            "--release",
-            "--message-format=json-render-diagnostics",
-        ])
-        .current_dir(src_dir)
-        // Pin the rustc cargo delegates to, so the recorded version and
-        // libdir describe the compiler that actually built the artifacts.
-        .env("RUSTC", &toolchain.rustc)
+fn cargo_build(
+    toolchain: &Toolchain,
+    src_dir: &Path,
+    linker: Option<&Path>,
+) -> Result<(PathBuf, PathBuf), String> {
+    let mut cmd = Command::new(&toolchain.cargo);
+    cmd.args([
+        "build",
+        "--release",
+        "--message-format=json-render-diagnostics",
+    ])
+    .current_dir(src_dir)
+    // Pin the rustc cargo delegates to, so the recorded version and
+    // libdir describe the compiler that actually built the artifacts.
+    .env("RUSTC", &toolchain.rustc);
+    if let Some(linker) = linker {
+        // Cargo's target-specific linker configuration, as an environment
+        // variable: `CARGO_TARGET_<HOST>_LINKER`. Unlike RUSTFLAGS this
+        // composes with whatever the user's environment already carries.
+        let key = format!(
+            "CARGO_TARGET_{}_LINKER",
+            toolchain.host.to_uppercase().replace('-', "_")
+        );
+        cmd.env(key, linker);
+    }
+    let mut child = cmd
         .stdout(Stdio::piped())
         // Diagnostics and cargo's own progress stream to the user unchanged.
         .stderr(Stdio::inherit())

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -18,6 +18,9 @@ fn demo_manifest() -> PathBuf {
 
 /// A scratch package the test may mutate: a manifest plus a two-file source
 /// graph (`src/lib.rr` declaring `mod math;`). Returns the manifest path.
+/// (Unix-gated with its callers, the fake-toolchain tests; on Windows it
+/// would be dead code under `-D warnings`.)
+#[cfg(unix)]
 fn package(dir: &Path, name: &str) -> PathBuf {
     let src = dir.join("src");
     std::fs::create_dir_all(&src).unwrap();
@@ -35,6 +38,7 @@ fn package(dir: &Path, name: &str) -> PathBuf {
 }
 
 /// (Re)write the scratch package's manifest.
+#[cfg(unix)]
 fn write_manifest(dir: &Path, name: &str, version: &str) -> PathBuf {
     let path = dir.join("rene.ncl");
     std::fs::write(

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -169,17 +169,21 @@ impl Fakes {
             format!(
                 "case \"$1\" in\n\
                  --version) echo 'rustc 9.9.9 (fake)';;\n\
+                 -vV) printf 'rustc 9.9.9 (fake)\\nhost: x86_64-unknown-fake\\n';;\n\
                  --print) echo '{}';;\n\
                  esac\n",
                 libdir.display()
             ),
         );
-        // Counts invocations, fabricates the artifacts, and reports them the
-        // way `--message-format=json` does. Runs with cwd = the unpacked
-        // source dir.
+        // Counts invocations, records the linker rene pinned through cargo's
+        // target-specific environment (keyed by the fake host triple above),
+        // fabricates the artifacts, and reports them the way
+        // `--message-format=json` does. Runs with cwd = the unpacked source
+        // dir.
         let cargo = script(
             "fake-cargo",
             "echo run >> \"$(dirname \"$0\")/cargo-runs\"\n\
+             echo \"linker=$CARGO_TARGET_X86_64_UNKNOWN_FAKE_LINKER\" >> \"$(dirname \"$0\")/cargo-env\"\n\
              mkdir -p target/release/deps\n\
              rlib=\"$PWD/target/release/deps/libreussir_rt-0000.rlib\"\n\
              staticlib=\"$PWD/target/release/libreussir_rt.a\"\n\
@@ -636,6 +640,42 @@ fn build_compiles_the_declared_targets_with_the_profile_knobs() {
     let rebuilt = fakes.rene(&["build", "--profile", "release"], &manifest, &root);
     assert!(rebuilt.status.success(), "stderr: {}", stderr(&rebuilt));
     assert_eq!(fakes.compiles().len(), 6, "the edit must rebuild");
+}
+
+/// `--linker` pins one linker end to end: cargo's target-specific
+/// environment for the runtime bake, and `rrc --linker` for the driver-level
+/// links — the Windows story, where rustc's own discovery under a vcvars
+/// shell resolves coreutils' `link` instead of MSVC's.
+#[cfg(unix)]
+#[test]
+fn build_pins_the_linker_through_the_bake_and_the_compiles() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp = tmp_dir.path().canonicalize().unwrap();
+    let root = tmp.join("reussir-build");
+    package(&tmp, "demo");
+    let manifest = write_targets_manifest(&tmp);
+    let fakes = Fakes::new(&tmp);
+    // Any existing file serves as "the linker" — nothing executes it here.
+    let linker = fakes.rustc.display().to_string();
+
+    let out = fakes.rene(&["build", "--linker", &linker], &manifest, &root);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    // The bake saw it through CARGO_TARGET_<HOST>_LINKER…
+    let cargo_env = std::fs::read_to_string(tmp.join("cargo-env")).unwrap();
+    assert_eq!(cargo_env.trim(), format!("linker={linker}"));
+
+    // …and every linked compile got `--linker`; the archive did not.
+    let compiles = fakes.compiles();
+    assert_eq!(compiles.len(), 3, "{compiles:#?}");
+    for line in &compiles {
+        let linked = !line.contains("--emit staticlib");
+        assert_eq!(
+            line.contains(&format!("--linker {linker}")),
+            linked,
+            "{line}"
+        );
+    }
 }
 
 /// `--target` narrows the build; unknown target and profile names are

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -14,9 +14,10 @@
 // RUN: %FileCheck %s --check-prefix=LISTING < %t.listing
 
 // Stdout is the artifact listing: the one declared target, under the
-// default profile's directory.
+// default profile's directory. (Single-line-ness is pinned by the exact
+// stdout assertions in crates/rene/tests/cli.rs; a `NOT: {{.}}` here trips
+// over the CRLF line endings Windows' python filecheck keeps.)
 // LISTING: {{[/\\]}}dev{{[/\\]}}demo
-// LISTING-NOT: {{.}}
 
 // The built executable runs.
 // RUN: %t.bdir/dev/demo%exe_ext

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -1,17 +1,16 @@
-// UNSUPPORTED: windows
 // `rene build`, end to end: the manifest declares the targets, the profile
 // picks the knobs, and rene drives the real `rrc` — package scan, runtime
 // bake, compile, link — to a running executable. The runtime is baked with
 // the host toolchain inside the test's build directory: slow once, then
 // shared by every RUN line below through the one `--build-dir`.
 //
-// Windows-gated off for now: the bake runs cargo → rustc → link.exe inside
-// lit's environment, where rustc's linker discovery finds Git-for-Windows'
-// coreutils `link` (the very thing `rrc --linker` pins for the driver-level
-// links, which codegen/executable.rr covers on Windows). Teaching the bake
-// the same pinning is a follow-up.
+// `%rrc_linker` pins MSVC's link.exe on Windows and is empty elsewhere.
+// rene threads it end to end: through cargo's target-specific environment
+// for the bake's own links, and as `rrc --linker` for the driver-level ones
+// — both places where rustc's discovery, under a vcvars shell whose PATH
+// carries Git-for-Windows' coreutils `link`, would resolve the wrong tool.
 
-// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir > %t.listing
+// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir %rrc_linker > %t.listing
 // RUN: %FileCheck %s --check-prefix=LISTING < %t.listing
 
 // Stdout is the artifact listing: the one declared target, under the
@@ -24,7 +23,7 @@
 
 // An unchanged package rebuilds nothing — the product record and the source
 // graph both hold — and the listing is the same artifact.
-// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir 2>%t.fresh.log > %t.fresh.listing
+// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir %rrc_linker 2>%t.fresh.log > %t.fresh.listing
 // RUN: %FileCheck %s --check-prefix=FRESH < %t.fresh.log
 // RUN: diff %t.listing %t.fresh.listing
 
@@ -33,7 +32,7 @@
 // A profile builds into its own directory with its own knobs (`release`
 // here also refines the built-in with the manifest's `codegen_units = 2`,
 // exercising the multi-unit link under rene).
-// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --profile release | %FileCheck %s --check-prefix=RELEASE
+// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --profile release %rrc_linker | %FileCheck %s --check-prefix=RELEASE
 // RUN: %t.bdir/release/demo%exe_ext
 
 // RELEASE: {{[/\\]}}release{{[/\\]}}demo


### PR DESCRIPTION
The follow-up parked in #465: make `rene build` work on Windows.

The one place rene still trusted rustc's linker discovery was the runtime bake: cargo → rustc → link.exe, which under a vcvars shell whose PATH carries Git-for-Windows' coreutils `link` resolves the wrong tool — the same failure `rrc --linker` already pins away for the driver-level links (#464), and the reason `rene/build.rr` stayed `UNSUPPORTED: windows`.

## What changed

- **The bake gets the pinning too**: `rene build --linker` (or the profile's `linker`) now reaches `rt::cargo_build` as cargo's target-specific `CARGO_TARGET_<HOST>_LINKER` environment variable — unlike RUSTFLAGS, this composes with whatever the user's environment already carries. The host triple comes from `rustc -vV`, whose first line keeps serving as the recorded toolchain version. The linker is deliberately excluded from the bake's freshness: whichever working linker linked the runtime, the artifacts are equivalent.
- **`rene/build.rr` un-gates on Windows**: every build RUN line carries `%rrc_linker` (empty off Windows) — including the freshness no-op check, since the CLI linker override is part of the product fingerprint and must match between runs.
- **rene-test.yml gains a windows-2025 leg**: the fake-toolchain CLI tests sit out there (`#[cfg(unix)]` shell scripts), but the crate must build on Windows and its unit, locking, and clean-protocol tests hold; the real Windows e2e runs under the MSVC full pipeline via lit.

## Tests

- Fake rustc learns `-vV` (reporting a fake host triple), and a new CLI test pins the whole path: the bake sees the linker through `CARGO_TARGET_X86_64_UNKNOWN_FAKE_LINKER`, every linked compile gets `--linker`, and the staticlib compile does not.
- Local verification (linux): all rene cargo tests (25 lib + 16 CLI), clippy clean, rene lit suite green including a forced-fresh bake run, full lit suite 419 passed / 0 failed.
- The real proof is this PR's own Windows MSVC pipeline run, where `rene/build.rr` now executes: bake, compile, link, and run under both built-in profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787621279&installation_model_id=426051&pr_number=466&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F466&signature=6f89c99fe6a7682358da450b9686d2299ae7143b7fab78d3906252bfc74eb844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->