### PR TITLE
[ci] publish versioned releases from v* tags in the release pipeline

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,8 +1,12 @@
 name: Nightly Release
 
+# Every push to main refreshes the rolling `nightly` prerelease; pushing a
+# `v*` tag runs the same build matrix and tests but publishes a versioned
+# release under that tag instead (marked latest, nightly untouched).
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
   workflow_dispatch:
 
 permissions:
@@ -98,9 +102,13 @@ jobs:
 
       - name: Package
         run: |
-          DATE=$(date +%Y-%m-%d)
           ARCH=$(uname -m)
-          PREFIX="reussir-nightly-${DATE}-linux-${ARCH}"
+          # Tag builds carry the version; main builds carry the date.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            PREFIX="reussir-${GITHUB_REF_NAME}-linux-${ARCH}"
+          else
+            PREFIX="reussir-nightly-$(date +%Y-%m-%d)-linux-${ARCH}"
+          fi
           mkdir -p "${PREFIX}/bin"
 
           # Only the user-facing toolchain ships: rrc and rrepl link
@@ -210,9 +218,13 @@ jobs:
 
       - name: Package
         run: |
-          DATE=$(date +%Y-%m-%d)
           ARCH=$(uname -m)
-          PREFIX="reussir-nightly-${DATE}-macos-${ARCH}"
+          # Tag builds carry the version; main builds carry the date.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            PREFIX="reussir-${GITHUB_REF_NAME}-macos-${ARCH}"
+          else
+            PREFIX="reussir-nightly-$(date +%Y-%m-%d)-macos-${ARCH}"
+          fi
           mkdir -p "${PREFIX}/bin"
 
           # Only the user-facing toolchain ships: rrc and rrepl link
@@ -501,8 +513,13 @@ jobs:
         shell: pwsh
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
-          $date = Get-Date -Format "yyyy-MM-dd"
-          $prefix = "reussir-nightly-$date-windows-x64-msvc"
+          # Tag builds carry the version; main builds carry the date.
+          if ($env:GITHUB_REF_TYPE -eq "tag") {
+            $prefix = "reussir-$($env:GITHUB_REF_NAME)-windows-x64-msvc"
+          } else {
+            $date = Get-Date -Format "yyyy-MM-dd"
+            $prefix = "reussir-nightly-$date-windows-x64-msvc"
+          }
           New-Item -ItemType Directory -Force -Path "$prefix\bin" | Out-Null
 
           # Only the user-facing toolchain ships: rrc and rrepl link
@@ -566,12 +583,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # The rolling-nightly bookkeeping only applies to main builds: a tag
+      # build publishes under its own immutable tag and must leave the
+      # nightly release alone.
       - name: Delete existing nightly release
+        if: github.ref_type != 'tag'
         run: gh release delete nightly --yes --cleanup-tag || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Force-tag nightly
+        if: github.ref_type != 'tag'
         run: |
           git tag -f nightly
           git push origin nightly --force
@@ -586,6 +608,7 @@ jobs:
         run: ls -lh artifacts/
 
       - name: Create or update nightly release
+        if: github.ref_type != 'tag'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: nightly
@@ -597,6 +620,33 @@ jobs:
             artifacts/*.zip
           body: |
             Automated nightly build from `${{ github.sha }}`.
+
+            **Contents:** the Reussir toolchain — `rrc` (ahead-of-time compiler), `rene` (package manager), and `rrepl` (REPL). LLVM/MLIR and the Reussir backend are linked statically into the binaries; no shared libraries ship and nothing needs `LD_LIBRARY_PATH`.
+
+            **Platforms:**
+            - Linux x86_64 (built against LLVM 22)
+            - Linux aarch64 (built against LLVM 22)
+            - macOS ARM64 (built against Homebrew LLVM)
+            - Windows x64 (built against MSVC LLVM via conda-forge)
+
+            **Usage:** Extract the archive and add `<prefix>/bin` to `PATH`.
+
+            Compiling programs requires a Rust toolchain (`rustc`/`cargo`) on `PATH`: the bundled `rene` bakes the `reussir-rt` runtime from its embedded source with your toolchain on first use — no toolchain or prebuilt runtime ships in this archive.
+
+      - name: Create versioned release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Reussir ${{ github.ref_name }}"
+          prerelease: false
+          make_latest: true
+          generate_release_notes: true
+          files: |
+            artifacts/*.tar.xz
+            artifacts/*.zip
+          body: |
+            Reussir ${{ github.ref_name }}, built from `${{ github.sha }}`. See `CHANGELOG.md` for the release notes.
 
             **Contents:** the Reussir toolchain — `rrc` (ahead-of-time compiler), `rene` (package manager), and `rrepl` (REPL). LLVM/MLIR and the Reussir backend are linked statically into the binaries; no shared libraries ship and nothing needs `LD_LIBRARY_PATH`.
 


### PR DESCRIPTION
## Summary
- trigger the release pipeline on `v*` tag pushes in addition to pushes to `main`
- tag builds run the identical build/test matrix, but package archives named after the tag (`reussir-v0.1.0-linux-x86_64.tar.xz`) rather than the nightly date
- tag builds publish a versioned release under the pushed tag (`make_latest: true`, not a prerelease, auto-generated notes + the usual usage body); the nightly delete/force-tag steps are skipped so the nightly channel is untouched

## Notes
- The workflow that runs for a tag is the one at the tagged commit, so branch `v0.1.x` (and tag `v0.1.0`) from main **after** this merges.
- Nightly behavior on main pushes is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788144148&installation_model_id=426051&pr_number=490&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F490&signature=41ba1c4e25f7f2fbc78d86b62a497d43982f0afb0825dcd2148ccb84ed6ea034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->