### PR TITLE
[core] round-trip field visibility through HIR text and .rri; RRI_FORMAT 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Language
+
+- Record fields now carry visibility: fields default to private and accept a
+  leading `pub` marker. A private field is accessible (projection,
+  assignment, construction) only from the record's defining module and its
+  descendant modules, inside a package and across packages alike; the marker
+  round-trips through HIR text and ships in `.rri` interfaces.
+  Enum-variant payloads are unaffected — variants stay
+  exactly as visible as their enum.
+
 ## 0.1.0
 
 The first tagged release of Reussir: an MLIR-based compiler framework for

--- a/crates/reussir-compiler/src/externs.rs
+++ b/crates/reussir-compiler/src/externs.rs
@@ -215,7 +215,7 @@ mod tests {
     fn file_tables_re_anchor_onto_the_source_root() {
         reussir_core::in_arena(|tcx| {
             let text = r#"
-                interface 2 package "dep" producer "t";
+                interface 1 package "dep" producer "t";
                 0 = "src/lib.rr";
                 1 = "<prelude>";
             "#;

--- a/crates/reussir-compiler/src/externs.rs
+++ b/crates/reussir-compiler/src/externs.rs
@@ -215,7 +215,7 @@ mod tests {
     fn file_tables_re_anchor_onto_the_source_root() {
         reussir_core::in_arena(|tcx| {
             let text = r#"
-                interface 1 package "dep" producer "t";
+                interface 2 package "dep" producer "t";
                 0 = "src/lib.rr";
                 1 = "<prelude>";
             "#;

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -849,7 +849,8 @@ fn emits_a_package_interface() {
     let rri = read(&out);
     assert!(
         rri.starts_with(&format!(
-            "interface 1 package \"demo\" producer \"rrc {}\";",
+            "interface {} package \"demo\" producer \"rrc {}\";",
+            reussir_core::full::interface::RRI_FORMAT,
             env!("CARGO_PKG_VERSION")
         )),
         "{rri}"

--- a/crates/reussir-core/src/full/interface.rs
+++ b/crates/reussir-core/src/full/interface.rs
@@ -35,7 +35,7 @@ use super::mono::{MonoInput, for_each_expr};
 /// The `.rri` format integer, bumped on any change to the textual grammar or
 /// its meaning. The header's `producer` string (the exact producing rrc
 /// version) gates the rest while the format is unstable.
-pub const RRI_FORMAT: u32 = 1;
+pub const RRI_FORMAT: u32 = 2;
 
 /// The defs and ancillary facts an `.rri` interface ships. All sets are over
 /// the producing elaboration's ids; emission resolves them back through the
@@ -269,7 +269,7 @@ mod tests {
                 })
                 .program(&elab.elaborated, &strings, &elab.records, &[]);
             assert!(
-                text.starts_with("interface 1 package \"demo\" producer \"rrc-test\";"),
+                text.starts_with("interface 2 package \"demo\" producer \"rrc-test\";"),
                 "{text}"
             );
             assert!(text.contains("fn #deep(v0 (x): i64) -> i64;"), "{text}");

--- a/crates/reussir-core/src/full/interface.rs
+++ b/crates/reussir-core/src/full/interface.rs
@@ -35,7 +35,7 @@ use super::mono::{MonoInput, for_each_expr};
 /// The `.rri` format integer, bumped on any change to the textual grammar or
 /// its meaning. The header's `producer` string (the exact producing rrc
 /// version) gates the rest while the format is unstable.
-pub const RRI_FORMAT: u32 = 2;
+pub const RRI_FORMAT: u32 = 1;
 
 /// The defs and ancillary facts an `.rri` interface ships. All sets are over
 /// the producing elaboration's ids; emission resolves them back through the
@@ -269,7 +269,7 @@ mod tests {
                 })
                 .program(&elab.elaborated, &strings, &elab.records, &[]);
             assert!(
-                text.starts_with("interface 2 package \"demo\" producer \"rrc-test\";"),
+                text.starts_with("interface 1 package \"demo\" producer \"rrc-test\";"),
                 "{text}"
             );
             assert!(text.contains("fn #deep(v0 (x): i64) -> i64;"), "{text}");

--- a/crates/reussir-core/src/full/interface.rs
+++ b/crates/reussir-core/src/full/interface.rs
@@ -140,8 +140,8 @@ pub fn export_closure(input: &MonoInput<'_, '_>) -> ExportClosure {
             continue;
         };
         let member_tys: Vec<Ty<'_>> = match &rec.fields {
-            Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _)| *t).collect(),
-            Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _)| *t).collect(),
+            Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _, _)| *t).collect(),
+            Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _, _)| *t).collect(),
             Some(RecordFields::Variants(vs)) => {
                 vs.iter().flat_map(|v| v.fields.iter().copied()).collect()
             }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -720,7 +720,7 @@ fn resolve_layout<'tcx>(
         Some(RecordFields::Named(fields)) => {
             let members: Vec<mir::Member<'tcx>> = fields
                 .iter()
-                .map(|(name, ty, is_mut)| mir::Member {
+                .map(|(name, ty, is_mut, _)| mir::Member {
                     ty: subst_ty(tcx, *ty, &subst),
                     is_field: *is_mut,
                     name: Some(mir::Symbol(symbols.get_or_intern(resolver.resolve(*name)))),
@@ -731,7 +731,7 @@ fn resolve_layout<'tcx>(
         Some(RecordFields::Unnamed(fields)) => {
             let members: Vec<mir::Member<'tcx>> = fields
                 .iter()
-                .map(|(ty, is_mut)| mir::Member {
+                .map(|(ty, is_mut, _)| mir::Member {
                     ty: subst_ty(tcx, *ty, &subst),
                     is_field: *is_mut,
                     name: None,
@@ -858,12 +858,12 @@ impl<'tcx> SyncEnv<'tcx> for MonoSyncEnv<'_, 'tcx> {
         Some(match fields {
             RecordFields::Named(fs) => fs
                 .iter()
-                .map(|(n, t, _)| (self.resolver.resolve(*n).to_owned(), ground(*t)))
+                .map(|(n, t, _, _)| (self.resolver.resolve(*n).to_owned(), ground(*t)))
                 .collect(),
             RecordFields::Unnamed(fs) => fs
                 .iter()
                 .enumerate()
-                .map(|(i, (t, _))| (i.to_string(), ground(*t)))
+                .map(|(i, (t, _, _))| (i.to_string(), ground(*t)))
                 .collect(),
             RecordFields::Variants(vs) => vs
                 .iter()
@@ -888,8 +888,8 @@ impl<'tcx> SyncEnv<'tcx> for MonoSyncEnv<'_, 'tcx> {
         let mut out = Vec::new();
         let mut walk = |t: Ty<'tcx>| crate::semi::traits::sync::collect_record_defs(t, &mut out);
         match fields {
-            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _)| walk(*t)),
-            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _)| walk(*t)),
+            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _, _)| walk(*t)),
+            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _, _)| walk(*t)),
             RecordFields::Variants(vs) => vs
                 .iter()
                 .for_each(|v| v.fields.iter().for_each(|t| walk(*t))),
@@ -1194,8 +1194,12 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 subst.insert(*gid, ty);
             }
             let field_tys: Vec<Ty<'tcx>> = match record.fields.as_ref() {
-                Some(RecordFields::Named(fields)) => fields.iter().map(|(_, ty, _)| *ty).collect(),
-                Some(RecordFields::Unnamed(fields)) => fields.iter().map(|(ty, _)| *ty).collect(),
+                Some(RecordFields::Named(fields)) => {
+                    fields.iter().map(|(_, ty, _, _)| *ty).collect()
+                }
+                Some(RecordFields::Unnamed(fields)) => {
+                    fields.iter().map(|(ty, _, _)| *ty).collect()
+                }
                 Some(RecordFields::Variants(variants)) => variants
                     .iter()
                     .flat_map(|v| v.fields.iter().copied())
@@ -1234,8 +1238,8 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             subst.insert(*gid, ty);
         }
         let field_tys: Vec<Ty<'tcx>> = match record.fields.as_ref() {
-            Some(RecordFields::Named(fields)) => fields.iter().map(|(_, ty, _)| *ty).collect(),
-            Some(RecordFields::Unnamed(fields)) => fields.iter().map(|(ty, _)| *ty).collect(),
+            Some(RecordFields::Named(fields)) => fields.iter().map(|(_, ty, _, _)| *ty).collect(),
+            Some(RecordFields::Unnamed(fields)) => fields.iter().map(|(ty, _, _)| *ty).collect(),
             Some(RecordFields::Variants(variants)) => variants
                 .iter()
                 .flat_map(|v| v.fields.iter().copied())

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -302,7 +302,7 @@ mod tests {
                     r#"
                         pub fn seed() -> u64 { 3 }
                         pub fn scale(x: u64, k: u64) -> u64 { x * k }
-                        pub struct Wrap { v: u64 }
+                        pub struct Wrap { pub v: u64 }
                     "#,
                 ),
                 (
@@ -643,6 +643,109 @@ mod tests {
                 );
             },
         );
+    }
+
+    /// The shared two-module package for the visibility tests: module `a`
+    /// defines the records, module `c` uses them from outside.
+    fn vis_package(consumer: &str, f: impl Fn(&[crate::semi::ctxt::Report])) {
+        let defs = r#"
+            pub struct S { pub a: i64, b: i64 }
+            pub struct P(pub i64, i64)
+            pub struct [regional] R { hidden: [field] R }
+        "#;
+        check_package(
+            "p",
+            &[(&[], "mod a; mod c;"), (&["a"], defs), (&["c"], consumer)],
+            |elab, _| f(&elab.reports),
+        );
+    }
+
+    #[test]
+    fn private_field_access_rejected_across_modules() {
+        vis_package("pub fn read(s: super::a::S) -> i64 { s.b }", |reports| {
+            assert!(
+                reports
+                    .iter()
+                    .any(|r| r.message == "field `b` of record `p::a::S` is private"),
+                "{reports:#?}"
+            );
+        });
+        // Assignment shares the resolver: the private diagnostic fires before
+        // mutability or source checking.
+        vis_package(
+            "regional fn poke(r: [flex] super::a::R) { r->hidden := 1 }",
+            |reports| {
+                assert!(
+                    reports
+                        .iter()
+                        .any(|r| r.message == "field `hidden` of record `p::a::R` is private"),
+                    "{reports:#?}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn pub_field_access_allowed_across_modules() {
+        vis_package(
+            "pub fn read(s: super::a::S, t: super::a::P) -> i64 { s.a + t.0 }",
+            |reports| assert!(reports.is_empty(), "{reports:#?}"),
+        );
+    }
+
+    #[test]
+    fn private_field_access_allowed_in_child_module() {
+        check_package(
+            "p",
+            &[
+                (&[], "mod a;"),
+                (&["a"], "mod sub;\npub struct S { pub a: i64, b: i64 }"),
+                (
+                    &["a", "sub"],
+                    "pub fn read(s: super::S) -> i64 { s.b }\n\
+                     pub fn make() -> super::S { super::S { a: 1, b: 2 } }",
+                ),
+            ],
+            |elab, _| assert!(!elab.has_errors(), "{:#?}", elab.reports),
+        );
+    }
+
+    #[test]
+    fn private_field_ctor_rejected_across_modules() {
+        vis_package(
+            "pub fn make() -> super::a::S { super::a::S { a: 1, b: 2 } }",
+            |reports| {
+                assert!(
+                    reports.iter().any(|r| r.message
+                        == "cannot construct `p::a::S` outside its module: field(s) `b` are private"),
+                    "{reports:#?}"
+                );
+            },
+        );
+        vis_package(
+            "pub fn make() -> super::a::P { super::a::P { 1, 2 } }",
+            |reports| {
+                assert!(
+                    reports.iter().any(|r| r.message
+                        == "cannot construct `p::a::P` outside its module: field(s) `1` are private"),
+                    "{reports:#?}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn tuple_index_respects_named_field_visibility() {
+        // `s.1` into a named record resolves the named field, so the private
+        // diagnostic names it.
+        vis_package("pub fn read(s: super::a::S) -> i64 { s.1 }", |reports| {
+            assert!(
+                reports
+                    .iter()
+                    .any(|r| r.message == "field `b` of record `p::a::S` is private"),
+                "{reports:#?}"
+            );
+        });
     }
 
     fn function<'a, 'tcx>(elab: &'a Elaborator<'_, 'tcx>, name: &str) -> &'a hir::Function<'tcx> {

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -611,6 +611,40 @@ mod tests {
         });
     }
 
+    #[test]
+    fn field_visibility_lands_in_record_tables() {
+        use crate::surface::Visibility::{Private, Public};
+
+        check(
+            "pub struct S { pub a: i64, b: i64 }\nstruct P(pub i64, bool)",
+            |elab, _| {
+                let fields_of = |name: &str| {
+                    elab.records
+                        .values()
+                        .find(|r| elab.sym(r.name) == name)
+                        .expect("record")
+                        .fields
+                        .clone()
+                        .expect("populated")
+                };
+                let crate::semi::ctxt::RecordFields::Named(fs) = fields_of("S") else {
+                    panic!("named fields");
+                };
+                assert_eq!(
+                    fs.iter().map(|&(_, _, m, v)| (m, v)).collect::<Vec<_>>(),
+                    [(false, Public), (false, Private)]
+                );
+                let crate::semi::ctxt::RecordFields::Unnamed(fs) = fields_of("P") else {
+                    panic!("unnamed fields");
+                };
+                assert_eq!(
+                    fs.iter().map(|&(_, m, v)| (m, v)).collect::<Vec<_>>(),
+                    [(false, Public), (false, Private)]
+                );
+            },
+        );
+    }
+
     fn function<'a, 'tcx>(elab: &'a Elaborator<'_, 'tcx>, name: &str) -> &'a hir::Function<'tcx> {
         elab.elaborated
             .iter()

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -13,6 +13,15 @@ use super::ctxt::{Elaborator, FuncProto, RecordFields};
 use super::fulfill::{collect_holes, ty_has_hole};
 use super::hir::{ArithOp, ClosureExpr, CmpOp, Expr, ExprKind, Function, VarId};
 
+/// Why a field access failed to resolve: the field does not exist (or the
+/// base is not a suitable record), or it exists but is private outside its
+/// defining module. Callers keep the two diagnostics distinct, mirroring the
+/// item-level "is private" vs "not found" split of extern resolution.
+enum FieldErr {
+    Missing,
+    Private { field: String, record: String },
+}
+
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Check a function definition: bind its parameters into Γ, check the body
     /// against the declared return type (`Γ ⊢ body ⇐ return_ty`), discharge the
@@ -956,10 +965,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
         // The target was just checked to be `Flex`, so the link's slot is seen
         // at its flex (writable) coloring.
-        let Some((idx, field_ty, mutable)) = self.resolve_field(*def, args, Flexivity::Flex, acc)
-        else {
-            self.error(span, "no such field on assignment target");
-            return self.poison(span);
+        let (idx, field_ty, mutable) = match self.resolve_field(*def, args, Flexivity::Flex, acc) {
+            Ok(resolved) => resolved,
+            Err(FieldErr::Missing) => {
+                self.error(span, "no such field on assignment target");
+                return self.poison(span);
+            }
+            Err(FieldErr::Private { field, record }) => {
+                self.error(
+                    span,
+                    format!("field `{field}` of record `{record}` is private"),
+                );
+                return self.poison(span);
+            }
         };
         if !mutable {
             self.error(span, "cannot assign to an immutable field");
@@ -1047,9 +1065,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 );
                 return self.poison(span);
             };
-            let Some((idx, field_ty, _)) = self.resolve_field(*def, args, *flex, acc) else {
-                self.error(span, "no such field");
-                return self.poison(span);
+            let (idx, field_ty, _) = match self.resolve_field(*def, args, *flex, acc) {
+                Ok(resolved) => resolved,
+                Err(FieldErr::Missing) => {
+                    self.error(span, "no such field");
+                    return self.poison(span);
+                }
+                Err(FieldErr::Private { field, record }) => {
+                    self.error(
+                        span,
+                        format!("field `{field}` of record `{record}` is private"),
+                    );
+                    return self.poison(span);
+                }
             };
             indices.push(idx);
             let field_ty = self.infer.shallow_resolve(field_ty);
@@ -1063,6 +1091,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.mk_expr(ExprKind::Proj(Box::new(base), indices), raw, span)
     }
 
+    /// May the code being checked read or write `record_def`'s private
+    /// fields? Rust's rule: a private field is accessible from the record's
+    /// defining module and its descendant modules. An extern record's path is
+    /// headed by its package name, which is never a prefix of a consumer
+    /// module, so cross-package privacy falls out of the same prefix test.
+    fn may_access_private_fields(&self, record_def: DefId) -> bool {
+        let path = &self.defs.path(record_def).0;
+        let def_module = &path[..path.len() - 1];
+        self.defs.module().starts_with(def_module)
+    }
+
     /// Resolve an access on a record type to `(field index, field type, mutable)`.
     /// The field type is instantiated with the record's type arguments and
     /// colored as seen through a base of flexivity `base_flex`
@@ -1073,31 +1112,44 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         args: &[Ty<'tcx>],
         base_flex: Flexivity,
         acc: &surface::Access,
-    ) -> Option<(u32, Ty<'tcx>, bool)> {
-        let record = self.records.get(&record_def)?;
+    ) -> Result<(u32, Ty<'tcx>, bool), FieldErr> {
+        let record = self.records.get(&record_def).ok_or(FieldErr::Missing)?;
         let ty_params = record.ty_params.clone();
-        let fields = record.fields.clone()?;
+        let fields = record.fields.clone().ok_or(FieldErr::Missing)?;
         let inst =
             Instantiation::from_pairs(ty_params.iter().map(|(_, g)| *g).zip(args.iter().copied()));
-        let (idx, decl_ty, mutable) = match (&fields, acc) {
+        let (idx, decl_ty, mutable, vis) = match (&fields, acc) {
             (RecordFields::Named(fs), surface::Access::Named(name)) => {
-                let i = fs.iter().position(|(n, _, _, _)| n == name)?;
-                (i, fs[i].1, fs[i].2)
+                let i = fs
+                    .iter()
+                    .position(|(n, _, _, _)| n == name)
+                    .ok_or(FieldErr::Missing)?;
+                (i, fs[i].1, fs[i].2, fs[i].3)
             }
             (RecordFields::Named(fs), surface::Access::Unnamed(n)) => {
                 let i = *n as usize;
-                let f = fs.get(i)?;
-                (i, f.1, f.2)
+                let f = fs.get(i).ok_or(FieldErr::Missing)?;
+                (i, f.1, f.2, f.3)
             }
             (RecordFields::Unnamed(fs), surface::Access::Unnamed(n)) => {
                 let i = *n as usize;
-                let f = fs.get(i)?;
-                (i, f.0, f.1)
+                let f = fs.get(i).ok_or(FieldErr::Missing)?;
+                (i, f.0, f.1, f.2)
             }
-            _ => return None,
+            _ => return Err(FieldErr::Missing),
         };
+        if vis == surface::Visibility::Private && !self.may_access_private_fields(record_def) {
+            let label = match (&fields, acc) {
+                (RecordFields::Named(fs), _) => self.sym(fs[idx].0).to_owned(),
+                _ => idx.to_string(),
+            };
+            return Err(FieldErr::Private {
+                field: label,
+                record: self.defs.path(record_def).display(self.resolver),
+            });
+        }
         let field_ty = self.field_member_ty(decl_ty, mutable, base_flex, &inst);
-        Some((idx as u32, field_ty, mutable))
+        Ok((idx as u32, field_ty, mutable))
     }
 
     // ----- constructors -----
@@ -1900,6 +1952,37 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 span,
                 "cannot construct a regional record outside of a region",
             );
+        }
+        // Constructing a record supplies every field, so a single private
+        // field makes the constructor itself module-private. One error listing
+        // the private fields, then checking continues (no poison — matches the
+        // regional check above). Variant construction is exempt by design:
+        // variant payloads carry no per-field visibility.
+        if !self.may_access_private_fields(def) {
+            let private: Vec<String> = match &record.fields {
+                Some(RecordFields::Named(fs)) => fs
+                    .iter()
+                    .filter(|(_, _, _, v)| *v == surface::Visibility::Private)
+                    .map(|(n, _, _, _)| format!("`{}`", self.sym(*n)))
+                    .collect(),
+                Some(RecordFields::Unnamed(fs)) => fs
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, (_, _, v))| *v == surface::Visibility::Private)
+                    .map(|(i, _)| format!("`{i}`"))
+                    .collect(),
+                _ => Vec::new(),
+            };
+            if !private.is_empty() {
+                self.error(
+                    span,
+                    format!(
+                        "cannot construct `{}` outside its module: field(s) {} are private",
+                        self.defs.path(def).display(self.resolver),
+                        private.join(", ")
+                    ),
+                );
+            }
         }
         let inst = self.instantiate(&record.generics_as_decls(), ty_args, span);
         let mut field_tys = self.field_types(&record.fields, &inst);

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1081,7 +1081,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             Instantiation::from_pairs(ty_params.iter().map(|(_, g)| *g).zip(args.iter().copied()));
         let (idx, decl_ty, mutable) = match (&fields, acc) {
             (RecordFields::Named(fs), surface::Access::Named(name)) => {
-                let i = fs.iter().position(|(n, _, _)| n == name)?;
+                let i = fs.iter().position(|(n, _, _, _)| n == name)?;
                 (i, fs[i].1, fs[i].2)
             }
             (RecordFields::Named(fs), surface::Access::Unnamed(n)) => {
@@ -2076,7 +2076,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match fields {
             Some(RecordFields::Named(fs)) => fs
                 .iter()
-                .map(|(n, t, is_field)| {
+                .map(|(n, t, is_field, _)| {
                     (
                         Some(*n),
                         self.field_member_ty(*t, *is_field, base_flex, inst),
@@ -2085,7 +2085,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 .collect(),
             Some(RecordFields::Unnamed(fs)) => fs
                 .iter()
-                .map(|(t, is_field)| (None, self.field_member_ty(*t, *is_field, base_flex, inst)))
+                .map(|(t, is_field, _)| {
+                    (None, self.field_member_ty(*t, *is_field, base_flex, inst))
+                })
                 .collect(),
             _ => Vec::new(),
         }

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -157,10 +157,10 @@ pub struct GenericInfo {
 /// A record's fields, with concrete field types resolved.
 #[derive(Clone, Debug)]
 pub enum RecordFields<'tcx> {
-    /// `(name, type, is_mutable)`.
-    Named(Vec<(TokenKey, Ty<'tcx>, bool)>),
-    /// `(type, is_mutable)`.
-    Unnamed(Vec<(Ty<'tcx>, bool)>),
+    /// `(name, type, is_mutable, visibility)`.
+    Named(Vec<(TokenKey, Ty<'tcx>, bool, surface::Visibility)>),
+    /// `(type, is_mutable, visibility)`.
+    Unnamed(Vec<(Ty<'tcx>, bool, surface::Visibility)>),
     Variants(Vec<Variant<'tcx>>),
     /// An opaque `#[ffi]` record: no fields, no constructors — the value is
     /// a foreign rc box whose payload only the foreign side interprets.
@@ -1359,8 +1359,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             };
             let (span, file, vis, name) = (rec.span, rec.file, rec.visibility, rec.name);
             let member_tys: Vec<Ty<'tcx>> = match &rec.fields {
-                Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _)| *t).collect(),
-                Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _)| *t).collect(),
+                Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _, _)| *t).collect(),
+                Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _, _)| *t).collect(),
                 Some(RecordFields::Variants(vs)) => {
                     vs.iter().flat_map(|v| v.fields.iter().copied()).collect()
                 }
@@ -1819,26 +1819,26 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             surface::RecordFields::Named(fs) => RecordFields::Named(
                 fs.iter()
                     .map(|f| {
-                        let (name, ty, mutable) = &f.value;
+                        let (name, ty, mutable, vis) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
                         self.reject_arc_member(default_cap, fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
-                        (*name, fty, *mutable)
+                        (*name, fty, *mutable, *vis)
                     })
                     .collect(),
             ),
             surface::RecordFields::Unnamed(fs) => RecordFields::Unnamed(
                 fs.iter()
                     .map(|f| {
-                        let (ty, mutable) = &f.value;
+                        let (ty, mutable, vis) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
                         self.reject_arc_member(default_cap, fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
-                        (fty, *mutable)
+                        (fty, *mutable, *vis)
                     })
                     .collect(),
             ),
@@ -1867,8 +1867,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // Validate that mutable (`[field]`) fields require a regional record.
         if default_cap != DefaultCap::Regional {
             let has_mut = match &fields {
-                RecordFields::Named(fs) => fs.iter().any(|(_, _, m)| *m),
-                RecordFields::Unnamed(fs) => fs.iter().any(|(_, m)| *m),
+                RecordFields::Named(fs) => fs.iter().any(|(_, _, m, _)| *m),
+                RecordFields::Unnamed(fs) => fs.iter().any(|(_, m, _)| *m),
                 RecordFields::Variants(_) | RecordFields::Opaque => false,
             };
             if has_mut {
@@ -1965,8 +1965,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return Vec::new();
         };
         let member_tys: Vec<Ty<'tcx>> = match &rec.fields {
-            Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _)| *t).collect(),
-            Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _)| *t).collect(),
+            Some(RecordFields::Named(fs)) => fs.iter().map(|(_, t, _, _)| *t).collect(),
+            Some(RecordFields::Unnamed(fs)) => fs.iter().map(|(t, _, _)| *t).collect(),
             Some(RecordFields::Variants(vs)) => {
                 vs.iter().flat_map(|v| v.fields.iter().copied()).collect()
             }

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -583,7 +583,7 @@ mod tests {
         });
     }
 
-    const DEP: &str = "pub struct Point { x: i64, y: i64 }\n\
+    const DEP: &str = "pub struct Point { pub x: i64, pub y: i64 }\n\
                        struct Hidden { v: i64 }\n\
                        fn private_helper(h: Hidden) -> i64 { h.v }\n\
                        pub fn api<T : Num>(x: T) -> T { private_helper(Hidden { v: 1 }); x }\n\
@@ -623,6 +623,22 @@ mod tests {
                 // but not the dump's record set.
                 assert!(!elab.records.is_empty());
                 assert!(elab.local_records().is_empty(), "dump stays consumer-only");
+                // Field visibility survives the `.rri` round trip and remap.
+                let point = elab
+                    .records
+                    .values()
+                    .find(|r| elab.sym(r.name) == "dep::Point")
+                    .expect("extern Point carried");
+                let crate::semi::ctxt::RecordFields::Named(fs) =
+                    point.fields.as_ref().expect("populated")
+                else {
+                    panic!("named fields");
+                };
+                assert!(
+                    fs.iter()
+                        .all(|&(_, _, _, v)| v == crate::surface::Visibility::Public),
+                    "{fs:#?}"
+                );
             },
         );
     }

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -584,6 +584,7 @@ mod tests {
     }
 
     const DEP: &str = "pub struct Point { pub x: i64, pub y: i64 }\n\
+                       pub struct Mixed { pub a: i64, b: i64 }\n\
                        struct Hidden { v: i64 }\n\
                        fn private_helper(h: Hidden) -> i64 { h.v }\n\
                        pub fn api<T : Num>(x: T) -> T { private_helper(Hidden { v: 1 }); x }\n\
@@ -639,6 +640,39 @@ mod tests {
                         .all(|&(_, _, _, v)| v == crate::surface::Visibility::Public),
                     "{fs:#?}"
                 );
+            },
+        );
+    }
+
+    #[test]
+    fn private_extern_fields_are_rejected_distinctly() {
+        check_with_dep(
+            DEP,
+            &[(
+                &[],
+                "fn a(m: dep::Mixed) -> i64 { m.a }\n\
+                 fn b(m: dep::Mixed) -> i64 { m.b }\n\
+                 fn c() -> dep::Mixed { dep::Mixed { a: 1, b: 2 } }\n\
+                 fn d(m: dep::Mixed) -> i64 { m.nope }",
+            )],
+            |elab| {
+                let messages: Vec<&str> = elab.reports.iter().map(|r| r.message.as_str()).collect();
+                // The pub field elaborates; the private one is access
+                // control, not absence — one level below the item-level
+                // is-private/not-found split.
+                assert!(
+                    messages.contains(&"field `b` of record `dep::Mixed` is private"),
+                    "{messages:#?}"
+                );
+                assert!(
+                    messages.contains(
+                        &"cannot construct `dep::Mixed` outside its module: \
+                          field(s) `b` are private"
+                    ),
+                    "{messages:#?}"
+                );
+                assert!(messages.contains(&"no such field"), "{messages:#?}");
+                assert_eq!(messages.len(), 3, "{messages:#?}");
             },
         );
     }

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -309,12 +309,12 @@ impl<'tcx> Remapper<'_, '_, 'tcx> {
         match fields {
             RecordFields::Named(fs) => RecordFields::Named(
                 fs.iter()
-                    .map(|&(name, ty, is_mut)| (self.key(name), self.ty(ty), is_mut))
+                    .map(|&(name, ty, is_mut, vis)| (self.key(name), self.ty(ty), is_mut, vis))
                     .collect(),
             ),
             RecordFields::Unnamed(fs) => RecordFields::Unnamed(
                 fs.iter()
-                    .map(|&(ty, is_mut)| (self.ty(ty), is_mut))
+                    .map(|&(ty, is_mut, vis)| (self.ty(ty), is_mut, vis))
                     .collect(),
             ),
             RecordFields::Variants(vs) => RecordFields::Variants(

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -28,7 +28,7 @@ use crate::semi::hir::{
 };
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{DefId, Flexivity, FpTy, GenericId, IntTy, Ty, TyCtxt, TyKind};
-use crate::surface::RecordKind;
+use crate::surface::{self, RecordKind};
 use crate::utils::string::StringToken;
 
 /// A parsed HIR program plus the fresh tables needed to re-print and resume it.
@@ -274,7 +274,15 @@ impl<'tcx> Builder<'_, 'tcx> {
                         .iter()
                         .map(|m| {
                             let name = self.names.intern(m.name.as_deref().unwrap_or(""));
-                            (name, self.ty(&m.ty), m.is_field)
+                            // Transitional until the HIR text form carries a
+                            // per-member visibility marker: resumed dumps
+                            // default to Public (nothing enforces yet).
+                            (
+                                name,
+                                self.ty(&m.ty),
+                                m.is_field,
+                                surface::Visibility::Public,
+                            )
                         })
                         .collect(),
                 )
@@ -282,7 +290,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::RecordBody::Compound(members) => RecordFields::Unnamed(
                 members
                     .iter()
-                    .map(|m| (self.ty(&m.ty), m.is_field))
+                    .map(|m| (self.ty(&m.ty), m.is_field, surface::Visibility::Public))
                     .collect(),
             ),
             raw::RecordBody::Variant(variants) => RecordFields::Variants(

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -274,15 +274,7 @@ impl<'tcx> Builder<'_, 'tcx> {
                         .iter()
                         .map(|m| {
                             let name = self.names.intern(m.name.as_deref().unwrap_or(""));
-                            // Transitional until the HIR text form carries a
-                            // per-member visibility marker: resumed dumps
-                            // default to Public (nothing enforces yet).
-                            (
-                                name,
-                                self.ty(&m.ty),
-                                m.is_field,
-                                surface::Visibility::Public,
-                            )
+                            (name, self.ty(&m.ty), m.is_field, member_vis(m))
                         })
                         .collect(),
                 )
@@ -290,7 +282,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::RecordBody::Compound(members) => RecordFields::Unnamed(
                 members
                     .iter()
-                    .map(|m| (self.ty(&m.ty), m.is_field, surface::Visibility::Public))
+                    .map(|m| (self.ty(&m.ty), m.is_field, member_vis(m)))
                     .collect(),
             ),
             raw::RecordBody::Variant(variants) => RecordFields::Variants(
@@ -671,6 +663,15 @@ fn cmp(op: raw::CmpOp) -> CmpOp {
         raw::CmpOp::Ge => CmpOp::Ge,
         raw::CmpOp::Eq => CmpOp::Eq,
         raw::CmpOp::Ne => CmpOp::Ne,
+    }
+}
+
+/// A member's `pub` marker as the surface visibility it round-trips.
+fn member_vis(m: &raw::Member) -> surface::Visibility {
+    if m.is_pub {
+        surface::Visibility::Public
+    } else {
+        surface::Visibility::Private
     }
 }
 
@@ -1145,6 +1146,45 @@ mod tests {
             "pub struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> } \
              regional fn foo<T>(bar: [flex] T) -> i32 { 0 } \
              regional fn use_ok(c: [flex] TestCell<i32>) -> i32 { foo(c) }",
+        );
+    }
+
+    #[test]
+    fn roundtrips_field_visibility() {
+        with_tcx(|tcx| {
+            let source = "pub struct [value] S { pub x: i64, y: i64 }\n\
+                          pub struct T(pub i64, i64)\n\
+                          pub struct [regional] R { pub c: [field] R, d: i64 }";
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+
+            let strings = elab.strings.entries();
+            let text = Printer::new(&elab.defs, elab.resolver).program(
+                &elab.elaborated,
+                &strings,
+                &elab.records,
+                &elab.trampolines,
+            );
+            // `pub` precedes the name, and the `field` marker; a private
+            // member carries no marker.
+            assert!(
+                text.contains("pub [value] struct #S { pub \"x\": i64, \"y\": i64 };"),
+                "{text}"
+            );
+            assert!(
+                text.contains("pub [shared] struct #T { pub i64, i64 };"),
+                "{text}"
+            );
+            assert!(text.contains("pub \"c\": field "), "{text}");
+        });
+        // And the marker survives print -> parse -> print byte-identically.
+        roundtrip(
+            "pub struct [value] S { pub x: i64, y: i64 }\n\
+             pub struct T(pub i64, i64)\n\
+             pub struct [regional] R { pub c: [field] R, d: i64 }",
         );
     }
 }

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -22,7 +22,7 @@ pub Program: raw::Program = <h:Header?> <items:Item*> => {
 
 /// The `.rri` interface header, required first in an interface dump and
 /// absent from a plain HIR program:
-/// `interface 2 package "demo" producer "rrc 0.1.0";`.
+/// `interface 1 package "demo" producer "rrc 0.1.0";`.
 Header: raw::InterfaceHeader =
     "interface" <format:"int"> "package" <package:"quoted"> "producer" <producer:"quoted"> ";"
     => raw::InterfaceHeader {

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -22,7 +22,7 @@ pub Program: raw::Program = <h:Header?> <items:Item*> => {
 
 /// The `.rri` interface header, required first in an interface dump and
 /// absent from a plain HIR program:
-/// `interface 1 package "demo" producer "rrc 0.1.0";`.
+/// `interface 2 package "demo" producer "rrc 0.1.0";`.
 Header: raw::InterfaceHeader =
     "interface" <format:"int"> "package" <package:"quoted"> "producer" <producer:"quoted"> ";"
     => raw::InterfaceHeader {
@@ -106,10 +106,11 @@ DefaultCap: raw::DefaultCap = {
     "[" "regional" "]" => raw::DefaultCap::Regional,
 };
 
-/// A compound field: an optional `name:` prefix (absent for a tuple field), an
-/// optional `field` marker (a mutable `[field]` link), and its type.
-Member: raw::Member = <n:(<"quoted"> ":")?> <f:"field"?> <t:Ty>
-    => raw::Member { name: n.map(|s| s.into()), is_field: f.is_some(), ty: t };
+/// A compound field: an optional `pub` visibility marker, an optional `name:`
+/// prefix (absent for a tuple field), an optional `field` marker (a mutable
+/// `[field]` link), and its type.
+Member: raw::Member = <p:"pub"?> <n:(<"quoted"> ":")?> <f:"field"?> <t:Ty>
+    => raw::Member { is_pub: p.is_some(), name: n.map(|s| s.into()), is_field: f.is_some(), ty: t };
 
 /// An enum variant: its source name and ordered field types.
 Variant: raw::Variant =

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -295,14 +295,14 @@ impl<'a> Printer<'a> {
             Some(RecordFields::Named(fields)) => {
                 let parts = fields
                     .iter()
-                    .map(|(name, ty, is_mut)| self.member(Some(*name), *ty, *is_mut))
+                    .map(|(name, ty, is_mut, _)| self.member(Some(*name), *ty, *is_mut))
                     .collect();
                 comma_sep(parts)
             }
             Some(RecordFields::Unnamed(fields)) => {
                 let parts = fields
                     .iter()
-                    .map(|(ty, is_mut)| self.member(None, *ty, *is_mut))
+                    .map(|(ty, is_mut, _)| self.member(None, *ty, *is_mut))
                     .collect();
                 comma_sep(parts)
             }

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -295,14 +295,14 @@ impl<'a> Printer<'a> {
             Some(RecordFields::Named(fields)) => {
                 let parts = fields
                     .iter()
-                    .map(|(name, ty, is_mut, _)| self.member(Some(*name), *ty, *is_mut))
+                    .map(|(name, ty, is_mut, vis)| self.member(Some(*name), *ty, *is_mut, *vis))
                     .collect();
                 comma_sep(parts)
             }
             Some(RecordFields::Unnamed(fields)) => {
                 let parts = fields
                     .iter()
-                    .map(|(ty, is_mut, _)| self.member(None, *ty, *is_mut))
+                    .map(|(ty, is_mut, vis)| self.member(None, *ty, *is_mut, *vis))
                     .collect();
                 comma_sep(parts)
             }
@@ -325,13 +325,23 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn member(&self, name: Option<TokenKey>, ty: Ty<'_>, is_mut: bool) -> Doc<'static> {
+    fn member(
+        &self,
+        name: Option<TokenKey>,
+        ty: Ty<'_>,
+        is_mut: bool,
+        vis: Visibility,
+    ) -> Doc<'static> {
+        let vis = match vis {
+            Visibility::Public => text("pub "),
+            Visibility::Private => Doc::Null,
+        };
         let name = match name {
             Some(n) => text(format!("\"{}\": ", self.resolver.resolve(n))),
             None => Doc::Null,
         };
         let marker = if is_mut { text("field ") } else { Doc::Null };
-        name + marker + self.ty(ty)
+        vis + name + marker + self.ty(ty)
     }
 
     fn trampoline(&self, t: &TrampolineRoot<'_>) -> Doc<'static> {

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -16,7 +16,7 @@ pub use crate::full::mir::raw::{
 #[derive(Clone, Debug)]
 pub struct Program {
     /// The `.rri` interface header, when the dump is a package interface
-    /// rather than a plain HIR program: `interface 2 package "demo"
+    /// rather than a plain HIR program: `interface 1 package "demo"
     /// producer "rrc …";`, always the first item.
     pub header: Option<InterfaceHeader>,
     pub files: Vec<FileEntry>,

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -16,7 +16,7 @@ pub use crate::full::mir::raw::{
 #[derive(Clone, Debug)]
 pub struct Program {
     /// The `.rri` interface header, when the dump is a package interface
-    /// rather than a plain HIR program: `interface 1 package "demo"
+    /// rather than a plain HIR program: `interface 2 package "demo"
     /// producer "rrc …";`, always the first item.
     pub header: Option<InterfaceHeader>,
     pub files: Vec<FileEntry>,
@@ -88,8 +88,9 @@ pub struct FfiPrelude {
 
 /// A record declaration carrying what mono reads: its path/kind/default cap, its
 /// generic parameters (with the `regional` ones marked), and its field layout.
-/// Field types are serialized (struct field *names* are not — mono does not read
-/// them) so the resumed HIR resolves ground record layouts identically.
+/// Field types, names, and `pub` visibility markers are serialized so the
+/// resumed HIR resolves ground record layouts identically and dependent
+/// packages see the same field-access rights through a `.rri`.
 #[derive(Clone, Debug)]
 pub struct Record {
     pub is_pub: bool,
@@ -109,7 +110,7 @@ pub struct Record {
 /// A record's field layout in the HIR form.
 #[derive(Clone, Debug)]
 pub enum RecordBody {
-    /// A struct's ordered fields (names dropped; mono does not read them).
+    /// A struct's ordered fields.
     Compound(Vec<Member>),
     /// An enum's variants, in declaration order.
     Variant(Vec<Variant>),
@@ -117,10 +118,11 @@ pub enum RecordBody {
     Opaque(String),
 }
 
-/// One compound field: an optional source name (absent for a tuple field), a
-/// `[field]`-mutability marker, and its type.
+/// One compound field: a `pub` visibility marker, an optional source name
+/// (absent for a tuple field), a `[field]`-mutability marker, and its type.
 #[derive(Clone, Debug)]
 pub struct Member {
+    pub is_pub: bool,
     pub name: Option<String>,
     pub is_field: bool,
     pub ty: Ty,

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -383,6 +383,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             self.error(span, "unknown enum".to_string());
             return Pat::Wild;
         };
+        // Struct patterns do not exist (only enum-variant and Nullable
+        // constructors match); if they ever land, private-field bindings must
+        // gate on `may_access_private_fields` like projection does.
         let Some(RecordFields::Variants(variants)) = &record.fields else {
             self.error(span, "not an enum".to_string());
             return Pat::Wild;

--- a/crates/reussir-core/src/semi/repl.rs
+++ b/crates/reussir-core/src/semi/repl.rs
@@ -347,6 +347,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     field,
                     self.tcx.mk_generic(generic),
                     false,
+                    surface::Visibility::Public,
                 )])),
                 regional_generics: Vec::new(),
                 span: None,

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -532,12 +532,12 @@ impl<'tcx> SyncEnv<'tcx> for ElabSyncEnv<'_, '_, 'tcx> {
         Some(match fields {
             RecordFields::Named(fs) => fs
                 .iter()
-                .map(|(n, t, _)| (self.el.sym(*n).to_owned(), subst(*t)))
+                .map(|(n, t, _, _)| (self.el.sym(*n).to_owned(), subst(*t)))
                 .collect(),
             RecordFields::Unnamed(fs) => fs
                 .iter()
                 .enumerate()
-                .map(|(i, (t, _))| (i.to_string(), subst(*t)))
+                .map(|(i, (t, _, _))| (i.to_string(), subst(*t)))
                 .collect(),
             RecordFields::Variants(vs) => vs
                 .iter()
@@ -562,8 +562,8 @@ impl<'tcx> SyncEnv<'tcx> for ElabSyncEnv<'_, '_, 'tcx> {
         let mut out = Vec::new();
         let mut walk = |t: Ty<'tcx>| crate::semi::traits::sync::collect_record_defs(t, &mut out);
         match fields {
-            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _)| walk(*t)),
-            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _)| walk(*t)),
+            RecordFields::Named(fs) => fs.iter().for_each(|(_, t, _, _)| walk(*t)),
+            RecordFields::Unnamed(fs) => fs.iter().for_each(|(t, _, _)| walk(*t)),
             RecordFields::Variants(vs) => vs
                 .iter()
                 .for_each(|v| v.fields.iter().for_each(|t| walk(*t))),

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -891,8 +891,10 @@ pub struct Function {
 
 #[derive(Clone, Debug)]
 pub enum RecordFields {
-    Named(Vec<Spanned<(TokenKey, Type, bool)>>),
-    Unnamed(Vec<Spanned<(Type, bool)>>),
+    /// Each named field is `(name, type, is_mutable, visibility)`.
+    Named(Vec<Spanned<(TokenKey, Type, bool, Visibility)>>),
+    /// Each unnamed field is `(type, is_mutable, visibility)`.
+    Unnamed(Vec<Spanned<(Type, bool, Visibility)>>),
     Variants(Vec<Spanned<(TokenKey, SmallVec<[Type; 2]>)>>),
     /// A field-less declaration (`struct V<T>;`): an opaque (FFI) record.
     Opaque,
@@ -1045,6 +1047,16 @@ fn visibility_of(node: &ResolvedNode) -> Visibility {
     }
 }
 
+/// Per-field visibility: the `pub` marker lives inside a nested VisFlag node
+/// (never as a direct token, which would collide with a field named `pub`).
+fn visibility_of_field(field: &ResolvedNode) -> Visibility {
+    if child_node(field, VisFlag).is_some() {
+        Visibility::Public
+    } else {
+        Visibility::Private
+    }
+}
+
 fn function_of(node: &ResolvedNode) -> Function {
     let body = expr_children(node).last().map(Expr::new);
     let return_type = child_node(node, RetType).map(|r| {
@@ -1118,14 +1130,17 @@ fn record_of(node: &ResolvedNode, kind: RecordKind) -> Record {
             nodes(named)
                 .filter(|n| n.kind() == NamedField)
                 .map(|f| {
+                    // A `pub` marker sits inside a VisFlag node, so the
+                    // direct-token scan still finds the field name.
                     let name = tokens(f)
                         .find(|t| t.kind().is_ident_like())
                         .expect("field name");
                     let flag = child_node(f, FieldFlag).is_some();
+                    let vis = visibility_of_field(f);
                     let ty = nodes(f)
                         .find(|n| is_type_kind(n.kind()))
                         .expect("field type");
-                    spanned(f, (key(name), Type::new(ty), flag))
+                    spanned(f, (key(name), Type::new(ty), flag, vis))
                 })
                 .collect(),
         )
@@ -1135,10 +1150,11 @@ fn record_of(node: &ResolvedNode, kind: RecordKind) -> Record {
                 .filter(|n| n.kind() == UnnamedField)
                 .map(|f| {
                     let flag = child_node(f, FieldFlag).is_some();
+                    let vis = visibility_of_field(f);
                     let ty = nodes(f)
                         .find(|n| is_type_kind(n.kind()))
                         .expect("field type");
-                    spanned(f, (Type::new(ty), flag))
+                    spanned(f, (Type::new(ty), flag, vis))
                 })
                 .collect(),
         )

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -10,6 +10,10 @@
 //! * tuples are arrays, an optional value is `null` or the value;
 //! * spans are `{"spanValue": v, "spanStartOffset": n, "spanEndOffset": n}`
 //!   with *character* offsets.
+//!
+//! Record fields carry a trailing visibility string: named fields are
+//! `[name, type, is_field, vis]` quads and unnamed fields `[type, is_field,
+//! vis]` triples, with `vis` either `"Public"` or `"Private"`.
 
 use serde_json::{Number, Value, json};
 
@@ -53,6 +57,15 @@ fn child_node(node: &ResolvedNode, kind: SyntaxKind) -> Option<&ResolvedNode> {
 
 fn is_ident_like(kind: SyntaxKind) -> bool {
     kind.is_ident_like()
+}
+
+/// Field visibility as the all-nullary-sum string encoding.
+fn visibility_str(field: &ResolvedNode) -> &'static str {
+    if child_node(field, VisFlag).is_some() {
+        "Public"
+    } else {
+        "Private"
+    }
 }
 
 fn is_expr_kind(kind: SyntaxKind) -> bool {
@@ -242,14 +255,18 @@ impl Emitter<'_> {
             let fields: Vec<Value> = nodes(named)
                 .filter(|n| n.kind() == NamedField)
                 .map(|f| {
+                    // A `pub` marker is nested inside a VisFlag node, so the
+                    // direct-token scan below still finds the real field name
+                    // (which may itself be spelled `pub`).
                     let name = tokens(f)
                         .find(|t| is_ident_like(t.kind()))
                         .expect("field name");
                     let flag = child_node(f, FieldFlag).is_some();
+                    let vis = visibility_str(f);
                     let ty = nodes(f)
                         .find(|n| is_type_kind(n.kind()))
                         .expect("field type");
-                    self.with_node_span(f, json!([name.text(), self.type_(ty), flag]))
+                    self.with_node_span(f, json!([name.text(), self.type_(ty), flag, vis]))
                 })
                 .collect();
             tagged("Named", Value::Array(fields))
@@ -258,10 +275,11 @@ impl Emitter<'_> {
                 .filter(|n| n.kind() == UnnamedField)
                 .map(|f| {
                     let flag = child_node(f, FieldFlag).is_some();
+                    let vis = visibility_str(f);
                     let ty = nodes(f)
                         .find(|n| is_type_kind(n.kind()))
                         .expect("field type");
-                    self.with_node_span(f, json!([self.type_(ty), flag]))
+                    self.with_node_span(f, json!([self.type_(ty), flag, vis]))
                 })
                 .collect();
             tagged("Unnamed", Value::Array(fields))

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -145,6 +145,8 @@ pub enum SyntaxKind {
     Capability,
     /// `[field]` flag on record fields.
     FieldFlag,
+    /// `pub` visibility marker on record fields.
+    VisFlag,
     /// `[flex]` flag on parameters/return types/let bindings.
     FlexFlag,
     /// An outer attribute `#[repr(fixed)]` on an item (e.g. an enum).

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -543,6 +543,51 @@ mod tests {
     }
 
     #[test]
+    fn field_visibility_parses_and_encodes() {
+        let json = json_of("pub struct S { pub x: i64, y: [field] T }");
+        let record = unwrap_span(&json[0]);
+        let named = &record["contents"]["recordFields"];
+        assert_eq!(named["tag"], "Named");
+        let x = &named["contents"][0]["spanValue"];
+        let y = &named["contents"][1]["spanValue"];
+        assert_eq!(x[0], "x");
+        assert_eq!(x[2], false);
+        assert_eq!(x[3], "Public");
+        assert_eq!(y[0], "y");
+        assert_eq!(y[2], true);
+        assert_eq!(y[3], "Private");
+
+        let json = json_of("struct P(pub i64, bool)");
+        let unnamed = &unwrap_span(&json[0])["contents"]["recordFields"];
+        assert_eq!(unnamed["tag"], "Unnamed");
+        assert_eq!(unnamed["contents"][0]["spanValue"][2], "Public");
+        assert_eq!(unnamed["contents"][1]["spanValue"][2], "Private");
+    }
+
+    /// `pub` stays a legal field name, field type, and path segment; the
+    /// marker is recognized only where a name/type cannot follow it.
+    #[test]
+    fn field_named_pub_stays_a_field_name() {
+        let json = json_of("struct S { pub: i64, pub pub: i64 }");
+        let named = &unwrap_span(&json[0])["contents"]["recordFields"]["contents"];
+        let first = &named[0]["spanValue"];
+        let second = &named[1]["spanValue"];
+        assert_eq!(first[0], "pub");
+        assert_eq!(first[3], "Private");
+        assert_eq!(second[0], "pub");
+        assert_eq!(second[3], "Public");
+
+        let json = json_of("struct T(pub, pub i64)");
+        let unnamed = &unwrap_span(&json[0])["contents"]["recordFields"]["contents"];
+        let first = &unnamed[0]["spanValue"];
+        let second = &unnamed[1]["spanValue"];
+        // The lone `pub` is a type named `pub`, not a visibility marker.
+        assert_eq!(first[1], false);
+        assert_eq!(first[2], "Private");
+        assert_eq!(second[2], "Public");
+    }
+
+    #[test]
     fn transform_item_requires_a_semicolon() {
         let parse = parse("transform [{ transform.yield }]");
         assert!(

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -206,12 +206,19 @@ impl Parser<'_> {
         m.complete(self, StructStmt);
     }
 
-    /// `{ name: [field]? type, ... }`.
+    /// `{ pub? name: [field]? type, ... }`.
     fn named_fields(&mut self) {
         let m = self.start();
         self.expect(LBrace);
         while !self.at(RBrace) && !self.at_eof() {
             let f = self.start();
+            // `pub` is also a legal field name (no reserved words); it is a
+            // visibility marker only when not immediately followed by `:`.
+            if self.at(PubKw) && self.nth(1) != Colon {
+                let v = self.start();
+                self.bump();
+                v.complete(self, VisFlag);
+            }
             self.expect_ident("a field name");
             self.expect(Colon);
             self.field_flag_opt();
@@ -227,12 +234,19 @@ impl Parser<'_> {
         m.complete(self, NamedFields);
     }
 
-    /// `( [field]? type, ... )`.
+    /// `( pub? [field]? type, ... )`.
     fn unnamed_fields(&mut self) {
         let m = self.start();
         self.expect(LParen);
         while !self.at(RParen) && !self.at_eof() {
             let f = self.start();
+            // `pub` is also a legal type name; it is a visibility marker only
+            // when what follows cannot continue a type headed by `pub`.
+            if self.at(PubKw) && !matches!(self.nth(1), Comma | RParen | PathSep | LAngle | Arrow) {
+                let v = self.start();
+                self.bump();
+                v.complete(self, VisFlag);
+            }
             self.field_flag_opt();
             self.type_();
             f.complete(self, UnnamedField);

--- a/tests/integration/frontend/emit_rri.rr
+++ b/tests/integration/frontend/emit_rri.rr
@@ -9,7 +9,7 @@
 // RUN: %rrc --package-root %S/emit_rri --package-name demo --emit rri -o - | %FileCheck %s
 // RUN: %rrc --package-root %S/emit_rri --package-name demo --emit rri -o - | %FileCheck %s --check-prefix=ABSENT
 
-// CHECK: interface 2 package "demo" producer "rrc
+// CHECK: interface 1 package "demo" producer "rrc
 // CHECK: 0 = "lib.rr";
 // CHECK: 1 = "util.rr";
 

--- a/tests/integration/frontend/emit_rri.rr
+++ b/tests/integration/frontend/emit_rri.rr
@@ -9,13 +9,15 @@
 // RUN: %rrc --package-root %S/emit_rri --package-name demo --emit rri -o - | %FileCheck %s
 // RUN: %rrc --package-root %S/emit_rri --package-name demo --emit rri -o - | %FileCheck %s --check-prefix=ABSENT
 
-// CHECK: interface 1 package "demo" producer "rrc
+// CHECK: interface 2 package "demo" producer "rrc
 // CHECK: 0 = "lib.rr";
 // CHECK: 1 = "util.rr";
 
-// The `pub` surface record keeps its marker; the private record ships (a
-// shipped prototype mentions it) without one.
+// The `pub` surface record keeps its marker — and its members keep their
+// per-field visibility; the private record ships (a shipped prototype
+// mentions it) without one.
 // CHECK: pub [shared] struct #demo::Point
+// CHECK-SAME: { pub "x": i64, "y": i64 };
 // CHECK: [shared] struct #demo::Secret
 
 // Ground functions — private or `pub`, same-module or cross-module — are

--- a/tests/integration/frontend/emit_rri/lib.rr
+++ b/tests/integration/frontend/emit_rri/lib.rr
@@ -5,7 +5,7 @@
 mod util;
 
 pub struct Point {
-    x: i64,
+    pub x: i64,
     y: i64,
 }
 

--- a/tests/integration/frontend/extern_resolve/lib.rr
+++ b/tests/integration/frontend/extern_resolve/lib.rr
@@ -4,8 +4,8 @@
 // ground, and a `pub` record surface a prototype mentions.
 
 pub struct Point {
-    x: i64,
-    y: i64,
+    pub x: i64,
+    pub y: i64,
 }
 
 struct Hidden {

--- a/tests/integration/frontend/field_vis.rr
+++ b/tests/integration/frontend/field_vis.rr
@@ -1,0 +1,38 @@
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
+// Roundtrip: emit HIR, re-parse it (`--from hir`), and re-emit — the per-field
+// `pub` marker must survive print -> parse -> print unchanged.
+// RUN: %rrc %s --emit hir --no-source-locations -o %t.hir
+// RUN: %rrc %t.hir --from hir --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
+// RUN: %rrc %s -o %t.o
+
+// Per-field `pub` visibility threads surface -> HIR text and stays
+// roundtrip-consistent for named, unnamed, and `[field]`-mutable members.
+// MIR is deliberately unaffected: visibility is erased before layout.
+
+// HIR-DAG: pub [value] struct #Named { pub "x": i64, "y": i64 };
+// HIR-DAG: pub [shared] struct #Tuple { pub i64, i64 };
+// HIR-DAG: pub [regional] struct #Link { pub "next": field Nullable<[regional] #Link>, "v": i64 };
+
+pub struct [value] Named {
+    pub x: i64,
+    y: i64,
+}
+
+pub struct Tuple(pub i64, i64)
+
+pub struct [regional] Link {
+    pub next: [field] Link,
+    v: i64,
+}
+
+fn use_named(n: Named) -> i64 {
+    n.x + n.y
+}
+
+fn use_tuple(t: Tuple) -> i64 {
+    t.0 + t.1
+}
+
+fn main() -> i64 {
+    use_named(Named { x: 1, y: 2 }) + use_tuple(Tuple { 3, 4 })
+}

--- a/tests/integration/frontend/field_vis_extern.rr
+++ b/tests/integration/frontend/field_vis_extern.rr
@@ -1,0 +1,39 @@
+// Field visibility across packages: a dependency's field markers ship in its
+// `.rri`, a consumer sees `pub` fields only, and the field-level diagnostics
+// mirror the item-level is-private/not-found split one level down.
+
+// RUN: %rrc --package-root %S/field_vis_extern --package-name dep --emit rri -o %t.rri
+
+// The markers ship in the interface …
+// RUN: %FileCheck %s --check-prefix=RRI < %t.rri
+// RRI: pub [shared] struct #dep::Gauge
+// RRI-SAME: { pub "level": i64, "secret": i64 };
+
+// … a consumer projecting the `pub` field elaborates …
+// RUN: %rrc %s --package-name app --extern dep=%t.rri --emit hir --no-source-locations -o - \
+// RUN:   | %FileCheck %s
+
+// … the private field is access control at projection …
+// RUN: echo 'fn peek(g: dep::Gauge) -> i64 { g.secret }' > %t.peek.rr
+// RUN: %not %rrc %t.peek.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=PRIVATE-FIELD
+// PRIVATE-FIELD: field `secret` of record `dep::Gauge` is private
+
+// … and at construction …
+// RUN: echo 'fn forge() -> dep::Gauge { dep::Gauge { level: 1, secret: 2 } }' > %t.forge.rr
+// RUN: %not %rrc %t.forge.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=PRIVATE-CTOR
+// PRIVATE-CTOR: cannot construct `dep::Gauge` outside its module: field(s) `secret` are private
+
+// … while a missing field stays not-found.
+// RUN: echo 'fn miss(g: dep::Gauge) -> i64 { g.nope }' > %t.miss.rr
+// RUN: %not %rrc %t.miss.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NOPE
+// NOPE: no such field
+// NOPE-NOT: is private
+
+pub fn read(g: dep::Gauge) -> i64 {
+    g.level
+}
+
+// CHECK: pub fn #app::read

--- a/tests/integration/frontend/field_vis_extern/lib.rr
+++ b/tests/integration/frontend/field_vis_extern/lib.rr
@@ -1,0 +1,16 @@
+// The dependency fixture: a `pub` record with one `pub` and one private
+// field, plus a `pub` accessor so the private field is reachable through the
+// package's own API.
+
+pub struct Gauge {
+    pub level: i64,
+    secret: i64,
+}
+
+pub fn make(n: i64) -> Gauge {
+    Gauge { level: n, secret: n * 2 }
+}
+
+pub fn reveal(g: Gauge) -> i64 {
+    g.secret
+}

--- a/tests/integration/frontend/field_vis_extern/lit.local.cfg
+++ b/tests/integration/frontend/field_vis_extern/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/field_vis_modules.rr
+++ b/tests/integration/frontend/field_vis_modules.rr
@@ -1,0 +1,23 @@
+// Field visibility inside one package: a private field is accessible from
+// its defining module and that module's descendants; a sibling module sees
+// only `pub` fields, at projection and construction alike.
+
+// The positive package: pub-field access from a sibling (`render`), private
+// access from the defining module (`geometry`) and its child
+// (`geometry::ops`) — elaborates clean and round-trips its markers.
+// RUN: %rrc --package-root %S/field_vis_modules --package-name pkg --emit hir --no-source-locations -o - \
+// RUN:   | %FileCheck %s
+
+// CHECK: pub [shared] struct #pkg::geometry::Rect { pub "w": i64, "h": i64 };
+// CHECK: pub fn #pkg::entry
+// CHECK: pub fn #pkg::geometry::area
+// CHECK: pub fn #pkg::geometry::ops::heightened
+// CHECK: pub fn #pkg::render::width
+
+// The negative package: a sibling module projecting and constructing across
+// the private field is access control, not absence.
+// RUN: %not %rrc --package-root %S/field_vis_modules_bad --package-name pkg --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=FIELD-PRIVATE
+
+// FIELD-PRIVATE-DAG: field `h` of record `pkg::geometry::Rect` is private
+// FIELD-PRIVATE-DAG: cannot construct `pkg::geometry::Rect` outside its module: field(s) `h` are private

--- a/tests/integration/frontend/field_vis_modules/geometry/mod.rr
+++ b/tests/integration/frontend/field_vis_modules/geometry/mod.rr
@@ -1,0 +1,15 @@
+mod ops;
+
+pub struct Rect {
+    pub w: i64,
+    h: i64,
+}
+
+pub fn make(n: i64) -> Rect {
+    Rect { w: n, h: n + 1 }
+}
+
+// The defining module reads its own private field freely.
+pub fn area(r: Rect) -> i64 {
+    r.w * r.h
+}

--- a/tests/integration/frontend/field_vis_modules/geometry/ops.rr
+++ b/tests/integration/frontend/field_vis_modules/geometry/ops.rr
@@ -1,0 +1,4 @@
+// A descendant of the defining module keeps private access.
+pub fn heightened(r: super::Rect) -> i64 {
+    r.h + super::Rect { w: 1, h: 2 }.h
+}

--- a/tests/integration/frontend/field_vis_modules/lib.rr
+++ b/tests/integration/frontend/field_vis_modules/lib.rr
@@ -1,0 +1,10 @@
+// The intra-package fixture: `geometry` defines a record with mixed field
+// visibility; the root, a sibling, and a child module exercise the access
+// rules the driving test pins.
+
+mod geometry;
+mod render;
+
+pub fn entry(n: i64) -> i64 {
+    render::width(geometry::make(n))
+}

--- a/tests/integration/frontend/field_vis_modules/lit.local.cfg
+++ b/tests/integration/frontend/field_vis_modules/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/field_vis_modules/render.rr
+++ b/tests/integration/frontend/field_vis_modules/render.rr
@@ -1,0 +1,4 @@
+// A sibling module sees only the `pub` field.
+pub fn width(r: super::geometry::Rect) -> i64 {
+    r.w
+}

--- a/tests/integration/frontend/field_vis_modules_bad/geometry.rr
+++ b/tests/integration/frontend/field_vis_modules_bad/geometry.rr
@@ -1,0 +1,8 @@
+pub struct Rect {
+    pub w: i64,
+    h: i64,
+}
+
+pub fn make(n: i64) -> Rect {
+    Rect { w: n, h: n + 1 }
+}

--- a/tests/integration/frontend/field_vis_modules_bad/lib.rr
+++ b/tests/integration/frontend/field_vis_modules_bad/lib.rr
@@ -1,0 +1,8 @@
+// The violating package: `spy` reaches for `geometry::Rect`'s private field.
+
+mod geometry;
+mod spy;
+
+pub fn entry(n: i64) -> i64 {
+    spy::peek(geometry::make(n))
+}

--- a/tests/integration/frontend/field_vis_modules_bad/lit.local.cfg
+++ b/tests/integration/frontend/field_vis_modules_bad/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/field_vis_modules_bad/spy.rr
+++ b/tests/integration/frontend/field_vis_modules_bad/spy.rr
@@ -1,0 +1,9 @@
+// Projection of a private field from a sibling module …
+pub fn peek(r: super::geometry::Rect) -> i64 {
+    r.h
+}
+
+// … and construction naming one.
+pub fn forge() -> super::geometry::Rect {
+    super::geometry::Rect { w: 1, h: 2 }
+}

--- a/tests/integration/rene/inventory/vendor/store/src/lib.rr
+++ b/tests/integration/rene/inventory/vendor/store/src/lib.rr
@@ -5,8 +5,8 @@
 // take the incoming price, sales subtract and keep the price on record.
 
 pub struct Item {
-    qty: i64,
-    unit_cents: i64
+    pub qty: i64,
+    pub unit_cents: i64
 }
 
 pub enum Txn {


### PR DESCRIPTION
Stacked on #494 (A3 of the field-visibility stack: A1 parser → A2 plumbing → **A3 round-trip** → A4 enforcement).

The HIR member form gains an optional leading `pub`:

```
pub [value] struct #Named { pub "x": i64, "y": i64 };
pub [shared] struct #Tuple { pub i64, i64 };
pub [regional] struct #Link { pub "next": field Nullable<[regional] #Link>, "v": i64 };
```

- **4-file lockstep in one PR** (the repo's hard rule for HIR text changes): `print.rs` (`member()` takes the visibility, prints `pub ` first), `grammar.lalrpop` (`Member` rule gains `<p:"pub"?>`), `raw.rs` (`Member.is_pub`), `build.rs` (rebuilds the real visibility, replacing A2's transitional Public). Gated by `roundtrips_field_visibility` (byte-equality print→parse→print) and the `field_vis.rr` lit test, whose `--from hir` re-emit leg pins **resumability**.
- `"pub"` already exists in the shared `ir_lex` lexer → no lexer change, no HIR/MIR keyword collision, grammar stays LR(1). **MIR `Member` rule and printer untouched** — visibility is erased before MIR. (Known corner, same class as unquotable path names: a member whose *type* is literally named `pub` no longer round-trips.)
- **RRI_FORMAT 1 → 2** — the single coordinated bump for this stack; the upcoming bounds-serialization PRs assert 2 rather than bumping again. All `interface 1` pins updated (incl. the two doc comments in `raw.rs`/`grammar.lalrpop`); `driver.rs` now interpolates `RRI_FORMAT`. Field visibility ships in `.rri` (pinned in `emit_rri.rr` + the externs unit rig, where `dep::Point`'s markers survive `declare_extern_package`).

⚠️ **Release note:** format 2's grammar is not final until the bounds-serialization PR (B1) lands — a format-2 `.rri` with bounds read by a post-A3/pre-B1 compiler dies with a parse error rather than the version message. Please don't cut a `v*` tag between this PR and B1.

Gate: `cargo test` 467 green, `ninja -C build check` 451/454 (new `field_vis.rr` passing; 3 unsupported = baseline), `ninja -C build rrc-test` green, `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788252341&installation_model_id=426051&pr_number=495&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F495&signature=e9cafe468284c039f02c684eadff5b834028fbacb925eb2e61381d4294cf96b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->