### PR TITLE
[frontend][mlir] AOT linkage from the reference graph: mono-export upgrade, weak_odr instances

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -441,7 +441,9 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         }
         if !emit_body
             || func.body.is_none()
-            || (func.visibility == Visibility::Private && !self.unit.is_split())
+            || (func.visibility == Visibility::Private
+                && !func.mono_exported
+                && !self.unit.is_split())
         {
             attributes.push((
                 Identifier::new(self.context, "sym_visibility"),
@@ -582,15 +584,25 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     // Another compilation unit may instantiate the same
                     // generic — emit the definition as mergeable. This holds
                     // for private generics too: a pub generic caller can force
-                    // their instantiation from downstream units. Partitioned
-                    // builds keep this: the home unit's `linkonce_odr`
-                    // definition satisfies the other units' external
-                    // declarations.
-                    dedup_instances.then_some("linkonce_odr")
-                } else if func.visibility == Visibility::Private && !self.unit.is_split() {
+                    // their instantiation from downstream units. `weak_odr`
+                    // rather than `linkonce_odr`: the home unit of a
+                    // partitioned build may hold no reference of its own to
+                    // the instance (only sibling units do), and a
+                    // `linkonce_odr` definition with no local use is fair
+                    // game for GlobalDCE — the definition must survive to
+                    // satisfy the other units' external declarations.
+                    dedup_instances.then_some("weak_odr")
+                } else if func.visibility == Visibility::Private
+                    && !func.mono_exported
+                    && !self.unit.is_split()
+                {
                     // Mirrors the `sym_visibility` promotion above: in a
                     // partitioned build any other unit may call this symbol,
-                    // so the definition must stay externally linkable.
+                    // so the definition must stay externally linkable. A
+                    // `mono_export` function keeps its external symbol even
+                    // in a single unit: a foreign package instantiating a
+                    // generic body of this package calls it across the link
+                    // (see `mir::Function::mono_exported`).
                     Some("internal")
                 } else {
                     None

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -90,12 +90,15 @@ pub enum LinkagePolicy {
     /// Every definition keeps external linkage (the pre-policy behavior).
     Jit,
     /// Ahead-of-time linkage, mirroring rustc's model:
-    /// - monomorphized generic instances (`_RI…` symbols) are `linkonce_odr`
+    /// - monomorphized generic instances (`_RI…` symbols) are `weak_odr`
     ///   when `dedup_instances` holds — any other compilation unit may emit
-    ///   the same instance and the linker keeps one — and plain external
-    ///   otherwise (COFF, where `linkonce_odr` definitions need comdat
-    ///   support we do not emit yet);
-    /// - private non-generic functions are `internal`;
+    ///   the same instance and the linker keeps one; `weak_odr` rather than
+    ///   `linkonce_odr` because the instance's home unit may not reference
+    ///   it itself — and plain external otherwise (COFF, where weak
+    ///   definitions need comdat support we do not emit yet);
+    /// - private non-generic functions are `internal`, unless marked
+    ///   `mono_export` (reachable from a generic body a foreign package may
+    ///   instantiate, so the symbol must survive for cross-package links);
     /// - `pub` non-generic functions and trampolines stay strong external —
     ///   they are the object's ABI surface.
     Aot { dedup_instances: bool },

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -85,6 +85,15 @@ pub struct Function<'tcx> {
     pub symbol: Symbol,
     pub transform_anchor: bool,
     pub visibility: Visibility,
+    /// The symbol must stay externally linkable even when private: the
+    /// function is reachable from a generic body another compilation may
+    /// instantiate (see [`super::mono::mono_exports`]), so a foreign
+    /// object's instance can call it across the link. In-memory only —
+    /// computed by one traversal of the HIR bodies (elaborated or loaded
+    /// from a textual dump), never serialized; a program re-entered from
+    /// textual MIR has no generic bodies left to witness reachability and
+    /// defaults to `false`.
+    pub mono_exported: bool,
     pub is_regional: bool,
     pub params: Vec<Param<'tcx>>,
     pub return_ty: Ty<'tcx>,

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -279,6 +279,10 @@ impl<'tcx> Builder<'_, 'tcx> {
             } else {
                 crate::surface::Visibility::Private
             },
+            // Not serialized: the set is recomputed from HIR bodies wherever
+            // they exist (elaboration, or a loaded .hir); a re-entered .mir
+            // has no generic bodies left to witness reachability.
+            mono_exported: false,
             is_regional: f.regional,
             params,
             return_ty,

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -120,12 +120,149 @@ pub struct Instance<'tcx> {
     pub ty_args: &'tcx [Ty<'tcx>],
 }
 
+/// The private ground functions whose symbols must stay externally linkable:
+/// everything reachable from a generic body that a *foreign* compilation may
+/// instantiate.
+///
+/// A `pub` generic's body is compiled wherever it is instantiated — under a
+/// package HIR index, in another package's objects entirely. Any ground call
+/// inside such a body then resolves at link time against *this* package's
+/// artifacts, so an `internal` callee would leave the foreign instance with an
+/// unresolvable symbol. The set is seeded with every `pub` generic body and
+/// closed transitively through the (private) generics those bodies call —
+/// their bodies travel and instantiate the same way. Ground `pub` functions
+/// are not seeds: their code is compiled here and only their (already
+/// external) symbol crosses the boundary.
+pub fn mono_exports(input: &MonoInput<'_, '_>) -> FxHashSet<DefId> {
+    let by_def: FxHashMap<DefId, &Function<'_>> =
+        input.elaborated.iter().map(|f| (f.def, f)).collect();
+    let mut exports = FxHashSet::default();
+    let mut visited = FxHashSet::default();
+    let mut queue: VecDeque<DefId> = input
+        .elaborated
+        .iter()
+        .filter(|f| f.visibility == crate::surface::Visibility::Public && !f.generics.is_empty())
+        .map(|f| f.def)
+        .collect();
+    visited.extend(queue.iter().copied());
+    while let Some(def) = queue.pop_front() {
+        let Some(body) = by_def.get(&def).and_then(|f| f.body.as_ref()) else {
+            continue;
+        };
+        for_each_call_target(body, &mut |target| {
+            let Some(callee) = by_def.get(&target) else {
+                return;
+            };
+            if callee.generics.is_empty() {
+                if callee.visibility == crate::surface::Visibility::Private {
+                    exports.insert(target);
+                }
+            } else if visited.insert(target) {
+                queue.push_back(target);
+            }
+        });
+    }
+    exports
+}
+
+/// Walk `expr` (including closure bodies and match arms), reporting the
+/// target of every direct function call.
+fn for_each_call_target(expr: &Expr<'_>, f: &mut impl FnMut(DefId)) {
+    use ExprKind::*;
+    match &expr.kind {
+        GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
+        | Poison => {}
+        Negate(e) | Not(e) | Cast(e, _) | RegionRun(e) | Proj(e, _) => {
+            for_each_call_target(e, f);
+        }
+        Arith(a, _, b) | Cmp(a, _, b) | Assign(a, _, b) => {
+            for_each_call_target(a, f);
+            for_each_call_target(b, f);
+        }
+        If(c, t, e) => {
+            for_each_call_target(c, f);
+            for_each_call_target(t, f);
+            for_each_call_target(e, f);
+        }
+        Match(scrutinee, tree) => {
+            for_each_call_target(scrutinee, f);
+            tree_call_targets(tree, f);
+        }
+        Let { value, .. } => for_each_call_target(value, f),
+        Seq(es) => es.iter().for_each(|e| for_each_call_target(e, f)),
+        FuncCall { target, args, .. } => {
+            f(*target);
+            args.iter().for_each(|e| for_each_call_target(e, f));
+        }
+        // Compound/variant targets name records, not functions; only their
+        // arguments can call.
+        CompoundCall { args, .. }
+        | VariantCall { args, .. }
+        | Intrinsic { args, .. }
+        | ArrayOp { args, .. } => {
+            args.iter().for_each(|e| for_each_call_target(e, f));
+        }
+        NullableCall(inner) => {
+            if let Some(e) = inner {
+                for_each_call_target(e, f);
+            }
+        }
+        Closure(c) => for_each_call_target(&c.body, f),
+        ClosureCall { target, args } => {
+            for_each_call_target(target, f);
+            args.iter().for_each(|e| for_each_call_target(e, f));
+        }
+    }
+}
+
+fn tree_call_targets(tree: &DecisionTree<'_>, f: &mut impl FnMut(DefId)) {
+    use DecisionTree::*;
+    match tree {
+        Uncovered | Unreachable => {}
+        Leaf { body, .. } => for_each_call_target(body, f),
+        Guard {
+            guard,
+            success,
+            failure,
+            ..
+        } => {
+            for_each_call_target(guard, f);
+            tree_call_targets(success, f);
+            tree_call_targets(failure, f);
+        }
+        Switch { cases, .. } => match cases {
+            SwitchCases::Int { cases, default } => {
+                cases.iter().for_each(|(_, t)| tree_call_targets(t, f));
+                tree_call_targets(default, f);
+            }
+            SwitchCases::Bool { if_true, if_false } => {
+                tree_call_targets(if_true, f);
+                tree_call_targets(if_false, f);
+            }
+            SwitchCases::Char { cases, default } => {
+                cases.iter().for_each(|(_, t)| tree_call_targets(t, f));
+                tree_call_targets(default, f);
+            }
+            SwitchCases::Ctor(trees) => trees.iter().for_each(|t| tree_call_targets(t, f)),
+            SwitchCases::String { cases, default } => {
+                cases.iter().for_each(|(_, t)| tree_call_targets(t, f));
+                tree_call_targets(default, f);
+            }
+            SwitchCases::Nullable { non_null, null } => {
+                tree_call_targets(non_null, f);
+                tree_call_targets(null, f);
+            }
+        },
+    }
+}
+
 /// Monomorphize an elaborated program into its ground Full MIR, alongside any
 /// diagnostics raised by the call-boundary regional check.
 pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx>, Vec<Report>) {
     let tcx: &'a TyCtxt<'tcx> = input.tcx;
     let by_def: FxHashMap<DefId, &Function<'tcx>> =
         input.elaborated.iter().map(|f| (f.def, f)).collect();
+    let exports = mono_exports(input);
 
     let mut driver = Driver {
         tcx,
@@ -310,6 +447,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             symbol,
             transform_anchor: input.transform_anchors.contains(&func.def),
             visibility: func.visibility,
+            mono_exported: exports.contains(&func.def),
             is_regional: func.is_regional,
             params,
             return_ty,
@@ -1492,6 +1630,45 @@ mod tests {
             let (_, reports) = monomorphize(&elab.mono_input());
             reports.into_iter().map(|r| r.message).collect()
         })
+    }
+
+    /// The mono-export set: private ground functions reachable from `pub`
+    /// generic bodies — transitively through private generics — and nothing
+    /// else. `pub` ground bodies do not seed (their code never leaves this
+    /// package), and unreachable privates stay unexported.
+    #[test]
+    fn mono_exports_reach_through_generic_bodies() {
+        let source = "
+            fn deep(x: i64) -> i64 { x + 1 }
+            fn mid<T : Num>(x: T) -> i64 { deep(2) }
+            fn from_ground(x: i64) -> i64 { x + 3 }
+            fn unreachable_helper(x: i64) -> i64 { x + 4 }
+            pub fn api<T : Num>(x: T) -> i64 { mid(x) }
+            pub fn ground(x: i64) -> i64 { from_ground(x) }
+        ";
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(
+                !elab.has_errors(),
+                "elaboration errors: {:#?}",
+                elab.reports
+            );
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "mono reports: {reports:#?}");
+            let exported: Vec<&str> = full
+                .functions
+                .iter()
+                .filter(|f| f.mono_exported)
+                .map(|f| full.symbol(f.symbol))
+                .collect();
+            // `deep` crosses the boundary: `api<T>` → `mid<T>` → `deep`.
+            // `from_ground` does not (`pub` ground bodies stay home), and the
+            // unreachable helper stays plain private.
+            assert_eq!(exported, ["_RC4deep"], "{:?}", symbols(&full));
+        });
     }
 
     /// Literals are arbitrary-precision end to end: extremes that the old

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -391,6 +391,7 @@ impl<'a, 'tcx> MirBuilder<'a, 'tcx> {
             symbol,
             transform_anchor: false,
             visibility: Visibility::Private,
+            mono_exported: false,
             is_regional: false,
             params,
             return_ty: ret,

--- a/tests/integration/frontend/linkage.rr
+++ b/tests/integration/frontend/linkage.rr
@@ -3,11 +3,15 @@
 
 // AOT linkage policy (rustc-style):
 // - private non-generic functions are `internal` — free to discard, inline,
-//   and call directly;
-// - monomorphized generic instances (`_RI…` symbols) are `linkonce_odr`:
-//   any other compilation unit may emit the identical instance (a future
+//   and call directly — unless they are reachable from a `pub` generic's
+//   body: such a body is compiled wherever it is instantiated (a downstream
+//   package, through the HIR index), so its ground callees' symbols must
+//   survive for the cross-package link (`mono_export`);
+// - monomorphized generic instances (`_RI…` symbols) are `weak_odr`:
+//   any other compilation unit may emit the identical instance (a sibling
 //   codegen unit, or a downstream package instantiating through a pub
-//   generic), and the linker keeps one;
+//   generic), and the linker keeps one — `weak_odr`, not `linkonce_odr`,
+//   because the defining unit may hold no reference of its own;
 // - `pub` non-generic functions and extern trampolines are strong external —
 //   the object's ABI surface.
 // The JIT/REPL keeps everything external instead (ORC resolves previously
@@ -25,14 +29,27 @@ pub fn entry(x: i64) -> i64 {
     helper(x) + double(x)
 }
 
+// A pub generic whose body calls a private ground function: `shift` must
+// stay externally linkable — a foreign instantiation of `scale` calls it.
+fn shift(x: i64) -> i64 {
+    x + 3
+}
+
+pub fn scale<T : Num>(x: T) -> i64 {
+    shift(1)
+}
+
 extern "C" trampoline "entry_ffi" = entry;
 
 // The generic instance is mergeable across compilation units when the
 // object format can carry the required COMDAT; COFF stays strong for now.
-// CHECK-DEDUP-DAG: define linkonce_odr i64 @_RIC6doublexE(i64 %0)
+// CHECK-DEDUP-DAG: define weak_odr i64 @_RIC6doublexE(i64 %0)
 // CHECK-COFF-DAG: define i64 @_RIC6doublexE(i64 %0)
-// The private helper is internal.
+// The private helper is internal: only pub *generic* bodies escape the
+// package, and `helper` is reachable only from the ground `entry`.
 // CHECK-DAG: define internal i64 @_RC6helper(i64 %0)
+// The mono-exported private helper keeps its external symbol.
+// CHECK-DAG: define i64 @_RC5shift(i64 %0)
 // The pub function and the trampoline are the strong external ABI surface.
 // CHECK-DAG: define i64 @_RC5entry(i64 %0)
 // CHECK-DAG: define i64 @entry_ffi(i64 %0)


### PR DESCRIPTION
## Summary

First PR of the cross-package HIR-index arc (#451: "allow rrc to load module hir as index, support cross module monomorphism"): recompute AOT linkage from the def reference graph, standalone — no new artifacts or flags.

Under a package HIR index, a `pub` generic's body is compiled wherever it is instantiated — in another package's objects entirely. Every ground function such a body can reach must therefore keep an externally linkable symbol, or the foreign instance dangles at link time.

- **`mono::mono_exports`**: one traversal of the elaborated HIR — seed with `pub` generic bodies, close transitively through the (private) generics they call; private ground functions in the closure are the export set. Computed from `MonoInput`, so the loaded-`.hir` re-entry path gets it for free. The bit rides in-memory on `mir::Function` and is deliberately **not** serialized: a re-entered `.mir` has no generic bodies left to witness reachability (accepted limitation of that debugging path — the set is always recomputable where HIR bodies exist, so the textual formats stay untouched).
- **`LinkagePolicy::Aot`**: mono-exported functions stay external instead of `internal`, and stay out of `sym_visibility private` so MLIR symbol DCE cannot drop them before LLVM sees them.
- **Instances `linkonce_odr` → `weak_odr`**: the home unit of a partitioned build may hold no reference of its own to an instance it defines, and an unreferenced `linkonce_odr` definition is fair game for GlobalDCE — dangling the sibling units' declarations. `weak_odr` is the same ODR contract minus discardability (rustc's choice for the same one-home-per-symbol partitioning). Scope unchanged: `Aot` with `dedup_instances` only — COFF stays plain external (comdat emission is a later PR), and the JIT policy stays all-external (ORC rejects weak definitions on Windows).

Next PRs in the arc: `--emit index` (versioned header over the sources-form HIR dump), `--extern` loading with consumer-source access control, cross-package monomorphization + `--link-lib`, COFF comdat.

## Test plan

- [x] `mono_exports_reach_through_generic_bodies` unit test: reachability through generic chains; `pub` ground bodies do not seed; unreachable privates stay unexported
- [x] `tests/integration/frontend/linkage.rr` extended: `weak_odr` instance, internal ground-only-reachable helper, external mono-exported helper, strong ABI surface
- [x] reussir-core 305/305, reussir-codegen 56/56, lit 427/427 (1 unsupported: lldb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787679130&installation_model_id=426051&pr_number=467&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F467&signature=d723f3fb5f63cb9d7a4bcb366cf63eb214da7f18ff0549a983e57670a5f64255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->