### PR TITLE
Windows validation: un-gate the rene e2e tests, string as an exposed collection

### DIFF
--- a/crates/reussir-rt/src/collections/string.rs
+++ b/crates/reussir-rt/src/collections/string.rs
@@ -2,6 +2,13 @@ use std::{marker::PhantomData, string::String as StdString};
 
 use crate::rc::{Rc, RcRef};
 
+/// A functional (copy-on-write, rc-boxed) string: the exposed string
+/// collection for Reussir's polymorphic FFI, crossing the boundary the same
+/// way [`crate::collections::vec::Vec`] does. Owning operations take `self`
+/// linearly and return the updated string (`make_mut` copies only when the
+/// box is shared); read-only operations borrow. The `#[repr(transparent)]`
+/// wrapper over [`Rc`] is what the FFI contract requires: the compiler
+/// treats the value as an rc pointer whose count sits at offset 0.
 #[derive(Clone)]
 #[repr(transparent)]
 pub struct String(Rc<StdString>);
@@ -35,6 +42,12 @@ impl String {
     pub fn push_str(mut self, s: Str) -> Self {
         self.make_mut().push_str(&s);
         self
+    }
+    pub fn len(&self) -> usize {
+        self.0.data_ref().len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.data_ref().is_empty()
     }
     pub fn as_ref(&self) -> StringRef<'_> {
         StringRef(self.0.as_ref())

--- a/tests/integration/frontend/ffi_flags.rr
+++ b/tests/integration/frontend/ffi_flags.rr
@@ -6,14 +6,14 @@
 // load-bearing) and the probe list.
 
 // RUN: env -u REUSSIR_RUSTC -u REUSSIR_RUSTC_DEPS %rrc %s -o %t.o --relocation-mode pic \
-// RUN:   --polyffi-rust-path %rustc_path --polyffi-libdir %library_path
+// RUN:   --polyffi-rust-path "%rustc_path" --polyffi-libdir %library_path
 
 // `--polyffi-libdir` is repeatable: every directory is searched (one
 // `rustc -L` each), so a package-free directory alongside the real one is
 // harmless — including listed first.
 // RUN: rm -rf %t.extra && mkdir -p %t.extra
 // RUN: env -u REUSSIR_RUSTC -u REUSSIR_RUSTC_DEPS %rrc %s -o %t.multi.o --relocation-mode pic \
-// RUN:   --polyffi-rust-path %rustc_path --polyffi-libdir %t.extra --polyffi-libdir %library_path
+// RUN:   --polyffi-rust-path "%rustc_path" --polyffi-libdir %t.extra --polyffi-libdir %library_path
 
 // A missing rustc or a bogus package directory fails in the driver, before
 // the pipeline runs — even when another directory in the list is fine.

--- a/tests/integration/frontend/ffi_string_e2e.c
+++ b/tests/integration/frontend/ffi_string_e2e.c
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+// Driver for ffi_string_e2e.rr. `main` returns `i64`, trivial at the
+// trampoline boundary, so the export returns directly.
+
+#include <stdint.h>
+
+extern int64_t reussir_main(void);
+
+int main(void) { return reussir_main() == 3 ? 0 : 1; }

--- a/tests/integration/frontend/ffi_string_e2e.rr
+++ b/tests/integration/frontend/ffi_string_e2e.rr
@@ -1,0 +1,49 @@
+// UNSUPPORTED: darwin
+// End-to-end polymorphic FFI over the runtime's copy-on-write string:
+// build a Rust `String` from Reussir one `char` at a time, measure it on
+// the Rust side (consuming and dropping the string there), and export the
+// result. The exact `Vec` shape (`ffi_vec_e2e.rr`) with the other exposed
+// collection, pinning that `collections::string::String` crosses the
+// boundary the same way `collections::vec::Vec` does.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/ffi_string_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/ffi_string_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+// The dev-profile shape: `-g` over a program whose every value is this
+// opaque record (the layout-query path `ffi_debug.rr` pins, with the
+// string instance).
+// RUN: %rrc %s -o %t.g.o --relocation-mode pic -g
+// RUN: %cc %t.g.o %S/ffi_string_e2e.c -o %t.g.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.g.exe
+
+extern "rust" [{
+    use reussir_rt::collections::string::String as RString;
+}];
+
+#[ffi(rust = "::reussir_rt::collections::string::String")]
+pub struct Text;
+
+#[ffi(import)]
+pub fn new() -> Text [{ RString::new() }];
+
+#[ffi(import)]
+pub fn push(s: Text, ch: char) -> Text [{ RString::push(s, ch) }];
+
+#[ffi(import)]
+pub fn total_bytes(s: Text) -> i64 [{
+    // A multi-byte scalar counts by its UTF-8 length: "aé" is three bytes.
+    s.as_str().len() as i64
+}];
+
+pub fn main() -> i64 {
+    let s = new();
+    let s = push(s, 'a');
+    let s = push(s, 'é');
+    total_bytes(s)
+}
+
+extern "C" trampoline "reussir_main" = main;

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -121,7 +121,10 @@ def _probe_openmp():
     flags = '-fopenmp'
     if libomp_dir:
         flags += ' -Wl,-rpath,%s' % libomp_dir
-    with tempfile.TemporaryDirectory() as tmp:
+    # Windows can hold the probe executable's lock a beat past process
+    # exit (observed under x64 emulation); a failed cleanup is not a
+    # failed probe.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
         src = os.path.join(tmp, 'omp.c')
         exe = os.path.join(tmp, 'omp')
         with open(src, 'w') as f:

--- a/tests/integration/rene/calc_release.rr
+++ b/tests/integration/rene/calc_release.rr
@@ -1,19 +1,17 @@
-// UNSUPPORTED: windows
-// On Windows CI this release-profile build reliably exceeds the 900s lit
-// timeout (three consecutive runs), while a fresh dev+release cycle of the
-// same package finishes in ~30s on Linux and the dev half (calc.rr) builds
-// and runs correctly on Windows. The hang is inside `rene build --profile
-// release` — after the dev stage passed, before the release listing is
-// printed — so the suspects are the `-O aggressive` middle-end on this
-// package (the one that previously exposed the inliner SCC blowup) or the
-// two-unit split link. Needs a Windows host to profile; see the PR #479
-// discussion.
+// On Windows CI this release-profile build once reliably exceeded the
+// 900s lit timeout (three consecutive runs), yet the same dev+release
+// cycle completes in seconds on an x86_64-pc-windows-msvc toolchain
+// driven from a Windows/arm64 host — including with the build restricted
+// to four CPUs — so the hang has not reproduced off the runner. The
+// build runs `-v` here so a recurrence names its hanging stage in the
+// timeout report (each package's compile and the launcher link log to
+// stderr at DEBUG).
 
 // The release profile (aggressive optimization, and a two-unit link from
 // the manifest's `codegen_units`) is the same interpreter as calc.rr:
 // identical session transcript from the identical input.
 
-// RUN: %rene build --manifest-path %S/calc/rene.ncl --build-dir %t.bdir --profile release %rrc_linker | %FileCheck %s --check-prefix=RELEASE
+// RUN: %rene -v build --manifest-path %S/calc/rene.ncl --build-dir %t.bdir --profile release %rrc_linker | %FileCheck %s --check-prefix=RELEASE
 
 // RELEASE: {{[/\\]}}release{{[/\\]}}calc
 

--- a/tests/integration/rene/inventory.rr
+++ b/tests/integration/rene/inventory.rr
@@ -1,11 +1,9 @@
-// UNSUPPORTED: windows
-// On COFF the built binaries crash at runtime before the first line of
-// output (dev: silent early exit; the shape survives the correct
-// `linkonce_odr` + comdat IR for the nullary tag dummies). The remaining
-// suspects are cross-unit nullary tagged immediates and/or the win64
-// packed (nontrivial) import boundary — both gated tests use packed
-// imports, while the trivially-crossing `calc` passes. See the PR #479
-// discussion for the minimal repro sketch.
+// This test was briefly gated off Windows for a dev-build crash that
+// turned out to be the `-g` opaque-FFI data-layout defect (an `ffi_object`
+// answering no layout queries), fixed before the gate was revisited: both
+// profiles build and run correctly under x86_64-pc-windows-msvc. The
+// `ffi_debug.rr` and `ffi_string_e2e.rr` `-g` runs pin the underlying
+// regression.
 
 // An inventory report as a four-dependency `rene build`: generic
 // containers (`collections`), the domain layer folding transactions into a

--- a/tests/integration/rene/stats.rr
+++ b/tests/integration/rene/stats.rr
@@ -1,10 +1,10 @@
-// UNSUPPORTED: windows
-// On COFF the built binaries crash at runtime before the first line of
-// output (release: stack overflow in the polyffi boundary). The remaining
-// suspects are cross-unit nullary tagged immediates and/or the win64
-// packed (nontrivial) import boundary — both gated tests use packed
-// imports, while the trivially-crossing `calc` passes. See the PR #479
-// discussion for the minimal repro sketch.
+// This test was briefly gated off Windows for runtime crashes observed
+// mid-bringup: the dev half was the `-g` opaque-FFI data-layout defect
+// (fixed before the gate was revisited), and the release stack overflow
+// has not reproduced since — on x86_64-pc-windows-msvc both profiles now
+// build and run correctly, with the linked binary carrying exactly one
+// folded `REUSSIR_TAG_DUMMY` definition (the cross-unit immediate
+// identity the overflow signature had implicated).
 
 // A statistics pipeline as a two-package `rene build`: stdin is parsed
 // into the runtime's rc vector inside `vecio`'s textures (bad tokens


### PR DESCRIPTION
## What

Follow-up to #479, validated on a real Windows host against `x86_64-pc-windows-msvc` (conda-forge LLVM/MLIR 22.1.8 + MSVC, per the CI pipeline): **all three Windows-gated failures are stale on the branch's final state**, and the runtime's `String` joins `Vec` as a pinned exposed collection.

### Un-gate the rene Windows tests

* `inventory.rr` / `stats.rr` — both profiles build and run with correct transcripts. Their crashes were the dev-profile `-g` opaque-FFI data-layout defect: the tests were gated while it was only partially fixed, and the finished fix (`3366081`) never got a Windows run. Verified the deeper suspect directly too: the linked stats release binary carries exactly one folded `REUSSIR_TAG_DUMMY` definition (PDB publics), so cross-unit tagged-immediate identity is sound under `link.exe`.
* `calc_release.rr` — the >900s CI hang did not reproduce in any shape (fresh build dir, dev-then-release in one dir, a four-CPU affinity run; seconds each). Un-gated, and the build now runs `rene -v` so a recurrence names its hanging stage in the lit timeout report. This CI run is the decisive check.

### String is an exposed collection

The `Rc<String>` segfault that pushed textio to a byte-vector `Text` was the same `-g` defect, not anything string-shaped: `collections::string::String` already satisfies the FFI contract. It now carries the same doc contract and borrowed `len`/`is_empty` surface as `Vec`, and `ffi_string_e2e.rr` pins the whole shape — unoptimized, `-Oaggressive`, and the `-g` dev profile — mirroring `ffi_vec_e2e.rr`.

### Harness portability

Two real bugs the Windows repro surfaced: the OpenMP probe treating Windows' laggy executable file-lock as a failed probe, and `ffi_flags.rr` passing `%rustc_path` unquoted (splits on toolchain paths containing spaces).

## Testing

* Full lit integration suite on `x86_64-pc-windows-msvc`: **408 passed, 0 failed** (36 platform-gated unsupported), including the three un-gated rene tests and the new string e2e.
* C++ unit tests 29/29; `reussir-rt` crate tests 19/19 (also green natively on `aarch64-pc-windows-msvc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787801205&installation_model_id=426051&pr_number=480&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F480&signature=dd1cdc62ba09201fe0404a7ea69947ee7a32b0fe6d74609577182d0ee352fcdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->