### PR TITLE
[syntax][core] accept `if` without `else` as sugar for an empty `else {}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Language
+
+- `if` without an `else` branch is now accepted as sugar for an empty
+  `else {}`: the whole expression is unit and the then-branch is checked
+  against unit. The elaborated HIR carries an explicit empty else-block, so
+  everything downstream of elaboration is unchanged.
+
 ## 0.1.0
 
 The first tagged release of Reussir: an MLIR-based compiler framework for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Language
-
-- `if` without an `else` branch is now accepted as sugar for an empty
-  `else {}`: the whole expression is unit and the then-branch is checked
-  against unit. The elaborated HIR carries an explicit empty else-block, so
-  everything downstream of elaboration is unchanged.
-
 ## 0.1.0
 
 The first tagged release of Reussir: an MLIR-based compiler framework for

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -895,6 +895,13 @@ mod tests {
         );
     }
 
+    /// The empty else-block synthesized for an `if` without `else` survives
+    /// the MIR textual round-trip.
+    #[test]
+    fn roundtrips_if_without_else() {
+        roundtrip("pub fn noop() { } pub fn tick(n: u64) { if n > 1 { noop() } }");
+    }
+
     #[test]
     fn roundtrips_records_and_projection() {
         // Exercises `@Pair{..}` constructors, the `Pair` record type, and

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -206,15 +206,21 @@ Cap: raw::Cap = {
 /// spanless expression is not wrapped (a spanless one-statement `Seq` prints
 /// indistinguishably and is normalized away — structurally, not semantically,
 /// significant).
-Block: raw::Expr = <sp:Span?> <first:Expr> <rest:(";" <Expr>)*> => {
-    if sp.is_none() && rest.is_empty() {
-        first
-    } else {
-        let mut v = vec![first];
-        v.extend(rest);
-        let ty = v.last().unwrap().ty.clone();
-        raw::Expr::new(raw::Kind::Seq(v), ty).with_span(sp)
-    }
+Block: raw::Expr = {
+    <sp:Span?> <first:Expr> <rest:(";" <Expr>)*> => {
+        if sp.is_none() && rest.is_empty() {
+            first
+        } else {
+            let mut v = vec![first];
+            v.extend(rest);
+            let ty = v.last().unwrap().ty.clone();
+            raw::Expr::new(raw::Kind::Seq(v), ty).with_span(sp)
+        }
+    },
+    // An empty block is an empty (unit) `Seq` — an empty function body, an
+    // empty surface `{}`, or the else-branch the elaborator synthesizes for
+    // an `if` without `else`.
+    <sp:Span?> => raw::Expr::new(raw::Kind::Seq(Vec::new()), raw::Ty::Unit).with_span(sp),
 };
 
 /// Every value expression is `Atom : Ty` — the node's type is always printed and

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -747,6 +747,30 @@ mod tests {
         });
     }
 
+    /// An `if` with no `else` is unit, so a non-unit then-branch is a type
+    /// error reported at the branch itself.
+    #[test]
+    fn if_without_else_requires_a_unit_then_branch() {
+        with_tcx(|tcx| {
+            let source = "fn bad(c: bool) -> i32 { if c { true } }";
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(elab.has_errors(), "expected a unit mismatch error");
+            let messages = elab
+                .reports
+                .iter()
+                .map(|r| r.message.clone())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                messages.contains("expected `unit`, found `bool`"),
+                "then-branch should be checked against unit: {messages}"
+            );
+        });
+    }
+
     /// Diagnostics spell types the way the surface does (`i32`, `bool`,
     /// `Nullable<TestCell<u64>>`, `[rigid] …`), never the internal `Debug` form
     /// (`Int(Signed(32))`).

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -278,7 +278,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             surface::ExprKind::ConstExpr(c) => self.infer_const(c, span),
             surface::ExprKind::Var(path) => self.infer_var(path, span),
             surface::ExprKind::ExprSeq(exprs) => self.infer_seq(exprs, span),
-            surface::ExprKind::If(c, t, f) => self.infer_if(c, t, f, span),
+            surface::ExprKind::If(c, t, f) => self.infer_if(c, t, f.as_ref(), span),
             surface::ExprKind::Let(name, ty, value) => {
                 self.infer_let(name, ty.as_ref(), value, span)
             }
@@ -401,18 +401,35 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     /// (IF) `Γ ⊢ if c t f ⇒ (If(hc,ht,hf) : T)`: `c ⇐ Bool`, `t ⇒ T`, then `f ⇐ T`
     /// (the then-branch's synthesized type drives the else-branch).
+    ///
+    /// An omitted else branch is sugar for an empty `else {}`: the elaborated
+    /// HIR carries a synthesized empty unit block, so the whole expression is
+    /// unit and the then-branch is checked against unit (`t ⇐ Unit`) — that
+    /// way a non-unit then-branch is reported at the branch itself rather
+    /// than at an else block the programmer never wrote.
     fn infer_if(
         &mut self,
         c: &surface::Expr,
         t: &surface::Expr,
-        f: &surface::Expr,
+        f: Option<&surface::Expr>,
         span: Option<Span>,
     ) -> Expr<'tcx> {
         let bool_ty = self.tcx.mk_bool();
         let c = self.check_expr(c, bool_ty);
-        let t = self.infer_expr(t);
+        let (t, f) = match f {
+            Some(f) => {
+                let t = self.infer_expr(t);
+                let f = self.check_expr(f, t.ty);
+                (t, f)
+            }
+            None => {
+                let unit = self.tcx.mk_unit();
+                let t = self.check_expr(t, unit);
+                let f = self.mk_expr(ExprKind::Seq(Vec::new()), unit, span);
+                (t, f)
+            }
+        };
         let result = t.ty;
-        let f = self.check_expr(f, result);
         self.mk_expr(
             ExprKind::If(Box::new(c), Box::new(t), Box::new(f)),
             result,

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -987,6 +987,38 @@ mod tests {
     }
 
     #[test]
+    fn roundtrips_if_without_else() {
+        roundtrip("pub fn noop() { } pub fn tick(n: u64) { if n > 1 { noop() } }");
+    }
+
+    /// The sugar is pure syntax: an omitted `else` elaborates to exactly the
+    /// HIR of an explicit empty `else {}`.
+    #[test]
+    fn if_without_else_matches_explicit_empty_else() {
+        fn printed_hir(source: &str) -> String {
+            with_tcx(|tcx| {
+                let parse = reussir_syntax::parse(source);
+                assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+                let prog = surface::program(&parse.root);
+                let elab = elaborate(tcx, &prog, parse.resolver());
+                assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+                let strings = elab.strings.entries();
+                Printer::new(&elab.defs, elab.resolver).program(
+                    &elab.elaborated,
+                    &strings,
+                    &elab.records,
+                    &elab.trampolines,
+                )
+            })
+        }
+
+        let sugar = printed_hir("pub fn noop() { } pub fn tick(n: u64) { if n > 1 { noop() } }");
+        let explicit =
+            printed_hir("pub fn noop() { } pub fn tick(n: u64) { if n > 1 { noop() } else { } }");
+        assert_eq!(sugar, explicit);
+    }
+
+    #[test]
     fn roundtrips_a_string_literal() {
         roundtrip("pub fn greet() -> str { \"hi\" }");
     }

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -273,15 +273,21 @@ Cap: raw::Cap = {
 /// spanless expression is not wrapped (a spanless one-statement `Seq` prints
 /// indistinguishably and is normalized away — structurally, not semantically,
 /// significant).
-Block: raw::Expr = <sp:Span?> <first:Expr> <rest:(";" <Expr>)*> => {
-    if sp.is_none() && rest.is_empty() {
-        first
-    } else {
-        let mut v = vec![first];
-        v.extend(rest);
-        let ty = v.last().unwrap().ty.clone();
-        raw::Expr::new(raw::Kind::Seq(v), ty).with_span(sp)
-    }
+Block: raw::Expr = {
+    <sp:Span?> <first:Expr> <rest:(";" <Expr>)*> => {
+        if sp.is_none() && rest.is_empty() {
+            first
+        } else {
+            let mut v = vec![first];
+            v.extend(rest);
+            let ty = v.last().unwrap().ty.clone();
+            raw::Expr::new(raw::Kind::Seq(v), ty).with_span(sp)
+        }
+    },
+    // An empty block is an empty (unit) `Seq` — an empty function body, an
+    // empty surface `{}`, or the else-branch the elaborator synthesizes for
+    // an `if` without `else`.
+    <sp:Span?> => raw::Expr::new(raw::Kind::Seq(Vec::new()), raw::Ty::Unit).with_span(sp),
 };
 
 /// Every value expression is `Atom : Ty`; `let` (always `unit`) and a braced

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -612,7 +612,9 @@ pub struct CtorCall {
 pub enum ExprKind {
     ConstExpr(Const),
     ExprSeq(Vec<Expr>),
-    If(Expr, Expr, Expr),
+    /// `if cond { then } else { other }`; `None` for the else branch means it
+    /// was omitted, which is sugar for an empty (unit) `else {}`.
+    If(Expr, Expr, Option<Expr>),
     Let(Spanned<TokenKey>, Option<(Type, bool)>, Expr),
     Match(Expr, Vec<(Pattern, Expr)>),
     RegionalExpr(Expr),
@@ -690,7 +692,7 @@ impl Expr {
                 let mut parts = expr_children(node);
                 let cond = Expr::new(parts.next().expect("condition"));
                 let then = Expr::new(parts.next().expect("then branch"));
-                let other = Expr::new(parts.next().expect("else branch"));
+                let other = parts.next().map(Expr::new);
                 ExprKind::If(cond, then, other)
             }
             LetExpr => {

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -516,7 +516,10 @@ impl Emitter<'_> {
                 let mut parts = expr_children(node).map(|e| self.expr(e));
                 let cond = parts.next().expect("condition");
                 let then = parts.next().expect("then branch");
-                let other = parts.next().expect("else branch");
+                // A missing `else` desugars to an empty (unit) block.
+                let other = parts
+                    .next()
+                    .unwrap_or_else(|| tagged("ExprSeq", Value::Array(Vec::new())));
                 tagged("If", json!([cond, then, other]))
             }
             LetExpr => {

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -312,6 +312,8 @@ mod tests {
             "f(1, 2)",
             "let a = 10; let b = 20; a + b",
             "if true { 1 } else { 0 }",
+            // The `else` branch may be omitted (unit `if`).
+            "if true { f() }",
             "{ let x = 1; x }",
             "|x: i32| x + 1",
             // `regional` NOT followed by `fn` is a regional expression.
@@ -377,6 +379,40 @@ mod tests {
         json_of(
             "fn f(x: i32, y: i32) -> i32 {\n    let z = x * 2 + y % 3;\n    if (z >= 0 && !(z == 4)) { z } else { -z }\n}",
         );
+    }
+
+    /// `if` without `else` is sugar for an empty `else {}`: the emitted AST
+    /// still carries three `If` parts, the last being an empty block.
+    #[test]
+    fn if_without_else_desugars_to_an_empty_else_block() {
+        fn find_if(v: &serde_json::Value) -> Option<&serde_json::Value> {
+            match v {
+                serde_json::Value::Object(map) => {
+                    if map.get("tag").and_then(|t| t.as_str()) == Some("If") {
+                        return Some(v);
+                    }
+                    map.values().find_map(find_if)
+                }
+                serde_json::Value::Array(items) => items.iter().find_map(find_if),
+                _ => None,
+            }
+        }
+
+        let json = json_of("fn f(c: bool) { if c { f(c) } }");
+        let if_node = find_if(&json).expect("an If node");
+        let parts = if_node["contents"].as_array().expect("If parts");
+        assert_eq!(parts.len(), 3, "desugared If still has three parts");
+        assert_eq!(
+            parts[2],
+            serde_json::json!({ "tag": "ExprSeq", "contents": [] })
+        );
+    }
+
+    /// A dangling `else` with no block is still a parse error.
+    #[test]
+    fn if_with_dangling_else_still_errors() {
+        let parse = parse("fn f(c: bool) { if c { } else }");
+        assert!(!parse.ok());
     }
 
     #[test]

--- a/crates/reussir-syntax/src/parser/expr.rs
+++ b/crates/reussir-syntax/src/parser/expr.rs
@@ -327,15 +327,19 @@ impl Parser<'_> {
         }
     }
 
-    /// `if cond { ... } else { ... }` — the `else` branch is mandatory and
-    /// the condition is parsed in no-struct mode.
+    /// `if cond { ... } (else { ... })?` — the condition is parsed in
+    /// no-struct mode. A missing `else` branch is sugar for an empty
+    /// `else {}`: the elaborator supplies a unit else-block, so the whole
+    /// expression is unit and the then-branch must be unit too.
     fn if_expr(&mut self) -> CompletedMarker {
         let m = self.start();
         self.bump(); // if
         self.expr_no_struct();
         self.block_expr();
-        self.expect(ElseKw);
-        self.block_expr();
+        if self.at(ElseKw) {
+            self.bump();
+            self.block_expr();
+        }
         m.complete(self, IfExpr)
     }
 

--- a/tests/integration/frontend/elab_errors.rr
+++ b/tests/integration/frontend/elab_errors.rr
@@ -22,3 +22,10 @@ fn ambiguous() -> i64 {
 fn huge(a: [f64; 70000, 70000]) -> f64 {
     0.0
 }
+
+// An `if` without `else` is sugar for an empty `else {}`, so the whole
+// expression is unit and a non-unit then-branch is rejected at the branch.
+// CHECK-DAG: type mismatch: expected `unit`, found `bool`
+fn non_unit_then(c: bool) -> i32 {
+    if c { true }
+}

--- a/tests/integration/frontend/if_no_else.rr
+++ b/tests/integration/frontend/if_no_else.rr
@@ -1,0 +1,19 @@
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
+
+// An `if` without an `else` branch is sugar for an empty `else {}`: the
+// elaborated HIR carries an explicit empty unit else-branch, and the whole
+// expression is unit.
+
+// CHECK: fn #noop() -> () {
+// CHECK: fn #tick(v0 (n): u64) -> () {
+// CHECK-NEXT: if (v0 : u64 > 1 : u64) : bool then {
+// CHECK-NEXT: #noop() : ()
+// CHECK-NEXT: } else {
+// CHECK: } : ()
+// CHECK-NEXT: }
+
+pub fn noop() { }
+
+pub fn tick(n: u64) {
+    if n > 1 { noop() }
+}


### PR DESCRIPTION
## Summary

Removes the need to write an empty `else {}`: `if cond { ... }` is now accepted and desugars to exactly what `if cond { ... } else {}` elaborates to.

- **Parser** (`reussir-syntax`): the `else` branch of `if_expr` is optional; a dangling `else` without a block is still a parse error.
- **Surface AST** (`reussir-core::surface`): `ExprKind::If` carries `Option<Expr>` for the else branch.
- **Elaborator** (`semi::check::infer_if`): an omitted branch synthesizes the empty unit `Seq` an explicit `else {}` produces, and the then-branch is checked against unit (`t ⇐ Unit`) so a non-unit then-branch is diagnosed at the branch itself (`type mismatch: expected `unit`, found ...`) rather than at an else block the programmer never wrote. Everything downstream of elaboration is unchanged.
- **JSON AST emitter** (`reussir-syntax::ast`): keeps the stable three-part `If` shape by emitting an empty `ExprSeq` for the missing branch.
- **Textual HIR/MIR grammars**: the synthesized branch is always an empty `Seq`, which the `Block` rules could not re-parse (they required at least one expression — empty function bodies had the same latent gap). Both grammars gain an empty-block alternative typed unit, keeping printed dumps round-trippable.

## Testing

Rust unit tests (`cargo test -p reussir-syntax -p reussir-core`, 371 passing):

- parser: JSON-shape test for the desugared `If`, dangling-`else` negative test, REPL expression-routing case;
- elaborator: desugar-equivalence test asserting the omitted and explicit empty `else` print identical HIR; diagnostic test asserting the `expected `unit`, found `bool`` message;
- textual formats: HIR and MIR round-trip tests through print → parse → re-print.

Lit integration tests (CHECK lines derived from the actual elaborator output; this environment has no MLIR toolchain, so CI runs them):

- `tests/integration/frontend/if_no_else.rr`: `--emit hir` shows the explicit empty unit else-branch;
- `tests/integration/frontend/elab_errors.rr`: new case for the non-unit then-branch diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iUBMoNbyQdjBSKHpoFBXk

---
_Generated by [Claude Code](https://claude.ai/code/session_012iUBMoNbyQdjBSKHpoFBXk)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788114869&installation_model_id=426051&pr_number=488&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F488&signature=d94d117841813f26e63b5742ca2aa57ad29e73565b9f8816d8d79c68142e0146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->