### PR TITLE
[rene] the ready-queue build pipeline (cross-package builds land)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.2",
+ "windows-sys",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +930,12 @@ checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "entities"
@@ -1306,6 +1324,19 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -2779,6 +2810,7 @@ dependencies = [
  "blake3",
  "compio",
  "futures-util",
+ "indicatif",
  "nickel-lang",
  "palc",
  "redb",
@@ -3797,6 +3829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3918,6 +3956,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/rene/Cargo.toml
+++ b/crates/rene/Cargo.toml
@@ -49,6 +49,7 @@ zstd.workspace = true
 # The `-j` admission semaphore: process concurrency is bounded separately
 # from the pool's worker threads (see `pool`).
 async-lock = "3"
+indicatif = "0.18.6"
 
 [build-dependencies]
 # Pack the `reussir-rt` source tree (tar + zstd) into the binary, with its

--- a/crates/rene/src/compile.rs
+++ b/crates/rene/src/compile.rs
@@ -112,7 +112,7 @@ pub async fn build(
         let key = tables::product_key(&opts.profile_name, name);
         let current = product_is_current(dir, &key, &fingerprint, &path)?;
         if current {
-            tracing::info!(target = name, "up to date");
+            tracing::debug!(target = name, "up to date");
         }
         plan.push((name, kind, path, key, current));
     }
@@ -139,7 +139,7 @@ pub async fn build(
         if *current {
             continue;
         }
-        tracing::info!(target = name, kind = kind.emit(), out = %path.display(), "compiling");
+        tracing::debug!(target = name, kind = kind.emit(), out = %path.display(), "compiling");
         let command = planned
             .remove(*name)
             .ok_or_else(|| format!("target `{name}` missing from the plan"))?;

--- a/crates/rene/src/compile.rs
+++ b/crates/rene/src/compile.rs
@@ -22,7 +22,9 @@ use std::ffi::OsString;
 use crate::db::BuildDir;
 use crate::deps::{self, Prepared};
 use crate::manifest::{Loaded, Profile, TargetKind};
+use crate::plan;
 use crate::pool::Pool;
+use crate::resolve::Graph;
 use crate::rt::RtArtifacts;
 use crate::tables;
 
@@ -69,6 +71,8 @@ pub async fn build(
     sources: &Prepared,
     rt: &RtArtifacts,
     opts: &Options,
+    graph: &Graph,
+    pool: &Pool,
 ) -> Result<Vec<Product>, String> {
     let manifest = &loaded.manifest;
     let selected: Vec<&str> = if opts.targets.is_empty() {
@@ -112,22 +116,41 @@ pub async fn build(
         }
         plan.push((name, kind, path, key, current));
     }
-    let stale = plan.iter().filter(|(_, _, _, _, current)| !current).count();
-    if stale > 0 {
-        let pool = Pool::new(opts.jobs)?;
-        let workers = &pool;
-        futures_util::future::try_join_all(
-            plan.iter().filter(|(_, _, _, _, current)| !current).map(
-                |(name, kind, path, _, _)| {
-                    tracing::info!(target = name, kind = kind.emit(), out = %path.display(), "compiling");
-                    let invocation = rrc_invocation(loaded, rt, opts, *kind, path);
-                    async move { workers.run(move || invocation.run()).await? }
-                },
-            ),
+    // The root's commands come from the same synthesis the dump prints
+    // (and the dependency pipeline runs): what `inspect --commands` shows
+    // is what happens here.
+    let mut planned: std::collections::BTreeMap<String, plan::PlannedCommand> =
+        plan::node_commands(
+            graph,
+            &graph.root,
+            &plan::Options {
+                profile_name: &opts.profile_name,
+                profile: &opts.profile,
+                linker: opts.linker.as_deref(),
+                build_dir: dir.root(),
+            },
+            Some(rt),
         )
-        .await?;
-        pool.shutdown().await?;
+        .into_iter()
+        .filter_map(|command| Some((command.target.clone()?, command)))
+        .collect();
+    let mut invocations = Vec::new();
+    for (name, kind, path, _, current) in &plan {
+        if *current {
+            continue;
+        }
+        tracing::info!(target = name, kind = kind.emit(), out = %path.display(), "compiling");
+        let command = planned
+            .remove(*name)
+            .ok_or_else(|| format!("target `{name}` missing from the plan"))?;
+        invocations.push(Invocation::from_planned(command, &rt.rustc));
     }
+    futures_util::future::try_join_all(
+        invocations
+            .into_iter()
+            .map(|invocation| async move { pool.run(move || invocation.run()).await? }),
+    )
+    .await?;
     let mut products = Vec::with_capacity(plan.len());
     for (name, _, path, key, current) in plan {
         if !current {
@@ -158,6 +181,19 @@ pub(crate) struct Invocation {
 }
 
 impl Invocation {
+    /// An `rrc` invocation from a planned command: the real program
+    /// resolved, the baking toolchain pinned through `REUSSIR_RUSTC`.
+    pub(crate) fn from_planned(command: plan::PlannedCommand, rustc: &Path) -> Invocation {
+        Invocation {
+            program: deps::resolve_rrc(),
+            args: command.args.into_iter().map(OsString::from).collect(),
+            // The toolchain that baked the runtime is the one the link step
+            // and the polyffi texture compiles must agree with.
+            envs: vec![("REUSSIR_RUSTC", rustc.into())],
+            out: command.out,
+        }
+    }
+
     /// Spawn and await the process (on whichever runtime polls this).
     /// rrc's diagnostics stream straight through to the user.
     pub(crate) async fn run(self) -> Result<(), String> {
@@ -180,44 +216,6 @@ impl Invocation {
     }
 }
 
-/// One target's `rrc` invocation.
-fn rrc_invocation(
-    loaded: &Loaded,
-    rt: &RtArtifacts,
-    opts: &Options,
-    kind: TargetKind,
-    out: &Path,
-) -> Invocation {
-    let mut args: Vec<OsString> = vec![
-        "--package-root".into(),
-        deps::source_root(loaded).into(),
-        "--package-name".into(),
-        (&loaded.manifest.package.name).into(),
-        "--emit".into(),
-        kind.emit().into(),
-        "-o".into(),
-        out.into(),
-    ];
-    for libdir in rt.libdirs() {
-        args.push("--polyffi-libdir".into());
-        args.push(libdir.into());
-    }
-    args.extend(
-        profile_flags(&opts.profile, kind, opts.linker.as_deref())
-            .into_iter()
-            .map(OsString::from),
-    );
-    Invocation {
-        program: deps::resolve_rrc(),
-        args,
-        // The toolchain that baked the runtime is the one the link step and
-        // the polyffi texture compiles must agree with.
-        envs: vec![("REUSSIR_RUSTC", rt.rustc.clone().into())],
-        out: out.to_owned(),
-    }
-}
-
-/// The profile, spelled as `rrc` flags.
 /// The `rrc` flags a profile expands to, as plain strings — shared by the
 /// real invocation above and the planned-command dump ([`crate::plan`]).
 pub(crate) fn profile_flags(

--- a/crates/rene/src/deps.rs
+++ b/crates/rene/src/deps.rs
@@ -216,14 +216,14 @@ pub async fn prepare(dir: &BuildDir, loaded: &Loaded) -> Result<Prepared, String
     let hash = config_hash(&loaded.dump);
     let reason = staleness(dir, &hash)?;
     if reason.is_up_to_date() {
-        tracing::info!("package sources are up to date");
+        tracing::debug!("package sources are up to date");
         return Ok(Prepared {
             files: dir.sources().map_err(|e| e.to_string())?,
             reason,
         });
     }
 
-    tracing::info!(%reason, "scanning the package source graph");
+    tracing::debug!(%reason, "scanning the package source graph");
     let root = source_root(loaded);
     let mut files = scan(&root, &loaded.manifest.package.name).await?;
     // Order by path, the order the table reads back in, so what this returns
@@ -232,7 +232,7 @@ pub async fn prepare(dir: &BuildDir, loaded: &Loaded) -> Result<Prepared, String
     dir.replace_sources(&files).map_err(|e| e.to_string())?;
     dir.set_status(&[(tables::SOURCES_CONFIG_HASH_KEY, hash.as_str())])
         .map_err(|e| e.to_string())?;
-    tracing::info!(files = files.len(), "recorded the source graph");
+    tracing::debug!(files = files.len(), "recorded the source graph");
     Ok(Prepared { files, reason })
 }
 

--- a/crates/rene/src/exec.rs
+++ b/crates/rene/src/exec.rs
@@ -140,6 +140,7 @@ async fn build_node(
         dir: Some(dir),
         profile_name: opts.profile_name,
         profile: opts.profile,
+        linker: opts.linker,
         build_dir: opts.build_dir,
     };
     // At this point the node's upstream artifacts are final, so the local

--- a/crates/rene/src/exec.rs
+++ b/crates/rene/src/exec.rs
@@ -1,0 +1,184 @@
+//! Executing the plan: the ready-queue dependency pipeline.
+//!
+//! Every dependency node runs the commands [`crate::plan::node_commands`]
+//! synthesizes — the same ones `inspect --commands` dumps — as soon as
+//! **all** of its dependencies have finished: no wave barriers, a node
+//! whose cone completes early starts early. The processes go through the
+//! [`Pool`], so `-j` bounds how many run at once while the scheduler
+//! tracks readiness above it.
+//!
+//! Per node: freshness is checked at dispatch time (its upstream artifacts
+//! are final by then — a current node is skipped whole), its sources are
+//! scanned, its interface and archive compile, and [`fresh::record_dep`]
+//! writes what the next build proves currency against. Progress renders on
+//! an indicatif multi-bar (hidden when stderr is not a terminal).
+
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
+use std::path::Path;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use futures_util::stream::FuturesUnordered;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+use crate::db::BuildDir;
+use crate::deps;
+use crate::fresh;
+use crate::manifest::Profile;
+use crate::plan;
+use crate::pool::Pool;
+use crate::compile;
+use crate::resolve::Graph;
+use crate::rt::RtArtifacts;
+
+/// What the pipeline runs under.
+pub struct Options<'a> {
+    pub profile_name: &'a str,
+    pub profile: &'a Profile,
+    /// `rene build --linker`, overriding the profile's.
+    pub linker: Option<&'a Path>,
+    /// `rene build -j`: the process admission bound (held by the [`Pool`]).
+    pub jobs: Option<NonZeroUsize>,
+    pub build_dir: &'a Path,
+}
+
+/// Build every dependency of the graph through the pool, each dispatched
+/// the moment its last dependency finishes. Returns how many nodes actually
+/// compiled (the rest were current).
+pub async fn build_deps(
+    dir: &BuildDir,
+    graph: &Graph,
+    rt: &RtArtifacts,
+    opts: &Options<'_>,
+    pool: &Pool,
+    progress: &MultiProgress,
+) -> Result<usize, String> {
+    let dep_names: Vec<&str> = graph
+        .nodes
+        .keys()
+        .map(String::as_str)
+        .filter(|name| *name != graph.root)
+        .collect();
+    if dep_names.is_empty() {
+        return Ok(0);
+    }
+    let deps_dir = opts.build_dir.join(opts.profile_name).join("deps");
+    std::fs::create_dir_all(&deps_dir)
+        .map_err(|e| format!("cannot create `{}`: {e}", deps_dir.display()))?;
+
+    let overall = progress.add(
+        ProgressBar::new(dep_names.len() as u64).with_style(
+            ProgressStyle::with_template("{bar:24} {pos}/{len} dependencies")
+                .expect("static template"),
+        ),
+    );
+
+    // Readiness over direct edges: a node dispatches when its last
+    // unfinished dependency completes.
+    let mut waiting_on: BTreeMap<&str, usize> = dep_names
+        .iter()
+        .map(|name| (*name, graph.nodes[*name].dependencies.len()))
+        .collect();
+    let mut dependents: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for name in &dep_names {
+        for dep in &graph.nodes[*name].dependencies {
+            dependents.entry(dep.as_str()).or_default().push(name);
+        }
+    }
+
+    let mut in_flight = FuturesUnordered::new();
+    for (name, waiting) in &waiting_on {
+        if *waiting == 0 {
+            in_flight.push(run_node(name, dir, graph, rt, opts, pool, progress));
+        }
+    }
+    let mut built = 0;
+    while let Some((finished, result)) = in_flight.next().await {
+        built += result? as usize;
+        overall.inc(1);
+        for dependent in dependents.get(finished).into_iter().flatten() {
+            let waiting = waiting_on
+                .get_mut(dependent)
+                .expect("every dependent is a known node");
+            *waiting -= 1;
+            if *waiting == 0 {
+                in_flight.push(run_node(dependent, dir, graph, rt, opts, pool, progress));
+            }
+        }
+    }
+    overall.finish_and_clear();
+    progress.remove(&overall);
+    Ok(built)
+}
+
+/// Build one node (or prove it current), tagging the result with its name
+/// so the scheduler can release its dependents.
+async fn run_node<'g>(
+    name: &'g str,
+    dir: &BuildDir,
+    graph: &'g Graph,
+    rt: &RtArtifacts,
+    opts: &Options<'_>,
+    pool: &Pool,
+    progress: &MultiProgress,
+) -> (&'g str, Result<bool, String>) {
+    let result = build_node(name, dir, graph, rt, opts, pool, progress).await;
+    (name, result)
+}
+
+async fn build_node(
+    name: &str,
+    dir: &BuildDir,
+    graph: &Graph,
+    rt: &RtArtifacts,
+    opts: &Options<'_>,
+    pool: &Pool,
+    progress: &MultiProgress,
+) -> Result<bool, String> {
+    let ctx = fresh::Context {
+        dir: Some(dir),
+        profile_name: opts.profile_name,
+        profile: opts.profile,
+        build_dir: opts.build_dir,
+    };
+    // At this point the node's upstream artifacts are final, so the local
+    // check is exact: current means nothing to do at all.
+    let state = fresh::node_state(graph, name, &ctx)?;
+    if state.is_current() {
+        tracing::info!(package = name, "up to date");
+        return Ok(false);
+    }
+    tracing::info!(package = name, reason = %state, "building");
+
+    let bar = progress.add(
+        ProgressBar::new_spinner().with_message(format!("{name}: scanning sources")),
+    );
+    bar.enable_steady_tick(Duration::from_millis(120));
+
+    // The dependency's own source graph — recorded with the build so the
+    // next run's freshness walk has something to compare against.
+    let src_root = graph.nodes[name].dir.join("src");
+    let package = name.to_owned();
+    let mut sources = pool
+        .run(move || async move { deps::scan(&src_root, &package).await })
+        .await??;
+    sources.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let plan_opts = plan::Options {
+        profile_name: opts.profile_name,
+        profile: opts.profile,
+        linker: opts.linker,
+        build_dir: opts.build_dir,
+    };
+    for command in plan::node_commands(graph, name, &plan_opts, Some(rt)) {
+        bar.set_message(format!("{name}: {}", command.emit));
+        let invocation = compile::Invocation::from_planned(command, &rt.rustc);
+        pool.run(move || invocation.run()).await??;
+    }
+    fresh::record_dep(graph, name, &ctx, rt, &sources)?;
+    bar.finish_and_clear();
+    progress.remove(&bar);
+    tracing::info!(package = name, "built");
+    Ok(true)
+}

--- a/crates/rene/src/exec.rs
+++ b/crates/rene/src/exec.rs
@@ -147,10 +147,10 @@ async fn build_node(
     // check is exact: current means nothing to do at all.
     let state = fresh::node_state(graph, name, &ctx)?;
     if state.is_current() {
-        tracing::info!(package = name, "up to date");
+        tracing::debug!(package = name, "up to date");
         return Ok(false);
     }
-    tracing::info!(package = name, reason = %state, "building");
+    tracing::debug!(package = name, reason = %state, "building");
 
     let bar = progress.add(
         ProgressBar::new_spinner().with_message(format!("{name}: scanning sources")),
@@ -180,6 +180,6 @@ async fn build_node(
     fresh::record_dep(graph, name, &ctx, rt, &sources)?;
     bar.finish_and_clear();
     progress.remove(&bar);
-    tracing::info!(package = name, "built");
+    tracing::debug!(package = name, "built");
     Ok(true)
 }

--- a/crates/rene/src/fresh.rs
+++ b/crates/rene/src/fresh.rs
@@ -138,6 +138,18 @@ pub fn recorded_bake(dir: Option<&BuildDir>) -> Result<Option<RtArtifacts>, Stri
         .and_then(|record| serde_json::from_str(&record).ok()))
 }
 
+/// One node's local freshness — no upstream-stale propagation, so at
+/// execution time (when the cone is final) the answer is exact.
+pub fn node_state(graph: &Graph, name: &str, ctx: &Context<'_>) -> Result<State, String> {
+    let bake = recorded_bake(ctx.dir)?;
+    let deps_dir = ctx.build_dir.join(ctx.profile_name).join("deps");
+    if name == graph.root {
+        root_state(graph, ctx, bake.as_ref())
+    } else {
+        dep_state(graph, name, ctx, bake.as_ref(), &deps_dir)
+    }
+}
+
 /// The freshness of every node of the graph, keyed by package name.
 pub fn states(graph: &Graph, ctx: &Context<'_>) -> Result<BTreeMap<String, State>, String> {
     let deps_dir = ctx.build_dir.join(ctx.profile_name).join("deps");

--- a/crates/rene/src/fresh.rs
+++ b/crates/rene/src/fresh.rs
@@ -124,6 +124,9 @@ pub struct Context<'a> {
     pub dir: Option<&'a BuildDir>,
     pub profile_name: &'a str,
     pub profile: &'a Profile,
+    /// The `--linker` override the compared build ran (or would run) with —
+    /// part of the root products' fingerprints.
+    pub linker: Option<&'a Path>,
     pub build_dir: &'a Path,
 }
 
@@ -271,7 +274,7 @@ fn root_state(
             profile_name: ctx.profile_name.to_owned(),
             profile: ctx.profile.clone(),
             targets: Vec::new(),
-            linker: None,
+            linker: ctx.linker.map(Path::to_path_buf),
             upstream,
             jobs: None,
         },
@@ -449,6 +452,7 @@ mod tests {
             dir: Some(&f.dir),
             profile_name: "dev",
             profile,
+            linker: None,
             build_dir: &f.build_dir,
         }
     }

--- a/crates/rene/src/lib.rs
+++ b/crates/rene/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod compile;
 pub mod db;
 pub mod deps;
+pub mod exec;
 pub mod fresh;
 pub mod manifest;
 pub mod plan;

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -259,7 +259,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
     if graph.nodes.len() > 1 {
         let solution = resolve::check(&graph)?;
         for (name, version) in &solution.pinned {
-            tracing::info!(package = %name, %version, "resolved");
+            tracing::debug!(package = %name, %version, "resolved");
         }
     }
 
@@ -283,7 +283,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
     // whoever drives rrc by hand — the pre-target workflow, kept working.
     if loaded.manifest.targets.is_empty() {
         if !sources.rescanned() {
-            tracing::info!(files = sources.files.len(), "nothing to do");
+            tracing::debug!(files = sources.files.len(), "nothing to do");
         }
         tracing::info!("no targets declared; pass these directories to `rrc --polyffi-libdir`:");
         for libdir in artifacts.libdirs() {
@@ -316,7 +316,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
     )
     .await?;
     if graph.nodes.len() > 1 {
-        tracing::info!(
+        tracing::debug!(
             built,
             fresh = graph.nodes.len() - 1 - built,
             "dependencies ready"

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -131,6 +131,12 @@ struct InspectArgs {
     /// The profile the `plan` section renders against.
     #[arg(long, default_value = "dev")]
     profile: String,
+
+    /// The linker override the compared build ran with (`rene build
+    /// --linker`): part of the root products' fingerprints, so freshness
+    /// must judge against the same value.
+    #[arg(long)]
+    linker: Option<PathBuf>,
 }
 
 fn main() -> ExitCode {
@@ -444,6 +450,7 @@ async fn inspect(args: &InspectArgs) -> Result<(), String> {
                     dir: held.as_ref(),
                     profile_name: &args.profile,
                     profile: &profile,
+                    linker: args.linker.as_deref(),
                     build_dir: &root,
                 },
             )?;
@@ -452,7 +459,7 @@ async fn inspect(args: &InspectArgs) -> Result<(), String> {
                 &plan::Options {
                     profile_name: &args.profile,
                     profile: &profile,
-                    linker: None,
+                    linker: args.linker.as_deref(),
                     build_dir: &root,
                 },
                 bake.as_ref(),

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -21,7 +21,7 @@ use std::process::ExitCode;
 use palc::Parser;
 
 use rene::db::{self, BuildDir, CleanOutcome};
-use rene::{compile, deps, fresh, manifest, plan, resolve, rt};
+use rene::{compile, deps, exec, fresh, manifest, plan, pool, resolve, rt};
 
 /// The default build directory name, next to the manifest.
 const BUILD_DIR: &str = "reussir-build";
@@ -194,6 +194,9 @@ fn init_tracing(verbose: bool) {
         });
     let _ = tracing_subscriber::fmt()
         .with_env_filter(filter)
+        // Plain text off-terminal: CI logs and FileCheck'd stderr must not
+        // carry ANSI escapes.
+        .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stderr()))
         .with_writer(std::io::stderr)
         .try_init();
 }
@@ -244,17 +247,15 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
     // Dependency resolution, before any expensive work too: load the
     // transitive path graph and let pubgrub verify the constraints hold
     // together (each package exists in exactly one version today, so this is
-    // a feasibility check; see `resolve`).
-    let graph = if loaded.manifest.dependencies.is_empty() {
-        None
-    } else {
-        let graph = resolve::load_graph(&loaded)?;
+    // a feasibility check; see `resolve`). A dependency-less package is a
+    // one-node graph through the same machinery.
+    let graph = resolve::load_graph(&loaded)?;
+    if graph.nodes.len() > 1 {
         let solution = resolve::check(&graph)?;
         for (name, version) in &solution.pinned {
             tracing::info!(package = %name, %version, "resolved");
         }
-        Some(graph)
-    };
+    }
 
     let root = resolve_build_dir(location)?;
     // Opening the status database takes the build directory's lock; hold it
@@ -285,6 +286,37 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
         return Ok(());
     }
 
+    // One pool for the whole build: `-j` admission over a few event-loop
+    // workers; one progress surface (hidden off-terminal).
+    let pool = pool::Pool::new(args.jobs)?;
+    let progress = indicatif::MultiProgress::new();
+
+    // The dependency pipeline: every node of the graph but the root, each
+    // dispatched the moment its last dependency finishes, each freshness-
+    // checked, compiled (interface + archive), and recorded.
+    let built = exec::build_deps(
+        &dir,
+        &graph,
+        &artifacts,
+        &exec::Options {
+            profile_name: &args.profile,
+            profile: &profile,
+            linker: args.linker.as_deref(),
+            jobs: args.jobs,
+            build_dir: &root,
+        },
+        &pool,
+        &progress,
+    )
+    .await?;
+    if graph.nodes.len() > 1 {
+        tracing::info!(
+            built,
+            fresh = graph.nodes.len() - 1 - built,
+            "dependencies ready"
+        );
+    }
+
     let products = compile::build(
         &dir,
         &loaded,
@@ -296,21 +328,20 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
             targets: args.targets.clone(),
             linker: args.linker.clone(),
             // The cone's artifact digests enter the fingerprint, so a
-            // product consuming a changed upstream artifact re-fingerprints
-            // (an absent one digests to a sentinel — see `fresh`).
-            upstream: graph
-                .as_ref()
-                .map(|graph| {
-                    rene::fresh::root_upstream_digests(
-                        graph,
-                        &root.join(&args.profile).join("deps"),
-                    )
-                })
-                .unwrap_or_default(),
+            // product consuming a changed upstream artifact re-fingerprints.
+            // Computed *after* the dependency pipeline: it hashes the final
+            // artifacts the targets will consume.
+            upstream: rene::fresh::root_upstream_digests(
+                &graph,
+                &root.join(&args.profile).join("deps"),
+            ),
             jobs: args.jobs,
         },
+        &graph,
+        &pool,
     )
     .await?;
+    pool.shutdown().await?;
     // Stdout carries the artifact listing, one path per target, in the
     // order they were declared (or selected).
     for product in &products {

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -241,7 +241,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
     let location = &args.location;
     let manifest_path = locate_manifest(&location.manifest_path)?;
     let loaded = manifest::load(&manifest_path).map_err(|e| e.to_string())?;
-    tracing::info!(
+    tracing::debug!(
         package = %loaded.manifest.package.name,
         manifest = %loaded.path.display(),
         profile = %args.profile,
@@ -276,8 +276,11 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
     let sources = deps::prepare(&dir, &loaded).await?;
     // The bake links the runtime dylib with the same linker pinning the
     // driver-level links get: the CLI override first, then the profile's.
+    // The progress surface exists from here on: the bake's spinner first,
+    // the pipeline's bars after.
+    let progress = indicatif::MultiProgress::new();
     let bake_linker = args.linker.clone().or_else(|| profile.linker.clone());
-    let artifacts = rt::prepare(&dir, bake_linker.as_deref()).await?;
+    let artifacts = rt::prepare(&dir, bake_linker.as_deref(), &progress).await?;
 
     // No declared targets: stop after the bake, reporting the libdirs for
     // whoever drives rrc by hand — the pre-target workflow, kept working.
@@ -293,9 +296,8 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
     }
 
     // One pool for the whole build: `-j` admission over a few event-loop
-    // workers; one progress surface (hidden off-terminal).
+    // workers.
     let pool = pool::Pool::new(args.jobs)?;
-    let progress = indicatif::MultiProgress::new();
 
     // The dependency pipeline: every node of the graph but the root, each
     // dispatched the moment its last dependency finishes, each freshness-

--- a/crates/rene/src/plan.rs
+++ b/crates/rene/src/plan.rs
@@ -39,6 +39,96 @@ const RUST_LIBDIR: &str = "<rust-libdir>";
 const RT_DEPS_DIR: &str = "<rt-deps-dir>";
 const BAKED_RUSTC: &str = "<baked-rustc>";
 
+/// One planned `rrc` invocation for a node — the shared synthesis behind
+/// both the dump ([`render`]) and the executed build ([`crate::exec`]), so
+/// the two cannot drift: what `inspect --commands` prints is what runs.
+pub(crate) struct PlannedCommand {
+    /// The `--emit` stage (`rri`, `staticlib`, or a root target's kind).
+    pub(crate) emit: &'static str,
+    /// The root target this builds, if it is a root command.
+    pub(crate) target: Option<String>,
+    /// The artifact the command writes.
+    pub(crate) out: PathBuf,
+    /// Full argv minus the leading program.
+    pub(crate) args: Vec<String>,
+}
+
+/// The commands that build one node of the graph, in execution order.
+pub(crate) fn node_commands(
+    graph: &Graph,
+    name: &str,
+    opts: &Options,
+    bake: Option<&RtArtifacts>,
+) -> Vec<PlannedCommand> {
+    let profile_dir = opts.build_dir.join(opts.profile_name);
+    let deps_dir = profile_dir.join("deps");
+    let node = &graph.nodes[name];
+    let transitive = transitive_deps(graph);
+    let externs = extern_args(graph, &transitive[name], &deps_dir);
+    if name == graph.root {
+        // Archives joined in dependency order: dependents before
+        // dependencies (the reverse of the build order, root excluded).
+        let mut link_order = topological(graph);
+        link_order.reverse();
+        link_order.retain(|n| *n != graph.root);
+        node.loaded
+            .manifest
+            .targets
+            .iter()
+            .map(|(target, decl)| {
+                let out = profile_dir.join(compile::artifact_file(
+                    target,
+                    decl.kind,
+                    opts.profile.target_triple.as_deref(),
+                ));
+                let mut args = package_args(node, &out, decl.kind.emit());
+                args.extend(compile::profile_flags(opts.profile, decl.kind, opts.linker));
+                args.extend(polyffi_args(bake));
+                args.extend(externs.iter().cloned());
+                if decl.kind.is_linked() {
+                    for dep in &link_order {
+                        args.push("--link-lib".to_owned());
+                        args.push(archive_path(&deps_dir, dep).display().to_string());
+                    }
+                }
+                PlannedCommand {
+                    emit: decl.kind.emit(),
+                    target: Some(target.clone()),
+                    out,
+                    args,
+                }
+            })
+            .collect()
+    } else {
+        let rri = deps_dir.join(format!("{name}.rri"));
+        let mut interface = package_args(node, &rri, "rri");
+        interface.extend(externs.iter().cloned());
+        let archive = archive_path(&deps_dir, name);
+        let mut staticlib = package_args(node, &archive, "staticlib");
+        staticlib.extend(compile::profile_flags(
+            opts.profile,
+            TargetKind::Staticlib,
+            opts.linker,
+        ));
+        staticlib.extend(polyffi_args(bake));
+        staticlib.extend(externs.iter().cloned());
+        vec![
+            PlannedCommand {
+                emit: "rri",
+                target: None,
+                out: rri,
+                args: interface,
+            },
+            PlannedCommand {
+                emit: "staticlib",
+                target: None,
+                out: archive,
+                args: staticlib,
+            },
+        ]
+    }
+}
+
 /// Render the plan as JSON: `nodes` in dependency-first order (each node's
 /// dependencies precede it), each with the commands that build it and —
 /// when the caller ran the freshness check — its `state`/`reason`.
@@ -48,75 +138,25 @@ pub fn render(
     bake: Option<&RtArtifacts>,
     states: Option<&BTreeMap<String, fresh::State>>,
 ) -> serde_json::Value {
-    let profile_dir = opts.build_dir.join(opts.profile_name);
-    let deps_dir = profile_dir.join("deps");
-    let order = topological(graph);
-    let transitive = transitive_deps(graph);
-    // Archives joined in dependency order: dependents before dependencies
-    // (the reverse of the build order, root excluded).
-    let link_order: Vec<String> = order
-        .iter()
-        .rev()
-        .filter(|name| **name != graph.root)
-        .cloned()
-        .collect();
-
-    let nodes: Vec<serde_json::Value> = order
+    let nodes: Vec<serde_json::Value> = topological(graph)
         .iter()
         .map(|name| {
             let node = &graph.nodes[name.as_str()];
-            let is_root = *name == graph.root;
-            let externs = extern_args(graph, &transitive[name.as_str()], &deps_dir);
-            let commands: Vec<serde_json::Value> = if is_root {
-                node.loaded
-                    .manifest
-                    .targets
-                    .iter()
-                    .map(|(target, decl)| {
-                        let out = profile_dir.join(compile::artifact_file(
-                            target,
-                            decl.kind,
-                            opts.profile.target_triple.as_deref(),
-                        ));
-                        let mut argv = package_args(node, &out, decl.kind.emit());
-                        argv.extend(compile::profile_flags(opts.profile, decl.kind, opts.linker));
-                        argv.extend(polyffi_args(bake));
-                        argv.extend(externs.iter().cloned());
-                        if decl.kind.is_linked() {
-                            // The dependency archives, `--link-lib` in
-                            // dependency order — dependents before their
-                            // dependencies, the order a linker's left-to-
-                            // right archive scan resolves across.
-                            for dep in &link_order {
-                                argv.push("--link-lib".to_owned());
-                                argv.push(archive_path(&deps_dir, dep).display().to_string());
-                            }
-                        }
-                        serde_json::json!({
+            let commands: Vec<serde_json::Value> = node_commands(graph, name, opts, bake)
+                .into_iter()
+                .map(|command| {
+                    let mut argv = vec!["rrc".to_owned()];
+                    argv.extend(command.args);
+                    match command.target {
+                        Some(target) => serde_json::json!({
                             "target": target,
-                            "emit": decl.kind.emit(),
+                            "emit": command.emit,
                             "argv": argv,
-                        })
-                    })
-                    .collect()
-            } else {
-                let rri = deps_dir.join(format!("{name}.rri"));
-                let mut interface = package_args(node, &rri, "rri");
-                interface.extend(externs.iter().cloned());
-                let archive = archive_path(&deps_dir, name);
-                let mut staticlib = package_args(node, &archive, "staticlib");
-                staticlib.extend(compile::profile_flags(
-                    opts.profile,
-                    TargetKind::Staticlib,
-                    opts.linker,
-                ));
-                staticlib.extend(polyffi_args(bake));
-                staticlib.extend(externs.iter().cloned());
-                vec![
-                    serde_json::json!({ "emit": "rri", "argv": interface }),
-                    serde_json::json!({ "emit": "staticlib", "argv": staticlib }),
-                ]
-            };
+                        }),
+                        None => serde_json::json!({ "emit": command.emit, "argv": argv }),
+                    }
+                })
+                .collect();
             let mut rendered = serde_json::json!({
                 "package": name,
                 "version": node.version.to_string(),

--- a/crates/rene/src/plan.rs
+++ b/crates/rene/src/plan.rs
@@ -184,7 +184,6 @@ pub fn render(
 /// The invocation prefix shared by every command of a package.
 fn package_args(node: &crate::resolve::Node, out: &Path, emit: &str) -> Vec<String> {
     vec![
-        "rrc".to_owned(),
         "--package-root".to_owned(),
         node.dir.join("src").display().to_string(),
         "--package-name".to_owned(),

--- a/crates/rene/src/rt.rs
+++ b/crates/rene/src/rt.rs
@@ -154,7 +154,7 @@ pub async fn prepare(dir: &BuildDir, linker: Option<&Path>) -> Result<RtArtifact
     let hash = bundle_hash();
 
     if let Some(cached) = fresh_bake(dir, &toolchain, &hash)? {
-        tracing::info!("reussir-rt is up to date");
+        tracing::debug!("reussir-rt is up to date");
         return Ok(cached);
     }
 
@@ -165,7 +165,7 @@ pub async fn prepare(dir: &BuildDir, linker: Option<&Path>) -> Result<RtArtifact
         std::fs::remove_dir_all(&src_dir)
             .map_err(|e| format!("cannot clear `{}`: {e}", src_dir.display()))?;
     }
-    tracing::info!(dest = %src_dir.display(), "extracting bundled reussir-rt source");
+    tracing::debug!(dest = %src_dir.display(), "extracting bundled reussir-rt source");
     unpack(dir.root()).map_err(|e| format!("cannot unpack the runtime bundle: {e}"))?;
 
     tracing::info!(
@@ -200,7 +200,7 @@ pub async fn prepare(dir: &BuildDir, linker: Option<&Path>) -> Result<RtArtifact
         (tables::RT_ARTIFACTS_KEY, record.as_str()),
     ])
     .map_err(|e| e.to_string())?;
-    tracing::info!(staticlib = %artifacts.staticlib.display(), "reussir-rt ready");
+    tracing::debug!(staticlib = %artifacts.staticlib.display(), "reussir-rt ready");
     Ok(artifacts)
 }
 

--- a/crates/rene/src/rt.rs
+++ b/crates/rene/src/rt.rs
@@ -149,7 +149,11 @@ async fn capture(program: &Path, args: &[&str]) -> Result<String, String> {
 /// whose PATH carries a coreutils `link` ahead of MSVC's). It is not part of
 /// the bake's freshness: whichever working linker linked the runtime, the
 /// artifacts are equivalent.
-pub async fn prepare(dir: &BuildDir, linker: Option<&Path>) -> Result<RtArtifacts, String> {
+pub async fn prepare(
+    dir: &BuildDir,
+    linker: Option<&Path>,
+    progress: &indicatif::MultiProgress,
+) -> Result<RtArtifacts, String> {
     let toolchain = Toolchain::resolve().await?;
     let hash = bundle_hash();
 
@@ -168,12 +172,23 @@ pub async fn prepare(dir: &BuildDir, linker: Option<&Path>) -> Result<RtArtifact
     tracing::debug!(dest = %src_dir.display(), "extracting bundled reussir-rt source");
     unpack(dir.root()).map_err(|e| format!("cannot unpack the runtime bundle: {e}"))?;
 
-    tracing::info!(
+    tracing::debug!(
         cargo = %toolchain.cargo.display(),
         rustc = %toolchain.version,
-        "building reussir-rt (once per toolchain or runtime change)"
+        "building reussir-rt"
     );
-    let (rlib, staticlib) = cargo_build(&toolchain, &src_dir, linker).await?;
+    // The bake is the build's one slow cold step (a real cargo build, with
+    // the network on a fresh directory); a spinner carries that while
+    // cargo's own output is captured — and replayed if the bake fails.
+    let bar = progress.add(
+        indicatif::ProgressBar::new_spinner()
+            .with_message("baking reussir-rt (once per toolchain or runtime change)"),
+    );
+    bar.enable_steady_tick(std::time::Duration::from_millis(120));
+    let result = cargo_build(&toolchain, &src_dir, linker).await;
+    bar.finish_and_clear();
+    progress.remove(&bar);
+    let (rlib, staticlib) = result?;
 
     // Cargo may report the uplifted rlib (`target/release/lib….rlib`) rather
     // than the hashed copy in `deps/`; polyffi's `rustc -L` needs `deps/`,
@@ -262,11 +277,14 @@ async fn cargo_build(
         );
         cmd.env(key, linker);
     }
-    // Diagnostics and cargo's own progress stream to the user unchanged
-    // (stderr inherits by default under compio).
+    // Both streams are captured: the JSON messages on stdout carry the
+    // artifact locations, and cargo's human progress on stderr stays out of
+    // the progress bars — replayed below only if the bake fails.
     let out = cmd
         .stdout(Stdio::piped())
         .expect("pipe stdout")
+        .stderr(Stdio::piped())
+        .expect("pipe stderr")
         .output()
         .await
         .map_err(|e| format!("cannot run `{}`: {e}", toolchain.cargo.display()))?;
@@ -297,7 +315,10 @@ async fn cargo_build(
         }
     }
     if !out.status.success() {
-        return Err("building reussir-rt failed (see cargo's output above)".to_owned());
+        return Err(format!(
+            "building reussir-rt failed:\n{}",
+            String::from_utf8_lossy(&out.stderr).trim_end()
+        ));
     }
     match (rlib, staticlib) {
         (Some(rlib), Some(staticlib)) => Ok((rlib, staticlib)),

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -334,7 +334,8 @@ fn build_is_a_no_op_when_no_source_changed() {
     assert_eq!(fakes.runs("rrc"), 1, "the first build must scan");
 
     for _ in 0..2 {
-        let out = fakes.rene(&["build"], &manifest, &root);
+        // `-v`: the freshness narration lives at DEBUG now.
+        let out = fakes.rene(&["-v", "build"], &manifest, &root);
         assert!(out.status.success(), "stderr: {}", stderr(&out));
         assert!(
             stderr(&out).contains("up to date"),

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -781,3 +781,117 @@ fn build_bakes_the_runtime_with_the_host_toolchain() {
         libdirs[1].display()
     );
 }
+
+/// The cross-package pipeline under the fake toolchain: the dependency's
+/// interface and archive compile before the root's targets, the root sees
+/// the cone (`--extern`/`--extern-src`) and links the archive
+/// (`--link-lib`), records make the second build a no-op, and a touched
+/// dependency source rebuilds it.
+#[cfg(unix)]
+#[test]
+fn build_runs_the_dependency_pipeline() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp = tmp_dir.path().canonicalize().unwrap();
+    let root = tmp.join("reussir-build");
+
+    // The root package, depending on `util` by path.
+    std::fs::create_dir_all(tmp.join("src")).unwrap();
+    std::fs::write(
+        tmp.join("src/lib.rr"),
+        "pub fn entry(n: u64) -> u64 { n }\n",
+    )
+    .unwrap();
+    let manifest = tmp.join("rene.ncl");
+    std::fs::write(
+        &manifest,
+        "{ package = { name = \"app\", version = \"0.1.0\" },\n\
+         \x20 dependencies.util = { path = \"vendor/util\", version = \"^1.0\" },\n\
+         \x20 targets.demo = { kind = 'executable } }\n",
+    )
+    .unwrap();
+    let util = tmp.join("vendor/util");
+    std::fs::create_dir_all(util.join("src")).unwrap();
+    std::fs::write(
+        util.join("src/lib.rr"),
+        "pub fn twice(n: u64) -> u64 { n + n }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        util.join("rene.ncl"),
+        "{ package = { name = \"util\", version = \"1.2.0\" } }\n",
+    )
+    .unwrap();
+
+    let fakes = Fakes::new(&tmp);
+    let out = fakes.rene(&["build"], &manifest, &root);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    let compiles = fakes.compiles();
+    // Dependency interface, dependency archive, root target — in order.
+    assert_eq!(compiles.len(), 3, "{compiles:#?}");
+    assert!(compiles[0].contains("--package-name util"), "{compiles:#?}");
+    assert!(compiles[0].contains("--emit rri"), "{compiles:#?}");
+    assert!(compiles[1].contains("--package-name util"), "{compiles:#?}");
+    assert!(compiles[1].contains("--emit staticlib"), "{compiles:#?}");
+    assert!(compiles[2].contains("--package-name app"), "{compiles:#?}");
+    assert!(compiles[2].contains("--emit executable"), "{compiles:#?}");
+    // The root sees the dependency's interface and sources, and links its
+    // archive.
+    let deps_dir = root.join("dev").join("deps");
+    assert!(
+        compiles[2].contains(&format!(
+            "--extern util={}",
+            deps_dir.join("util.rri").display()
+        )),
+        "{compiles:#?}"
+    );
+    assert!(
+        compiles[2].contains(&format!(
+            "--extern-src util={}",
+            util.join("src").display()
+        )),
+        "{compiles:#?}"
+    );
+    assert!(
+        compiles[2].contains(&format!(
+            "--link-lib {}",
+            deps_dir.join("libutil.a").display()
+        )),
+        "{compiles:#?}"
+    );
+    // The dependency's compiles never see link flags or their own extern.
+    assert!(!compiles[0].contains("--link-lib"), "{compiles:#?}");
+    assert!(!compiles[1].contains("--extern"), "{compiles:#?}");
+
+    // Everything is recorded: the second build compiles nothing.
+    let out = fakes.rene(&["build"], &manifest, &root);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(
+        fakes.compiles().len(),
+        3,
+        "stderr: {}\n{:#?}",
+        stderr(&out),
+        fakes.compiles()
+    );
+
+    // A touched dependency source re-runs its two compiles. The root's
+    // target does NOT re-run: the fake fabricates byte-identical artifacts,
+    // and the root's fingerprint hashes upstream *content* — the early
+    // cutoff, demonstrated. (With a real compiler the archive's bytes would
+    // change and the root would relink.)
+    std::fs::write(
+        util.join("src/lib.rr"),
+        "pub fn twice(n: u64) -> u64 { n * 2 }\n",
+    )
+    .unwrap();
+    let out = fakes.rene(&["build"], &manifest, &root);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let after = fakes.compiles();
+    assert_eq!(after.len(), 5, "{after:#?}");
+    assert!(after[3].contains("--emit rri"), "{after:#?}");
+    assert!(after[4].contains("--emit staticlib"), "{after:#?}");
+    assert!(
+        after[3..].iter().all(|line| !line.contains("--package-name app")),
+        "the root re-ran despite identical upstream bytes: {after:#?}"
+    );
+}

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -480,12 +480,15 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         // subprogram attribute. A body-less declaration gets neither — its home
         // unit describes it (a declaration must not carry a DISubprogram
         // definition).
-        let func_loc = if emit_body {
+        let func_loc = if emit_body && func.body.is_some() {
             if let Some(args) = self.dbg_func_args_attr(func) {
                 attributes.push(args);
             }
             self.subprogram_location(func)
         } else {
+            // A body-less function is a declaration wherever it lowers — an
+            // extern prototype has no home unit at all — and a declaration
+            // must not carry a DISubprogram definition.
             self.location(func.body.and_then(|b| b.span))
         };
 

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -23,8 +23,10 @@
 // RUN: %t.bdir/dev/demo%exe_ext
 
 // An unchanged package rebuilds nothing — the product record and the source
-// graph both hold — and the listing is the same artifact.
-// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir %rrc_linker 2>%t.fresh.log > %t.fresh.listing
+// graph both hold — and the listing is the same artifact. (`-v`: the
+// freshness narration lives at DEBUG so the default build keeps the
+// progress bars clean.)
+// RUN: %rene -v build --manifest-path %S/build/rene.ncl --build-dir %t.bdir %rrc_linker 2>%t.fresh.log > %t.fresh.listing
 // RUN: %FileCheck %s --check-prefix=FRESH < %t.fresh.log
 // RUN: diff %t.listing %t.fresh.listing
 

--- a/tests/integration/rene/deps/src/lib.rr
+++ b/tests/integration/rene/deps/src/lib.rr
@@ -1,4 +1,8 @@
 #[main]
-pub fn entry() -> () {
-    ()
+pub fn entry() {
+    let n: u64 = 21;
+    let doubled = util::twice(n);
+    let grounded = util::ground(doubled);
+    let base = logs::level();
+    let total = grounded + base;
 }

--- a/tests/integration/rene/deps/vendor/util/src/lib.rr
+++ b/tests/integration/rene/deps/vendor/util/src/lib.rr
@@ -1,3 +1,12 @@
-pub fn twice(n: u64) -> u64 {
-    n + n
+fn helper(x: u64) -> u64 {
+    x + 1
+}
+
+pub fn twice<T : Num>(x: T) -> T {
+    helper(0);
+    x + x
+}
+
+pub fn ground(x: u64) -> u64 {
+    helper(x) + logs::level()
 }

--- a/tests/integration/rene/deps_build.rr
+++ b/tests/integration/rene/deps_build.rr
@@ -1,0 +1,36 @@
+// The executed cross-package build, end to end: `rene build` resolves the
+// graph (app 0.1.0 → util 1.2.9 → logs 0.3.4), bakes the runtime, then runs
+// the plan's commands through the ready-queue pipeline — each dependency
+// compiles (interface + archive) the moment its own dependencies finish,
+// the root's targets compile against the cone (`--extern`) and link the
+// archives (`--link-lib`) — and the executable runs: `app` instantiates
+// `util::twice` (a generic crossing the interface), calls `util::ground`
+// (whose body reaches `logs` transitively), and `logs::level` directly.
+//
+// `%rrc_linker` pins MSVC's link.exe on Windows, as in build.rr.
+
+// RUN: %rene build --manifest-path %S/deps/rene.ncl --build-dir %t.bdir %rrc_linker -j 2 > %t.listing 2> %t.log
+// RUN: %FileCheck %s --check-prefix=LISTING < %t.listing
+// RUN: %t.bdir/dev/demo%exe_ext
+
+// The listing carries the root's products, declared order.
+// LISTING: {{[/\\]}}dev{{[/\\]}}demo
+// LISTING: shared
+
+// The dependencies' interfaces and archives landed in `<profile>/deps/`.
+// RUN: ls %t.bdir/dev/deps | %FileCheck %s --check-prefix=DEPS
+// DEPS-DAG: logs.rri
+// DEPS-DAG: util.rri
+
+// A second build proves everything current — dependencies and targets —
+// and lists the same artifacts.
+// RUN: %rene build --manifest-path %S/deps/rene.ncl --build-dir %t.bdir %rrc_linker 2> %t.fresh.log > %t.fresh.listing
+// RUN: %FileCheck %s --check-prefix=FRESH < %t.fresh.log
+// RUN: diff %t.listing %t.fresh.listing
+
+// FRESH: dependencies ready built=0 fresh=2
+
+// The plan dump agrees: every node current, by name.
+// RUN: %rene inspect --manifest-path %S/deps/rene.ncl --build-dir %t.bdir --frozen --commands | %FileCheck %s --check-prefix=STATE
+
+// STATE-COUNT-3: "state": "current"

--- a/tests/integration/rene/deps_build.rr
+++ b/tests/integration/rene/deps_build.rr
@@ -31,6 +31,6 @@
 // FRESH: dependencies ready built=0 fresh=2
 
 // The plan dump agrees: every node current, by name.
-// RUN: %rene inspect --manifest-path %S/deps/rene.ncl --build-dir %t.bdir --frozen --commands | %FileCheck %s --check-prefix=STATE
+// RUN: %rene inspect --manifest-path %S/deps/rene.ncl --build-dir %t.bdir --frozen --commands %rrc_linker | %FileCheck %s --check-prefix=STATE
 
 // STATE-COUNT-3: "state": "current"

--- a/tests/integration/rene/deps_build.rr
+++ b/tests/integration/rene/deps_build.rr
@@ -24,7 +24,7 @@
 
 // A second build proves everything current — dependencies and targets —
 // and lists the same artifacts.
-// RUN: %rene build --manifest-path %S/deps/rene.ncl --build-dir %t.bdir %rrc_linker 2> %t.fresh.log > %t.fresh.listing
+// RUN: %rene -v build --manifest-path %S/deps/rene.ncl --build-dir %t.bdir %rrc_linker 2> %t.fresh.log > %t.fresh.listing
 // RUN: %FileCheck %s --check-prefix=FRESH < %t.fresh.log
 // RUN: diff %t.listing %t.fresh.listing
 

--- a/tests/integration/rene/fib.rr
+++ b/tests/integration/rene/fib.rr
@@ -1,0 +1,13 @@
+// The release-profile demo: plain recursive Fibonacci, its console done
+// entirely through polyffi — `read_input` pulls n from stdin and
+// `print_result` writes the answer, both `#[ffi(import)]` Rust textures
+// compiled against the baked runtime rene provides. One `rene build`, one
+// pipe, no C driver.
+
+// RUN: %rene build --manifest-path %S/fib/rene.ncl --build-dir %t.bdir --profile release %rrc_linker | %FileCheck %s --check-prefix=LISTING
+
+// LISTING: release{{[/\\]}}fib
+
+// RUN: echo 24 | %t.bdir/release/fib%exe_ext | %FileCheck %s
+
+// CHECK: fib(24) = 46368

--- a/tests/integration/rene/fib/lit.local.cfg
+++ b/tests/integration/rene/fib/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/rene/fib/rene.ncl
+++ b/tests/integration/rene/fib/rene.ncl
@@ -1,0 +1,4 @@
+{
+  package = { name = "fib", version = "0.1.0" },
+  targets.fib = { kind = 'executable },
+}

--- a/tests/integration/rene/fib/src/lib.rr
+++ b/tests/integration/rene/fib/src/lib.rr
@@ -1,0 +1,34 @@
+// Plain recursive Fibonacci behind a polyffi console: input read from
+// stdin and the result printed through `#[ffi(import)]` Rust textures —
+// no C driver, the whole loop is Reussir + the runtime.
+
+#[ffi(import)]
+fn read_input() -> u64 [{
+    {
+        let mut line = String::new();
+        std::io::stdin().read_line(&mut line).ok();
+        line.trim().parse().unwrap_or(10)
+    }
+}];
+
+#[ffi(import)]
+fn print_result(n: u64, value: u64) -> u64 [{
+    {
+        println!("fib({n}) = {value}");
+        value
+    }
+}];
+
+fn fib(n: u64) -> u64 {
+    if n <= 1 {
+        n
+    } else {
+        fib(n - 1) + fib(n - 2)
+    }
+}
+
+#[main]
+pub fn entry() {
+    let n = read_input();
+    let value = print_result(n, fib(n));
+}

--- a/tests/integration/rene/source_graph.rr
+++ b/tests/integration/rene/source_graph.rr
@@ -38,7 +38,9 @@
 // SCAN:      "state": "up-to-date"
 
 // Nothing moved, so the record stands and a second run re-scans nothing.
-// RUN: %rene inspect --manifest-path %t.pkg/rene.ncl 2>&1 >/dev/null | %FileCheck %s --check-prefix=NOOP
+// (`-v`: the freshness narration lives at DEBUG so default runs keep the
+// progress bars clean.)
+// RUN: %rene -v inspect --manifest-path %t.pkg/rene.ncl 2>&1 >/dev/null | %FileCheck %s --check-prefix=NOOP
 // RUN: %rene inspect --frozen --manifest-path %t.pkg/rene.ncl | %FileCheck %s --check-prefix=CACHED
 
 // NOOP: package sources are up to date


### PR DESCRIPTION
## Summary

`rene build` now executes the plan: the full cross-package build works end to end, in three commits.

1. **Shared command synthesis** — `plan::node_commands` produces each node's commands; `render` prints them and the pipeline runs them, so what `inspect --commands` shows is what happens, by construction.
2. **A codegen fix the pipeline surfaced** — `--extern` + `-g` (the dev profile) was an untested combination: extern prototypes lowered with a definition-style `DISubprogram`, which LLVM's verifier rejects on declarations. One-line fix matching the debug branch to its own comment (the visibility branch already handled body-less functions).
3. **The pipeline** — every dependency node dispatches **the moment its last dependency finishes** (ready queue, no wave barriers), through the pool's `-j` admission. Per node: freshness at dispatch time (current nodes skip whole, reasons logged), source scan, interface + archive compiles, `fresh::record_dep`. Root targets come from the same synthesis (`--extern`/`--extern-src` cone, `--link-lib` in dependency order) with fingerprints hashing the final upstream artifacts. Progress on an indicatif multi-bar (overall + per-node spinners), hidden off-terminal; tracing drops ANSI off-terminal too.

Live behavior on the three-package fixture (`app` instantiates `util::twice` across the interface; `util::ground` reaches `logs` transitively):

- build → run → `demo` exits 0; interfaces + archives in `<profile>/deps/`
- second build: `dependencies ready built=0 fresh=2`, every plan node `"state": "current"`
- `touch logs/src/lib.rr` → only `logs` rebuilds; byte-identical outputs leave `util` **and both root targets** untouched — the early cutoff, observed live and pinned in tests

## Test plan

- [x] new `rene/deps_build.rr` lit e2e: build, run, artifact layout, no-op rebuild, all-current states
- [x] fake-toolchain CLI test: command order (dep rri → dep archive → root), extern/link-lib wiring, no-op second build, and the early cutoff (touched dep rebuilds, root stays — the fake's identical bytes prove content propagation)
- [x] rene 38/38 + CLI 17/17 + real bake; full lit 432/432; workspace clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gNkXrdGZAPjM1nnpWXaJi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787709943&installation_model_id=426051&pr_number=477&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F477&signature=fb310e98b64c16da88fd937616f0f848cc6c270cd8c94dba3af39e274a8f3596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->