### PR TITLE
[tests] rene e2e: impl methods over a vendor dep (shapes)

### DIFF
--- a/tests/integration/rene/README.md
+++ b/tests/integration/rene/README.md
@@ -17,5 +17,6 @@ program exercises.
 | `calc.rr`      | interpreter app + polyffi I/O dep: lexer/parser/eval modules |
 | `inventory.rr` | four deps, two polyffi units, cross-package generics         |
 | `stats.rr`     | float pipeline + polyffi vector I/O, multi-unit release      |
+| `shapes.rr`    | impl methods over a vendor dep: value/Arc/regional receivers, cross-package generic method, private fields behind methods |
 | `wasi_examples.rr` | the packages above cross-built for `wasm32-wasip1`, run on wasmer |
 | `wasi_threads.rr` | `wasm32-wasip1-threads`: real threads over a shared map   |

--- a/tests/integration/rene/shapes.rr
+++ b/tests/integration/rene/shapes.rr
@@ -1,0 +1,28 @@
+// Methods over a vendor dep as a realistic `rene build`: the app computes
+// every printed value through `geom`'s impl methods across the package
+// boundary — a value receiver reading a private field, an `Arc<Self>`
+// receiver, a regional `[flex] Self` receiver bumped inside the dep's own
+// region (frozen result read by the app), and one generic method the app
+// instantiates at two types via both dot and path spellings — reporting
+// through the `console` polyffi package. The method calls live in an app
+// submodule, so resolution also crosses in-package module files, and the
+// app's own `Tally` is impl'd from that submodule — a package-level impl.
+
+// RUN: %rene build --manifest-path %S/shapes/rene.ncl --build-dir %t.bdir %rrc_linker | %FileCheck %s --check-prefix=LISTING
+
+// LISTING: {{[/\\]}}dev{{[/\\]}}shapes
+
+// RUN: %t.bdir/dev/shapes%exe_ext | %FileCheck %s
+
+// CHECK:      35
+// CHECK-NEXT: 42
+// CHECK-NEXT: 12
+// CHECK-NEXT: 21
+// CHECK-NEXT: 3
+// CHECK-NEXT: 21
+
+// The release profile is the same session, optimized.
+// RUN: %rene build --manifest-path %S/shapes/rene.ncl --build-dir %t.bdir --profile release %rrc_linker | %FileCheck %s --check-prefix=RELEASE
+// RUN: %t.bdir/release/shapes%exe_ext | %FileCheck %s
+
+// RELEASE: {{[/\\]}}release{{[/\\]}}shapes

--- a/tests/integration/rene/shapes/lit.local.cfg
+++ b/tests/integration/rene/shapes/lit.local.cfg
@@ -1,0 +1,2 @@
+# The package the shapes test compiles; not tests themselves.
+config.suffixes = []

--- a/tests/integration/rene/shapes/rene.ncl
+++ b/tests/integration/rene/shapes/rene.ncl
@@ -1,0 +1,17 @@
+# Methods over a vendor dep: the app calls `geom`'s impl methods (value,
+# Arc, and regional receivers; one generic method at two instantiations)
+# across the package boundary, printing through the `console` polyffi
+# package. `release` re-runs the same session optimized.
+{
+  package = {
+    name | String = "shapes",
+    version = "1.0.0",
+  },
+  dependencies = {
+    geom = { path = "vendor/geom", version = "^1.0" },
+    console = { path = "vendor/console", version = "^1.0" },
+  },
+  targets = {
+    shapes = { kind = 'executable },
+  },
+}

--- a/tests/integration/rene/shapes/src/lib.rr
+++ b/tests/integration/rene/shapes/src/lib.rr
@@ -1,0 +1,16 @@
+// The app: every value it prints comes out of a `geom` method called
+// across the package boundary; the calls themselves live in a submodule,
+// so method resolution also crosses in-package module files.
+
+mod report;
+
+// Impl blocks are package-level: `report` (a different module) adds this
+// type's methods below.
+pub struct Tally {
+    pub n: i64,
+}
+
+#[main]
+pub fn entry() {
+    report::run()
+}

--- a/tests/integration/rene/shapes/src/report.rr
+++ b/tests/integration/rene/shapes/src/report.rr
@@ -1,0 +1,22 @@
+// A package-level impl: the type lives in the crate root, its methods here.
+impl super::Tally {
+    pub fn bumped(self: Self) -> i64 {
+        self.n + 1
+    }
+}
+
+pub fn run() {
+    // Value receiver over a private field: 5 * 7.
+    console::print(geom::Rect::make(5).area());
+    // Arc receiver: 41 + 1.
+    console::print(geom::Shared::make(41).read());
+    // Regional receiver inside the dep's region, frozen result read here:
+    // (3 + 1) * 3.
+    console::print(geom::Acc::folded(3).total());
+    // The generic method at two instantiations, dot and path spellings.
+    console::print(geom::Pair::make(20, 1).sum());
+    let small: geom::Pair<i32> = geom::Pair::make(2, 1);
+    console::print32(geom::Pair::sum(small));
+    // The cross-module impl above: 20 + 1.
+    console::print(super::Tally { n: 20 }.bumped())
+}

--- a/tests/integration/rene/shapes/vendor/console/rene.ncl
+++ b/tests/integration/rene/shapes/vendor/console/rene.ncl
@@ -1,0 +1,5 @@
+# The console package: the imported print functions the app reports
+# through — this package is the build's I/O unit.
+{
+  package = { name = "console", version = "1.0.0" },
+}

--- a/tests/integration/rene/shapes/vendor/console/src/lib.rr
+++ b/tests/integration/rene/shapes/vendor/console/src/lib.rr
@@ -1,0 +1,8 @@
+// The report surface: imported print functions, one per width the app
+// computes at.
+
+#[ffi(import)]
+pub fn print(v: i64) [{ println!("{v}") }];
+
+#[ffi(import)]
+pub fn print32(v: i32) [{ println!("{v}") }];

--- a/tests/integration/rene/shapes/vendor/geom/rene.ncl
+++ b/tests/integration/rene/shapes/vendor/geom/rene.ncl
@@ -1,0 +1,5 @@
+# The geometry package: records with private fields encapsulated behind
+# impl methods, exercised by the app across the package boundary.
+{
+  package = { name = "geom", version = "1.0.0" },
+}

--- a/tests/integration/rene/shapes/vendor/geom/src/lib.rr
+++ b/tests/integration/rene/shapes/vendor/geom/src/lib.rr
@@ -1,0 +1,73 @@
+// The geometry domain: every record keeps state private behind `pub`
+// methods — the field-visibility model working across a package boundary —
+// with one method per receiver form and a generic method the app
+// instantiates at two types.
+
+pub struct Rect {
+    pub w: i64,
+    h: i64,
+}
+
+impl Rect {
+    pub fn make(w: i64) -> Rect {
+        Rect { w: w, h: w + 2 }
+    }
+
+    // Reads the private field: only methods (scoped to the defining
+    // module) can.
+    pub fn area(self: Self) -> i64 {
+        self.w * self.h
+    }
+}
+
+pub struct Shared {
+    v: i64,
+}
+
+impl Shared {
+    pub fn make(v: i64) -> Arc<Shared> {
+        Arc<Shared> { v: v }
+    }
+
+    pub fn read(self: Arc<Self>) -> i64 {
+        self.v + 1
+    }
+}
+
+pub struct [regional] Acc {
+    v: i64,
+}
+
+impl Acc {
+    regional fn bump(self: [flex] Self) -> i64 {
+        self.v + 1
+    }
+
+    pub fn total(self: Self) -> i64 {
+        self.v * 3
+    }
+
+    // Builds, bumps, and freezes an accumulator in one region — the
+    // regional receiver at work behind a plain callable surface.
+    pub fn folded(seed: i64) -> Acc {
+        regional {
+            let a: [flex] Acc = Acc { v: seed };
+            Acc { v: a.bump() }
+        }
+    }
+}
+
+pub struct Pair<T> {
+    a: T,
+    b: T,
+}
+
+impl<T: Num> Pair<T> {
+    pub fn make(a: T, b: T) -> Pair<T> {
+        Pair { a: a, b: b }
+    }
+
+    pub fn sum(self: Pair<T>) -> T {
+        self.a + self.b
+    }
+}


### PR DESCRIPTION
Stacked on #506 (D2, the final PR of the stack — success-path e2e through a real static link).

`tests/integration/rene/shapes/`: a two-dep `rene build` where every printed value comes out of a `geom` impl method called across the package boundary:

- value receiver reading a **private field** (encapsulation via methods — the A-stack visibility model in real use),
- `Arc<Self>` receiver,
- regional `[flex] Self` receiver bumped inside the dep's own region, frozen result read by the app,
- one generic method instantiated at **two types** (cross-package weak_odr through a real link), via both dot and path spellings,
- reported through a `console` polyffi package; the calls live in an app **submodule**, so resolution also crosses in-package module files.

Driver `shapes.rr` builds and runs both `dev` and `release` profiles and FileChecks the session output (`35 / 42 / 12 / 21 / 3`). README table row added. Negative cases intentionally live in D1's lit tests — this is the build/link/run proof.

Gate: `ninja -C build check` 462/465 (both profile runs green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788256301&installation_model_id=426051&pr_number=507&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F507&signature=842249a0593016d2a5ebe5927b8c2ae2ba178caa1f5e9f1e44c4137d873767d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->