### PR TITLE
[core] trait identity: DefKind::Trait namespace, DefId-keyed TraitDb with rollback

### DIFF
--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -686,10 +686,11 @@ mod tests {
     fn lower_source(source: &str) -> String {
         let context = crate::testing::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -743,10 +744,11 @@ transform [{
 }];"#;
         let context = crate::testing::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let program = surface::program(&parse.root);
-            let elab = elaborate(tcx, &program, parse.resolver());
+            let elab = elaborate(tcx, &program, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -774,10 +776,11 @@ transform [{
         let src = "pub fn add(a: i64, b: i64) -> i64 { a + b }\n";
         let context = crate::testing::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -820,10 +823,11 @@ transform [{
         "#;
         let context = crate::testing::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -876,10 +880,11 @@ transform [{
         "#;
         let context = crate::testing::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -939,10 +944,11 @@ transform [{
         "#;
         let context = crate::testing::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -1195,10 +1201,11 @@ transform [{
         "#;
         let context = reussir_backend::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -1332,10 +1339,11 @@ transform [{
         "#;
         let context = crate::testing::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             let (full, _) = monomorphize(&elab.mono_input());
             let err = lower_program(&context, tcx, &full, None, None, LinkagePolicy::Jit, &[])
                 .expect_err("an arc over a non-shared record must not lower");
@@ -1357,10 +1365,11 @@ transform [{
         "#;
         let context = crate::testing::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "{:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "{reports:#?}");
@@ -1386,10 +1395,11 @@ transform [{
         "#;
         let context = crate::testing::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -1421,10 +1431,11 @@ transform [{
         "#;
         let context = reussir_backend::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -1451,10 +1462,11 @@ transform [{
         "#;
         let context = reussir_backend::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -1514,10 +1526,11 @@ transform [{
         "#;
         let context = reussir_backend::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -1559,10 +1572,11 @@ transform [{
         "#;
         let context = reussir_backend::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -1637,10 +1651,11 @@ transform [{
         "#;
         let context = reussir_backend::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -1701,10 +1716,11 @@ transform [{
         "#;
         let context = reussir_backend::context();
         in_arena(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");

--- a/crates/reussir-codegen/tests/frontend_e2e.rs
+++ b/crates/reussir-codegen/tests/frontend_e2e.rs
@@ -22,10 +22,11 @@ fn jit_run<R>(source: &str, run: impl FnOnce(&OrcJit) -> R) -> R {
     let context = testing::context();
     // Frontend + lowering, inside the arena scope; the module outlives it.
     let mut module = in_arena(|tcx| {
-        let parse = reussir_syntax::parse(source);
+        let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+        let parse = reussir_syntax::parse_with_interner(source, interner.clone());
         assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
         let prog = surface::program(&parse.root);
-        let elab = elaborate(tcx, &prog, parse.resolver());
+        let elab = elaborate(tcx, &prog, &interner);
         assert!(
             !elab.has_errors(),
             "elaboration errors: {:#?}",
@@ -210,10 +211,11 @@ fn lowers_variant_debug_info_through_the_pipeline() {
     "#;
     let context = testing::context();
     let mut module = in_arena(|tcx| {
-        let parse = reussir_syntax::parse(src);
+        let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+        let parse = reussir_syntax::parse_with_interner(src, interner.clone());
         assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
         let prog = surface::program(&parse.root);
-        let elab = elaborate(tcx, &prog, parse.resolver());
+        let elab = elaborate(tcx, &prog, &interner);
         assert!(
             !elab.has_errors(),
             "elaboration errors: {:#?}",

--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -95,7 +95,7 @@ pub(crate) fn frontend_package<'c, 'tcx>(
             files,
         })
         .collect();
-    let elab = elaborate_package_with_externs(tcx, &files, interner, &mut keys, &extern_pkgs);
+    let elab = elaborate_package_with_externs(tcx, &files, interner, &extern_pkgs);
     if render_reports(&pkg.cache, &elab.reports) {
         return Err(String::new());
     }
@@ -218,7 +218,8 @@ pub(crate) fn frontend<'c, 'tcx>(
     let source = sources.source(FileId::ROOT);
     match input {
         Stage::Rr => {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             if !parse.ok() {
                 let color = std::io::stderr().is_terminal();
                 let _ = diagnostics::render_errors(
@@ -231,7 +232,7 @@ pub(crate) fn frontend<'c, 'tcx>(
                 return Err(String::new());
             }
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             if render_reports(sources, &elab.reports) {
                 return Err(String::new());
             }

--- a/crates/reussir-core/docs/trait-system.md
+++ b/crates/reussir-core/docs/trait-system.md
@@ -400,9 +400,20 @@ impl Ord for i32 { fn cmp(self, other: i32) -> Ordering { … } }
 impl<T: Ord> Ord for List<T> where … { … }
 ```
 
-That is: lexer keywords (`trait`, `impl`, `for`, `where`), grammar rules, CST
-kinds, and AST/JSON lowering in `reussir-syntax`. **Decision: this is in the
-first cut** — user-declared traits from the start, not deferred.
+That is: grammar rules, CST kinds, and AST/JSON lowering in `reussir-syntax`.
+**Decision: this is in the first cut** — user-declared traits from the start,
+not deferred.
+
+> **As built (surface layer):** `trait`, `impl`, and `for` are *contextual
+> identifiers*, not lexer keywords — the language has no reserved words, so
+> `fn trait(trait: i64)` stays legal and `trait + 1` is an expression over a
+> variable named `trait`. Trait bodies carry method *signatures only*
+> (default bodies deferred per Phase 3; the parser consumes an offending body
+> losslessly and reports). Supertraits are bare `+`-separated paths; `where`
+> is not parsed (deferred). `impl Trait<args> for Type` uses a greedy
+> single-shot `for` rule (`impl for { }` is an inherent impl of a type named
+> `for`); a primitive in either head position is rejected this cut. Typed
+> views: `surface::TraitDecl` and `ImplBlock::trait_ref`.
 
 Flexivity bounds reuse the existing bound position. The names `Irrelevant`,
 `Regional`, `Flex`, `Rigid` in a bound list are recognized as built-in

--- a/crates/reussir-core/src/full/interface.rs
+++ b/crates/reussir-core/src/full/interface.rs
@@ -225,10 +225,11 @@ mod tests {
             pub fn ground(x: i64) -> i64 { from_ground(x) }
         ";
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 !elab.has_errors(),
                 "elaboration errors: {:#?}",

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -638,10 +638,11 @@ mod tests {
     /// (the text-faithful round-trip contract).
     fn roundtrip(source: &str) {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -686,10 +687,11 @@ mod tests {
     fn roundtrip_with_locations(source: &str) {
         use reussir_syntax::source::SourceCache;
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");
@@ -735,10 +737,11 @@ mod tests {
         let file_name = r#"<quoted"path\name>"#;
 
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -719,10 +719,11 @@ mod tests {
 
     fn render(source: &str) -> String {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "errors: {:#?}", elab.reports);
             let (full, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "mono reports: {reports:#?}");

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -1681,10 +1681,11 @@ mod tests {
     /// the program to `f`.
     fn with_full<R>(source: &str, f: impl FnOnce(&mir::Program<'_>) -> R) -> R {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 !elab.has_errors(),
                 "elaboration errors: {:#?}",
@@ -1710,10 +1711,11 @@ mod tests {
     /// diagnostics' messages.
     fn mono_reports(source: &str) -> Vec<String> {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 !elab.has_errors(),
                 "elaboration errors: {:#?}",
@@ -1739,10 +1741,11 @@ mod tests {
             pub fn ground(x: i64) -> i64 { from_ground(x) }
         ";
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 !elab.has_errors(),
                 "elaboration errors: {:#?}",
@@ -1785,13 +1788,15 @@ mod tests {
     fn negative_zero_is_not_folded() {
         use crate::full::mir::print::Printer as MirPrinter;
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(
                 "pub fn nz() -> f64 { -0.0 } \
                  pub fn nn() -> f64 { -1.5 }",
+                interner.clone(),
             );
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "{:#?}", elab.reports);
             let (mir, reports) = monomorphize(&elab.mono_input());
             assert!(reports.is_empty(), "{reports:#?}");
@@ -1854,10 +1859,11 @@ mod tests {
                       fn id<T>(x: T) -> T { x } \
                       pub fn mk(x: i32, y: i32) -> Pair { id(Pair { a: x, b: y }) }";
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "{:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "{:#?}", elab.reports);
 
             // Monomorphize the original elaboration.
@@ -1953,10 +1959,11 @@ mod tests {
 
         with_tcx(|tcx| {
             // ----- parse + semi-elaborate -----
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 !elab.has_errors(),
                 "elaboration errors: {:#?}",
@@ -2295,10 +2302,11 @@ mod tests {
             regional fn use_bad(p: Pair) -> i32 { foo(p) }
         "#;
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 !elab.has_errors(),
                 "elaboration errors: {:#?}",
@@ -2495,10 +2503,11 @@ mod tests {
             regional fn use_bad(w: [flex] Wrapper<Pair>) -> i32 { 0 }
         "#;
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 !elab.has_errors(),
                 "elaboration errors: {:#?}",
@@ -2838,10 +2847,11 @@ mod tests {
             regional fn use_bad(b: [flex] Box<Pair>, z: Nullable<Pair>) -> i32 { store(b, z) }
         "#;
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(src);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(src, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 !elab.has_errors(),
                 "elaboration errors: {:#?}",

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -37,21 +37,23 @@ pub use ctxt::{
 };
 pub use externs::ExternPackage;
 
-use reussir_syntax::Interner;
-use reussir_syntax::kind::{Resolver, TokenKey};
+use reussir_syntax::SessionInterner;
 
 use crate::surface;
 use ty::TyCtxt;
 
 /// Elaborate a whole surface program. Returns the elaborator holding the
-/// collected, type-checked items and any diagnostics. `resolver` turns the
-/// surface AST's interned token keys back into source text.
+/// collected, type-checked items and any diagnostics. `interner` is the
+/// shared session table the program was parsed with — it resolves the
+/// surface AST's token keys back to text *and* interns the elaborator's own
+/// names, both through `&self` (the threaded interner is interior-mutable,
+/// so sharing it is never `&mut`).
 pub fn elaborate<'a, 'tcx>(
     tcx: &'a TyCtxt<'tcx>,
     program: &surface::Program,
-    resolver: &'a dyn Resolver<TokenKey>,
+    interner: &'a SessionInterner,
 ) -> Elaborator<'a, 'tcx> {
-    let mut elab = Elaborator::new(tcx, resolver);
+    let mut elab = Elaborator::new(tcx, interner);
     elab.run(program);
     elab
 }
@@ -59,14 +61,14 @@ pub fn elaborate<'a, 'tcx>(
 /// Elaborate a whole package — one translation unit spanning many files, each
 /// under its own module path. All items are declared before any is resolved,
 /// so cross-file references work in any order. Every file must have been
-/// parsed with **one shared interner** (`resolver` resolves its keys):
-/// cross-file resolution compares interned keys.
+/// parsed with the **one shared session interner** passed here: cross-file
+/// resolution compares interned keys.
 pub fn elaborate_package<'a, 'tcx>(
     tcx: &'a TyCtxt<'tcx>,
     files: &[PackageFile<'_>],
-    resolver: &'a dyn Resolver<TokenKey>,
+    interner: &'a SessionInterner,
 ) -> Elaborator<'a, 'tcx> {
-    let mut elab = Elaborator::new(tcx, resolver);
+    let mut elab = Elaborator::new(tcx, interner);
     elab.run_package(files);
     elab
 }
@@ -74,18 +76,21 @@ pub fn elaborate_package<'a, 'tcx>(
 /// [`elaborate_package`] against loaded dependency interfaces: every extern
 /// package's items are declared first (the declare-only twin of the
 /// in-package scan, see [`externs`]), so consumer references `dep::item`
-/// resolve during the same run — `pub` items only. `interner` must back
-/// `resolver`: extern paths re-intern into the consumer's key space.
+/// resolve during the same run — `pub` items only. Extern paths re-intern
+/// into the session table.
 pub fn elaborate_package_with_externs<'a, 'tcx>(
     tcx: &'a TyCtxt<'tcx>,
     files: &[PackageFile<'_>],
-    resolver: &'a dyn Resolver<TokenKey>,
-    interner: &mut impl Interner<TokenKey>,
+    interner: &'a SessionInterner,
     externs: &[ExternPackage<'_, 'tcx>],
 ) -> Elaborator<'a, 'tcx> {
-    let mut elab = Elaborator::new(tcx, resolver);
+    let mut elab = Elaborator::new(tcx, interner);
     for ext in externs {
-        elab.declare_extern_package(interner, ext);
+        // The extern declare pass is generic over `&mut impl Interner` (it
+        // also serves owned tables); the session table satisfies that
+        // spelling by a handle copy — an `Arc` clone, not a table copy.
+        let mut handle = interner.clone();
+        elab.declare_extern_package(&mut handle, ext);
     }
     elab.run_package(files);
     elab
@@ -101,10 +106,11 @@ mod tests {
     /// on the resulting elaborator.
     fn check(source: &str, f: impl for<'a, 'tcx> FnOnce(&Elaborator<'a, 'tcx>, &TyCtxt<'tcx>)) {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 !elab.has_errors(),
                 "elaboration errors: {:#?}",
@@ -581,10 +587,11 @@ mod tests {
         with_tcx(|tcx| {
             let source = "pub struct [regional] R { pub v: i64 }\n\
                           impl R { fn bad(self: [flex] Self) -> i64 { self.v } }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports.iter().any(|r| r
                     .message
@@ -600,10 +607,11 @@ mod tests {
         with_tcx(|tcx| {
             let source = "pub struct A { pub v: i64 }\npub struct B { pub v: i64 }\n\
                           impl A { fn bad(self: B) -> i64 { self.v } }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports.iter().any(|r| r
                     .message
@@ -656,10 +664,11 @@ mod tests {
         with_tcx(|tcx| {
             let source = "pub struct P { pub x: i64 }\n\
                           impl P { fn bad(n: i64, self: Self) -> i64 { n } }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports.iter().any(|r| r
                     .message
@@ -672,10 +681,11 @@ mod tests {
 
     fn elaborate_source(source: &str, f: impl for<'a, 'tcx> FnOnce(&Elaborator<'a, 'tcx>)) {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             f(&elab);
         });
     }
@@ -984,10 +994,11 @@ mod tests {
             // must report it instead of handing monomorphization a type
             // `subst_ty` would panic on.
             let source = "fn f() -> i64 { let x = Nullable::Null; 42 }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             let ambiguous: Vec<_> = elab
                 .reports
                 .iter()
@@ -1006,10 +1017,11 @@ mod tests {
                           struct P { z: f64 }\n\
                           fn f(a: i32) -> i32 { a }\n\
                           fn f(b: f64, c: f64) -> f64 { b }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
 
             let duplicates = elab
                 .reports
@@ -1294,10 +1306,11 @@ pub struct Rect { pub w: i64 }",
     fn pub_impl_block_rejected() {
         with_tcx(|tcx| {
             let source = "struct P { x: i64 }\npub impl P { fn get(p: P) -> i64 { p.x } }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports.iter().any(|r| r
                     .message
@@ -1333,10 +1346,11 @@ pub struct Rect { pub w: i64 }",
         with_tcx(|tcx| {
             let source = "pub struct Box<T> { pub v: T }\n\
                           impl<T: Num> Box<T> { fn bad<T: Num>(b: Box<T>) -> i64 { 0 } }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports
                     .iter()
@@ -1579,9 +1593,10 @@ pub struct Rect { pub w: i64 }",
     fn reports_type_mismatch() {
         with_tcx(|tcx| {
             let source = "fn bad() -> bool { 1 }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(elab.has_errors(), "expected a type mismatch error");
         });
     }
@@ -1592,10 +1607,11 @@ pub struct Rect { pub w: i64 }",
     fn if_without_else_requires_a_unit_then_branch() {
         with_tcx(|tcx| {
             let source = "fn bad(c: bool) -> i32 { if c { true } }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(elab.has_errors(), "expected a unit mismatch error");
             let messages = elab
                 .reports
@@ -1617,10 +1633,11 @@ pub struct Rect { pub w: i64 }",
     fn diagnostics_render_types_in_surface_syntax() {
         let messages = |source: &str| {
             with_tcx(|tcx| {
-                let parse = reussir_syntax::parse(source);
+                let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+                let parse = reussir_syntax::parse_with_interner(source, interner.clone());
                 assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
                 let prog = surface::program(&parse.root);
-                let elab = elaborate(tcx, &prog, parse.resolver());
+                let elab = elaborate(tcx, &prog, &interner);
                 assert!(elab.has_errors(), "expected an error");
                 elab.reports
                     .iter()
@@ -1739,9 +1756,10 @@ pub struct Rect { pub w: i64 }",
                     }
                 }
             "#;
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports
                     .iter()
@@ -1805,9 +1823,10 @@ pub struct Rect { pub w: i64 }",
                     Outer { inner: Inner { v: v }, tag: v }
                 }
             "#;
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports
                     .iter()
@@ -1822,9 +1841,10 @@ pub struct Rect { pub w: i64 }",
     fn rejects_regional_call_outside_region() {
         with_tcx(|tcx| {
             let source = "regional fn r() -> i32 { 0 }\nfn caller() -> i32 { r() }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports.iter().any(|r| r.message.contains("regional")),
                 "expected a regional-call error: {:#?}",
@@ -1840,9 +1860,10 @@ pub struct Rect { pub w: i64 }",
             // value record is rejected right at the declaration.
             let source = "struct Pair { a: i32 }\n\
                           struct [regional] Holder { item: [field] Pair }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports
                     .iter()
@@ -1860,9 +1881,10 @@ pub struct Rect { pub w: i64 }",
             // value cannot be materialized, so it cannot escape its region).
             let source = "struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> }\n\
                           regional fn f(c: [flex] TestCell<i32>) -> i32 { let g = || c; 0 }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(
                 elab.reports
                     .iter()
@@ -1879,10 +1901,11 @@ pub struct Rect { pub w: i64 }",
     /// program against its fully-qualified spelling.
     fn printed_hir(source: &str) -> String {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
             let strings = elab.strings.entries();
             crate::semi::hir::print::Printer::new(&elab.defs, elab.resolver).program(
@@ -2004,10 +2027,11 @@ pub struct Rect { pub w: i64 }",
     /// Elaborate a source string and return its diagnostics (for negative tests).
     fn reports_of(source: &str) -> Vec<crate::semi::Report> {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            elaborate(tcx, &prog, parse.resolver()).reports.clone()
+            elaborate(tcx, &prog, &interner).reports.clone()
         })
     }
 
@@ -2459,7 +2483,7 @@ pub struct Rect { pub w: i64 }",
             let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
             let resolver: &dyn reussir_syntax::kind::Resolver<reussir_syntax::kind::TokenKey> =
                 &interner;
-            let mut elab = Elaborator::new(tcx, resolver);
+            let mut elab = Elaborator::new(tcx, &interner);
             for src in [
                 "struct Q { x: i64 }\nstruct S { p: Q }",
                 "fn f(s: Arc<S>) -> i32 { 0 }",

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1078,6 +1078,48 @@ mod tests {
         );
     }
 
+    /// Until the trait stacks land, trait items are rejected cleanly — and
+    /// a trait impl's members are never misattached as inherent methods.
+    #[test]
+    fn trait_items_are_rejected_for_now() {
+        elaborate_source("trait X { fn m(self: Self); }", |elab| {
+            assert!(
+                elab.reports.iter().any(|r| r
+                    .message
+                    .contains("`trait` declarations are not supported yet")),
+                "{:#?}",
+                elab.reports
+            );
+        });
+        elaborate_source(
+            "pub struct P { pub x: i64 }
+             impl Show for P { fn show(self: Self) -> i64 { 1 } }
+             impl P { pub fn ok(self: Self) -> i64 { self.x } }",
+            |elab| {
+                assert_eq!(
+                    elab.reports.len(),
+                    1,
+                    "exactly the placeholder, no cascades: {:#?}",
+                    elab.reports
+                );
+                assert!(
+                    elab.reports[0].message.contains(
+                        "trait implementations (`impl Trait for Type`) are not supported yet"
+                    ),
+                    "{:#?}",
+                    elab.reports
+                );
+                // The trait impl's member was not declared as an inherent
+                // method, while the inherent block's member was.
+                assert!(
+                    !elab.functions.values().any(|f| elab.sym(f.name) == "show"),
+                    "misattached trait-impl member"
+                );
+                assert!(elab.functions.values().any(|f| elab.sym(f.name) == "ok"));
+            },
+        );
+    }
+
     #[test]
     fn impl_members_declare_under_type_path_and_resolve_cross_file() {
         check_package(

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -391,7 +391,6 @@ pub struct Elaborator<'a, 'tcx> {
     pub resolver: &'a dyn Resolver<TokenKey>,
     pub traits: TraitDb<'tcx>,
     pub builtins: Builtins,
-    pub trait_names: FxHashMap<&'static str, TraitId>,
     /// Resolution registry: item `DefId`s and their fully-qualified paths.
     pub defs: DefTable,
     /// Frequency-and-recency weight per name, accumulated as names resolve
@@ -485,6 +484,8 @@ pub struct Elaborator<'a, 'tcx> {
 pub struct Checkpoint {
     pub(super) defs: usize,
     pub(super) generics: usize,
+    pub(super) traits: usize,
+    pub(super) impls: usize,
     pub(super) trampolines: usize,
     pub(super) transform_anchors: usize,
     pub(super) transform_scripts: usize,
@@ -495,26 +496,24 @@ pub struct Checkpoint {
 }
 
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
-    pub fn new(tcx: &'a TyCtxt<'tcx>, resolver: &'a dyn Resolver<TokenKey>) -> Self {
+    pub fn new(tcx: &'a TyCtxt<'tcx>, interner: &'a reussir_syntax::SessionInterner) -> Self {
+        // Builtin trait defs occupy the first DefIds, declared before any
+        // user or extern item and before the first REPL checkpoint — so
+        // rollback can never retract them. `Builtins::register` is generic
+        // over `&mut impl Interner` (it also serves owned tables, which
+        // genuinely mutate); the session table satisfies that spelling by
+        // a handle copy — an `Arc` clone, not a table copy.
+        let mut defs = DefTable::new();
         let mut traits = TraitDb::new();
-        let builtins = Builtins::register(&mut traits, tcx);
-        let trait_names = [
-            ("Num", builtins.num),
-            ("Integral", builtins.integral),
-            ("FloatingPoint", builtins.floating_point),
-            ("PtrLike", builtins.ptr_like),
-            ("Sync", builtins.sync),
-        ]
-        .into_iter()
-        .collect();
+        let mut handle = interner.clone();
+        let builtins = Builtins::register(&mut traits, &mut defs, &mut handle, tcx);
         Elaborator {
             tcx,
-            resolver,
-            defs: DefTable::new(),
+            resolver: &**interner,
+            defs,
             frecency: Frecency::new(),
             traits,
             builtins,
-            trait_names,
             trampolines: Vec::new(),
             transform_anchors: Vec::new(),
             transform_scripts: Vec::new(),
@@ -923,6 +922,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match kind {
             DefKind::Record => self.defs.lookup_record(&key),
             DefKind::Function => self.defs.lookup_function(&key),
+            DefKind::Trait => self.defs.lookup_trait(&key),
         }
     }
 
@@ -932,6 +932,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match self.defs.info(def).kind {
             DefKind::Record => self.records.get(&def).map(|r| r.visibility),
             DefKind::Function => self.functions.get(&def).map(|f| f.visibility),
+            DefKind::Trait => self
+                .traits
+                .trait_by_def(def)
+                .map(|id| self.traits.trait_def(id).visibility),
         }
     }
 
@@ -950,6 +954,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let what = match kind {
             DefKind::Record => "record",
             DefKind::Function => "function",
+            DefKind::Trait => "trait",
         };
         Some(format!(
             "{what} `{}` in package `{}` is private",
@@ -1063,7 +1068,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Hint for an unknown trait bound, drawn from the built-in trait names.
     /// Built-ins carry no usage history, so every candidate has zero frecency.
     pub(super) fn trait_suggestion(&self, name: &str) -> String {
-        self.fuzzy_hint(name, self.trait_names.keys().map(|&k| (k, 0.0)))
+        self.fuzzy_hint(
+            name,
+            self.defs
+                .trait_names()
+                .map(|k| (self.sym(k), self.frecency.score(k))),
+        )
     }
 
     /// Search `candidates` (each a `(name, frecency)` pair) for the best
@@ -1105,8 +1115,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     /// Every bounded generic's bounds, for the HIR printer's binder
     /// serialization (`$0 (T): Num`). Derived data — no new elaborator
-    /// state. Builtin traits are root names, so each path is one segment;
-    /// user-declared traits will carry their full module path here.
+    /// state. Segments come from the trait's qualified path: builtin traits
+    /// live at the crate root, so their serialization stays one segment.
     pub fn bound_names(&self) -> FxHashMap<GenericId, Vec<hir::Bound>> {
         self.generics
             .iter()
@@ -1117,9 +1127,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     .bounds
                     .iter()
                     .map(|&t| {
-                        hir::Bound::Trait(hir::BoundPath {
-                            segments: vec![self.traits.trait_def(t).name.clone()],
-                        })
+                        let def = self.traits.trait_def(t).def;
+                        let segments = self
+                            .defs
+                            .path(def)
+                            .0
+                            .iter()
+                            .map(|&seg| self.sym(seg).to_owned())
+                            .collect();
+                        hir::Bound::Trait(hir::BoundPath { segments })
                     })
                     .collect();
                 (GenericId(i as u32), bounds)
@@ -1127,23 +1143,77 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .collect()
     }
 
-    /// Resolve a bound path (by basename) to a built-in trait.
-    pub fn resolve_bound(&mut self, path: &surface::Path, span: Option<Span>) -> Option<TraitId> {
-        let name = self.sym(path.basename);
-        self.resolve_bound_name(name, span)
+    /// A trait's display name — its qualified path.
+    pub(super) fn trait_display(&self, id: TraitId) -> String {
+        self.defs
+            .path(self.traits.trait_def(id).def)
+            .display(self.resolver)
     }
 
-    /// Resolve a bound's basename against the builtin trait table — shared by
-    /// surface bounds and the extern reload of serialized interface bounds.
-    pub(super) fn resolve_bound_name(&mut self, name: &str, span: Option<Span>) -> Option<TraitId> {
-        match self.trait_names.get(name) {
-            Some(&id) => Some(id),
-            None => {
-                let hint = self.trait_suggestion(name);
-                self.error(span, format!("unknown trait bound `{name}`{hint}"));
-                None
+    /// Resolve a bound path to a trait, through the trait namespace: extern
+    /// heads gate on `pub`, bare names see the current module then the crate
+    /// root (where the builtins live), qualified paths resolve like any
+    /// other reference.
+    pub fn resolve_bound(&mut self, path: &surface::Path, span: Option<Span>) -> Option<TraitId> {
+        let expanded = self.expand_path(path);
+        let path = expanded.as_ref().unwrap_or(path);
+        let def = if self.extern_head(path).is_some() {
+            self.resolve_extern(path, DefKind::Trait)
+        } else if path.segments.is_empty() {
+            self.defs.resolve_trait(path.basename)
+        } else {
+            self.defs
+                .resolve_trait_path(&self.classify_segs(path), path.basename)
+        };
+        let Some(def) = def else {
+            if let Some(msg) = self.extern_private_msg(path, DefKind::Trait) {
+                self.error(span, msg);
+                return None;
             }
-        }
+            let hint = if path.segments.is_empty() {
+                self.trait_suggestion(self.sym(path.basename))
+            } else {
+                String::new()
+            };
+            let shown = self.path_display(path);
+            self.error(span, format!("unknown trait bound `{shown}`{hint}"));
+            return None;
+        };
+        self.record_use(path.basename);
+        Some(
+            self.traits
+                .trait_by_def(def)
+                .expect("every trait-namespace def has a TraitDb entry"),
+        )
+    }
+
+    /// Resolve a serialized bound's path segments (interned) — the `.rri`
+    /// reload side. Absolute lookup: a single segment is a crate-root name,
+    /// exactly where the builtins live.
+    pub(super) fn resolve_bound_segments(
+        &mut self,
+        segments: &[TokenKey],
+        span: Option<Span>,
+    ) -> Option<TraitId> {
+        let Some(def) = self.defs.lookup_trait(segments) else {
+            let shown = segments
+                .iter()
+                .map(|&s| self.sym(s))
+                .collect::<Vec<_>>()
+                .join("::");
+            let hint = if segments.len() == 1 {
+                self.trait_suggestion(self.sym(segments[0]))
+            } else {
+                String::new()
+            };
+            self.error(span, format!("unknown trait bound `{shown}`{hint}"));
+            return None;
+        };
+        Some(
+            self.traits
+                .trait_by_def(def)
+                .expect("every trait-namespace def has a TraitDb entry"),
+        )
     }
 
     fn resolve_bounds(&mut self, bounds: &[surface::Path], span: Option<Span>) -> Vec<TraitId> {
@@ -1177,13 +1247,16 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// deliberately left to grow — stale entries are unreachable once the
     /// defs that referenced them are retracted.
     ///
-    /// Any *future* accumulated state must be added here: notably, once
-    /// user-defined traits/impls land, `traits` stops being fixed at
-    /// construction and a rejected batch's impls must roll back too.
+    /// Any *future* accumulated state must be added here. The trait registry
+    /// is covered: `traits`/`impls` counters truncate the [`TraitDb`] tails
+    /// (dense ids), so a rejected batch's trait declarations and impls
+    /// retract with their defs.
     pub fn checkpoint(&self) -> Checkpoint {
         Checkpoint {
             defs: self.defs.len(),
             generics: self.generics.len(),
+            traits: self.traits.traits_len(),
+            impls: self.traits.impls_len(),
             trampolines: self.trampolines.len(),
             transform_anchors: self.transform_anchors.len(),
             transform_scripts: self.transform_scripts.len(),
@@ -1206,6 +1279,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.functions.retain(|def, _| def.0 < live);
         self.ffi_imports.retain(|def, _| def.0 < live);
         self.generics.truncate(cp.generics);
+        self.traits.truncate(cp.traits, cp.impls);
         self.trampolines.truncate(cp.trampolines);
         self.transform_anchors.truncate(cp.transform_anchors);
         self.transform_scripts.truncate(cp.transform_scripts);

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1344,7 +1344,22 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                                  mark individual members `pub` instead",
                             );
                         }
-                        impls.push((ib, span, scope));
+                        if ib.trait_ref.is_some() {
+                            // Not collected: members must not be declared as
+                            // inherent methods of the target.
+                            self.error(
+                                span,
+                                "trait implementations (`impl Trait for Type`) \
+                                 are not supported yet",
+                            );
+                        } else {
+                            impls.push((ib, span, scope));
+                        }
+                    }
+                    surface::StmtKind::Trait(_) => {
+                        self.validate_transform_anchor(&attrs, None);
+                        self.reject_ffi_attr(ffi, span);
+                        self.error(span, "`trait` declarations are not supported yet");
                     }
                     // Foreign preludes register during this scan (like
                     // bindings) so they apply file-wide regardless of order.

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -91,12 +91,14 @@ impl<'tcx> Elaborator<'_, 'tcx> {
                 let existing = match info.kind {
                     DefKind::Record => self.defs.lookup_record(&segs),
                     DefKind::Function => self.defs.lookup_function(&segs),
+                    DefKind::Trait => self.defs.lookup_trait(&segs),
                 };
                 let def = existing.unwrap_or_else(|| {
                     self.defs.set_module(module.to_vec());
                     match info.kind {
                         DefKind::Record => self.defs.declare_record(*name),
                         DefKind::Function => self.defs.declare_function(*name),
+                        DefKind::Trait => self.defs.declare_trait(*name),
                     }
                     .expect("a missed lookup cannot clash")
                 });
@@ -108,7 +110,8 @@ impl<'tcx> Elaborator<'_, 'tcx> {
 
         for (pdef, rec) in &parsed.records {
             let def = defs[pdef.0 as usize];
-            let generics = self.remap_generics(&rec.ty_params, &keys, &parsed.generic_bounds);
+            let generics =
+                self.remap_generics(&rec.ty_params, &keys, &parsed.generic_bounds, interner);
             let remap = Remapper {
                 tcx: self.tcx,
                 defs: &defs,
@@ -134,7 +137,8 @@ impl<'tcx> Elaborator<'_, 'tcx> {
 
         for func in &parsed.funcs {
             let def = defs[func.def.0 as usize];
-            let generics = self.remap_generics(&func.generics, &keys, &parsed.generic_bounds);
+            let generics =
+                self.remap_generics(&func.generics, &keys, &parsed.generic_bounds, interner);
             let remap = Remapper {
                 tcx: self.tcx,
                 defs: &defs,
@@ -213,6 +217,7 @@ impl<'tcx> Elaborator<'_, 'tcx> {
         binder: &[(TokenKey, GenericId)],
         keys: &[TokenKey],
         bounds: &FxHashMap<GenericId, Vec<crate::semi::hir::Bound>>,
+        interner: &mut impl Interner<TokenKey>,
     ) -> RemappedGenerics {
         let mut map = FxHashMap::default();
         let binder = binder
@@ -223,8 +228,16 @@ impl<'tcx> Elaborator<'_, 'tcx> {
                     .map(|bs| {
                         bs.iter()
                             .filter_map(|bound| {
-                                let path = bound.trait_path();
-                                self.resolve_bound_name(path.basename(), None)
+                                // Serialized paths resolve absolutely: one
+                                // segment is a crate-root name, where the
+                                // builtins live.
+                                let segs: Vec<TokenKey> = bound
+                                    .trait_path()
+                                    .segments
+                                    .iter()
+                                    .map(|s| interner.get_or_intern(s))
+                                    .collect();
+                                self.resolve_bound_segments(&segs, None)
                             })
                             .collect()
                     })

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -224,7 +224,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 {
                     Discharge::Solved
                 } else {
-                    let name = &self.traits.trait_def(want).name;
+                    let name = self.trait_display(want);
                     Discharge::Failed(format!(
                         "the bound `{name}` is not satisfied by this generic"
                     ))
@@ -268,7 +268,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 match self.traits.select(&goal) {
                     Ok(_) => Discharge::Solved,
                     Err(_) => {
-                        let name = &self.traits.trait_def(tref.trait_id).name;
+                        let name = self.trait_display(tref.trait_id);
                         Discharge::Failed(format!(
                             "`{}` does not implement `{name}`",
                             self.ty_display(self_ty)

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -722,10 +722,11 @@ mod tests {
     /// equality.
     fn roundtrip(source: &str) {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
             let strings = elab.strings.entries();
@@ -772,10 +773,11 @@ mod tests {
     fn roundtrip_with_locations(source: &str) {
         use reussir_syntax::source::SourceCache;
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
             let cache = SourceCache::single("<test>", source);
@@ -834,10 +836,11 @@ mod tests {
         let file_name = r#"<quoted"path\name>"#;
 
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
             let mut cache = SourceCache::new();
@@ -1026,10 +1029,11 @@ mod tests {
     fn if_without_else_matches_explicit_empty_else() {
         fn printed_hir(source: &str) -> String {
             with_tcx(|tcx| {
-                let parse = reussir_syntax::parse(source);
+                let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+                let parse = reussir_syntax::parse_with_interner(source, interner.clone());
                 assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
                 let prog = surface::program(&parse.root);
-                let elab = elaborate(tcx, &prog, parse.resolver());
+                let elab = elaborate(tcx, &prog, &interner);
                 assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
                 let strings = elab.strings.entries();
                 Printer::new(&elab.defs, elab.resolver).program(
@@ -1081,10 +1085,11 @@ mod tests {
                           struct Hidden { value: i64 } \
                           pub fn get(d: Data) -> i64 { d.value } \
                           fn peek(h: Hidden) -> i64 { h.value }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
             let strings = elab.strings.entries();
@@ -1175,10 +1180,11 @@ mod tests {
                       fn f<T : Integral + Sync>(x: T) -> T { x }\n\
                       fn g<T>(x: T) -> T { x }";
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
             let strings = elab.strings.entries();
@@ -1246,10 +1252,11 @@ mod tests {
             let source = "pub struct [value] S { pub x: i64, y: i64 }\n\
                           pub struct T(pub i64, i64)\n\
                           pub struct [regional] R { pub c: [field] R, d: i64 }";
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             assert!(!elab.has_errors(), "elab errors: {:#?}", elab.reports);
 
             let strings = elab.strings.entries();

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -965,10 +965,11 @@ mod tests {
     /// Elaborate a source string and return its diagnostics.
     fn reports_of(source: &str) -> Vec<crate::semi::Report> {
         with_tcx(|tcx| {
-            let parse = reussir_syntax::parse(source);
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
             let prog = surface::program(&parse.root);
-            let elab = elaborate(tcx, &prog, parse.resolver());
+            let elab = elaborate(tcx, &prog, &interner);
             elab.reports.clone()
         })
     }

--- a/crates/reussir-core/src/semi/repl.rs
+++ b/crates/reussir-core/src/semi/repl.rs
@@ -373,7 +373,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 mod tests {
     use std::sync::Arc;
 
-    use reussir_syntax::{Interner, MultiThreadedTokenInterner, new_threaded_interner};
+    use reussir_syntax::{MultiThreadedTokenInterner, SharedInterner, new_threaded_interner};
 
     use crate::semi::repl::ReplExprRequest;
     use crate::semi::ty::{FpTy, IntTy, Ty, TyCtxt, TyKind};
@@ -407,9 +407,8 @@ mod tests {
             let expr = surface::repl_expr(&p.parse.root);
             let export = format!("__repl_expr_{}", self.counter);
             self.counter += 1;
-            let key = Interner::get_or_intern(&mut self.interner.clone(), &export);
-            let dec_key =
-                Interner::get_or_intern(&mut self.interner.clone(), &format!("{export}_dec"));
+            let key = self.interner.intern(&export);
+            let dec_key = self.interner.intern(&format!("{export}_dec"));
             self.elab
                 .try_repl_expr(
                     &ReplExprRequest {
@@ -429,15 +428,10 @@ mod tests {
     fn session<R>(f: impl for<'a, 'tcx> FnOnce(&mut Session<'a, 'tcx>, &TyCtxt<'tcx>) -> R) -> R {
         with_tcx(|tcx| {
             let interner = Arc::new(new_threaded_interner());
-            // The elaborator borrows the session interner as its resolver —
-            // the same shape a real REPL driver uses.
-            let resolver: &dyn reussir_syntax::kind::Resolver<reussir_syntax::kind::TokenKey> =
-                &interner;
-            let mut interning = interner.clone();
-            let box_name = Interner::get_or_intern(&mut interning, "__ReplBox");
-            let box_param = Interner::get_or_intern(&mut interning, "T");
-            let box_field = Interner::get_or_intern(&mut interning, "value");
-            let mut elab = Elaborator::new(tcx, resolver);
+            let box_name = interner.intern("__ReplBox");
+            let box_param = interner.intern("T");
+            let box_field = interner.intern("value");
+            let mut elab = Elaborator::new(tcx, &interner);
             let repl_box = elab
                 .install_repl_box(box_name, box_param, box_field)
                 .expect("fresh session");
@@ -574,13 +568,13 @@ mod tests {
             // it: the wrapper takes the binding's box as a parameter and
             // projects the value in a prologue.
             let x_ty = s.eval("41").expect("bind rhs");
-            let x_key = Interner::get_or_intern(&mut s.interner.clone(), "x");
+            let x_key = s.interner.intern("x");
 
             let p = reussir_syntax::parse_repl("x + 1", s.interner.clone());
             assert!(p.parse.ok());
             let expr = surface::repl_expr(&p.parse.root);
-            let key = Interner::get_or_intern(&mut s.interner.clone(), "__repl_expr_1");
-            let dec = Interner::get_or_intern(&mut s.interner.clone(), "__repl_expr_1_dec");
+            let key = s.interner.intern("__repl_expr_1");
+            let dec = s.interner.intern("__repl_expr_1_dec");
             let (ty, _) = s
                 .elab
                 .try_repl_expr(
@@ -610,8 +604,8 @@ mod tests {
             // An unknown name still errors cleanly.
             let p = reussir_syntax::parse_repl("y + 1", s.interner.clone());
             let expr = surface::repl_expr(&p.parse.root);
-            let key = Interner::get_or_intern(&mut s.interner.clone(), "__repl_expr_2");
-            let dec = Interner::get_or_intern(&mut s.interner.clone(), "__repl_expr_2_dec");
+            let key = s.interner.intern("__repl_expr_2");
+            let dec = s.interner.intern("__repl_expr_2_dec");
             let errs = s
                 .elab
                 .try_repl_expr(

--- a/crates/reussir-core/src/semi/resolve.rs
+++ b/crates/reussir-core/src/semi/resolve.rs
@@ -29,6 +29,7 @@ use crate::semi::ty::DefId;
 pub enum DefKind {
     Record,
     Function,
+    Trait,
 }
 
 /// A fully-qualified item path: the enclosing module segments, then the item
@@ -80,10 +81,11 @@ pub struct DefTable {
     /// The module path items currently declare under and bare references
     /// resolve against (empty = crate root; `[pkg, sub]` inside a package).
     module: Vec<TokenKey>,
-    /// Type-namespace scope (records) and value-namespace scope (functions),
-    /// keyed by the item's full qualified path.
+    /// Type-namespace scope (records), value-namespace scope (functions),
+    /// and trait-namespace scope, keyed by the item's full qualified path.
     types: FxHashMap<Box<[TokenKey]>, DefId>,
     values: FxHashMap<Box<[TokenKey]>, DefId>,
+    traits: FxHashMap<Box<[TokenKey]>, DefId>,
 }
 
 impl DefTable {
@@ -133,6 +135,12 @@ impl DefTable {
         self.declare(|s| &mut s.values, name, DefKind::Function)
     }
 
+    /// Declare a trait in the current module's trait namespace. `None` on
+    /// clash.
+    pub fn declare_trait(&mut self, name: TokenKey) -> Option<DefId> {
+        self.declare(|s| &mut s.traits, name, DefKind::Trait)
+    }
+
     /// Look up an exact fully-qualified path in the type namespace.
     pub fn lookup_record(&self, path: &[TokenKey]) -> Option<DefId> {
         self.types.get(path).copied()
@@ -141,6 +149,11 @@ impl DefTable {
     /// Look up an exact fully-qualified path in the value namespace.
     pub fn lookup_function(&self, path: &[TokenKey]) -> Option<DefId> {
         self.values.get(path).copied()
+    }
+
+    /// Look up an exact fully-qualified path in the trait namespace.
+    pub fn lookup_trait(&self, path: &[TokenKey]) -> Option<DefId> {
+        self.traits.get(path).copied()
     }
 
     /// Resolve a *bare* type reference: the current module first, then the
@@ -153,6 +166,13 @@ impl DefTable {
     /// crate root.
     pub fn resolve_function(&self, name: TokenKey) -> Option<DefId> {
         self.resolve_bare(&self.values, name)
+    }
+
+    /// Resolve a *bare* trait reference: the current module first, then the
+    /// crate root (where the builtin traits live, giving them prelude
+    /// visibility that a same-named module-local trait shadows).
+    pub fn resolve_trait(&self, name: TokenKey) -> Option<DefId> {
+        self.resolve_bare(&self.traits, name)
     }
 
     fn resolve_bare(
@@ -176,6 +196,11 @@ impl DefTable {
     /// Resolve a *qualified* value reference (see [`Self::resolve_qualified`]).
     pub fn resolve_function_path(&self, segs: &[PathSeg], name: TokenKey) -> Option<DefId> {
         self.resolve_qualified(&self.values, segs, name)
+    }
+
+    /// Resolve a *qualified* trait reference (see [`Self::resolve_qualified`]).
+    pub fn resolve_trait_path(&self, segs: &[PathSeg], name: TokenKey) -> Option<DefId> {
+        self.resolve_qualified(&self.traits, segs, name)
     }
 
     /// Resolve `segs::name` against the current module:
@@ -262,6 +287,14 @@ impl DefTable {
             .map(|p| *p.last().expect("paths are never empty"))
     }
 
+    /// Every trait name (the item's own, unqualified name) in the trait
+    /// namespace, for "did you mean" suggestions.
+    pub fn trait_names(&self) -> impl Iterator<Item = TokenKey> + '_ {
+        self.traits
+            .keys()
+            .map(|p| *p.last().expect("paths are never empty"))
+    }
+
     /// The number of declared defs — a checkpoint for [`DefTable::truncate`].
     pub fn len(&self) -> usize {
         self.defs.len()
@@ -282,6 +315,7 @@ impl DefTable {
             let scope = match info.kind {
                 DefKind::Record => &mut self.types,
                 DefKind::Function => &mut self.values,
+                DefKind::Trait => &mut self.traits,
             };
             let removed = scope.remove(info.path.0.as_slice());
             debug_assert_eq!(removed, Some(id), "scope must point at the popped def");
@@ -417,6 +451,32 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn trait_namespace_is_independent() {
+        let mut t = DefTable::new();
+        let name = k(1);
+        let r = t.declare_record(name).expect("record");
+        let f = t.declare_function(name).expect("function");
+        let tr = t.declare_trait(name).expect("trait");
+        assert!(r != f && f != tr && r != tr);
+        assert_eq!(t.resolve_trait(name), Some(tr));
+        // A second trait of the same name in the same module clashes.
+        assert!(t.declare_trait(name).is_none());
+    }
+
+    #[test]
+    fn truncate_retracts_a_trait_def() {
+        let mut t = DefTable::new();
+        let name = k(1);
+        let live = t.len();
+        let tr = t.declare_trait(name).expect("trait");
+        assert_eq!(t.lookup_trait(&[name]), Some(tr));
+        t.truncate(live);
+        assert_eq!(t.lookup_trait(&[name]), None);
+        // The retracted name is reusable.
+        assert!(t.declare_trait(name).is_some());
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/traits/builtins.rs
+++ b/crates/reussir-core/src/semi/traits/builtins.rs
@@ -18,7 +18,12 @@
 //! and bound syntax only: ground `Sync` goals are answered *structurally* by
 //! [`crate::semi::traits::sync`], never by impl search, so it has no impls.
 
+use reussir_syntax::Interner;
+use reussir_syntax::kind::TokenKey;
+
+use crate::semi::resolve::DefTable;
 use crate::semi::ty::{FpTy, GenericId, IntTy, Ty, TyCtxt};
+use crate::surface;
 
 use super::def::{ImplDef, TraitDef};
 use super::{ImplId, TraitDb, TraitId, TraitRef};
@@ -36,9 +41,21 @@ pub struct Builtins {
 }
 
 impl Builtins {
-    /// Register the built-in traits and their primitive impls into `db`.
-    pub fn register<'tcx>(db: &mut TraitDb<'tcx>, tcx: &TyCtxt<'tcx>) -> Builtins {
-        // Every built-in trait has a single `Self` parameter, generic #0.
+    /// Register the built-in traits and their primitive impls into `db`,
+    /// declaring each trait in `defs`' trait namespace at the crate root —
+    /// so a bare `Num` resolves from any module through the root fallback
+    /// (prelude visibility), while a same-named user trait in a module
+    /// shadows it for bare references.
+    pub fn register<'tcx>(
+        db: &mut TraitDb<'tcx>,
+        defs: &mut DefTable,
+        interner: &mut impl Interner<TokenKey>,
+        tcx: &TyCtxt<'tcx>,
+    ) -> Builtins {
+        // Every built-in trait has a single `Self` parameter, generic #0 —
+        // deliberately UNALLOCATED in the elaborator's generics table (the
+        // builtin defs predate it, and allocating would shift every dump's
+        // `$n` numbering).
         let self_g = GenericId(0);
         let self_ref = |trait_id: TraitId| TraitRef {
             trait_id,
@@ -57,21 +74,32 @@ impl Builtins {
         let ptr_like = fresh_trait();
         let sync = fresh_trait();
 
-        let declare = |id, name: &str, supertraits, db: &mut TraitDb<'tcx>| {
-            db.add_trait(TraitDef {
-                id,
-                name: name.to_owned(),
-                params: vec![self_g],
-                supertraits,
-                methods: vec![],
-                assoc_tys: vec![],
-            });
-        };
-        declare(num, "Num", vec![], db);
-        declare(integral, "Integral", vec![self_ref(num)], db);
-        declare(floating_point, "FloatingPoint", vec![self_ref(num)], db);
-        declare(ptr_like, "PtrLike", vec![], db);
-        declare(sync, "Sync", vec![], db);
+        let mut declare =
+            |id, name: &str, supertraits, db: &mut TraitDb<'tcx>, defs: &mut DefTable| {
+                let key = interner.get_or_intern(name);
+                let def = defs.declare_trait(key).expect("builtins precede user defs");
+                db.add_trait(TraitDef {
+                    id,
+                    def,
+                    visibility: surface::Visibility::Public,
+                    sealed: true,
+                    params: vec![self_g],
+                    supertraits,
+                    methods: vec![],
+                    assoc_tys: vec![],
+                });
+            };
+        declare(num, "Num", vec![], db, defs);
+        declare(integral, "Integral", vec![self_ref(num)], db, defs);
+        declare(
+            floating_point,
+            "FloatingPoint",
+            vec![self_ref(num)],
+            db,
+            defs,
+        );
+        declare(ptr_like, "PtrLike", vec![], db, defs);
+        declare(sync, "Sync", vec![], db, defs);
 
         let mut next_impl = 0u32;
         let mut implement = |trait_id: TraitId, self_ty: Ty<'tcx>, db: &mut TraitDb<'tcx>| {

--- a/crates/reussir-core/src/semi/traits/db.rs
+++ b/crates/reussir-core/src/semi/traits/db.rs
@@ -8,6 +8,10 @@
 //! type is still a hole all arrive in Phase 1 — slotting into this same
 //! [`TraitDb::select`] entry point.
 
+use rustc_hash::FxHashMap;
+
+use crate::semi::ty::DefId;
+
 use super::def::{ImplDef, TraitDef};
 use super::{Evidence, ImplId, Obligation, TraitId, TraitRef};
 
@@ -16,6 +20,8 @@ use super::{Evidence, ImplId, Obligation, TraitId, TraitRef};
 pub struct TraitDb<'tcx> {
     traits: Vec<TraitDef<'tcx>>,
     impls: Vec<ImplDef<'tcx>>,
+    /// The dense [`TraitId`] of each path-keyed trait def.
+    by_def: FxHashMap<DefId, TraitId>,
 }
 
 /// Why an obligation could not be discharged.
@@ -39,8 +45,42 @@ impl<'tcx> TraitDb<'tcx> {
             "trait ids must be dense"
         );
         let id = def.id;
+        let displaced = self.by_def.insert(def.def, id);
+        debug_assert!(displaced.is_none(), "one TraitDb entry per trait def");
         self.traits.push(def);
         id
+    }
+
+    /// The dense id of the trait declared under `def`, if any. Every
+    /// trait-namespace def has an entry — the elaborator registers them
+    /// together.
+    pub fn trait_by_def(&self, def: DefId) -> Option<TraitId> {
+        self.by_def.get(&def).copied()
+    }
+
+    /// Checkpoint counters for [`TraitDb::truncate`].
+    pub fn traits_len(&self) -> usize {
+        self.traits.len()
+    }
+
+    pub fn impls_len(&self) -> usize {
+        self.impls.len()
+    }
+
+    /// Retract every trait past `traits` and every impl past `impls` — the
+    /// REPL's atomic-rollback hook, mirroring `DefTable::truncate` (ids are
+    /// dense, so popping the tails restores exactly the checkpointed state).
+    pub fn truncate(&mut self, traits: usize, impls: usize) {
+        while self.traits.len() > traits {
+            let def = self.traits.pop().expect("len checked above");
+            let removed = self.by_def.remove(&def.def);
+            debug_assert_eq!(
+                removed,
+                Some(def.id),
+                "by_def must point at the popped trait"
+            );
+        }
+        self.impls.truncate(impls);
     }
 
     pub fn add_impl(&mut self, def: ImplDef<'tcx>) -> ImplId {
@@ -159,10 +199,81 @@ mod tests {
     }
 
     #[test]
+    fn truncate_retracts_traits_and_impls() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut db = TraitDb::new();
+            let mut defs = crate::semi::resolve::DefTable::new();
+            let mut interner = lasso::Rodeo::<reussir_syntax::kind::TokenKey>::new();
+            let b = Builtins::register(&mut db, &mut defs, &mut interner, tcx);
+            let (traits, impls) = (db.traits_len(), db.impls_len());
+
+            // Register a user trait + impl past the builtins, then retract.
+            let key = reussir_syntax::Interner::get_or_intern(&mut interner, "Show");
+            let def = defs.declare_trait(key).expect("fresh");
+            let id = TraitId(traits as u32);
+            db.add_trait(TraitDef {
+                id,
+                def,
+                visibility: crate::surface::Visibility::Public,
+                sealed: false,
+                params: vec![crate::semi::ty::GenericId(0)],
+                supertraits: vec![],
+                methods: vec![],
+                assoc_tys: vec![],
+            });
+            let unit = tcx.mk_unit();
+            db.add_impl(ImplDef {
+                id: ImplId(impls as u32),
+                generics: vec![],
+                trait_ref: TraitRef {
+                    trait_id: id,
+                    args: vec![unit],
+                },
+                self_ty: unit,
+                where_clauses: vec![],
+            });
+            assert_eq!(db.trait_by_def(def), Some(id));
+
+            db.truncate(traits, impls);
+            assert_eq!(db.traits_len(), traits);
+            assert_eq!(db.impls_len(), impls);
+            assert_eq!(db.trait_by_def(def), None);
+            // The builtins survive and re-adding at the same dense ids works.
+            assert_eq!(db.trait_by_def(db.trait_def(b.num).def), Some(b.num));
+            db.add_trait(TraitDef {
+                id,
+                def,
+                visibility: crate::surface::Visibility::Public,
+                sealed: false,
+                params: vec![crate::semi::ty::GenericId(0)],
+                supertraits: vec![],
+                methods: vec![],
+                assoc_tys: vec![],
+            });
+            assert_eq!(db.trait_by_def(def), Some(id));
+        });
+    }
+
+    #[test]
+    fn trait_by_def_round_trips_builtins() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut db = TraitDb::new();
+            let mut defs = crate::semi::resolve::DefTable::new();
+            let mut interner = lasso::Rodeo::<reussir_syntax::kind::TokenKey>::new();
+            let b = Builtins::register(&mut db, &mut defs, &mut interner, tcx);
+            for id in [b.num, b.integral, b.floating_point, b.ptr_like, b.sync] {
+                assert_eq!(db.trait_by_def(db.trait_def(id).def), Some(id));
+            }
+        });
+    }
+
+    #[test]
     fn primitive_membership_is_data_not_hardcoded() {
         with_tcx(|tcx: &TyCtxt| {
             let mut db = TraitDb::new();
-            let b = Builtins::register(&mut db, tcx);
+            let mut defs = crate::semi::resolve::DefTable::new();
+            let mut interner = lasso::Rodeo::<reussir_syntax::kind::TokenKey>::new();
+            let b = Builtins::register(&mut db, &mut defs, &mut interner, tcx);
 
             let i32 = tcx.mk_int(IntTy::Signed(32));
             let f32 = tcx.mk_fp(FpTy::Ieee(32));
@@ -198,17 +309,19 @@ mod tests {
                 args: vec![tcx.mk_generic(self_g)],
             };
             let (top, mid, sub) = (TraitId(0), TraitId(1), TraitId(2));
-            let def = |id: TraitId, name: &str, supers| TraitDef {
+            let def = |id: TraitId, def: u32, supers| TraitDef {
                 id,
-                name: name.to_owned(),
+                def: crate::semi::ty::DefId(def),
+                visibility: crate::surface::Visibility::Public,
+                sealed: false,
                 params: vec![self_g],
                 supertraits: supers,
                 methods: vec![],
                 assoc_tys: vec![],
             };
-            db.add_trait(def(top, "Top", vec![]));
-            db.add_trait(def(mid, "Mid", vec![self_ref(top)]));
-            db.add_trait(def(sub, "Sub", vec![self_ref(mid)]));
+            db.add_trait(def(top, 0, vec![]));
+            db.add_trait(def(mid, 1, vec![self_ref(top)]));
+            db.add_trait(def(sub, 2, vec![self_ref(mid)]));
 
             let unit = tcx.mk_unit();
             db.add_impl(ImplDef {

--- a/crates/reussir-core/src/semi/traits/def.rs
+++ b/crates/reussir-core/src/semi/traits/def.rs
@@ -3,7 +3,8 @@
 //! These are the program's trait items after name resolution. Method bodies are
 //! deliberately absent in Phase 0 — only the shapes the resolver needs.
 
-use crate::semi::ty::{GenericId, Ty};
+use crate::semi::ty::{DefId, GenericId, Ty};
+use crate::surface;
 
 use super::{ImplId, Obligation, TraitId, TraitRef};
 
@@ -26,7 +27,17 @@ pub struct AssocTyDef {
 #[derive(Clone, Debug)]
 pub struct TraitDef<'tcx> {
     pub id: TraitId,
-    pub name: String,
+    /// The trait's path-keyed identity in the [`DefTable`] — the single
+    /// source of its name and module for display, resolution, and
+    /// serialization.
+    ///
+    /// [`DefTable`]: crate::semi::resolve::DefTable
+    pub def: DefId,
+    pub visibility: surface::Visibility,
+    /// A sealed trait cannot be implemented by user code: the builtin
+    /// value-class traits (whose operations lower by ground type) and the
+    /// structural `Sync`.
+    pub sealed: bool,
     /// Type parameters; `params[0]` is the implicit `Self`.
     pub params: Vec<GenericId>,
     /// Super-traits (`trait Sub: Super`). These subsume the old hard-coded class

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -974,6 +974,34 @@ pub enum StmtKind {
     Transform(TransformScript),
     Import(ImportDecl),
     Impl(ImplBlock),
+    Trait(TraitDecl),
+}
+
+/// A `trait Name<T>: A + B { fn m(...) -> U; }` declaration. `Self` is
+/// implicit and not listed among `generics`; member signatures have
+/// `body`/`foreign_body` = `None` (the parser rejects bodies).
+#[derive(Clone, Debug)]
+pub struct TraitDecl {
+    pub visibility: Visibility,
+    pub name: TokenKey,
+    /// Each declared generic is `(name, bounds)`.
+    pub generics: SmallVec<[(TokenKey, Vec<Path>); 2]>,
+    /// Supertrait references from the `: A + B<C>` list.
+    pub supertraits: Vec<TraitRef>,
+    pub members: Vec<Spanned<Function>>,
+}
+
+/// A trait reference in the surface syntax: a qualified path plus its type
+/// arguments (`Eq`, `pkg::Convert<K>`) — the shape shared by supertrait
+/// lists and `impl` trait heads. Arguments always parse and project;
+/// whether a position *admits* them is the elaborator's call (supertrait
+/// references reject a non-empty list this cut — trait references are not
+/// parameterized yet, though the layers below already carry argument lists
+/// end to end).
+#[derive(Clone, Debug)]
+pub struct TraitRef {
+    pub path: Path,
+    pub args: SmallVec<[Type; 2]>,
 }
 
 /// An `impl<T: B> Type<args> { fn ... }` block: the block-level generics, the
@@ -985,6 +1013,9 @@ pub struct ImplBlock {
     pub visibility: Visibility,
     /// Each block-level generic is `(name, bounds)`.
     pub generics: SmallVec<[(TokenKey, Vec<Path>); 2]>,
+    /// `Some((path, args))` for a trait implementation
+    /// `impl Trait<args> for Type`; `None` for an inherent block.
+    pub trait_ref: Option<TraitRef>,
     pub target: Path,
     pub target_args: SmallVec<[Type; 2]>,
     pub members: Vec<Spanned<Function>>,
@@ -1024,6 +1055,7 @@ impl Stmt {
             TransformStmt => StmtKind::Transform(transform_of(node)),
             ImportStmt => StmtKind::Import(import_of(node)),
             ImplStmt => StmtKind::Impl(impl_of(node)),
+            TraitStmt => StmtKind::Trait(trait_of(node)),
             k => unreachable!("unexpected statement node {k:?}"),
         }
     }
@@ -1067,6 +1099,23 @@ fn attribute_of(node: &ResolvedNode) -> Attribute {
         values,
         span: node_span(node),
     }
+}
+
+/// The defining name of an item introduced by a *contextual* keyword (which
+/// lexes as a plain `Ident`): the first identifier-like direct token after
+/// the first `Ident` spelled `intro`. (`pub trait trait` names a trait
+/// `trait`: PubKw is ident-like but not Ident-kind, so the introducer scan
+/// skips it.)
+fn name_after_text<'n>(node: &'n ResolvedNode, intro: &str) -> &'n ResolvedToken {
+    let mut seen_intro = false;
+    for t in tokens(node) {
+        if !seen_intro && t.kind() == Ident && t.text() == intro {
+            seen_intro = true;
+        } else if seen_intro && t.kind().is_ident_like() {
+            return t;
+        }
+    }
+    panic!("missing name token in {:?}", node.kind())
 }
 
 fn visibility_of(node: &ResolvedNode) -> Visibility {
@@ -1138,12 +1187,11 @@ fn source_block_of(node: &ResolvedNode) -> Option<SourceBlock> {
     })
 }
 
-fn impl_of(node: &ResolvedNode) -> ImplBlock {
-    let target_ty = nodes(node)
-        .find(|n| n.kind() == PathType)
-        .expect("impl target type");
-    let target = path_of(child_node(target_ty, PathKind).expect("target path"));
-    let target_args = child_node(target_ty, TypeArgList)
+/// Split a `PathType` node into its qualified path and type arguments —
+/// the projection behind every [`TraitRef`] and `impl` head.
+fn path_type_parts(ty: &ResolvedNode) -> (Path, SmallVec<[Type; 2]>) {
+    let path = path_of(child_node(ty, PathKind).expect("type path"));
+    let args = child_node(ty, TypeArgList)
         .map(|l| {
             nodes(l)
                 .filter(|n| is_type_kind(n.kind()))
@@ -1151,6 +1199,23 @@ fn impl_of(node: &ResolvedNode) -> ImplBlock {
                 .collect()
         })
         .unwrap_or_default();
+    (path, args)
+}
+
+fn trait_ref_of(ty: &ResolvedNode) -> TraitRef {
+    let (path, args) = path_type_parts(ty);
+    TraitRef { path, args }
+}
+
+fn impl_of(node: &ResolvedNode) -> ImplBlock {
+    // Two direct PathType heads iff the `for` separator was parsed: the
+    // first is then the trait reference, the second the target.
+    let mut heads = nodes(node).filter(|n| n.kind() == PathType);
+    let first = heads.next().expect("impl target type");
+    let (trait_ref, (target, target_args)) = match heads.next() {
+        Some(second) => (Some(trait_ref_of(first)), path_type_parts(second)),
+        None => (None, path_type_parts(first)),
+    };
     let members = nodes(node)
         .filter(|n| n.kind() == FnStmt)
         .map(|f| spanned(f, function_of(f)))
@@ -1158,9 +1223,29 @@ fn impl_of(node: &ResolvedNode) -> ImplBlock {
     ImplBlock {
         visibility: visibility_of(node),
         generics: generics_of(node),
+        trait_ref,
         target,
         target_args,
         members,
+    }
+}
+
+fn trait_of(node: &ResolvedNode) -> TraitDecl {
+    TraitDecl {
+        visibility: visibility_of(node),
+        name: key(name_after_text(node, "trait")),
+        generics: generics_of(node),
+        // Direct PathType children of TraitStmt are exactly the supertrait
+        // list: the name is a token, bound paths nest under
+        // GenericParamList, and member types nest under FnStmt.
+        supertraits: nodes(node)
+            .filter(|n| n.kind() == PathType)
+            .map(trait_ref_of)
+            .collect(),
+        members: nodes(node)
+            .filter(|n| n.kind() == FnStmt)
+            .map(|f| spanned(f, function_of(f)))
+            .collect(),
     }
 }
 
@@ -1418,6 +1503,69 @@ mod tests {
         assert!(touch.is_regional);
         let (_, _, rflex) = &touch.params[0];
         assert!(rflex, "the `[flex]` receiver flag projects");
+    }
+
+    #[test]
+    fn trait_decl_projects_name_generics_supers_and_sig_members() {
+        let parse = parse(
+            "pub trait Ord<T: Num>: Eq + Show {
+                 fn cmp(self: Self, other: T) -> i64;
+                 fn zero() -> T;
+             }",
+        );
+        let prog = program(&parse.root);
+        let resolver = parse.resolver();
+        let StmtKind::Trait(decl) = prog[0].kind() else {
+            panic!("expected a trait declaration");
+        };
+        assert_eq!(decl.visibility, Visibility::Public);
+        assert_eq!(resolver.resolve(decl.name), "Ord");
+        assert_eq!(decl.generics.len(), 1);
+        assert_eq!(decl.generics[0].1.len(), 1, "bound carried");
+        let supers: Vec<&str> = decl
+            .supertraits
+            .iter()
+            .map(|s| resolver.resolve(s.path.basename))
+            .collect();
+        assert_eq!(supers, ["Eq", "Show"]);
+        // Supertrait references carry their arguments structurally.
+        assert!(decl.supertraits.iter().all(|s| s.args.is_empty()));
+        assert_eq!(decl.members.len(), 2);
+        let cmp = &decl.members[0].value;
+        assert!(cmp.body.is_none());
+        assert_eq!(resolver.resolve(cmp.params[0].0), "self");
+        // The receiver is optional at the view level: statics project too.
+        assert!(decl.members[1].value.params.is_empty());
+    }
+
+    #[test]
+    fn impl_of_projects_trait_ref() {
+        let parse = parse("impl<T: Num> Show<T> for Vec<T> { fn show(self: Self) -> i64 { 1 } }");
+        let prog = program(&parse.root);
+        let resolver = parse.resolver();
+        let StmtKind::Impl(ib) = prog[0].kind() else {
+            panic!("expected an impl block");
+        };
+        let tr = ib.trait_ref.as_ref().expect("trait ref");
+        assert_eq!(resolver.resolve(tr.path.basename), "Show");
+        assert_eq!(tr.args.len(), 1);
+        assert_eq!(resolver.resolve(ib.target.basename), "Vec");
+        assert_eq!(ib.target_args.len(), 1);
+        assert_eq!(ib.members.len(), 1);
+    }
+
+    /// The greedy `for` projection rule: a lone head named `for` is the
+    /// inherent target.
+    #[test]
+    fn for_named_type_projects_as_inherent_target() {
+        let parse = parse("impl for { fn get(self: Self) -> i64 { 1 } }");
+        let prog = program(&parse.root);
+        let resolver = parse.resolver();
+        let StmtKind::Impl(ib) = prog[0].kind() else {
+            panic!("expected an impl block");
+        };
+        assert!(ib.trait_ref.is_none());
+        assert_eq!(resolver.resolve(ib.target.basename), "for");
     }
 
     #[test]

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -145,6 +145,7 @@ impl Emitter<'_> {
             TransformStmt => self.transform_stmt(node),
             ImportStmt => self.import_stmt(node),
             ImplStmt => self.impl_stmt(node),
+            TraitStmt => self.trait_stmt(node),
             k => unreachable!("unexpected statement node {k:?}"),
         };
         tagged("SpannedStmt", self.with_node_span(node, inner))
@@ -339,9 +340,15 @@ impl Emitter<'_> {
     }
 
     fn impl_stmt(&self, node: &ResolvedNode) -> Value {
-        let target = nodes(node)
-            .find(|n| n.kind() == PathType)
-            .expect("impl target type");
+        // Two direct PathType heads iff the `for` separator was parsed: the
+        // first is then the trait reference, the second the target.
+        let mut heads = nodes(node).filter(|n| n.kind() == PathType);
+        let first = heads.next().expect("impl target type");
+        let second = heads.next();
+        let (trait_ref, target) = match second {
+            Some(second) => (Some(first), second),
+            None => (None, first),
+        };
         let members: Vec<Value> = nodes(node)
             .filter(|n| n.kind() == FnStmt)
             .map(|f| self.with_node_span(f, self.fn_stmt(f)))
@@ -351,8 +358,46 @@ impl Emitter<'_> {
             json!({
                 "implVisibility": self.visibility(node),
                 "implGenerics": self.generic_params(node),
+                "implTrait": trait_ref.map_or(Value::Null, |t| self.type_(t)),
                 "implTarget": self.type_(target),
                 "implMembers": members,
+            }),
+        )
+    }
+
+    fn trait_stmt(&self, node: &ResolvedNode) -> Value {
+        // The introducer lexes as a plain `Ident` spelled `trait`; the name
+        // is the first ident-like token after it (`pub trait trait` names a
+        // trait `trait` — PubKw is ident-like but not Ident-kind).
+        let mut seen_intro = false;
+        let mut name = None;
+        for t in tokens(node) {
+            if !seen_intro && t.kind() == Ident && t.text() == "trait" {
+                seen_intro = true;
+            } else if seen_intro && is_ident_like(t.kind()) {
+                name = Some(t);
+                break;
+            }
+        }
+        let name = name.expect("trait name");
+        // Supertrait references are path types, emitted exactly like the
+        // `impl` trait head so both spellings share one JSON shape.
+        let supers: Vec<Value> = nodes(node)
+            .filter(|n| n.kind() == PathType)
+            .map(|p| self.type_(p))
+            .collect();
+        let members: Vec<Value> = nodes(node)
+            .filter(|n| n.kind() == FnStmt)
+            .map(|f| self.with_node_span(f, self.fn_stmt(f)))
+            .collect();
+        tagged(
+            "TraitStmt",
+            json!({
+                "traitVisibility": self.visibility(node),
+                "traitName": name.text(),
+                "traitGenerics": self.generic_params(node),
+                "traitSupers": supers,
+                "traitMembers": members,
             }),
         )
     }

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -132,6 +132,9 @@ pub enum SyntaxKind {
     ImportStmt,
     /// `impl<T: B> Type<T> { fn ... }` — an inherent-method block.
     ImplStmt,
+    /// A trait declaration (method signatures only):
+    /// `trait Name<T>: A + B { fn m(...) -> U; }`.
+    TraitStmt,
     GenericParamList,
     GenericParam,
     ParamList,

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -151,10 +151,12 @@ fn repl_route(p: &parser::Parser) -> ReplInputKind {
         // `extern "C" trampoline ...` — a string cannot follow a variable.
         ExternKw => p.nth(1) == StringLit,
         // `pub <item>` — mirrors `stmt`'s post-visibility dispatch.
-        PubKw => matches!(
-            p.nth(1),
-            RegionalKw | FnKw | StructKw | EnumKw | ModKw | ExternKw | ImportKw
-        ),
+        PubKw => {
+            matches!(
+                p.nth(1),
+                RegionalKw | FnKw | StructKw | EnumKw | ModKw | ExternKw | ImportKw
+            ) || (p.nth_text(1) == "trait" && p.nth(2).is_ident_like() && p.nth(2) != AsKw)
+        }
         // `regional fn` is an item; any other `regional ...` is a region
         // expression.
         RegionalKw => p.nth(1) == FnKw,
@@ -167,6 +169,11 @@ fn repl_route(p: &parser::Parser) -> ReplInputKind {
             if p.current_text() == "impl"
                 && (p.nth(1) == LAngle || (p.nth(1).is_ident_like() && p.nth(1) != AsKw)) =>
         {
+            true
+        }
+        // `trait Name` heads a declaration; `trait + 1` / `trait as i64`
+        // stay expressions over a variable named `trait`.
+        Ident if p.current_text() == "trait" && p.nth(1).is_ident_like() && p.nth(1) != AsKw => {
             true
         }
         _ => false,
@@ -309,6 +316,11 @@ mod tests {
             // `impl` heads an item when a generic list or type name follows.
             "impl Point { fn get(self: Self) -> i64 { 1 } }",
             "impl<T: Num> Box<T> { pub fn get(self: Self) -> T { self.0 } }",
+            // Trait declarations and trait implementations.
+            "trait Ord { fn cmp(self: Self, other: Self) -> i64; }",
+            "pub trait Marker { }",
+            "impl Show for Point { fn show(self: Self) -> i64 { 1 } }",
+            "impl<T: Num> Convert<T> for Box<T> { fn conv(self: Self) -> T { self.0 } }",
         ];
         for source in items {
             let rp = parse_repl(source, interner.clone());
@@ -347,6 +359,11 @@ mod tests {
             // A variable named `impl` heads an expression.
             "impl + 1",
             "impl as i64",
+            // A variable named `trait` heads an expression; bare `trait`
+            // has nothing ident-like after it.
+            "trait + 1",
+            "trait as i64",
+            "trait",
         ];
         for source in exprs {
             let rp = parse_repl(source, interner.clone());
@@ -679,6 +696,166 @@ mod tests {
         json_of("fn shared(field: i32) -> i32 { field }");
         // `impl` included: legal as a parameter and a variable.
         json_of("fn f(impl: i64) -> i64 { impl }");
+        // `trait` and `for` too.
+        json_of("fn trait(trait: i64) -> i64 { trait }");
+        json_of("fn for(for: i64) -> i64 { for }");
+    }
+
+    #[test]
+    fn trait_decl_encodes_supers_generics_and_sig_members() {
+        let json = json_of(
+            "pub trait Ord<T>: Eq + Show {
+                 fn cmp(self: Self, other: T) -> i64;
+                 regional fn touch(self: [flex] Self);
+             }",
+        );
+        let decl = unwrap_span(&json[0]);
+        assert_eq!(decl["tag"], "TraitStmt");
+        let c = &decl["contents"];
+        assert_eq!(c["traitVisibility"], "Public");
+        assert_eq!(c["traitName"], "Ord");
+        assert_eq!(c["traitGenerics"][0][0], "T");
+        let supers = c["traitSupers"].as_array().expect("supers");
+        assert_eq!(supers.len(), 2);
+        let members = c["traitMembers"].as_array().expect("members");
+        assert_eq!(members.len(), 2);
+        let cmp = &members[0]["spanValue"]["contents"];
+        assert_eq!(cmp["funcName"], "cmp");
+        assert!(cmp["funcBody"].is_null());
+        assert!(cmp["funcForeignBody"].is_null());
+        let touch = &members[1]["spanValue"]["contents"];
+        assert_eq!(touch["funcIsRegional"], true);
+        assert_eq!(touch["funcParams"][0][2], true);
+    }
+
+    #[test]
+    fn impl_trait_for_encodes_trait_and_target() {
+        let json = json_of("impl<T: Num> Show<T> for Vec<T> { fn show(self: Self) -> i64 { 1 } }");
+        let block = unwrap_span(&json[0]);
+        assert_eq!(block["tag"], "ImplStmt");
+        let c = &block["contents"];
+        assert!(!c["implTrait"].is_null());
+        assert_eq!(c["implMembers"].as_array().expect("members").len(), 1);
+    }
+
+    /// The greedy `for` rule: `for` stays a legal type name in both impl
+    /// head positions.
+    #[test]
+    fn for_stays_a_type_name() {
+        let json = json_of("impl for { fn get(self: Self) -> i64 { 1 } }");
+        let c = &unwrap_span(&json[0])["contents"];
+        assert!(c["implTrait"].is_null());
+        let json = json_of("impl for for X { fn get(self: Self) -> i64 { 1 } }");
+        let c = &unwrap_span(&json[0])["contents"];
+        assert!(!c["implTrait"].is_null());
+    }
+
+    #[test]
+    fn trait_method_body_is_rejected() {
+        let source = "trait T { fn m(self: Self) -> i64 { 1 } fn ok(self: Self) -> i64; }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|e| e.message.contains("end the signature with `;`")),
+            "{:#?}",
+            parse.errors
+        );
+        assert_eq!(parse.root.text(), source);
+        // The member after the rejected body survives.
+        let decl = parse
+            .root
+            .children()
+            .find(|n| n.kind() == SyntaxKind::TraitStmt)
+            .expect("trait decl");
+        assert_eq!(
+            decl.children()
+                .filter(|n| n.kind() == SyntaxKind::FnStmt)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn trait_foreign_body_rejected() {
+        let source = "trait T { fn m(self: Self) -> i64 [{ x }]; }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|e| e.message.contains("foreign body")),
+            "{:#?}",
+            parse.errors
+        );
+        assert_eq!(parse.root.text(), source);
+    }
+
+    #[test]
+    fn trait_supertrait_args_parse() {
+        // A supertrait reference is a path type: arguments parse and reach
+        // the tree (whether they are *admitted* is the elaborator's call).
+        let parse = super::parse("trait A: B<C> { }");
+        assert!(parse.ok(), "{:#?}", parse.errors);
+        let decl = parse
+            .root
+            .children()
+            .find(|n| n.kind() == SyntaxKind::TraitStmt)
+            .expect("trait decl");
+        let sup = decl
+            .children()
+            .find(|n| n.kind() == SyntaxKind::PathType)
+            .expect("supertrait reference");
+        assert!(
+            sup.children().any(|n| n.kind() == SyntaxKind::TypeArgList),
+            "arguments reach the tree"
+        );
+    }
+
+    #[test]
+    fn trait_member_recovery_continues() {
+        let source = "trait T { 42 fn ok(self: Self) -> i64; }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert_eq!(parse.root.text(), source);
+        let decl = parse
+            .root
+            .children()
+            .find(|n| n.kind() == SyntaxKind::TraitStmt)
+            .expect("trait decl");
+        assert!(decl.children().any(|n| n.kind() == SyntaxKind::FnStmt));
+    }
+
+    #[test]
+    fn impl_for_prim_positions() {
+        let source = "impl Show for i64 { }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|e| e.message.contains("must be a named type")),
+            "{:#?}",
+            parse.errors
+        );
+        assert_eq!(parse.root.text(), source);
+
+        let source = "impl i64 for X { }";
+        let parse = super::parse(source);
+        assert!(!parse.ok());
+        assert!(
+            parse
+                .errors
+                .iter()
+                .any(|e| e.message.contains("must be a named trait")),
+            "{:#?}",
+            parse.errors
+        );
+        assert_eq!(parse.root.text(), source);
     }
 
     #[test]

--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -32,6 +32,31 @@ use source::CharMap;
 // names); its `Resolver` counterpart is re-exported from [`kind`].
 pub use cstree::interning::{Interner, MultiThreadedTokenInterner, new_threaded_interner};
 
+/// The shared session string table: one threaded interner backs the parser,
+/// the elaborator, and the REPL. The handle is an `Arc` — the *table* is
+/// shared and interior-mutable, so holders pass `&SessionInterner` and
+/// nothing about sharing it is ever `&mut`. (cstree's [`Interner`] trait
+/// spells `get_or_intern(&mut self)` and implements it for the `Arc`
+/// handle; a handle copy satisfies that spelling without copying the
+/// table — see [`SharedInterner::intern`]. Only a locally-owned table — a
+/// `Rodeo`, the HIR parser's `Names` — legitimately interns through
+/// `&mut impl Interner`.)
+pub type SessionInterner = std::sync::Arc<MultiThreadedTokenInterner>;
+
+/// `&self` interning over the shared session table.
+pub trait SharedInterner {
+    fn intern(&self, text: &str) -> kind::TokenKey;
+}
+
+impl SharedInterner for SessionInterner {
+    fn intern(&self, text: &str) -> kind::TokenKey {
+        // A handle copy (`Arc` clone, a refcount bump) satisfies the
+        // trait's `&mut self` spelling; the write lands in the shared,
+        // interior-mutable table.
+        Interner::get_or_intern(&mut self.clone(), text)
+    }
+}
+
 // The single source of truth for the contextual primitive-type and
 // capability names. Consumers that re-encode these sets by hand (the AST
 // emitter, `surface` lowering in `reussir-core`) test against them.

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -10,6 +10,9 @@
 //! import-stmt ::= 'import' path ('as' name)? ';'
 //! fn-stmt     ::= 'regional'? 'fn' name generics? '(' params ')' ('->' '[flex]'? type)?
 //!                     (block | ';' | RAW-MLIR-LITERAL ';')
+//! trait-stmt  ::= 'trait' name generics? (':' path ('+' path)*)? '{' trait-method* '}'
+//! trait-method ::= 'regional'? 'fn' name generics? '(' params ')' ('->' '[flex]'? type)? ';'
+//! impl-stmt   ::= 'impl' generics? (type-atom 'for')? type-atom '{' (pub? regional? fn ...)* '}'
 //! struct-stmt ::= 'struct' capability? name generics? (named-fields | unnamed-fields | ';')
 //! enum-stmt   ::= 'enum' capability? name generics? '{' variant,* '}'
 //! mod-stmt    ::= 'mod' name ';'
@@ -46,7 +49,11 @@ impl Parser<'_> {
     pub(crate) fn source_file(&mut self) {
         let m = self.start();
         while !self.at_eof() {
-            if self.current().starts_stmt() || self.at_transform_stmt() || self.at_impl_stmt() {
+            if self.current().starts_stmt()
+                || self.at_transform_stmt()
+                || self.at_impl_stmt()
+                || self.at_trait_stmt()
+            {
                 self.stmt();
             } else {
                 // Statement-level recovery: collect the unexpected tokens
@@ -54,13 +61,14 @@ impl Parser<'_> {
                 // again.
                 let e = self.start();
                 self.error(format!(
-                    "expected a top-level item (fn, struct, enum, mod, extern, impl, transform, or import), found {}",
+                    "expected a top-level item (fn, struct, enum, mod, extern, impl, trait, transform, or import), found {}",
                     self.current().describe()
                 ));
                 while !self.at_eof()
                     && !self.current().starts_stmt()
                     && !self.at_transform_stmt()
                     && !self.at_impl_stmt()
+                    && !self.at_trait_stmt()
                 {
                     self.bump();
                 }
@@ -86,9 +94,10 @@ impl Parser<'_> {
             ImportKw => self.import_stmt(m),
             Ident if self.at_transform_stmt() => self.transform_stmt(m),
             Ident if self.at_impl_stmt() => self.impl_stmt(m),
+            Ident if self.at_trait_stmt() => self.trait_stmt(m),
             _ => {
                 self.error(format!(
-                    "expected `fn`, `struct`, `enum`, `mod`, `extern`, `impl`, `transform`, or `import` after visibility, found {}",
+                    "expected `fn`, `struct`, `enum`, `mod`, `extern`, `impl`, `trait`, `transform`, or `import` after visibility, found {}",
                     self.current().describe()
                 ));
                 // Consume nothing further; the outer loop recovers.
@@ -110,7 +119,97 @@ impl Parser<'_> {
             && (self.nth(1) == LAngle || (self.nth(1).is_ident_like() && self.nth(1) != AsKw))
     }
 
-    /// `impl generics? Type<args>? { (pub? (regional? fn ...))* }`.
+    /// `trait` is likewise contextual: it heads a declaration only when its
+    /// name follows — `trait + 1` stays an expression over a variable named
+    /// `trait`, `trait as i64` a cast of one. No generic-list case: the
+    /// trait's name precedes its generics (unlike `impl<T>`).
+    fn at_trait_stmt(&self) -> bool {
+        self.at_ctx_kw("trait") && self.nth(1).is_ident_like() && self.nth(1) != AsKw
+    }
+
+    /// `trait Name generics? (':' path ('+' path)*)? '{' trait-method* '}'`.
+    /// Supertraits are bare `+`-separated paths; members are signatures only.
+    fn trait_stmt(&mut self, m: Marker) {
+        self.bump(); // the `trait` ident
+        self.expect_ident("a trait name");
+        if self.at(LAngle) {
+            self.generic_param_list();
+        }
+        if self.at(Colon) {
+            self.bump();
+            self.path_type();
+            while self.at(Plus) {
+                self.bump();
+                self.path_type();
+            }
+        }
+        self.expect(LBrace);
+        while !self.at(RBrace) && !self.at_eof() {
+            if self.at(RegionalKw) || self.at(FnKw) {
+                let member = self.start();
+                self.trait_method(member);
+            } else {
+                // Member-level recovery: `pub` is not a member starter —
+                // trait methods take the trait's visibility.
+                let e = self.start();
+                self.error(format!(
+                    "expected `fn` or `regional fn` in a `trait` body, found {}",
+                    self.current().describe()
+                ));
+                while !self.at_eof() && !self.at(RBrace) && !self.at(RegionalKw) && !self.at(FnKw) {
+                    self.bump();
+                }
+                e.complete(self, ErrorNode);
+            }
+        }
+        self.expect(RBrace);
+        m.complete(self, TraitStmt);
+    }
+
+    /// A trait method signature — `fn_stmt`'s body-less twin, completing an
+    /// ordinary `FnStmt` node so downstream views project members uniformly.
+    fn trait_method(&mut self, m: Marker) {
+        if self.at(RegionalKw) {
+            self.bump();
+        }
+        self.expect(FnKw);
+        self.expect_ident("a method name");
+        if self.at(LAngle) {
+            self.generic_param_list();
+        }
+        self.param_list();
+        if self.at(Arrow) {
+            let r = self.start();
+            self.bump();
+            self.flex_flag_opt();
+            self.type_();
+            r.complete(self, RetType);
+        }
+        if self.at(Semicolon) {
+            self.bump();
+        } else if self.at(LBrace) {
+            self.error(
+                "trait methods are signatures; end the signature with `;`                  (default method bodies are not supported)",
+            );
+            // Consume the body losslessly so recovery continues at the next
+            // member instead of cascading.
+            self.block_expr();
+            if self.at(Semicolon) {
+                self.bump();
+            }
+        } else if self.at(RawMlirLiteral) {
+            self.error("trait methods cannot have a foreign body");
+            self.bump();
+            if self.at(Semicolon) {
+                self.bump();
+            }
+        } else {
+            self.error("expected `;` after a trait method signature");
+        }
+        m.complete(self, FnStmt);
+    }
+
+    /// `impl generics? (Trait<args> 'for')? Type<args>? { (pub? (regional? fn ...))* }`.
     fn impl_stmt(&mut self, m: Marker) {
         self.bump(); // the `impl` ident
         if self.at(LAngle) {
@@ -118,11 +217,31 @@ impl Parser<'_> {
         }
         if PRIM_TYPES.contains(&self.current_text()) {
             let e = self.start();
-            self.error("the target of `impl` must be a named type");
+            if self.nth_text(1) == "for" {
+                self.error("the trait of an `impl` must be a named trait");
+            } else {
+                self.error("the target of `impl` must be a named type");
+            }
             self.bump();
             e.complete(self, ErrorNode);
         } else if self.type_atom().is_none() {
             self.error("expected a type name as the `impl` target");
+        }
+        // `impl Trait<args> for Type`: a contextual `for` after the first
+        // head makes it the trait reference and the next atom the target.
+        // Greedy, single-shot: `impl for { }` is an inherent impl of a type
+        // named `for` (the first atom consumed it), `impl for for X { }` a
+        // trait named `for` implemented for `X`.
+        if self.at_ctx_kw("for") {
+            self.bump();
+            if PRIM_TYPES.contains(&self.current_text()) {
+                let e = self.start();
+                self.error("the target of `impl` must be a named type");
+                self.bump();
+                e.complete(self, ErrorNode);
+            } else if self.type_atom().is_none() {
+                self.error("expected a type name as the `impl` target after `for`");
+            }
         }
         self.expect(LBrace);
         while !self.at(RBrace) && !self.at_eof() {
@@ -571,6 +690,14 @@ impl Parser<'_> {
             self.bump();
             return Some(m.complete(self, PrimType));
         }
+        Some(self.path_type())
+    }
+
+    /// A named-type reference — a qualified path with optional type
+    /// arguments, completed as a `PathType` node. Shared by type atoms,
+    /// the `impl` heads, and supertrait references (which accept the same
+    /// shape; whether arguments are *admitted* there is semantics).
+    fn path_type(&mut self) -> CompletedMarker {
         let m = self.start();
         self.path();
         if self.at(LAngle) {
@@ -585,7 +712,7 @@ impl Parser<'_> {
             self.expect(RAngle);
             args.complete(self, TypeArgList);
         }
-        Some(m.complete(self, PathType))
+        m.complete(self, PathType)
     }
 
     /// A statically shaped array type: `[T; e1, e2, ...]` with one extent


### PR DESCRIPTION
Stacked on #508 (T-SEM-1 of the trait stack — identity groundwork).

- **`DefKind::Trait` third namespace** in `DefTable`: declare/lookup/resolve (bare + qualified)/suggestions/truncate — a record, a function, and a trait may share a name (pinned). Every `DefKind` match site was compiler-forced and covered (externs remap, extern visibility/gating, truncate).
- **`TraitDb` is DefId-keyed**: `by_def` map + `traits_len`/`impls_len`/`truncate(traits, impls)` with dense-id pops; **Checkpoint grows `traits`/`impls`** and rollback retracts both — the `ctxt.rs` "documented gap" is closed and pinned (`truncate_retracts_traits_and_impls`, incl. re-adding at the same dense ids).
- **`trait_names` string map deleted** (the stringly seam): builtins are declared through the DefTable at the crate root — bare `Num` resolves anywhere via the root fallback (prelude visibility, module-local shadowing); `TraitDef` carries `def: DefId` + `visibility` + `sealed` instead of `name: String`; diagnostics display via `trait_display` (qualified path). `resolve_bound` is full path resolution (extern heads `pub`-gated with the is-private split); the `.rri` reload side (`resolve_bound_segments`) resolves absolutely — builtin bound serialization stays byte-identical (`$0 (T): Num`).
- **Interner threading**: declaring builtins needs interning, so `Elaborator::new`/`elaborate`/`elaborate_package` take `&mut impl Interner` (the `declare_extern_package` precedent); driver single-file leg + REPL session updated; ~40 test call sites swept to the shared-interner form.
- No behavior change to bound checking, `.rri` output, or diagnostics wording — existing suites pass byte-for-byte (536 cargo tests).

Gate: `cargo test` 536 green, `ninja -C build check` 462/465 (baseline), `rrc-test` green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788325527&installation_model_id=426051&pr_number=509&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F509&signature=7ce59c645d078602f7560a887619ed459191985b429db4ad236efef031f0344f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->