### PR TITLE
[frontend] rrc: load package interfaces with --extern; extern-head resolution + access control

### DIFF
--- a/crates/reussir-compiler/src/driver.rs
+++ b/crates/reussir-compiler/src/driver.rs
@@ -130,6 +130,16 @@ fn run(cli: &Cli) -> Result<bool, String> {
         (None, None, _) => None,
     };
 
+    // Extern package paths root at package names, so only a package can
+    // consume them (mirrors --emit rri, which only a package can produce).
+    if package.is_none() && !(cli.externs.is_empty() && cli.extern_srcs.is_empty()) {
+        return Err(
+            "--extern requires package mode: --package-root, or an input file rooted \
+             by --package-name"
+                .into(),
+        );
+    }
+
     // `--scan-deps` stops after discovery: list the package's source graph
     // instead of compiling.
     if cli.scan_deps {
@@ -246,8 +256,9 @@ fn run(cli: &Cli) -> Result<bool, String> {
         if cli.disable_backend_multithreading {
             context.enable_multi_threading(false);
         }
-        let produced =
-            match in_arena(|tcx| frontend_package(&context, tcx, target, &pkg, &interner, cli)) {
+        let produced = match in_arena(|tcx| {
+            frontend_package(&context, tcx, target, &pkg, &pkg_name, &interner, cli)
+        }) {
                 Ok(produced) => produced,
                 Err(msg) => {
                     if !msg.is_empty() {

--- a/crates/reussir-compiler/src/driver/cli.rs
+++ b/crates/reussir-compiler/src/driver/cli.rs
@@ -108,6 +108,20 @@ pub(crate) struct Cli {
     #[arg(long = "target-features")]
     pub(crate) target_features: Option<String>,
 
+    /// A dependency package interface: `NAME=PATH` loads the `.rri` at PATH
+    /// under the package name NAME (which must match the interface's own
+    /// header). Repeatable; names must be distinct, and neither `core` nor
+    /// this compilation's package name. See `docs/design/rri.md`.
+    #[arg(long = "extern", value_name = "NAME=PATH")]
+    pub(crate) externs: Vec<crate::externs::ExternPair>,
+
+    /// The source root a loaded interface's package-root-relative file table
+    /// re-anchors onto: `NAME=DIR` applies to the `--extern` of the same
+    /// NAME. Without it that interface's files load as unfetchable virtual
+    /// files (locations degrade to name-only).
+    #[arg(long = "extern-src", value_name = "NAME=DIR")]
+    pub(crate) extern_srcs: Vec<crate::externs::ExternPair>,
+
     /// `rustc` used to compile polymorphic-FFI textures. A bare name resolves
     /// through `PATH` (the host-toolchain workflow: `--polyffi-rust-path
     /// rustc`); takes precedence over the `REUSSIR_RUSTC` environment

--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -42,13 +42,15 @@ pub(crate) fn frontend_package<'c, 'tcx>(
     interner: &std::sync::Arc<reussir_syntax::MultiThreadedTokenInterner>,
     cli: &Cli,
 ) -> Result<Produced<'c>, String> {
-    use reussir_core::semi::{PackageFile, elaborate_package};
+    use reussir_core::semi::{ExternPackage, PackageFile, elaborate_package_with_externs};
 
     // Dependency interfaces load and gate first — their tables must exist
-    // before any consumer resolution runs. Loaded-but-unconsumed for now:
-    // resolution and monomorphization pick these up in the next commits.
+    // before any consumer resolution runs. Diagnostics stay on the consumer's
+    // cache: no report carries an extern file id yet (extern bodies are never
+    // re-checked here); rendering against `LoadedExtern::sources()` lands
+    // with cross-package monomorphization.
     let extern_specs = crate::externs::join_specs(&cli.externs, &cli.extern_srcs)?;
-    let _externs = crate::externs::load(tcx, &extern_specs, Some(pkg_name))?;
+    let externs = crate::externs::load(tcx, &extern_specs, Some(pkg_name))?;
 
     let name = pkg.cache.name(FileId::ROOT);
     let programs: Vec<surface::Program> = pkg
@@ -71,7 +73,14 @@ pub(crate) fn frontend_package<'c, 'tcx>(
             program,
         })
         .collect();
-    let elab = elaborate_package(tcx, &files, interner);
+    let extern_pkgs: Vec<ExternPackage<'_, 'tcx>> = externs
+        .iter()
+        .map(|ext| ExternPackage {
+            name: &ext.name,
+            parsed: &ext.parsed,
+        })
+        .collect();
+    let elab = elaborate_package_with_externs(tcx, &files, interner, &mut keys, &extern_pkgs);
     if render_reports(&pkg.cache, &elab.reports) {
         return Err(String::new());
     }
@@ -84,7 +93,10 @@ pub(crate) fn frontend_package<'c, 'tcx>(
         .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
         .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports);
         let strings = elab.strings.entries();
-        let text = printer.program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
+        // The dump describes the consumer package: extern-imported records
+        // are filtered out (extern bodies never joined `elaborated`).
+        let records = elab.local_records();
+        let text = printer.program(&elab.elaborated, &strings, &records, &elab.trampolines);
         return Ok(Produced::Text(text));
     }
     if target == Stage::Rri {

--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -38,10 +38,17 @@ pub(crate) fn frontend_package<'c, 'tcx>(
     tcx: &TyCtxt<'tcx>,
     target: Stage,
     pkg: &package::PackageSource,
+    pkg_name: &str,
     interner: &std::sync::Arc<reussir_syntax::MultiThreadedTokenInterner>,
     cli: &Cli,
 ) -> Result<Produced<'c>, String> {
     use reussir_core::semi::{PackageFile, elaborate_package};
+
+    // Dependency interfaces load and gate first — their tables must exist
+    // before any consumer resolution runs. Loaded-but-unconsumed for now:
+    // resolution and monomorphization pick these up in the next commits.
+    let extern_specs = crate::externs::join_specs(&cli.externs, &cli.extern_srcs)?;
+    let _externs = crate::externs::load(tcx, &extern_specs, Some(pkg_name))?;
 
     let name = pkg.cache.name(FileId::ROOT);
     let programs: Vec<surface::Program> = pkg

--- a/crates/reussir-compiler/src/externs.rs
+++ b/crates/reussir-compiler/src/externs.rs
@@ -1,0 +1,180 @@
+//! Loading dependency package interfaces (`--extern name=path.rri`).
+//!
+//! An `.rri` is a textual HIR document reduced to the export closure behind
+//! a versioned header (`docs/design/rri.md`). This module owns the consumer
+//! side of the contract's first leg: parsing the `--extern`/`--extern-src`
+//! spellings and gating the header (format, package name, reserved names)
+//! before anything is offered to resolution. What the loaded tables *feed*
+//! (elaboration, monomorphization) arrives in later commits.
+
+use std::path::PathBuf;
+
+use reussir_core::full::interface::RRI_FORMAT;
+use reussir_core::semi::hir::build::{self, Parsed};
+use reussir_core::semi::ty::TyCtxt;
+
+/// One `--extern` occurrence, joined with its optional `--extern-src` root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternSpec {
+    pub name: String,
+    pub path: PathBuf,
+    /// The directory the interface's package-root-relative file table
+    /// re-anchors onto; `None` loads the files as unfetchable virtual
+    /// entries (locations degrade to name-only).
+    pub src_root: Option<PathBuf>,
+}
+
+/// A `NAME=VALUE` flag argument, split at the first `=`: the flag's typed
+/// form (`--extern dep=out/dep.rri`, `--extern-src dep=vendor/dep`), parsed
+/// by the CLI itself via [`FromStr`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternPair {
+    pub name: String,
+    pub value: PathBuf,
+}
+
+impl std::str::FromStr for ExternPair {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s.split_once('=') {
+            Some((name, value)) if !name.is_empty() && !value.is_empty() => Ok(ExternPair {
+                name: name.to_owned(),
+                value: PathBuf::from(value),
+            }),
+            _ => Err(format!("`{s}`: expected `NAME=PATH`")),
+        }
+    }
+}
+
+/// Join and cross-check the `--extern` / `--extern-src` occurrences:
+/// distinct extern names, and every source root naming a declared extern.
+pub fn join_specs(
+    externs: &[ExternPair],
+    extern_srcs: &[ExternPair],
+) -> Result<Vec<ExternSpec>, String> {
+    let mut specs: Vec<ExternSpec> = Vec::with_capacity(externs.len());
+    for pair in externs {
+        if specs.iter().any(|s| s.name == pair.name) {
+            return Err(format!("`--extern {}=...` given twice", pair.name));
+        }
+        specs.push(ExternSpec {
+            name: pair.name.clone(),
+            path: pair.value.clone(),
+            src_root: None,
+        });
+    }
+    for pair in extern_srcs {
+        let Some(spec) = specs.iter_mut().find(|s| s.name == pair.name) else {
+            return Err(format!(
+                "`--extern-src {}=...` names no `--extern {}=...`",
+                pair.name, pair.name
+            ));
+        };
+        if spec.src_root.is_some() {
+            return Err(format!("`--extern-src {}=...` given twice", pair.name));
+        }
+        spec.src_root = Some(pair.value.clone());
+    }
+    Ok(specs)
+}
+
+/// A dependency interface loaded into the consumer's `TyCtxt`.
+pub struct LoadedExtern<'tcx> {
+    pub name: String,
+    pub src_root: Option<PathBuf>,
+    pub parsed: Parsed<'tcx>,
+}
+
+/// Load every interface, gating each header: it must be present (a plain
+/// HIR dump is not an interface), carry the supported format, and describe
+/// the package the flag named. `core` and the compiling package's own name
+/// are reserved.
+pub fn load<'tcx>(
+    tcx: &TyCtxt<'tcx>,
+    specs: &[ExternSpec],
+    root_package: Option<&str>,
+) -> Result<Vec<LoadedExtern<'tcx>>, String> {
+    let mut loaded = Vec::with_capacity(specs.len());
+    for spec in specs {
+        if spec.name == "core" {
+            return Err("`--extern core=...`: `core` is the builtin package".into());
+        }
+        if Some(spec.name.as_str()) == root_package {
+            return Err(format!(
+                "`--extern {}=...` shadows the package being compiled",
+                spec.name
+            ));
+        }
+        let text = std::fs::read_to_string(&spec.path)
+            .map_err(|e| format!("cannot read `{}`: {e}", spec.path.display()))?;
+        let parsed = build::parse_program(tcx, &text)
+            .map_err(|e| format!("`{}`: {e}", spec.path.display()))?;
+        let Some(header) = &parsed.header else {
+            return Err(format!(
+                "`{}` is a plain HIR dump, not a package interface; \
+                 recompile the dependency with `--emit rri`",
+                spec.path.display()
+            ));
+        };
+        if header.format != RRI_FORMAT {
+            return Err(format!(
+                "`{}`: interface format {} (from {}) is not the supported {}; \
+                 rebuild the dependency with this compiler",
+                spec.path.display(),
+                header.format,
+                header.producer,
+                RRI_FORMAT
+            ));
+        }
+        if header.package != spec.name {
+            return Err(format!(
+                "`{}` describes package `{}`, but was loaded as `--extern {}=...`",
+                spec.path.display(),
+                header.package,
+                spec.name
+            ));
+        }
+        loaded.push(LoadedExtern {
+            name: spec.name.clone(),
+            src_root: spec.src_root.clone(),
+            parsed,
+        });
+    }
+    Ok(loaded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(v: &[&str]) -> Vec<ExternPair> {
+        v.iter().map(|x| x.parse().unwrap()).collect()
+    }
+
+    #[test]
+    fn pairs_split_at_the_first_equals() {
+        let pair: ExternPair = "dep=out/dep=v1.rri".parse().unwrap();
+        assert_eq!(pair.name, "dep");
+        assert_eq!(pair.value, PathBuf::from("out/dep=v1.rri"));
+        assert!("dep".parse::<ExternPair>().is_err());
+        assert!("=x".parse::<ExternPair>().is_err());
+        assert!("dep=".parse::<ExternPair>().is_err());
+    }
+
+    #[test]
+    fn specs_join_and_cross_check() {
+        let specs = p(&["dep=a.rri", "util=b.rri"]);
+        let specs = join_specs(&specs, &p(&["dep=/src"])).unwrap();
+        assert_eq!(specs.len(), 2);
+        assert_eq!(
+            specs[0].src_root.as_deref(),
+            Some(std::path::Path::new("/src"))
+        );
+        assert_eq!(specs[1].src_root, None);
+
+        assert!(join_specs(&p(&["dep=a", "dep=b"]), &[]).is_err());
+        assert!(join_specs(&p(&["dep=a"]), &p(&["other=/x"])).is_err());
+        assert!(join_specs(&p(&["dep=a"]), &p(&["dep=/x", "dep=/y"])).is_err());
+    }
+}

--- a/crates/reussir-compiler/src/externs.rs
+++ b/crates/reussir-compiler/src/externs.rs
@@ -86,6 +86,53 @@ pub struct LoadedExtern<'tcx> {
     pub parsed: Parsed<'tcx>,
 }
 
+impl LoadedExtern<'_> {
+    /// The interface's file table, re-anchored. An `.rri` records its files
+    /// package-root-relative on purpose (byte-stability across checkouts);
+    /// this is DWARF's `comp_dir` split, and the source root is the base
+    /// directory the environment supplies: with one, entries join onto it,
+    /// so diagnostics and the DWARF of locally emitted instances point at
+    /// the producing package's real sources. Without one, entries become
+    /// unfetchable virtual names carrying the package — locations degrade
+    /// to name-only, and never resolve against the consumer's own tree.
+    pub fn re_anchored_files(&self) -> Vec<String> {
+        self.parsed
+            .files
+            .iter()
+            .map(|rel| {
+                if rel.starts_with('<') {
+                    // Already virtual at the producer; keep verbatim.
+                    rel.clone()
+                } else if let Some(root) = &self.src_root {
+                    root.join(rel).display().to_string()
+                } else {
+                    format!("<{}/{rel}>", self.name)
+                }
+            })
+            .collect()
+    }
+
+    /// A source cache over the re-anchored table — real paths registered for
+    /// lazy loading, virtual entries name-only — so spans inside imported
+    /// items keep resolving in consumer diagnostics. `None` when the
+    /// interface was printed without locations.
+    pub fn sources(&self) -> Option<reussir_syntax::source::SourceCache> {
+        let files = self.re_anchored_files();
+        if files.is_empty() {
+            return None;
+        }
+        let mut cache = reussir_syntax::source::SourceCache::new();
+        for name in &files {
+            if name.starts_with('<') {
+                cache.add_unavailable(name);
+            } else {
+                cache.add_lazy_file(name);
+            }
+        }
+        Some(cache)
+    }
+}
+
 /// Load every interface, gating each header: it must be present (a plain
 /// HIR dump is not an interface), carry the supported format, and describe
 /// the package the flag named. `core` and the compiling package's own name
@@ -160,6 +207,36 @@ mod tests {
         assert!("dep".parse::<ExternPair>().is_err());
         assert!("=x".parse::<ExternPair>().is_err());
         assert!("dep=".parse::<ExternPair>().is_err());
+    }
+
+    #[test]
+    fn file_tables_re_anchor_onto_the_source_root() {
+        reussir_core::in_arena(|tcx| {
+            let text = "interface 1 package \"dep\" producer \"t\";\n\
+                        0 = \"src/lib.rr\";\n\
+                        1 = \"<prelude>\";\n";
+            let parsed = build::parse_program(tcx, text).unwrap();
+            let mut ext = LoadedExtern {
+                name: "dep".into(),
+                src_root: None,
+                parsed,
+            };
+            // No root: unfetchable virtual names carrying the package;
+            // producer-virtual entries pass through.
+            assert_eq!(ext.re_anchored_files(), ["<dep/src/lib.rr>", "<prelude>"]);
+            ext.src_root = Some(PathBuf::from("/vendor/dep"));
+            let files = ext.re_anchored_files();
+            assert_eq!(
+                files[0],
+                std::path::Path::new("/vendor/dep")
+                    .join("src/lib.rr")
+                    .display()
+                    .to_string()
+            );
+            assert_eq!(files[1], "<prelude>");
+            let cache = ext.sources().expect("table is non-empty");
+            assert_eq!(cache.len(), 2);
+        });
     }
 
     #[test]

--- a/crates/reussir-compiler/src/externs.rs
+++ b/crates/reussir-compiler/src/externs.rs
@@ -212,9 +212,11 @@ mod tests {
     #[test]
     fn file_tables_re_anchor_onto_the_source_root() {
         reussir_core::in_arena(|tcx| {
-            let text = "interface 1 package \"dep\" producer \"t\";\n\
-                        0 = \"src/lib.rr\";\n\
-                        1 = \"<prelude>\";\n";
+            let text = r#"
+                interface 1 package "dep" producer "t";
+                0 = "src/lib.rr";
+                1 = "<prelude>";
+            "#;
             let parsed = build::parse_program(tcx, text).unwrap();
             let mut ext = LoadedExtern {
                 name: "dep".into(),

--- a/crates/reussir-compiler/src/lib.rs
+++ b/crates/reussir-compiler/src/lib.rs
@@ -12,6 +12,7 @@
 //! the [`Finalized`] module to [`emit_to_file`].
 
 pub mod driver;
+pub mod externs;
 pub mod package;
 
 use std::ffi::{CString, c_char};

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -23,6 +23,7 @@ pub mod ty;
 // The elaboration passes.
 pub mod check;
 pub mod ctxt;
+pub mod externs;
 pub mod fulfill;
 pub mod hir;
 pub mod pattern;
@@ -34,7 +35,9 @@ pub use ctxt::{
     Checkpoint, DefaultCap, Elaborator, PackageFile, Report, Severity, TransformScript,
     render_reports, render_reports_to,
 };
+pub use externs::ExternPackage;
 
+use reussir_syntax::Interner;
 use reussir_syntax::kind::{Resolver, TokenKey};
 
 use crate::surface;
@@ -64,6 +67,26 @@ pub fn elaborate_package<'a, 'tcx>(
     resolver: &'a dyn Resolver<TokenKey>,
 ) -> Elaborator<'a, 'tcx> {
     let mut elab = Elaborator::new(tcx, resolver);
+    elab.run_package(files);
+    elab
+}
+
+/// [`elaborate_package`] against loaded dependency interfaces: every extern
+/// package's items are declared first (the declare-only twin of the
+/// in-package scan, see [`externs`]), so consumer references `dep::item`
+/// resolve during the same run — `pub` items only. `interner` must back
+/// `resolver`: extern paths re-intern into the consumer's key space.
+pub fn elaborate_package_with_externs<'a, 'tcx>(
+    tcx: &'a TyCtxt<'tcx>,
+    files: &[PackageFile<'_>],
+    resolver: &'a dyn Resolver<TokenKey>,
+    interner: &mut impl Interner<TokenKey>,
+    externs: &[ExternPackage<'_, 'tcx>],
+) -> Elaborator<'a, 'tcx> {
+    let mut elab = Elaborator::new(tcx, resolver);
+    for ext in externs {
+        elab.declare_extern_package(interner, ext);
+    }
     elab.run_package(files);
     elab
 }

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -3,6 +3,7 @@
 use reussir_syntax::kind::TokenKey;
 
 use crate::semi::infer::Instantiation;
+use crate::semi::resolve::DefKind;
 use crate::semi::traits::{Obligation, TraitId, TraitRef};
 use crate::semi::ty::CellKind;
 use crate::semi::ty::{DefId, Flexivity, GenericId, Ty, TyKind};
@@ -599,6 +600,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return done;
         }
         let Some(def) = self.resolve_function_ref(&fc.name) else {
+            // A hit on a *private* item of a loaded extern package reports
+            // access, not absence.
+            if let Some(msg) = self.extern_private_msg(&fc.name, DefKind::Function) {
+                self.error(span, msg);
+                return self.poison(span);
+            }
             let hint = if fc.name.segments.is_empty() {
                 self.function_suggestion(fc.name.basename)
             } else {
@@ -1697,6 +1704,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 );
             }
             let Some(def) = self.resolve_record_ref(path) else {
+                // Either the qualifier (`dep::Enum::Variant`) or the record
+                // itself (`dep::Struct{…}`) may be the private extern hit.
+                if let Some(msg) = self
+                    .extern_private_ctor_msg(path)
+                    .or_else(|| self.extern_private_msg(path, DefKind::Record))
+                {
+                    self.error(span, msg);
+                    return self.poison(span);
+                }
                 let hint = self.record_suggestion(enum_key);
                 let shown = self.path_display(path);
                 self.error(span, format!("unknown constructor `{shown}`{hint}"));
@@ -1738,6 +1754,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return self.poison(span);
         };
         let Some(def) = self.resolve_record_ref(&ipath) else {
+            if let Some(msg) = self.extern_private_msg(&ipath, DefKind::Record) {
+                self.error(span, msg);
+                return self.poison(span);
+            }
             let shown = self.path_display(&ipath);
             self.error(span, format!("unknown record `{shown}`"));
             return self.poison(span);

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -3,10 +3,10 @@
 
 use reussir_syntax::kind::{Resolver, TokenKey};
 use reussir_syntax::source::{FileId, SourceCache};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::semi::infer::InferCtxt;
-use crate::semi::resolve::DefTable;
+use crate::semi::resolve::{DefKind, DefTable};
 use crate::semi::traits::builtins::Builtins;
 use crate::semi::traits::{TraitDb, TraitId};
 use crate::semi::ty::{DefId, Flexivity, GenericId, HoleId, Ty, TyCtxt, TyKind};
@@ -393,6 +393,28 @@ pub struct Elaborator<'a, 'tcx> {
     pub imports: Vec<ImportBinding>,
     pub generics: Vec<GenericInfo>,
     pub strings: StringUniqifier,
+    /// Heads of loaded extern packages ([`Elaborator::declare_extern_package`]):
+    /// a reference path led by one resolves in that package's table only —
+    /// never module-relatively — so an extern head and a local module cannot
+    /// shadow one another.
+    pub extern_heads: FxHashSet<TokenKey>,
+    /// Extern-owned defs and the package head that owns each. The `pub` gate
+    /// keys on this, and the HIR dump excludes these
+    /// ([`Elaborator::local_records`]) — the dump describes the consumer
+    /// package only.
+    pub extern_defs: FxHashMap<DefId, TokenKey>,
+    /// Extern functions remapped into the consumer's spaces — generic bodies
+    /// to instantiate, ground prototypes to declare against — held for
+    /// cross-package monomorphization (a later commit). Never part of the
+    /// printed program or the export surface.
+    pub extern_functions: Vec<Function<'tcx>>,
+    /// String literals referenced by extern bodies. Tokens are
+    /// content-addressed (BLAKE3), so entries carry over without remapping.
+    pub extern_strings: Vec<(crate::utils::string::StringToken, String)>,
+    /// Foreign bodies of extern `#[ffi(import)]` functions, keyed by their
+    /// consumer defs, with the preludes of their files.
+    pub extern_ffi_imports: FxHashMap<DefId, FfiImport>,
+    pub extern_ffi_preludes: Vec<FfiPrelude>,
     pub elaborated: Vec<Function<'tcx>>,
     pub reports: Vec<Report>,
     /// The file whose items are currently being processed; stamped onto every
@@ -473,6 +495,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             functions: FxHashMap::default(),
             generics: Vec::new(),
             strings: StringUniqifier::new(),
+            extern_heads: FxHashSet::default(),
+            extern_defs: FxHashMap::default(),
+            extern_functions: Vec::new(),
+            extern_strings: Vec::new(),
+            extern_ffi_imports: FxHashMap::default(),
+            extern_ffi_preludes: Vec::new(),
             elaborated: Vec::new(),
             reports: Vec::new(),
             current_file: FileId::ROOT,
@@ -682,6 +710,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
             return;
         }
+        // Extern package heads are reserved the same way: a binding shadowing
+        // one would silently reroute every `dep::…` reference in the file.
+        if self.extern_heads.contains(&name) {
+            self.error(
+                Some(decl.name.span()),
+                format!("`{shown}` names a loaded extern package and cannot be bound by an import"),
+            );
+            return;
+        }
         if self
             .imports
             .iter()
@@ -769,10 +806,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Resolve a type reference: bare names in the current module (falling
     /// back to the crate root), qualified paths per the module-relative rules
     /// (see [`DefTable::resolve_record_path`]). The path is first expanded
-    /// through the file's `import` bindings ([`Self::expand_path`]).
+    /// through the file's `import` bindings ([`Self::expand_path`]); one led
+    /// by an extern package head resolves in that package's table only
+    /// ([`Self::resolve_extern`]).
     pub(super) fn resolve_record_ref(&self, path: &surface::Path) -> Option<DefId> {
         let expanded = self.expand_path(path);
         let path = expanded.as_ref().unwrap_or(path);
+        if self.extern_head(path).is_some() {
+            return self.resolve_extern(path, DefKind::Record);
+        }
         if path.segments.is_empty() {
             self.defs.resolve_record(path.basename)
         } else {
@@ -785,6 +827,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     pub(super) fn resolve_function_ref(&self, path: &surface::Path) -> Option<DefId> {
         let expanded = self.expand_path(path);
         let path = expanded.as_ref().unwrap_or(path);
+        if self.extern_head(path).is_some() {
+            return self.resolve_extern(path, DefKind::Function);
+        }
         if path.segments.is_empty() {
             self.defs.resolve_function(path.basename)
         } else {
@@ -808,9 +853,99 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 basename: enum_name,
                 segments: mods.iter().copied().collect(),
             };
+            if self.extern_head(&mods_path).is_some() {
+                return self.resolve_extern(&mods_path, DefKind::Record);
+            }
             self.defs
                 .resolve_record_path(&self.classify_segs(&mods_path), enum_name)
         }
+    }
+
+    // ----- extern-package resolution -----
+
+    /// The path's first segment when it names a loaded extern package.
+    fn extern_head(&self, path: &surface::Path) -> Option<TokenKey> {
+        path.segments
+            .first()
+            .copied()
+            .filter(|k| self.extern_heads.contains(k))
+    }
+
+    /// Resolve a reference into a loaded extern package: the path is looked
+    /// up **absolute** in that package's namespace — the module-relative and
+    /// root-relative fallbacks never apply. Only `pub` items resolve; a
+    /// private hit yields `None` here and the targeted diagnostic through
+    /// [`Self::extern_private_msg`] on the caller's failure path.
+    fn resolve_extern(&self, path: &surface::Path, kind: DefKind) -> Option<DefId> {
+        let def = self.lookup_extern(path, kind)?;
+        (self.item_visibility(def)? == surface::Visibility::Public).then_some(def)
+    }
+
+    /// Exact-path lookup for an extern-headed reference (no access check).
+    fn lookup_extern(&self, path: &surface::Path, kind: DefKind) -> Option<DefId> {
+        let key: Vec<TokenKey> = path
+            .segments
+            .iter()
+            .copied()
+            .chain([path.basename])
+            .collect();
+        match kind {
+            DefKind::Record => self.defs.lookup_record(&key),
+            DefKind::Function => self.defs.lookup_function(&key),
+        }
+    }
+
+    /// A declared item's visibility, from whichever table holds it. `None`
+    /// for a def with no item entry (a path-only handle).
+    fn item_visibility(&self, def: DefId) -> Option<surface::Visibility> {
+        match self.defs.info(def).kind {
+            DefKind::Record => self.records.get(&def).map(|r| r.visibility),
+            DefKind::Function => self.functions.get(&def).map(|f| f.visibility),
+        }
+    }
+
+    /// The access-control diagnostic for a failed reference that names a
+    /// *private* item of a loaded extern package; `None` for every other
+    /// failure, so the caller keeps its ordinary not-found report and a
+    /// private hit stays distinguishable from a missing one.
+    pub(super) fn extern_private_msg(&self, path: &surface::Path, kind: DefKind) -> Option<String> {
+        let expanded = self.expand_path(path);
+        let path = expanded.as_ref().unwrap_or(path);
+        let head = self.extern_head(path)?;
+        let def = self.lookup_extern(path, kind)?;
+        if self.item_visibility(def)? == surface::Visibility::Public {
+            return None;
+        }
+        let what = match kind {
+            DefKind::Record => "record",
+            DefKind::Function => "function",
+        };
+        Some(format!(
+            "{what} `{}` in package `{}` is private",
+            self.sym(path.basename),
+            self.sym(head)
+        ))
+    }
+
+    /// [`Self::extern_private_msg`] over a constructor path's *qualifier*
+    /// (`dep::Enum::Variant` names the record `dep::Enum`).
+    pub(super) fn extern_private_ctor_msg(&self, path: &surface::Path) -> Option<String> {
+        let (&enum_name, mods) = path.segments.split_last()?;
+        let qualifier = surface::Path {
+            basename: enum_name,
+            segments: mods.iter().copied().collect(),
+        };
+        self.extern_private_msg(&qualifier, DefKind::Record)
+    }
+
+    /// The consumer package's own records — extern-imported ones excluded —
+    /// for printing: the HIR/rri dumps describe this package only.
+    pub fn local_records(&self) -> FxHashMap<DefId, Record<'tcx>> {
+        self.records
+            .iter()
+            .filter(|(def, _)| !self.extern_defs.contains_key(def))
+            .map(|(def, rec)| (*def, rec.clone()))
+            .collect()
     }
 
     /// Whether `prefix` spells the canonical `core::intrinsic::<family>`

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -171,11 +171,19 @@ impl<'tcx> Elaborator<'_, 'tcx> {
     }
 
     /// Re-allocate an extern item's generic binder in the global table. The
-    /// interface does not serialize trait bounds (the producer already
-    /// enforced them on its own bodies), so extern binders re-allocate
-    /// unbounded: consumer-side obligations arise only from the consumer's
-    /// own expressions until bounds join the interface format with the trait
-    /// system.
+    /// interface does not serialize trait bounds yet, so extern binders
+    /// re-allocate unbounded: consumer-side obligations arise only from the
+    /// consumer's own expressions.
+    ///
+    /// TODO(#451, cross-package mono): this is a soundness gap for the
+    /// *builtin* traits (Num/Integral/FloatingPoint/PtrLike/Sync) — a local
+    /// call of `api<T: Num>` discharges the obligation at the call site, but
+    /// an imported prototype arrives unbounded, so the violation only
+    /// surfaces later inside monomorphization, far from the user's mistake.
+    /// Builtin bounds must join the interface format before cross-package
+    /// monomorphization ships. When they do: bounds serialize as qualified
+    /// *paths* (the shape user-defined traits will need), not bare names,
+    /// and the format stays at version 1 — nothing is released yet.
     fn remap_generics(
         &mut self,
         binder: &[(TokenKey, GenericId)],

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -175,15 +175,18 @@ impl<'tcx> Elaborator<'_, 'tcx> {
     /// re-allocate unbounded: consumer-side obligations arise only from the
     /// consumer's own expressions.
     ///
-    /// TODO(#451, cross-package mono): this is a soundness gap for the
-    /// *builtin* traits (Num/Integral/FloatingPoint/PtrLike/Sync) — a local
-    /// call of `api<T: Num>` discharges the obligation at the call site, but
-    /// an imported prototype arrives unbounded, so the violation only
-    /// surfaces later inside monomorphization, far from the user's mistake.
-    /// Builtin bounds must join the interface format before cross-package
-    /// monomorphization ships. When they do: bounds serialize as qualified
-    /// *paths* (the shape user-defined traits will need), not bare names,
-    /// and the format stays at version 1 — nothing is released yet.
+    /// This is safe for the builtin traits: shipped bodies are *elaborated*
+    /// HIR (trait machinery consumed at the producer — `x + x` under
+    /// `T : Num` ships as `Arith`), so a bad instantiation cannot
+    /// miscompile; it grounds into an operation monomorphization rejects
+    /// with a spanned report. What is lost is only diagnostic placement —
+    /// the error fires inside the imported body instead of at the
+    /// consumer's call site.
+    ///
+    /// TODO(#451, trait system): revisit when real traits define what a
+    /// bound is. When bounds join the interface, they serialize as
+    /// qualified *paths* (the shape user-defined traits need), not bare
+    /// names, and the format stays at version 1 — nothing is released yet.
     fn remap_generics(
         &mut self,
         binder: &[(TokenKey, GenericId)],

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -1,0 +1,687 @@
+//! Extern packages joining the consumer's elaboration: the declare-only twin
+//! of `run_package`'s scan pass, over a parsed dependency interface.
+//!
+//! A [`Parsed`] interface carries its own [`Names`](crate::semi::hir::build::Names)
+//! interner and dense
+//! [`DefTable`](crate::semi::resolve::DefTable) — nothing in it is keyed in
+//! the consumer's token or def spaces. Declaring an extern package therefore
+//! re-interns every name through the consumer's interner, maps every def to a
+//! consumer `DefId` under the same qualified path (paths are the stable
+//! cross-package identity), re-allocates generics in the elaborator's global
+//! table, and rebuilds every type over the mapped defs. Prototypes and
+//! records land in the same `functions`/`records` tables the checker reads;
+//! bodies, strings, and ffi textures land in the `extern_*` side tables held
+//! for cross-package monomorphization (a later commit) so they stay out of
+//! the consumer's printed program and export surface. Resolution reaches the
+//! declared items only through the package head, gated on `pub`
+//! (`ctxt::resolve_extern`).
+
+use reussir_syntax::Interner;
+use reussir_syntax::kind::{InternKey, TokenKey};
+use rustc_hash::FxHashMap;
+
+use crate::semi::ctxt::{Elaborator, FuncProto, Record, RecordFields, Variant};
+use crate::semi::hir::build::Parsed;
+use crate::semi::hir::{ClosureExpr, DecisionTree, Expr, ExprKind, Function, SwitchCases};
+use crate::semi::resolve::DefKind;
+use crate::semi::ty::{DefId, GenericId, Ty, TyCtxt, TyKind};
+
+/// One loaded dependency interface, ready to join elaboration: its `--extern`
+/// name (the head of every declared path) and the parsed tables. Header
+/// gating (format, package name, reserved names) is the driver's job.
+pub struct ExternPackage<'p, 'tcx> {
+    pub name: &'p str,
+    pub parsed: &'p Parsed<'tcx>,
+}
+
+impl<'tcx> Elaborator<'_, 'tcx> {
+    /// Declare `ext`'s items into the consumer's tables, under paths rooted
+    /// at the extern package name. Must run before the consumer's own items
+    /// are declared; `interner` must back the elaborator's own resolver
+    /// (cross-space resolution compares interned keys).
+    pub fn declare_extern_package(
+        &mut self,
+        interner: &mut impl Interner<TokenKey>,
+        ext: &ExternPackage<'_, 'tcx>,
+    ) {
+        let head = interner.get_or_intern(ext.name);
+        self.extern_heads.insert(head);
+        let parsed = ext.parsed;
+
+        // One consumer key per producer key, densely indexed, so the remap
+        // below never threads the interner.
+        let keys: Vec<TokenKey> = parsed
+            .names
+            .entries()
+            .iter()
+            .map(|s| interner.get_or_intern(s))
+            .collect();
+
+        // Map every producer def to a consumer def under its re-interned
+        // qualified path — lookup-first, so a path an earlier extern already
+        // declared unifies instead of clashing.
+        let module = self.defs.module().to_vec();
+        let defs: Vec<DefId> = (0..parsed.defs.len())
+            .map(|i| {
+                let info = parsed.defs.info(DefId(i as u32));
+                let segs: Vec<TokenKey> =
+                    info.path.0.iter().map(|k| keys[k.into_u32() as usize]).collect();
+                let (name, module) = segs.split_last().expect("paths are never empty");
+                let existing = match info.kind {
+                    DefKind::Record => self.defs.lookup_record(&segs),
+                    DefKind::Function => self.defs.lookup_function(&segs),
+                };
+                let def = existing.unwrap_or_else(|| {
+                    self.defs.set_module(module.to_vec());
+                    match info.kind {
+                        DefKind::Record => self.defs.declare_record(*name),
+                        DefKind::Function => self.defs.declare_function(*name),
+                    }
+                    .expect("a missed lookup cannot clash")
+                });
+                self.extern_defs.entry(def).or_insert(head);
+                def
+            })
+            .collect();
+        self.defs.set_module(module);
+
+        for (pdef, rec) in &parsed.records {
+            let def = defs[pdef.0 as usize];
+            let generics = self.remap_generics(&rec.ty_params, &keys);
+            let remap = Remapper {
+                tcx: self.tcx,
+                defs: &defs,
+                keys: &keys,
+                generics: &generics.map,
+            };
+            let record = Record {
+                def,
+                name: remap.key(rec.name),
+                visibility: rec.visibility,
+                ty_params: generics.binder,
+                kind: rec.kind,
+                default_cap: rec.default_cap,
+                repr_fixed: rec.repr_fixed,
+                ffi: rec.ffi.clone(),
+                fields: rec.fields.as_ref().map(|f| remap.fields(f)),
+                regional_generics: remap.generic_ids(&rec.regional_generics),
+                // Spans index the extern package's own file table; nothing
+                // renders them yet (extern items are never re-checked here).
+                // Re-anchoring onto `--extern-src` lands with cross-package
+                // monomorphization diagnostics.
+                span: rec.span,
+                file: rec.file,
+            };
+            self.records.entry(def).or_insert(record);
+        }
+
+        for func in &parsed.funcs {
+            let def = defs[func.def.0 as usize];
+            let generics = self.remap_generics(&func.generics, &keys);
+            let remap = Remapper {
+                tcx: self.tcx,
+                defs: &defs,
+                keys: &keys,
+                generics: &generics.map,
+            };
+            let function = Function {
+                def,
+                name: remap.key(func.name),
+                visibility: func.visibility,
+                generics: generics.binder.clone(),
+                regional_generics: remap.generic_ids(&func.regional_generics),
+                params: func
+                    .params
+                    .iter()
+                    .map(|&(name, var, ty)| (remap.key(name), var, remap.ty(ty)))
+                    .collect(),
+                return_ty: remap.ty(func.return_ty),
+                is_regional: func.is_regional,
+                body: func.body.as_ref().map(|b| remap.expr(b)),
+                span: func.span,
+                file: func.file,
+            };
+            self.functions.entry(def).or_insert_with(|| FuncProto {
+                def,
+                name: function.name,
+                visibility: function.visibility,
+                generics: generics.binder,
+                regional_generics: function.regional_generics.clone(),
+                params: function
+                    .params
+                    .iter()
+                    .map(|&(name, _, ty)| (name, ty))
+                    .collect(),
+                return_ty: function.return_ty,
+                is_regional: function.is_regional,
+                span: function.span,
+                file: function.file,
+            });
+            if let Some(import) = parsed.ffi_imports.get(&func.def) {
+                self.extern_ffi_imports.insert(def, import.clone());
+            }
+            self.extern_functions.push(function);
+        }
+
+        self.extern_strings.extend(parsed.strings.iter().cloned());
+        self.extern_ffi_preludes
+            .extend(parsed.ffi_preludes.iter().cloned());
+        // Transform metadata of shipped bodies is not carried yet —
+        // cross-package monomorphization decides its shape (deferred).
+    }
+
+    /// Re-allocate an extern item's generic binder in the global table. The
+    /// interface does not serialize trait bounds (the producer already
+    /// enforced them on its own bodies), so extern binders re-allocate
+    /// unbounded: consumer-side obligations arise only from the consumer's
+    /// own expressions until bounds join the interface format with the trait
+    /// system.
+    fn remap_generics(
+        &mut self,
+        binder: &[(TokenKey, GenericId)],
+        keys: &[TokenKey],
+    ) -> RemappedGenerics {
+        let mut map = FxHashMap::default();
+        let binder = binder
+            .iter()
+            .map(|&(name, old)| {
+                let name = keys[name.into_u32() as usize];
+                let fresh = self.fresh_generic(name, Vec::new());
+                map.insert(old, fresh);
+                (name, fresh)
+            })
+            .collect();
+        RemappedGenerics { binder, map }
+    }
+}
+
+/// An extern item's generic binder after re-allocation: the consumer-space
+/// binder list and the producer→consumer id map the type remap reads.
+struct RemappedGenerics {
+    binder: Vec<(TokenKey, GenericId)>,
+    map: FxHashMap<GenericId, GenericId>,
+}
+
+/// Per-item remapping state: producer→consumer def and key tables plus the
+/// item's generic re-numbering. Rebuilds types through the shared `TyCtxt`;
+/// everything else copies structurally.
+struct Remapper<'m, 'a, 'tcx> {
+    tcx: &'a TyCtxt<'tcx>,
+    defs: &'m [DefId],
+    keys: &'m [TokenKey],
+    generics: &'m FxHashMap<GenericId, GenericId>,
+}
+
+impl<'tcx> Remapper<'_, '_, 'tcx> {
+    fn def(&self, def: DefId) -> DefId {
+        self.defs[def.0 as usize]
+    }
+
+    fn key(&self, key: TokenKey) -> TokenKey {
+        self.keys[key.into_u32() as usize]
+    }
+
+    fn generic(&self, id: GenericId) -> GenericId {
+        *self
+            .generics
+            .get(&id)
+            .expect("generic bound by the item's binder")
+    }
+
+    fn generic_ids(&self, ids: &[GenericId]) -> Vec<GenericId> {
+        ids.iter().map(|&g| self.generic(g)).collect()
+    }
+
+    fn ty(&self, ty: Ty<'tcx>) -> Ty<'tcx> {
+        match *ty.kind() {
+            TyKind::Record { def, args, flex } => {
+                let args: Vec<Ty<'tcx>> = args.iter().map(|&a| self.ty(a)).collect();
+                self.tcx.mk_record(self.def(def), &args, flex)
+            }
+            TyKind::Generic(g) => self.tcx.mk_generic(self.generic(g)),
+            TyKind::Nullable(inner) => {
+                let inner = self.ty(inner);
+                self.tcx.mk_nullable(inner)
+            }
+            TyKind::Arc(inner) => {
+                let inner = self.ty(inner);
+                self.tcx.mk_arc(inner)
+            }
+            TyKind::Cell { elem, kind } => {
+                let elem = self.ty(elem);
+                self.tcx.mk_cell(elem, kind)
+            }
+            TyKind::Array { elem, dims } => {
+                let elem = self.ty(elem);
+                self.tcx.mk_array(elem, dims)
+            }
+            TyKind::Closure { params, ret } => {
+                let params: Vec<Ty<'tcx>> = params.iter().map(|&p| self.ty(p)).collect();
+                let ret = self.ty(ret);
+                self.tcx.mk_closure(&params, ret)
+            }
+            // Scalars carry no defs or generics; holes cannot occur in a
+            // fully elaborated interface.
+            _ => ty,
+        }
+    }
+
+    fn tys(&self, tys: &[Ty<'tcx>]) -> Vec<Ty<'tcx>> {
+        tys.iter().map(|&t| self.ty(t)).collect()
+    }
+
+    fn fields(&self, fields: &RecordFields<'tcx>) -> RecordFields<'tcx> {
+        match fields {
+            RecordFields::Named(fs) => RecordFields::Named(
+                fs.iter()
+                    .map(|&(name, ty, is_mut)| (self.key(name), self.ty(ty), is_mut))
+                    .collect(),
+            ),
+            RecordFields::Unnamed(fs) => RecordFields::Unnamed(
+                fs.iter().map(|&(ty, is_mut)| (self.ty(ty), is_mut)).collect(),
+            ),
+            RecordFields::Variants(vs) => RecordFields::Variants(
+                vs.iter()
+                    .map(|v| Variant {
+                        name: self.key(v.name),
+                        fields: self.tys(&v.fields),
+                    })
+                    .collect(),
+            ),
+            RecordFields::Opaque => RecordFields::Opaque,
+        }
+    }
+
+    fn boxed(&self, expr: &Expr<'tcx>) -> Box<Expr<'tcx>> {
+        Box::new(self.expr(expr))
+    }
+
+    fn exprs(&self, exprs: &[Expr<'tcx>]) -> Vec<Expr<'tcx>> {
+        exprs.iter().map(|e| self.expr(e)).collect()
+    }
+
+    fn expr(&self, expr: &Expr<'tcx>) -> Expr<'tcx> {
+        let kind = match &expr.kind {
+            ExprKind::GlobalStr(_)
+            | ExprKind::ConstChar(_)
+            | ExprKind::ConstInt(_)
+            | ExprKind::ConstFloat(_)
+            | ExprKind::ConstBool(_)
+            | ExprKind::Var(_)
+            | ExprKind::Poison => expr.kind.clone(),
+            ExprKind::Negate(x) => ExprKind::Negate(self.boxed(x)),
+            ExprKind::Not(x) => ExprKind::Not(self.boxed(x)),
+            ExprKind::Arith(l, op, r) => ExprKind::Arith(self.boxed(l), *op, self.boxed(r)),
+            ExprKind::Cmp(l, op, r) => ExprKind::Cmp(self.boxed(l), *op, self.boxed(r)),
+            ExprKind::Cast(x, ty) => ExprKind::Cast(self.boxed(x), self.ty(*ty)),
+            ExprKind::If(c, t, f) => ExprKind::If(self.boxed(c), self.boxed(t), self.boxed(f)),
+            ExprKind::RegionRun(x) => ExprKind::RegionRun(self.boxed(x)),
+            ExprKind::Proj(base, path) => ExprKind::Proj(self.boxed(base), path.clone()),
+            ExprKind::Match(scrut, tree) => ExprKind::Match(self.boxed(scrut), self.tree(tree)),
+            ExprKind::Assign(dst, field, src) => {
+                ExprKind::Assign(self.boxed(dst), *field, self.boxed(src))
+            }
+            ExprKind::Let {
+                var,
+                name,
+                span,
+                value,
+            } => ExprKind::Let {
+                var: *var,
+                name: self.key(*name),
+                span: *span,
+                value: self.boxed(value),
+            },
+            ExprKind::Seq(items) => ExprKind::Seq(self.exprs(items)),
+            ExprKind::FuncCall {
+                target,
+                ty_args,
+                args,
+                regional,
+            } => ExprKind::FuncCall {
+                target: self.def(*target),
+                ty_args: self.tys(ty_args),
+                args: self.exprs(args),
+                regional: *regional,
+            },
+            ExprKind::CompoundCall {
+                target,
+                ty_args,
+                args,
+            } => ExprKind::CompoundCall {
+                target: self.def(*target),
+                ty_args: self.tys(ty_args),
+                args: self.exprs(args),
+            },
+            ExprKind::VariantCall {
+                target,
+                ty_args,
+                variant,
+                args,
+            } => ExprKind::VariantCall {
+                target: self.def(*target),
+                ty_args: self.tys(ty_args),
+                variant: *variant,
+                args: self.exprs(args),
+            },
+            ExprKind::NullableCall(inner) => {
+                ExprKind::NullableCall(inner.as_ref().map(|x| self.boxed(x)))
+            }
+            ExprKind::Intrinsic { op, args } => ExprKind::Intrinsic {
+                op: *op,
+                args: self.exprs(args),
+            },
+            ExprKind::ArrayOp { op, args } => ExprKind::ArrayOp {
+                op: *op,
+                args: self.exprs(args),
+            },
+            ExprKind::Closure(closure) => ExprKind::Closure(ClosureExpr {
+                captures: closure
+                    .captures
+                    .iter()
+                    .map(|&(v, t)| (v, self.ty(t)))
+                    .collect(),
+                params: closure
+                    .params
+                    .iter()
+                    .map(|&(v, t)| (v, self.ty(t)))
+                    .collect(),
+                body: self.boxed(&closure.body),
+            }),
+            ExprKind::ClosureCall { target, args } => ExprKind::ClosureCall {
+                target: self.boxed(target),
+                args: self.exprs(args),
+            },
+        };
+        Expr {
+            kind,
+            ty: self.ty(expr.ty),
+            span: expr.span,
+            id: expr.id,
+        }
+    }
+
+    fn tree(&self, tree: &DecisionTree<'tcx>) -> DecisionTree<'tcx> {
+        match tree {
+            DecisionTree::Uncovered => DecisionTree::Uncovered,
+            DecisionTree::Unreachable => DecisionTree::Unreachable,
+            DecisionTree::Leaf { body, bindings } => DecisionTree::Leaf {
+                body: self.boxed(body),
+                bindings: bindings.clone(),
+            },
+            DecisionTree::Guard {
+                bindings,
+                guard,
+                success,
+                failure,
+            } => DecisionTree::Guard {
+                bindings: bindings.clone(),
+                guard: self.boxed(guard),
+                success: Box::new(self.tree(success)),
+                failure: Box::new(self.tree(failure)),
+            },
+            DecisionTree::Switch { scrutinee, cases } => DecisionTree::Switch {
+                scrutinee: scrutinee.clone(),
+                cases: self.cases(cases),
+            },
+        }
+    }
+
+    fn cases(&self, cases: &SwitchCases<'tcx>) -> SwitchCases<'tcx> {
+        let boxed = |t: &DecisionTree<'tcx>| Box::new(self.tree(t));
+        match cases {
+            SwitchCases::Int { cases, default } => SwitchCases::Int {
+                cases: cases.iter().map(|&(n, ref t)| (n, self.tree(t))).collect(),
+                default: boxed(default),
+            },
+            SwitchCases::Bool { if_true, if_false } => SwitchCases::Bool {
+                if_true: boxed(if_true),
+                if_false: boxed(if_false),
+            },
+            SwitchCases::Char { cases, default } => SwitchCases::Char {
+                cases: cases.iter().map(|&(c, ref t)| (c, self.tree(t))).collect(),
+                default: boxed(default),
+            },
+            SwitchCases::Ctor(arms) => {
+                SwitchCases::Ctor(arms.iter().map(|t| self.tree(t)).collect())
+            }
+            SwitchCases::String { cases, default } => SwitchCases::String {
+                cases: cases.iter().map(|&(s, ref t)| (s, self.tree(t))).collect(),
+                default: boxed(default),
+            },
+            SwitchCases::Nullable { non_null, null } => SwitchCases::Nullable {
+                non_null: boxed(non_null),
+                null: boxed(null),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use reussir_syntax::Interner as _;
+    use reussir_syntax::source::FileId;
+
+    use super::*;
+    use crate::semi::hir::print::Printer;
+    use crate::semi::{PackageFile, elaborate_package};
+    use crate::{surface, with_tcx};
+
+    /// Elaborate `src` as a package rooted at `dep`, print its HIR, and
+    /// re-parse — the same round trip `--extern` performs. (The reduction and
+    /// header gating are the driver's business; declaration sees a `Parsed`.)
+    fn dep_interface<'tcx>(tcx: &TyCtxt<'tcx>, src: &str) -> Parsed<'tcx> {
+        let interner = Arc::new(reussir_syntax::new_threaded_interner());
+        let mut keys = interner.clone();
+        let dep = keys.get_or_intern("dep");
+        let parse = reussir_syntax::parse_with_interner(src, interner.clone());
+        assert!(parse.ok(), "dep parse errors: {:#?}", parse.errors);
+        let prog = surface::program(&parse.root);
+        let files = [PackageFile {
+            file: FileId::ROOT,
+            module: vec![dep],
+            program: &prog,
+        }];
+        let elab = elaborate_package(tcx, &files, &interner);
+        assert!(!elab.has_errors(), "dep elab errors: {:#?}", elab.reports);
+        let strings = elab.strings.entries();
+        let text = Printer::new(&elab.defs, elab.resolver).program(
+            &elab.elaborated,
+            &strings,
+            &elab.records,
+            &elab.trampolines,
+        );
+        crate::semi::hir::build::parse_program(tcx, &text).expect("re-parse")
+    }
+
+    /// Declare `dep_src`'s printed interface, then elaborate `app_files`
+    /// (module path, source) as a package rooted at `app` against it.
+    fn check_with_dep(
+        dep_src: &str,
+        app_files: &[(&[&str], &str)],
+        f: impl for<'a, 'tcx> FnOnce(&Elaborator<'a, 'tcx>),
+    ) {
+        with_tcx(|tcx| {
+            let parsed = dep_interface(tcx, dep_src);
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let mut keys = interner.clone();
+            let app = keys.get_or_intern("app");
+            let parses: Vec<_> = app_files
+                .iter()
+                .map(|(_, src)| {
+                    let p = reussir_syntax::parse_with_interner(src, interner.clone());
+                    assert!(p.ok(), "app parse errors for {src:?}: {:#?}", p.errors);
+                    p
+                })
+                .collect();
+            let programs: Vec<surface::Program> =
+                parses.iter().map(|p| surface::program(&p.root)).collect();
+            let files: Vec<PackageFile> = app_files
+                .iter()
+                .zip(&programs)
+                .enumerate()
+                .map(|(i, ((module, _), program))| {
+                    let mut path = vec![app];
+                    path.extend(module.iter().map(|seg| keys.get_or_intern(seg)));
+                    PackageFile {
+                        file: FileId::from_index(i as u32),
+                        module: path,
+                        program,
+                    }
+                })
+                .collect();
+            let mut elab = Elaborator::new(tcx, &interner);
+            elab.declare_extern_package(
+                &mut keys,
+                &ExternPackage {
+                    name: "dep",
+                    parsed: &parsed,
+                },
+            );
+            elab.run_package(&files);
+            f(&elab);
+        });
+    }
+
+    const DEP: &str = "pub struct Point { x: i64, y: i64 }\n\
+                       struct Hidden { v: i64 }\n\
+                       fn private_helper(h: Hidden) -> i64 { h.v }\n\
+                       pub fn api<T : Num>(x: T) -> T { private_helper(Hidden { v: 1 }); x }\n\
+                       pub fn ground(x: i64) -> i64 { x + 1 }\n\
+                       pub enum Opt { None, Some(i64) }";
+
+    #[test]
+    fn pub_items_resolve_through_the_package_head() {
+        check_with_dep(
+            DEP,
+            &[(
+                &[],
+                "fn go(x: i64) -> i64 {\n\
+                     let p = dep::Point { x: dep::api(x), y: dep::ground(x) };\n\
+                     p.x + p.y\n\
+                 }\n\
+                 fn pick(x: i64) -> i64 {\n\
+                     let o = dep::Opt::Some{x};\n\
+                     match o {\n\
+                         dep::Opt::Some(v) => v,\n\
+                         dep::Opt::None => 0\n\
+                     }\n\
+                 }",
+            )],
+            |elab| {
+                assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+                // The extern bodies are carried (remapped) for later
+                // monomorphization, outside the consumer's own item list.
+                let api = elab
+                    .extern_functions
+                    .iter()
+                    .find(|f| elab.defs.path(f.def).display(elab.resolver) == "dep::api")
+                    .expect("api carried");
+                assert!(api.body.is_some(), "generic body ships and is carried");
+                assert_eq!(elab.elaborated.len(), 2, "consumer items only");
+                // Extern records join `records` (the checker reads layouts)
+                // but not the dump's record set.
+                assert!(!elab.records.is_empty());
+                assert!(elab.local_records().is_empty(), "dump stays consumer-only");
+            },
+        );
+    }
+
+    #[test]
+    fn private_extern_items_are_rejected_distinctly() {
+        check_with_dep(
+            DEP,
+            &[(
+                &[],
+                "fn a(x: i64) -> i64 { dep::private_helper(x) }\n\
+                 fn b(x: i64) -> i64 { dep::nope(x) }\n\
+                 fn c(h: dep::Hidden) -> i64 { 0 }\n\
+                 fn d() -> i64 { dep::Hidden { v: 1 }; 0 }",
+            )],
+            |elab| {
+                let messages: Vec<&str> =
+                    elab.reports.iter().map(|r| r.message.as_str()).collect();
+                // A private hit is access control, not absence …
+                assert!(
+                    messages
+                        .iter()
+                        .any(|m| *m == "function `private_helper` in package `dep` is private"),
+                    "{messages:#?}"
+                );
+                assert!(
+                    messages
+                        .iter()
+                        .filter(|m| m.contains("record `Hidden` in package `dep` is private"))
+                        .count()
+                        == 2,
+                    "type and constructor positions both gate: {messages:#?}"
+                );
+                // … and absence stays not-found.
+                assert!(
+                    messages
+                        .iter()
+                        .any(|m| m.contains("unknown function `dep::nope`")),
+                    "{messages:#?}"
+                );
+                assert!(
+                    !messages.iter().any(|m| m.contains("unknown function `dep::private_helper`")),
+                    "private must not double-report as unknown: {messages:#?}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn extern_head_and_local_modules_never_shadow() {
+        // A local module named like the extern: `dep::…` resolves in the
+        // extern package only (miss, not the local module), while the local
+        // module stays reachable through `root::`.
+        check_with_dep(
+            DEP,
+            &[
+                (
+                    &[],
+                    "fn go(x: i64) -> i64 { dep::local(x) }\n\
+                     fn ok(x: i64) -> i64 { root::dep::local(x) }",
+                ),
+                (&["dep"], "pub fn local(x: i64) -> i64 { x }"),
+            ],
+            |elab| {
+                let messages: Vec<&str> =
+                    elab.reports.iter().map(|r| r.message.as_str()).collect();
+                assert!(
+                    messages
+                        .iter()
+                        .any(|m| m.contains("unknown function `dep::local`")),
+                    "the extern head owns the path: {messages:#?}"
+                );
+                assert!(
+                    !messages.iter().any(|m| m.contains("root::dep")),
+                    "`root::` still reaches the local module: {messages:#?}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn imports_cannot_bind_an_extern_head() {
+        check_with_dep(
+            DEP,
+            &[(
+                &[],
+                "import core::intrinsic::math as dep;\nfn go() -> i64 { 0 }",
+            )],
+            |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r
+                        .message
+                        .contains("`dep` names a loaded extern package")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+}

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -66,6 +66,13 @@ pub struct Names {
 }
 
 impl Names {
+    /// Every interned string, densely indexed by key — the extern declare
+    /// pass re-interns the whole table into the consumer's interner (see
+    /// [`crate::semi::externs`]).
+    pub fn entries(&self) -> &[String] {
+        &self.strings
+    }
+
     fn intern(&mut self, s: &str) -> TokenKey {
         if let Some(&k) = self.map.get(s) {
             return k;

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -368,6 +368,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     d
                 }
                 None => {
+                    if let Some(msg) = self.extern_private_ctor_msg(&ctor.path) {
+                        self.error(span, msg);
+                        return Pat::Wild;
+                    }
                     let hint = self.record_suggestion(seg);
                     self.error(span, format!("unknown enum `{}`{hint}", self.sym(seg)));
                     return Pat::Wild;

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -40,6 +40,7 @@
 //! monomorphization.
 
 use crate::semi::infer::Instantiation;
+use crate::semi::resolve::DefKind;
 use crate::semi::traits::sync::{SyncEnv, SyncVerdict, wf_arc};
 use crate::semi::ty::{DefId, Flexivity, FpTy, IntTy, Ty, TyKind};
 use crate::surface::{self, FpType, IntegralType, TypeKind};
@@ -305,6 +306,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         key: reussir_syntax::kind::TokenKey,
     ) -> Ty<'tcx> {
         let Some(def) = self.resolve_record_ref(path) else {
+            // A private record of a loaded extern package reports access,
+            // not absence.
+            if let Some(msg) = self.extern_private_msg(path, DefKind::Record) {
+                self.error(Some(span), msg);
+                return self.tcx.mk(TyKind::Bottom);
+            }
             let hint = if path.segments.is_empty() {
                 self.record_suggestion(key)
             } else {

--- a/tests/integration/frontend/extern_load.rr
+++ b/tests/integration/frontend/extern_load.rr
@@ -1,0 +1,51 @@
+// Loading dependency package interfaces: `--extern name=path.rri` parses the
+// interface into the compilation and gates its header (format, package name,
+// reserved names). Consumption — resolution against the loaded defs, then
+// cross-package monomorphization — lands separately; this pins the loading
+// contract itself. The dep interface is emitted from this very file: the two
+// roles differ only by package name.
+
+// RUN: %rrc %s --package-name dep --emit rri -o %t.rri
+// RUN: %rrc %s --package-name dep --emit hir --no-source-locations -o %t.hir
+
+// Loading succeeds and the consumer compiles as usual.
+// RUN: %rrc %s --package-name app --extern dep=%t.rri --emit hir --no-source-locations -o - \
+// RUN:   | %FileCheck %s
+
+// The header's package must match the flag's name.
+// RUN: %not %rrc %s --package-name app --extern other=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=MISMATCH
+// MISMATCH: describes package `dep`, but was loaded as `--extern other=...`
+
+// A plain HIR dump is not an interface.
+// RUN: %not %rrc %s --package-name app --extern dep=%t.hir --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=PLAIN
+// PLAIN: plain HIR dump, not a package interface
+
+// `core` and the compiling package's own name are reserved.
+// RUN: %not %rrc %s --package-name app --extern core=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=CORE
+// CORE: `core` is the builtin package
+// RUN: %not %rrc %s --package-name dep --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=SHADOW
+// SHADOW: shadows the package being compiled
+
+// Extern names are unique, a source root must name a declared extern, and
+// only a package can consume interfaces.
+// RUN: %not %rrc %s --package-name app --extern dep=%t.rri --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=DUP
+// DUP: `--extern dep=...` given twice
+// RUN: %not %rrc %s --package-name app --extern dep=%t.rri --extern-src other=%S --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NOSRC
+// NOSRC: `--extern-src other=...` names no `--extern other=...`
+// RUN: %not %rrc %s --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NOPKG
+// NOPKG: --extern requires package mode
+
+pub fn id<T : Num>(x: T) -> T { x }
+
+fn helper(x: i64) -> i64 { x + 1 }
+
+pub fn entry(x: i64) -> i64 { helper(x) }
+
+// CHECK: pub fn #app::entry

--- a/tests/integration/frontend/extern_resolve.rr
+++ b/tests/integration/frontend/extern_resolve.rr
@@ -1,0 +1,75 @@
+// Extern-head resolution and access control: consumer references through a
+// loaded interface's package head resolve to its `pub` items only, print as
+// `#dep::…` call targets, and never join the consumer's own dump items. A
+// private hit is access control ("is private"), distinct from not-found, and
+// the extern head neither shadows nor is shadowed by a local module.
+
+// RUN: %rrc --package-root %S/extern_resolve --package-name dep --emit rri -o %t.rri
+
+// `pub` function calls (generic and ground) and the `pub` record resolve;
+// the dump's items stay the consumer's own.
+// RUN: %rrc %s --package-name app --extern dep=%t.rri --emit hir --no-source-locations -o - \
+// RUN:   | %FileCheck %s
+// RUN: %rrc %s --package-name app --extern dep=%t.rri --emit hir --no-source-locations -o - \
+// RUN:   | %FileCheck %s --check-prefix=OWN
+
+// A private function resolves to access control, not absence …
+// RUN: echo 'fn f(x: i64) -> i64 { dep::private_helper(x) }' > %t.private.rr
+// RUN: %not %rrc %t.private.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=PRIVATE
+// PRIVATE: function `private_helper` in package `dep` is private
+
+// … a private record likewise …
+// RUN: echo 'fn g() -> i64 { dep::Hidden { v: 1 }; 0 }' > %t.hidden.rr
+// RUN: %not %rrc %t.hidden.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=HIDDEN
+// HIDDEN: record `Hidden` in package `dep` is private
+
+// … and a missing item stays not-found.
+// RUN: echo 'fn h(x: i64) -> i64 { dep::nope(x) }' > %t.nope.rr
+// RUN: %not %rrc %t.nope.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NOPE
+// NOPE: unknown function `dep::nope`
+
+// A type error against an extern signature reports like any local one: the
+// caret lands in the consumer's source with the `dep::`-qualified call on
+// the rendered line, checked against the imported prototype's real types.
+// RUN: echo 'fn bad(x: bool) -> i64 { dep::ground(x) }' > %t.bad.rr
+// RUN: %not %rrc %t.bad.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=MISMATCH
+// MISMATCH: type mismatch: expected `i64`, found `bool`
+// MISMATCH: dep::ground(x)
+
+// The extern head owns its paths exclusively: a local module named `dep`
+// misses on `dep::…` but stays reachable through `root::dep::…` (which must
+// produce no diagnostic of its own).
+// RUN: %not %rrc --package-root %S/extern_resolve_shadow --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=SHADOW
+// SHADOW: unknown function `dep::local`
+// SHADOW-NOT: unknown function `root::dep::local`
+
+pub fn call_api(x: i64) -> i64 {
+    dep::api(x)
+}
+
+pub fn call_ground(x: i64) -> i64 {
+    dep::ground(x)
+}
+
+pub fn use_point(x: i64) -> i64 {
+    let p = dep::Point { x: x, y: 1 };
+    p.x + p.y
+}
+
+// Calls print as fully-qualified extern paths.
+// CHECK: pub fn #app::call_api
+// CHECK: #dep::api::<i64>
+// CHECK: pub fn #app::call_ground
+// CHECK: #dep::ground
+// CHECK: pub fn #app::use_point
+// CHECK: #dep::Point
+
+// No extern definitions leak into the consumer's dump: the imported record
+// and the shipped bodies/prototypes stay out of the printed program.
+// OWN-NOT: struct #dep::
+// OWN-NOT: fn #dep::

--- a/tests/integration/frontend/extern_resolve/lib.rr
+++ b/tests/integration/frontend/extern_resolve/lib.rr
@@ -1,0 +1,30 @@
+// The dependency fixture for extern-head resolution: a `pub` generic whose
+// body reaches a private ground helper over a private record (both ship in
+// the interface — the body whole, the helper as a prototype), a `pub`
+// ground, and a `pub` record surface a prototype mentions.
+
+pub struct Point {
+    x: i64,
+    y: i64,
+}
+
+struct Hidden {
+    v: i64,
+}
+
+fn private_helper(h: Hidden) -> i64 {
+    h.v
+}
+
+pub fn api<T : Num>(x: T) -> T {
+    private_helper(Hidden { v: 1 });
+    x
+}
+
+pub fn ground(x: i64) -> i64 {
+    x + 1
+}
+
+pub fn origin() -> Point {
+    Point { x: 0, y: 0 }
+}

--- a/tests/integration/frontend/extern_resolve/lit.local.cfg
+++ b/tests/integration/frontend/extern_resolve/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/extern_resolve_shadow/dep.rr
+++ b/tests/integration/frontend/extern_resolve_shadow/dep.rr
@@ -1,0 +1,3 @@
+pub fn local(x: i64) -> i64 {
+    x
+}

--- a/tests/integration/frontend/extern_resolve_shadow/lib.rr
+++ b/tests/integration/frontend/extern_resolve_shadow/lib.rr
@@ -1,0 +1,13 @@
+// A consumer with a local module named like the loaded extern: the extern
+// head owns `dep::…` exclusively (the reference below misses), while the
+// local module stays reachable through `root::dep::…`.
+
+mod dep;
+
+fn go(x: i64) -> i64 {
+    dep::local(x)
+}
+
+fn ok(x: i64) -> i64 {
+    root::dep::local(x)
+}

--- a/tests/integration/frontend/extern_resolve_shadow/lit.local.cfg
+++ b/tests/integration/frontend/extern_resolve_shadow/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []


### PR DESCRIPTION
## Summary

Third PR of the cross-package HIR-index arc (#451; after #467 linkage and #468 `--emit rri`): the consumer side's first leg, in three reviewer-sized commits.

1. **`--extern name=path.rri` loads and gates interfaces** — a typed `NAME=PATH` flag pair (`ExternPair: FromStr`), header gating (format, package-name match against the header, `core`/self/duplicate rejection, plain-`.hir`-is-not-an-interface), parsing into the compilation's `TyCtxt`. Package mode only, mirroring `--emit rri`.
2. **File tables re-anchor onto `--extern-src` roots** — an `.rri` records files package-root-relative (byte-stability); the consumer supplies the base directory, DWARF's `comp_dir` split. Without a root, entries load as unfetchable virtual names (never resolved against the consumer's tree).
3. **Extern-head resolution + access control** — extern packages declare into the elaborator ahead of the package scan (names re-interned, `DefId`s remapped). A path led by an extern head resolves absolutely in that package alone (no shadowing either way; `root::` still reaches a local module of the same name). Only `pub` resolves from consumer source; a private hit is *access control* — "function `f` in package `dep` is private" — distinct from not-found: the first resolution-time visibility rule in the language. Imported bodies/records stay out of the consumer's dump, export surface, and mono roots.

Deferred to the next PR (cross-package monomorphization): consuming the imported bodies, `--link-lib`, rendering diagnostics against re-anchored extern sources, trait bounds in the interface format.

## Test plan

- [x] `externs` unit tests: pair parsing, spec cross-checks, file-table re-anchoring (root / no-root / producer-virtual)
- [x] reussir-core tests 312/312 (extern declare, pub resolve incl. ctor+pattern, private-vs-missing, no-shadow, import-head rejection)
- [x] lit `extern_load.rr`: load + every gate; `extern_resolve.rr`: `#dep::…` call targets in the consumer dump, no item leakage, private fn/record, not-found, shadowing, and a type-mismatch against an extern signature caret-ing the consumer line with the `dep::`-qualified call
- [x] full lit suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787695995&installation_model_id=426051&pr_number=470&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F470&signature=c4133d20bd5842fe7994a3887eba1d8d853817c4d4745fbf6810a6b0e5d938f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->