### PR TITLE
[closure] make payload alignment explicit

### DIFF
--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -563,11 +563,10 @@ def ReussirRcBoxType
     // variant overlays the refcount on the element's leading count slot, so
     // box pointer == element pointer.
     bool isHeaderFused() const;
-    size_t getElementIndex() const {
-      if (isRegional())
-        return 3;
-      return isHeaderFused() ? 0 : 1;
-    }
+    // Canonical physical header fields, shared by data-layout computation and
+    // LLVM type conversion.
+    llvm::SmallVector<mlir::Type> getHeaderTypes() const;
+    size_t getElementIndex() const { return getHeaderTypes().size(); }
   }];
 }
 
@@ -612,6 +611,15 @@ def ReussirClosureBoxType
   let extraClassDeclaration = [{
     static constexpr size_t VTABLE_INDEX = 0;
     static constexpr size_t ARG_CURSOR_INDEX = 1;
+    static constexpr size_t PAYLOAD_TAIL_INDEX = 2;
+    static constexpr size_t PAYLOAD_INDEX_WITHOUT_PADDING = 0;
+    static constexpr size_t PAYLOAD_INDEX_WITH_PADDING = 1;
+
+    // Canonical physical header fields, shared by data-layout computation and
+    // LLVM type conversion.
+    llvm::SmallVector<mlir::Type> getHeaderTypes() const;
+    uint64_t getPayloadPadding(const ::mlir::DataLayout &dataLayout) const;
+    size_t getPayloadIndex(const ::mlir::DataLayout &dataLayout) const;
   }];
 }
 

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -2224,6 +2224,8 @@ struct ReussirClosureCreateOpConversionPattern
 
     // Get the RcBox<ClosureBox> type
     RcBoxType rcBoxType = op.getRcClosureBoxType();
+    auto closureBoxType =
+        llvm::cast<ClosureBoxType>(rcBoxType.getElementType());
     auto convertedRcBoxType = converter->convertType(rcBoxType);
 
     // Token is the pointer to RcBox<ClosureBox>
@@ -2245,15 +2247,17 @@ struct ReussirClosureCreateOpConversionPattern
         mlir::LLVM::StoreOp::create(rewriter, loc, vtableAddr, vtablePtrSlot);
     vtableStore.setInvariantGroup(true);
 
-    // 3. Assign cursor (GEP[0, 1, 1]) to the value of GEP[0, 1, 2]
-    //    (cursor points to the start of payload area)
+    // 3. Assign cursor to the payload aggregate, past any layout padding.
     auto cursorSlot = mlir::LLVM::GEPOp::create(
         rewriter, loc, llvmPtrType, convertedRcBoxType, tokenPtr,
         llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1,
                                            ClosureBoxType::ARG_CURSOR_INDEX});
+    int64_t payloadIndex = static_cast<int64_t>(closureBoxType.getPayloadIndex(
+        getDataLayout(*converter, op.getOperation())));
     auto payloadStart = mlir::LLVM::GEPOp::create(
         rewriter, loc, llvmPtrType, convertedRcBoxType, tokenPtr,
-        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1, 2});
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{
+            0, 1, ClosureBoxType::PAYLOAD_TAIL_INDEX, payloadIndex});
     mlir::LLVM::StoreOp::create(rewriter, loc, payloadStart, cursorSlot);
 
     // Replace with the token pointer (which is now a valid RcPtr<Closure>)
@@ -2575,13 +2579,14 @@ public:
     auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
 
     // This operation assumes that the closure is already uniquely owned.
-    // First, use GEP[0, 1, ARG_CURSOR_INDEX] and load op to read the cursor
-    // RcBox {
-    //    size_t refcnt;
-    //    {
-    //        void* vtable;
-    //        void* cursor;
-    //        // trailing payload
+    // First, load the cursor from the pointer-aligned header.
+    // ClosureBox {
+    //    void* vtable;
+    //    void* cursor;
+    //    packed {
+    //        // Present only when required by DataLayout.
+    //        i8 padding[N];
+    //        Payload payload;
     //    };
     // }
     auto cursorPtr = mlir::LLVM::GEPOp::create(
@@ -2753,15 +2758,20 @@ struct ReussirClosureInspectPayloadOpConversionPattern
         llvm::cast<ClosureBoxType>(refType.getElementType());
 
     auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
-    auto structType = getTypeConverter()->convertType(closureBoxType);
+    auto converter =
+        static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
+    auto structType = converter->convertType(closureBoxType);
 
-    // GEP[0, N+2] where N is the payload index
-    // ClosureBox layout: { vtable (0), cursor (1), payload... (2+) }
-    int64_t gepIndex =
-        static_cast<int64_t>(op.getPayloadIndex().getZExtValue()) + 2;
+    // The payload keeps its normal aggregate layout inside the packed tail.
+    int64_t payloadFieldIndex =
+        static_cast<int64_t>(op.getPayloadIndex().getZExtValue());
+    int64_t payloadIndex = static_cast<int64_t>(closureBoxType.getPayloadIndex(
+        getDataLayout(*converter, op.getOperation())));
     rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
         op, llvmPtrType, structType, adaptor.getClosureBoxRef(),
-        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, gepIndex});
+        llvm::ArrayRef<mlir::LLVM::GEPArg>{0,
+                                           ClosureBoxType::PAYLOAD_TAIL_INDEX,
+                                           payloadIndex, payloadFieldIndex});
     return mlir::success();
   }
 };

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -272,28 +272,41 @@ void populateReussirToLLVMTypeConversions(mlir::LLVMTypeConverter &converter) {
   converter.addConversion([&converter](RcBoxType type) -> mlir::Type {
     // A box of a fused-header variant IS the variant record: its refcount
     // lives in the record's leading count slot.
-    if (auto recordTy = llvm::dyn_cast<RecordType>(type.getElementType());
-        recordTy && recordTy.hasFusedHeader() && !type.isRegional())
-      return converter.convertType(recordTy);
+    if (type.isHeaderFused())
+      return converter.convertType(type.getElementType());
     llvm::SmallVector<mlir::Type> members;
-    auto ptrTy = mlir::LLVM::LLVMPointerType::get(type.getContext());
-    if (type.isRegional()) {
-      members.push_back(ptrTy);
-      members.push_back(ptrTy);
-      members.push_back(ptrTy);
-    } else
-      members.push_back(mlir::IntegerType::get(type.getContext(), 32));
+    for (mlir::Type headerType : type.getHeaderTypes())
+      members.push_back(converter.convertType(headerType));
     members.push_back(converter.convertType(type.getElementType()));
     return mlir::LLVM::LLVMStructType::getLiteral(type.getContext(), members);
   });
 
-  converter.addConversion([&converter](ClosureBoxType type) {
-    llvm::SmallVector<mlir::Type> members;
-    auto ptrTy = mlir::LLVM::LLVMPointerType::get(type.getContext());
-    members.push_back(ptrTy);
-    members.push_back(ptrTy);
+  converter.addConversion([&converter, dataLayout](ClosureBoxType type) {
+    llvm::SmallVector<mlir::Type> payloadMembers;
     for (auto payloadType : type.getPayloadTypes())
-      members.push_back(converter.convertType(payloadType));
+      payloadMembers.push_back(converter.convertType(payloadType));
+
+    auto payloadStruct = mlir::LLVM::LLVMStructType::getLiteral(
+        type.getContext(), payloadMembers);
+
+    // Keep the closure box pointer-aligned regardless of the payload. Packing
+    // only the payload tail prevents the normally laid-out payload aggregate
+    // from raising the box alignment; explicit padding places that aggregate
+    // at its required address.
+    llvm::SmallVector<mlir::Type> tailMembers;
+    uint64_t payloadPadding = type.getPayloadPadding(*dataLayout);
+    if (payloadPadding != 0) {
+      auto i8Ty = mlir::IntegerType::get(type.getContext(), 8);
+      tailMembers.push_back(
+          mlir::LLVM::LLVMArrayType::get(i8Ty, payloadPadding));
+    }
+    tailMembers.push_back(payloadStruct);
+    auto payloadTail = mlir::LLVM::LLVMStructType::getLiteral(
+        type.getContext(), tailMembers, /*isPacked=*/true);
+    llvm::SmallVector<mlir::Type> members;
+    for (mlir::Type headerType : type.getHeaderTypes())
+      members.push_back(converter.convertType(headerType));
+    members.push_back(payloadTail);
     return mlir::LLVM::LLVMStructType::getLiteral(type.getContext(), members);
   });
 

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -275,42 +275,54 @@ mlir::Type memberStorageType(mlir::MLIRContext *context, mlir::Type rawMember,
 }
 
 //===----------------------------------------------------------------------===//
-// deriveCompoundSizeAndAlignment
+// deriveCompoundLayout
 //===----------------------------------------------------------------------===//
-std::optional<std::tuple<llvm::TypeSize, llvm::Align, mlir::Type>>
-deriveCompoundSizeAndAlignment(mlir::MLIRContext *context,
-                               llvm::ArrayRef<mlir::Type> members,
-                               llvm::ArrayRef<bool> memberIsField,
-                               const mlir::DataLayout &dataLayout,
-                               bool memBoxInternal) {
-  llvm::TypeSize resultSize = llvm::TypeSize::getFixed(0);
+struct CompoundLayout {
+  // `dataSize` ends at the final member; `size` additionally includes the
+  // aggregate's trailing alignment padding.
+  llvm::TypeSize size;
+  llvm::TypeSize dataSize;
+  llvm::Align alignment;
+  mlir::Type memberWithLargestAlignment;
+  llvm::SmallVector<uint64_t> memberOffsets;
+};
+
+std::optional<CompoundLayout> deriveCompoundLayout(
+    mlir::MLIRContext *context, llvm::ArrayRef<mlir::Type> members,
+    llvm::ArrayRef<bool> memberIsField, const mlir::DataLayout &dataLayout,
+    bool memBoxInternal = false) {
+  uint64_t dataSize = 0;
   llvm::Align resultAlignment{1};
   mlir::Type memberWithLargestAlignment;
   if (memberIsField.size() != members.size())
     llvm::report_fatal_error(
         "Number of member capabilities must match number of members");
-  for (auto [rawMember, isField] : llvm::zip(members, memberIsField)) {
+  llvm::SmallVector<uint64_t> memberOffsets(members.size());
+  for (size_t index = 0; index < members.size(); ++index) {
+    mlir::Type rawMember = members[index];
     if (!rawMember)
       continue;
-    mlir::Type member =
-        memberStorageType(context, rawMember, isField, memBoxInternal);
+    mlir::Type member = memberStorageType(context, rawMember,
+                                          memberIsField[index], memBoxInternal);
     llvm::TypeSize memberSize = dataLayout.getTypeSize(member);
     if (!memberSize.isFixed())
       return std::nullopt;
 
     uint64_t memberAlignment = dataLayout.getTypeABIAlignment(member);
     llvm::Align memberAlign(memberAlignment);
-    uint64_t alignedSize = llvm::alignTo(resultSize, memberAlign);
+    uint64_t memberOffset = llvm::alignTo(dataSize, memberAlign);
+    memberOffsets[index] = memberOffset;
     if (memberAlign > resultAlignment) {
       resultAlignment = memberAlign;
       memberWithLargestAlignment = member;
     }
-    resultSize =
-        llvm::TypeSize::getFixed(alignedSize + memberSize.getFixedValue());
+    dataSize = memberOffset + memberSize.getFixedValue();
   }
-  resultSize = llvm::alignTo(resultSize, resultAlignment.value());
-  return std::make_optional(
-      std::make_tuple(resultSize, resultAlignment, memberWithLargestAlignment));
+  llvm::TypeSize size =
+      llvm::TypeSize::getFixed(llvm::alignTo(dataSize, resultAlignment));
+  return CompoundLayout{size, llvm::TypeSize::getFixed(dataSize),
+                        resultAlignment, memberWithLargestAlignment,
+                        std::move(memberOffsets)};
 }
 
 //===----------------------------------------------------------------------===//
@@ -638,6 +650,16 @@ bool RcBoxType::isHeaderFused() const {
   return recordTy && recordTy.hasFusedHeader() && !isRegional();
 }
 
+llvm::SmallVector<mlir::Type> RcBoxType::getHeaderTypes() const {
+  if (isHeaderFused())
+    return {};
+  if (isRegional()) {
+    auto ptrTy = mlir::LLVM::LLVMPointerType::get(getContext());
+    return {ptrTy, ptrTy, ptrTy};
+  }
+  return {mlir::IntegerType::get(getContext(), 32)};
+}
+
 bool RecordType::hasFusedHeader() const {
   return isVariant() && getDefaultCapability() != Capability::value;
 }
@@ -700,12 +722,12 @@ RecordType::LayoutInfo RecordType::getElementRegionLayoutInfo(
       members[physical] = getMembers()[logical];
       memberIsField[physical] = getMemberIsField()[logical];
     }
-    auto derived = deriveCompoundSizeAndAlignment(getContext(), members,
-                                                  memberIsField, dataLayout);
+    auto derived =
+        deriveCompoundLayout(getContext(), members, memberIsField, dataLayout);
     if (!derived)
       llvm_unreachable("RecordType must have a fixed size");
-    auto [sizeInBytes, alignment, memberWithLargestAlignment] = *derived;
-    return {sizeInBytes, alignment, memberWithLargestAlignment};
+    return {derived->size, derived->alignment,
+            derived->memberWithLargestAlignment};
   }
   llvm::TypeSize largestSize = llvm::TypeSize::getZero();
   llvm::Align largestAlignment = llvm::Align(1);
@@ -1277,49 +1299,39 @@ void RcBoxType::print(mlir::AsmPrinter &printer) const {
 //===----------------------------------------------------------------------===//
 // RcBoxType DataLayoutInterface
 //===----------------------------------------------------------------------===//
+namespace {
+std::optional<CompoundLayout>
+deriveLayoutForRcBox(RcBoxType type, const mlir::DataLayout &dataLayout) {
+  llvm::SmallVector<mlir::Type> members = type.getHeaderTypes();
+  members.push_back(type.getElementType());
+  llvm::SmallVector<bool> memberIsField(members.size(), false);
+  return deriveCompoundLayout(type.getContext(), members, memberIsField,
+                              dataLayout,
+                              /*memBoxInternal=*/true);
+}
+} // namespace
+
 llvm::TypeSize
 RcBoxType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
                              mlir::DataLayoutEntryListRef params) const {
   // A box whose element carries a fused header IS the element: the refcount
   // overlays the element's leading count slot.
-  if (auto recordTy = llvm::dyn_cast<RecordType>(getEleTy());
-      recordTy && recordTy.hasFusedHeader() && !isRegional())
-    return dataLayout.getTypeSizeInBits(recordTy);
-  mlir::IndexType ptrWord = mlir::IndexType::get(getContext());
-  mlir::IntegerType countType = mlir::IntegerType::get(getContext(), 32);
-  auto derived =
-      isRegional()
-          ? deriveCompoundSizeAndAlignment(
-                getContext(), {ptrWord, ptrWord, ptrWord, getEleTy()},
-                {false, false, false, false}, dataLayout, true)
-          : deriveCompoundSizeAndAlignment(getContext(),
-                                           {countType, getEleTy()},
-                                           {false, false}, dataLayout, true);
+  if (isHeaderFused())
+    return dataLayout.getTypeSizeInBits(getElementType());
+  auto derived = deriveLayoutForRcBox(*this, dataLayout);
   if (!derived)
     llvm_unreachable("RcBoxType must have a fixed size");
-  auto [sizeInBytes, _x, _y] = *derived;
-  return sizeInBytes * 8; // Convert to bits
+  return derived->size * 8; // Convert to bits
 }
 
 uint64_t RcBoxType::getABIAlignment(const mlir::DataLayout &dataLayout,
                                     mlir::DataLayoutEntryListRef params) const {
-  if (auto recordTy = llvm::dyn_cast<RecordType>(getEleTy());
-      recordTy && recordTy.hasFusedHeader() && !isRegional())
-    return dataLayout.getTypeABIAlignment(recordTy);
-  mlir::IndexType ptrWord = mlir::IndexType::get(getContext());
-  mlir::IntegerType countType = mlir::IntegerType::get(getContext(), 32);
-  auto derived =
-      isRegional()
-          ? deriveCompoundSizeAndAlignment(
-                getContext(), {ptrWord, ptrWord, ptrWord, getEleTy()},
-                {false, false, false, false}, dataLayout, true)
-          : deriveCompoundSizeAndAlignment(getContext(),
-                                           {countType, getEleTy()},
-                                           {false, false}, dataLayout, true);
+  if (isHeaderFused())
+    return dataLayout.getTypeABIAlignment(getElementType());
+  auto derived = deriveLayoutForRcBox(*this, dataLayout);
   if (!derived)
     llvm_unreachable("RcBoxType must have a fixed alignment");
-  auto [_x, alignment, _y] = *derived;
-  return alignment.value();
+  return derived->alignment.value();
 }
 
 MLIR_DATA_LAYOUT_EXPAND_PREFERRED_ALIGN(
@@ -1572,23 +1584,72 @@ mlir::Type getProjectedType(mlir::Type type, bool fieldCap, Capability refCap,
 // ClosureBoxType DataLayoutInterface
 //===----------------------------------------------------------------------===//
 
+llvm::SmallVector<mlir::Type> ClosureBoxType::getHeaderTypes() const {
+  auto ptrTy = mlir::LLVM::LLVMPointerType::get(getContext());
+  return {ptrTy, ptrTy};
+}
+
 namespace {
-std::optional<std::tuple<llvm::TypeSize, llvm::Align, mlir::Type>>
+struct ClosureBoxLayout {
+  llvm::TypeSize size;
+  llvm::Align alignment;
+  uint64_t payloadPadding;
+};
+
+std::optional<ClosureBoxLayout>
 deriveLayoutForClosureBox(mlir::MLIRContext *context,
                           llvm::ArrayRef<mlir::Type> payloadTypes,
                           const mlir::DataLayout &dataLayout) {
-  auto ptrTy = mlir::LLVM::LLVMPointerType::get(context);
-  llvm::SmallVector<mlir::Type> members = {ptrTy, ptrTy};
-  llvm::SmallVector<bool> memberCapabilities = {false, false};
+  auto closureType = ClosureBoxType::get(context, payloadTypes);
+  llvm::SmallVector<mlir::Type> closureHeaderMembers =
+      closureType.getHeaderTypes();
+  llvm::SmallVector<bool> closureHeaderIsField(closureHeaderMembers.size(),
+                                               false);
+  auto closureHeaderLayout = deriveCompoundLayout(
+      context, closureHeaderMembers, closureHeaderIsField, dataLayout);
+  if (!closureHeaderLayout)
+    return std::nullopt;
 
-  // Add payload types
-  for (auto payloadType : payloadTypes) {
-    members.push_back(payloadType);
-    memberCapabilities.push_back(false);
-  }
-  // This is not the memory box but the payload argument
-  return deriveCompoundSizeAndAlignment(context, members, memberCapabilities,
-                                        dataLayout, /*memBoxInternal=*/false);
+  if (payloadTypes.empty())
+    return ClosureBoxLayout{closureHeaderLayout->size,
+                            closureHeaderLayout->alignment,
+                            /*payloadPadding=*/0};
+
+  llvm::SmallVector<bool> memberIsField(payloadTypes.size(), false);
+  auto payloadLayout =
+      deriveCompoundLayout(context, payloadTypes, memberIsField, dataLayout,
+                           /*memBoxInternal=*/false);
+  if (!payloadLayout)
+    return std::nullopt;
+
+  // Lay out the allocation prefix using the same nested aggregate boundary as
+  // LLVM lowering. The closure member's offset and its header's data size
+  // locate the payload cursor without encoding any target-specific offsets.
+  auto closureHeaderTy =
+      mlir::LLVM::LLVMStructType::getLiteral(context, closureHeaderMembers);
+  auto boxType = RcBoxType::get(context, closureType);
+  llvm::SmallVector<mlir::Type> prefixMembers = boxType.getHeaderTypes();
+  prefixMembers.push_back(closureHeaderTy);
+  llvm::SmallVector<bool> prefixIsField(prefixMembers.size(), false);
+  auto prefixLayout =
+      deriveCompoundLayout(context, prefixMembers, prefixIsField, dataLayout,
+                           /*memBoxInternal=*/true);
+  if (!prefixLayout)
+    return std::nullopt;
+
+  uint64_t closureOffset = prefixLayout->memberOffsets.back();
+  uint64_t payloadOffset =
+      closureOffset + closureHeaderLayout->dataSize.getFixedValue();
+  uint64_t alignedPayloadOffset =
+      llvm::alignTo(payloadOffset, payloadLayout->alignment);
+  uint64_t payloadPadding = alignedPayloadOffset - payloadOffset;
+  uint64_t closureDataSize = closureHeaderLayout->dataSize.getFixedValue() +
+                             payloadPadding +
+                             payloadLayout->size.getFixedValue();
+
+  return ClosureBoxLayout{llvm::TypeSize::getFixed(llvm::alignTo(
+                              closureDataSize, closureHeaderLayout->alignment)),
+                          closureHeaderLayout->alignment, payloadPadding};
 }
 } // namespace
 
@@ -1599,8 +1660,7 @@ ClosureBoxType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
       deriveLayoutForClosureBox(getContext(), getPayloadTypes(), dataLayout);
   if (!derived)
     llvm_unreachable("ClosureBoxType must have a fixed size");
-  auto [sizeInBytes, _x, _y] = *derived;
-  return sizeInBytes * 8; // Convert to bits
+  return derived->size * 8; // Convert to bits
 }
 
 uint64_t
@@ -1610,8 +1670,22 @@ ClosureBoxType::getABIAlignment(const mlir::DataLayout &dataLayout,
       deriveLayoutForClosureBox(getContext(), getPayloadTypes(), dataLayout);
   if (!derived)
     llvm_unreachable("ClosureBoxType must have a fixed alignment");
-  auto [_x, alignment, _y] = *derived;
-  return alignment.value();
+  return derived->alignment.value();
+}
+
+uint64_t
+ClosureBoxType::getPayloadPadding(const mlir::DataLayout &dataLayout) const {
+  auto derived =
+      deriveLayoutForClosureBox(getContext(), getPayloadTypes(), dataLayout);
+  if (!derived)
+    llvm_unreachable("ClosureBoxType must have a fixed layout");
+  return derived->payloadPadding;
+}
+
+size_t
+ClosureBoxType::getPayloadIndex(const mlir::DataLayout &dataLayout) const {
+  return getPayloadPadding(dataLayout) == 0 ? PAYLOAD_INDEX_WITHOUT_PADDING
+                                            : PAYLOAD_INDEX_WITH_PADDING;
 }
 
 MLIR_DATA_LAYOUT_EXPAND_PREFERRED_ALIGN(

--- a/tests/integration/conversion/closure_apply.mlir
+++ b/tests/integration/conversion/closure_apply.mlir
@@ -6,7 +6,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
   
   // Test function that accepts a closure and applies an argument to it
   // CHECK-LABEL: define ptr @apply_to_closure(ptr %0, i32 %1) {
-  // CHECK: %3 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %3 = getelementptr { i32, { ptr, ptr, <{ {} }> } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %4 = load ptr, ptr %3, align 8
   // CHECK: %5 = ptrtoint ptr %4 to i64
   // CHECK: %6 = sub i64 0, %5
@@ -26,7 +26,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
   // Test function that applies multiple arguments to a closure
   // CHECK-LABEL: define ptr @apply_multiple_args(ptr %0, i32 %1, i64 %2) {
-  // CHECK: %4 = getelementptr { i32, { ptr, ptr, i64 } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %4 = getelementptr { i32, { ptr, ptr, <{ { i64 } }> } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %5 = load ptr, ptr %4, align 8
   // CHECK: %6 = ptrtoint ptr %5 to i64
   // CHECK: %7 = sub i64 0, %6
@@ -38,7 +38,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
   // CHECK: %12 = add nuw i64 %11, 4
   // CHECK: %13 = inttoptr i64 %12 to ptr
   // CHECK: store ptr %13, ptr %4, align 8
-  // CHECK: %14 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %14 = getelementptr { i32, { ptr, ptr, <{ {} }> } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %15 = load ptr, ptr %14, align 8
   // CHECK: %16 = ptrtoint ptr %15 to i64
   // CHECK: %17 = sub i64 0, %16
@@ -59,7 +59,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
   // Test function that applies an argument to a closure with no return value
   // CHECK-LABEL: define ptr @apply_void_closure(ptr %0, i32 %1) {
-  // CHECK: %3 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %3 = getelementptr { i32, { ptr, ptr, <{ {} }> } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %4 = load ptr, ptr %3, align 8
   // CHECK: %5 = ptrtoint ptr %4 to i64
   // CHECK: %6 = sub i64 0, %5
@@ -79,7 +79,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 
   // Test function that applies a small type (i8) to verify alignment handling
   // CHECK-LABEL: define ptr @apply_small_type(ptr %0, i8 %1) {
-  // CHECK: %3 = getelementptr { i32, { ptr, ptr } }, ptr %0, i32 0, i32 1, i32 1
+  // CHECK: %3 = getelementptr { i32, { ptr, ptr, <{ {} }> } }, ptr %0, i32 0, i32 1, i32 1
   // CHECK: %4 = load ptr, ptr %3, align 8
   // CHECK: store i8 %1, ptr %4, align 1
   // CHECK: %5 = ptrtoint ptr %4 to i64

--- a/tests/integration/conversion/closure_box_layout.mlir
+++ b/tests/integration/conversion/closure_box_layout.mlir
@@ -1,0 +1,37 @@
+// RUN: %reussir-opt %s --reussir-token-instantiation | \
+// RUN:   %FileCheck %s --check-prefix=TOKEN
+// RUN: %reussir-opt %s --reussir-token-instantiation \
+// RUN:   --reussir-closure-outlining --reussir-convert-to-llvm | \
+// RUN:   %FileCheck %s --check-prefix=LLVM
+
+// A wasm32 closure box remains pointer-aligned even when its payload requires
+// stronger alignment. The explicit padding keeps the cursor and payload
+// correctly positioned without allowing the payload to move the header.
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    !llvm.ptr = dense<32> : vector<4xi64>,
+    i64 = dense<64> : vector<2xi64>,
+    i32 = dense<32> : vector<2xi64>,
+    i8 = dense<8> : vector<2xi64>>,
+  llvm.data_layout = "e-m:e-p:32:32-i64:64-i128:128-n32:64-S128",
+  llvm.target_triple = "wasm32-unknown-wasip1"
+} {
+  // TOKEN-LABEL: func.func @make
+  // TOKEN: %[[TOKEN:.*]] = reussir.token.alloc : <align : 4, size : 24>
+  // TOKEN: reussir.closure.create
+  // TOKEN: token (%[[TOKEN]] : <align : 4, size : 24>)
+  func.func @make() -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+    %closure = reussir.closure.create
+        -> !reussir.rc<!reussir.closure<(i64) -> i64>> {
+      body {
+      ^bb0(%value: i64):
+        reussir.closure.yield %value : i64
+      }
+    }
+    return %closure : !reussir.rc<!reussir.closure<(i64) -> i64>>
+  }
+
+  // LLVM-LABEL: llvm.func @make
+  // LLVM: llvm.getelementptr {{.*}}[0, 1, 1] : {{.*}}, !llvm.struct<(i32, struct<(ptr, ptr, struct<packed (array<4 x i8>, struct<(i64)>)>)>)>
+  // LLVM: llvm.getelementptr {{.*}}[0, 1, 2, 1] : {{.*}}, !llvm.struct<(i32, struct<(ptr, ptr, struct<packed (array<4 x i8>, struct<(i64)>)>)>)>
+}

--- a/tests/integration/conversion/closure_uniqify_2.mlir
+++ b/tests/integration/conversion/closure_uniqify_2.mlir
@@ -13,7 +13,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 }
 
 // CHECK: llvm.func @test_closure_uniqify_with_input(%[[INPUT:.*]]: !llvm.ptr) -> !llvm.ptr {
-// CHECK:   %[[GEP_REFCNT:.*]] = llvm.getelementptr %[[INPUT]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr, i32)>)>
+// CHECK:   %[[GEP_REFCNT:.*]] = llvm.getelementptr %[[INPUT]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr, struct<packed (struct<(i32)>)>)>)>
 // CHECK:   %[[REFCNT:.*]] = llvm.load %[[GEP_REFCNT]] : !llvm.ptr -> i32
 // CHECK:   %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:   %[[IS_UNIQUE:.*]] = llvm.icmp "eq" %[[REFCNT]], %[[ONE]] : i32
@@ -21,12 +21,12 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<64> :
 // CHECK: ^[[THEN]]:  // pred: ^bb0
 // CHECK:   llvm.br ^[[JOIN:bb[0-9]+]](%[[INPUT]] : !llvm.ptr)
 // CHECK: ^[[ELSE]]:  // pred: ^bb0
-// CHECK:   %[[GEP_VTABLE:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr, i32)>)>
+// CHECK:   %[[GEP_VTABLE:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr, struct<packed (struct<(i32)>)>)>)>
 // CHECK:   %[[VTABLE:.*]] = llvm.load %[[GEP_VTABLE]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[GEP_CLONE:.*]] = llvm.getelementptr %[[VTABLE]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr, ptr)>
 // CHECK:   %[[CLONE_FUNC:.*]] = llvm.load %[[GEP_CLONE]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[CLONED:.*]] = llvm.call %[[CLONE_FUNC]](%[[INPUT]]) : !llvm.ptr, (!llvm.ptr) -> !llvm.ptr
-// CHECK:   %[[GEP_VTABLE2:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr, i32)>)>
+// CHECK:   %[[GEP_VTABLE2:.*]] = llvm.getelementptr %[[INPUT]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(ptr, ptr, struct<packed (struct<(i32)>)>)>)>
 // CHECK:   %[[VTABLE2:.*]] = llvm.load %[[GEP_VTABLE2]] invariant_group : !llvm.ptr -> !llvm.ptr
 // CHECK:   %[[GEP_DROP:.*]] = llvm.getelementptr %[[VTABLE2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr, ptr)>
 // CHECK:   %[[DROP_FUNC:.*]] = llvm.load %[[GEP_DROP]] invariant_group : !llvm.ptr -> !llvm.ptr


### PR DESCRIPTION
## Summary

- define canonical physical header members for `RcBox` and `ClosureBox`, shared by semantic data-layout queries and LLVM type conversion
- extend the aggregate-layout helper to return target-derived member offsets, unpadded data extent, total size, and ABI alignment
- derive closure payload padding from the actual nested RC/closure allocation prefix through `DataLayout`, with no target-specific offsets
- keep `ClosureBox` pointer-aligned while preserving normal alignment within the payload aggregate
- emit a padding array only when its computed size is non-zero, and update payload GEPs for the nested payload tail
- add a wasm32 regression covering token size/alignment, LLVM structure, cursor placement, and payload placement

## Validation

- C++ unit tests: 30 passed
- Rust tests:
  - `reussir-backend`: 13 passed, 1 environment-dependent test ignored
  - `reussir-codegen`: 35 unit tests and 21 runtime tests passed
  - `rrc`: 9 library, 22 driver, and 1 debug-info test passed
- sanitized `reussir-rt` variants built: ASan, LSan, MSan, and TSan
- full lit suite outside the ptrace-restricted sandbox: 444 passed, 1 platform-unsupported
- `wasm32-wasip1-threads` inventory example built with Rene and ran to completion under Wasmer, printing `total 253.50` and `with tax 273.78`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787894419&installation_model_id=426051&pr_number=484&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F484&signature=57c8aecf65c6864dc8a6ea9f0a5a7ef3ad2884ad48446169c40eea04af1f7b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
