### PR TITLE
[frontend] cross-package monomorphization and --link-lib

### DIFF
--- a/crates/reussir-compiler/src/driver.rs
+++ b/crates/reussir-compiler/src/driver.rs
@@ -246,7 +246,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
             }
         }
         let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
-        let pkg = match load_package_or_render(&root, &pkg_name, &interner) {
+        let mut pkg = match load_package_or_render(&root, &pkg_name, &interner) {
             Ok(pkg) => pkg,
             Err(msg) if msg.is_empty() => return Ok(false),
             Err(msg) => return Err(msg),
@@ -257,7 +257,7 @@ fn run(cli: &Cli) -> Result<bool, String> {
             context.enable_multi_threading(false);
         }
         let produced = match in_arena(|tcx| {
-            frontend_package(&context, tcx, target, &pkg, &pkg_name, &interner, cli)
+            frontend_package(&context, tcx, target, &mut pkg, &pkg_name, &interner, cli)
         }) {
                 Ok(produced) => produced,
                 Err(msg) => {

--- a/crates/reussir-compiler/src/driver/cli.rs
+++ b/crates/reussir-compiler/src/driver/cli.rs
@@ -77,6 +77,13 @@ pub(crate) struct Cli {
     #[arg(long = "linker", value_name = "PATH")]
     pub(crate) linker: Option<PathBuf>,
 
+    /// A dependency's static library, joined into the link by path (after
+    /// this compilation's own members): the archive the declared symbols of
+    /// a package loaded via `--extern` resolve against. Repeatable, in
+    /// dependency order.
+    #[arg(long = "link-lib", value_name = "PATH")]
+    pub(crate) link_libs: Vec<PathBuf>,
+
     /// Extra argument for the link step, passed through as `-C link-arg=`
     /// (repeatable; appended after the driver's own link inputs). Applies to
     /// `--emit executable` and `--emit dynlib`.

--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -37,7 +37,7 @@ pub(crate) fn frontend_package<'c, 'tcx>(
     context: &'c reussir_backend::melior::Context,
     tcx: &TyCtxt<'tcx>,
     target: Stage,
-    pkg: &package::PackageSource,
+    pkg: &mut package::PackageSource,
     pkg_name: &str,
     interner: &std::sync::Arc<reussir_syntax::MultiThreadedTokenInterner>,
     cli: &Cli,
@@ -45,12 +45,25 @@ pub(crate) fn frontend_package<'c, 'tcx>(
     use reussir_core::semi::{ExternPackage, PackageFile, elaborate_package_with_externs};
 
     // Dependency interfaces load and gate first — their tables must exist
-    // before any consumer resolution runs. Diagnostics stay on the consumer's
-    // cache: no report carries an extern file id yet (extern bodies are never
-    // re-checked here); rendering against `LoadedExtern::sources()` lands
-    // with cross-package monomorphization.
+    // before any consumer resolution runs.
     let extern_specs = crate::externs::join_specs(&cli.externs, &cli.extern_srcs)?;
     let externs = crate::externs::load(tcx, &extern_specs, Some(pkg_name))?;
+
+    // Extern sources join the consumer's cache only when the pipeline runs
+    // into monomorphization: that is where reports and debug locations can
+    // land inside imported bodies. The text-dump targets (`hir`, `rri`) print
+    // the consumer's file table verbatim, so growing the cache there would
+    // leak consumer-anchored dependency paths into the artifact (breaking the
+    // rri's byte-stability across checkouts).
+    let extern_files: Vec<Vec<FileId>> = if target > Stage::Rri {
+        externs
+            .iter()
+            .map(|ext| ext.register_sources(&mut pkg.cache))
+            .collect()
+    } else {
+        externs.iter().map(|_| Vec::new()).collect()
+    };
+    let pkg: &package::PackageSource = pkg;
 
     let name = pkg.cache.name(FileId::ROOT);
     let programs: Vec<surface::Program> = pkg
@@ -75,9 +88,11 @@ pub(crate) fn frontend_package<'c, 'tcx>(
         .collect();
     let extern_pkgs: Vec<ExternPackage<'_, 'tcx>> = externs
         .iter()
-        .map(|ext| ExternPackage {
+        .zip(&extern_files)
+        .map(|(ext, files)| ExternPackage {
             name: &ext.name,
             parsed: &ext.parsed,
+            files,
         })
         .collect();
     let elab = elaborate_package_with_externs(tcx, &files, interner, &mut keys, &extern_pkgs);

--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -307,6 +307,9 @@ pub(crate) fn frontend<'c, 'tcx>(
                 ffi_imports: &parsed.ffi_imports,
                 ffi_preludes: &parsed.ffi_preludes,
                 strings: parsed.strings.clone(),
+                // A plain `.hir` re-entry is a closed world; interfaces load
+                // via `--extern` (package mode) only.
+                externs: Default::default(),
             };
             let (full, reports) = monomorphize(&input);
             match &dump_sources {

--- a/crates/reussir-compiler/src/driver/link.rs
+++ b/crates/reussir-compiler/src/driver/link.rs
@@ -142,6 +142,14 @@ pub(crate) fn link_product(
     for member in &scratch.members {
         cmd.arg(format!("-Clink-arg={}", member.display()));
     }
+    // Dependency staticlibs (`--link-lib`), after this compilation's own
+    // members: declared extern symbols — dependency ground functions, and
+    // the mono-exported private helpers their shipped bodies reach —
+    // resolve here. Named by path like the runtime archive below, and for
+    // the same reason.
+    for lib in &cli.link_libs {
+        cmd.arg(format!("-Clink-arg={}", lib.display()));
+    }
 
     // The runtime. The static archive is named by *path*, not `-l static=`:
     // rustc lowers the latter to a bare `-l` on ELF and Mach-O, and the

--- a/crates/reussir-compiler/src/externs.rs
+++ b/crates/reussir-compiler/src/externs.rs
@@ -2,10 +2,10 @@
 //!
 //! An `.rri` is a textual HIR document reduced to the export closure behind
 //! a versioned header (`docs/design/rri.md`). This module owns the consumer
-//! side of the contract's first leg: parsing the `--extern`/`--extern-src`
-//! spellings and gating the header (format, package name, reserved names)
-//! before anything is offered to resolution. What the loaded tables *feed*
-//! (elaboration, monomorphization) arrives in later commits.
+//! side of the contract: parsing the `--extern`/`--extern-src` spellings,
+//! gating the header (format, package name, reserved names) before anything
+//! is offered to resolution, and re-anchoring the interface's file table
+//! into the consumer's source cache so imported spans render and debug.
 
 use std::path::PathBuf;
 

--- a/crates/reussir-compiler/src/externs.rs
+++ b/crates/reussir-compiler/src/externs.rs
@@ -112,24 +112,26 @@ impl LoadedExtern<'_> {
             .collect()
     }
 
-    /// A source cache over the re-anchored table — real paths registered for
-    /// lazy loading, virtual entries name-only — so spans inside imported
-    /// items keep resolving in consumer diagnostics. `None` when the
-    /// interface was printed without locations.
-    pub fn sources(&self) -> Option<reussir_syntax::source::SourceCache> {
-        let files = self.re_anchored_files();
-        if files.is_empty() {
-            return None;
-        }
-        let mut cache = reussir_syntax::source::SourceCache::new();
-        for name in &files {
-            if name.starts_with('<') {
-                cache.add_unavailable(name);
-            } else {
-                cache.add_lazy_file(name);
-            }
-        }
-        Some(cache)
+    /// Append the re-anchored table to `cache` — real paths registered for
+    /// lazy loading, virtual entries name-only — returning the consumer-cache
+    /// id of each producer file index. The returned map feeds
+    /// `ExternPackage::files`, so spans inside imported items resolve in
+    /// consumer diagnostics and instance debug info. Empty when the interface
+    /// was printed without locations.
+    pub fn register_sources(
+        &self,
+        cache: &mut reussir_syntax::source::SourceCache,
+    ) -> Vec<reussir_syntax::source::FileId> {
+        self.re_anchored_files()
+            .iter()
+            .map(|name| {
+                if name.starts_with('<') {
+                    cache.add_unavailable(name)
+                } else {
+                    cache.add_lazy_file(name)
+                }
+            })
+            .collect()
     }
 }
 
@@ -236,8 +238,14 @@ mod tests {
                     .to_string()
             );
             assert_eq!(files[1], "<prelude>");
-            let cache = ext.sources().expect("table is non-empty");
-            assert_eq!(cache.len(), 2);
+            // Registration appends after the consumer's own entries and
+            // returns the producer-index → consumer-id map.
+            let mut cache = reussir_syntax::source::SourceCache::single("lib.rr", "");
+            let ids = ext.register_sources(&mut cache);
+            assert_eq!(ids.len(), 2);
+            assert_eq!(ids[0].index(), 1);
+            assert_eq!(ids[1].index(), 2);
+            assert!(!cache.is_available(ids[1]), "virtual entries stay name-only");
         });
     }
 

--- a/crates/reussir-core/src/full/interface.rs
+++ b/crates/reussir-core/src/full/interface.rs
@@ -63,6 +63,10 @@ pub struct ExportClosure {
 /// compiled here and only the symbol crosses). Walking a body classifies each
 /// call target the same way and collects the types and strings it mentions;
 /// the record set then closes over field types.
+///
+/// Only `elaborated` — this package's own items — seeds or joins the closure:
+/// imported functions (`MonoInput::externs`) are a dependency's surface, and
+/// a consumer never re-exports its dependency.
 pub fn export_closure(input: &MonoInput<'_, '_>) -> ExportClosure {
     let by_def: rustc_hash::FxHashMap<DefId, &crate::semi::hir::Function<'_>> =
         input.elaborated.iter().map(|f| (f.def, f)).collect();

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -10,9 +10,12 @@
 //!
 //! # Roots
 //!
-//! Every non-generic function (emitted even if uncalled — whole-program DCE is
-//! the backend's job) plus every trampoline target. Generic functions are
-//! emitted once per distinct instantiation discovered from a reachable body.
+//! Every **local** non-generic function (emitted even if uncalled —
+//! whole-program DCE is the backend's job) plus every trampoline target.
+//! Generic functions are emitted once per distinct instantiation discovered
+//! from a reachable body. Imported functions ([`MonoExterns`]) are never
+//! roots: they are reached only through calls, instantiating from their
+//! shipped bodies or lowering to declarations from their prototypes.
 //!
 //! # Worklist
 //!
@@ -91,6 +94,36 @@ pub struct MonoInput<'a, 'tcx> {
     pub ffi_imports: &'a FxHashMap<DefId, FfiImport>,
     pub ffi_preludes: &'a [FfiPrelude],
     pub strings: Vec<(StringToken, String)>,
+    /// The dependency-interface tables (`--extern`); empty defaults for a
+    /// single-package compilation.
+    pub externs: MonoExterns<'a, 'tcx>,
+}
+
+/// What loaded dependency interfaces contribute to monomorphization: the
+/// remapped extern tables an [`Elaborator`] collected via
+/// `declare_extern_package`.
+///
+/// Imported functions join instantiation lookup (`by_def`) but are **never
+/// roots** — a ground import compiles in its own package and only its symbol
+/// crosses the boundary — and never seed the export closure
+/// ([`super::interface::export_closure`] walks `elaborated` only: a consumer
+/// does not re-export its dependency). An enqueued instance whose imported
+/// function carries a body instantiates here exactly like a local one (its
+/// `_RI` symbol dedups `weak_odr` against any other emitter); a bodyless
+/// prototype lowers to a `mir::Function` declaration the link resolves
+/// against the dependency's artifact.
+#[derive(Default)]
+pub struct MonoExterns<'a, 'tcx> {
+    pub functions: &'a [Function<'tcx>],
+    /// String literals imported bodies reference. Tokens are
+    /// content-addressed, so they merge into the program's table by token.
+    pub strings: &'a [(StringToken, String)],
+    /// Foreign bodies of imported `#[ffi(import)]` functions, keyed by their
+    /// consumer defs; their textures render per instance like local ones.
+    pub ffi_imports: Option<&'a FxHashMap<DefId, FfiImport>>,
+    /// Preludes of the imported ffi bodies' files (file ids already remapped
+    /// into the consumer's cache, so the per-file pairing holds).
+    pub ffi_preludes: &'a [FfiPrelude],
 }
 
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
@@ -108,6 +141,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             ffi_imports: &self.ffi_imports,
             ffi_preludes: &self.ffi_preludes,
             strings: self.strings.entries(),
+            externs: MonoExterns {
+                functions: &self.extern_functions,
+                strings: &self.extern_strings,
+                ffi_imports: Some(&self.extern_ffi_imports),
+                ffi_preludes: &self.extern_ffi_preludes,
+            },
         }
     }
 }
@@ -249,8 +288,14 @@ fn tree_exprs<'e, 'tcx>(tree: &'e DecisionTree<'tcx>, f: &mut impl FnMut(&'e Exp
 /// diagnostics raised by the call-boundary regional check.
 pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx>, Vec<Report>) {
     let tcx: &'a TyCtxt<'tcx> = input.tcx;
-    let by_def: FxHashMap<DefId, &Function<'tcx>> =
-        input.elaborated.iter().map(|f| (f.def, f)).collect();
+    // Instantiation looks up local *and* imported functions; only locals are
+    // seeded as roots below.
+    let by_def: FxHashMap<DefId, &Function<'tcx>> = input
+        .elaborated
+        .iter()
+        .chain(input.externs.functions)
+        .map(|f| (f.def, f))
+        .collect();
     let exports = mono_exports(input);
 
     let mut driver = Driver {
@@ -260,6 +305,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         symbols: Rodeo::default(),
         queue: VecDeque::new(),
         seen: FxHashSet::default(),
+        origins: FxHashMap::default(),
         records: FxHashSet::default(),
         record_defs: input.records,
         reported_arcs: FxHashSet::default(),
@@ -268,14 +314,16 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         ids: mir::ExprIdGen::default(),
     };
 
-    // Seed roots: every non-generic function, then every trampoline target.
+    // Seed roots: every *local* non-generic function, then every trampoline
+    // target. Imported grounds must not seed — their definitions live in the
+    // dependency's artifact and only calls reach them (as declarations).
     for f in input.elaborated {
         if f.generics.is_empty() {
-            driver.enqueue(f.def, tcx.intern_tys(&[]));
+            driver.enqueue(f.def, tcx.intern_tys(&[]), f.span);
         }
     }
     for t in input.trampolines {
-        driver.enqueue(t.target, tcx.intern_tys(&t.ty_args));
+        driver.enqueue(t.target, tcx.intern_tys(&t.ty_args), None);
     }
 
     // FFI accumulators. `ffi_mangler` is a second (stateless) mangler the
@@ -292,7 +340,27 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
     let mut functions = Vec::new();
     while let Some(inst) = driver.queue.pop_front() {
         let Some(func) = by_def.get(&inst.def) else {
-            // No body/prototype recorded (e.g. an item that failed to elaborate).
+            // Neither a local definition nor an imported body/prototype: with
+            // externs in play a silent skip would manufacture an undefined
+            // symbol at link time, so report at the discovering call site. A
+            // stale or incomplete dependency interface is the expected cause;
+            // an item that failed to elaborate never reaches mono (the driver
+            // stops on elaboration errors).
+            let (file, span) = driver
+                .origins
+                .get(&inst)
+                .copied()
+                .unwrap_or((FileId::ROOT, None));
+            driver.cur_file = file;
+            let path = input.defs.path(inst.def).display(input.resolver);
+            driver.error(
+                span,
+                format!(
+                    "no body or prototype recorded for `{path}`: the definition is \
+                     neither in this package nor in a loaded dependency interface \
+                     (is a stale `.rri` being passed via `--extern`?)"
+                ),
+            );
             continue;
         };
         driver.cur_file = func.file;
@@ -336,10 +404,18 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
 
         let symbol = driver.symbol_of(inst.def, inst.ty_args);
 
-        // An `#[ffi(import)]` instance: render its boundary wrapper texture
-        // and register the import trampoline. The function itself stays a
-        // bodyless declaration under `symbol` (emitted below as usual).
-        if let Some(fimport) = input.ffi_imports.get(&inst.def) {
+        // An `#[ffi(import)]` instance (local or imported — a polyffi texture
+        // inside a shipped body compiles in the consumer's pipeline): render
+        // its boundary wrapper texture and register the import trampoline.
+        // The function itself stays a bodyless declaration under `symbol`
+        // (emitted below as usual).
+        let ffi_import = input.ffi_imports.get(&inst.def).or_else(|| {
+            input
+                .externs
+                .ffi_imports
+                .and_then(|imports| imports.get(&inst.def))
+        });
+        if let Some(fimport) = ffi_import {
             let fctx = FfiCtx {
                 records: input.records,
                 instance_symbol: &instance_symbol,
@@ -396,9 +472,12 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
                 }
                 let body_text =
                     ffi_render::substitute_placeholders(&fimport.body, &placeholders);
+                // File ids are one space (externs remap at declaration), so
+                // the per-file prelude pairing holds across both tables.
                 let preludes: Vec<&str> = input
                     .ffi_preludes
                     .iter()
+                    .chain(input.externs.ffi_preludes)
                     .filter(|p| p.file == fimport.file)
                     .map(|p| p.body.as_str())
                     .collect();
@@ -594,6 +673,18 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
     ffi_imports_out.sort_by_cached_key(|f| driver.symbols.resolve(&f.symbol.0).to_owned());
     ffi_textures.sort_by_cached_key(|t| driver.symbols.resolve(&t.anchor.0).to_owned());
 
+    // Imported bodies' `GlobalStr` tokens must resolve in the program's
+    // table. Tokens are content-addressed, so a literal both sides use is
+    // one entry.
+    let mut string_literals = input.strings.clone();
+    let mut seen_strings: FxHashSet<StringToken> =
+        string_literals.iter().map(|(token, _)| *token).collect();
+    for (token, text) in input.externs.strings {
+        if seen_strings.insert(*token) {
+            string_literals.push((*token, text.clone()));
+        }
+    }
+
     let Driver {
         symbols, reports, ..
     } = driver;
@@ -602,7 +693,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             functions,
             records,
             trampolines,
-            string_literals: input.strings.clone(),
+            string_literals,
             transform_scripts: input.transform_scripts.to_vec(),
             ffi_imports: ffi_imports_out,
             ffi_textures,
@@ -827,6 +918,10 @@ struct Driver<'a, 'tcx> {
     queue: VecDeque<Instance<'tcx>>,
     /// Function instances already enqueued (so each is emitted once).
     seen: FxHashSet<Instance<'tcx>>,
+    /// Where each instance was first demanded — the discovering call's file
+    /// and span — so an instantiation target with no recorded body or
+    /// prototype reports at its call site.
+    origins: FxHashMap<Instance<'tcx>, (FileId, Option<Span>)>,
     /// Ground record instances whose layout is needed (keyed flex-independently).
     records: FxHashSet<(DefId, &'tcx [Ty<'tcx>])>,
     /// Record definitions (for their default capability) — the deferred `Arc`
@@ -872,10 +967,13 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         });
     }
 
-    /// Enqueue a function instance if it has not been seen.
-    fn enqueue(&mut self, def: DefId, ty_args: &'tcx [Ty<'tcx>]) {
+    /// Enqueue a function instance if it has not been seen, recording the
+    /// demanding site (`span` in [`cur_file`](Self::cur_file)) for the
+    /// missing-definition diagnostic.
+    fn enqueue(&mut self, def: DefId, ty_args: &'tcx [Ty<'tcx>], span: Option<Span>) {
         let inst = Instance { def, ty_args };
         if self.seen.insert(inst) {
+            self.origins.insert(inst, (self.cur_file, span));
             // Bound the queue by type-argument depth. The queue is the only thing
             // that grows, and polymorphic recursion makes each instance one level
             // deeper than the last, so an unbounded chain trips this rather than
@@ -1248,7 +1346,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         let ty = subst_ty(self.tcx, e.ty, subst);
         self.note_records(ty);
         self.check_arc_inners(ty, e.span);
-        let kind = self.lower_kind(&e.kind, subst);
+        let kind = self.lower_kind(&e.kind, subst, e.span);
         self.check_literal_range(&kind, ty, e.span);
         mir::Expr {
             id: self.ids.fresh(),
@@ -1301,7 +1399,12 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         }
     }
 
-    fn lower_kind(&mut self, kind: &ExprKind<'tcx>, subst: &Subst<'tcx>) -> mir::ExprKind<'tcx> {
+    fn lower_kind(
+        &mut self,
+        kind: &ExprKind<'tcx>,
+        subst: &Subst<'tcx>,
+        span: Option<Span>,
+    ) -> mir::ExprKind<'tcx> {
         use mir::ExprKind as M;
         match kind {
             ExprKind::GlobalStr(s) => M::GlobalStr(*s),
@@ -1365,7 +1468,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 regional,
             } => {
                 let ty_args = self.ground_args(ty_args, subst);
-                self.enqueue(*target, ty_args);
+                self.enqueue(*target, ty_args, span);
                 let callee = self.symbol_of(*target, ty_args);
                 M::Call {
                     callee,
@@ -1781,6 +1884,7 @@ mod tests {
                 ffi_imports: &parsed.ffi_imports,
                 ffi_preludes: &parsed.ffi_preludes,
                 strings: parsed.strings.clone(),
+                externs: MonoExterns::default(),
             };
             let (mir1, r1) = monomorphize(&input);
             assert!(r1.is_empty(), "{r1:#?}");
@@ -1888,6 +1992,7 @@ mod tests {
                 ffi_imports: &hir.ffi_imports,
                 ffi_preludes: &hir.ffi_preludes,
                 strings: hir.strings.clone(),
+                externs: MonoExterns::default(),
             };
             let (mir_resumed, r_resumed) = monomorphize(&resumed_input);
             assert!(r_resumed.is_empty(), "resumed mono reports: {r_resumed:#?}");
@@ -2405,6 +2510,320 @@ mod tests {
                 "expected a `[field]` regionality diagnostic, got {reports:#?}"
             );
         });
+    }
+
+    // ----- cross-package monomorphization -----
+
+    /// Elaborate `dep_src` as package `dep`, reduce it to its export closure,
+    /// print the interface, re-parse, and declare it into a consumer
+    /// elaborating `app_src` as package `app` — the round trip `--extern`
+    /// performs — then monomorphize the consumer. `edit` mutates the printed
+    /// interface text in between (identity for the well-formed cases).
+    fn mono_with_dep(
+        dep_src: &str,
+        app_src: &str,
+        edit: impl Fn(String) -> String,
+        f: impl for<'a, 'tcx> FnOnce(&Elaborator<'a, 'tcx>, &mir::Program<'tcx>, &[Report]),
+    ) {
+        use std::sync::Arc;
+
+        use reussir_syntax::Interner as _;
+        use reussir_syntax::source::FileId;
+
+        use crate::full::interface::{RRI_FORMAT, export_closure};
+        use crate::semi::externs::ExternPackage;
+        use crate::semi::hir::print::{InterfaceEmit, Printer as HirPrinter};
+        use crate::semi::{PackageFile, elaborate_package};
+
+        with_tcx(|tcx| {
+            let dep_interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let mut dep_keys = dep_interner.clone();
+            let dep = dep_keys.get_or_intern("dep");
+            let parse = reussir_syntax::parse_with_interner(dep_src, dep_interner.clone());
+            assert!(parse.ok(), "dep parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let files = [PackageFile {
+                file: FileId::ROOT,
+                module: vec![dep],
+                program: &prog,
+            }];
+            let dep_elab = elaborate_package(tcx, &files, &dep_interner);
+            assert!(
+                !dep_elab.has_errors(),
+                "dep elab errors: {:#?}",
+                dep_elab.reports
+            );
+            let closure = export_closure(&dep_elab.mono_input());
+            let strings: Vec<_> = dep_elab
+                .strings
+                .entries()
+                .into_iter()
+                .filter(|(token, _)| closure.strings.contains(token))
+                .collect();
+            let text = HirPrinter::new(&dep_elab.defs, dep_elab.resolver)
+                .with_interface(InterfaceEmit {
+                    format: RRI_FORMAT,
+                    package: "dep",
+                    producer: "t",
+                    bodies: &closure.bodies,
+                    protos: &closure.protos,
+                    records: &closure.records,
+                    file_root: None,
+                })
+                .program(&dep_elab.elaborated, &strings, &dep_elab.records, &[]);
+            let text = edit(text);
+            let parsed = crate::semi::hir::build::parse_program(tcx, &text)
+                .expect("interface re-parses");
+
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let mut keys = interner.clone();
+            let app = keys.get_or_intern("app");
+            let parse = reussir_syntax::parse_with_interner(app_src, interner.clone());
+            assert!(parse.ok(), "app parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let files = [PackageFile {
+                file: FileId::ROOT,
+                module: vec![app],
+                program: &prog,
+            }];
+            let mut elab = Elaborator::new(tcx, &interner);
+            elab.declare_extern_package(
+                &mut keys,
+                &ExternPackage {
+                    name: "dep",
+                    parsed: &parsed,
+                    files: &[],
+                },
+            );
+            elab.run_package(&files);
+            assert!(!elab.has_errors(), "app elab errors: {:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            f(&elab, &full, &reports);
+        });
+    }
+
+    /// The printed text of one function item (`fn @sym… {…}` / `fn @sym…;`)
+    /// out of a whole-program MIR dump.
+    fn mir_item(program_text: &str, symbol: &str) -> String {
+        let needle = format!("fn @{symbol}(");
+        program_text
+            .split("\n\n")
+            .find(|item| item.contains(&needle))
+            .unwrap_or_else(|| panic!("`{symbol}` not in:\n{program_text}"))
+            .to_owned()
+    }
+
+    /// An imported generic instantiates in the consumer byte-for-byte like
+    /// the same instantiation made inside the dependency: same `_RI` symbol
+    /// (path-based v0 mangling), same lowered body, callee resolved to the
+    /// dependency's ground helper — which itself lowers to a bodyless
+    /// declaration (its definition lives in the dep's artifact).
+    #[test]
+    fn imported_generic_instantiates_like_the_dep_itself() {
+        use crate::full::mir::print::Printer as MirPrinter;
+
+        const DEP: &str = "fn helper(x: i64) -> i64 { x + 1 }\n\
+                           pub fn twice<T : Num>(x: T) -> T { helper(0); x + x }";
+
+        // The dependency's own instantiation of `twice<i64>`.
+        let dep_side = with_tcx(|tcx| {
+            use std::sync::Arc;
+
+            use reussir_syntax::Interner as _;
+            use reussir_syntax::source::FileId;
+
+            use crate::semi::{PackageFile, elaborate_package};
+
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let mut keys = interner.clone();
+            let dep = keys.get_or_intern("dep");
+            let src = format!("{DEP}\npub fn local_use(n: i64) -> i64 {{ twice(n) }}");
+            let parse = reussir_syntax::parse_with_interner(&src, interner.clone());
+            assert!(parse.ok(), "{:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let files = [PackageFile {
+                file: FileId::ROOT,
+                module: vec![dep],
+                program: &prog,
+            }];
+            let elab = elaborate_package(tcx, &files, &interner);
+            assert!(!elab.has_errors(), "{:#?}", elab.reports);
+            let (full, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "{reports:#?}");
+            let text = MirPrinter::new(&elab.defs, elab.resolver).program(&full);
+            mir_item(&text, "_RINvC3dep5twicexE")
+        });
+
+        mono_with_dep(
+            DEP,
+            "pub fn use_it(n: i64) -> i64 { dep::twice(n) }",
+            |text| text,
+            |elab, full, reports| {
+                assert!(reports.is_empty(), "{reports:#?}");
+                let text = MirPrinter::new(&elab.defs, elab.resolver).program(full);
+                let instance = mir_item(&text, "_RINvC3dep5twicexE");
+                assert_eq!(
+                    instance, dep_side,
+                    "the consumer's instance must match the dep's own"
+                );
+                assert!(
+                    instance.contains('{'),
+                    "the instance is a definition:\n{instance}"
+                );
+                // The private ground callee crossed as a prototype only.
+                let helper = mir_item(&text, "_RNvC3dep6helper");
+                assert!(helper.trim_end().ends_with(';'), "a declaration:\n{helper}");
+                // The consumer's own root calls the instance by symbol.
+                let user = mir_item(&text, "_RNvC3app6use_it");
+                assert!(user.contains("_RINvC3dep5twicexE"), "{user}");
+            },
+        );
+    }
+
+    /// An imported ground `pub` function lowers to a declaration when called
+    /// and is not emitted at all otherwise: imported functions are never mono
+    /// roots (the dependency compiled their bodies; a consumer root would
+    /// re-emit a definition it does not have).
+    #[test]
+    fn imported_grounds_declare_when_called_and_never_root() {
+        mono_with_dep(
+            "pub fn ground(x: i64) -> i64 { x + 1 }\n\
+             pub fn unused(x: i64) -> i64 { x + 2 }",
+            "pub fn go(n: i64) -> i64 { dep::ground(n) }",
+            |text| text,
+            |_, full, reports| {
+                assert!(reports.is_empty(), "{reports:#?}");
+                let called = full
+                    .functions
+                    .iter()
+                    .find(|f| full.symbol(f.symbol) == "_RNvC3dep6ground")
+                    .expect("called import declared");
+                assert!(called.body.is_none(), "declaration, not definition");
+                assert!(
+                    !symbols(full).iter().any(|s| s.contains("unused")),
+                    "uncalled imports must not seed: {:?}",
+                    symbols(full)
+                );
+            },
+        );
+    }
+
+    /// Imported items never join the consumer's export surface: the closure
+    /// seeds from the consumer's own items only, and no dep-derived MIR
+    /// function is `mono_exported`.
+    #[test]
+    fn imported_functions_never_seed_exports() {
+        mono_with_dep(
+            "fn helper(x: i64) -> i64 { x }\n\
+             pub fn api<T : Num>(x: T) -> T { helper(0); x }",
+            "fn local_helper(x: i64) -> i64 { x }\n\
+             pub fn wrap<T : Num>(x: T) -> T { local_helper(0); dep::api(x) }",
+            |text| text,
+            |elab, full, reports| {
+                assert!(reports.is_empty(), "{reports:#?}");
+                let closure = crate::full::interface::export_closure(&elab.mono_input());
+                for def in closure.bodies.iter().chain(&closure.protos) {
+                    let path = elab.defs.path(*def).display(elab.resolver);
+                    assert!(
+                        path.starts_with("app::"),
+                        "a consumer does not re-export its dependency: {path}"
+                    );
+                }
+                for f in &full.functions {
+                    if full.symbol(f.symbol).contains("dep") {
+                        assert!(
+                            !f.mono_exported,
+                            "{} must not be mono-exported",
+                            full.symbol(f.symbol)
+                        );
+                    }
+                }
+                // The consumer's own reachable private ground still exports.
+                let local = full
+                    .functions
+                    .iter()
+                    .find(|f| full.symbol(f.symbol) == "_RNvC3app12local_helper")
+                    .expect("local helper emitted");
+                assert!(local.mono_exported);
+            },
+        );
+    }
+
+    /// Strings referenced by imported bodies merge into the program table by
+    /// their content-addressed token — shared literals collapse to one entry.
+    #[test]
+    fn extern_strings_merge_by_token() {
+        mono_with_dep(
+            "pub fn tagged<T : Num>(x: T) -> i64 { let s = \"from-dep\"; 0 }",
+            "pub fn go(n: i64) -> i64 { let t = \"from-dep\"; dep::tagged(n) }",
+            |text| text,
+            |_, full, reports| {
+                assert!(reports.is_empty(), "{reports:#?}");
+                let hits = full
+                    .string_literals
+                    .iter()
+                    .filter(|(_, payload)| payload == "from-dep")
+                    .count();
+                assert_eq!(hits, 1, "{:?}", full.string_literals);
+            },
+        );
+    }
+
+    /// A record reachable only through an imported body still resolves a
+    /// ground layout (the `note_records` path reads the shared record table,
+    /// which holds imported records).
+    #[test]
+    fn records_used_only_by_imported_bodies_get_layouts() {
+        mono_with_dep(
+            "struct Hidden { v: i64 }\n\
+             pub fn boxed<T : Num>(x: T) -> i64 { let h = Hidden { v: 1 }; h.v }",
+            "pub fn go(n: i64) -> i64 { dep::boxed(n) }",
+            |text| text,
+            |_, full, reports| {
+                assert!(reports.is_empty(), "{reports:#?}");
+                let hidden = full
+                    .records
+                    .iter()
+                    .find(|r| full.symbol(r.symbol) == "_RNvC3dep6Hidden")
+                    .expect("imported record instance collected");
+                let mir::RecordLayout::Compound(members) = hidden.layout else {
+                    panic!("compound layout expected, got {:?}", hidden.layout);
+                };
+                assert_eq!(members.len(), 1, "fields resolved, not defaulted");
+            },
+        );
+    }
+
+    /// An instantiation target that is neither local nor imported is a
+    /// reported error, not a silent skip: with externs in play the skip would
+    /// manufacture an undefined symbol at link time. Simulated by stripping a
+    /// shipped generic out of the interface (a stale/incomplete `.rri`).
+    #[test]
+    fn unknown_instantiation_target_reports() {
+        mono_with_dep(
+            "fn helper<T>(x: T) -> T { x }\n\
+             pub fn api<T>(x: T) -> T { helper(x) }",
+            "pub fn go(n: i64) -> i64 { dep::api(n) }",
+            |text| {
+                // Drop the `helper` item wholesale (items are separated by
+                // blank lines), leaving `api`'s shipped body calling a def
+                // the interface no longer carries.
+                text.split("\n\n")
+                    .filter(|item| !item.starts_with("fn #dep::helper"))
+                    .collect::<Vec<_>>()
+                    .join("\n\n")
+            },
+            |_, _, reports| {
+                assert!(
+                    reports.iter().any(|r| {
+                        r.message
+                            .contains("no body or prototype recorded for `dep::helper`")
+                            && r.message.contains("stale")
+                    }),
+                    "{reports:#?}"
+                );
+            },
+        );
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -404,9 +404,11 @@ pub struct Elaborator<'a, 'tcx> {
     /// package only.
     pub extern_defs: FxHashMap<DefId, TokenKey>,
     /// Extern functions remapped into the consumer's spaces — generic bodies
-    /// to instantiate, ground prototypes to declare against — held for
-    /// cross-package monomorphization (a later commit). Never part of the
-    /// printed program or the export surface.
+    /// to instantiate, ground prototypes to declare against — consumed by
+    /// cross-package monomorphization ([`MonoInput::externs`]). Never part
+    /// of the printed program or the export surface.
+    ///
+    /// [`MonoInput::externs`]: crate::full::mono::MonoInput::externs
     pub extern_functions: Vec<Function<'tcx>>,
     /// String literals referenced by extern bodies. Tokens are
     /// content-addressed (BLAKE3), so entries carry over without remapping.

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -18,6 +18,7 @@
 
 use reussir_syntax::Interner;
 use reussir_syntax::kind::{InternKey, TokenKey};
+use reussir_syntax::source::FileId;
 use rustc_hash::FxHashMap;
 
 use crate::semi::ctxt::{Elaborator, FuncProto, Record, RecordFields, Variant};
@@ -32,6 +33,17 @@ use crate::semi::ty::{DefId, GenericId, Ty, TyCtxt, TyKind};
 pub struct ExternPackage<'p, 'tcx> {
     pub name: &'p str,
     pub parsed: &'p Parsed<'tcx>,
+    /// Consumer-cache [`FileId`] per entry of the interface's own file table
+    /// (dense, indexed by producer file index). The driver appends the
+    /// extern's re-anchored file table to the consumer's source cache and
+    /// passes the resulting ids here, so every declared item's `file` lands
+    /// in the consumer's id space — reports raised inside an imported body
+    /// (cross-package monomorphization) and the debug locations of locally
+    /// emitted instances then resolve against the dependency's sources.
+    /// Empty when extern locations can never render (text-dump targets stop
+    /// before monomorphization); file fields then keep producer-relative ids
+    /// nothing reads.
+    pub files: &'p [FileId],
 }
 
 impl<'tcx> Elaborator<'_, 'tcx> {
@@ -47,6 +59,11 @@ impl<'tcx> Elaborator<'_, 'tcx> {
         let head = interner.get_or_intern(ext.name);
         self.extern_heads.insert(head);
         let parsed = ext.parsed;
+        // Producer-relative file ids → consumer-cache ids (spans are byte
+        // offsets into the same content, so they carry over untouched). An
+        // id outside the map (no map given, or a table-less interface) stays
+        // as-is: nothing renders it.
+        let file_of = |old: FileId| ext.files.get(old.index()).copied().unwrap_or(old);
 
         // One consumer key per producer key, densely indexed, so the remap
         // below never threads the interner.
@@ -105,12 +122,8 @@ impl<'tcx> Elaborator<'_, 'tcx> {
                 ffi: rec.ffi.clone(),
                 fields: rec.fields.as_ref().map(|f| remap.fields(f)),
                 regional_generics: remap.generic_ids(&rec.regional_generics),
-                // Spans index the extern package's own file table; nothing
-                // renders them yet (extern items are never re-checked here).
-                // Re-anchoring onto `--extern-src` lands with cross-package
-                // monomorphization diagnostics.
                 span: rec.span,
-                file: rec.file,
+                file: file_of(rec.file),
             };
             self.records.entry(def).or_insert(record);
         }
@@ -139,7 +152,7 @@ impl<'tcx> Elaborator<'_, 'tcx> {
                 is_regional: func.is_regional,
                 body: func.body.as_ref().map(|b| remap.expr(b)),
                 span: func.span,
-                file: func.file,
+                file: file_of(func.file),
             };
             self.functions.entry(def).or_insert_with(|| FuncProto {
                 def,
@@ -158,14 +171,21 @@ impl<'tcx> Elaborator<'_, 'tcx> {
                 file: function.file,
             });
             if let Some(import) = parsed.ffi_imports.get(&func.def) {
-                self.extern_ffi_imports.insert(def, import.clone());
+                let mut import = import.clone();
+                import.file = file_of(import.file);
+                self.extern_ffi_imports.insert(def, import);
             }
             self.extern_functions.push(function);
         }
 
         self.extern_strings.extend(parsed.strings.iter().cloned());
+        // Preludes pair with imports by file, so both sides remap together.
         self.extern_ffi_preludes
-            .extend(parsed.ffi_preludes.iter().cloned());
+            .extend(parsed.ffi_preludes.iter().map(|prelude| {
+                let mut prelude = prelude.clone();
+                prelude.file = file_of(prelude.file);
+                prelude
+            }));
         // Transform metadata of shipped bodies is not carried yet —
         // cross-package monomorphization decides its shape (deferred).
     }
@@ -549,6 +569,7 @@ mod tests {
                 &ExternPackage {
                     name: "dep",
                     parsed: &parsed,
+                    files: &[],
                 },
             );
             elab.run_package(&files);
@@ -674,6 +695,99 @@ mod tests {
                 );
             },
         );
+    }
+
+    /// Declaring with a file map rewrites every imported item's `file` —
+    /// functions (with and without bodies), prototypes, records, ffi imports
+    /// and their preludes — into the consumer's cache id space; spans stay
+    /// (byte offsets into the same content). Without a map (text-dump
+    /// targets), ids pass through untouched.
+    #[test]
+    fn extern_item_files_remap_into_the_consumer_cache() {
+        use reussir_syntax::source::SourceCache;
+
+        let dep_src = "extern \"rust\" [{ use reussir_rt::collections::vec::Vec as RVec; }];\n\
+                       #[ffi(rust = \"::reussir_rt::collections::vec::Vec\")]\n\
+                       pub struct Vec<T>;\n\
+                       #[ffi(import)]\n\
+                       pub fn new<T>() -> Vec<T> [{ RVec::new() }];\n\
+                       pub struct Point { x: i64, y: i64 }\n\
+                       fn helper(p: Point) -> i64 { p.x }\n\
+                       pub fn api<T : Num>(x: T) -> T { helper(Point { x: 1, y: 2 }); x }\n\
+                       pub fn ground(x: i64) -> i64 { x + 1 }";
+        with_tcx(|tcx| {
+            // Elaborate the dep and print it in sources form, so the parsed
+            // interface carries a file table and per-item `in <id>` files.
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let mut keys = interner.clone();
+            let dep = keys.get_or_intern("dep");
+            let parse = reussir_syntax::parse_with_interner(dep_src, interner.clone());
+            assert!(parse.ok(), "dep parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let files = [PackageFile {
+                file: FileId::ROOT,
+                module: vec![dep],
+                program: &prog,
+            }];
+            let elab = elaborate_package(tcx, &files, &interner);
+            assert!(!elab.has_errors(), "dep elab errors: {:#?}", elab.reports);
+            let cache = SourceCache::single("lib.rr", dep_src);
+            let strings = elab.strings.entries();
+            let text = Printer::with_sources(&elab.defs, elab.resolver, &cache)
+                .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
+            let parsed = crate::semi::hir::build::parse_program(tcx, &text).expect("re-parse");
+            assert_eq!(parsed.files, ["lib.rr"], "table travels");
+
+            let with_declared = |files: &[FileId], check: &dyn Fn(&Elaborator)| {
+                let interner = Arc::new(reussir_syntax::new_threaded_interner());
+                let mut keys = interner.clone();
+                let mut elab = Elaborator::new(tcx, &interner);
+                elab.declare_extern_package(
+                    &mut keys,
+                    &ExternPackage {
+                        name: "dep",
+                        parsed: &parsed,
+                        files,
+                    },
+                );
+                check(&elab);
+            };
+
+            // The consumer's cache already holds its own files, so the dep's
+            // single entry lands at some later id.
+            let mapped = FileId::from_index(7);
+            with_declared(&[mapped], &|consumer| {
+                for func in &consumer.extern_functions {
+                    assert_eq!(func.file, mapped, "function files remap");
+                    assert!(func.span.is_some(), "spans survive the remap");
+                }
+                for proto in consumer.functions.values() {
+                    assert_eq!(proto.file, mapped, "prototype files remap");
+                }
+                for record in consumer.records.values() {
+                    assert_eq!(record.file, mapped, "record files remap");
+                }
+                assert!(
+                    !consumer.extern_ffi_imports.is_empty(),
+                    "ffi import carried"
+                );
+                for import in consumer.extern_ffi_imports.values() {
+                    assert_eq!(import.file, mapped, "ffi import files remap");
+                }
+                assert!(!consumer.extern_ffi_preludes.is_empty(), "prelude carried");
+                for prelude in &consumer.extern_ffi_preludes {
+                    assert_eq!(prelude.file, mapped, "prelude files remap");
+                }
+            });
+
+            // No map: ids pass through (nothing renders them).
+            with_declared(&[], &|untouched| {
+                for func in &untouched.extern_functions {
+                    assert_eq!(func.file, FileId::ROOT);
+                }
+            });
+        });
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -10,9 +10,9 @@
 //! cross-package identity), re-allocates generics in the elaborator's global
 //! table, and rebuilds every type over the mapped defs. Prototypes and
 //! records land in the same `functions`/`records` tables the checker reads;
-//! bodies, strings, and ffi textures land in the `extern_*` side tables held
-//! for cross-package monomorphization (a later commit) so they stay out of
-//! the consumer's printed program and export surface. Resolution reaches the
+//! bodies, strings, and ffi textures land in the `extern_*` side tables
+//! cross-package monomorphization consumes (`MonoInput::externs`) so they
+//! stay out of the consumer's printed program and export surface. Resolution reaches the
 //! declared items only through the package head, gated on `pub`
 //! (`ctxt::resolve_extern`).
 

--- a/tests/integration/frontend/extern_link.rr
+++ b/tests/integration/frontend/extern_link.rr
@@ -1,0 +1,40 @@
+// The full cross-package build: the dependency compiles once into a
+// staticlib + interface, the consumer instantiates its generics locally
+// (`weak_odr`, so any other unit's identical instance collapses with it)
+// and declares its ground code, and `--link-lib` joins the dependency's
+// archive so those declarations — including the mono-exported private
+// helper the shipped body calls — resolve at link time.
+
+// RUN: %rrc --package-root %S/extern_mono_dep --package-name dep --emit rri -o %t.rri
+// RUN: %rrc --package-root %S/extern_mono_dep --package-name dep --emit staticlib --relocation-mode pic -o %t.dep.a
+// RUN: %rrc %s --package-name app --extern dep=%t.rri --link-lib %t.dep.a \
+// RUN:   --emit executable --relocation-mode pic %rrc_linker -o %t.exe
+// RUN: %t.exe
+
+// The dependency's archive carries the mono-exported private helper as a
+// strong external definition; the consumer's side of the link only ever
+// declares it.
+// RUN: %llvm-nm %t.dep.a | %FileCheck %s --check-prefix=DEP
+// DEP: T _RNvC3dep6helper
+
+// The consumer's own object: the imported generic's instance is a weak
+// (`weak_odr`) definition, the dependency's ground code stays undefined
+// until the archive joins.
+// RUN: %rrc %s --package-name app --extern dep=%t.rri --emit obj --relocation-mode pic -o %t.o
+// RUN: %llvm-nm %t.o | %FileCheck %s %linkage_check_prefixes
+// CHECK-DEDUP-DAG: W _RINvC3dep5twicexE
+// CHECK-COFF-DAG: T _RINvC3dep5twicexE
+// CHECK-DAG: U _RNvC3dep6ground
+// CHECK-DAG: U _RNvC3dep6helper
+
+// The entry exercises the instantiated generic (which itself calls the
+// dependency-private helper) and the declared ground function; a resolved
+// and runnable link is the assertion, value checks live in extern_mono.rr.
+fn use_dep(n: i64) -> i64 {
+    dep::twice(n) + dep::ground(n)
+}
+
+#[main]
+pub fn entry() {
+    let a = use_dep(20);
+}

--- a/tests/integration/frontend/extern_mono.rr
+++ b/tests/integration/frontend/extern_mono.rr
@@ -1,0 +1,48 @@
+// Cross-package monomorphization: an imported generic instantiates in the
+// consumer's compilation from its shipped body; imported ground functions
+// (pub, and the private helper the instantiated body calls) lower to
+// declarations the link later resolves against the dependency's artifact;
+// and a mono-time diagnostic raised inside an imported body carets into the
+// dependency's re-anchored sources (`--extern-src`).
+
+// RUN: %rrc --package-root %S/extern_mono_dep --package-name dep --emit rri -o %t.rri
+
+// The instance is a definition, the ground imports are declarations, and the
+// re-anchored dep source joins the consumer's file table.
+// RUN: %rrc %s --package-name app --extern dep=%t.rri --extern-src dep=%S/extern_mono_dep --emit mir -o - \
+// RUN:   | %FileCheck %s --check-prefix=MIR
+// MIR-DAG: = "{{.*}}extern_mono_dep{{/|\\\\}}lib.rr";
+// MIR-DAG: pub fn @_RINvC3dep5twicexE(v0 (x): i64) -> i64 in {{[0-9]+}} {
+// MIR-DAG: fn @_RNvC3dep6helper(v0 (x): i64) -> i64 in {{[0-9]+}};
+// MIR-DAG: pub fn @_RNvC3dep6ground(v0 (x): i64) -> i64 in {{[0-9]+}};
+// MIR-DAG: pub fn @_RNvC3app9use_twice(v0 (n): i64) -> i64 in {{[0-9]+}} {
+
+// The consumer-emitted instance carries the mergeable instance linkage
+// (`weak_odr` where the object format dedups) — any other package emitting
+// the same instance collapses to one definition at link; the imported
+// grounds stay external declarations.
+// RUN: %rrc %s --package-name app --extern dep=%t.rri --emit llvm-ir -O none -o %t.ll
+// RUN: %FileCheck %s %linkage_check_prefixes < %t.ll
+// CHECK-DEDUP-DAG: define weak_odr i64 @_RINvC3dep5twicexE(i64 %0)
+// CHECK-COFF-DAG: define i64 @_RINvC3dep5twicexE(i64 %0)
+// CHECK-DAG: declare i64 @_RNvC3dep6helper(i64
+// CHECK-DAG: declare i64 @_RNvC3dep6ground(i64
+// CHECK-DAG: define i64 @_RNvC3app9use_twice(i64 %0)
+
+// A bad instantiation of an imported generic reports into the dependency's
+// own source: `flexy`'s `[flex] T` demands a regional record, and the caret
+// lands on its declaration in the re-anchored dep file.
+// RUN: echo 'fn go() -> i64 { regional { dep::flexy<i64>(0) } }' > %t.bad.rr
+// RUN: %not %rrc %t.bad.rr --package-name app --extern dep=%t.rri --extern-src dep=%S/extern_mono_dep --emit mir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=FLEX
+// FLEX: requires a regional record
+// FLEX: extern_mono_dep{{/|\\\\}}lib.rr
+// FLEX: pub regional fn flexy
+
+pub fn use_twice(n: i64) -> i64 {
+    dep::twice(n)
+}
+
+pub fn use_ground(n: i64) -> i64 {
+    dep::ground(n)
+}

--- a/tests/integration/frontend/extern_mono_dep/lib.rr
+++ b/tests/integration/frontend/extern_mono_dep/lib.rr
@@ -1,0 +1,21 @@
+// The dependency behind extern_mono.rr: a pub generic whose body calls a
+// private ground helper (the helper crosses as a prototype), a pub ground,
+// and a pub generic with a regional (`[flex]`) constraint that only a
+// mono-time instantiation can violate.
+
+fn helper(x: i64) -> i64 {
+    x + 1
+}
+
+pub fn twice<T : Num>(x: T) -> T {
+    helper(0);
+    x + x
+}
+
+pub fn ground(x: i64) -> i64 {
+    helper(x)
+}
+
+pub regional fn flexy<T>(bar: [flex] T) -> i64 {
+    0
+}

--- a/tests/integration/frontend/extern_mono_dep/lit.local.cfg
+++ b/tests/integration/frontend/extern_mono_dep/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []


### PR DESCRIPTION
## Summary

Fourth PR of the cross-package arc (#451; after #467/#468/#470): a consumer now *builds* against a dependency, in three commits.

1. **Extern sources join the consumer's source cache** — imported items' FileIds remap into the consumer cache at declaration (`ExternPackage.files` dense id map); re-anchored real paths lazy-load, rootless externs stay virtual. The cache grows only past `Stage::Rri`, so `--emit hir/rri` artifacts never leak consumer-anchored dep paths (byte-stability preserved). Any mono report inside an imported body now carets into the dep's real source.
2. **Cross-package monomorphization** — `MonoInput` gains `MonoExterns` (functions/strings/ffi); `by_def` covers imported functions while roots stay local-only. Imported generic bodies instantiate through the existing path (`weak_odr` via #467, verified not changed); bodyless prototypes flow through the existing `body: None` → declaration path. Mono's silent skip becomes a located error ("no body or prototype recorded… stale `.rri`?") at the demanding call site. `export_closure`/`mono_exports` provably don't seed from externs. The mono-time incompatibility test instantiates dep's `[flex]` generic badly and FileChecks the caret into the dep's re-anchored source.
3. **`--link-lib`** — dependency staticlibs named by path after the compilation's own members. E2e: dep → rri + staticlib; consumer → `--extern` + `--link-lib` → executable, runs; `llvm-nm` pins the `weak_odr` instance and the U(consumer)/T(dep archive) split for the mono-exported private helper.

Note for reviewers: mono's algorithm (worklist/seen/instantiation/roots) is unchanged; the visible churn in `mono.rs` is ~318 lines of new unit tests plus span-provenance plumbing (`origins`) so the stale-interface error reports at its call site.

Known UX consequence of the bounds deferral (revisits with the trait system): a bare literal at an imported generic (`dep::twice(20)`) needs a typed context — the `Num` default can't fire against an unbounded imported binder.

## Test plan
- [x] reussir-core 319/319 (6 new mono tests: identical-instantiation vs dep, declare-not-root, no export seeding, string merge, record layouts, unknown-target report), compiler-lib 9/9, codegen 56/56
- [x] lit: `extern_mono.rr` (MIR + llvm-ir dispositions, weak_odr, dep-source diagnostic), `extern_link.rr` (e2e link + run + nm), full suite 433/434 (1 pre-existing unsupported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787702971&installation_model_id=426051&pr_number=472&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F472&signature=2c8c9e8becd66218dd14c61fb0ba80c0fb664d3a508857d619e1040415fc8cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->