### PR TITLE
[core][tests] impl coverage: REPL retraction, extern-target rejection, lit round-trip

### DIFF
--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -476,6 +476,41 @@ mod tests {
         assert!(m.contains("expects 2 argument(s)"), "{m}");
     }
 
+    /// Impl members ride the ordinary defs/generics/functions tables, so the
+    /// Checkpoint's truncate-and-retain rollback is sufficient: a rejected
+    /// batch retracts them and the method name is reusable.
+    #[test]
+    fn rejected_batch_retracts_impl_members() {
+        use std::sync::Arc;
+
+        with_tcx(|tcx| {
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = |src: &str| {
+                let p = reussir_syntax::parse_with_interner(src, interner.clone());
+                assert!(p.ok(), "parse errors for {src:?}: {:#?}", p.errors);
+                p
+            };
+            let mut elab = Elaborator::new(tcx, &interner);
+
+            let p1 = parse("pub struct P { pub x: i64 }");
+            elab.try_extend(&surface::program(&p1.root))
+                .expect("record");
+
+            // A batch whose impl member has a type error is rejected whole.
+            let p2 = parse("impl P { pub fn get(p: P) -> i64 { true } }");
+            elab.try_extend(&surface::program(&p2.root))
+                .expect_err("bad member body");
+            assert!(!elab.has_errors());
+
+            // The retracted method name is free again and elaborates.
+            let p3 = parse("impl P { pub fn get(p: P) -> i64 { p.x } }");
+            elab.try_extend(&surface::program(&p3.root))
+                .expect("redeclared member");
+            let p4 = parse("fn use_it(p: P) -> i64 { P::get(p) }");
+            elab.try_extend(&surface::program(&p4.root)).expect("call");
+        });
+    }
+
     #[test]
     fn try_extend_accumulates_and_rolls_back_atomically() {
         use std::sync::Arc;

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -601,6 +601,26 @@ mod tests {
                        pub enum Opt { None, Some(i64) }";
 
     #[test]
+    fn impl_of_extern_package_type_rejected() {
+        check_with_dep(
+            DEP,
+            &[(
+                &[],
+                "impl dep::Point { pub fn flip(p: dep::Point) -> i64 { p.x } }",
+            )],
+            |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r.message.contains(
+                        "cannot define methods for `dep::Point` from extern package `dep`"
+                    )),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
     fn extern_bounds_reload() {
         check_with_dep(
             DEP,

--- a/tests/integration/frontend/impl_assoc_fn.rr
+++ b/tests/integration/frontend/impl_assoc_fn.rr
@@ -1,0 +1,39 @@
+// RUN: %rrc %s --package-name demo --emit hir --no-source-locations -o - | %FileCheck %s
+// Roundtrip: a member is a plain function under the type-suffixed path, so
+// the dump re-enters and re-emits identically.
+// RUN: %rrc %s --package-name demo --emit hir --no-source-locations -o %t.hir
+// RUN: %rrc %t.hir --from hir --emit hir --no-source-locations -o - | %FileCheck %s
+// RUN: %rrc %s --package-name demo -o %t.o
+
+// Impl members declare under `[module.., Type, name]`: the HIR prints them
+// as ordinary `#demo::Point::area`-style functions and path calls resolve
+// to the same target — no new HIR construct, no format change.
+
+pub struct Point {
+    pub x: i64,
+    y: i64,
+}
+
+impl Point {
+    pub fn make(x: i64) -> Point {
+        Point { x: x, y: x + 1 }
+    }
+
+    // The member body reads the target's private field: its scope is the
+    // type's defining module.
+    pub fn area(p: Point) -> i64 {
+        p.x * p.y
+    }
+}
+
+pub fn use_it(n: i64) -> i64 {
+    Point::area(Point::make(n))
+}
+
+// Functions print in elaboration order (plain fns before members), so the
+// item lines match as a DAG.
+// CHECK: pub [shared] struct #demo::Point { pub "x": i64, "y": i64 };
+// CHECK-DAG: pub fn #demo::Point::area(v0 (p): #demo::Point) -> i64 {
+// CHECK-DAG: pub fn #demo::Point::make(v0 (x): i64) -> #demo::Point
+// CHECK-DAG: pub fn #demo::use_it(v0 (n): i64) -> i64 {
+// CHECK-DAG: #demo::Point::area(#demo::Point::make(v0 : i64) : #demo::Point) : i64


### PR DESCRIPTION
Stacked on #501 (C3b — the coverage half of the C3 split).

- `rejected_batch_retracts_impl_members`: a REPL batch whose impl member fails type checking rolls back wholesale; the method name is free again and the redeclared member resolves via `P::get(p)` — pins that members need **no** Checkpoint changes (ordinary defs/generics/functions entries).
- `impl_of_extern_package_type_rejected`: `impl dep::Point { … }` in a consumer reports ``cannot define methods for `dep::Point` from extern package `dep` `` through a real `.rri` load.
- `impl_assoc_fn.rr` (lit): members print as ordinary `#demo::Point::area` functions in HIR text, the member body reads the target's **private** field, path calls resolve to the same targets, and the dump **re-enters via `--from hir` and re-emits identically** (no new HIR construct, no format change), then compiles to an object.

Gate: `cargo test` 349 core green, `ninja -C build check` 454/457 (new lit test passing; 3 unsupported = baseline), fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788254821&installation_model_id=426051&pr_number=502&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F502&signature=2758a04d7282efcc44adce23775d99e6872da35a1072fb0242a0ec30601f9f07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->