### PR TITLE
[rene] select products with --bin and --lib

### DIFF
--- a/crates/rene/src/compile.rs
+++ b/crates/rene/src/compile.rs
@@ -36,8 +36,11 @@ pub struct Options {
     pub profile_name: String,
     /// The resolved profile (built-in refined by the manifest's).
     pub profile: Profile,
-    /// `--target` filters; empty means every declared target.
-    pub targets: Vec<String>,
+    /// `--bin` filters; empty together with [`Self::libs`] means every
+    /// declared target.
+    pub bins: Vec<String>,
+    /// `--lib` filters; both `dynlib` and `staticlib` are libraries.
+    pub libs: Vec<String>,
     /// `rene build --linker`, overriding the profile's.
     pub linker: Option<PathBuf>,
     /// The dependency cone's artifact digests
@@ -75,23 +78,20 @@ pub async fn build(
     pool: &Pool,
 ) -> Result<Vec<Product>, String> {
     let manifest = &loaded.manifest;
-    let selected: Vec<&str> = if opts.targets.is_empty() {
+    let selected: Vec<&str> = if opts.bins.is_empty() && opts.libs.is_empty() {
         manifest.targets.keys().map(String::as_str).collect()
     } else {
-        for name in &opts.targets {
-            if !manifest.targets.contains_key(name) {
-                return Err(format!(
-                    "no target named `{name}`: the manifest declares {}",
-                    manifest
-                        .targets
-                        .keys()
-                        .map(|t| format!("`{t}`"))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ));
-            }
+        for name in &opts.bins {
+            check_selected_bin(manifest, name)?;
         }
-        opts.targets.iter().map(String::as_str).collect()
+        for name in &opts.libs {
+            check_selected_library(manifest, name)?;
+        }
+        opts.bins
+            .iter()
+            .chain(&opts.libs)
+            .map(String::as_str)
+            .collect()
     };
 
     let out_dir = dir.root().join(&opts.profile_name);
@@ -168,6 +168,59 @@ pub async fn build(
         });
     }
     Ok(products)
+}
+
+fn check_selected_bin(manifest: &crate::manifest::Manifest, name: &str) -> Result<(), String> {
+    let Some(target) = manifest.targets.get(name) else {
+        return Err(unknown_selection(manifest, name, "binary", |kind| {
+            kind == TargetKind::Executable
+        }));
+    };
+    if target.kind != TargetKind::Executable {
+        return Err(format!(
+            "target `{name}` is {}, not a binary; select it with `--lib {name}`",
+            target.kind.emit()
+        ));
+    }
+    Ok(())
+}
+
+fn check_selected_library(manifest: &crate::manifest::Manifest, name: &str) -> Result<(), String> {
+    let Some(target) = manifest.targets.get(name) else {
+        return Err(unknown_selection(
+            manifest,
+            name,
+            "library",
+            TargetKind::is_library,
+        ));
+    };
+    if !target.kind.is_library() {
+        return Err(format!(
+            "target `{name}` is {}, not a library; select it with `--bin {name}`",
+            target.kind.emit()
+        ));
+    }
+    Ok(())
+}
+
+fn unknown_selection(
+    manifest: &crate::manifest::Manifest,
+    name: &str,
+    group: &str,
+    accepts: impl Fn(TargetKind) -> bool,
+) -> String {
+    let declared = manifest
+        .targets
+        .iter()
+        .filter(|(_, target)| accepts(target.kind))
+        .map(|(name, _)| format!("`{name}`"))
+        .collect::<Vec<_>>();
+    let suffix = if declared.is_empty() {
+        format!("the manifest declares no {group} targets")
+    } else {
+        format!("the manifest declares {}", declared.join(", "))
+    };
+    format!("no {group} target named `{name}`: {suffix}")
 }
 
 /// One `rrc` compile as owned data — everything a pool worker needs to

--- a/crates/rene/src/fresh.rs
+++ b/crates/rene/src/fresh.rs
@@ -273,7 +273,8 @@ fn root_state(
         &compile::Options {
             profile_name: ctx.profile_name.to_owned(),
             profile: ctx.profile.clone(),
-            targets: Vec::new(),
+            bins: Vec::new(),
+            libs: Vec::new(),
             linker: ctx.linker.map(Path::to_path_buf),
             upstream,
             jobs: None,

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -73,9 +73,15 @@ struct BuildArgs {
     #[arg(long, default_value = "dev")]
     profile: String,
 
-    /// Build only this declared target (repeatable). Default: all of them.
-    #[arg(long = "target")]
-    targets: Vec<String>,
+    /// Build only this declared executable target (repeatable). If neither
+    /// `--bin` nor `--lib` is given, build every declared target.
+    #[arg(long = "bin", value_name = "NAME")]
+    bins: Vec<String>,
+
+    /// Build only this declared library target (repeatable). Both `dynlib`
+    /// and `staticlib` targets are libraries.
+    #[arg(long = "lib", value_name = "NAME")]
+    libs: Vec<String>,
 
     /// The linker rrc's link step hands to rustc (`rrc --linker`),
     /// overriding the profile's. Useful where rustc's own discovery resolves
@@ -333,7 +339,8 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
         &compile::Options {
             profile_name: args.profile.clone(),
             profile,
-            targets: args.targets.clone(),
+            bins: args.bins.clone(),
+            libs: args.libs.clone(),
             linker: args.linker.clone(),
             // The cone's artifact digests enter the fingerprint, so a
             // product consuming a changed upstream artifact re-fingerprints.

--- a/crates/rene/src/manifest.rs
+++ b/crates/rene/src/manifest.rs
@@ -89,6 +89,11 @@ impl TargetKind {
         }
     }
 
+    /// Whether `rene build --lib` selects this kind.
+    pub fn is_library(self) -> bool {
+        matches!(self, TargetKind::Dynlib | TargetKind::Staticlib)
+    }
+
     /// Whether `rrc` finishes this kind with a link step — where the
     /// link-only knobs (`runtime_linkage`, `linker`, `link_args`) apply.
     pub fn is_linked(self) -> bool {

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -76,6 +76,16 @@ fn build_fails_cleanly_without_a_manifest() {
 }
 
 #[test]
+fn build_help_uses_kind_specific_target_selectors() {
+    let out = run(&mut rene(&["build", "--help"]));
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let help = String::from_utf8(out.stdout).unwrap();
+    assert!(help.contains("--bin <NAME>"), "{help}");
+    assert!(help.contains("--lib <NAME>"), "{help}");
+    assert!(!help.contains("--target <"), "{help}");
+}
+
+#[test]
 fn build_refuses_a_build_dir_held_by_another_instance() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().join("reussir-build");
@@ -683,11 +693,11 @@ fn build_pins_the_linker_through_the_bake_and_the_compiles() {
     }
 }
 
-/// `--target` narrows the build; unknown target and profile names are
-/// refused with their names.
+/// `--bin` and `--lib` narrow the build by target kind; unknown names,
+/// kind mismatches, and unknown profiles are refused with their names.
 #[cfg(unix)]
 #[test]
-fn build_selects_targets_and_refuses_unknown_names() {
+fn build_selects_bins_and_libs_and_refuses_invalid_names() {
     let tmp_dir = tempfile::tempdir().unwrap();
     let tmp = tmp_dir.path().canonicalize().unwrap();
     let root = tmp.join("reussir-build");
@@ -695,7 +705,7 @@ fn build_selects_targets_and_refuses_unknown_names() {
     let manifest = write_targets_manifest(&tmp);
     let fakes = Fakes::new(&tmp);
 
-    let out = fakes.rene(&["build", "--target", "demo"], &manifest, &root);
+    let out = fakes.rene(&["build", "--bin", "demo"], &manifest, &root);
     assert!(out.status.success(), "stderr: {}", stderr(&out));
     let stdout = String::from_utf8(out.stdout).unwrap();
     assert_eq!(
@@ -708,10 +718,55 @@ fn build_selects_targets_and_refuses_unknown_names() {
     assert!(compiles[0].contains("-O none"), "{}", compiles[0]);
     assert!(compiles[0].contains("-g"), "{}", compiles[0]);
 
-    let out = fakes.rene(&["build", "--target", "bogus"], &manifest, &root);
+    let out = fakes.rene(
+        &["build", "--lib", "shared", "--lib", "archive"],
+        &manifest,
+        &root,
+    );
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let dylib = if cfg!(target_vendor = "apple") {
+        "libshared.dylib"
+    } else {
+        "libshared.so"
+    };
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        [
+            root.join("dev").join(dylib).display().to_string(),
+            root.join("dev").join("libarchive.a").display().to_string(),
+        ]
+    );
+    assert_eq!(fakes.compiles().len(), 3);
+
+    let out = fakes.rene(&["build", "--bin", "bogus"], &manifest, &root);
     assert_eq!(out.status.code(), Some(1));
     assert!(
-        stderr(&out).contains("no target named `bogus`"),
+        stderr(&out).contains("no binary target named `bogus`"),
+        "stderr: {}",
+        stderr(&out)
+    );
+
+    let out = fakes.rene(&["build", "--lib", "bogus"], &manifest, &root);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr(&out).contains("no library target named `bogus`"),
+        "stderr: {}",
+        stderr(&out)
+    );
+
+    let out = fakes.rene(&["build", "--bin", "shared"], &manifest, &root);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr(&out).contains("select it with `--lib shared`"),
+        "stderr: {}",
+        stderr(&out)
+    );
+
+    let out = fakes.rene(&["build", "--lib", "demo"], &manifest, &root);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr(&out).contains("select it with `--bin demo`"),
         "stderr: {}",
         stderr(&out)
     );

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -51,9 +51,9 @@
 // PLAN-NEXT: "--polyffi-libdir",
 // PLAN-NEXT: "{{[^<].*}}"
 
-// An undeclared profile or target is refused by name, before any work.
+// An undeclared profile or binary target is refused by name.
 // RUN: %not %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --profile bogus 2>&1 | %FileCheck %s --check-prefix=NOPROFILE
-// RUN: %not %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --target bogus 2>&1 | %FileCheck %s --check-prefix=NOTARGET
+// RUN: %not %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --bin bogus 2>&1 | %FileCheck %s --check-prefix=NOTARGET
 
 // NOPROFILE: no profile named `bogus`
-// NOTARGET: no target named `bogus`
+// NOTARGET: no binary target named `bogus`

--- a/tests/integration/rene/deps_build.rr
+++ b/tests/integration/rene/deps_build.rr
@@ -17,6 +17,17 @@
 // LISTING: {{[/\\]}}dev{{[/\\]}}demo
 // LISTING: shared
 
+// Kind-specific selectors narrow the listing (and would narrow compilation
+// when a selected product were stale), leaving `--target` available for
+// machine-target selection.
+// RUN: %rene build --manifest-path %S/deps/rene.ncl --build-dir %t.bdir --bin demo %rrc_linker | %FileCheck %s --check-prefix=BIN
+// RUN: %rene build --manifest-path %S/deps/rene.ncl --build-dir %t.bdir --lib shared %rrc_linker | %FileCheck %s --check-prefix=LIB
+
+// BIN: {{[/\\]}}dev{{[/\\]}}demo
+// BIN-NOT: shared
+// LIB: shared
+// LIB-NOT: {{[/\\]}}demo
+
 // The dependencies' interfaces and archives landed in `<profile>/deps/`.
 // RUN: ls %t.bdir/dev/deps | %FileCheck %s --check-prefix=DEPS
 // DEPS-DAG: logs.rri


### PR DESCRIPTION
## Summary

- replace `rene build --target NAME` product selection with repeatable `--bin NAME` and `--lib NAME`
- validate selectors against executable versus library target kinds, with actionable mismatch diagnostics
- keep the no-selector behavior of building every declared product
- leave `--target` available for machine-target support in the follow-up WASM bring-up PR

## Testing

- `ninja -C build rene-test`
- `ninja -C build reussir-ut rrc-test reussir-codegen-test reussir-backend-test`
- `build/bin/reussir-ut`
- `cargo clippy --locked --package rene --all-targets -- -D warnings`
- `ninja -C build check` (438 passed, 5 unsupported)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787883449&installation_model_id=426051&pr_number=482&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F482&signature=c63da14217e6f65956d3e4310f2f96bd06843b4c884377b68d1d67e41e7ee7e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->