### PR TITLE
[core] serialize generic trait bounds in the textual HIR and .rri binder

### DIFF
--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -100,13 +100,15 @@ pub(crate) fn frontend_package<'c, 'tcx>(
         return Err(String::new());
     }
     if target == Stage::Hir {
+        let bounds = elab.bound_names();
         let printer = if cli.no_source_locations {
             hir::print::Printer::new(&elab.defs, elab.resolver)
         } else {
             hir::print::Printer::with_sources(&elab.defs, elab.resolver, &pkg.cache)
         }
         .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
-        .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports);
+        .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
+        .with_bounds(&bounds);
         let strings = elab.strings.entries();
         // The dump describes the consumer package: extern-imported records
         // are filtered out (extern bodies never joined `elaborated`).
@@ -161,6 +163,7 @@ pub(crate) fn frontend_package<'c, 'tcx>(
             _ => None,
         }
         .map(|root| root.canonicalize().unwrap_or(root));
+        let bounds = elab.bound_names();
         let printer = if cli.no_source_locations {
             hir::print::Printer::new(&elab.defs, elab.resolver)
         } else {
@@ -168,6 +171,7 @@ pub(crate) fn frontend_package<'c, 'tcx>(
         }
         .with_transform_metadata(&anchors, &scripts)
         .with_ffi_metadata(&ffi_preludes, &ffi_imports)
+        .with_bounds(&bounds)
         .with_interface(hir::print::InterfaceEmit {
             format: interface::RRI_FORMAT,
             package: cli.package_name.as_deref().unwrap_or_default(),
@@ -232,13 +236,15 @@ pub(crate) fn frontend<'c, 'tcx>(
                 return Err(String::new());
             }
             if target == Stage::Hir {
+                let bounds = elab.bound_names();
                 let printer = if cli.no_source_locations {
                     hir::print::Printer::new(&elab.defs, elab.resolver)
                 } else {
                     hir::print::Printer::with_sources(&elab.defs, elab.resolver, sources)
                 }
                 .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
-                .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports);
+                .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
+                .with_bounds(&bounds);
                 let strings = elab.strings.entries();
                 let text =
                     printer.program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
@@ -286,7 +292,8 @@ pub(crate) fn frontend<'c, 'tcx>(
                     _ => hir::print::Printer::new(&parsed.defs, &parsed.names),
                 }
                 .with_transform_metadata(&parsed.transform_anchors, &parsed.transform_scripts)
-                .with_ffi_metadata(&parsed.ffi_preludes, &parsed.ffi_imports);
+                .with_ffi_metadata(&parsed.ffi_preludes, &parsed.ffi_imports)
+                .with_bounds(&parsed.generic_bounds);
                 let text = printer.program(
                     &parsed.funcs,
                     &parsed.strings,

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -858,7 +858,7 @@ fn emits_a_package_interface() {
     // The generic ships whole; the grounds it reaches are bodyless
     // prototypes; the unreachable private function is absent.
     assert!(
-        rri.contains("pub fn #demo::api<$0 (T)>(v0 (x): $0) -> i64 in 0"),
+        rri.contains("pub fn #demo::api<$0 (T): Num>(v0 (x): $0) -> i64 in 0"),
         "{rri}"
     );
     assert!(

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -16,6 +16,7 @@ use crate::utils::fuzzy::FuzzyIndex;
 use crate::utils::string::StringUniqifier;
 
 use super::fulfill::FulfillCtxt;
+use super::hir;
 use super::hir::{ExprId, Function, VarId};
 
 /// The capability a record declares by default. (Per-use [`crate::semi::ty::Flexivity`]
@@ -1074,20 +1075,26 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         &self.generics[generic.0 as usize].bounds
     }
 
-    /// Every bounded generic's bound names, for the HIR printer's binder
-    /// serialization (`$0 (T): Num`). Derived data — no new elaborator state.
-    pub fn bound_names(&self) -> FxHashMap<GenericId, Vec<String>> {
+    /// Every bounded generic's bounds, for the HIR printer's binder
+    /// serialization (`$0 (T): Num`). Derived data — no new elaborator
+    /// state. Builtin traits are root names, so each path is one segment;
+    /// user-declared traits will carry their full module path here.
+    pub fn bound_names(&self) -> FxHashMap<GenericId, Vec<hir::Bound>> {
         self.generics
             .iter()
             .enumerate()
             .filter(|(_, info)| !info.bounds.is_empty())
             .map(|(i, info)| {
-                let names = info
+                let bounds = info
                     .bounds
                     .iter()
-                    .map(|&t| self.traits.trait_def(t).name.clone())
+                    .map(|&t| {
+                        hir::Bound::Trait(hir::BoundPath {
+                            segments: vec![self.traits.trait_def(t).name.clone()],
+                        })
+                    })
                     .collect();
-                (GenericId(i as u32), names)
+                (GenericId(i as u32), bounds)
             })
             .collect()
     }

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1074,6 +1074,24 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         &self.generics[generic.0 as usize].bounds
     }
 
+    /// Every bounded generic's bound names, for the HIR printer's binder
+    /// serialization (`$0 (T): Num`). Derived data — no new elaborator state.
+    pub fn bound_names(&self) -> FxHashMap<GenericId, Vec<String>> {
+        self.generics
+            .iter()
+            .enumerate()
+            .filter(|(_, info)| !info.bounds.is_empty())
+            .map(|(i, info)| {
+                let names = info
+                    .bounds
+                    .iter()
+                    .map(|&t| self.traits.trait_def(t).name.clone())
+                    .collect();
+                (GenericId(i as u32), names)
+            })
+            .collect()
+    }
+
     /// Resolve a bound path (by basename) to a built-in trait.
     pub fn resolve_bound(&mut self, path: &surface::Path, span: Option<Span>) -> Option<TraitId> {
         let name = self.sym(path.basename);

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -26,6 +26,53 @@ lalrpop_util::lalrpop_mod!(
     "/semi/hir/grammar.rs"
 );
 
+/// The qualified path of a bound's trait in the textual HIR/.rri, as owned
+/// segments — structural, so consumers resolve by segment rather than
+/// re-splitting a joined string.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BoundPath {
+    pub segments: Vec<String>,
+}
+
+impl BoundPath {
+    /// The trait's own name — the last segment.
+    pub fn basename(&self) -> &str {
+        self.segments.last().expect("a bound path is never empty")
+    }
+}
+
+impl std::fmt::Display for BoundPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.segments.join("::"))
+    }
+}
+
+/// One bound on a generic binder (`$0 (T): Num + Sync`) as it round-trips
+/// through the textual HIR and `.rri`. An enum so future bound kinds
+/// (capability bounds, …) extend it structurally; the only kind today is a
+/// trait named by qualified path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Bound {
+    Trait(BoundPath),
+}
+
+impl Bound {
+    /// The trait path for resolution; every current bound kind carries one.
+    pub fn trait_path(&self) -> &BoundPath {
+        match self {
+            Bound::Trait(path) => path,
+        }
+    }
+}
+
+impl std::fmt::Display for Bound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Bound::Trait(path) => path.fmt(f),
+        }
+    }
+}
+
 /// A local variable, unique within a function body.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct VarId(pub u32);

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -23,7 +23,7 @@ use crate::semi::ctxt::{
 use crate::semi::hir::grammar as hir_ir;
 use crate::semi::hir::raw;
 use crate::semi::hir::{
-    ArithOp, ClosureExpr, CmpOp, DecisionTree, Expr, ExprId, ExprKind, Function, PatVarRef,
+    ArithOp, Bound, ClosureExpr, CmpOp, DecisionTree, Expr, ExprId, ExprKind, Function, PatVarRef,
     SwitchCases, VarId,
 };
 use crate::semi::resolve::DefTable;
@@ -51,12 +51,12 @@ pub struct Parsed<'tcx> {
     pub ffi_preludes: Vec<FfiPrelude>,
     pub defs: DefTable,
     pub names: Names,
-    /// Serialized trait-bound names per generic binder (`$0 (T): Num`),
-    /// keyed by the dump's `$n` ids — machine emissions number generics
-    /// globally (one elaborator table), so the map is collision-free;
-    /// a hand-written dump that reuses an id across items with different
-    /// bounds is last-write-wins. Empty entries are omitted.
-    pub generic_bounds: FxHashMap<GenericId, Vec<String>>,
+    /// Serialized bounds per generic binder (`$0 (T): Num`), keyed by the
+    /// dump's `$n` ids — machine emissions number generics globally (one
+    /// elaborator table), so the map is collision-free; a hand-written dump
+    /// that reuses an id across items with different bounds is
+    /// last-write-wins. Empty entries are omitted.
+    pub generic_bounds: FxHashMap<GenericId, Vec<Bound>>,
     /// The dump's source-file table, in id order: each file's display name.
     /// Item/expr spans are byte offsets into these files (by [`FileId`] =
     /// table index); a `<bracketed>` name is virtual (content not on disk).
@@ -202,8 +202,8 @@ struct Builder<'a, 'tcx> {
     tcx: &'a TyCtxt<'tcx>,
     names: Names,
     defs: DefTable,
-    /// Bound names collected off every parsed binder (see [`Parsed::generic_bounds`]).
-    generic_bounds: FxHashMap<GenericId, Vec<String>>,
+    /// Bounds collected off every parsed binder (see [`Parsed::generic_bounds`]).
+    generic_bounds: FxHashMap<GenericId, Vec<Bound>>,
     /// Monotonic counter for fresh [`ExprId`]s during the rebuild.
     next_expr_id: u32,
 }
@@ -1192,17 +1192,22 @@ mod tests {
             assert!(text.contains("fn #g<$2 (T)>"), "{text}");
 
             let parsed = parse_program(tcx, &text).expect("re-parse");
-            let mut entries: Vec<(u32, Vec<String>)> = parsed
+            let trait_bound = |name: &str| {
+                crate::semi::hir::Bound::Trait(crate::semi::hir::BoundPath {
+                    segments: vec![name.to_string()],
+                })
+            };
+            let mut entries: Vec<(u32, Vec<crate::semi::hir::Bound>)> = parsed
                 .generic_bounds
                 .iter()
                 .map(|(g, bs)| (g.0, bs.clone()))
                 .collect();
-            entries.sort();
+            entries.sort_by_key(|(g, _)| *g);
             assert_eq!(
                 entries,
                 [
-                    (0, vec!["Num".to_string()]),
-                    (1, vec!["Integral".to_string(), "Sync".to_string()]),
+                    (0, vec![trait_bound("Num")]),
+                    (1, vec![trait_bound("Integral"), trait_bound("Sync")]),
                 ]
             );
         });

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -51,6 +51,12 @@ pub struct Parsed<'tcx> {
     pub ffi_preludes: Vec<FfiPrelude>,
     pub defs: DefTable,
     pub names: Names,
+    /// Serialized trait-bound names per generic binder (`$0 (T): Num`),
+    /// keyed by the dump's `$n` ids — machine emissions number generics
+    /// globally (one elaborator table), so the map is collision-free;
+    /// a hand-written dump that reuses an id across items with different
+    /// bounds is last-write-wins. Empty entries are omitted.
+    pub generic_bounds: FxHashMap<GenericId, Vec<String>>,
     /// The dump's source-file table, in id order: each file's display name.
     /// Item/expr spans are byte offsets into these files (by [`FileId`] =
     /// table index); a `<bracketed>` name is virtual (content not on disk).
@@ -128,6 +134,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
         tcx,
         names: Names::default(),
         defs: DefTable::new(),
+        generic_bounds: FxHashMap::default(),
         next_expr_id: 0,
     };
     // Records first so their `DefId`s exist before function bodies reference them.
@@ -186,6 +193,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
         ffi_preludes,
         defs: b.defs,
         names: b.names,
+        generic_bounds: b.generic_bounds,
         files,
     })
 }
@@ -194,6 +202,8 @@ struct Builder<'a, 'tcx> {
     tcx: &'a TyCtxt<'tcx>,
     names: Names,
     defs: DefTable,
+    /// Bound names collected off every parsed binder (see [`Parsed::generic_bounds`]).
+    generic_bounds: FxHashMap<GenericId, Vec<String>>,
     /// Monotonic counter for fresh [`ExprId`]s during the rebuild.
     next_expr_id: u32,
 }
@@ -239,6 +249,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                     Some(name) => self.names.intern(name),
                     None => self.names.intern(&format!("${}", g.id)),
                 };
+                if !g.bounds.is_empty() {
+                    self.generic_bounds
+                        .insert(GenericId(g.id), g.bounds.clone());
+                }
                 (key, GenericId(g.id))
             })
             .collect();
@@ -715,9 +729,11 @@ mod tests {
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
             let strings = elab.strings.entries();
+            let bounds = elab.bound_names();
             let text = Printer::new(&elab.defs, elab.resolver)
                 .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
                 .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
+                .with_bounds(&bounds)
                 .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             let parsed = parse_program(tcx, &text).expect("re-parse");
             assert_eq!(parsed.transform_anchors.len(), elab.transform_anchors.len());
@@ -735,6 +751,7 @@ mod tests {
             let text2 = Printer::new(&parsed.defs, &parsed.names)
                 .with_transform_metadata(&parsed.transform_anchors, &parsed.transform_scripts)
                 .with_ffi_metadata(&parsed.ffi_preludes, &parsed.ffi_imports)
+                .with_bounds(&parsed.generic_bounds)
                 .program(
                     &parsed.funcs,
                     &parsed.strings,
@@ -763,9 +780,11 @@ mod tests {
 
             let cache = SourceCache::single("<test>", source);
             let strings = elab.strings.entries();
+            let bounds = elab.bound_names();
             let text = Printer::with_sources(&elab.defs, elab.resolver, &cache)
                 .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
                 .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
+                .with_bounds(&bounds)
                 .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             assert!(
                 text.contains("0 = \"<test>\";"),
@@ -794,6 +813,7 @@ mod tests {
             let text2 = Printer::with_sources(&parsed.defs, &parsed.names, &cache2)
                 .with_transform_metadata(&parsed.transform_anchors, &parsed.transform_scripts)
                 .with_ffi_metadata(&parsed.ffi_preludes, &parsed.ffi_imports)
+                .with_bounds(&parsed.generic_bounds)
                 .program(
                     &parsed.funcs,
                     &parsed.strings,
@@ -1147,6 +1167,59 @@ mod tests {
              regional fn foo<T>(bar: [flex] T) -> i32 { 0 } \
              regional fn use_ok(c: [flex] TestCell<i32>) -> i32 { foo(c) }",
         );
+    }
+
+    #[test]
+    fn bounded_generics_roundtrip() {
+        let source = "struct M<T : Num> { v: T }\n\
+                      fn f<T : Integral + Sync>(x: T) -> T { x }\n\
+                      fn g<T>(x: T) -> T { x }";
+        with_tcx(|tcx| {
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+
+            let strings = elab.strings.entries();
+            let bounds = elab.bound_names();
+            let text = Printer::new(&elab.defs, elab.resolver)
+                .with_bounds(&bounds)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
+            assert!(text.contains("struct #M<$0 (T): Num>"), "{text}");
+            assert!(text.contains(": Integral + Sync>"), "{text}");
+            // The unbounded generic prints bare.
+            assert!(text.contains("fn #g<$2 (T)>"), "{text}");
+
+            let parsed = parse_program(tcx, &text).expect("re-parse");
+            let mut entries: Vec<(u32, Vec<String>)> = parsed
+                .generic_bounds
+                .iter()
+                .map(|(g, bs)| (g.0, bs.clone()))
+                .collect();
+            entries.sort();
+            assert_eq!(
+                entries,
+                [
+                    (0, vec!["Num".to_string()]),
+                    (1, vec!["Integral".to_string(), "Sync".to_string()]),
+                ]
+            );
+        });
+        // And byte-stability through both round-trip forms.
+        roundtrip(source);
+        roundtrip_with_locations(source);
+    }
+
+    /// A pre-bounds dump (bound-less binder) still parses, with empty bounds.
+    #[test]
+    fn boundless_binder_still_parses() {
+        with_tcx(|tcx| {
+            let text = "fn #id<$0 (T)>(v0 (x): $0) -> $0 {\n    v0 : $0\n}\n";
+            let parsed = parse_program(tcx, text).expect("parse");
+            assert!(parsed.generic_bounds.is_empty());
+            assert_eq!(parsed.funcs.len(), 1);
+        });
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 use crate::ir_lex::{LexError, Token, unescape_debug_str};
 use crate::literal::{FloatLit, Integer};
 use crate::semi::hir::raw as raw;
+use crate::semi::hir::{Bound, BoundPath};
 use crate::semi::ty::CellKind;
 
 grammar<'input>;
@@ -203,11 +204,18 @@ Generic: raw::Generic = <r:"regional"?> <g:"generic"> <name:("(" <DebugName> ")"
         bounds: bounds.unwrap_or_default(),
     };
 
-/// A `+`-separated trait-bound list; each bound is a qualified path.
-Bounds: Vec<String> = <first:QPath> <rest:("+" <QPath>)*> => {
+/// A `+`-separated bound list; each bound is a trait named by qualified
+/// path, kept as segments.
+Bounds: Vec<Bound> = <first:BoundItem> <rest:("+" <BoundItem>)*> => {
     let mut v = vec![first];
     v.extend(rest);
     v
+};
+
+BoundItem: Bound = <first:Name> <rest:("::" <Name>)*> => {
+    let mut segments = vec![first.to_string()];
+    segments.extend(rest.iter().map(|s| s.to_string()));
+    Bound::Trait(BoundPath { segments })
 };
 
 /// Source identifiers remain legal when they spell a transform directive.

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -192,10 +192,23 @@ PathArgsTail: (String, Vec<raw::Ty>) = {
 };
 
 /// A generic binder: `$0 (T)` — positional id plus its source name, which
-/// foreign bodies reference through `[:T:]` placeholders. The name is
-/// optional for compatibility with dumps that predate it.
-Generic: raw::Generic = <r:"regional"?> <g:"generic"> <name:("(" <DebugName> ")")?>
-    => raw::Generic { id: g, regional: r.is_some(), name: name.map(|n| n.into_owned()) };
+/// foreign bodies reference through `[:T:]` placeholders, plus optional
+/// `+`-separated trait bounds (`$0 (T): Num + Sync`). The name and the
+/// bounds are optional for compatibility with dumps that predate them.
+Generic: raw::Generic = <r:"regional"?> <g:"generic"> <name:("(" <DebugName> ")")?> <bounds:(":" <Bounds>)?>
+    => raw::Generic {
+        id: g,
+        regional: r.is_some(),
+        name: name.map(|n| n.into_owned()),
+        bounds: bounds.unwrap_or_default(),
+    };
+
+/// A `+`-separated trait-bound list; each bound is a qualified path.
+Bounds: Vec<String> = <first:QPath> <rest:("+" <QPath>)*> => {
+    let mut v = vec![first];
+    v.extend(rest);
+    v
+};
 
 /// Source identifiers remain legal when they spell a transform directive.
 Name: &'input str = {

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -48,6 +48,10 @@ pub struct Printer<'a> {
     transform_scripts: &'a [TransformScript],
     ffi_preludes: &'a [FfiPrelude],
     ffi_imports: Option<&'a rustc_hash::FxHashMap<DefId, FfiImport>>,
+    /// Per-generic trait-bound names to serialize in binders (`$0 (T): Num`).
+    /// Absent for display-only dumps that predate the caller wiring; the
+    /// round-trip helpers and the driver always attach it.
+    bounds: Option<&'a rustc_hash::FxHashMap<GenericId, Vec<String>>>,
     interface: Option<InterfaceEmit<'a>>,
 }
 
@@ -85,6 +89,7 @@ impl<'a> Printer<'a> {
             transform_scripts: &[],
             ffi_preludes: &[],
             ffi_imports: None,
+            bounds: None,
             interface: None,
         }
     }
@@ -103,6 +108,7 @@ impl<'a> Printer<'a> {
             transform_scripts: &[],
             ffi_preludes: &[],
             ffi_imports: None,
+            bounds: None,
             interface: None,
         }
     }
@@ -127,6 +133,15 @@ impl<'a> Printer<'a> {
     ) -> Self {
         self.ffi_preludes = preludes;
         self.ffi_imports = Some(imports);
+        self
+    }
+
+    /// Attach per-generic trait-bound names to serialize in binders.
+    pub fn with_bounds(
+        mut self,
+        bounds: &'a rustc_hash::FxHashMap<GenericId, Vec<String>>,
+    ) -> Self {
+        self.bounds = Some(bounds);
         self
     }
 
@@ -254,8 +269,12 @@ impl<'a> Printer<'a> {
                 } else {
                     ""
                 };
+                let bounds = match self.bounds.and_then(|m| m.get(g)) {
+                    Some(bs) if !bs.is_empty() => format!(": {}", bs.join(" + ")),
+                    _ => String::new(),
+                };
                 text(format!(
-                    "{r}${} ({})",
+                    "{r}${} ({}){bounds}",
                     g.0,
                     spell_name(self.resolver.resolve(*name))
                 ))

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -21,7 +21,7 @@ use crate::semi::ctxt::{
     DefaultCap, FfiImport, FfiPrelude, Record, RecordFields, TrampolineRoot, TransformScript,
 };
 use crate::semi::hir::{
-    ArithOp, CmpOp, DecisionTree, Expr, ExprKind, Function, PatVarRef, SwitchCases, VarId,
+    ArithOp, Bound, CmpOp, DecisionTree, Expr, ExprKind, Function, PatVarRef, SwitchCases, VarId,
 };
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{DefId, Flexivity, FpTy, GenericId, IntTy, Ty, TyKind};
@@ -48,10 +48,10 @@ pub struct Printer<'a> {
     transform_scripts: &'a [TransformScript],
     ffi_preludes: &'a [FfiPrelude],
     ffi_imports: Option<&'a rustc_hash::FxHashMap<DefId, FfiImport>>,
-    /// Per-generic trait-bound names to serialize in binders (`$0 (T): Num`).
-    /// Absent for display-only dumps that predate the caller wiring; the
+    /// Per-generic bounds to serialize in binders (`$0 (T): Num`). Absent
+    /// for display-only dumps that predate the caller wiring; the
     /// round-trip helpers and the driver always attach it.
-    bounds: Option<&'a rustc_hash::FxHashMap<GenericId, Vec<String>>>,
+    bounds: Option<&'a rustc_hash::FxHashMap<GenericId, Vec<Bound>>>,
     interface: Option<InterfaceEmit<'a>>,
 }
 
@@ -136,11 +136,8 @@ impl<'a> Printer<'a> {
         self
     }
 
-    /// Attach per-generic trait-bound names to serialize in binders.
-    pub fn with_bounds(
-        mut self,
-        bounds: &'a rustc_hash::FxHashMap<GenericId, Vec<String>>,
-    ) -> Self {
+    /// Attach per-generic bounds to serialize in binders.
+    pub fn with_bounds(mut self, bounds: &'a rustc_hash::FxHashMap<GenericId, Vec<Bound>>) -> Self {
         self.bounds = Some(bounds);
         self
     }
@@ -270,7 +267,10 @@ impl<'a> Printer<'a> {
                     ""
                 };
                 let bounds = match self.bounds.and_then(|m| m.get(g)) {
-                    Some(bs) if !bs.is_empty() => format!(": {}", bs.join(" + ")),
+                    Some(bs) if !bs.is_empty() => {
+                        let spelled: Vec<String> = bs.iter().map(Bound::to_string).collect();
+                        format!(": {}", spelled.join(" + "))
+                    }
                     _ => String::new(),
                 };
                 text(format!(

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -201,6 +201,9 @@ pub struct Generic {
     /// `#[ffi(import)]` instantiates in a consumer package. Absent in older
     /// dumps; the rebuild then falls back to the positional `$n` spelling.
     pub name: Option<String>,
+    /// The binder's serialized trait bounds (`$0 (T): Num + Sync`), each a
+    /// qualified path. Empty in dumps that predate bounds.
+    pub bounds: Vec<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -201,9 +201,9 @@ pub struct Generic {
     /// `#[ffi(import)]` instantiates in a consumer package. Absent in older
     /// dumps; the rebuild then falls back to the positional `$n` spelling.
     pub name: Option<String>,
-    /// The binder's serialized trait bounds (`$0 (T): Num + Sync`), each a
-    /// qualified path. Empty in dumps that predate bounds.
-    pub bounds: Vec<String>,
+    /// The binder's serialized bounds (`$0 (T): Num + Sync`). Empty in
+    /// dumps that predate bounds.
+    pub bounds: Vec<crate::semi::hir::Bound>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/reussir-repl/src/commands.rs
+++ b/crates/reussir-repl/src/commands.rs
@@ -64,9 +64,11 @@ pub fn dispatch(session: &mut ReplSession<'_, '_>, command: &str) -> Outcome {
                     .map(|(k, v)| (*k, v.clone()))
                     .collect();
                 let strings = elab.strings.entries();
+                let bounds = elab.bound_names();
                 let text = Printer::new(&elab.defs, elab.resolver)
                     .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
                     .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
+                    .with_bounds(&bounds)
                     .program(&funcs, &strings, &records, &elab.trampolines);
                 Outcome::Text(text)
             }

--- a/tests/integration/frontend/emit_rri.rr
+++ b/tests/integration/frontend/emit_rri.rr
@@ -27,8 +27,8 @@
 // CHECK: pub fn #demo::origin() -> #demo::Point in 0 [{{[0-9]+}}..{{[0-9]+}}];
 
 // The `pub` generic and the private generic it calls ship with bodies.
-// CHECK: pub fn #demo::scale<$1 (T)>(v0 (x): $1) -> i64 in 0 [{{[0-9]+}}..{{[0-9]+}}] {
-// CHECK: fn #demo::scale_impl<$0 (T)>(v0 (x): $0, v1 (k): i64) -> i64 in 0 [{{[0-9]+}}..{{[0-9]+}}] {
+// CHECK: pub fn #demo::scale<$1 (T): Num>(v0 (x): $1) -> i64 in 0 [{{[0-9]+}}..{{[0-9]+}}] {
+// CHECK: fn #demo::scale_impl<$0 (T): Num>(v0 (x): $0, v1 (k): i64) -> i64 in 0 [{{[0-9]+}}..{{[0-9]+}}] {
 
 // CHECK: pub fn #demo::util::mul(v0 (a): i64, v1 (b): i64) -> i64 in 1 [{{[0-9]+}}..{{[0-9]+}}];
 

--- a/tests/integration/frontend/rbtree_balance_left.rr
+++ b/tests/integration/frontend/rbtree_balance_left.rr
@@ -42,9 +42,9 @@ fn balance_left<T : Num>(l : Tree<T>, k : T, r : Tree<T>) -> Tree<T> {
 
 // CHECK: [value] enum #Color { Red(), Black() };
 // CHECK-EMPTY:
-// CHECK-NEXT: [shared] enum #Tree<$0 (T)> { Branch(#Color, #Tree::<$0>, $0, #Tree::<$0>), Leaf() };
+// CHECK-NEXT: [shared] enum #Tree<$0 (T): Num> { Branch(#Color, #Tree::<$0>, $0, #Tree::<$0>), Leaf() };
 // CHECK-EMPTY:
-// CHECK-NEXT: fn #balance_left<$1 (T)>(v0 (l): #Tree::<$1>, v1 (k): $1, v2 (r): #Tree::<$1>) -> #Tree::<$1> {
+// CHECK-NEXT: fn #balance_left<$1 (T): Num>(v0 (l): #Tree::<$1>, v1 (k): $1, v2 (r): #Tree::<$1>) -> #Tree::<$1> {
 // CHECK-NEXT:     match v0 : #Tree::<$1> {
 // CHECK-NEXT:         switch scrut {
 // CHECK-NEXT:             #0 => {

--- a/tests/integration/frontend/trampoline.rr
+++ b/tests/integration/frontend/trampoline.rr
@@ -1,5 +1,8 @@
 // RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s
 // RUN: %rrc %s --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=FULL
+// Resume: the bounded binder survives `--from hir` re-emission.
+// RUN: %rrc %s --emit hir --no-source-locations -o %t.hir
+// RUN: %rrc %t.hir --from hir --emit hir --no-source-locations -o - | %FileCheck %s
 
 fn foo<T : Num>(x : T) -> i32 {
     x as i32 + 1
@@ -9,7 +12,7 @@ extern "C" trampoline "bar" = foo<i32>;
 
 // CHECK: extern "C" trampoline "bar" = #foo::<i32>;
 // CHECK-EMPTY:
-// CHECK-NEXT: fn #foo<$0 (T)>(v0 (x): $0) -> i32 {
+// CHECK-NEXT: fn #foo<$0 (T): Num>(v0 (x): $0) -> i32 {
 // CHECK-NEXT:     ((v0 : $0 as i32) : i32 + 1 : i32) : i32
 // CHECK-NEXT: }
 


### PR DESCRIPTION
Stacked on #496 (B1 of the bounds round-trip pair; B2 makes externs *reload* them, closing TODO #451).

The generics binder gains optional `+`-separated trait bounds:

```
pub fn #demo::scale<$1 (T): Num>(v0 (x): $1) -> i64 { … }
fn f<$0 (T): Integral + Sync>(…)
```

- **4-file lockstep**: `raw::Generic.bounds: Vec<String>` (empty = pre-bounds dump, still parses — pinned by `boundless_binder_still_parses`), `Generic` lalrpop rule + new `Bounds` production (LR(1); no ir_lex change, `:`/`+`/`::` exist), printer `generics_binder` appends, `build.rs` collects into `Parsed.generic_bounds`.
- The printer takes bounds via an opt-in `with_bounds(&FxHashMap<GenericId, Vec<String>>)` builder — buildable from **both** sides (`Elaborator::bound_names()` mapping TraitId→TraitDef.name, and `Parsed.generic_bounds` verbatim), which is what makes print→parse→re-print byte-stable. Attached at: driver package/single-file `--emit hir`, `--emit rri`, the `--from hir` resume re-print, REPL `:dump context`, and both round-trip helpers.
- **Resumability pinned in lit**: `trampoline.rr` gains a `--from hir` re-emit RUN checking the bounded binder survives; `emit_rri.rr`'s two-run diff now also pins deterministic bound order.
- **RRI_FORMAT stays 2** (asserted, not bumped — the A3 bump covers this optional-suffix grammar extension). MIR untouched.
- Fixture CHECK updates: `trampoline.rr`, `emit_rri.rr`, `rbtree_balance_left.rr`, driver.rs `emits_a_package_interface`.

Gate: `cargo test` 475 green, `ninja -C build check` 453/456 (baseline), `ninja -C build rrc-test` green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788253445&installation_model_id=426051&pr_number=497&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F497&signature=e555ea70b2bdabdc2c58964d633c3bc60742594a53dbd6f60dd95928b8f1acf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->