### PR TITLE
[syntax][core] parse `trait` declarations and `impl Trait for Type` heads

### DIFF
--- a/crates/reussir-core/docs/trait-system.md
+++ b/crates/reussir-core/docs/trait-system.md
@@ -400,9 +400,20 @@ impl Ord for i32 { fn cmp(self, other: i32) -> Ordering { … } }
 impl<T: Ord> Ord for List<T> where … { … }
 ```
 
-That is: lexer keywords (`trait`, `impl`, `for`, `where`), grammar rules, CST
-kinds, and AST/JSON lowering in `reussir-syntax`. **Decision: this is in the
-first cut** — user-declared traits from the start, not deferred.
+That is: grammar rules, CST kinds, and AST/JSON lowering in `reussir-syntax`.
+**Decision: this is in the first cut** — user-declared traits from the start,
+not deferred.
+
+> **As built (surface layer):** `trait`, `impl`, and `for` are *contextual
+> identifiers*, not lexer keywords — the language has no reserved words, so
+> `fn trait(trait: i64)` stays legal and `trait + 1` is an expression over a
+> variable named `trait`. Trait bodies carry method *signatures only*
+> (default bodies deferred per Phase 3; the parser consumes an offending body
+> losslessly and reports). Supertraits are bare `+`-separated paths; `where`
+> is not parsed (deferred). `impl Trait<args> for Type` uses a greedy
+> single-shot `for` rule (`impl for { }` is an inherent impl of a type named
+> `for`); a primitive in either head position is rejected this cut. Typed
+> views: `surface::TraitDecl` and `ImplBlock::trait_ref`.
 
 Flexivity bounds reuse the existing bound position. The names `Irrelevant`,
 `Regional`, `Flex`, `Rigid` in a bound list are recognized as built-in

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1078,6 +1078,48 @@ mod tests {
         );
     }
 
+    /// Until the trait stacks land, trait items are rejected cleanly — and
+    /// a trait impl's members are never misattached as inherent methods.
+    #[test]
+    fn trait_items_are_rejected_for_now() {
+        elaborate_source("trait X { fn m(self: Self); }", |elab| {
+            assert!(
+                elab.reports.iter().any(|r| r
+                    .message
+                    .contains("`trait` declarations are not supported yet")),
+                "{:#?}",
+                elab.reports
+            );
+        });
+        elaborate_source(
+            "pub struct P { pub x: i64 }
+             impl Show for P { fn show(self: Self) -> i64 { 1 } }
+             impl P { pub fn ok(self: Self) -> i64 { self.x } }",
+            |elab| {
+                assert_eq!(
+                    elab.reports.len(),
+                    1,
+                    "exactly the placeholder, no cascades: {:#?}",
+                    elab.reports
+                );
+                assert!(
+                    elab.reports[0].message.contains(
+                        "trait implementations (`impl Trait for Type`) are not supported yet"
+                    ),
+                    "{:#?}",
+                    elab.reports
+                );
+                // The trait impl's member was not declared as an inherent
+                // method, while the inherent block's member was.
+                assert!(
+                    !elab.functions.values().any(|f| elab.sym(f.name) == "show"),
+                    "misattached trait-impl member"
+                );
+                assert!(elab.functions.values().any(|f| elab.sym(f.name) == "ok"));
+            },
+        );
+    }
+
     #[test]
     fn impl_members_declare_under_type_path_and_resolve_cross_file() {
         check_package(

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1344,7 +1344,22 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                                  mark individual members `pub` instead",
                             );
                         }
-                        impls.push((ib, span, scope));
+                        if ib.trait_ref.is_some() {
+                            // Not collected: members must not be declared as
+                            // inherent methods of the target.
+                            self.error(
+                                span,
+                                "trait implementations (`impl Trait for Type`) \
+                                 are not supported yet",
+                            );
+                        } else {
+                            impls.push((ib, span, scope));
+                        }
+                    }
+                    surface::StmtKind::Trait(_) => {
+                        self.validate_transform_anchor(&attrs, None);
+                        self.reject_ffi_attr(ffi, span);
+                        self.error(span, "`trait` declarations are not supported yet");
                     }
                     // Foreign preludes register during this scan (like
                     // bindings) so they apply file-wide regardless of order.

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -974,6 +974,34 @@ pub enum StmtKind {
     Transform(TransformScript),
     Import(ImportDecl),
     Impl(ImplBlock),
+    Trait(TraitDecl),
+}
+
+/// A `trait Name<T>: A + B { fn m(...) -> U; }` declaration. `Self` is
+/// implicit and not listed among `generics`; member signatures have
+/// `body`/`foreign_body` = `None` (the parser rejects bodies).
+#[derive(Clone, Debug)]
+pub struct TraitDecl {
+    pub visibility: Visibility,
+    pub name: TokenKey,
+    /// Each declared generic is `(name, bounds)`.
+    pub generics: SmallVec<[(TokenKey, Vec<Path>); 2]>,
+    /// Supertrait references from the `: A + B<C>` list.
+    pub supertraits: Vec<TraitRef>,
+    pub members: Vec<Spanned<Function>>,
+}
+
+/// A trait reference in the surface syntax: a qualified path plus its type
+/// arguments (`Eq`, `pkg::Convert<K>`) — the shape shared by supertrait
+/// lists and `impl` trait heads. Arguments always parse and project;
+/// whether a position *admits* them is the elaborator's call (supertrait
+/// references reject a non-empty list this cut — trait references are not
+/// parameterized yet, though the layers below already carry argument lists
+/// end to end).
+#[derive(Clone, Debug)]
+pub struct TraitRef {
+    pub path: Path,
+    pub args: SmallVec<[Type; 2]>,
 }
 
 /// An `impl<T: B> Type<args> { fn ... }` block: the block-level generics, the
@@ -985,6 +1013,9 @@ pub struct ImplBlock {
     pub visibility: Visibility,
     /// Each block-level generic is `(name, bounds)`.
     pub generics: SmallVec<[(TokenKey, Vec<Path>); 2]>,
+    /// `Some((path, args))` for a trait implementation
+    /// `impl Trait<args> for Type`; `None` for an inherent block.
+    pub trait_ref: Option<TraitRef>,
     pub target: Path,
     pub target_args: SmallVec<[Type; 2]>,
     pub members: Vec<Spanned<Function>>,
@@ -1024,6 +1055,7 @@ impl Stmt {
             TransformStmt => StmtKind::Transform(transform_of(node)),
             ImportStmt => StmtKind::Import(import_of(node)),
             ImplStmt => StmtKind::Impl(impl_of(node)),
+            TraitStmt => StmtKind::Trait(trait_of(node)),
             k => unreachable!("unexpected statement node {k:?}"),
         }
     }
@@ -1067,6 +1099,23 @@ fn attribute_of(node: &ResolvedNode) -> Attribute {
         values,
         span: node_span(node),
     }
+}
+
+/// The defining name of an item introduced by a *contextual* keyword (which
+/// lexes as a plain `Ident`): the first identifier-like direct token after
+/// the first `Ident` spelled `intro`. (`pub trait trait` names a trait
+/// `trait`: PubKw is ident-like but not Ident-kind, so the introducer scan
+/// skips it.)
+fn name_after_text<'n>(node: &'n ResolvedNode, intro: &str) -> &'n ResolvedToken {
+    let mut seen_intro = false;
+    for t in tokens(node) {
+        if !seen_intro && t.kind() == Ident && t.text() == intro {
+            seen_intro = true;
+        } else if seen_intro && t.kind().is_ident_like() {
+            return t;
+        }
+    }
+    panic!("missing name token in {:?}", node.kind())
 }
 
 fn visibility_of(node: &ResolvedNode) -> Visibility {
@@ -1138,12 +1187,11 @@ fn source_block_of(node: &ResolvedNode) -> Option<SourceBlock> {
     })
 }
 
-fn impl_of(node: &ResolvedNode) -> ImplBlock {
-    let target_ty = nodes(node)
-        .find(|n| n.kind() == PathType)
-        .expect("impl target type");
-    let target = path_of(child_node(target_ty, PathKind).expect("target path"));
-    let target_args = child_node(target_ty, TypeArgList)
+/// Split a `PathType` node into its qualified path and type arguments —
+/// the projection behind every [`TraitRef`] and `impl` head.
+fn path_type_parts(ty: &ResolvedNode) -> (Path, SmallVec<[Type; 2]>) {
+    let path = path_of(child_node(ty, PathKind).expect("type path"));
+    let args = child_node(ty, TypeArgList)
         .map(|l| {
             nodes(l)
                 .filter(|n| is_type_kind(n.kind()))
@@ -1151,6 +1199,23 @@ fn impl_of(node: &ResolvedNode) -> ImplBlock {
                 .collect()
         })
         .unwrap_or_default();
+    (path, args)
+}
+
+fn trait_ref_of(ty: &ResolvedNode) -> TraitRef {
+    let (path, args) = path_type_parts(ty);
+    TraitRef { path, args }
+}
+
+fn impl_of(node: &ResolvedNode) -> ImplBlock {
+    // Two direct PathType heads iff the `for` separator was parsed: the
+    // first is then the trait reference, the second the target.
+    let mut heads = nodes(node).filter(|n| n.kind() == PathType);
+    let first = heads.next().expect("impl target type");
+    let (trait_ref, (target, target_args)) = match heads.next() {
+        Some(second) => (Some(trait_ref_of(first)), path_type_parts(second)),
+        None => (None, path_type_parts(first)),
+    };
     let members = nodes(node)
         .filter(|n| n.kind() == FnStmt)
         .map(|f| spanned(f, function_of(f)))
@@ -1158,9 +1223,29 @@ fn impl_of(node: &ResolvedNode) -> ImplBlock {
     ImplBlock {
         visibility: visibility_of(node),
         generics: generics_of(node),
+        trait_ref,
         target,
         target_args,
         members,
+    }
+}
+
+fn trait_of(node: &ResolvedNode) -> TraitDecl {
+    TraitDecl {
+        visibility: visibility_of(node),
+        name: key(name_after_text(node, "trait")),
+        generics: generics_of(node),
+        // Direct PathType children of TraitStmt are exactly the supertrait
+        // list: the name is a token, bound paths nest under
+        // GenericParamList, and member types nest under FnStmt.
+        supertraits: nodes(node)
+            .filter(|n| n.kind() == PathType)
+            .map(trait_ref_of)
+            .collect(),
+        members: nodes(node)
+            .filter(|n| n.kind() == FnStmt)
+            .map(|f| spanned(f, function_of(f)))
+            .collect(),
     }
 }
 
@@ -1418,6 +1503,69 @@ mod tests {
         assert!(touch.is_regional);
         let (_, _, rflex) = &touch.params[0];
         assert!(rflex, "the `[flex]` receiver flag projects");
+    }
+
+    #[test]
+    fn trait_decl_projects_name_generics_supers_and_sig_members() {
+        let parse = parse(
+            "pub trait Ord<T: Num>: Eq + Show {
+                 fn cmp(self: Self, other: T) -> i64;
+                 fn zero() -> T;
+             }",
+        );
+        let prog = program(&parse.root);
+        let resolver = parse.resolver();
+        let StmtKind::Trait(decl) = prog[0].kind() else {
+            panic!("expected a trait declaration");
+        };
+        assert_eq!(decl.visibility, Visibility::Public);
+        assert_eq!(resolver.resolve(decl.name), "Ord");
+        assert_eq!(decl.generics.len(), 1);
+        assert_eq!(decl.generics[0].1.len(), 1, "bound carried");
+        let supers: Vec<&str> = decl
+            .supertraits
+            .iter()
+            .map(|s| resolver.resolve(s.path.basename))
+            .collect();
+        assert_eq!(supers, ["Eq", "Show"]);
+        // Supertrait references carry their arguments structurally.
+        assert!(decl.supertraits.iter().all(|s| s.args.is_empty()));
+        assert_eq!(decl.members.len(), 2);
+        let cmp = &decl.members[0].value;
+        assert!(cmp.body.is_none());
+        assert_eq!(resolver.resolve(cmp.params[0].0), "self");
+        // The receiver is optional at the view level: statics project too.
+        assert!(decl.members[1].value.params.is_empty());
+    }
+
+    #[test]
+    fn impl_of_projects_trait_ref() {
+        let parse = parse("impl<T: Num> Show<T> for Vec<T> { fn show(self: Self) -> i64 { 1 } }");
+        let prog = program(&parse.root);
+        let resolver = parse.resolver();
+        let StmtKind::Impl(ib) = prog[0].kind() else {
+            panic!("expected an impl block");
+        };
+        let tr = ib.trait_ref.as_ref().expect("trait ref");
+        assert_eq!(resolver.resolve(tr.path.basename), "Show");
+        assert_eq!(tr.args.len(), 1);
+        assert_eq!(resolver.resolve(ib.target.basename), "Vec");
+        assert_eq!(ib.target_args.len(), 1);
+        assert_eq!(ib.members.len(), 1);
+    }
+
+    /// The greedy `for` projection rule: a lone head named `for` is the
+    /// inherent target.
+    #[test]
+    fn for_named_type_projects_as_inherent_target() {
+        let parse = parse("impl for { fn get(self: Self) -> i64 { 1 } }");
+        let prog = program(&parse.root);
+        let resolver = parse.resolver();
+        let StmtKind::Impl(ib) = prog[0].kind() else {
+            panic!("expected an impl block");
+        };
+        assert!(ib.trait_ref.is_none());
+        assert_eq!(resolver.resolve(ib.target.basename), "for");
     }
 
     #[test]

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -145,6 +145,7 @@ impl Emitter<'_> {
             TransformStmt => self.transform_stmt(node),
             ImportStmt => self.import_stmt(node),
             ImplStmt => self.impl_stmt(node),
+            TraitStmt => self.trait_stmt(node),
             k => unreachable!("unexpected statement node {k:?}"),
         };
         tagged("SpannedStmt", self.with_node_span(node, inner))
@@ -339,9 +340,15 @@ impl Emitter<'_> {
     }
 
     fn impl_stmt(&self, node: &ResolvedNode) -> Value {
-        let target = nodes(node)
-            .find(|n| n.kind() == PathType)
-            .expect("impl target type");
+        // Two direct PathType heads iff the `for` separator was parsed: the
+        // first is then the trait reference, the second the target.
+        let mut heads = nodes(node).filter(|n| n.kind() == PathType);
+        let first = heads.next().expect("impl target type");
+        let second = heads.next();
+        let (trait_ref, target) = match second {
+            Some(second) => (Some(first), second),
+            None => (None, first),
+        };
         let members: Vec<Value> = nodes(node)
             .filter(|n| n.kind() == FnStmt)
             .map(|f| self.with_node_span(f, self.fn_stmt(f)))
@@ -351,8 +358,46 @@ impl Emitter<'_> {
             json!({
                 "implVisibility": self.visibility(node),
                 "implGenerics": self.generic_params(node),
+                "implTrait": trait_ref.map_or(Value::Null, |t| self.type_(t)),
                 "implTarget": self.type_(target),
                 "implMembers": members,
+            }),
+        )
+    }
+
+    fn trait_stmt(&self, node: &ResolvedNode) -> Value {
+        // The introducer lexes as a plain `Ident` spelled `trait`; the name
+        // is the first ident-like token after it (`pub trait trait` names a
+        // trait `trait` — PubKw is ident-like but not Ident-kind).
+        let mut seen_intro = false;
+        let mut name = None;
+        for t in tokens(node) {
+            if !seen_intro && t.kind() == Ident && t.text() == "trait" {
+                seen_intro = true;
+            } else if seen_intro && is_ident_like(t.kind()) {
+                name = Some(t);
+                break;
+            }
+        }
+        let name = name.expect("trait name");
+        // Supertrait references are path types, emitted exactly like the
+        // `impl` trait head so both spellings share one JSON shape.
+        let supers: Vec<Value> = nodes(node)
+            .filter(|n| n.kind() == PathType)
+            .map(|p| self.type_(p))
+            .collect();
+        let members: Vec<Value> = nodes(node)
+            .filter(|n| n.kind() == FnStmt)
+            .map(|f| self.with_node_span(f, self.fn_stmt(f)))
+            .collect();
+        tagged(
+            "TraitStmt",
+            json!({
+                "traitVisibility": self.visibility(node),
+                "traitName": name.text(),
+                "traitGenerics": self.generic_params(node),
+                "traitSupers": supers,
+                "traitMembers": members,
             }),
         )
     }

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -132,6 +132,9 @@ pub enum SyntaxKind {
     ImportStmt,
     /// `impl<T: B> Type<T> { fn ... }` — an inherent-method block.
     ImplStmt,
+    /// A trait declaration (method signatures only):
+    /// `trait Name<T>: A + B { fn m(...) -> U; }`.
+    TraitStmt,
     GenericParamList,
     GenericParam,
     ParamList,

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -151,10 +151,12 @@ fn repl_route(p: &parser::Parser) -> ReplInputKind {
         // `extern "C" trampoline ...` — a string cannot follow a variable.
         ExternKw => p.nth(1) == StringLit,
         // `pub <item>` — mirrors `stmt`'s post-visibility dispatch.
-        PubKw => matches!(
-            p.nth(1),
-            RegionalKw | FnKw | StructKw | EnumKw | ModKw | ExternKw | ImportKw
-        ),
+        PubKw => {
+            matches!(
+                p.nth(1),
+                RegionalKw | FnKw | StructKw | EnumKw | ModKw | ExternKw | ImportKw
+            ) || (p.nth_text(1) == "trait" && p.nth(2).is_ident_like() && p.nth(2) != AsKw)
+        }
         // `regional fn` is an item; any other `regional ...` is a region
         // expression.
         RegionalKw => p.nth(1) == FnKw,
@@ -167,6 +169,11 @@ fn repl_route(p: &parser::Parser) -> ReplInputKind {
             if p.current_text() == "impl"
                 && (p.nth(1) == LAngle || (p.nth(1).is_ident_like() && p.nth(1) != AsKw)) =>
         {
+            true
+        }
+        // `trait Name` heads a declaration; `trait + 1` / `trait as i64`
+        // stay expressions over a variable named `trait`.
+        Ident if p.current_text() == "trait" && p.nth(1).is_ident_like() && p.nth(1) != AsKw => {
             true
         }
         _ => false,
@@ -309,6 +316,11 @@ mod tests {
             // `impl` heads an item when a generic list or type name follows.
             "impl Point { fn get(self: Self) -> i64 { 1 } }",
             "impl<T: Num> Box<T> { pub fn get(self: Self) -> T { self.0 } }",
+            // Trait declarations and trait implementations.
+            "trait Ord { fn cmp(self: Self, other: Self) -> i64; }",
+            "pub trait Marker { }",
+            "impl Show for Point { fn show(self: Self) -> i64 { 1 } }",
+            "impl<T: Num> Convert<T> for Box<T> { fn conv(self: Self) -> T { self.0 } }",
         ];
         for source in items {
             let rp = parse_repl(source, interner.clone());
@@ -347,6 +359,11 @@ mod tests {
             // A variable named `impl` heads an expression.
             "impl + 1",
             "impl as i64",
+            // A variable named `trait` heads an expression; bare `trait`
+            // has nothing ident-like after it.
+            "trait + 1",
+            "trait as i64",
+            "trait",
         ];
         for source in exprs {
             let rp = parse_repl(source, interner.clone());
@@ -679,6 +696,166 @@ mod tests {
         json_of("fn shared(field: i32) -> i32 { field }");
         // `impl` included: legal as a parameter and a variable.
         json_of("fn f(impl: i64) -> i64 { impl }");
+        // `trait` and `for` too.
+        json_of("fn trait(trait: i64) -> i64 { trait }");
+        json_of("fn for(for: i64) -> i64 { for }");
+    }
+
+    #[test]
+    fn trait_decl_encodes_supers_generics_and_sig_members() {
+        let json = json_of(
+            "pub trait Ord<T>: Eq + Show {
+                 fn cmp(self: Self, other: T) -> i64;
+                 regional fn touch(self: [flex] Self);
+             }",
+        );
+        let decl = unwrap_span(&json[0]);
+        assert_eq!(decl["tag"], "TraitStmt");
+        let c = &decl["contents"];
+        assert_eq!(c["traitVisibility"], "Public");
+        assert_eq!(c["traitName"], "Ord");
+        assert_eq!(c["traitGenerics"][0][0], "T");
+        let supers = c["traitSupers"].as_array().expect("supers");
+        assert_eq!(supers.len(), 2);
+        let members = c["traitMembers"].as_array().expect("members");
+        assert_eq!(members.len(), 2);
+        let cmp = &members[0]["spanValue"]["contents"];
+        assert_eq!(cmp["funcName"], "cmp");
+        assert!(cmp["funcBody"].is_null());
+        assert!(cmp["funcForeignBody"].is_null());
+        let touch = &members[1]["spanValue"]["contents"];
+        assert_eq!(touch["funcIsRegional"], true);
+        assert_eq!(touch["funcParams"][0][2], true);
+    }
+
+    #[test]
+    fn impl_trait_for_encodes_trait_and_target() {
+        let json = json_of("impl<T: Num> Show<T> for Vec<T> { fn show(self: Self) -> i64 { 1 } }");
+        let block = unwrap_span(&json[0]);
+        assert_eq!(block["tag"], "ImplStmt");
+        let c = &block["contents"];
+        assert!(!c["implTrait"].is_null());
+        assert_eq!(c["implMembers"].as_array().expect("members").len(), 1);
+    }
+
+    /// The greedy `for` rule: `for` stays a legal type name in both impl
+    /// head positions.
+    #[test]
+    fn for_stays_a_type_name() {
+        let json = json_of("impl for { fn get(self: Self) -> i64 { 1 } }");
+        let c = &unwrap_span(&json[0])["contents"];
+        assert!(c["implTrait"].is_null());
+        let json = json_of("impl for for X { fn get(self: Self) -> i64 { 1 } }");
+        let c = &unwrap_span(&json[0])["contents"];
+        assert!(!c["implTrait"].is_null());
+    }
+
+    #[test]
+    fn trait_method_body_is_rejected() {
+        let source = "trait T { fn m(self: Self) -> i64 { 1 } fn ok(self: Self) -> i64; }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|e| e.message.contains("end the signature with `;`")),
+            "{:#?}",
+            parse.errors
+        );
+        assert_eq!(parse.root.text(), source);
+        // The member after the rejected body survives.
+        let decl = parse
+            .root
+            .children()
+            .find(|n| n.kind() == SyntaxKind::TraitStmt)
+            .expect("trait decl");
+        assert_eq!(
+            decl.children()
+                .filter(|n| n.kind() == SyntaxKind::FnStmt)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn trait_foreign_body_rejected() {
+        let source = "trait T { fn m(self: Self) -> i64 [{ x }]; }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|e| e.message.contains("foreign body")),
+            "{:#?}",
+            parse.errors
+        );
+        assert_eq!(parse.root.text(), source);
+    }
+
+    #[test]
+    fn trait_supertrait_args_parse() {
+        // A supertrait reference is a path type: arguments parse and reach
+        // the tree (whether they are *admitted* is the elaborator's call).
+        let parse = super::parse("trait A: B<C> { }");
+        assert!(parse.ok(), "{:#?}", parse.errors);
+        let decl = parse
+            .root
+            .children()
+            .find(|n| n.kind() == SyntaxKind::TraitStmt)
+            .expect("trait decl");
+        let sup = decl
+            .children()
+            .find(|n| n.kind() == SyntaxKind::PathType)
+            .expect("supertrait reference");
+        assert!(
+            sup.children().any(|n| n.kind() == SyntaxKind::TypeArgList),
+            "arguments reach the tree"
+        );
+    }
+
+    #[test]
+    fn trait_member_recovery_continues() {
+        let source = "trait T { 42 fn ok(self: Self) -> i64; }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert_eq!(parse.root.text(), source);
+        let decl = parse
+            .root
+            .children()
+            .find(|n| n.kind() == SyntaxKind::TraitStmt)
+            .expect("trait decl");
+        assert!(decl.children().any(|n| n.kind() == SyntaxKind::FnStmt));
+    }
+
+    #[test]
+    fn impl_for_prim_positions() {
+        let source = "impl Show for i64 { }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|e| e.message.contains("must be a named type")),
+            "{:#?}",
+            parse.errors
+        );
+        assert_eq!(parse.root.text(), source);
+
+        let source = "impl i64 for X { }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|e| e.message.contains("must be a named trait")),
+            "{:#?}",
+            parse.errors
+        );
+        assert_eq!(parse.root.text(), source);
     }
 
     #[test]

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -10,6 +10,9 @@
 //! import-stmt ::= 'import' path ('as' name)? ';'
 //! fn-stmt     ::= 'regional'? 'fn' name generics? '(' params ')' ('->' '[flex]'? type)?
 //!                     (block | ';' | RAW-MLIR-LITERAL ';')
+//! trait-stmt  ::= 'trait' name generics? (':' path ('+' path)*)? '{' trait-method* '}'
+//! trait-method ::= 'regional'? 'fn' name generics? '(' params ')' ('->' '[flex]'? type)? ';'
+//! impl-stmt   ::= 'impl' generics? (type-atom 'for')? type-atom '{' (pub? regional? fn ...)* '}'
 //! struct-stmt ::= 'struct' capability? name generics? (named-fields | unnamed-fields | ';')
 //! enum-stmt   ::= 'enum' capability? name generics? '{' variant,* '}'
 //! mod-stmt    ::= 'mod' name ';'
@@ -46,7 +49,11 @@ impl Parser<'_> {
     pub(crate) fn source_file(&mut self) {
         let m = self.start();
         while !self.at_eof() {
-            if self.current().starts_stmt() || self.at_transform_stmt() || self.at_impl_stmt() {
+            if self.current().starts_stmt()
+                || self.at_transform_stmt()
+                || self.at_impl_stmt()
+                || self.at_trait_stmt()
+            {
                 self.stmt();
             } else {
                 // Statement-level recovery: collect the unexpected tokens
@@ -54,13 +61,14 @@ impl Parser<'_> {
                 // again.
                 let e = self.start();
                 self.error(format!(
-                    "expected a top-level item (fn, struct, enum, mod, extern, impl, transform, or import), found {}",
+                    "expected a top-level item (fn, struct, enum, mod, extern, impl, trait, transform, or import), found {}",
                     self.current().describe()
                 ));
                 while !self.at_eof()
                     && !self.current().starts_stmt()
                     && !self.at_transform_stmt()
                     && !self.at_impl_stmt()
+                    && !self.at_trait_stmt()
                 {
                     self.bump();
                 }
@@ -86,9 +94,10 @@ impl Parser<'_> {
             ImportKw => self.import_stmt(m),
             Ident if self.at_transform_stmt() => self.transform_stmt(m),
             Ident if self.at_impl_stmt() => self.impl_stmt(m),
+            Ident if self.at_trait_stmt() => self.trait_stmt(m),
             _ => {
                 self.error(format!(
-                    "expected `fn`, `struct`, `enum`, `mod`, `extern`, `impl`, `transform`, or `import` after visibility, found {}",
+                    "expected `fn`, `struct`, `enum`, `mod`, `extern`, `impl`, `trait`, `transform`, or `import` after visibility, found {}",
                     self.current().describe()
                 ));
                 // Consume nothing further; the outer loop recovers.
@@ -110,7 +119,97 @@ impl Parser<'_> {
             && (self.nth(1) == LAngle || (self.nth(1).is_ident_like() && self.nth(1) != AsKw))
     }
 
-    /// `impl generics? Type<args>? { (pub? (regional? fn ...))* }`.
+    /// `trait` is likewise contextual: it heads a declaration only when its
+    /// name follows — `trait + 1` stays an expression over a variable named
+    /// `trait`, `trait as i64` a cast of one. No generic-list case: the
+    /// trait's name precedes its generics (unlike `impl<T>`).
+    fn at_trait_stmt(&self) -> bool {
+        self.at_ctx_kw("trait") && self.nth(1).is_ident_like() && self.nth(1) != AsKw
+    }
+
+    /// `trait Name generics? (':' path ('+' path)*)? '{' trait-method* '}'`.
+    /// Supertraits are bare `+`-separated paths; members are signatures only.
+    fn trait_stmt(&mut self, m: Marker) {
+        self.bump(); // the `trait` ident
+        self.expect_ident("a trait name");
+        if self.at(LAngle) {
+            self.generic_param_list();
+        }
+        if self.at(Colon) {
+            self.bump();
+            self.path_type();
+            while self.at(Plus) {
+                self.bump();
+                self.path_type();
+            }
+        }
+        self.expect(LBrace);
+        while !self.at(RBrace) && !self.at_eof() {
+            if self.at(RegionalKw) || self.at(FnKw) {
+                let member = self.start();
+                self.trait_method(member);
+            } else {
+                // Member-level recovery: `pub` is not a member starter —
+                // trait methods take the trait's visibility.
+                let e = self.start();
+                self.error(format!(
+                    "expected `fn` or `regional fn` in a `trait` body, found {}",
+                    self.current().describe()
+                ));
+                while !self.at_eof() && !self.at(RBrace) && !self.at(RegionalKw) && !self.at(FnKw) {
+                    self.bump();
+                }
+                e.complete(self, ErrorNode);
+            }
+        }
+        self.expect(RBrace);
+        m.complete(self, TraitStmt);
+    }
+
+    /// A trait method signature — `fn_stmt`'s body-less twin, completing an
+    /// ordinary `FnStmt` node so downstream views project members uniformly.
+    fn trait_method(&mut self, m: Marker) {
+        if self.at(RegionalKw) {
+            self.bump();
+        }
+        self.expect(FnKw);
+        self.expect_ident("a method name");
+        if self.at(LAngle) {
+            self.generic_param_list();
+        }
+        self.param_list();
+        if self.at(Arrow) {
+            let r = self.start();
+            self.bump();
+            self.flex_flag_opt();
+            self.type_();
+            r.complete(self, RetType);
+        }
+        if self.at(Semicolon) {
+            self.bump();
+        } else if self.at(LBrace) {
+            self.error(
+                "trait methods are signatures; end the signature with `;`                  (default method bodies are not supported)",
+            );
+            // Consume the body losslessly so recovery continues at the next
+            // member instead of cascading.
+            self.block_expr();
+            if self.at(Semicolon) {
+                self.bump();
+            }
+        } else if self.at(RawMlirLiteral) {
+            self.error("trait methods cannot have a foreign body");
+            self.bump();
+            if self.at(Semicolon) {
+                self.bump();
+            }
+        } else {
+            self.error("expected `;` after a trait method signature");
+        }
+        m.complete(self, FnStmt);
+    }
+
+    /// `impl generics? (Trait<args> 'for')? Type<args>? { (pub? (regional? fn ...))* }`.
     fn impl_stmt(&mut self, m: Marker) {
         self.bump(); // the `impl` ident
         if self.at(LAngle) {
@@ -118,11 +217,31 @@ impl Parser<'_> {
         }
         if PRIM_TYPES.contains(&self.current_text()) {
             let e = self.start();
-            self.error("the target of `impl` must be a named type");
+            if self.nth_text(1) == "for" {
+                self.error("the trait of an `impl` must be a named trait");
+            } else {
+                self.error("the target of `impl` must be a named type");
+            }
             self.bump();
             e.complete(self, ErrorNode);
         } else if self.type_atom().is_none() {
             self.error("expected a type name as the `impl` target");
+        }
+        // `impl Trait<args> for Type`: a contextual `for` after the first
+        // head makes it the trait reference and the next atom the target.
+        // Greedy, single-shot: `impl for { }` is an inherent impl of a type
+        // named `for` (the first atom consumed it), `impl for for X { }` a
+        // trait named `for` implemented for `X`.
+        if self.at_ctx_kw("for") {
+            self.bump();
+            if PRIM_TYPES.contains(&self.current_text()) {
+                let e = self.start();
+                self.error("the target of `impl` must be a named type");
+                self.bump();
+                e.complete(self, ErrorNode);
+            } else if self.type_atom().is_none() {
+                self.error("expected a type name as the `impl` target after `for`");
+            }
         }
         self.expect(LBrace);
         while !self.at(RBrace) && !self.at_eof() {
@@ -571,6 +690,14 @@ impl Parser<'_> {
             self.bump();
             return Some(m.complete(self, PrimType));
         }
+        Some(self.path_type())
+    }
+
+    /// A named-type reference — a qualified path with optional type
+    /// arguments, completed as a `PathType` node. Shared by type atoms,
+    /// the `impl` heads, and supertrait references (which accept the same
+    /// shape; whether arguments are *admitted* there is semantics).
+    fn path_type(&mut self) -> CompletedMarker {
         let m = self.start();
         self.path();
         if self.at(LAngle) {
@@ -585,7 +712,7 @@ impl Parser<'_> {
             self.expect(RAngle);
             args.complete(self, TypeArgList);
         }
-        Some(m.complete(self, PathType))
+        m.complete(self, PathType)
     }
 
     /// A statically shaped array type: `[T; e1, e2, ...]` with one extent


### PR DESCRIPTION
First PR of the **trait-system stack** (RFC Phase 1: full coherence trait system, `impl .. for ..`, builtin-trait DSL — design per `docs/trait-system.md` + the session design review).

```rust
pub trait Ord<T>: Eq + Show {
    fn cmp(self: Self, other: T) -> i64;
    regional fn touch(self: [flex] Self);
}
impl<T: Num> Show<T> for Vec<T> { fn show(self: Self) -> i64 { 1 } }
```

- **Contextual, no reserved words**: `trait`/`for` lex as plain identifiers; `fn trait(trait: i64)`, `fn for(for: i64)`, `trait + 1`, `trait as i64` all keep today's meaning (pinned). REPL routes `trait Name` / `pub trait` as items.
- **Signatures only**: default bodies report ("end the signature with `;`") and are consumed losslessly for recovery; foreign bodies rejected; members complete as ordinary `FnStmt`s (uniform projection, `body = None`); receivers optional at parse level (statics like `fn zero() -> T;` parse — validation is elaboration's job).
- **Greedy `for` rule** (pinned corners): `impl for { }` = inherent impl of a type named `for`; `impl for for X { }` = trait named `for` for `X`; inherent impls are **byte-identical CSTs** to before. Primitives rejected in both head positions this cut (`impl Show for i64` is a documented follow-up).
- **Views**: `surface::TraitDecl`, `StmtKind::Trait`, `ImplBlock.trait_ref` via the two-head positional split; JSON oracle grows `TraitStmt` + `implTrait`.
- **Sound at this point of the stack**: the elaborator rejects both forms cleanly ("not supported yet"); a trait impl's members are *never* declared (pinned: no misattached inherent methods, no cascades, REPL batches retract). No HIR/`.rri`/TraitDb/Checkpoint changes; `RRI_FORMAT` untouched.
- RFC §7 updated with the as-built grammar (contextual words, not lexer keywords).

Gate: `cargo test` 532 green (59 syntax / 381 core), `ninja -C build check` 462/465 (baseline), `rrc-test` green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788324765&installation_model_id=426051&pr_number=508&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F508&signature=eb6aee062ca05be3aacea9582a3265b6d961bcce4271d04252238f360643af01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->