### PR TITLE
[core] typed surface view for impl blocks

### DIFF
--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -645,6 +645,26 @@ mod tests {
         );
     }
 
+    /// Temporary until impl scanning lands: the placeholder arm reports
+    /// cleanly instead of panicking.
+    #[test]
+    fn impl_block_reports_not_supported_yet() {
+        with_tcx(|tcx| {
+            let source = "struct P { x: i64 }\nimpl P { fn get(self: Self) -> i64 { 1 } }";
+            let parse = reussir_syntax::parse(source);
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, parse.resolver());
+            assert!(
+                elab.reports
+                    .iter()
+                    .any(|r| r.message.contains("not supported yet")),
+                "{:#?}",
+                elab.reports
+            );
+        });
+    }
+
     /// The shared two-module package for the visibility tests: module `a`
     /// defines the records, module `c` uses them from outside.
     fn vis_package(consumer: &str, f: impl Fn(&[crate::semi::ctxt::Report])) {

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1304,7 +1304,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                             file: *file,
                         });
                     }
-                    surface::StmtKind::Impl => {
+                    surface::StmtKind::Impl(_) => {
                         self.validate_transform_anchor(&attrs, None);
                         self.reject_ffi_attr(ffi, span);
                         self.error(span, "`impl` blocks are not supported yet");

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -959,9 +959,21 @@ pub enum StmtKind {
     ExternSource(ExternSource),
     Transform(TransformScript),
     Import(ImportDecl),
-    /// An `impl` block. Placeholder until elaboration supports it — the
-    /// typed view lands with the impl-scan work.
-    Impl,
+    Impl(ImplBlock),
+}
+
+/// An `impl<T: B> Type<args> { fn ... }` block: the block-level generics, the
+/// target type head with its applied arguments, and the member functions.
+#[derive(Clone, Debug)]
+pub struct ImplBlock {
+    /// Parses for uniformity with the other items; `pub impl` is rejected at
+    /// elaboration (members carry their own visibility).
+    pub visibility: Visibility,
+    /// Each block-level generic is `(name, bounds)`.
+    pub generics: SmallVec<[(TokenKey, Vec<Path>); 2]>,
+    pub target: Path,
+    pub target_args: SmallVec<[Type; 2]>,
+    pub members: Vec<Spanned<Function>>,
 }
 
 /// A statement (a view over a top-level item node).
@@ -997,7 +1009,7 @@ impl Stmt {
             ExternSourceStmt => StmtKind::ExternSource(extern_source_of(node)),
             TransformStmt => StmtKind::Transform(transform_of(node)),
             ImportStmt => StmtKind::Import(import_of(node)),
-            ImplStmt => StmtKind::Impl,
+            ImplStmt => StmtKind::Impl(impl_of(node)),
             k => unreachable!("unexpected statement node {k:?}"),
         }
     }
@@ -1110,6 +1122,32 @@ fn source_block_of(node: &ResolvedNode) -> Option<SourceBlock> {
             end: span.end - 1,
         },
     })
+}
+
+fn impl_of(node: &ResolvedNode) -> ImplBlock {
+    let target_ty = nodes(node)
+        .find(|n| n.kind() == PathType)
+        .expect("impl target type");
+    let target = path_of(child_node(target_ty, PathKind).expect("target path"));
+    let target_args = child_node(target_ty, TypeArgList)
+        .map(|l| {
+            nodes(l)
+                .filter(|n| is_type_kind(n.kind()))
+                .map(Type::new)
+                .collect()
+        })
+        .unwrap_or_default();
+    let members = nodes(node)
+        .filter(|n| n.kind() == FnStmt)
+        .map(|f| spanned(f, function_of(f)))
+        .collect();
+    ImplBlock {
+        visibility: visibility_of(node),
+        generics: generics_of(node),
+        target,
+        target_args,
+        members,
+    }
 }
 
 fn record_of(node: &ResolvedNode, kind: RecordKind) -> Record {
@@ -1328,6 +1366,44 @@ mod tests {
             // `Type::kind` is the lazy view that runs `prim_type`.
             f.params[0].1.kind();
         }
+    }
+
+    #[test]
+    fn impl_block_projects_visibility_target_generics_members() {
+        let parse = parse(
+            "impl<T: Num + Sync> Box<T> {\n\
+                 pub fn get(self: Self) -> T { 1 }\n\
+                 regional fn touch(self: [flex] Self) { 2 }\n\
+             }",
+        );
+        let prog = program(&parse.root);
+        let resolver = parse.resolver();
+        let StmtKind::Impl(ib) = prog[0].kind() else {
+            panic!("expected an impl block");
+        };
+        assert_eq!(ib.visibility, Visibility::Private);
+        assert_eq!(resolver.resolve(ib.target.basename), "Box");
+        assert!(ib.target.segments.is_empty());
+        assert_eq!(ib.target_args.len(), 1);
+        assert_eq!(ib.generics.len(), 1);
+        let (g, bounds) = &ib.generics[0];
+        assert_eq!(resolver.resolve(*g), "T");
+        assert_eq!(bounds.len(), 2);
+
+        assert_eq!(ib.members.len(), 2);
+        let get = &ib.members[0].value;
+        assert_eq!(resolver.resolve(get.name), "get");
+        assert_eq!(get.visibility, Visibility::Public);
+        assert!(!get.is_regional);
+        let (pname, _, pflex) = &get.params[0];
+        assert_eq!(resolver.resolve(*pname), "self");
+        assert!(!pflex);
+        let touch = &ib.members[1].value;
+        assert_eq!(resolver.resolve(touch.name), "touch");
+        assert_eq!(touch.visibility, Visibility::Private);
+        assert!(touch.is_regional);
+        let (_, _, rflex) = &touch.params[0];
+        assert!(rflex, "the `[flex]` receiver flag projects");
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #499 (C2 of the impl stack: C1 parser → **C2 surface view** → C3 scan/declare → C4 receivers → C5 dispatch → C6 e2e).

`StmtKind::Impl` grows its payload: `ImplBlock { visibility, generics (with bounds), target: Path, target_args, members: Vec<Spanned<Function>> }`, projected lazily from the CST. `function_of` is reused verbatim for members — member-level `pub`/`regional` are direct tokens of the member `FnStmt`, so the existing scans just work (the `[flex]` receiver flag projects through the normal param triple).

The elaborator still reports "impl blocks are not supported yet" (arm updated to destructure the payload); scanning/declaration lands next. Pinned by `impl_block_projects_visibility_target_generics_members` and the temporary `impl_block_reports_not_supported_yet` (deleted by C3).

Gate: `cargo test` 484 green, `ninja -C build check` 453/456 (baseline), fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788254246&installation_model_id=426051&pr_number=500&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F500&signature=2f0ccee0dc031e219f3de352cf7d08a437c9876689e2ebed6397be5bed2c5d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->