### PR TITLE
[core] enforce field visibility at projection, assignment, and construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Language
+
+- Record fields now carry visibility: fields default to private and accept a
+  leading `pub` marker. A private field is accessible (projection,
+  assignment, construction) only from the record's defining module and its
+  descendant modules, inside a package and across packages alike; the marker
+  round-trips through HIR text and ships in `.rri` interfaces.
+  Enum-variant payloads are unaffected — variants stay
+  exactly as visible as their enum.
+
 ## 0.1.0
 
 The first tagged release of Reussir: an MLIR-based compiler framework for

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -302,7 +302,7 @@ mod tests {
                     r#"
                         pub fn seed() -> u64 { 3 }
                         pub fn scale(x: u64, k: u64) -> u64 { x * k }
-                        pub struct Wrap { v: u64 }
+                        pub struct Wrap { pub v: u64 }
                     "#,
                 ),
                 (
@@ -643,6 +643,109 @@ mod tests {
                 );
             },
         );
+    }
+
+    /// The shared two-module package for the visibility tests: module `a`
+    /// defines the records, module `c` uses them from outside.
+    fn vis_package(consumer: &str, f: impl Fn(&[crate::semi::ctxt::Report])) {
+        let defs = r#"
+            pub struct S { pub a: i64, b: i64 }
+            pub struct P(pub i64, i64)
+            pub struct [regional] R { hidden: [field] R }
+        "#;
+        check_package(
+            "p",
+            &[(&[], "mod a; mod c;"), (&["a"], defs), (&["c"], consumer)],
+            |elab, _| f(&elab.reports),
+        );
+    }
+
+    #[test]
+    fn private_field_access_rejected_across_modules() {
+        vis_package("pub fn read(s: super::a::S) -> i64 { s.b }", |reports| {
+            assert!(
+                reports
+                    .iter()
+                    .any(|r| r.message == "field `b` of record `p::a::S` is private"),
+                "{reports:#?}"
+            );
+        });
+        // Assignment shares the resolver: the private diagnostic fires before
+        // mutability or source checking.
+        vis_package(
+            "regional fn poke(r: [flex] super::a::R) { r->hidden := 1 }",
+            |reports| {
+                assert!(
+                    reports
+                        .iter()
+                        .any(|r| r.message == "field `hidden` of record `p::a::R` is private"),
+                    "{reports:#?}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn pub_field_access_allowed_across_modules() {
+        vis_package(
+            "pub fn read(s: super::a::S, t: super::a::P) -> i64 { s.a + t.0 }",
+            |reports| assert!(reports.is_empty(), "{reports:#?}"),
+        );
+    }
+
+    #[test]
+    fn private_field_access_allowed_in_child_module() {
+        check_package(
+            "p",
+            &[
+                (&[], "mod a;"),
+                (&["a"], "mod sub;\npub struct S { pub a: i64, b: i64 }"),
+                (
+                    &["a", "sub"],
+                    "pub fn read(s: super::S) -> i64 { s.b }\n\
+                     pub fn make() -> super::S { super::S { a: 1, b: 2 } }",
+                ),
+            ],
+            |elab, _| assert!(!elab.has_errors(), "{:#?}", elab.reports),
+        );
+    }
+
+    #[test]
+    fn private_field_ctor_rejected_across_modules() {
+        vis_package(
+            "pub fn make() -> super::a::S { super::a::S { a: 1, b: 2 } }",
+            |reports| {
+                assert!(
+                    reports.iter().any(|r| r.message
+                        == "cannot construct `p::a::S` outside its module: field(s) `b` are private"),
+                    "{reports:#?}"
+                );
+            },
+        );
+        vis_package(
+            "pub fn make() -> super::a::P { super::a::P { 1, 2 } }",
+            |reports| {
+                assert!(
+                    reports.iter().any(|r| r.message
+                        == "cannot construct `p::a::P` outside its module: field(s) `1` are private"),
+                    "{reports:#?}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn tuple_index_respects_named_field_visibility() {
+        // `s.1` into a named record resolves the named field, so the private
+        // diagnostic names it.
+        vis_package("pub fn read(s: super::a::S) -> i64 { s.1 }", |reports| {
+            assert!(
+                reports
+                    .iter()
+                    .any(|r| r.message == "field `b` of record `p::a::S` is private"),
+                "{reports:#?}"
+            );
+        });
     }
 
     fn function<'a, 'tcx>(elab: &'a Elaborator<'_, 'tcx>, name: &str) -> &'a hir::Function<'tcx> {

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -13,6 +13,15 @@ use super::ctxt::{Elaborator, FuncProto, RecordFields};
 use super::fulfill::{collect_holes, ty_has_hole};
 use super::hir::{ArithOp, ClosureExpr, CmpOp, Expr, ExprKind, Function, VarId};
 
+/// Why a field access failed to resolve: the field does not exist (or the
+/// base is not a suitable record), or it exists but is private outside its
+/// defining module. Callers keep the two diagnostics distinct, mirroring the
+/// item-level "is private" vs "not found" split of extern resolution.
+enum FieldErr {
+    Missing,
+    Private { field: String, record: String },
+}
+
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Check a function definition: bind its parameters into Γ, check the body
     /// against the declared return type (`Γ ⊢ body ⇐ return_ty`), discharge the
@@ -956,10 +965,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
         // The target was just checked to be `Flex`, so the link's slot is seen
         // at its flex (writable) coloring.
-        let Some((idx, field_ty, mutable)) = self.resolve_field(*def, args, Flexivity::Flex, acc)
-        else {
-            self.error(span, "no such field on assignment target");
-            return self.poison(span);
+        let (idx, field_ty, mutable) = match self.resolve_field(*def, args, Flexivity::Flex, acc) {
+            Ok(resolved) => resolved,
+            Err(FieldErr::Missing) => {
+                self.error(span, "no such field on assignment target");
+                return self.poison(span);
+            }
+            Err(FieldErr::Private { field, record }) => {
+                self.error(
+                    span,
+                    format!("field `{field}` of record `{record}` is private"),
+                );
+                return self.poison(span);
+            }
         };
         if !mutable {
             self.error(span, "cannot assign to an immutable field");
@@ -1047,9 +1065,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 );
                 return self.poison(span);
             };
-            let Some((idx, field_ty, _)) = self.resolve_field(*def, args, *flex, acc) else {
-                self.error(span, "no such field");
-                return self.poison(span);
+            let (idx, field_ty, _) = match self.resolve_field(*def, args, *flex, acc) {
+                Ok(resolved) => resolved,
+                Err(FieldErr::Missing) => {
+                    self.error(span, "no such field");
+                    return self.poison(span);
+                }
+                Err(FieldErr::Private { field, record }) => {
+                    self.error(
+                        span,
+                        format!("field `{field}` of record `{record}` is private"),
+                    );
+                    return self.poison(span);
+                }
             };
             indices.push(idx);
             let field_ty = self.infer.shallow_resolve(field_ty);
@@ -1063,6 +1091,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.mk_expr(ExprKind::Proj(Box::new(base), indices), raw, span)
     }
 
+    /// May the code being checked read or write `record_def`'s private
+    /// fields? Rust's rule: a private field is accessible from the record's
+    /// defining module and its descendant modules. An extern record's path is
+    /// headed by its package name, which is never a prefix of a consumer
+    /// module, so cross-package privacy falls out of the same prefix test.
+    fn may_access_private_fields(&self, record_def: DefId) -> bool {
+        let path = &self.defs.path(record_def).0;
+        let def_module = &path[..path.len() - 1];
+        self.defs.module().starts_with(def_module)
+    }
+
     /// Resolve an access on a record type to `(field index, field type, mutable)`.
     /// The field type is instantiated with the record's type arguments and
     /// colored as seen through a base of flexivity `base_flex`
@@ -1073,31 +1112,44 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         args: &[Ty<'tcx>],
         base_flex: Flexivity,
         acc: &surface::Access,
-    ) -> Option<(u32, Ty<'tcx>, bool)> {
-        let record = self.records.get(&record_def)?;
+    ) -> Result<(u32, Ty<'tcx>, bool), FieldErr> {
+        let record = self.records.get(&record_def).ok_or(FieldErr::Missing)?;
         let ty_params = record.ty_params.clone();
-        let fields = record.fields.clone()?;
+        let fields = record.fields.clone().ok_or(FieldErr::Missing)?;
         let inst =
             Instantiation::from_pairs(ty_params.iter().map(|(_, g)| *g).zip(args.iter().copied()));
-        let (idx, decl_ty, mutable) = match (&fields, acc) {
+        let (idx, decl_ty, mutable, vis) = match (&fields, acc) {
             (RecordFields::Named(fs), surface::Access::Named(name)) => {
-                let i = fs.iter().position(|(n, _, _, _)| n == name)?;
-                (i, fs[i].1, fs[i].2)
+                let i = fs
+                    .iter()
+                    .position(|(n, _, _, _)| n == name)
+                    .ok_or(FieldErr::Missing)?;
+                (i, fs[i].1, fs[i].2, fs[i].3)
             }
             (RecordFields::Named(fs), surface::Access::Unnamed(n)) => {
                 let i = *n as usize;
-                let f = fs.get(i)?;
-                (i, f.1, f.2)
+                let f = fs.get(i).ok_or(FieldErr::Missing)?;
+                (i, f.1, f.2, f.3)
             }
             (RecordFields::Unnamed(fs), surface::Access::Unnamed(n)) => {
                 let i = *n as usize;
-                let f = fs.get(i)?;
-                (i, f.0, f.1)
+                let f = fs.get(i).ok_or(FieldErr::Missing)?;
+                (i, f.0, f.1, f.2)
             }
-            _ => return None,
+            _ => return Err(FieldErr::Missing),
         };
+        if vis == surface::Visibility::Private && !self.may_access_private_fields(record_def) {
+            let label = match (&fields, acc) {
+                (RecordFields::Named(fs), _) => self.sym(fs[idx].0).to_owned(),
+                _ => idx.to_string(),
+            };
+            return Err(FieldErr::Private {
+                field: label,
+                record: self.defs.path(record_def).display(self.resolver),
+            });
+        }
         let field_ty = self.field_member_ty(decl_ty, mutable, base_flex, &inst);
-        Some((idx as u32, field_ty, mutable))
+        Ok((idx as u32, field_ty, mutable))
     }
 
     // ----- constructors -----
@@ -1900,6 +1952,37 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 span,
                 "cannot construct a regional record outside of a region",
             );
+        }
+        // Constructing a record supplies every field, so a single private
+        // field makes the constructor itself module-private. One error listing
+        // the private fields, then checking continues (no poison — matches the
+        // regional check above). Variant construction is exempt by design:
+        // variant payloads carry no per-field visibility.
+        if !self.may_access_private_fields(def) {
+            let private: Vec<String> = match &record.fields {
+                Some(RecordFields::Named(fs)) => fs
+                    .iter()
+                    .filter(|(_, _, _, v)| *v == surface::Visibility::Private)
+                    .map(|(n, _, _, _)| format!("`{}`", self.sym(*n)))
+                    .collect(),
+                Some(RecordFields::Unnamed(fs)) => fs
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, (_, _, v))| *v == surface::Visibility::Private)
+                    .map(|(i, _)| format!("`{i}`"))
+                    .collect(),
+                _ => Vec::new(),
+            };
+            if !private.is_empty() {
+                self.error(
+                    span,
+                    format!(
+                        "cannot construct `{}` outside its module: field(s) {} are private",
+                        self.defs.path(def).display(self.resolver),
+                        private.join(", ")
+                    ),
+                );
+            }
         }
         let inst = self.instantiate(&record.generics_as_decls(), ty_args, span);
         let mut field_tys = self.field_types(&record.fields, &inst);

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -584,6 +584,7 @@ mod tests {
     }
 
     const DEP: &str = "pub struct Point { pub x: i64, pub y: i64 }\n\
+                       pub struct Mixed { pub a: i64, b: i64 }\n\
                        struct Hidden { v: i64 }\n\
                        fn private_helper(h: Hidden) -> i64 { h.v }\n\
                        pub fn api<T : Num>(x: T) -> T { private_helper(Hidden { v: 1 }); x }\n\
@@ -639,6 +640,39 @@ mod tests {
                         .all(|&(_, _, _, v)| v == crate::surface::Visibility::Public),
                     "{fs:#?}"
                 );
+            },
+        );
+    }
+
+    #[test]
+    fn private_extern_fields_are_rejected_distinctly() {
+        check_with_dep(
+            DEP,
+            &[(
+                &[],
+                "fn a(m: dep::Mixed) -> i64 { m.a }\n\
+                 fn b(m: dep::Mixed) -> i64 { m.b }\n\
+                 fn c() -> dep::Mixed { dep::Mixed { a: 1, b: 2 } }\n\
+                 fn d(m: dep::Mixed) -> i64 { m.nope }",
+            )],
+            |elab| {
+                let messages: Vec<&str> = elab.reports.iter().map(|r| r.message.as_str()).collect();
+                // The pub field elaborates; the private one is access
+                // control, not absence — one level below the item-level
+                // is-private/not-found split.
+                assert!(
+                    messages.contains(&"field `b` of record `dep::Mixed` is private"),
+                    "{messages:#?}"
+                );
+                assert!(
+                    messages.contains(
+                        &"cannot construct `dep::Mixed` outside its module: \
+                          field(s) `b` are private"
+                    ),
+                    "{messages:#?}"
+                );
+                assert!(messages.contains(&"no such field"), "{messages:#?}");
+                assert_eq!(messages.len(), 3, "{messages:#?}");
             },
         );
     }

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -383,6 +383,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             self.error(span, "unknown enum".to_string());
             return Pat::Wild;
         };
+        // Struct patterns do not exist (only enum-variant and Nullable
+        // constructors match); if they ever land, private-field bindings must
+        // gate on `may_access_private_fields` like projection does.
         let Some(RecordFields::Variants(variants)) = &record.fields else {
             self.error(span, "not an enum".to_string());
             return Pat::Wild;

--- a/tests/integration/frontend/extern_resolve/lib.rr
+++ b/tests/integration/frontend/extern_resolve/lib.rr
@@ -4,8 +4,8 @@
 // ground, and a `pub` record surface a prototype mentions.
 
 pub struct Point {
-    x: i64,
-    y: i64,
+    pub x: i64,
+    pub y: i64,
 }
 
 struct Hidden {

--- a/tests/integration/frontend/field_vis_extern.rr
+++ b/tests/integration/frontend/field_vis_extern.rr
@@ -1,0 +1,39 @@
+// Field visibility across packages: a dependency's field markers ship in its
+// `.rri`, a consumer sees `pub` fields only, and the field-level diagnostics
+// mirror the item-level is-private/not-found split one level down.
+
+// RUN: %rrc --package-root %S/field_vis_extern --package-name dep --emit rri -o %t.rri
+
+// The markers ship in the interface …
+// RUN: %FileCheck %s --check-prefix=RRI < %t.rri
+// RRI: pub [shared] struct #dep::Gauge
+// RRI-SAME: { pub "level": i64, "secret": i64 };
+
+// … a consumer projecting the `pub` field elaborates …
+// RUN: %rrc %s --package-name app --extern dep=%t.rri --emit hir --no-source-locations -o - \
+// RUN:   | %FileCheck %s
+
+// … the private field is access control at projection …
+// RUN: echo 'fn peek(g: dep::Gauge) -> i64 { g.secret }' > %t.peek.rr
+// RUN: %not %rrc %t.peek.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=PRIVATE-FIELD
+// PRIVATE-FIELD: field `secret` of record `dep::Gauge` is private
+
+// … and at construction …
+// RUN: echo 'fn forge() -> dep::Gauge { dep::Gauge { level: 1, secret: 2 } }' > %t.forge.rr
+// RUN: %not %rrc %t.forge.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=PRIVATE-CTOR
+// PRIVATE-CTOR: cannot construct `dep::Gauge` outside its module: field(s) `secret` are private
+
+// … while a missing field stays not-found.
+// RUN: echo 'fn miss(g: dep::Gauge) -> i64 { g.nope }' > %t.miss.rr
+// RUN: %not %rrc %t.miss.rr --package-name app --extern dep=%t.rri --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=NOPE
+// NOPE: no such field
+// NOPE-NOT: is private
+
+pub fn read(g: dep::Gauge) -> i64 {
+    g.level
+}
+
+// CHECK: pub fn #app::read

--- a/tests/integration/frontend/field_vis_extern/lib.rr
+++ b/tests/integration/frontend/field_vis_extern/lib.rr
@@ -1,0 +1,16 @@
+// The dependency fixture: a `pub` record with one `pub` and one private
+// field, plus a `pub` accessor so the private field is reachable through the
+// package's own API.
+
+pub struct Gauge {
+    pub level: i64,
+    secret: i64,
+}
+
+pub fn make(n: i64) -> Gauge {
+    Gauge { level: n, secret: n * 2 }
+}
+
+pub fn reveal(g: Gauge) -> i64 {
+    g.secret
+}

--- a/tests/integration/frontend/field_vis_extern/lit.local.cfg
+++ b/tests/integration/frontend/field_vis_extern/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/field_vis_modules.rr
+++ b/tests/integration/frontend/field_vis_modules.rr
@@ -1,0 +1,23 @@
+// Field visibility inside one package: a private field is accessible from
+// its defining module and that module's descendants; a sibling module sees
+// only `pub` fields, at projection and construction alike.
+
+// The positive package: pub-field access from a sibling (`render`), private
+// access from the defining module (`geometry`) and its child
+// (`geometry::ops`) — elaborates clean and round-trips its markers.
+// RUN: %rrc --package-root %S/field_vis_modules --package-name pkg --emit hir --no-source-locations -o - \
+// RUN:   | %FileCheck %s
+
+// CHECK: pub [shared] struct #pkg::geometry::Rect { pub "w": i64, "h": i64 };
+// CHECK: pub fn #pkg::entry
+// CHECK: pub fn #pkg::geometry::area
+// CHECK: pub fn #pkg::geometry::ops::heightened
+// CHECK: pub fn #pkg::render::width
+
+// The negative package: a sibling module projecting and constructing across
+// the private field is access control, not absence.
+// RUN: %not %rrc --package-root %S/field_vis_modules_bad --package-name pkg --emit hir -o - 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=FIELD-PRIVATE
+
+// FIELD-PRIVATE-DAG: field `h` of record `pkg::geometry::Rect` is private
+// FIELD-PRIVATE-DAG: cannot construct `pkg::geometry::Rect` outside its module: field(s) `h` are private

--- a/tests/integration/frontend/field_vis_modules/geometry/mod.rr
+++ b/tests/integration/frontend/field_vis_modules/geometry/mod.rr
@@ -1,0 +1,15 @@
+mod ops;
+
+pub struct Rect {
+    pub w: i64,
+    h: i64,
+}
+
+pub fn make(n: i64) -> Rect {
+    Rect { w: n, h: n + 1 }
+}
+
+// The defining module reads its own private field freely.
+pub fn area(r: Rect) -> i64 {
+    r.w * r.h
+}

--- a/tests/integration/frontend/field_vis_modules/geometry/ops.rr
+++ b/tests/integration/frontend/field_vis_modules/geometry/ops.rr
@@ -1,0 +1,4 @@
+// A descendant of the defining module keeps private access.
+pub fn heightened(r: super::Rect) -> i64 {
+    r.h + super::Rect { w: 1, h: 2 }.h
+}

--- a/tests/integration/frontend/field_vis_modules/lib.rr
+++ b/tests/integration/frontend/field_vis_modules/lib.rr
@@ -1,0 +1,10 @@
+// The intra-package fixture: `geometry` defines a record with mixed field
+// visibility; the root, a sibling, and a child module exercise the access
+// rules the driving test pins.
+
+mod geometry;
+mod render;
+
+pub fn entry(n: i64) -> i64 {
+    render::width(geometry::make(n))
+}

--- a/tests/integration/frontend/field_vis_modules/lit.local.cfg
+++ b/tests/integration/frontend/field_vis_modules/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/field_vis_modules/render.rr
+++ b/tests/integration/frontend/field_vis_modules/render.rr
@@ -1,0 +1,4 @@
+// A sibling module sees only the `pub` field.
+pub fn width(r: super::geometry::Rect) -> i64 {
+    r.w
+}

--- a/tests/integration/frontend/field_vis_modules_bad/geometry.rr
+++ b/tests/integration/frontend/field_vis_modules_bad/geometry.rr
@@ -1,0 +1,8 @@
+pub struct Rect {
+    pub w: i64,
+    h: i64,
+}
+
+pub fn make(n: i64) -> Rect {
+    Rect { w: n, h: n + 1 }
+}

--- a/tests/integration/frontend/field_vis_modules_bad/lib.rr
+++ b/tests/integration/frontend/field_vis_modules_bad/lib.rr
@@ -1,0 +1,8 @@
+// The violating package: `spy` reaches for `geometry::Rect`'s private field.
+
+mod geometry;
+mod spy;
+
+pub fn entry(n: i64) -> i64 {
+    spy::peek(geometry::make(n))
+}

--- a/tests/integration/frontend/field_vis_modules_bad/lit.local.cfg
+++ b/tests/integration/frontend/field_vis_modules_bad/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = []

--- a/tests/integration/frontend/field_vis_modules_bad/spy.rr
+++ b/tests/integration/frontend/field_vis_modules_bad/spy.rr
@@ -1,0 +1,9 @@
+// Projection of a private field from a sibling module …
+pub fn peek(r: super::geometry::Rect) -> i64 {
+    r.h
+}
+
+// … and construction naming one.
+pub fn forge() -> super::geometry::Rect {
+    super::geometry::Rect { w: 1, h: 2 }
+}

--- a/tests/integration/rene/inventory/vendor/store/src/lib.rr
+++ b/tests/integration/rene/inventory/vendor/store/src/lib.rr
@@ -5,8 +5,8 @@
 // take the incoming price, sales subtract and keep the price on record.
 
 pub struct Item {
-    qty: i64,
-    unit_cents: i64
+    pub qty: i64,
+    pub unit_cents: i64
 }
 
 pub enum Txn {


### PR DESCRIPTION
Stacked on #495 (A4, final PR of the field-visibility stack: A1 parser → A2 plumbing → A3 round-trip → **A4 enforcement**).

Rust's rule, one level below item visibility: a private field is accessible only from its record's defining module and its descendant modules — intra-package **and** cross-package (an extern record's path is headed by its package name, never a prefix of a consumer module, so privacy falls out of the same path-prefix test with zero extern-specific code).

- `resolve_field` → `Result<_, FieldErr>`: **"is private" stays distinct from "no such field"**, mirroring the item-level split `extern_resolve.rr` pins. Projection and assignment report ``field `x` of record `pkg::mod::S` is private``.
- Construction supplies every field, so one private field makes the constructor module-private: ``cannot construct `path` outside its module: field(s) `y` are private`` (one error, checking continues — same style as the regional-construction check). Variant construction exempt by design.
- Struct patterns don't exist yet; a note at `check_ctor_pat` marks the gate they'll need.
- **Behavioral change:** all existing private fields become module-private. In-tree blast radius was exactly four fixtures (now `pub`): `package_relative_paths` unit fixture, externs `DEP` rig, `extern_resolve/lib.rr`, rene `inventory` vendor store. Out-of-tree code will need `pub` on cross-module fields — CHANGELOG entry included.
- Tests: 5 semi unit tests (cross-module reject/allow, child-module allow, ctor reject incl. tuple case, tuple-index-into-named), externs `private_extern_fields_are_rejected_distinctly` (project/construct/missing all distinct through a real `.rri` round-trip), and two lit suites: `field_vis_modules.rr` (positive package + violating sibling package) and `field_vis_extern.rr` (markers in the `.rri`, consumer gating, private-vs-missing split).

Noted (out of scope): rene's freshness key doesn't include `RRI_FORMAT`, so stale build dirs keep old-format dep `.rri`s that fail the version gate instead of rebuilding. Fresh/CI builds unaffected.

Gate: `cargo test` 473 green, `ninja -C build check` 453/456 (3 unsupported = baseline), `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788253049&installation_model_id=426051&pr_number=496&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F496&signature=e38e8555378939bbaad1b011e549092f7954beb739cfcffb84bef433b7a70911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->