### PR TITLE
[rene] add machine target support

### DIFF
--- a/crates/rene/build.rs
+++ b/crates/rene/build.rs
@@ -35,8 +35,9 @@ fn main() {
     // versions of the reachable packages and pruning the rest.
     let lock = fs::read_to_string(&workspace_lock).expect("failed to read Cargo.lock");
 
-    // Archive layout: everything under a `reussir-rt/` root, so unpacking into
-    // the build directory yields `<build-dir>/reussir-rt/{Cargo.toml,src/**}`.
+    // Archive layout: everything under a `reussir-rt/` root, so unpacking
+    // into a target's build prefix yields
+    // `<build-dir>/<target>/reussir-rt/{Cargo.toml,src/**}`.
     let mut tar = tar::Builder::new(Vec::new());
     append_text(&mut tar, "reussir-rt/Cargo.toml", &manifest);
     append_text(&mut tar, "reussir-rt/Cargo.lock", &lock);

--- a/crates/rene/src/compile.rs
+++ b/crates/rene/src/compile.rs
@@ -4,7 +4,8 @@
 //! `src/lib.rr`, the profile's knobs as flags, `--emit` from the target's
 //! kind, and the baked runtime's libdirs for polyffi and the link step.
 //! Artifacts land in `<build-dir>/<profile>/`, named per platform
-//! (`demo`/`demo.exe`, `libdemo.so`/`libdemo.dylib`/`demo.dll`,
+//! (`demo`/`demo.exe`/`demo.wasm`,
+//! `libdemo.so`/`libdemo.dylib`/`demo.dll`,
 //! `libdemo.a`/`demo.lib`).
 //!
 //! Each product's build is recorded in the status database under
@@ -401,11 +402,14 @@ pub(crate) fn product_is_current(
 pub(crate) fn artifact_file(name: &str, kind: TargetKind, triple: Option<&str>) -> String {
     let windows = triple.map_or(cfg!(windows), |t| t.contains("windows"));
     let apple = triple.map_or(cfg!(target_vendor = "apple"), |t| t.contains("apple"));
+    let wasm = triple.is_some_and(|t| t.starts_with("wasm"));
     match kind {
         TargetKind::Executable if windows => format!("{name}.exe"),
+        TargetKind::Executable if wasm => format!("{name}.wasm"),
         TargetKind::Executable => name.to_owned(),
         TargetKind::Dynlib if windows => format!("{name}.dll"),
         TargetKind::Dynlib if apple => format!("lib{name}.dylib"),
+        TargetKind::Dynlib if wasm => format!("{name}.wasm"),
         TargetKind::Dynlib => format!("lib{name}.so"),
         TargetKind::Staticlib if windows => format!("{name}.lib"),
         TargetKind::Staticlib => format!("lib{name}.a"),
@@ -421,20 +425,25 @@ mod tests {
         let linux = Some("x86_64-unknown-linux-gnu");
         let mac = Some("aarch64-apple-darwin");
         let win = Some("x86_64-pc-windows-msvc");
+        let wasm = Some("wasm32-wasip1");
         for (kind, expect) in [
-            (TargetKind::Executable, ["demo", "demo", "demo.exe"]),
+            (
+                TargetKind::Executable,
+                ["demo", "demo", "demo.exe", "demo.wasm"],
+            ),
             (
                 TargetKind::Dynlib,
-                ["libdemo.so", "libdemo.dylib", "demo.dll"],
+                ["libdemo.so", "libdemo.dylib", "demo.dll", "demo.wasm"],
             ),
             (
                 TargetKind::Staticlib,
-                ["libdemo.a", "libdemo.a", "demo.lib"],
+                ["libdemo.a", "libdemo.a", "demo.lib", "libdemo.a"],
             ),
         ] {
             assert_eq!(artifact_file("demo", kind, linux), expect[0]);
             assert_eq!(artifact_file("demo", kind, mac), expect[1]);
             assert_eq!(artifact_file("demo", kind, win), expect[2]);
+            assert_eq!(artifact_file("demo", kind, wasm), expect[3]);
         }
     }
 }

--- a/crates/rene/src/compile.rs
+++ b/crates/rene/src/compile.rs
@@ -36,6 +36,8 @@ pub struct Options {
     pub profile_name: String,
     /// The resolved profile (built-in refined by the manifest's).
     pub profile: Profile,
+    /// The resolved machine target: CLI, profile default, then rustc host.
+    pub target: String,
     /// `--bin` filters; empty together with [`Self::libs`] means every
     /// declared target.
     pub bins: Vec<String>,
@@ -104,11 +106,7 @@ pub async fn build(
     let mut plan = Vec::with_capacity(selected.len());
     for name in selected {
         let kind = manifest.targets[name].kind;
-        let path = out_dir.join(artifact_file(
-            name,
-            kind,
-            opts.profile.target_triple.as_deref(),
-        ));
+        let path = out_dir.join(artifact_file(name, kind, Some(&opts.target)));
         let key = tables::product_key(&opts.profile_name, name);
         let current = product_is_current(dir, &key, &fingerprint, &path)?;
         if current {
@@ -126,6 +124,7 @@ pub async fn build(
             &plan::Options {
                 profile_name: &opts.profile_name,
                 profile: &opts.profile,
+                target: &opts.target,
                 linker: opts.linker.as_deref(),
                 build_dir: dir.root(),
             },
@@ -279,6 +278,7 @@ impl Invocation {
 /// real invocation above and the planned-command dump ([`crate::plan`]).
 pub(crate) fn profile_flags(
     profile: &Profile,
+    target: &str,
     kind: TargetKind,
     linker: Option<&Path>,
 ) -> Vec<String> {
@@ -314,9 +314,7 @@ pub(crate) fn profile_flags(
     if let Some(encoding) = &profile.nullary_variant_encoding {
         push(&mut args, "--nullary-variant-encoding", encoding);
     }
-    if let Some(triple) = &profile.target_triple {
-        push(&mut args, "--target-triple", triple);
-    }
+    push(&mut args, "--target-triple", target);
     if let Some(cpu) = &profile.target_cpu {
         push(&mut args, "--target-cpu", cpu);
     }
@@ -364,6 +362,7 @@ pub(crate) fn fingerprint(
     let mut hasher = blake3::Hasher::new();
     hasher.update(deps::config_hash(&loaded.dump).as_bytes());
     hasher.update(opts.profile_name.as_bytes());
+    hasher.update(opts.target.as_bytes());
     for file in files {
         hasher.update(file.path.as_bytes());
         hasher.update(&file.record.hash);
@@ -398,7 +397,7 @@ pub(crate) fn product_is_current(
 }
 
 /// The artifact's file name for `name`, per the target platform — the
-/// profile's `target_triple` when set, the host otherwise.
+/// resolved machine target.
 pub(crate) fn artifact_file(name: &str, kind: TargetKind, triple: Option<&str>) -> String {
     let windows = triple.map_or(cfg!(windows), |t| t.contains("windows"));
     let apple = triple.map_or(cfg!(target_vendor = "apple"), |t| t.contains("apple"));

--- a/crates/rene/src/exec.rs
+++ b/crates/rene/src/exec.rs
@@ -22,13 +22,13 @@ use futures_util::StreamExt;
 use futures_util::stream::FuturesUnordered;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
+use crate::compile;
 use crate::db::BuildDir;
 use crate::deps;
 use crate::fresh;
 use crate::manifest::Profile;
 use crate::plan;
 use crate::pool::Pool;
-use crate::compile;
 use crate::resolve::Graph;
 use crate::rt::RtArtifacts;
 
@@ -36,6 +36,7 @@ use crate::rt::RtArtifacts;
 pub struct Options<'a> {
     pub profile_name: &'a str,
     pub profile: &'a Profile,
+    pub target: &'a str,
     /// `rene build --linker`, overriding the profile's.
     pub linker: Option<&'a Path>,
     /// `rene build -j`: the process admission bound (held by the [`Pool`]).
@@ -140,6 +141,7 @@ async fn build_node(
         dir: Some(dir),
         profile_name: opts.profile_name,
         profile: opts.profile,
+        target: opts.target,
         linker: opts.linker,
         build_dir: opts.build_dir,
     };
@@ -169,6 +171,7 @@ async fn build_node(
     let plan_opts = plan::Options {
         profile_name: opts.profile_name,
         profile: opts.profile,
+        target: opts.target,
         linker: opts.linker,
         build_dir: opts.build_dir,
     };

--- a/crates/rene/src/fresh.rs
+++ b/crates/rene/src/fresh.rs
@@ -124,6 +124,7 @@ pub struct Context<'a> {
     pub dir: Option<&'a BuildDir>,
     pub profile_name: &'a str,
     pub profile: &'a Profile,
+    pub target: &'a str,
     /// The `--linker` override the compared build ran (or would run) with —
     /// part of the root products' fingerprints.
     pub linker: Option<&'a Path>,
@@ -133,10 +134,10 @@ pub struct Context<'a> {
 /// The recorded runtime bake, if any — the toolchain identity freshness
 /// compares against, and the real paths the plan dump expands its
 /// placeholders with.
-pub fn recorded_bake(dir: Option<&BuildDir>) -> Result<Option<RtArtifacts>, String> {
+pub fn recorded_bake(dir: Option<&BuildDir>, target: &str) -> Result<Option<RtArtifacts>, String> {
     let Some(dir) = dir else { return Ok(None) };
     Ok(dir
-        .status(tables::RT_ARTIFACTS_KEY)
+        .status(&tables::rt_artifacts_key(target))
         .map_err(|e| e.to_string())?
         .and_then(|record| serde_json::from_str(&record).ok()))
 }
@@ -144,7 +145,7 @@ pub fn recorded_bake(dir: Option<&BuildDir>) -> Result<Option<RtArtifacts>, Stri
 /// One node's local freshness — no upstream-stale propagation, so at
 /// execution time (when the cone is final) the answer is exact.
 pub fn node_state(graph: &Graph, name: &str, ctx: &Context<'_>) -> Result<State, String> {
-    let bake = recorded_bake(ctx.dir)?;
+    let bake = recorded_bake(ctx.dir, ctx.target)?;
     let deps_dir = ctx.build_dir.join(ctx.profile_name).join("deps");
     if name == graph.root {
         root_state(graph, ctx, bake.as_ref())
@@ -156,7 +157,7 @@ pub fn node_state(graph: &Graph, name: &str, ctx: &Context<'_>) -> Result<State,
 /// The freshness of every node of the graph, keyed by package name.
 pub fn states(graph: &Graph, ctx: &Context<'_>) -> Result<BTreeMap<String, State>, String> {
     let deps_dir = ctx.build_dir.join(ctx.profile_name).join("deps");
-    let bake = recorded_bake(ctx.dir)?;
+    let bake = recorded_bake(ctx.dir, ctx.target)?;
     let cones = plan::transitive_deps(graph);
     let mut states: BTreeMap<String, State> = BTreeMap::new();
     for name in plan::topological(graph) {
@@ -219,7 +220,7 @@ fn dep_state(
     if record.config_hash != deps::config_hash(&node.loaded.dump) {
         return Ok(State::ConfigChanged);
     }
-    if record.profile_digest != profile_digest(ctx.profile_name, ctx.profile) {
+    if record.profile_digest != profile_digest(ctx.profile_name, ctx.profile, ctx.target) {
         return Ok(State::ProfileChanged);
     }
     if record.toolchain != bake.rustc_version {
@@ -236,7 +237,7 @@ fn dep_state(
     for dep in &graph.nodes[name].dependencies {
         // Direct edges suffice locally: transitive drift reaches this node
         // through its dependency's own record (and the propagation pass).
-        if record.upstream.get(dep) != Some(&artifact_digest(deps_dir, dep)) {
+        if record.upstream.get(dep) != Some(&artifact_digest(deps_dir, dep, ctx.target)) {
             return Ok(State::UpstreamChanged(dep.clone()));
         }
     }
@@ -265,7 +266,11 @@ fn root_state(
     }
     let files = dir.sources().map_err(|e| e.to_string())?;
     let deps_dir = ctx.build_dir.join(ctx.profile_name).join("deps");
-    let upstream = upstream_digests(&deps_dir, &plan::transitive_deps(graph)[&graph.root]);
+    let upstream = upstream_digests(
+        &deps_dir,
+        &plan::transitive_deps(graph)[&graph.root],
+        ctx.target,
+    );
     let fingerprint = compile::fingerprint(
         &node.loaded,
         &files,
@@ -273,6 +278,7 @@ fn root_state(
         &compile::Options {
             profile_name: ctx.profile_name.to_owned(),
             profile: ctx.profile.clone(),
+            target: ctx.target.to_owned(),
             bins: Vec::new(),
             libs: Vec::new(),
             linker: ctx.linker.map(Path::to_path_buf),
@@ -283,11 +289,7 @@ fn root_state(
     let out_dir = ctx.build_dir.join(ctx.profile_name);
     for (target, decl) in &node.loaded.manifest.targets {
         let key = tables::product_key(ctx.profile_name, target);
-        let path = out_dir.join(compile::artifact_file(
-            target,
-            decl.kind,
-            ctx.profile.target_triple.as_deref(),
-        ));
+        let path = out_dir.join(compile::artifact_file(target, decl.kind, Some(ctx.target)));
         if !compile::product_is_current(dir, &key, &fingerprint, &path)? {
             return Ok(State::TargetStale(target.clone()));
         }
@@ -312,15 +314,15 @@ pub fn record_dep(
     let deps_dir = ctx.build_dir.join(ctx.profile_name).join("deps");
     let record = DepRecord {
         config_hash: deps::config_hash(&node.loaded.dump),
-        profile_digest: profile_digest(ctx.profile_name, ctx.profile),
+        profile_digest: profile_digest(ctx.profile_name, ctx.profile, ctx.target),
         toolchain: bake.rustc_version.clone(),
         upstream: graph.nodes[name]
             .dependencies
             .iter()
-            .map(|dep| (dep.clone(), artifact_digest(&deps_dir, dep)))
+            .map(|dep| (dep.clone(), artifact_digest(&deps_dir, dep, ctx.target)))
             .collect(),
         rri: deps_dir.join(format!("{name}.rri")),
-        archive: plan::archive_path(&deps_dir, name),
+        archive: plan::archive_path(&deps_dir, name, ctx.target),
     };
     let record = serde_json::to_string(&record).map_err(|e| e.to_string())?;
     let sources = serde_json::to_string(sources).map_err(|e| e.to_string())?;
@@ -335,11 +337,11 @@ pub fn record_dep(
 /// An absent artifact digests to a sentinel rather than an error, so a
 /// fingerprint can be taken before anything is built — and changes the
 /// moment the artifact appears.
-pub fn artifact_digest(deps_dir: &Path, name: &str) -> String {
+pub fn artifact_digest(deps_dir: &Path, name: &str, target: &str) -> String {
     let mut hasher = blake3::Hasher::new();
     for path in [
         deps_dir.join(format!("{name}.rri")),
-        plan::archive_path(deps_dir, name),
+        plan::archive_path(deps_dir, name, target),
     ] {
         match std::fs::read(&path) {
             Ok(bytes) => {
@@ -355,25 +357,33 @@ pub fn artifact_digest(deps_dir: &Path, name: &str) -> String {
 
 /// The root's whole cone digested — what `rene build` folds into the
 /// product fingerprints.
-pub fn root_upstream_digests(graph: &Graph, deps_dir: &Path) -> BTreeMap<String, String> {
-    upstream_digests(deps_dir, &plan::transitive_deps(graph)[&graph.root])
+pub fn root_upstream_digests(
+    graph: &Graph,
+    deps_dir: &Path,
+    target: &str,
+) -> BTreeMap<String, String> {
+    upstream_digests(deps_dir, &plan::transitive_deps(graph)[&graph.root], target)
 }
 
 /// The whole cone's artifact digests, name-keyed — what a consumer's
 /// fingerprint hashes.
-pub fn upstream_digests(deps_dir: &Path, cone: &[String]) -> BTreeMap<String, String> {
+pub fn upstream_digests(
+    deps_dir: &Path,
+    cone: &[String],
+    target: &str,
+) -> BTreeMap<String, String> {
     cone.iter()
-        .map(|dep| (dep.clone(), artifact_digest(deps_dir, dep)))
+        .map(|dep| (dep.clone(), artifact_digest(deps_dir, dep, target)))
         .collect()
 }
 
 /// Digest of the knobs a profile expands to for a dependency's compiles
 /// (archives are the shared shape; the profile name rides along because two
 /// names with equal knobs still build into different directories).
-fn profile_digest(profile_name: &str, profile: &Profile) -> String {
+fn profile_digest(profile_name: &str, profile: &Profile, target: &str) -> String {
     let mut hasher = blake3::Hasher::new();
     hasher.update(profile_name.as_bytes());
-    for flag in compile::profile_flags(profile, TargetKind::Staticlib, None) {
+    for flag in compile::profile_flags(profile, target, TargetKind::Staticlib, None) {
         hasher.update(flag.as_bytes());
         hasher.update(&[0]);
     }
@@ -385,6 +395,8 @@ mod tests {
     use super::*;
     use crate::manifest;
     use crate::resolve;
+
+    const TEST_TARGET: &str = "x86_64-unknown-test";
 
     /// A two-package graph on disk (`app` → `util`), an open build dir with
     /// a fake bake record, and fake built artifacts for `util`.
@@ -419,15 +431,17 @@ mod tests {
         let build_dir = tmp.path().join("build");
         let dir = BuildDir::open(&build_dir).unwrap();
         let bake = fake_bake();
-        dir.set_status(&[(
-            tables::RT_ARTIFACTS_KEY,
-            &serde_json::to_string(&bake).unwrap(),
-        )])
-        .unwrap();
+        let bake_key = tables::rt_artifacts_key(TEST_TARGET);
+        dir.set_status(&[(bake_key.as_str(), &serde_json::to_string(&bake).unwrap())])
+            .unwrap();
         let deps_dir = build_dir.join("dev").join("deps");
         std::fs::create_dir_all(&deps_dir).unwrap();
         std::fs::write(deps_dir.join("util.rri"), "interface").unwrap();
-        std::fs::write(plan::archive_path(&deps_dir, "util"), "archive").unwrap();
+        std::fs::write(
+            plan::archive_path(&deps_dir, "util", TEST_TARGET),
+            "archive",
+        )
+        .unwrap();
         Fixture {
             _tmp: tmp,
             graph,
@@ -439,10 +453,11 @@ mod tests {
 
     fn fake_bake() -> RtArtifacts {
         RtArtifacts {
+            target: TEST_TARGET.to_owned(),
             rustc: PathBuf::from("rustc"),
             rustc_version: "rustc 1.0.0-test".to_owned(),
             rust_libdir: PathBuf::from("lib"),
-            deps_dir: PathBuf::from("deps"),
+            deps_dirs: vec![PathBuf::from("deps")],
             staticlib: PathBuf::from("librt.a"),
             rlib: PathBuf::from("librt.rlib"),
         }
@@ -453,6 +468,7 @@ mod tests {
             dir: Some(&f.dir),
             profile_name: "dev",
             profile,
+            target: TEST_TARGET,
             linker: None,
             build_dir: &f.build_dir,
         }
@@ -526,14 +542,18 @@ mod tests {
         record_dep(&f.graph, "util", &ctx, &bake, &util_sources(&f)).unwrap();
 
         // A missing artifact is named.
-        std::fs::remove_file(plan::archive_path(&f.deps_dir, "util")).unwrap();
+        std::fs::remove_file(plan::archive_path(&f.deps_dir, "util", TEST_TARGET)).unwrap();
         let states_now = states(&f.graph, &ctx).unwrap();
         assert!(
             matches!(&states_now["util"], State::ArtifactMissing(path) if path.contains("util")),
             "{:?}",
             states_now["util"]
         );
-        std::fs::write(plan::archive_path(&f.deps_dir, "util"), "archive").unwrap();
+        std::fs::write(
+            plan::archive_path(&f.deps_dir, "util", TEST_TARGET),
+            "archive",
+        )
+        .unwrap();
 
         // A different profile name: profile-changed (records are per
         // profile *name*, two names never share).
@@ -548,11 +568,9 @@ mod tests {
         // A changed toolchain: toolchain-changed.
         let mut newer = fake_bake();
         newer.rustc_version = "rustc 2.0.0-test".to_owned();
+        let bake_key = tables::rt_artifacts_key(TEST_TARGET);
         f.dir
-            .set_status(&[(
-                tables::RT_ARTIFACTS_KEY,
-                &serde_json::to_string(&newer).unwrap(),
-            )])
+            .set_status(&[(bake_key.as_str(), &serde_json::to_string(&newer).unwrap())])
             .unwrap();
         let states_now = states(&f.graph, &ctx).unwrap();
         assert_eq!(states_now["util"], State::ToolchainChanged);
@@ -579,9 +597,9 @@ mod tests {
 
         // (a) artifact_digest changes when bytes change, so any recorded
         // consumer mismatches.
-        let before = artifact_digest(&f.deps_dir, "util");
+        let before = artifact_digest(&f.deps_dir, "util", TEST_TARGET);
         std::fs::write(f.deps_dir.join("util.rri"), "interface v2").unwrap();
-        assert_ne!(before, artifact_digest(&f.deps_dir, "util"));
+        assert_ne!(before, artifact_digest(&f.deps_dir, "util", TEST_TARGET));
 
         // (b) a current node over a non-current cone reports the wait:
         // util's record now names the old… re-record, then invalidate util

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -83,6 +83,11 @@ struct BuildArgs {
     #[arg(long = "lib", value_name = "NAME")]
     libs: Vec<String>,
 
+    /// Build for this machine target triple. Overrides the selected
+    /// profile's `default_target_triple`; otherwise rustc's host is used.
+    #[arg(long, value_name = "TRIPLE")]
+    target: Option<String>,
+
     /// The linker rrc's link step hands to rustc (`rrc --linker`),
     /// overriding the profile's. Useful where rustc's own discovery resolves
     /// the wrong tool.
@@ -137,6 +142,12 @@ struct InspectArgs {
     /// The profile the `plan` section renders against.
     #[arg(long, default_value = "dev")]
     profile: String,
+
+    /// Render commands for this machine target triple. Overrides the
+    /// selected profile's `default_target_triple`; otherwise rustc's host
+    /// is used.
+    #[arg(long, value_name = "TRIPLE")]
+    target: Option<String>,
 
     /// The linker override the compared build ran with (`rene build
     /// --linker`): part of the root products' fingerprints, so freshness
@@ -286,7 +297,12 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
     // the pipeline's bars after.
     let progress = indicatif::MultiProgress::new();
     let bake_linker = args.linker.clone().or_else(|| profile.linker.clone());
-    let artifacts = rt::prepare(&dir, bake_linker.as_deref(), &progress).await?;
+    let requested_target = args
+        .target
+        .as_deref()
+        .or(profile.default_target_triple.as_deref());
+    let artifacts = rt::prepare(&dir, requested_target, bake_linker.as_deref(), &progress).await?;
+    let target = artifacts.target.clone();
 
     // No declared targets: stop after the bake, reporting the libdirs for
     // whoever drives rrc by hand — the pre-target workflow, kept working.
@@ -315,6 +331,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
         &exec::Options {
             profile_name: &args.profile,
             profile: &profile,
+            target: &target,
             linker: args.linker.as_deref(),
             jobs: args.jobs,
             build_dir: &root,
@@ -339,6 +356,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
         &compile::Options {
             profile_name: args.profile.clone(),
             profile,
+            target: target.clone(),
             bins: args.bins.clone(),
             libs: args.libs.clone(),
             linker: args.linker.clone(),
@@ -349,6 +367,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
             upstream: rene::fresh::root_upstream_digests(
                 &graph,
                 &root.join(&args.profile).join("deps"),
+                &target,
             ),
             jobs: args.jobs,
         },
@@ -452,13 +471,19 @@ async fn inspect(args: &InspectArgs) -> Result<(), String> {
         }
         if args.commands {
             let profile = manifest::resolve_profile(&loaded.manifest, &args.profile)?;
-            let bake = fresh::recorded_bake(held.as_ref())?;
+            let requested_target = args
+                .target
+                .as_deref()
+                .or(profile.default_target_triple.as_deref());
+            let target = rt::resolve_target(requested_target).await?;
+            let bake = fresh::recorded_bake(held.as_ref(), &target)?;
             let states = fresh::states(
                 &graph,
                 &fresh::Context {
                     dir: held.as_ref(),
                     profile_name: &args.profile,
                     profile: &profile,
+                    target: &target,
                     linker: args.linker.as_deref(),
                     build_dir: &root,
                 },
@@ -468,6 +493,7 @@ async fn inspect(args: &InspectArgs) -> Result<(), String> {
                 &plan::Options {
                     profile_name: &args.profile,
                     profile: &profile,
+                    target: &target,
                     linker: args.linker.as_deref(),
                     build_dir: &root,
                 },

--- a/crates/rene/src/manifest.rs
+++ b/crates/rene/src/manifest.rs
@@ -143,8 +143,8 @@ pub struct Profile {
     pub sanitizers: Vec<String>,
     /// `rrc --nullary-variant-encoding`.
     pub nullary_variant_encoding: Option<String>,
-    /// `rrc --target-triple`.
-    pub target_triple: Option<String>,
+    /// Default machine target when `rene build --target` is absent.
+    pub default_target_triple: Option<String>,
     /// `rrc --target-cpu`.
     pub target_cpu: Option<String>,
     /// `rrc --target-features`.
@@ -182,7 +182,7 @@ impl Profile {
             runtime_linkage,
             linker,
             nullary_variant_encoding,
-            target_triple,
+            default_target_triple,
             target_cpu,
             target_features,
             reuse_across_call,
@@ -435,7 +435,12 @@ mod tests {
                 archive = { kind = 'staticlib },
               },
               profiles = {
-                release = { lto = "thin", codegen_units = 4, link_args = ["-lm"] },
+                release = {
+                  lto = "thin",
+                  codegen_units = 4,
+                  link_args = ["-lm"],
+                  default_target_triple = "wasm32-unknown-unknown",
+                },
                 asan = { sanitizers = ["address"], nullary_variant_encoding = "arch-independent" },
               },
             }
@@ -450,6 +455,10 @@ mod tests {
         assert_eq!(m.profiles["release"].lto.as_deref(), Some("thin"));
         assert_eq!(m.profiles["release"].codegen_units, Some(4));
         assert_eq!(m.profiles["release"].link_args, ["-lm"]);
+        assert_eq!(
+            m.profiles["release"].default_target_triple.as_deref(),
+            Some("wasm32-unknown-unknown")
+        );
         assert_eq!(m.profiles["asan"].sanitizers, ["address"]);
     }
 
@@ -498,6 +507,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         for manifest in [
             r#"{ package = { name = "p" }, profiles = { dev = { optt = "none" } } }"#,
+            r#"{ package = { name = "p" }, profiles = { dev = { target_triple = "x" } } }"#,
             r#"{ package = { name = "p" }, targets = { t = { kind = 'executable, knid = 1 } } }"#,
             r#"{ package = { name = "p" }, targets = { t = { kind = "exe" } } }"#,
         ] {

--- a/crates/rene/src/plan.rs
+++ b/crates/rene/src/plan.rs
@@ -29,6 +29,7 @@ use crate::rt::RtArtifacts;
 pub struct Options<'a> {
     pub profile_name: &'a str,
     pub profile: &'a Profile,
+    pub target: &'a str,
     /// `rene build --linker`, overriding the profile's.
     pub linker: Option<&'a Path>,
     pub build_dir: &'a Path,
@@ -76,19 +77,25 @@ pub(crate) fn node_commands(
             .targets
             .iter()
             .map(|(target, decl)| {
-                let out = profile_dir.join(compile::artifact_file(
-                    target,
-                    decl.kind,
-                    opts.profile.target_triple.as_deref(),
-                ));
+                let out =
+                    profile_dir.join(compile::artifact_file(target, decl.kind, Some(opts.target)));
                 let mut args = package_args(node, &out, decl.kind.emit());
-                args.extend(compile::profile_flags(opts.profile, decl.kind, opts.linker));
+                args.extend(compile::profile_flags(
+                    opts.profile,
+                    opts.target,
+                    decl.kind,
+                    opts.linker,
+                ));
                 args.extend(polyffi_args(bake));
                 args.extend(externs.iter().cloned());
                 if decl.kind.is_linked() {
                     for dep in &link_order {
                         args.push("--link-lib".to_owned());
-                        args.push(archive_path(&deps_dir, dep).display().to_string());
+                        args.push(
+                            archive_path(&deps_dir, dep, opts.target)
+                                .display()
+                                .to_string(),
+                        );
                     }
                 }
                 PlannedCommand {
@@ -103,10 +110,11 @@ pub(crate) fn node_commands(
         let rri = deps_dir.join(format!("{name}.rri"));
         let mut interface = package_args(node, &rri, "rri");
         interface.extend(externs.iter().cloned());
-        let archive = archive_path(&deps_dir, name);
+        let archive = archive_path(&deps_dir, name, opts.target);
         let mut staticlib = package_args(node, &archive, "staticlib");
         staticlib.extend(compile::profile_flags(
             opts.profile,
+            opts.target,
             TargetKind::Staticlib,
             opts.linker,
         ));
@@ -176,6 +184,7 @@ pub fn render(
     });
     serde_json::json!({
         "profile": opts.profile_name,
+        "target": opts.target,
         "env": { "REUSSIR_RUSTC": rustc },
         "nodes": nodes,
     })
@@ -214,23 +223,25 @@ fn extern_args(graph: &Graph, deps: &[String], deps_dir: &Path) -> Vec<String> {
 }
 
 fn polyffi_args(bake: Option<&RtArtifacts>) -> Vec<String> {
-    let (rust_libdir, rt_deps) = match bake {
-        Some(bake) => (
-            bake.rust_libdir.display().to_string(),
-            bake.deps_dir.display().to_string(),
-        ),
-        None => (RUST_LIBDIR.to_owned(), RT_DEPS_DIR.to_owned()),
+    let libdirs = match bake {
+        Some(bake) => bake
+            .libdirs()
+            .map(|path| path.display().to_string())
+            .collect(),
+        None => vec![RUST_LIBDIR.to_owned(), RT_DEPS_DIR.to_owned()],
     };
-    vec![
-        "--polyffi-libdir".to_owned(),
-        rust_libdir,
-        "--polyffi-libdir".to_owned(),
-        rt_deps,
-    ]
+    libdirs
+        .into_iter()
+        .flat_map(|path| ["--polyffi-libdir".to_owned(), path])
+        .collect()
 }
 
-pub(crate) fn archive_path(deps_dir: &Path, name: &str) -> PathBuf {
-    deps_dir.join(compile::artifact_file(name, TargetKind::Staticlib, None))
+pub(crate) fn archive_path(deps_dir: &Path, name: &str, target: &str) -> PathBuf {
+    deps_dir.join(compile::artifact_file(
+        name,
+        TargetKind::Staticlib,
+        Some(target),
+    ))
 }
 
 /// Dependency-first order: every node appears after all of its dependencies

--- a/crates/rene/src/rt.rs
+++ b/crates/rene/src/rt.rs
@@ -308,6 +308,11 @@ fn fresh_bake(
         return Ok(None);
     };
     let valid = artifacts.target == toolchain.target
+        // The path is part of an explicit toolchain selection. In
+        // particular, changing REUSSIR_RUSTC from a cached bare `rustc` to a
+        // rustup/Nix absolute path must not silently restore the old value
+        // merely because both binaries report the same version string.
+        && artifacts.rustc == toolchain.rustc
         && artifacts.rustc_version == toolchain.version
         && artifacts.rlib.is_file()
         && artifacts.staticlib.is_file()

--- a/crates/rene/src/rt.rs
+++ b/crates/rene/src/rt.rs
@@ -177,6 +177,18 @@ fn validate_target(target: &str) -> Result<String, String> {
     }
 }
 
+/// Whether the bundled runtime must use its platform allocator instead of
+/// mimalloc for `target`.
+///
+/// mimalloc's backend is C and does not support WebAssembly targets. WASI
+/// supplies the libc allocator used by reussir-rt's no-default-features
+/// backend; freestanding wasm targets are classified the same way so they
+/// fail, if unsupported, at that platform allocator boundary rather than in
+/// mimalloc's native C build.
+fn target_should_disable_mimalloc(target: &str) -> bool {
+    matches!(target.split('-').next(), Some("wasm32" | "wasm64"))
+}
+
 async fn capture(program: &Path, args: &[&str]) -> Result<String, String> {
     let out = compio::process::Command::new(program)
         .args(args)
@@ -313,17 +325,18 @@ async fn cargo_build(
     linker: Option<&Path>,
 ) -> Result<(PathBuf, PathBuf, Vec<PathBuf>), String> {
     let mut cmd = compio::process::Command::new(&toolchain.cargo);
-    cmd.args([
-        "build",
-        "--release",
-        "--target",
-        toolchain.target.as_str(),
-        "--message-format=json-render-diagnostics",
-    ])
-    .current_dir(src_dir)
-    // Pin the rustc cargo delegates to, so the recorded version and
-    // libdir describe the compiler that actually built the artifacts.
-    .env("RUSTC", &toolchain.rustc);
+    cmd.args(["build", "--release", "--target", toolchain.target.as_str()]);
+    // The bundled mimalloc backend builds C code and is not yet a WebAssembly
+    // allocator. WASI supplies the libc malloc family used by the runtime's
+    // size-recovering fallback, so select that backend for wasm targets.
+    if target_should_disable_mimalloc(&toolchain.target) {
+        cmd.arg("--no-default-features");
+    }
+    cmd.arg("--message-format=json-render-diagnostics")
+        .current_dir(src_dir)
+        // Pin the rustc cargo delegates to, so the recorded version and
+        // libdir describe the compiler that actually built the artifacts.
+        .env("RUSTC", &toolchain.rustc);
     if let Some(linker) = linker {
         // Cargo's target-specific linker configuration, as an environment
         // variable: `CARGO_TARGET_<TARGET>_LINKER`. Unlike RUSTFLAGS this
@@ -418,6 +431,24 @@ async fn cargo_build(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn allocator_backend_follows_the_target_architecture() {
+        for target in [
+            "wasm32-wasip1",
+            "wasm32-unknown-unknown",
+            "wasm64-unknown-unknown",
+        ] {
+            assert!(target_should_disable_mimalloc(target), "{target}");
+        }
+        for target in [
+            "x86_64-unknown-linux-gnu",
+            "aarch64-apple-darwin",
+            "wasmtime-unknown-linux-gnu",
+        ] {
+            assert!(!target_should_disable_mimalloc(target), "{target}");
+        }
+    }
 
     #[test]
     fn the_bundle_unpacks_to_a_standalone_crate() {

--- a/crates/rene/src/rt.rs
+++ b/crates/rene/src/rt.rs
@@ -5,10 +5,11 @@
 //! cross-platform: rlibs and symbol hashes are version-locked to the rustc
 //! that produced them, so the runtime must be built by the user's toolchain;
 //! see docs/design/system-rust-runtime.md). `prepare` unpacks it into
-//! `<build-dir>/reussir-rt/` and runs `cargo build --release` there, yielding
-//! the rlib+deps directory polymorphic FFI links against (`rustc -L`) and the
-//! static library final executables link. The result is recorded in the
-//! status database and reused until the bundle hash or the toolchain changes.
+//! `<build-dir>/<target>/reussir-rt/` and runs Cargo with `--target <target>`
+//! there, yielding the rlib+deps directory polymorphic FFI
+//! links against (`rustc -L`) and the static library final executables link.
+//! The result is recorded per target in the status database and reused until
+//! the bundle hash or the toolchain changes.
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -35,10 +36,12 @@ pub fn unpack(dest: &Path) -> std::io::Result<()> {
     tar::Archive::new(decoder).unpack(dest)
 }
 
-/// The baked runtime: the toolchain that built it and the artifacts consumers
-/// need. Stored as JSON under [`tables::RT_ARTIFACTS_KEY`].
+/// The baked runtime: the target, toolchain that built it, and artifacts
+/// consumers need. Stored as JSON under [`tables::rt_artifacts_key`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RtArtifacts {
+    /// The machine target this runtime was baked for.
+    pub target: String,
     /// The rustc that baked the runtime — also the one `rrc`'s link step and
     /// polyffi texture compiles must use (`REUSSIR_RUSTC`), so the runtime
     /// and everything linked against it agree on one toolchain.
@@ -48,9 +51,10 @@ pub struct RtArtifacts {
     /// The toolchain's target libdir (`rustc --print target-libdir`) — the
     /// "detected rust lib" directory polyffi links the standard library from.
     pub rust_libdir: PathBuf,
-    /// The baked `deps` directory: `libreussir_rt`'s rlib and every
-    /// dependency rlib, for polyffi's `rustc -L`.
-    pub deps_dir: PathBuf,
+    /// Cargo dependency directories needed to consume the runtime. With an
+    /// explicit `--target`, target libraries and host-built proc macros live
+    /// in different trees; polyffi's `rustc -L` needs both.
+    pub deps_dirs: Vec<PathBuf>,
     /// The static library final executables link the runtime from.
     pub staticlib: PathBuf,
     pub rlib: PathBuf,
@@ -58,9 +62,11 @@ pub struct RtArtifacts {
 
 impl RtArtifacts {
     /// The library directories to pass to `rrc` (`--polyffi-libdir`): the
-    /// detected rust lib and the freshly baked runtime.
-    pub fn libdirs(&self) -> [&Path; 2] {
-        [&self.rust_libdir, &self.deps_dir]
+    /// target standard library and every Cargo dependency directory needed
+    /// by the freshly baked runtime.
+    pub fn libdirs(&self) -> impl Iterator<Item = &Path> {
+        std::iter::once(self.rust_libdir.as_path())
+            .chain(self.deps_dirs.iter().map(PathBuf::as_path))
     }
 }
 
@@ -69,9 +75,9 @@ struct Toolchain {
     cargo: PathBuf,
     rustc: PathBuf,
     version: String,
-    /// The host triple `rustc -vV` reports — the target the bake builds for,
-    /// and so the key of cargo's target-specific configuration.
-    host: String,
+    /// The resolved target the bake builds for, and so the key of cargo's
+    /// target-specific configuration.
+    target: String,
     rust_libdir: PathBuf,
 }
 
@@ -80,14 +86,9 @@ impl Toolchain {
     /// honors), then cargo's own `CARGO`/`RUSTC`, then `PATH` — which
     /// respects rustup shims, so a `rust-toolchain.toml` in the user's
     /// project still picks the toolchain naturally.
-    async fn resolve() -> Result<Self, String> {
-        let pick = |specific: &str, generic: &str, default: &str| {
-            std::env::var_os(specific)
-                .or_else(|| std::env::var_os(generic))
-                .map_or_else(|| PathBuf::from(default), PathBuf::from)
-        };
-        let cargo = pick("REUSSIR_CARGO", "CARGO", "cargo");
-        let rustc = pick("REUSSIR_RUSTC", "RUSTC", "rustc");
+    async fn resolve(requested_target: Option<&str>) -> Result<Self, String> {
+        let cargo = pick_program("REUSSIR_CARGO", "CARGO", "cargo");
+        let rustc = pick_program("REUSSIR_RUSTC", "RUSTC", "rustc");
         let verbose_version = capture(&rustc, &["-vV"]).await?;
         let version = verbose_version
             .lines()
@@ -105,15 +106,74 @@ impl Toolchain {
             })?
             .trim()
             .to_owned();
-        let rust_libdir =
-            PathBuf::from(capture(&rustc, &["--print", "target-libdir"]).await?);
+        let target = match requested_target {
+            Some(target) => validate_target(target)?,
+            None => validate_target(&host)?,
+        };
+        let rust_libdir = PathBuf::from(
+            capture(
+                &rustc,
+                &["--print", "target-libdir", "--target", target.as_str()],
+            )
+            .await?,
+        );
         Ok(Toolchain {
             cargo,
             rustc,
             version,
-            host,
+            target,
             rust_libdir,
         })
+    }
+}
+
+fn pick_program(specific: &str, generic: &str, default: &str) -> PathBuf {
+    std::env::var_os(specific)
+        .or_else(|| std::env::var_os(generic))
+        .map_or_else(|| PathBuf::from(default), PathBuf::from)
+}
+
+/// Resolve the target used by a command that does not bake the runtime:
+/// an explicit/profile target wins, otherwise use the selected rustc's host.
+pub async fn resolve_target(requested: Option<&str>) -> Result<String, String> {
+    if let Some(target) = requested {
+        return validate_target(target);
+    }
+    let rustc = pick_program("REUSSIR_RUSTC", "RUSTC", "rustc");
+    let verbose_version = capture(&rustc, &["-vV"]).await?;
+    verbose_version
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))
+        .ok_or_else(|| {
+            format!(
+                "`{} -vV` reported no `host:` line:\n{verbose_version}",
+                rustc.display()
+            )
+        })
+        .and_then(|host| validate_target(host.trim()))
+}
+
+/// Target triples become one build-directory path component and one status
+/// key component. Accept Rust-style triples, including dotted ARM targets,
+/// while rejecting path syntax and empty/special components.
+fn validate_target(target: &str) -> Result<String, String> {
+    if target.ends_with(".json") {
+        return Err(format!(
+            "invalid target triple `{target}`: custom target JSON specifications are not supported"
+        ));
+    }
+    let valid = !target.is_empty()
+        && target != "."
+        && target != ".."
+        && target
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if valid {
+        Ok(target.to_owned())
+    } else {
+        Err(format!(
+            "invalid target triple `{target}`: expected only ASCII letters, digits, `-`, `_`, or `.`"
+        ))
     }
 }
 
@@ -151,10 +211,11 @@ async fn capture(program: &Path, args: &[&str]) -> Result<String, String> {
 /// artifacts are equivalent.
 pub async fn prepare(
     dir: &BuildDir,
+    requested_target: Option<&str>,
     linker: Option<&Path>,
     progress: &indicatif::MultiProgress,
 ) -> Result<RtArtifacts, String> {
-    let toolchain = Toolchain::resolve().await?;
+    let toolchain = Toolchain::resolve(requested_target).await?;
     let hash = bundle_hash();
 
     if let Some(cached) = fresh_bake(dir, &toolchain, &hash)? {
@@ -162,15 +223,18 @@ pub async fn prepare(
         return Ok(cached);
     }
 
-    let src_dir = dir.root().join(RT_DIR);
+    let target_dir = dir.root().join(&toolchain.target);
+    let src_dir = target_dir.join(RT_DIR);
     if src_dir.exists() {
-        // Stale source (older rene or toolchain switch): re-extract from
-        // scratch rather than patching files into an unknown tree.
+        // Stale source: re-extract from scratch rather than patching files
+        // into an unknown tree. Other targets' trees remain intact.
         std::fs::remove_dir_all(&src_dir)
             .map_err(|e| format!("cannot clear `{}`: {e}", src_dir.display()))?;
     }
+    std::fs::create_dir_all(&target_dir)
+        .map_err(|e| format!("cannot create `{}`: {e}", target_dir.display()))?;
     tracing::debug!(dest = %src_dir.display(), "extracting bundled reussir-rt source");
-    unpack(dir.root()).map_err(|e| format!("cannot unpack the runtime bundle: {e}"))?;
+    unpack(&target_dir).map_err(|e| format!("cannot unpack the runtime bundle: {e}"))?;
 
     tracing::debug!(
         cargo = %toolchain.cargo.display(),
@@ -188,31 +252,23 @@ pub async fn prepare(
     let result = cargo_build(&toolchain, &src_dir, linker).await;
     bar.finish_and_clear();
     progress.remove(&bar);
-    let (rlib, staticlib) = result?;
+    let (rlib, staticlib, deps_dirs) = result?;
 
-    // Cargo may report the uplifted rlib (`target/release/lib….rlib`) rather
-    // than the hashed copy in `deps/`; polyffi's `rustc -L` needs `deps/`,
-    // where the dependency rlibs live alongside the runtime's.
-    let deps_dir = {
-        let parent = rlib.parent().unwrap_or(Path::new("."));
-        if parent.file_name() == Some("deps".as_ref()) {
-            parent.to_owned()
-        } else {
-            parent.join("deps")
-        }
-    };
     let artifacts = RtArtifacts {
+        target: toolchain.target.clone(),
         rustc: toolchain.rustc,
         rustc_version: toolchain.version,
         rust_libdir: toolchain.rust_libdir,
-        deps_dir,
+        deps_dirs,
         staticlib,
         rlib,
     };
     let record = serde_json::to_string(&artifacts).map_err(|e| e.to_string())?;
+    let source_key = tables::rt_source_hash_key(&artifacts.target);
+    let artifacts_key = tables::rt_artifacts_key(&artifacts.target);
     dir.set_status(&[
-        (tables::RT_SOURCE_HASH_KEY, hash.as_str()),
-        (tables::RT_ARTIFACTS_KEY, record.as_str()),
+        (source_key.as_str(), hash.as_str()),
+        (artifacts_key.as_str(), record.as_str()),
     ])
     .map_err(|e| e.to_string())?;
     tracing::debug!(staticlib = %artifacts.staticlib.display(), "reussir-rt ready");
@@ -226,25 +282,24 @@ fn fresh_bake(
     toolchain: &Toolchain,
     hash: &str,
 ) -> Result<Option<RtArtifacts>, String> {
-    let recorded_hash = dir
-        .status(tables::RT_SOURCE_HASH_KEY)
-        .map_err(|e| e.to_string())?;
+    let source_key = tables::rt_source_hash_key(&toolchain.target);
+    let artifacts_key = tables::rt_artifacts_key(&toolchain.target);
+    let recorded_hash = dir.status(&source_key).map_err(|e| e.to_string())?;
     if recorded_hash.as_deref() != Some(hash) {
         return Ok(None);
     }
-    let Some(record) = dir
-        .status(tables::RT_ARTIFACTS_KEY)
-        .map_err(|e| e.to_string())?
-    else {
+    let Some(record) = dir.status(&artifacts_key).map_err(|e| e.to_string())? else {
         return Ok(None);
     };
     let Ok(artifacts) = serde_json::from_str::<RtArtifacts>(&record) else {
         // An older rene may have written a different shape; just rebake.
         return Ok(None);
     };
-    let valid = artifacts.rustc_version == toolchain.version
+    let valid = artifacts.target == toolchain.target
+        && artifacts.rustc_version == toolchain.version
         && artifacts.rlib.is_file()
-        && artifacts.staticlib.is_file();
+        && artifacts.staticlib.is_file()
+        && artifacts.libdirs().all(Path::is_dir);
     Ok(valid.then_some(artifacts))
 }
 
@@ -256,11 +311,13 @@ async fn cargo_build(
     toolchain: &Toolchain,
     src_dir: &Path,
     linker: Option<&Path>,
-) -> Result<(PathBuf, PathBuf), String> {
+) -> Result<(PathBuf, PathBuf, Vec<PathBuf>), String> {
     let mut cmd = compio::process::Command::new(&toolchain.cargo);
     cmd.args([
         "build",
         "--release",
+        "--target",
+        toolchain.target.as_str(),
         "--message-format=json-render-diagnostics",
     ])
     .current_dir(src_dir)
@@ -269,11 +326,21 @@ async fn cargo_build(
     .env("RUSTC", &toolchain.rustc);
     if let Some(linker) = linker {
         // Cargo's target-specific linker configuration, as an environment
-        // variable: `CARGO_TARGET_<HOST>_LINKER`. Unlike RUSTFLAGS this
+        // variable: `CARGO_TARGET_<TARGET>_LINKER`. Unlike RUSTFLAGS this
         // composes with whatever the user's environment already carries.
         let key = format!(
             "CARGO_TARGET_{}_LINKER",
-            toolchain.host.to_uppercase().replace('-', "_")
+            toolchain
+                .target
+                .chars()
+                .map(|ch| {
+                    if ch.is_ascii_alphanumeric() {
+                        ch.to_ascii_uppercase()
+                    } else {
+                        '_'
+                    }
+                })
+                .collect::<String>()
         );
         cmd.env(key, linker);
     }
@@ -291,6 +358,7 @@ async fn cargo_build(
 
     let mut rlib = None;
     let mut staticlib = None;
+    let mut deps_dirs = std::collections::BTreeSet::new();
     let stdout = String::from_utf8_lossy(&out.stdout);
     for line in stdout.lines() {
         let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) else {
@@ -301,15 +369,23 @@ async fn cargo_build(
         }
         let name = msg["target"]["name"].as_str().unwrap_or_default();
         tracing::debug!(%name, "compiled");
-        if name != "reussir-rt" && name != "reussir_rt" {
-            continue;
-        }
         for file in msg["filenames"].as_array().into_iter().flatten() {
             let Some(path) = file.as_str() else { continue };
-            match Path::new(path).extension().and_then(|e| e.to_str()) {
-                Some("rlib") => rlib = Some(PathBuf::from(path)),
+            let path = Path::new(path);
+            if let Some(parent) = path.parent()
+                && parent.file_name() == Some("deps".as_ref())
+            {
+                // Includes both target dependencies and host-built proc
+                // macros when Cargo separates them for `--target`.
+                deps_dirs.insert(parent.to_owned());
+            }
+            if name != "reussir-rt" && name != "reussir_rt" {
+                continue;
+            }
+            match path.extension().and_then(|e| e.to_str()) {
+                Some("rlib") => rlib = Some(path.to_owned()),
                 // `.a` everywhere but MSVC, `.lib` there.
-                Some("a") | Some("lib") => staticlib = Some(PathBuf::from(path)),
+                Some("a") | Some("lib") => staticlib = Some(path.to_owned()),
                 _ => {}
             }
         }
@@ -321,7 +397,20 @@ async fn cargo_build(
         ));
     }
     match (rlib, staticlib) {
-        (Some(rlib), Some(staticlib)) => Ok((rlib, staticlib)),
+        (Some(rlib), Some(staticlib)) => {
+            // Cargo may report the uplifted runtime rlib
+            // (`…/release/lib….rlib`) rather than its hashed `deps/` copy.
+            // Ensure that target dependency directory is present even when
+            // no dependency artifact message named it.
+            let parent = rlib.parent().unwrap_or(Path::new("."));
+            let runtime_deps = if parent.file_name() == Some("deps".as_ref()) {
+                parent.to_owned()
+            } else {
+                parent.join("deps")
+            };
+            deps_dirs.insert(runtime_deps);
+            Ok((rlib, staticlib, deps_dirs.into_iter().collect()))
+        }
         _ => Err("cargo succeeded but did not report the runtime's rlib and staticlib".to_owned()),
     }
 }
@@ -351,6 +440,20 @@ mod tests {
         // Versions are pinned through the bundled lock file (no vendoring;
         // the host cargo fetches, the lock decides versions).
         assert!(tmp.path().join(RT_DIR).join("Cargo.lock").is_file());
+    }
+
+    #[test]
+    fn target_triples_are_safe_path_components() {
+        for target in [
+            "x86_64-unknown-linux-gnu",
+            "wasm32-unknown-unknown",
+            "thumbv8m.main-none-eabi",
+        ] {
+            assert_eq!(validate_target(target).unwrap(), target);
+        }
+        for target in ["", ".", "..", "../wasm32", "x/y", "target.json"] {
+            assert!(validate_target(target).is_err(), "{target}");
+        }
     }
 
     #[test]

--- a/crates/rene/src/tables.rs
+++ b/crates/rene/src/tables.rs
@@ -36,14 +36,19 @@ pub const SOURCES: TableDefinition<&str, (&str, u64, u64, &[u8; 32])> =
 /// changed configuration may change the package's layout.
 pub const SOURCES_CONFIG_HASH_KEY: &str = "sources.config-hash";
 
-/// Blake3 hex digest of the bundled `reussir-rt` source archive the baked
-/// runtime was built from (a JSON string). Written by [`crate::rt`]; a
-/// mismatch with the running `rene`'s bundle invalidates the bake.
-pub const RT_SOURCE_HASH_KEY: &str = "rt.source-hash";
+/// Status key for the Blake3 hex digest of the bundled `reussir-rt` source
+/// archive baked for `target`. Each target keeps an independent record and
+/// source tree, so switching targets does not evict a usable bake.
+pub fn rt_source_hash_key(target: &str) -> String {
+    format!("rt.{target}.source-hash")
+}
 
-/// The baked runtime's artifact record, a JSON [`crate::rt::RtArtifacts`]:
-/// toolchain identity plus the paths `build` reports to the user.
-pub const RT_ARTIFACTS_KEY: &str = "rt.artifacts";
+/// Status key for a target's baked runtime artifact record, a JSON
+/// [`crate::rt::RtArtifacts`]: target, toolchain identity, and artifact
+/// paths.
+pub fn rt_artifacts_key(target: &str) -> String {
+    format!("rt.{target}.artifacts")
+}
 
 /// The status key of one built product's record, a JSON
 /// [`crate::compile::ProductRecord`]: the fingerprint it was built under and

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -76,13 +76,13 @@ fn build_fails_cleanly_without_a_manifest() {
 }
 
 #[test]
-fn build_help_uses_kind_specific_target_selectors() {
+fn build_help_distinguishes_products_from_the_machine_target() {
     let out = run(&mut rene(&["build", "--help"]));
     assert!(out.status.success(), "stderr: {}", stderr(&out));
     let help = String::from_utf8(out.stdout).unwrap();
     assert!(help.contains("--bin <NAME>"), "{help}");
     assert!(help.contains("--lib <NAME>"), "{help}");
-    assert!(!help.contains("--target <"), "{help}");
+    assert!(help.contains("--target <TRIPLE>"), "{help}");
 }
 
 #[test]
@@ -197,11 +197,20 @@ impl Fakes {
         let cargo = script(
             "fake-cargo",
             "echo run >> \"$(dirname \"$0\")/cargo-runs\"\n\
+             echo \"$*\" >> \"$(dirname \"$0\")/cargo-args\"\n\
              echo \"linker=$CARGO_TARGET_X86_64_UNKNOWN_FAKE_LINKER\" >> \"$(dirname \"$0\")/cargo-env\"\n\
-             mkdir -p target/release/deps\n\
-             rlib=\"$PWD/target/release/deps/libreussir_rt-0000.rlib\"\n\
-             staticlib=\"$PWD/target/release/libreussir_rt.a\"\n\
-             touch \"$rlib\" \"$staticlib\"\n\
+             target=\"\"; prev=\"\"\n\
+             for arg in \"$@\"; do\n\
+               [ \"$prev\" = \"--target\" ] && target=\"$arg\"\n\
+               prev=\"$arg\"\n\
+             done\n\
+             [ -n \"$target\" ] || exit 2\n\
+             mkdir -p \"target/$target/release/deps\" target/release/deps\n\
+             proc_macro=\"$PWD/target/release/deps/libnum_enum_derive-fake.so\"\n\
+             rlib=\"$PWD/target/$target/release/deps/libreussir_rt-0000.rlib\"\n\
+             staticlib=\"$PWD/target/$target/release/libreussir_rt.a\"\n\
+             touch \"$proc_macro\" \"$rlib\" \"$staticlib\"\n\
+             printf '{\"reason\":\"compiler-artifact\",\"target\":{\"name\":\"num_enum_derive\"},\"filenames\":[\"%s\"]}\\n' \"$proc_macro\"\n\
              printf '{\"reason\":\"compiler-artifact\",\"target\":{\"name\":\"reussir-rt\"},\"filenames\":[\"%s\",\"%s\"]}\\n' \"$rlib\" \"$staticlib\"\n"
                 .to_owned(),
         );
@@ -262,6 +271,14 @@ impl Fakes {
         }
     }
 
+    /// The cargo bake invocations, one argv line each.
+    fn cargo_invocations(&self) -> Vec<String> {
+        match std::fs::read_to_string(self.dir.join("cargo-args")) {
+            Ok(log) => log.lines().map(str::to_owned).collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
     /// A `rene` invocation wired to the fake toolchain.
     fn rene(&self, args: &[&str], manifest: &Path, build_dir: &Path) -> Output {
         run(rene(args)
@@ -301,24 +318,35 @@ fn build_bakes_the_runtime_and_prints_the_libdirs() {
     let out = fakes.rene(&["build"], &manifest, &root);
     assert!(out.status.success(), "stderr: {}", stderr(&out));
 
-    // Stdout is exactly the two `--polyffi-libdir` directories: the detected
-    // rust lib, then the freshly baked runtime's deps dir.
+    // Stdout is exactly the `--polyffi-libdir` directories: the detected
+    // Rust lib, Cargo's host proc-macro deps, then its target deps.
     let stdout = String::from_utf8(out.stdout).unwrap();
     let lines: Vec<&str> = stdout.lines().collect();
-    let deps_dir = root.join("reussir-rt/target/release/deps");
+    let target = "x86_64-unknown-fake";
+    let target_deps = root.join(format!("{target}/reussir-rt/target/{target}/release/deps"));
+    let host_deps = root.join(format!("{target}/reussir-rt/target/release/deps"));
     assert_eq!(
         lines,
         [
             fakes.libdir.display().to_string(),
-            deps_dir.display().to_string()
+            host_deps.display().to_string(),
+            target_deps.display().to_string(),
         ]
     );
 
     // The bundle really was unpacked, and the bake recorded.
-    assert!(root.join("reussir-rt/Cargo.toml").is_file());
+    assert!(root.join(target).join("reussir-rt/Cargo.toml").is_file());
     let dir = BuildDir::open(&root).unwrap();
-    assert!(dir.status(tables::RT_SOURCE_HASH_KEY).unwrap().is_some());
-    assert!(dir.status(tables::RT_ARTIFACTS_KEY).unwrap().is_some());
+    assert!(
+        dir.status(&tables::rt_source_hash_key(target))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        dir.status(&tables::rt_artifacts_key(target))
+            .unwrap()
+            .is_some()
+    );
     drop(dir);
 
     // A second build must reuse the bake: same output, no new cargo run.
@@ -326,6 +354,131 @@ fn build_bakes_the_runtime_and_prints_the_libdirs() {
     assert!(out.status.success(), "stderr: {}", stderr(&out));
     assert_eq!(String::from_utf8(out.stdout).unwrap(), stdout);
     assert_eq!(fakes.runs("cargo"), 1, "the second build re-ran cargo");
+    assert!(fakes.cargo_invocations()[0].contains("--target x86_64-unknown-fake"));
+}
+
+/// The profile supplies a default target, the CLI overrides it, and the two
+/// target-prefixed runtime bakes remain independently reusable.
+#[cfg(unix)]
+#[test]
+fn build_resolves_the_target_and_keeps_each_runtime_bake() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp = tmp_dir.path().canonicalize().unwrap();
+    let root = tmp.join("reussir-build");
+    let manifest = package(&tmp, "demo");
+    std::fs::write(
+        &manifest,
+        r#"
+        {
+          package = { name = "demo", version = "0.1.0" },
+          targets.demo.kind = 'executable,
+          profiles.dev.default_target_triple = "wasm32-unknown-unknown",
+        }
+        "#,
+    )
+    .unwrap();
+    let fakes = Fakes::new(&tmp);
+
+    let default = fakes.rene(&["build"], &manifest, &root);
+    assert!(default.status.success(), "stderr: {}", stderr(&default));
+    assert_eq!(
+        String::from_utf8(default.stdout).unwrap().trim(),
+        root.join("dev/demo").display().to_string()
+    );
+
+    let override_target = "aarch64-unknown-linux-gnu";
+    let overridden = fakes.rene(&["build", "--target", override_target], &manifest, &root);
+    assert!(
+        overridden.status.success(),
+        "stderr: {}",
+        stderr(&overridden)
+    );
+    assert_eq!(
+        String::from_utf8(overridden.stdout).unwrap().trim(),
+        root.join("dev/demo").display().to_string()
+    );
+
+    for target in ["wasm32-unknown-unknown", override_target] {
+        assert!(root.join(target).join("reussir-rt/Cargo.toml").is_file());
+        let dir = BuildDir::open(&root).unwrap();
+        assert!(
+            dir.status(&tables::rt_artifacts_key(target))
+                .unwrap()
+                .is_some()
+        );
+    }
+    assert_eq!(
+        fakes.cargo_invocations(),
+        [
+            "build --release --target wasm32-unknown-unknown --message-format=json-render-diagnostics",
+            "build --release --target aarch64-unknown-linux-gnu --message-format=json-render-diagnostics",
+        ]
+    );
+    let compiles = fakes.compiles();
+    assert_eq!(compiles.len(), 2, "{compiles:#?}");
+    assert!(
+        compiles[0].contains("--target-triple wasm32-unknown-unknown"),
+        "{compiles:#?}"
+    );
+    assert!(
+        compiles[1].contains("--target-triple aarch64-unknown-linux-gnu"),
+        "{compiles:#?}"
+    );
+
+    let inspected = fakes.rene(
+        &[
+            "inspect",
+            "--frozen",
+            "--commands",
+            "--target",
+            override_target,
+        ],
+        &manifest,
+        &root,
+    );
+    assert!(inspected.status.success(), "stderr: {}", stderr(&inspected));
+    let report: serde_json::Value = serde_json::from_slice(&inspected.stdout).unwrap();
+    assert_eq!(report["plan"]["target"], override_target);
+    assert!(
+        report["plan"]["env"]["REUSSIR_RUSTC"]
+            .as_str()
+            .unwrap()
+            .contains("fake-rustc")
+    );
+
+    let default_again = fakes.rene(&["build"], &manifest, &root);
+    assert!(
+        default_again.status.success(),
+        "stderr: {}",
+        stderr(&default_again)
+    );
+    assert_eq!(fakes.runs("cargo"), 2, "the default target was rebaked");
+    let compiles = fakes.compiles();
+    assert_eq!(compiles.len(), 3, "{compiles:#?}");
+    assert!(
+        compiles[2].contains("--target-triple wasm32-unknown-unknown"),
+        "{compiles:#?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn build_rejects_a_target_that_is_not_one_safe_triple_component() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp = tmp_dir.path().canonicalize().unwrap();
+    let root = tmp.join("reussir-build");
+    let manifest = package(&tmp, "demo");
+    let fakes = Fakes::new(&tmp);
+
+    let out = fakes.rene(&["build", "--target", "../escape"], &manifest, &root);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr(&out).contains("invalid target triple `../escape`"),
+        "stderr: {}",
+        stderr(&out)
+    );
+    assert_eq!(fakes.runs("cargo"), 0);
+    assert!(!tmp.join("escape").exists());
 }
 
 /// The first build records the graph; a build that finds every recorded file
@@ -622,6 +775,10 @@ fn build_compiles_the_declared_targets_with_the_profile_knobs() {
         assert!(line.contains("--lto thin"), "{line}");
         assert!(line.contains("--codegen-units 2"), "{line}");
         assert!(line.contains("--relocation-mode pic"), "{line}");
+        assert!(
+            line.contains("--target-triple x86_64-unknown-fake"),
+            "{line}"
+        );
         assert!(line.contains("--polyffi-libdir"), "{line}");
         assert!(
             line.contains(&format!("rustc={}", fakes.rustc.display())),
@@ -676,7 +833,7 @@ fn build_pins_the_linker_through_the_bake_and_the_compiles() {
     let out = fakes.rene(&["build", "--linker", &linker], &manifest, &root);
     assert!(out.status.success(), "stderr: {}", stderr(&out));
 
-    // The bake saw it through CARGO_TARGET_<HOST>_LINKER…
+    // The bake saw it through CARGO_TARGET_<TARGET>_LINKER…
     let cargo_env = std::fs::read_to_string(tmp.join("cargo-env")).unwrap();
     assert_eq!(cargo_env.trim(), format!("linker={linker}"));
 

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -742,22 +742,17 @@ fn build_compiles_the_declared_targets_with_the_profile_knobs() {
     let out = fakes.rene(&["build", "--profile", "release"], &manifest, &root);
     assert!(out.status.success(), "stderr: {}", stderr(&out));
 
-    // Stdout lists the artifacts, BTreeMap (declaration-name) order, named
-    // for the host platform (these tests are unix-only, so the split is
-    // Apple vs ELF).
+    // Stdout lists the artifacts in BTreeMap (declaration-name) order. The
+    // fake rustc reports `x86_64-unknown-fake`, an ELF-like target regardless
+    // of the platform running this test.
     let stdout = String::from_utf8(out.stdout).unwrap();
     let release = root.join("release");
-    let dylib = if cfg!(target_vendor = "apple") {
-        "libshared.dylib"
-    } else {
-        "libshared.so"
-    };
     assert_eq!(
         stdout.lines().collect::<Vec<_>>(),
         [
             release.join("libarchive.a").display().to_string(),
             release.join("demo").display().to_string(),
-            release.join(dylib).display().to_string(),
+            release.join("libshared.so").display().to_string(),
         ]
     );
     for line in stdout.lines() {
@@ -882,15 +877,10 @@ fn build_selects_bins_and_libs_and_refuses_invalid_names() {
     );
     assert!(out.status.success(), "stderr: {}", stderr(&out));
     let stdout = String::from_utf8(out.stdout).unwrap();
-    let dylib = if cfg!(target_vendor = "apple") {
-        "libshared.dylib"
-    } else {
-        "libshared.so"
-    };
     assert_eq!(
         stdout.lines().collect::<Vec<_>>(),
         [
-            root.join("dev").join(dylib).display().to_string(),
+            root.join("dev/libshared.so").display().to_string(),
             root.join("dev").join("libarchive.a").display().to_string(),
         ]
     );
@@ -980,18 +970,27 @@ fn build_bakes_the_runtime_with_the_host_toolchain() {
 
     let stdout = String::from_utf8(out.stdout).unwrap();
     let libdirs: Vec<PathBuf> = stdout.lines().map(PathBuf::from).collect();
-    assert_eq!(libdirs.len(), 2, "stdout: {stdout}");
+    assert_eq!(libdirs.len(), 3, "stdout: {stdout}");
     // The detected rust libdir holds the standard library…
     assert!(libdirs[0].is_dir());
-    // …and the baked deps dir holds the runtime rlib polyffi links against.
-    assert!(libdirs[1].is_dir());
+    // …while explicit `--target` keeps host proc macros and target libraries
+    // in separate Cargo deps directories. One holds the runtime rlib polyffi
+    // links against; ordering varies with the target triple's spelling.
+    assert!(libdirs[1..].iter().all(|dir| dir.is_dir()));
     assert!(
-        std::fs::read_dir(&libdirs[1])
-            .unwrap()
-            .filter_map(Result::ok)
-            .any(|e| e.file_name().to_string_lossy().starts_with("libreussir_rt")),
-        "no libreussir_rt in {}",
-        libdirs[1].display()
+        libdirs[1..].iter().any(|dir| {
+            std::fs::read_dir(dir)
+                .unwrap()
+                .filter_map(Result::ok)
+                .any(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with("libreussir_rt")
+                })
+        }),
+        "no libreussir_rt in {:#?}",
+        &libdirs[1..]
     );
 }
 

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -355,6 +355,27 @@ fn build_bakes_the_runtime_and_prints_the_libdirs() {
     assert_eq!(String::from_utf8(out.stdout).unwrap(), stdout);
     assert_eq!(fakes.runs("cargo"), 1, "the second build re-ran cargo");
     assert!(fakes.cargo_invocations()[0].contains("--target x86_64-unknown-fake"));
+
+    // A compiler at a different explicit path is a different toolchain
+    // selection even when it reports the same version. Do not restore the
+    // old cached path and hand that stale value to rrc.
+    let alternate_rustc = tmp.join("alternate-rustc");
+    std::fs::copy(&fakes.rustc, &alternate_rustc).unwrap();
+    let with_alternate = || {
+        run(rene(&["build", "--manifest-path"])
+            .arg(&manifest)
+            .arg("--build-dir")
+            .arg(&root)
+            .env("REUSSIR_RRC", &fakes.rrc)
+            .env("REUSSIR_CARGO", &fakes.cargo)
+            .env("REUSSIR_RUSTC", &alternate_rustc))
+    };
+    let out = with_alternate();
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(fakes.runs("cargo"), 2, "the rustc path did not rebake");
+    let out = with_alternate();
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(fakes.runs("cargo"), 2, "the new rustc path was not cached");
 }
 
 /// The profile supplies a default target, the CLI overrides it, and the two

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -383,7 +383,7 @@ fn build_resolves_the_target_and_keeps_each_runtime_bake() {
     assert!(default.status.success(), "stderr: {}", stderr(&default));
     assert_eq!(
         String::from_utf8(default.stdout).unwrap().trim(),
-        root.join("dev/demo").display().to_string()
+        root.join("dev/demo.wasm").display().to_string()
     );
 
     let override_target = "aarch64-unknown-linux-gnu";
@@ -410,7 +410,7 @@ fn build_resolves_the_target_and_keeps_each_runtime_bake() {
     assert_eq!(
         fakes.cargo_invocations(),
         [
-            "build --release --target wasm32-unknown-unknown --message-format=json-render-diagnostics",
+            "build --release --target wasm32-unknown-unknown --no-default-features --message-format=json-render-diagnostics",
             "build --release --target aarch64-unknown-linux-gnu --message-format=json-render-diagnostics",
         ]
     );

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -188,7 +188,8 @@ unsafe extern "C" {
     /// Monomorphizes and compiles polymorphic FFI operations in the module.
     /// Returns true on success. `rust_path` and the `lib_dirs` array (of
     /// `n_lib_dirs` entries) name the rustc executable and the Rust package
-    /// search directories explicitly; pass an empty string ref / an empty
+    /// search directories explicitly; `target_triple` is passed to
+    /// `rustc --target` when non-empty. Pass an empty string ref / an empty
     /// array to fall back to the `REUSSIR_RUSTC` / `REUSSIR_RUSTC_DEPS`
     /// environment variables and the built-in probe list.
     pub fn reussirCompilePolymorphicFFI(
@@ -197,6 +198,7 @@ unsafe extern "C" {
         rust_path: MlirStringRef,
         lib_dirs: *const MlirStringRef,
         n_lib_dirs: isize,
+        target_triple: MlirStringRef,
     ) -> bool;
 
     /// Gathers the LLVM bitcode modules attached to compiled operations into a

--- a/crates/reussir-backend/src/llvm.rs
+++ b/crates/reussir-backend/src/llvm.rs
@@ -38,6 +38,10 @@ pub struct PolyffiPaths {
     /// The directories searched for Rust packages (one `rustc -L` each) —
     /// `libreussir_rt` and friends.
     pub libdirs: Vec<String>,
+    /// The machine target passed to the texture's `rustc --target`. `None`
+    /// leaves rustc on its native host, matching an omitted rrc
+    /// `--target-triple`.
+    pub target_triple: Option<String>,
 }
 
 // Views an optional string as the borrowed MlirStringRef the C API takes; the
@@ -188,6 +192,7 @@ impl LlvmLowering {
                 opt_string_ref(&paths.rust_path),
                 libdirs.as_ptr(),
                 libdirs.len() as isize,
+                opt_string_ref(&paths.target_triple),
             ) {
                 return Err("failed to compile polymorphic FFI".into());
             }

--- a/crates/reussir-compiler/src/driver/link.rs
+++ b/crates/reussir-compiler/src/driver/link.rs
@@ -132,6 +132,15 @@ pub(crate) fn link_product(
 
     let mut cmd = std::process::Command::new(&rustc);
     cmd.arg("--edition").arg("2024");
+    // LLVM, the embedded Rust textures, and the Rust launcher must agree on
+    // one machine target. Keep native rrc invocations implicit, but preserve
+    // an explicit `--target-triple` all the way through the final rustc link.
+    if let Some(target) = &cli.target_triple {
+        // Use rustc's target *name*, not LLVM's normalized triple: rustc
+        // accepts `wasm32-wasip1`, while LLVM canonicalizes it to
+        // `wasm32-unknown-wasip1`.
+        cmd.arg("--target").arg(target);
+    }
     match target {
         Stage::Executable => {
             let launcher = scratch.dir().join("launcher.rs");
@@ -389,7 +398,11 @@ pub(crate) fn polyffi_paths(cli: &Cli) -> Result<PolyffiPaths, String> {
             Ok(dir.to_string_lossy().into_owned())
         })
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(PolyffiPaths { rust_path, libdirs })
+    Ok(PolyffiPaths {
+        rust_path,
+        libdirs,
+        target_triple: cli.target_triple.clone(),
+    })
 }
 
 /// A bare `--polyffi-rust-path` name (no separator) searches `PATH`; anything

--- a/crates/reussir-compiler/src/driver/link.rs
+++ b/crates/reussir-compiler/src/driver/link.rs
@@ -318,21 +318,33 @@ pub(crate) fn bundled_lld_dir(rustc: &str) -> Option<PathBuf> {
 /// `REUSSIR_RUSTC` environment variable, then `rustc` on `PATH` — the same
 /// order the polyffi texture compiles resolve in.
 pub(crate) fn resolve_link_rustc(cli: &Cli) -> Result<String, String> {
-    if let Some(path) = &cli.polyffi_rust_path {
-        return resolve_rustc(path);
-    }
-    if let Some(env) = std::env::var_os("REUSSIR_RUSTC") {
-        let path = PathBuf::from(&env);
-        if !path.is_file() {
-            return Err(format!("REUSSIR_RUSTC `{}` does not exist", path.display()));
-        }
-        return Ok(path.to_string_lossy().into_owned());
+    if let Some(rustc) = configured_rustc(cli)? {
+        return Ok(rustc);
     }
     resolve_rustc(Path::new("rustc")).map_err(|_| {
         "cannot find `rustc` for the link step: pass --polyffi-rust-path or set \
          REUSSIR_RUSTC"
             .to_owned()
     })
+}
+
+/// Resolve only an explicit CLI/environment rustc, leaving `None` when the
+/// caller should use its own fallback discovery. Bare environment values
+/// search `PATH` just like `--polyffi-rust-path rustc`.
+fn configured_rustc(cli: &Cli) -> Result<Option<String>, String> {
+    if let Some(path) = &cli.polyffi_rust_path {
+        return resolve_rustc(path).map(Some);
+    }
+    if let Some(env) = std::env::var_os("REUSSIR_RUSTC") {
+        let path = PathBuf::from(&env);
+        return resolve_rustc(&path).map(Some).map_err(|_| {
+            format!(
+                "REUSSIR_RUSTC `{}` does not exist and was not found on PATH",
+                path.display()
+            )
+        });
+    }
+    Ok(None)
 }
 
 /// The directories searched for the runtime library: `--polyffi-libdir`, then
@@ -380,11 +392,11 @@ pub(crate) fn find_in_libdirs(libdirs: &[PathBuf], name: &str) -> Result<PathBuf
 /// Both are validated here so a typo fails with a clear driver diagnostic
 /// instead of a texture-compile error deep in the pipeline.
 pub(crate) fn polyffi_paths(cli: &Cli) -> Result<PolyffiPaths, String> {
-    let rust_path = cli
-        .polyffi_rust_path
-        .as_deref()
-        .map(resolve_rustc)
-        .transpose()?;
+    // Resolve configured bare names before crossing the C API. This also
+    // makes the polyffi compile and final link use exactly the same compiler
+    // selection semantics. With neither source configured, keep the backend
+    // API's legacy discovery fallback.
+    let rust_path = configured_rustc(cli)?;
     let libdirs = cli
         .polyffi_libdir
         .iter()
@@ -409,7 +421,7 @@ pub(crate) fn polyffi_paths(cli: &Cli) -> Result<PolyffiPaths, String> {
 /// else is used as given. Either way the executable must exist.
 pub(crate) fn resolve_rustc(path: &Path) -> Result<String, String> {
     let is_bare = path.components().count() == 1 && !path.is_absolute();
-    if is_bare && !path.exists() {
+    if is_bare {
         let name = path.as_os_str().to_owned();
         let found = std::env::var_os("PATH").and_then(|paths| {
             std::env::split_paths(&paths).find_map(|dir| {

--- a/crates/reussir-compiler/src/lib.rs
+++ b/crates/reussir-compiler/src/lib.rs
@@ -35,7 +35,7 @@ use llvm_sys::target_machine::{
     LLVMCodeGenFileType, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMCreateTargetDataLayout,
     LLVMCreateTargetMachine, LLVMDisposeTargetMachine, LLVMGetDefaultTargetTriple,
     LLVMGetHostCPUFeatures, LLVMGetHostCPUName, LLVMGetTargetFromTriple, LLVMRelocMode,
-    LLVMTargetMachineEmitToFile, LLVMTargetMachineRef, LLVMTargetRef,
+    LLVMNormalizeTargetTriple, LLVMTargetMachineEmitToFile, LLVMTargetMachineRef, LLVMTargetRef,
 };
 
 use reussir_backend::llvm::{Finalized, LtoMode, run_backend_llvm_pipeline};
@@ -172,7 +172,13 @@ impl TargetMachine {
             let foreign = spec.triple.is_some();
             let triple = match spec.triple.as_deref() {
                 Some(t) => {
-                    CString::new(t).map_err(|_| "target triple contains a NUL byte".to_string())?
+                    let requested = CString::new(t)
+                        .map_err(|_| "target triple contains a NUL byte".to_string())?;
+                    // Rust target names may use LLVM aliases (notably
+                    // `wasm32-wasip1`). Stamp LLVM's canonical spelling so
+                    // rustc-produced polyffi bitcode links without a
+                    // different-target-triples warning.
+                    take_llvm_string(LLVMNormalizeTargetTriple(requested.as_ptr()))
                 }
                 None => take_llvm_string(LLVMGetDefaultTargetTriple()),
             };

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -353,6 +353,73 @@ module {
     assert_recorded_target(&log, "wasm32-wasip1");
 }
 
+/// A bare REUSSIR_RUSTC value follows PATH before crossing into the C++
+/// polyffi compiler. A failed texture compile must not leave its temporary
+/// source or bitcode in rrc's working directory.
+#[cfg(unix)]
+#[test]
+fn resolves_bare_environment_rustc_for_polyffi() {
+    let dir = scratch("polyffi-bare-rustc");
+    let bin = dir.path().join("bin");
+    let work = dir.path().join("work");
+    std::fs::create_dir_all(&bin).expect("create fake bin");
+    std::fs::create_dir_all(&work).expect("create work directory");
+    let input = dir.path().join("texture.mlir");
+    std::fs::write(
+        &input,
+        r##"
+module {
+  reussir.polyffi texture("#[unsafe(no_mangle)] pub unsafe extern \"C\" fn target_probe() {}")
+}
+"##,
+    )
+    .expect("write polyffi module");
+    shell_script(
+        &bin,
+        "rustc",
+        "printf '%s\n' \"$@\" > \"$FAKE_RUSTC_LOG\"\nexit 1\n",
+    );
+    let inherited_path = std::env::var_os("PATH");
+    let path = std::env::join_paths(std::iter::once(bin.clone()).chain(
+        inherited_path
+            .as_deref()
+            .into_iter()
+            .flat_map(std::env::split_paths),
+    ))
+    .expect("construct PATH");
+    let log = dir.path().join("rustc-args");
+    let output = Command::new(env!("CARGO_BIN_EXE_rrc"))
+        .args([
+            input.as_os_str(),
+            "-o".as_ref(),
+            dir.path().join("texture.ll").as_os_str(),
+            "--emit".as_ref(),
+            "llvm-ir".as_ref(),
+            "--target-triple".as_ref(),
+            "wasm32-wasip1-threads".as_ref(),
+            "--polyffi-libdir".as_ref(),
+            dir.path().as_os_str(),
+        ])
+        .current_dir(&work)
+        .env("PATH", path)
+        .env("REUSSIR_RUSTC", "rustc")
+        .env("FAKE_RUSTC_LOG", &log)
+        .output()
+        .expect("spawn rrc");
+    assert!(
+        !output.status.success(),
+        "the recording rustc deliberately fails"
+    );
+    assert_recorded_target(&log, "wasm32-wasip1-threads");
+    let leftovers: Vec<_> = std::fs::read_dir(&work)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name())
+        .filter(|name| name.to_string_lossy().starts_with("reussir_rust_module_"))
+        .collect();
+    assert!(leftovers.is_empty(), "temporary files leaked: {leftovers:?}");
+}
+
 /// A linked product's launcher is another Rust compilation; it must use the
 /// same explicit target as LLVM and the embedded textures.
 #[cfg(unix)]

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -34,6 +34,26 @@ fn rrc(args: &[&Path]) -> Output {
         .expect("spawn rrc")
 }
 
+#[cfg(unix)]
+fn shell_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = dir.join(name);
+    std::fs::write(&path, format!("#!/bin/sh\n{body}")).expect("write shell script");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+        .expect("make shell script executable");
+    path
+}
+
+#[cfg(unix)]
+fn assert_recorded_target(log: &Path, target: &str) {
+    let args: Vec<_> = read(log).lines().map(str::to_owned).collect();
+    assert!(
+        args.windows(2).any(|pair| pair == ["--target", target]),
+        "rustc did not receive `--target {target}`: {args:#?}"
+    );
+}
+
 /// Compile `input` to `target` (`--emit target`), writing `out`; assert success.
 fn emit(input: &Path, target: &str, out: &Path) {
     let output = rrc(&[
@@ -284,6 +304,101 @@ fn compiles_to_the_wasm_target() {
         "not a wasm object, leading bytes: {:02x?}",
         &bytes[..bytes.len().min(8)]
     );
+}
+
+/// The target selected for LLVM must also reach the direct rustc invocation
+/// that compiles an embedded polymorphic-FFI texture.
+#[cfg(unix)]
+#[test]
+fn passes_the_target_to_polyffi_rustc() {
+    let dir = scratch("polyffi-target");
+    let input = dir.path().join("texture.mlir");
+    std::fs::write(
+        &input,
+        r##"
+module {
+  reussir.polyffi texture("#[unsafe(no_mangle)] pub unsafe extern \"C\" fn target_probe() {}")
+}
+"##,
+    )
+    .expect("write polyffi module");
+    let rustc = shell_script(
+        dir.path(),
+        "record-rustc",
+        "printf '%s\n' \"$@\" > \"$FAKE_RUSTC_LOG\"\nexit 1\n",
+    );
+    let log = dir.path().join("rustc-args");
+    let output = Command::new(env!("CARGO_BIN_EXE_rrc"))
+        .args([
+            input.as_os_str(),
+            "-o".as_ref(),
+            dir.path().join("texture.ll").as_os_str(),
+            "--emit".as_ref(),
+            "llvm-ir".as_ref(),
+            "--target-triple".as_ref(),
+            "wasm32-wasip1".as_ref(),
+            "--polyffi-rust-path".as_ref(),
+            rustc.as_os_str(),
+            "--polyffi-libdir".as_ref(),
+            dir.path().as_os_str(),
+        ])
+        .current_dir(dir.path())
+        .env("FAKE_RUSTC_LOG", &log)
+        .output()
+        .expect("spawn rrc");
+    assert!(
+        !output.status.success(),
+        "the recording rustc deliberately fails"
+    );
+    assert_recorded_target(&log, "wasm32-wasip1");
+}
+
+/// A linked product's launcher is another Rust compilation; it must use the
+/// same explicit target as LLVM and the embedded textures.
+#[cfg(unix)]
+#[test]
+fn passes_the_target_to_linking_rustc() {
+    let dir = scratch("link-target");
+    let input = dir.path().join("program.ll");
+    std::fs::write(&input, "define void @__reussir_main() {\n  ret void\n}\n")
+        .expect("write LLVM IR");
+    std::fs::write(dir.path().join("libreussir_rt.rlib"), "").expect("write fake runtime");
+    let rustc = shell_script(
+        dir.path(),
+        "record-rustc",
+        "printf '%s\n' \"$@\" > \"$FAKE_RUSTC_LOG\"\n\
+         previous=''\n\
+         for arg in \"$@\"; do\n\
+           if [ \"$previous\" = '-o' ]; then : > \"$arg\"; fi\n\
+           previous=\"$arg\"\n\
+         done\n",
+    );
+    let log = dir.path().join("rustc-args");
+    let output_path = dir.path().join("program.wasm");
+    let output = Command::new(env!("CARGO_BIN_EXE_rrc"))
+        .args([
+            input.as_os_str(),
+            "-o".as_ref(),
+            output_path.as_os_str(),
+            "--emit".as_ref(),
+            "executable".as_ref(),
+            "--target-triple".as_ref(),
+            "wasm32-wasip1".as_ref(),
+            "--polyffi-rust-path".as_ref(),
+            rustc.as_os_str(),
+            "--polyffi-libdir".as_ref(),
+            dir.path().as_os_str(),
+        ])
+        .env("FAKE_RUSTC_LOG", &log)
+        .output()
+        .expect("spawn rrc");
+    assert!(
+        output.status.success(),
+        "link driver failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output_path.is_file(), "recording rustc did not make output");
+    assert_recorded_target(&log, "wasm32-wasip1");
 }
 
 /// `--scan-deps` describes the package source graph — `lib.rr` plus

--- a/crates/reussir-repl/src/main.rs
+++ b/crates/reussir-repl/src/main.rs
@@ -124,7 +124,22 @@ fn run(cli: &Cli) -> Result<(), String> {
 }
 
 fn main() -> ExitCode {
-    let cli = Cli::parse();
+    // `palc` represents `--help` as a parse error. Keep the conventional CLI
+    // contract used by `rrc` and `rene`: help goes to stdout with exit 0,
+    // while genuine usage errors go to stderr with exit 2.
+    let cli = match Cli::try_parse_from(std::env::args_os()) {
+        Ok(cli) => cli,
+        Err(err) => match err.try_into_help() {
+            Ok(help) => {
+                println!("{help}");
+                return ExitCode::SUCCESS;
+            }
+            Err(err) => {
+                eprintln!("{err}");
+                return ExitCode::from(2);
+            }
+        },
+    };
     match run(&cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(message) => {

--- a/docs/design/system-rust-runtime.md
+++ b/docs/design/system-rust-runtime.md
@@ -249,10 +249,10 @@ phase 4.
   keyed by toolchain+source hash (Koka builds per project). Cargo's target
   dir gives us safe sharing for free; a `--rt-target-dir` escape hatch can
   serve hermetic build systems (Nix, Bazel) that want project-local builds.
-- **Cross-compilation**: the cache key already includes the target triple;
-  polyffi invocations need `--target` propagation and the final link needs
-  a target-appropriate staticlib. Deferred until cross-compilation is a
-  supported flow generally.
+- **Cross-compilation**: `rene` keys runtime bakes by target and propagates the
+  selected triple to Cargo and `rrc`. Individual targets still need compatible
+  runtime features, linkers, and Rust standard-library components before the
+  full cross-compilation flow is supported.
 - **Windows**: staticlib-by-default sidesteps the `reussir_rt.dll` +
   `libstd` DLL story; MSVC vs GNU toolchain flavor must match the user's
   C toolchain — detect from the rustc host triple and warn on mismatch.

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -112,13 +112,14 @@ MlirPass reussirCreateReconcileUnrealizedCastsPass(void);
 // Monomorphizes and compiles polymorphic FFI operations in the module. Returns
 // true on success. `rustPath` and the `libDirs` array (of `nLibDirs` entries)
 // name the rustc executable and the Rust package search directories
-// explicitly; pass an empty string ref / an empty array to fall back to the
-// REUSSIR_RUSTC / REUSSIR_RUSTC_DEPS environment variables and the built-in
-// probe list.
+// explicitly; a non-empty `targetTriple` is passed to `rustc --target`. Pass
+// an empty string ref / an empty array to fall back to the REUSSIR_RUSTC /
+// REUSSIR_RUSTC_DEPS environment variables and the built-in probe list.
 bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized,
                                   MlirStringRef rustPath,
                                   const MlirStringRef *libDirs,
-                                  intptr_t nLibDirs);
+                                  intptr_t nLibDirs,
+                                  MlirStringRef targetTriple);
 
 // Gathers the LLVM bitcode modules attached to compiled operations into a
 // single LLVM module owned by `context`. Returns NULL on failure; otherwise the

--- a/include/Reussir/Conversion/Passes.h
+++ b/include/Reussir/Conversion/Passes.h
@@ -38,13 +38,15 @@ namespace reussir {
 // monomorphizing their templates and compiling them to LLVM bitcode.
 // `rustPath` and `libDirs`, when non-empty, name the `rustc` executable and
 // the package search directories explicitly (see `findRustCompiler` /
-// `findRustCompilerDeps` for the fallback discovery).
+// `findRustCompilerDeps` for the fallback discovery). A non-empty
+// `targetTriple` is passed to the texture compiler as `rustc --target`.
 //
 //===----------------------------------------------------------------------===//
 mlir::LogicalResult
 compilePolymorphicFFI(mlir::ModuleOp moduleOp, bool optimized = false,
                       llvm::StringRef rustPath = {},
-                      llvm::ArrayRef<llvm::StringRef> libDirs = {});
+                      llvm::ArrayRef<llvm::StringRef> libDirs = {},
+                      llvm::StringRef targetTriple = {});
 
 //===----------------------------------------------------------------------===//
 // Variant debug-info fixup (post-translation)

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -194,13 +194,15 @@ MlirPass reussirCreateReconcileUnrealizedCastsPass(void) {
 bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized,
                                   MlirStringRef rustPath,
                                   const MlirStringRef *libDirs,
-                                  intptr_t nLibDirs) {
+                                  intptr_t nLibDirs,
+                                  MlirStringRef targetTriple) {
   llvm::SmallVector<llvm::StringRef> dirs;
   dirs.reserve(nLibDirs);
   for (intptr_t i = 0; i < nLibDirs; ++i)
     dirs.push_back(unwrap(libDirs[i]));
   return succeeded(reussir::compilePolymorphicFFI(unwrap(module), optimized,
-                                                  unwrap(rustPath), dirs));
+                                                  unwrap(rustPath), dirs,
+                                                  unwrap(targetTriple)));
 }
 
 LLVMModuleRef reussirGatherCompiledModules(MlirModule module,

--- a/lib/Conversion/CompilePolymorphicFFI/CompilePolymorphicFFI.cpp
+++ b/lib/Conversion/CompilePolymorphicFFI/CompilePolymorphicFFI.cpp
@@ -193,7 +193,8 @@ static std::string monomorphize(mlir::ModuleOp moduleOp, ReussirPolyFFIOp op) {
 mlir::LogicalResult
 compilePolymorphicFFI(mlir::ModuleOp moduleOp, bool optimized,
                       llvm::StringRef rustPath,
-                      llvm::ArrayRef<llvm::StringRef> libDirs) {
+                      llvm::ArrayRef<llvm::StringRef> libDirs,
+                      llvm::StringRef targetTriple) {
   llvm::LLVMContext context;
   llvm::SmallVector<ReussirPolyFFIOp> uncompiledOps;
   moduleOp.walk([&](ReussirPolyFFIOp op) {
@@ -204,6 +205,10 @@ compilePolymorphicFFI(mlir::ModuleOp moduleOp, bool optimized,
   llvm::SmallVector<llvm::StringRef> additionalArgs;
   if (optimized)
     additionalArgs.push_back("-O");
+  if (!targetTriple.empty()) {
+    additionalArgs.push_back("--target");
+    additionalArgs.push_back(targetTriple);
+  }
 
   for (ReussirPolyFFIOp op : uncompiledOps) {
     std::string monomorphized = monomorphize(moduleOp, op);

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -959,7 +959,7 @@ RcBoxType RcType::getInnerBoxType() const {
   mlir::Type eleTy = getElementType();
   if (auto closureTy = llvm::dyn_cast<ClosureType>(eleTy))
     eleTy = ClosureBoxType::get(getContext(), closureTy.getInputTypes());
-  return RcBoxType::get(getContext(), getEleTy(), isFlexOrRigid);
+  return RcBoxType::get(getContext(), eleTy, isFlexOrRigid);
 }
 
 bool RcType::mayCarrySpecialPointerTag() const {

--- a/lib/RustCompiler/RustCompiler.cpp
+++ b/lib/RustCompiler/RustCompiler.cpp
@@ -22,6 +22,7 @@
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/FileSystem.h>
+#include <llvm/Support/FileUtilities.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/Path.h>
 #include <llvm/Support/Program.h>
@@ -76,8 +77,13 @@ llvm::StringRef findRustCompiler(llvm::StringRef preferred) {
   // first check if REUSSIR_RUSTC is set
   if (const char *env_p = std::getenv("REUSSIR_RUSTC"))
     return env_p;
+  // A bare `rustc` is the normal installation shape. ExecuteAndWait requires
+  // a resolved program path, so recognize PATH here before trying the
+  // project-relative fallback locations below.
+  if (llvm::sys::findProgramByName(RUSTC_HINTS.front()))
+    return RUSTC_HINTS.front();
   // locate rustc in known paths
-  for (const auto &path : RUSTC_HINTS) {
+  for (const auto &path : llvm::drop_begin(RUSTC_HINTS)) {
     if (llvm::sys::fs::exists(path))
       return path;
   }
@@ -121,6 +127,16 @@ std::unique_ptr<llvm::MemoryBuffer> compileRustSourceToBitcode(
     llvm::ArrayRef<llvm::StringRef> additionalArgs, llvm::StringRef rustcPath,
     llvm::ArrayRef<llvm::StringRef> rustcDepsDirs) {
   rustcPath = findRustCompiler(rustcPath);
+  // ExecuteAndWait does not search PATH: its Program parameter is expected to
+  // have come from findProgramByName. Resolve explicit/env bare names as well
+  // as the default discovery result before spawning.
+  auto resolvedRustc = llvm::sys::findProgramByName(rustcPath);
+  if (!resolvedRustc) {
+    llvm::errs() << "Could not find rustc executable `" << rustcPath << "`\n";
+    return nullptr;
+  }
+  std::string rustcExecutable = *resolvedRustc;
+  rustcPath = rustcExecutable;
   llvm::SmallVector<std::string> rustcDepsPaths =
       findRustCompilerDeps(rustcDepsDirs);
   if (rustcPath.empty() || rustcDepsPaths.empty()) {
@@ -139,12 +155,18 @@ std::unique_ptr<llvm::MemoryBuffer> compileRustSourceToBitcode(
   llvm::SmallString<32> resultBitcodeFilePath;
   std::error_code srcFileCode = llvm::sys::fs::createUniqueFile(
       "reussir_rust_module_%%%%%%.rs", srcFilePath);
-  std::error_code resultBitcodeFileCode = llvm::sys::fs::createUniqueFile(
-      "reussir_rust_module_%%%%%%.bc", resultBitcodeFilePath);
-  if (srcFileCode || resultBitcodeFileCode) {
-    llvm::errs() << "Could not create temporary files for Rust compilation\n";
+  if (srcFileCode) {
+    llvm::errs() << "Could not create temporary Rust source file\n";
     return nullptr;
   }
+  llvm::FileRemover srcFileRemover(srcFilePath);
+  std::error_code resultBitcodeFileCode = llvm::sys::fs::createUniqueFile(
+      "reussir_rust_module_%%%%%%.bc", resultBitcodeFilePath);
+  if (resultBitcodeFileCode) {
+    llvm::errs() << "Could not create temporary Rust bitcode file\n";
+    return nullptr;
+  }
+  llvm::FileRemover resultBitcodeFileRemover(resultBitcodeFilePath);
   {
     int fd = -1;
     std::error_code code = llvm::sys::fs::openFileForWrite(srcFilePath, fd);
@@ -169,16 +191,21 @@ std::unique_ptr<llvm::MemoryBuffer> compileRustSourceToBitcode(
   for (auto arg : additionalArgs)
     args.push_back(arg);
   // Execute rustc
-  int code = llvm::sys::ExecuteAndWait(rustcPath, args);
+  std::string executionError;
+  int code =
+      llvm::sys::ExecuteAndWait(rustcPath, args, std::nullopt, {},
+                                /*SecondsToWait=*/0, /*MemoryLimit=*/0,
+                                &executionError);
   if (code != 0) {
     llvm::errs() << "Rust compilation failed with exit code " << code << "\n";
+    if (!executionError.empty())
+      llvm::errs() << "Failed to execute rustc: " << executionError << "\n";
     llvm::errs() << "Full command: " << rustcPath << " ";
-    llvm::interleave(args, llvm::errs(), " ");
+    // args[0] is argv[0], not a second command-line argument.
+    llvm::interleave(llvm::drop_begin(args), llvm::errs(), " ");
     llvm::errs() << "\n";
     return nullptr;
   }
-  if (auto err = llvm::sys::fs::remove(srcFilePath))
-    llvm::errs() << "Failed to discard source file\n";
   // Load the bitcode file into a buffer
   std::unique_ptr<llvm::MemoryBuffer> buffer;
   {
@@ -194,8 +221,6 @@ std::unique_ptr<llvm::MemoryBuffer> compileRustSourceToBitcode(
     buffer = std::move(*bufferOrErr);
 #endif
   }
-  if (auto err = llvm::sys::fs::remove(resultBitcodeFilePath))
-    llvm::errs() << "Failed to discard bitcode file\n";
   return buffer;
 }
 

--- a/tests/integration/conversion/closure_apply.mlir
+++ b/tests/integration/conversion/closure_apply.mlir
@@ -26,7 +26,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
   // Test function that applies multiple arguments to a closure
   // CHECK-LABEL: define ptr @apply_multiple_args(ptr %0, i32 %1, i64 %2) {
-  // CHECK: %4 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %4 = getelementptr { i32, { ptr, ptr, i64 } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %5 = load ptr, ptr %4, align 8
   // CHECK: %6 = ptrtoint ptr %5 to i64
   // CHECK: %7 = sub i64 0, %6

--- a/tests/integration/conversion/closure_uniqify_2.mlir
+++ b/tests/integration/conversion/closure_uniqify_2.mlir
@@ -13,7 +13,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 }
 
 // CHECK: llvm.func @test_closure_uniqify_with_input(%[[INPUT:.*]]: !llvm.ptr) -> !llvm.ptr {
-// CHECK:   %[[GEP_REFCNT:.*]] = llvm.getelementptr %[[INPUT]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr)>)>
+// CHECK:   %[[GEP_REFCNT:.*]] = llvm.getelementptr %[[INPUT]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr, i32)>)>
 // CHECK:   %[[REFCNT:.*]] = llvm.load %[[GEP_REFCNT]] : !llvm.ptr -> i32
 // CHECK:   %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:   %[[IS_UNIQUE:.*]] = llvm.icmp "eq" %[[REFCNT]], %[[ONE]] : i32
@@ -21,12 +21,12 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK: ^[[THEN]]:  // pred: ^bb0
 // CHECK:   llvm.br ^[[JOIN:bb[0-9]+]](%[[INPUT]] : !llvm.ptr)
 // CHECK: ^[[ELSE]]:  // pred: ^bb0
-// CHECK:   %[[GEP_VTABLE:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr)>)>
+// CHECK:   %[[GEP_VTABLE:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr, i32)>)>
 // CHECK:   %[[VTABLE:.*]] = llvm.load %[[GEP_VTABLE]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[GEP_CLONE:.*]] = llvm.getelementptr %[[VTABLE]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr, ptr)>
 // CHECK:   %[[CLONE_FUNC:.*]] = llvm.load %[[GEP_CLONE]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[CLONED:.*]] = llvm.call %[[CLONE_FUNC]](%[[INPUT]]) : !llvm.ptr, (!llvm.ptr) -> !llvm.ptr
-// CHECK:   %[[GEP_VTABLE2:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr)>)>
+// CHECK:   %[[GEP_VTABLE2:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr, i32)>)>
 // CHECK:   %[[VTABLE2:.*]] = llvm.load %[[GEP_VTABLE2]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[GEP_DROP:.*]] = llvm.getelementptr %[[VTABLE2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr, ptr)>
 // CHECK:   %[[DROP_FUNC:.*]] = llvm.load %[[GEP_DROP]] invariant_group : !llvm.ptr -> !llvm.ptr

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -46,10 +46,15 @@
 // RUN: %rene inspect --manifest-path %S/build/rene.ncl --build-dir %t.bdir --frozen --commands | %FileCheck %s --check-prefix=PLAN
 
 // PLAN: "REUSSIR_RUSTC": "{{[^<].*}}"
+// PLAN: "--target-triple",
+// PLAN-NEXT: "{{[^"]+}}",
 // PLAN: "--polyffi-libdir",
 // PLAN-NEXT: "{{[^<].*}}",
 // PLAN-NEXT: "--polyffi-libdir",
 // PLAN-NEXT: "{{[^<].*}}"
+// PLAN-NEXT: "--polyffi-libdir",
+// PLAN-NEXT: "{{[^<].*}}"
+// PLAN: "target": "{{[^"]+-[^"]+}}"
 
 // An undeclared profile or binary target is refused by name.
 // RUN: %not %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --profile bogus 2>&1 | %FileCheck %s --check-prefix=NOPROFILE

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -61,7 +61,7 @@
 // executable its WebAssembly suffix.
 // RUN: %rene inspect --manifest-path %S/build/rene.ncl --build-dir %t.bdir --frozen --commands --target wasm32-wasip1 | %FileCheck %s --check-prefix=WASM
 
-// WASM: "{{.*[/\\]}}dev{{[/\\]}}demo.wasm"
+// WASM: "{{.*[/\\]+}}dev{{[/\\]+}}demo.wasm"
 // WASM: "--target-triple",
 // WASM-NEXT: "wasm32-wasip1",
 // WASM: "target": "wasm32-wasip1"

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -56,6 +56,16 @@
 // PLAN-NEXT: "{{[^<].*}}"
 // PLAN: "target": "{{[^"]+-[^"]+}}"
 
+// A cross-target plan needs no target toolchain to render: the public
+// contract already names the WASI target at rrc's boundary and gives the
+// executable its WebAssembly suffix.
+// RUN: %rene inspect --manifest-path %S/build/rene.ncl --build-dir %t.bdir --frozen --commands --target wasm32-wasip1 | %FileCheck %s --check-prefix=WASM
+
+// WASM: "{{.*[/\\]}}dev{{[/\\]}}demo.wasm"
+// WASM: "--target-triple",
+// WASM-NEXT: "wasm32-wasip1",
+// WASM: "target": "wasm32-wasip1"
+
 // An undeclared profile or binary target is refused by name.
 // RUN: %not %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --profile bogus 2>&1 | %FileCheck %s --check-prefix=NOPROFILE
 // RUN: %not %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --bin bogus 2>&1 | %FileCheck %s --check-prefix=NOTARGET

--- a/tests/integration/repl-rs/cli.repl
+++ b/tests/integration/repl-rs/cli.repl
@@ -1,0 +1,9 @@
+// REQUIRES: rrepl
+
+// The release archives smoke-test every user-facing binary with `--help`
+// from a bare environment. Help is successful and is written to stdout.
+// RUN: %rrepl --help > %t.help
+// RUN: %FileCheck %s --check-prefix=HELP < %t.help
+
+// HELP: Reussir REPL (Rust pipeline).
+// HELP: Usage: rrepl [OPTIONS]

--- a/tests/unittest/cases/rustc_invoke.cpp
+++ b/tests/unittest/cases/rustc_invoke.cpp
@@ -76,4 +76,21 @@ TEST(RustCompilerTest, ExplicitPathsOverrideDiscovery) {
   ASSERT_NE(m, nullptr);
   EXPECT_NE(m->getFunction("__reussir_extern_Vec_f64_new"), nullptr);
 }
+
+TEST(RustCompilerTest, BareCompilerNameResolvesThroughPath) {
+  primeRustDiscoveryEnv();
+  llvm::SmallVector<std::string> deps = findRustCompilerDeps();
+  ASSERT_FALSE(deps.empty());
+  llvm::SmallVector<llvm::StringRef> depDirs(deps.begin(), deps.end());
+#ifdef _WIN32
+  constexpr llvm::StringRef bareRustc = "rustc.exe";
+#else
+  constexpr llvm::StringRef bareRustc = "rustc";
+#endif
+  llvm::LLVMContext context;
+  std::unique_ptr<llvm::Module> m =
+      compileRustSource(context, EXAMPLE_SOURCE, {}, bareRustc, depDirs);
+  ASSERT_NE(m, nullptr);
+  EXPECT_NE(m->getFunction("__reussir_extern_Vec_f64_new"), nullptr);
+}
 } // namespace reussir


### PR DESCRIPTION
## Summary

- add machine target selection to `rene build` and `rene inspect`, with precedence CLI > profile `default_target_triple` > rustc host
- bake the embedded runtime under `<build-dir>/<triple>/reussir-rt` and keep target-specific status records so bakes coexist
- pass the resolved target through Cargo, rrc, polymorphic-FFI texture compilation, and the final Rust link; normalize Rust target aliases at the LLVM boundary
- disable the mimalloc feature for `wasm32`/`wasm64` runtime bakes and use the runtime's platform allocator backend
- name WebAssembly executable and dynamic-library products with a `.wasm` suffix

## Testing

- `ninja -C build rene-test -j1`
- `ninja -C build rrc-test -j1`
- `ninja -C build reussir-backend-test -j1`
- `ninja -C build reussir-codegen-test -j1`
- `ninja -C build reussir-ut -j1 && build/bin/reussir-ut`
- `ninja -C build check -j1` (438 passed, 5 unsupported)
- changed-package clippy checks with warnings denied
- built `tests/integration/rene/fib` for `wasm32-wasip1` and ran it with Wasmer: `fib(10) = 55`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787884673&installation_model_id=426051&pr_number=483&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F483&signature=20c66f9dc29dc9afd39987d3dde120454c12a962d2d11471497e1b65cd667b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
