### PR TITLE
[syntax] parse `pub` on record fields and encode field visibility

### DIFF
--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -10,6 +10,10 @@
 //! * tuples are arrays, an optional value is `null` or the value;
 //! * spans are `{"spanValue": v, "spanStartOffset": n, "spanEndOffset": n}`
 //!   with *character* offsets.
+//!
+//! Record fields carry a trailing visibility string: named fields are
+//! `[name, type, is_field, vis]` quads and unnamed fields `[type, is_field,
+//! vis]` triples, with `vis` either `"Public"` or `"Private"`.
 
 use serde_json::{Number, Value, json};
 
@@ -53,6 +57,15 @@ fn child_node(node: &ResolvedNode, kind: SyntaxKind) -> Option<&ResolvedNode> {
 
 fn is_ident_like(kind: SyntaxKind) -> bool {
     kind.is_ident_like()
+}
+
+/// Field visibility as the all-nullary-sum string encoding.
+fn visibility_str(field: &ResolvedNode) -> &'static str {
+    if child_node(field, VisFlag).is_some() {
+        "Public"
+    } else {
+        "Private"
+    }
 }
 
 fn is_expr_kind(kind: SyntaxKind) -> bool {
@@ -242,14 +255,18 @@ impl Emitter<'_> {
             let fields: Vec<Value> = nodes(named)
                 .filter(|n| n.kind() == NamedField)
                 .map(|f| {
+                    // A `pub` marker is nested inside a VisFlag node, so the
+                    // direct-token scan below still finds the real field name
+                    // (which may itself be spelled `pub`).
                     let name = tokens(f)
                         .find(|t| is_ident_like(t.kind()))
                         .expect("field name");
                     let flag = child_node(f, FieldFlag).is_some();
+                    let vis = visibility_str(f);
                     let ty = nodes(f)
                         .find(|n| is_type_kind(n.kind()))
                         .expect("field type");
-                    self.with_node_span(f, json!([name.text(), self.type_(ty), flag]))
+                    self.with_node_span(f, json!([name.text(), self.type_(ty), flag, vis]))
                 })
                 .collect();
             tagged("Named", Value::Array(fields))
@@ -258,10 +275,11 @@ impl Emitter<'_> {
                 .filter(|n| n.kind() == UnnamedField)
                 .map(|f| {
                     let flag = child_node(f, FieldFlag).is_some();
+                    let vis = visibility_str(f);
                     let ty = nodes(f)
                         .find(|n| is_type_kind(n.kind()))
                         .expect("field type");
-                    self.with_node_span(f, json!([self.type_(ty), flag]))
+                    self.with_node_span(f, json!([self.type_(ty), flag, vis]))
                 })
                 .collect();
             tagged("Unnamed", Value::Array(fields))

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -145,6 +145,8 @@ pub enum SyntaxKind {
     Capability,
     /// `[field]` flag on record fields.
     FieldFlag,
+    /// `pub` visibility marker on record fields.
+    VisFlag,
     /// `[flex]` flag on parameters/return types/let bindings.
     FlexFlag,
     /// An outer attribute `#[repr(fixed)]` on an item (e.g. an enum).

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -543,6 +543,51 @@ mod tests {
     }
 
     #[test]
+    fn field_visibility_parses_and_encodes() {
+        let json = json_of("pub struct S { pub x: i64, y: [field] T }");
+        let record = unwrap_span(&json[0]);
+        let named = &record["contents"]["recordFields"];
+        assert_eq!(named["tag"], "Named");
+        let x = &named["contents"][0]["spanValue"];
+        let y = &named["contents"][1]["spanValue"];
+        assert_eq!(x[0], "x");
+        assert_eq!(x[2], false);
+        assert_eq!(x[3], "Public");
+        assert_eq!(y[0], "y");
+        assert_eq!(y[2], true);
+        assert_eq!(y[3], "Private");
+
+        let json = json_of("struct P(pub i64, bool)");
+        let unnamed = &unwrap_span(&json[0])["contents"]["recordFields"];
+        assert_eq!(unnamed["tag"], "Unnamed");
+        assert_eq!(unnamed["contents"][0]["spanValue"][2], "Public");
+        assert_eq!(unnamed["contents"][1]["spanValue"][2], "Private");
+    }
+
+    /// `pub` stays a legal field name, field type, and path segment; the
+    /// marker is recognized only where a name/type cannot follow it.
+    #[test]
+    fn field_named_pub_stays_a_field_name() {
+        let json = json_of("struct S { pub: i64, pub pub: i64 }");
+        let named = &unwrap_span(&json[0])["contents"]["recordFields"]["contents"];
+        let first = &named[0]["spanValue"];
+        let second = &named[1]["spanValue"];
+        assert_eq!(first[0], "pub");
+        assert_eq!(first[3], "Private");
+        assert_eq!(second[0], "pub");
+        assert_eq!(second[3], "Public");
+
+        let json = json_of("struct T(pub, pub i64)");
+        let unnamed = &unwrap_span(&json[0])["contents"]["recordFields"]["contents"];
+        let first = &unnamed[0]["spanValue"];
+        let second = &unnamed[1]["spanValue"];
+        // The lone `pub` is a type named `pub`, not a visibility marker.
+        assert_eq!(first[1], false);
+        assert_eq!(first[2], "Private");
+        assert_eq!(second[2], "Public");
+    }
+
+    #[test]
     fn transform_item_requires_a_semicolon() {
         let parse = parse("transform [{ transform.yield }]");
         assert!(

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -206,12 +206,19 @@ impl Parser<'_> {
         m.complete(self, StructStmt);
     }
 
-    /// `{ name: [field]? type, ... }`.
+    /// `{ pub? name: [field]? type, ... }`.
     fn named_fields(&mut self) {
         let m = self.start();
         self.expect(LBrace);
         while !self.at(RBrace) && !self.at_eof() {
             let f = self.start();
+            // `pub` is also a legal field name (no reserved words); it is a
+            // visibility marker only when not immediately followed by `:`.
+            if self.at(PubKw) && self.nth(1) != Colon {
+                let v = self.start();
+                self.bump();
+                v.complete(self, VisFlag);
+            }
             self.expect_ident("a field name");
             self.expect(Colon);
             self.field_flag_opt();
@@ -227,12 +234,19 @@ impl Parser<'_> {
         m.complete(self, NamedFields);
     }
 
-    /// `( [field]? type, ... )`.
+    /// `( pub? [field]? type, ... )`.
     fn unnamed_fields(&mut self) {
         let m = self.start();
         self.expect(LParen);
         while !self.at(RParen) && !self.at_eof() {
             let f = self.start();
+            // `pub` is also a legal type name; it is a visibility marker only
+            // when what follows cannot continue a type headed by `pub`.
+            if self.at(PubKw) && !matches!(self.nth(1), Comma | RParen | PathSep | LAngle | Arrow) {
+                let v = self.start();
+                self.bump();
+                v.complete(self, VisFlag);
+            }
             self.field_flag_opt();
             self.type_();
             f.complete(self, UnnamedField);


### PR DESCRIPTION
First PR of the member-visibility / member-function stack (A1 of A1–A4 field visibility, then generic-bounds round-trip, then impl blocks + `self` receivers).

Record fields accept an optional leading `pub`:

```rust
pub struct S { pub x: i64, y: [field] T }
struct P(pub i64, bool)
```

- The marker is wrapped in a new `VisFlag` node (mirroring `FieldFlag`/`FlexFlag`), so every existing positional token scan — item-level `visibility()`, field-name extraction, `surface.rs` lowering in reussir-core — remains correct without lockstep edits. reussir-core parses and ignores the marker until the plumbing (A2) and enforcement (A4) PRs.
- No reserved words: one token of lookahead keeps `pub` legal as a field *name* (`pub: i64`, visibility iff not followed by `:`) and as a *type* head in unnamed fields (`(pub)`, `(pub, i64)`, `(pub::T)`, `(pub<i64>)`, `(pub -> i64)` all parse as today). Pinned by `field_named_pub_stays_a_field_name`.
- JSON surface AST: named fields become `[name, type, is_field, vis]` quads, unnamed `[type, is_field, vis]` triples with `vis ∈ {"Public","Private"}`; conventions doc updated. (The Haskell consumer is gone; in-tree consumers are the CLI binary and the crate's own tests.)

Gate: `cargo test` green (48 syntax tests, workspace unaffected), `cargo fmt --check` clean, `ninja -C build check` 450/453 pass (3 unsupported = baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788251386&installation_model_id=426051&pr_number=493&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F493&signature=44a05c5f0806909f9aa6a3a80b15e3b9e3a5c451b63ebe43b806e59f53141e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->