### PR TITLE
[core] resolve serialized bounds when declaring extern packages

### DIFF
--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1102,6 +1102,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Resolve a bound path (by basename) to a built-in trait.
     pub fn resolve_bound(&mut self, path: &surface::Path, span: Option<Span>) -> Option<TraitId> {
         let name = self.sym(path.basename);
+        self.resolve_bound_name(name, span)
+    }
+
+    /// Resolve a bound's basename against the builtin trait table — shared by
+    /// surface bounds and the extern reload of serialized interface bounds.
+    pub(super) fn resolve_bound_name(&mut self, name: &str, span: Option<Span>) -> Option<TraitId> {
         match self.trait_names.get(name) {
             Some(&id) => Some(id),
             None => {

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -108,7 +108,7 @@ impl<'tcx> Elaborator<'_, 'tcx> {
 
         for (pdef, rec) in &parsed.records {
             let def = defs[pdef.0 as usize];
-            let generics = self.remap_generics(&rec.ty_params, &keys);
+            let generics = self.remap_generics(&rec.ty_params, &keys, &parsed.generic_bounds);
             let remap = Remapper {
                 tcx: self.tcx,
                 defs: &defs,
@@ -134,7 +134,7 @@ impl<'tcx> Elaborator<'_, 'tcx> {
 
         for func in &parsed.funcs {
             let def = defs[func.def.0 as usize];
-            let generics = self.remap_generics(&func.generics, &keys);
+            let generics = self.remap_generics(&func.generics, &keys, &parsed.generic_bounds);
             let remap = Remapper {
                 tcx: self.tcx,
                 defs: &defs,
@@ -194,34 +194,41 @@ impl<'tcx> Elaborator<'_, 'tcx> {
         // cross-package monomorphization decides its shape (deferred).
     }
 
-    /// Re-allocate an extern item's generic binder in the global table. The
-    /// interface does not serialize trait bounds yet, so extern binders
-    /// re-allocate unbounded: consumer-side obligations arise only from the
-    /// consumer's own expressions.
+    /// Re-allocate an extern item's generic binder in the global table,
+    /// resolving the interface's serialized bound paths (by basename, against
+    /// the builtin trait table) into real `TraitId`s. `instantiate` then
+    /// registers the bounds as obligations at every consumer call of an
+    /// extern generic, so a bad instantiation reports at the consumer's call
+    /// site instead of inside the imported body at monomorphization.
     ///
-    /// This is safe for the builtin traits: shipped bodies are *elaborated*
-    /// HIR (trait machinery consumed at the producer — `x + x` under
-    /// `T : Num` ships as `Arith`), so a bad instantiation cannot
-    /// miscompile; it grounds into an operation monomorphization rejects
-    /// with a spanned report. What is lost is only diagnostic placement —
-    /// the error fires inside the imported body instead of at the
-    /// consumer's call site.
-    ///
-    /// TODO(#451, trait system): revisit when real traits define what a
-    /// bound is. When bounds join the interface, they serialize as
-    /// qualified *paths* (the shape user-defined traits need), not bare
-    /// names, and the format stays at version 1 — nothing is released yet.
+    /// A bound naming an unknown trait (a version-skewed dependency) reports
+    /// through the shared "unknown trait bound" diagnostic and the binder
+    /// degrades to the resolvable subset; shipped bodies are *elaborated*
+    /// HIR, so this can never miscompile — the residue still grounds into an
+    /// operation monomorphization rejects with a spanned report.
     fn remap_generics(
         &mut self,
         binder: &[(TokenKey, GenericId)],
         keys: &[TokenKey],
+        bounds: &FxHashMap<GenericId, Vec<crate::semi::hir::Bound>>,
     ) -> RemappedGenerics {
         let mut map = FxHashMap::default();
         let binder = binder
             .iter()
             .map(|&(name, old)| {
+                let tids: Vec<_> = bounds
+                    .get(&old)
+                    .map(|bs| {
+                        bs.iter()
+                            .filter_map(|bound| {
+                                let path = bound.trait_path();
+                                self.resolve_bound_name(path.basename(), None)
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
                 let name = keys[name.into_u32() as usize];
-                let fresh = self.fresh_generic(name, Vec::new());
+                let fresh = self.fresh_generic(name, tids);
                 map.insert(old, fresh);
                 (name, fresh)
             })
@@ -524,12 +531,10 @@ mod tests {
         let elab = elaborate_package(tcx, &files, &interner);
         assert!(!elab.has_errors(), "dep elab errors: {:#?}", elab.reports);
         let strings = elab.strings.entries();
-        let text = Printer::new(&elab.defs, elab.resolver).program(
-            &elab.elaborated,
-            &strings,
-            &elab.records,
-            &elab.trampolines,
-        );
+        let bounds = elab.bound_names();
+        let text = Printer::new(&elab.defs, elab.resolver)
+            .with_bounds(&bounds)
+            .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
         crate::semi::hir::build::parse_program(tcx, &text).expect("re-parse")
     }
 
@@ -588,8 +593,168 @@ mod tests {
                        struct Hidden { v: i64 }\n\
                        fn private_helper(h: Hidden) -> i64 { h.v }\n\
                        pub fn api<T : Num>(x: T) -> T { private_helper(Hidden { v: 1 }); x }\n\
+                       pub fn narrow<T : Integral>(x: T) -> T { x }\n\
+                       pub fn both<T : Num + Sync>(x: T) -> T { x }\n\
+                       pub struct Holder<T : Num> { pub v: T }\n\
                        pub fn ground(x: i64) -> i64 { x + 1 }\n\
                        pub enum Opt { None, Some(i64) }";
+
+    #[test]
+    fn extern_bounds_reload() {
+        check_with_dep(
+            DEP,
+            &[(&[], "fn go(x: i64) -> i64 { dep::api(x) }")],
+            |elab| {
+                assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
+                let api = elab
+                    .extern_functions
+                    .iter()
+                    .find(|f| elab.defs.path(f.def).display(elab.resolver) == "dep::api")
+                    .expect("api carried");
+                let (_, g) = api.generics[0];
+                assert_eq!(
+                    elab.generic_bounds(g),
+                    [elab.builtins.num],
+                    "reloaded binder carries the serialized bound"
+                );
+            },
+        );
+    }
+
+    /// A single-bound extern function checks at the consumer call site:
+    /// the satisfied instantiation is clean, the violating one names the
+    /// bound.
+    #[test]
+    fn extern_fn_bound_satisfied_and_violated() {
+        check_with_dep(
+            DEP,
+            &[(&[], "fn ok(x: i64) -> i64 { dep::narrow(x) }")],
+            |elab| assert!(!elab.has_errors(), "{:#?}", elab.reports),
+        );
+        check_with_dep(
+            DEP,
+            &[(&[], "fn bad(x: f64) -> f64 { dep::narrow(x) }")],
+            |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r.message.contains("Integral")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    /// A multi-bound binder reloads with every TraitId, in order.
+    #[test]
+    fn extern_multi_bound_reloads_whole() {
+        check_with_dep(
+            DEP,
+            &[(&[], "fn ok(x: i64) -> i64 { dep::both(x) }")],
+            |elab| {
+                assert!(!elab.has_errors(), "{:#?}", elab.reports);
+                let both = elab
+                    .extern_functions
+                    .iter()
+                    .find(|f| elab.defs.path(f.def).display(elab.resolver) == "dep::both")
+                    .expect("both carried");
+                let (_, g) = both.generics[0];
+                assert_eq!(
+                    elab.generic_bounds(g),
+                    [elab.builtins.num, elab.builtins.sync],
+                    "both bounds reload, in declaration order"
+                );
+            },
+        );
+    }
+
+    /// A bounded extern *record* checks its bound where the consumer
+    /// instantiates it — construction included.
+    #[test]
+    fn extern_record_bound_checks_at_construction() {
+        check_with_dep(
+            DEP,
+            &[(&[], "fn ok() -> i64 { dep::Holder { v: 2 }.v }")],
+            |elab| assert!(!elab.has_errors(), "{:#?}", elab.reports),
+        );
+        check_with_dep(
+            DEP,
+            &[(&[], "fn bad() -> bool { dep::Holder { v: true }.v }")],
+            |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r.message.contains("Num")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn extern_bound_violation_reports_at_consumer_call_site() {
+        check_with_dep(
+            DEP,
+            &[(&[], "fn bad(p: dep::Point) -> dep::Point { dep::api(p) }")],
+            |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r.message.contains("Num")),
+                    "expected a Num-bound violation at the consumer call: {:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn extern_unknown_bound_reports() {
+        with_tcx(|tcx| {
+            let text = "pub fn #dep::odd<$0 (T): NotATrait>(v0 (x): $0) -> $0 {\n    v0 : $0\n}\n";
+            let parsed = crate::semi::hir::build::parse_program(tcx, text).expect("parse");
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let mut keys = interner.clone();
+            let mut elab = Elaborator::new(tcx, &interner);
+            elab.declare_extern_package(
+                &mut keys,
+                &ExternPackage {
+                    name: "dep",
+                    parsed: &parsed,
+                    files: &[],
+                },
+            );
+            assert!(
+                elab.reports
+                    .iter()
+                    .any(|r| r.message.contains("unknown trait bound `NotATrait`")),
+                "{:#?}",
+                elab.reports
+            );
+            // Declaration completes: the binder degrades to the resolvable
+            // subset instead of aborting the load.
+            assert_eq!(elab.extern_functions.len(), 1);
+        });
+    }
+
+    #[test]
+    fn extern_boundless_dump_still_loads() {
+        with_tcx(|tcx| {
+            let text = "pub fn #dep::id<$0 (T)>(v0 (x): $0) -> $0 {\n    v0 : $0\n}\n";
+            let parsed = crate::semi::hir::build::parse_program(tcx, text).expect("parse");
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let mut keys = interner.clone();
+            let mut elab = Elaborator::new(tcx, &interner);
+            elab.declare_extern_package(
+                &mut keys,
+                &ExternPackage {
+                    name: "dep",
+                    parsed: &parsed,
+                    files: &[],
+                },
+            );
+            assert!(elab.reports.is_empty(), "{:#?}", elab.reports);
+            let id = &elab.extern_functions[0];
+            let (_, g) = id.generics[0];
+            assert!(elab.generic_bounds(g).is_empty());
+        });
+    }
 
     #[test]
     fn pub_items_resolve_through_the_package_head() {

--- a/docs/design/rri.md
+++ b/docs/design/rri.md
@@ -93,6 +93,15 @@ interface 1 package "demo" producer "rrc 0.5.0 (7d9c4d3)";
 The header is a grammar item (parsed, not sniffed by the driver), rejected in
 plain `.hir` re-entry and required first in `.rri`.
 
+**Generic binders carry their trait bounds** as `+`-separated qualified paths
+(`<$0 (T): Num + Sync>`). Loading resolves each bound by its final
+path segment against the builtin trait table and re-registers it on the
+remapped generic, so a bad instantiation of an imported generic reports at
+the consumer's call site rather than inside the imported body at
+monomorphization. A bound-less binder (a pre-bounds dump) reloads with no
+bounds; an unknown bound name reports "unknown trait bound" and the binder
+degrades to the resolvable subset.
+
 **Spans stay.** The rri is printed in the sources form
 (`Printer::with_sources`): file table plus per-item/per-node spans, so
 diagnostics raised while instantiating an upstream body point into the

--- a/tests/integration/frontend/extern_load.rr
+++ b/tests/integration/frontend/extern_load.rr
@@ -8,6 +8,10 @@
 // RUN: %rrc %s --package-name dep --emit rri -o %t.rri
 // RUN: %rrc %s --package-name dep --emit hir --no-source-locations -o %t.hir
 
+// Trait bounds are physically present in the artifact `--extern` consumes.
+// RUN: %FileCheck %s --check-prefix=RRI < %t.rri
+// RRI: pub fn #dep::id<$0 (T): Num>(v0 (x): $0) -> $0
+
 // Loading succeeds and the consumer compiles as usual.
 // RUN: %rrc %s --package-name app --extern dep=%t.rri --emit hir --no-source-locations -o - \
 // RUN:   | %FileCheck %s


### PR DESCRIPTION
Stacked on #497 (B2, closing the bounds round-trip pair and the reload half of TODO #451).

`remap_generics` resolves each serialized bound path (by final segment, against the builtin trait table) into a real `TraitId` on the remapped generic — extern binders no longer reload unbounded. `instantiate` then registers those bounds as obligations at every consumer call of an extern generic, so **a bad instantiation reports at the consumer's call site** instead of inside the imported body at monomorphization.

- `resolve_bound` factors into a path shim over the new shared `resolve_bound_name`.
- Unknown bound in an interface (version-skewed dep) → shared "unknown trait bound" diagnostic; the binder degrades to the resolvable subset and the load completes (shipped bodies are elaborated HIR — nothing can miscompile). Pre-bounds dumps reload with empty bounds.
- **RRI_FORMAT stays 2** (asserted, not bumped — B1's optional suffix is the only grammar delta).
- The externs unit rig's `dep_interface` now attaches bounds, so every existing externs test exercises serialize→reload; new tests: `extern_bounds_reload`, `extern_bound_violation_reports_at_consumer_call_site`, `extern_unknown_bound_reports`, `extern_boundless_dump_still_loads`. `extern_load.rr` pins `pub fn #dep::id<$0 (T): Num>` physically in the `.rri`.
- `docs/design/rri.md`: format section documents binder bounds + the format-2 header.

⚠️ Intended tightening: a consumer passing its own unbounded generic into a bounded extern generic now errors at the call site ("the bound is not satisfied by this generic"-class), where it previously slid to a mono-time report inside the imported body.

Gate: `cargo test` 479 green, `ninja -C build check` 453/456 (baseline), `rrc-test` green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788253703&installation_model_id=426051&pr_number=498&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F498&signature=73402ef4f01cbbd98be691e3810bf302a9bbc7d1476405663619287715de98ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->