### PR TITLE
[tests] extern_mono: COFF instances are weak_odr in a comdat group

### DIFF
--- a/tests/integration/frontend/extern_mono.rr
+++ b/tests/integration/frontend/extern_mono.rr
@@ -38,7 +38,9 @@
 // RUN: %not %rrc %t.bad.rr --package-name app --extern dep=%t.rri --extern-src dep=%S/extern_mono_dep --emit mir -o - 2>&1 \
 // RUN:   | %FileCheck %s --check-prefix=FLEX
 // FLEX: requires a regional record
-// FLEX: extern_mono_dep{{/|\\\\}}lib.rr
+// The caret prints the raw re-anchored path — a single separator, unlike
+// the escaped file-table strings the MIR checks match.
+// FLEX: extern_mono_dep{{[/\\]}}lib.rr
 // FLEX: pub regional fn flexy
 
 pub fn use_twice(n: i64) -> i64 {

--- a/tests/integration/frontend/extern_mono.rr
+++ b/tests/integration/frontend/extern_mono.rr
@@ -17,14 +17,16 @@
 // MIR-DAG: pub fn @_RNvC3dep6ground(v0 (x): i64) -> i64 in {{[0-9]+}};
 // MIR-DAG: pub fn @_RNvC3app9use_twice(v0 (n): i64) -> i64 in {{[0-9]+}} {
 
-// The consumer-emitted instance carries the mergeable instance linkage
-// (`weak_odr` where the object format dedups) — any other package emitting
-// the same instance collapses to one definition at link; the imported
-// grounds stay external declarations.
+// The consumer-emitted instance carries the mergeable instance linkage —
+// any other package emitting the same instance collapses to one definition
+// at link: `weak_odr` bound natively on ELF/Mach-O, `weak_odr` + a comdat
+// group on COFF (same as linkage.rr pins for the in-package instances).
+// The imported grounds stay external declarations.
 // RUN: %rrc %s --package-name app --extern dep=%t.rri --emit llvm-ir -O none -o %t.ll
 // RUN: %FileCheck %s %linkage_check_prefixes < %t.ll
 // CHECK-DEDUP-DAG: define weak_odr i64 @_RINvC3dep5twicexE(i64 %0)
-// CHECK-COFF-DAG: define i64 @_RINvC3dep5twicexE(i64 %0)
+// CHECK-COFF-DAG: $_RINvC3dep5twicexE = comdat any
+// CHECK-COFF-DAG: define weak_odr i64 @_RINvC3dep5twicexE(i64 %0) comdat
 // CHECK-DAG: declare i64 @_RNvC3dep6helper(i64
 // CHECK-DAG: declare i64 @_RNvC3dep6ground(i64
 // CHECK-DAG: define i64 @_RNvC3app9use_twice(i64 %0)


### PR DESCRIPTION
## Summary

Fixes the Windows-only lit failure on main: the #472×#473 logical conflict. `extern_mono.rr` (from #472) pinned the consumer-emitted instance as a plain external `define` on COFF; #473 moved COFF instance dedup to `weak_odr` + a comdat group. Each PR was green alone — the first combined Windows run (and every one since) failed on it.

The expectation now matches what `linkage.rr` pins for in-package instances:

```
CHECK-COFF-DAG: $_RINvC3dep5twicexE = comdat any
CHECK-COFF-DAG: define weak_odr i64 @_RINvC3dep5twicexE(i64 %0) comdat
```

Verified two ways without a Windows box: FileCheck with the COFF prefix set against locally cross-emitted `--target-triple x86_64-pc-windows-msvc` IR (passes), and the native DEDUP-prefix lit run (still passes).

## Test plan

- [x] `FileCheck --check-prefixes=CHECK,CHECK-COFF` over cross-emitted COFF IR
- [x] native `extern_mono.rr` lit run green
- [ ] the Windows MSVC Full Pipeline on this PR is the real assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gNkXrdGZAPjM1nnpWXaJi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787714871&installation_model_id=426051&pr_number=478&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F478&signature=5a02f66b63357c27040a384e43fcea2f29e2d88dd854da10e7b68d1477fa7ce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->