### PR TITLE
[core] carry per-field visibility through the surface and semi record tables

### DIFF
--- a/crates/reussir-core/src/full/interface.rs
+++ b/crates/reussir-core/src/full/interface.rs
@@ -140,8 +140,8 @@ pub fn export_closure(input: &MonoInput<'_, '_>) -> ExportClosure {
             continue;
         };
         let member_tys: Vec<Ty<'_>> = match &rec.fields {
-            Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _)| *t).collect(),
-            Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _)| *t).collect(),
+            Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _, _)| *t).collect(),
+            Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _, _)| *t).collect(),
             Some(RecordFields::Variants(vs)) => {
                 vs.iter().flat_map(|v| v.fields.iter().copied()).collect()
             }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -720,7 +720,7 @@ fn resolve_layout<'tcx>(
         Some(RecordFields::Named(fields)) => {
             let members: Vec<mir::Member<'tcx>> = fields
                 .iter()
-                .map(|(name, ty, is_mut)| mir::Member {
+                .map(|(name, ty, is_mut, _)| mir::Member {
                     ty: subst_ty(tcx, *ty, &subst),
                     is_field: *is_mut,
                     name: Some(mir::Symbol(symbols.get_or_intern(resolver.resolve(*name)))),
@@ -731,7 +731,7 @@ fn resolve_layout<'tcx>(
         Some(RecordFields::Unnamed(fields)) => {
             let members: Vec<mir::Member<'tcx>> = fields
                 .iter()
-                .map(|(ty, is_mut)| mir::Member {
+                .map(|(ty, is_mut, _)| mir::Member {
                     ty: subst_ty(tcx, *ty, &subst),
                     is_field: *is_mut,
                     name: None,
@@ -858,12 +858,12 @@ impl<'tcx> SyncEnv<'tcx> for MonoSyncEnv<'_, 'tcx> {
         Some(match fields {
             RecordFields::Named(fs) => fs
                 .iter()
-                .map(|(n, t, _)| (self.resolver.resolve(*n).to_owned(), ground(*t)))
+                .map(|(n, t, _, _)| (self.resolver.resolve(*n).to_owned(), ground(*t)))
                 .collect(),
             RecordFields::Unnamed(fs) => fs
                 .iter()
                 .enumerate()
-                .map(|(i, (t, _))| (i.to_string(), ground(*t)))
+                .map(|(i, (t, _, _))| (i.to_string(), ground(*t)))
                 .collect(),
             RecordFields::Variants(vs) => vs
                 .iter()
@@ -888,8 +888,8 @@ impl<'tcx> SyncEnv<'tcx> for MonoSyncEnv<'_, 'tcx> {
         let mut out = Vec::new();
         let mut walk = |t: Ty<'tcx>| crate::semi::traits::sync::collect_record_defs(t, &mut out);
         match fields {
-            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _)| walk(*t)),
-            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _)| walk(*t)),
+            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _, _)| walk(*t)),
+            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _, _)| walk(*t)),
             RecordFields::Variants(vs) => vs
                 .iter()
                 .for_each(|v| v.fields.iter().for_each(|t| walk(*t))),
@@ -1194,8 +1194,12 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 subst.insert(*gid, ty);
             }
             let field_tys: Vec<Ty<'tcx>> = match record.fields.as_ref() {
-                Some(RecordFields::Named(fields)) => fields.iter().map(|(_, ty, _)| *ty).collect(),
-                Some(RecordFields::Unnamed(fields)) => fields.iter().map(|(ty, _)| *ty).collect(),
+                Some(RecordFields::Named(fields)) => {
+                    fields.iter().map(|(_, ty, _, _)| *ty).collect()
+                }
+                Some(RecordFields::Unnamed(fields)) => {
+                    fields.iter().map(|(ty, _, _)| *ty).collect()
+                }
                 Some(RecordFields::Variants(variants)) => variants
                     .iter()
                     .flat_map(|v| v.fields.iter().copied())
@@ -1234,8 +1238,8 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             subst.insert(*gid, ty);
         }
         let field_tys: Vec<Ty<'tcx>> = match record.fields.as_ref() {
-            Some(RecordFields::Named(fields)) => fields.iter().map(|(_, ty, _)| *ty).collect(),
-            Some(RecordFields::Unnamed(fields)) => fields.iter().map(|(ty, _)| *ty).collect(),
+            Some(RecordFields::Named(fields)) => fields.iter().map(|(_, ty, _, _)| *ty).collect(),
+            Some(RecordFields::Unnamed(fields)) => fields.iter().map(|(ty, _, _)| *ty).collect(),
             Some(RecordFields::Variants(variants)) => variants
                 .iter()
                 .flat_map(|v| v.fields.iter().copied())

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -611,6 +611,40 @@ mod tests {
         });
     }
 
+    #[test]
+    fn field_visibility_lands_in_record_tables() {
+        use crate::surface::Visibility::{Private, Public};
+
+        check(
+            "pub struct S { pub a: i64, b: i64 }\nstruct P(pub i64, bool)",
+            |elab, _| {
+                let fields_of = |name: &str| {
+                    elab.records
+                        .values()
+                        .find(|r| elab.sym(r.name) == name)
+                        .expect("record")
+                        .fields
+                        .clone()
+                        .expect("populated")
+                };
+                let crate::semi::ctxt::RecordFields::Named(fs) = fields_of("S") else {
+                    panic!("named fields");
+                };
+                assert_eq!(
+                    fs.iter().map(|&(_, _, m, v)| (m, v)).collect::<Vec<_>>(),
+                    [(false, Public), (false, Private)]
+                );
+                let crate::semi::ctxt::RecordFields::Unnamed(fs) = fields_of("P") else {
+                    panic!("unnamed fields");
+                };
+                assert_eq!(
+                    fs.iter().map(|&(_, m, v)| (m, v)).collect::<Vec<_>>(),
+                    [(false, Public), (false, Private)]
+                );
+            },
+        );
+    }
+
     fn function<'a, 'tcx>(elab: &'a Elaborator<'_, 'tcx>, name: &str) -> &'a hir::Function<'tcx> {
         elab.elaborated
             .iter()

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1081,7 +1081,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             Instantiation::from_pairs(ty_params.iter().map(|(_, g)| *g).zip(args.iter().copied()));
         let (idx, decl_ty, mutable) = match (&fields, acc) {
             (RecordFields::Named(fs), surface::Access::Named(name)) => {
-                let i = fs.iter().position(|(n, _, _)| n == name)?;
+                let i = fs.iter().position(|(n, _, _, _)| n == name)?;
                 (i, fs[i].1, fs[i].2)
             }
             (RecordFields::Named(fs), surface::Access::Unnamed(n)) => {
@@ -2076,7 +2076,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match fields {
             Some(RecordFields::Named(fs)) => fs
                 .iter()
-                .map(|(n, t, is_field)| {
+                .map(|(n, t, is_field, _)| {
                     (
                         Some(*n),
                         self.field_member_ty(*t, *is_field, base_flex, inst),
@@ -2085,7 +2085,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 .collect(),
             Some(RecordFields::Unnamed(fs)) => fs
                 .iter()
-                .map(|(t, is_field)| (None, self.field_member_ty(*t, *is_field, base_flex, inst)))
+                .map(|(t, is_field, _)| {
+                    (None, self.field_member_ty(*t, *is_field, base_flex, inst))
+                })
                 .collect(),
             _ => Vec::new(),
         }

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -157,10 +157,10 @@ pub struct GenericInfo {
 /// A record's fields, with concrete field types resolved.
 #[derive(Clone, Debug)]
 pub enum RecordFields<'tcx> {
-    /// `(name, type, is_mutable)`.
-    Named(Vec<(TokenKey, Ty<'tcx>, bool)>),
-    /// `(type, is_mutable)`.
-    Unnamed(Vec<(Ty<'tcx>, bool)>),
+    /// `(name, type, is_mutable, visibility)`.
+    Named(Vec<(TokenKey, Ty<'tcx>, bool, surface::Visibility)>),
+    /// `(type, is_mutable, visibility)`.
+    Unnamed(Vec<(Ty<'tcx>, bool, surface::Visibility)>),
     Variants(Vec<Variant<'tcx>>),
     /// An opaque `#[ffi]` record: no fields, no constructors — the value is
     /// a foreign rc box whose payload only the foreign side interprets.
@@ -1359,8 +1359,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             };
             let (span, file, vis, name) = (rec.span, rec.file, rec.visibility, rec.name);
             let member_tys: Vec<Ty<'tcx>> = match &rec.fields {
-                Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _)| *t).collect(),
-                Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _)| *t).collect(),
+                Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _, _)| *t).collect(),
+                Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _, _)| *t).collect(),
                 Some(RecordFields::Variants(vs)) => {
                     vs.iter().flat_map(|v| v.fields.iter().copied()).collect()
                 }
@@ -1819,26 +1819,26 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             surface::RecordFields::Named(fs) => RecordFields::Named(
                 fs.iter()
                     .map(|f| {
-                        let (name, ty, mutable) = &f.value;
+                        let (name, ty, mutable, vis) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
                         self.reject_arc_member(default_cap, fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
-                        (*name, fty, *mutable)
+                        (*name, fty, *mutable, *vis)
                     })
                     .collect(),
             ),
             surface::RecordFields::Unnamed(fs) => RecordFields::Unnamed(
                 fs.iter()
                     .map(|f| {
-                        let (ty, mutable) = &f.value;
+                        let (ty, mutable, vis) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
                         self.reject_arc_member(default_cap, fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
-                        (fty, *mutable)
+                        (fty, *mutable, *vis)
                     })
                     .collect(),
             ),
@@ -1867,8 +1867,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // Validate that mutable (`[field]`) fields require a regional record.
         if default_cap != DefaultCap::Regional {
             let has_mut = match &fields {
-                RecordFields::Named(fs) => fs.iter().any(|(_, _, m)| *m),
-                RecordFields::Unnamed(fs) => fs.iter().any(|(_, m)| *m),
+                RecordFields::Named(fs) => fs.iter().any(|(_, _, m, _)| *m),
+                RecordFields::Unnamed(fs) => fs.iter().any(|(_, m, _)| *m),
                 RecordFields::Variants(_) | RecordFields::Opaque => false,
             };
             if has_mut {
@@ -1965,8 +1965,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return Vec::new();
         };
         let member_tys: Vec<Ty<'tcx>> = match &rec.fields {
-            Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _)| *t).collect(),
-            Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _)| *t).collect(),
+            Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _, _)| *t).collect(),
+            Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _, _)| *t).collect(),
             Some(RecordFields::Variants(vs)) => {
                 vs.iter().flat_map(|v| v.fields.iter().copied()).collect()
             }

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -309,12 +309,12 @@ impl<'tcx> Remapper<'_, '_, 'tcx> {
         match fields {
             RecordFields::Named(fs) => RecordFields::Named(
                 fs.iter()
-                    .map(|&(name, ty, is_mut)| (self.key(name), self.ty(ty), is_mut))
+                    .map(|&(name, ty, is_mut, vis)| (self.key(name), self.ty(ty), is_mut, vis))
                     .collect(),
             ),
             RecordFields::Unnamed(fs) => RecordFields::Unnamed(
                 fs.iter()
-                    .map(|&(ty, is_mut)| (self.ty(ty), is_mut))
+                    .map(|&(ty, is_mut, vis)| (self.ty(ty), is_mut, vis))
                     .collect(),
             ),
             RecordFields::Variants(vs) => RecordFields::Variants(

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -28,7 +28,7 @@ use crate::semi::hir::{
 };
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{DefId, Flexivity, FpTy, GenericId, IntTy, Ty, TyCtxt, TyKind};
-use crate::surface::RecordKind;
+use crate::surface::{self, RecordKind};
 use crate::utils::string::StringToken;
 
 /// A parsed HIR program plus the fresh tables needed to re-print and resume it.
@@ -274,7 +274,15 @@ impl<'tcx> Builder<'_, 'tcx> {
                         .iter()
                         .map(|m| {
                             let name = self.names.intern(m.name.as_deref().unwrap_or(""));
-                            (name, self.ty(&m.ty), m.is_field)
+                            // Transitional until the HIR text form carries a
+                            // per-member visibility marker: resumed dumps
+                            // default to Public (nothing enforces yet).
+                            (
+                                name,
+                                self.ty(&m.ty),
+                                m.is_field,
+                                surface::Visibility::Public,
+                            )
                         })
                         .collect(),
                 )
@@ -282,7 +290,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::RecordBody::Compound(members) => RecordFields::Unnamed(
                 members
                     .iter()
-                    .map(|m| (self.ty(&m.ty), m.is_field))
+                    .map(|m| (self.ty(&m.ty), m.is_field, surface::Visibility::Public))
                     .collect(),
             ),
             raw::RecordBody::Variant(variants) => RecordFields::Variants(

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -295,14 +295,14 @@ impl<'a> Printer<'a> {
             Some(RecordFields::Named(fields)) => {
                 let parts = fields
                     .iter()
-                    .map(|(name, ty, is_mut)| self.member(Some(*name), *ty, *is_mut))
+                    .map(|(name, ty, is_mut, _)| self.member(Some(*name), *ty, *is_mut))
                     .collect();
                 comma_sep(parts)
             }
             Some(RecordFields::Unnamed(fields)) => {
                 let parts = fields
                     .iter()
-                    .map(|(ty, is_mut)| self.member(None, *ty, *is_mut))
+                    .map(|(ty, is_mut, _)| self.member(None, *ty, *is_mut))
                     .collect();
                 comma_sep(parts)
             }

--- a/crates/reussir-core/src/semi/repl.rs
+++ b/crates/reussir-core/src/semi/repl.rs
@@ -347,6 +347,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     field,
                     self.tcx.mk_generic(generic),
                     false,
+                    surface::Visibility::Public,
                 )])),
                 regional_generics: Vec::new(),
                 span: None,

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -532,12 +532,12 @@ impl<'tcx> SyncEnv<'tcx> for ElabSyncEnv<'_, '_, 'tcx> {
         Some(match fields {
             RecordFields::Named(fs) => fs
                 .iter()
-                .map(|(n, t, _)| (self.el.sym(*n).to_owned(), subst(*t)))
+                .map(|(n, t, _, _)| (self.el.sym(*n).to_owned(), subst(*t)))
                 .collect(),
             RecordFields::Unnamed(fs) => fs
                 .iter()
                 .enumerate()
-                .map(|(i, (t, _))| (i.to_string(), subst(*t)))
+                .map(|(i, (t, _, _))| (i.to_string(), subst(*t)))
                 .collect(),
             RecordFields::Variants(vs) => vs
                 .iter()
@@ -562,8 +562,8 @@ impl<'tcx> SyncEnv<'tcx> for ElabSyncEnv<'_, '_, 'tcx> {
         let mut out = Vec::new();
         let mut walk = |t: Ty<'tcx>| crate::semi::traits::sync::collect_record_defs(t, &mut out);
         match fields {
-            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _)| walk(*t)),
-            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _)| walk(*t)),
+            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _, _)| walk(*t)),
+            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _, _)| walk(*t)),
             RecordFields::Variants(vs) => vs
                 .iter()
                 .for_each(|v| v.fields.iter().for_each(|t| walk(*t))),

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -891,8 +891,10 @@ pub struct Function {
 
 #[derive(Clone, Debug)]
 pub enum RecordFields {
-    Named(Vec<Spanned<(TokenKey, Type, bool)>>),
-    Unnamed(Vec<Spanned<(Type, bool)>>),
+    /// Each named field is `(name, type, is_mutable, visibility)`.
+    Named(Vec<Spanned<(TokenKey, Type, bool, Visibility)>>),
+    /// Each unnamed field is `(type, is_mutable, visibility)`.
+    Unnamed(Vec<Spanned<(Type, bool, Visibility)>>),
     Variants(Vec<Spanned<(TokenKey, SmallVec<[Type; 2]>)>>),
     /// A field-less declaration (`struct V<T>;`): an opaque (FFI) record.
     Opaque,
@@ -1045,6 +1047,16 @@ fn visibility_of(node: &ResolvedNode) -> Visibility {
     }
 }
 
+/// Per-field visibility: the `pub` marker lives inside a nested VisFlag node
+/// (never as a direct token, which would collide with a field named `pub`).
+fn visibility_of_field(field: &ResolvedNode) -> Visibility {
+    if child_node(field, VisFlag).is_some() {
+        Visibility::Public
+    } else {
+        Visibility::Private
+    }
+}
+
 fn function_of(node: &ResolvedNode) -> Function {
     let body = expr_children(node).last().map(Expr::new);
     let return_type = child_node(node, RetType).map(|r| {
@@ -1118,14 +1130,17 @@ fn record_of(node: &ResolvedNode, kind: RecordKind) -> Record {
             nodes(named)
                 .filter(|n| n.kind() == NamedField)
                 .map(|f| {
+                    // A `pub` marker sits inside a VisFlag node, so the
+                    // direct-token scan still finds the field name.
                     let name = tokens(f)
                         .find(|t| t.kind().is_ident_like())
                         .expect("field name");
                     let flag = child_node(f, FieldFlag).is_some();
+                    let vis = visibility_of_field(f);
                     let ty = nodes(f)
                         .find(|n| is_type_kind(n.kind()))
                         .expect("field type");
-                    spanned(f, (key(name), Type::new(ty), flag))
+                    spanned(f, (key(name), Type::new(ty), flag, vis))
                 })
                 .collect(),
         )
@@ -1135,10 +1150,11 @@ fn record_of(node: &ResolvedNode, kind: RecordKind) -> Record {
                 .filter(|n| n.kind() == UnnamedField)
                 .map(|f| {
                     let flag = child_node(f, FieldFlag).is_some();
+                    let vis = visibility_of_field(f);
                     let ty = nodes(f)
                         .find(|n| is_type_kind(n.kind()))
                         .expect("field type");
-                    spanned(f, (Type::new(ty), flag))
+                    spanned(f, (Type::new(ty), flag, vis))
                 })
                 .collect(),
         )


### PR DESCRIPTION
Stacked on #493 (A2 of the field-visibility stack: A1 parser → **A2 plumbing** → A3 HIR/.rri round-trip → A4 enforcement).

`surface::RecordFields` and `ctxt::RecordFields` grow a per-field `surface::Visibility`:

- named fields: `(name, type, is_mutable)` → `(name, type, is_mutable, visibility)`; unnamed: `(type, is_mutable)` → `(type, is_mutable, visibility)`. The existing bool remains `[field]` mutability — not overloaded.
- `populate_record` threads the parsed value; `externs.rs` `fields()` copies it verbatim so extern-loaded records keep it; the remaining ~30 destructuring sites are one-token `, _` insertions across `semi/` and `full/` (the enum arity change must compile atomically, so they all belong to this PR).
- HIR-text resume (`--from hir`/.rri) transitionally defaults members to `Public` — behavior-invisible because nothing enforces until A4, and A3 (which lands before A4) replaces it with the real serialized marker.
- Enum-variant payloads deliberately carry no per-field visibility (Rust-consistent: variants are exactly as visible as their enum).
- No new Elaborator state → no `Checkpoint` change (visibility rides inside existing `Record` entries).

This PR is observationally inert: zero `.rr` fixture changes, no diagnostics change. Pinned by `field_visibility_lands_in_record_tables`.

Gate: `cargo test` 466 green, `cargo fmt` clean, `ninja -C build check` 450/453 (3 unsupported = baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788251767&installation_model_id=426051&pr_number=494&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F494&signature=2a89781afdb2e615e9ff6d9f0f3833314a83f5136e2ea52f70af9705d0e90f40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->