### PR TITLE
[syntax][core] parse contextual `impl` blocks with member functions

### DIFF
--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1304,6 +1304,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                             file: *file,
                         });
                     }
+                    surface::StmtKind::Impl => {
+                        self.validate_transform_anchor(&attrs, None);
+                        self.reject_ffi_attr(ffi, span);
+                        self.error(span, "`impl` blocks are not supported yet");
+                    }
                     // Foreign preludes register during this scan (like
                     // bindings) so they apply file-wide regardless of order.
                     surface::StmtKind::ExternSource(src) => {

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -959,6 +959,9 @@ pub enum StmtKind {
     ExternSource(ExternSource),
     Transform(TransformScript),
     Import(ImportDecl),
+    /// An `impl` block. Placeholder until elaboration supports it — the
+    /// typed view lands with the impl-scan work.
+    Impl,
 }
 
 /// A statement (a view over a top-level item node).
@@ -994,6 +997,7 @@ impl Stmt {
             ExternSourceStmt => StmtKind::ExternSource(extern_source_of(node)),
             TransformStmt => StmtKind::Transform(transform_of(node)),
             ImportStmt => StmtKind::Import(import_of(node)),
+            ImplStmt => StmtKind::Impl,
             k => unreachable!("unexpected statement node {k:?}"),
         }
     }

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -144,6 +144,7 @@ impl Emitter<'_> {
             ExternSourceStmt => self.extern_source_stmt(node),
             TransformStmt => self.transform_stmt(node),
             ImportStmt => self.import_stmt(node),
+            ImplStmt => self.impl_stmt(node),
             k => unreachable!("unexpected statement node {k:?}"),
         };
         tagged("SpannedStmt", self.with_node_span(node, inner))
@@ -335,6 +336,25 @@ impl Emitter<'_> {
                     .expect("non-empty path")
             });
         tagged("ImportStmt", json!([name.text(), self.path(path)]))
+    }
+
+    fn impl_stmt(&self, node: &ResolvedNode) -> Value {
+        let target = nodes(node)
+            .find(|n| n.kind() == PathType)
+            .expect("impl target type");
+        let members: Vec<Value> = nodes(node)
+            .filter(|n| n.kind() == FnStmt)
+            .map(|f| self.with_node_span(f, self.fn_stmt(f)))
+            .collect();
+        tagged(
+            "ImplStmt",
+            json!({
+                "implVisibility": self.visibility(node),
+                "implGenerics": self.generic_params(node),
+                "implTarget": self.type_(target),
+                "implMembers": members,
+            }),
+        )
     }
 
     fn extern_stmt(&self, node: &ResolvedNode) -> Value {

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -130,6 +130,8 @@ pub enum SyntaxKind {
     TransformStmt,
     /// `import path (as name)?;` — a file-scoped path abbreviation.
     ImportStmt,
+    /// `impl<T: B> Type<T> { fn ... }` — an inherent-method block.
+    ImplStmt,
     GenericParamList,
     GenericParam,
     ParamList,

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -161,6 +161,14 @@ fn repl_route(p: &parser::Parser) -> ReplInputKind {
         // An outer attribute `#[...]` only ever heads an item.
         Pound => true,
         Ident if p.current_text() == "transform" && p.nth(1) == RawMlirLiteral => true,
+        // `impl<...>` / `impl Type` — mirrors the parser's contextual gate;
+        // `impl + 1` (a variable named `impl`) stays an expression.
+        Ident
+            if p.current_text() == "impl"
+                && (p.nth(1) == LAngle || (p.nth(1).is_ident_like() && p.nth(1) != AsKw)) =>
+        {
+            true
+        }
         _ => false,
     };
     if starts_item {
@@ -298,6 +306,9 @@ mod tests {
             "extern \"rust\" [{ use reussir_rt::collections::vec::Vec; }];",
             "#[ffi(rust = \"::reussir_rt::collections::vec::Vec\")]\npub struct Vec<T>;",
             "#[ffi(import)]\npub fn push<T>(v: Vec<T>, x: T) -> Vec<T> [{ Vec::push(v, x) }];",
+            // `impl` heads an item when a generic list or type name follows.
+            "impl Point { fn get(self: Self) -> i64 { 1 } }",
+            "impl<T: Num> Box<T> { pub fn get(self: Self) -> T { self.0 } }",
         ];
         for source in items {
             let rp = parse_repl(source, interner.clone());
@@ -333,6 +344,9 @@ mod tests {
             // `import` as a keyword-named variable.
             "import + 1",
             "import as i64",
+            // A variable named `impl` heads an expression.
+            "impl + 1",
+            "impl as i64",
         ];
         for source in exprs {
             let rp = parse_repl(source, interner.clone());
@@ -663,6 +677,72 @@ mod tests {
         // The surface language has no reserved identifiers.
         json_of("fn f() -> i32 { let value = 1; value }");
         json_of("fn shared(field: i32) -> i32 { field }");
+        // `impl` included: legal as a parameter and a variable.
+        json_of("fn f(impl: i64) -> i64 { impl }");
+    }
+
+    #[test]
+    fn impl_block_parses_members_and_generics() {
+        let json = json_of(
+            "impl<T: Num> Box<T> {\n\
+                 pub fn get(self: Self) -> T { 1 }\n\
+                 regional fn touch(self: [flex] Self) { 2 }\n\
+             }",
+        );
+        let block = unwrap_span(&json[0]);
+        assert_eq!(block["tag"], "ImplStmt");
+        let contents = &block["contents"];
+        assert_eq!(contents["implVisibility"], "Private");
+        assert_eq!(contents["implGenerics"][0][0], "T");
+        let members = contents["implMembers"].as_array().expect("members");
+        assert_eq!(members.len(), 2);
+        let get = &members[0]["spanValue"];
+        assert_eq!(get["tag"], "FunctionStmt");
+        assert_eq!(get["contents"]["funcName"], "get");
+        assert_eq!(get["contents"]["funcVisibility"], "Public");
+        assert_eq!(get["contents"]["funcParams"][0][0], "self");
+        assert_eq!(get["contents"]["funcParams"][0][2], false);
+        let touch = &members[1]["spanValue"];
+        assert_eq!(touch["contents"]["funcName"], "touch");
+        assert_eq!(touch["contents"]["funcVisibility"], "Private");
+        assert_eq!(touch["contents"]["funcIsRegional"], true);
+        // `[flex]` on the receiver annotation.
+        assert_eq!(touch["contents"]["funcParams"][0][2], true);
+    }
+
+    #[test]
+    fn impl_target_prim_type_is_rejected() {
+        let source = "impl i64 { fn f(self: Self) -> i64 { 1 } }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|e| e.message.contains("must be a named type")),
+            "{:#?}",
+            parse.errors
+        );
+        // Losslessness holds under the error.
+        assert_eq!(parse.root.text(), source);
+    }
+
+    #[test]
+    fn impl_member_recovery_continues_to_next_member() {
+        let source = "impl P { 42 fn ok(self: Self) -> i64 { 1 } }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert_eq!(parse.root.text(), source);
+        // The junk lands in an error node and the member after it survives.
+        let block = parse
+            .root
+            .children()
+            .find(|n| n.kind() == SyntaxKind::ImplStmt)
+            .expect("impl block");
+        assert!(
+            block.children().any(|n| n.kind() == SyntaxKind::FnStmt),
+            "member after junk was not recovered"
+        );
     }
 
     #[test]

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -46,7 +46,7 @@ impl Parser<'_> {
     pub(crate) fn source_file(&mut self) {
         let m = self.start();
         while !self.at_eof() {
-            if self.current().starts_stmt() || self.at_transform_stmt() {
+            if self.current().starts_stmt() || self.at_transform_stmt() || self.at_impl_stmt() {
                 self.stmt();
             } else {
                 // Statement-level recovery: collect the unexpected tokens
@@ -54,10 +54,14 @@ impl Parser<'_> {
                 // again.
                 let e = self.start();
                 self.error(format!(
-                    "expected a top-level item (fn, struct, enum, mod, extern, transform, or import), found {}",
+                    "expected a top-level item (fn, struct, enum, mod, extern, impl, transform, or import), found {}",
                     self.current().describe()
                 ));
-                while !self.at_eof() && !self.current().starts_stmt() && !self.at_transform_stmt() {
+                while !self.at_eof()
+                    && !self.current().starts_stmt()
+                    && !self.at_transform_stmt()
+                    && !self.at_impl_stmt()
+                {
                     self.bump();
                 }
                 e.complete(self, ErrorNode);
@@ -81,9 +85,10 @@ impl Parser<'_> {
             ExternKw => self.extern_trampoline_stmt(m),
             ImportKw => self.import_stmt(m),
             Ident if self.at_transform_stmt() => self.transform_stmt(m),
+            Ident if self.at_impl_stmt() => self.impl_stmt(m),
             _ => {
                 self.error(format!(
-                    "expected `fn`, `struct`, `enum`, `mod`, `extern`, `transform`, or `import` after visibility, found {}",
+                    "expected `fn`, `struct`, `enum`, `mod`, `extern`, `impl`, `transform`, or `import` after visibility, found {}",
                     self.current().describe()
                 ));
                 // Consume nothing further; the outer loop recovers.
@@ -94,6 +99,68 @@ impl Parser<'_> {
 
     fn at_transform_stmt(&self) -> bool {
         self.at_ctx_kw("transform") && self.nth(1) == RawMlirLiteral
+    }
+
+    /// `impl` is contextual (the language has no reserved words): it heads an
+    /// impl block only when followed by a generic-parameter list or a type
+    /// name — `impl + 1` stays an expression over a variable named `impl`,
+    /// and `impl as i64` a cast of one.
+    fn at_impl_stmt(&self) -> bool {
+        self.at_ctx_kw("impl")
+            && (self.nth(1) == LAngle || (self.nth(1).is_ident_like() && self.nth(1) != AsKw))
+    }
+
+    /// `impl generics? Type<args>? { (pub? (regional? fn ...))* }`.
+    fn impl_stmt(&mut self, m: Marker) {
+        self.bump(); // the `impl` ident
+        if self.at(LAngle) {
+            self.generic_param_list();
+        }
+        if PRIM_TYPES.contains(&self.current_text()) {
+            let e = self.start();
+            self.error("the target of `impl` must be a named type");
+            self.bump();
+            e.complete(self, ErrorNode);
+        } else if self.type_atom().is_none() {
+            self.error("expected a type name as the `impl` target");
+        }
+        self.expect(LBrace);
+        while !self.at(RBrace) && !self.at_eof() {
+            if self.at(PubKw) || self.at(RegionalKw) || self.at(FnKw) {
+                let member = self.start();
+                if self.at(PubKw) {
+                    self.bump();
+                }
+                if self.at(RegionalKw) || self.at(FnKw) {
+                    self.fn_stmt(member);
+                } else {
+                    self.error(format!(
+                        "expected `fn` or `regional fn` after visibility, found {}",
+                        self.current().describe()
+                    ));
+                    member.complete(self, ErrorNode);
+                }
+            } else {
+                // Member-level recovery: skip to something that can start a
+                // member (or the closing brace) under an error node.
+                let e = self.start();
+                self.error(format!(
+                    "expected `pub`, `fn`, or `regional fn` in an `impl` block, found {}",
+                    self.current().describe()
+                ));
+                while !self.at_eof()
+                    && !self.at(RBrace)
+                    && !self.at(PubKw)
+                    && !self.at(RegionalKw)
+                    && !self.at(FnKw)
+                {
+                    self.bump();
+                }
+                e.complete(self, ErrorNode);
+            }
+        }
+        self.expect(RBrace);
+        m.complete(self, ImplStmt);
     }
 
     /// `transform [{ opaque MLIR }];`.


### PR DESCRIPTION
Stacked on #498 (C1, first PR of the impl-block/member-function stack: **C1 parser** → C2 surface view → C3 scan/declare → C4 `self` receivers → C5 method dispatch → C6 mangling+e2e).

```rust
impl<T: Num> Box<T> {
    pub fn get(self: Self) -> T { … }
    regional fn touch(self: [flex] Self) { … }
}
```

- **`impl` stays contextual** (no reserved words): item iff followed by `<` or a type name — `impl + 1` / `impl as i64` stay expressions over a variable named `impl`, `fn f(impl: i64)` stays legal. Pinned in `keywords_are_contextual` and the REPL routing test (both routes).
- Reuses `generic_param_list` (bounds come free) and `type_atom` for the target; a primitive target is rejected with "the target of `impl` must be a named type". Members are ordinary `FnStmt` nodes with optional leading `pub`; member-level recovery collects junk under an error node and continues at the next member (lossless, pinned).
- JSON surface AST gains the `ImplStmt` encoding (members reuse the `FunctionStmt` encoding), so `to_json` has no `unreachable!` window.
- **No panic window in core**: `StmtKind::Impl` placeholder + a clean "impl blocks are not supported yet" diagnostic keep every point of the stack sound; the typed `ImplBlock` view replaces it in the next PR.
- Note: `pub impl` parses (the leading-`pub` bump is shared); rejection is semantic and lands with the scan PR, mirroring `pub import`.

Gate: `cargo test` 482 green (51 syntax), `ninja -C build check` 453/456 (baseline), `rrc-test` green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788254059&installation_model_id=426051&pr_number=499&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F499&signature=b3b760d7b0e90022d3c3f1ea44b4dfe247578fd4177dbdbfcab040b87679ea9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->