### PR TITLE
[trait-dsl] add crates/reussir-trait-dsl: the `builtin_traits!` proc-macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,6 +3264,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "reussir-trait-dsl"
+version = "0.1.0"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/reussir-compiler",
     "crates/reussir-repl",
     "crates/rene",
+    "crates/reussir-trait-dsl",
 ]
 # The backend crates (and reussir-codegen, which depends on them) link against
 # MLIR and the staged Reussir C API, so they are excluded from the default
@@ -21,6 +22,7 @@ default-members = [
     "crates/reussir-syntax",
     "crates/reussir-core",
     "crates/rene",
+    "crates/reussir-trait-dsl",
 ]
 
 [workspace.package]
@@ -29,6 +31,12 @@ edition = "2024"
 license = "(Apache-2.0 OR MIT)"
 
 [workspace.dependencies]
+# The builtin_traits! registration DSL (reussir-trait-dsl) parses with syn and
+# emits with quote; heck snake_cases trait names into Builtins field names.
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+heck = "0.5"
 ariadne = "0.5"
 blake3 = "1"
 rapidhash = "4.4.1"

--- a/crates/reussir-trait-dsl/Cargo.toml
+++ b/crates/reussir-trait-dsl/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "reussir-trait-dsl"
+description = "builtin_traits! — declarative registration DSL for Reussir's built-in (lang-item) traits"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+heck.workspace = true

--- a/crates/reussir-trait-dsl/src/ast.rs
+++ b/crates/reussir-trait-dsl/src/ast.rs
@@ -1,0 +1,186 @@
+//! The `builtin_traits!` grammar and its `syn` parser.
+//!
+//! Every token in the DSL is a real Rust keyword or punctuation, so `syn`'s
+//! keyword tokens carry the parse:
+//!
+//! ```text
+//! input      ::= item*
+//! item       ::= trait-item | impl-item
+//! trait-item ::= attr* 'trait' ident (':' ident ('+' ident)*)? (';' | '{' method* '}')
+//! method     ::= 'fn' ident '(' (ident ':' tyref) (',' ident ':' tyref)* ')'
+//!                ('->' tyref)? ';'
+//! tyref      ::= 'Self' | ident
+//! impl-item  ::= 'impl' ident 'for' ident ('|' ident)* ';'
+//! attr       ::= '#[sealed]' | '#[structural]' | doc comment
+//! ```
+
+use syn::Token;
+use syn::ext::IdentExt;
+use syn::parse::{Parse, ParseStream};
+
+pub(crate) struct Input {
+    pub items: Vec<Item>,
+}
+
+pub(crate) enum Item {
+    Trait(TraitDecl),
+    Impl(ImplDecl),
+}
+
+pub(crate) struct TraitDecl {
+    /// Forwarded doc comments (rendered onto the generated `Builtins` field).
+    pub docs: Vec<syn::Attribute>,
+    pub sealed: bool,
+    pub structural: bool,
+    pub name: syn::Ident,
+    pub supertraits: Vec<syn::Ident>,
+    /// Parsed but rejected in expansion this cut (reserved grammar).
+    pub methods: Vec<MethodSig>,
+}
+
+pub(crate) struct MethodSig {
+    pub name: syn::Ident,
+    #[allow(dead_code)]
+    pub params: Vec<(syn::Ident, TypeRef)>,
+    #[allow(dead_code)]
+    pub ret: Option<TypeRef>,
+}
+
+pub(crate) enum TypeRef {
+    SelfTy,
+    Scalar(syn::Ident),
+}
+
+pub(crate) struct ImplDecl {
+    pub trait_name: syn::Ident,
+    pub self_tys: Vec<syn::Ident>,
+}
+
+impl Parse for Input {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut items = Vec::new();
+        while !input.is_empty() {
+            items.push(input.parse()?);
+        }
+        Ok(Input { items })
+    }
+}
+
+impl Parse for Item {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(Token![impl]) {
+            return Ok(Item::Impl(input.parse()?));
+        }
+        Ok(Item::Trait(input.parse()?))
+    }
+}
+
+impl Parse for TraitDecl {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let attrs = input.call(syn::Attribute::parse_outer)?;
+        let mut docs = Vec::new();
+        let mut sealed = false;
+        let mut structural = false;
+        for attr in attrs {
+            if attr.path().is_ident("doc") {
+                docs.push(attr);
+            } else if attr.path().is_ident("sealed") {
+                sealed = true;
+            } else if attr.path().is_ident("structural") {
+                structural = true;
+            } else {
+                return Err(syn::Error::new_spanned(
+                    &attr,
+                    "unknown attribute; `builtin_traits!` accepts `#[sealed]`, \
+                     `#[structural]`, and doc comments",
+                ));
+            }
+        }
+        input.parse::<Token![trait]>()?;
+        let name: syn::Ident = input.parse()?;
+        let mut supertraits = Vec::new();
+        if input.peek(Token![:]) {
+            input.parse::<Token![:]>()?;
+            supertraits.push(input.parse()?);
+            while input.peek(Token![+]) {
+                input.parse::<Token![+]>()?;
+                supertraits.push(input.parse()?);
+            }
+        }
+        let mut methods = Vec::new();
+        if input.peek(syn::token::Brace) {
+            let body;
+            syn::braced!(body in input);
+            while !body.is_empty() {
+                methods.push(body.parse()?);
+            }
+        } else {
+            input.parse::<Token![;]>()?;
+        }
+        Ok(TraitDecl {
+            docs,
+            sealed,
+            structural,
+            name,
+            supertraits,
+            methods,
+        })
+    }
+}
+
+impl Parse for MethodSig {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        input.parse::<Token![fn]>()?;
+        let name: syn::Ident = input.parse()?;
+        let args;
+        syn::parenthesized!(args in input);
+        let mut params = Vec::new();
+        while !args.is_empty() {
+            // `self` is a keyword to Rust but an ordinary parameter name in
+            // the DSL's signature grammar.
+            let pname: syn::Ident = args.call(syn::Ident::parse_any)?;
+            args.parse::<Token![:]>()?;
+            let ty: TypeRef = args.parse()?;
+            params.push((pname, ty));
+            if args.peek(Token![,]) {
+                args.parse::<Token![,]>()?;
+            }
+        }
+        let ret = if input.peek(Token![->]) {
+            input.parse::<Token![->]>()?;
+            Some(input.parse()?)
+        } else {
+            None
+        };
+        input.parse::<Token![;]>()?;
+        Ok(MethodSig { name, params, ret })
+    }
+}
+
+impl Parse for TypeRef {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(Token![Self]) {
+            input.parse::<Token![Self]>()?;
+            return Ok(TypeRef::SelfTy);
+        }
+        Ok(TypeRef::Scalar(input.parse()?))
+    }
+}
+
+impl Parse for ImplDecl {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        input.parse::<Token![impl]>()?;
+        let trait_name: syn::Ident = input.parse()?;
+        input.parse::<Token![for]>()?;
+        let mut self_tys = vec![input.parse()?];
+        while input.peek(Token![|]) {
+            input.parse::<Token![|]>()?;
+            self_tys.push(input.parse()?);
+        }
+        input.parse::<Token![;]>()?;
+        Ok(ImplDecl {
+            trait_name,
+            self_tys,
+        })
+    }
+}

--- a/crates/reussir-trait-dsl/src/expand.rs
+++ b/crates/reussir-trait-dsl/src/expand.rs
@@ -1,0 +1,359 @@
+//! Validation and code generation for `builtin_traits!`.
+//!
+//! The generated code targets the registration contract of
+//! `reussir-core::semi::traits` (paths spelled `crate::semi::…`, so the
+//! macro only expands meaningfully inside that crate): caller-assigned dense
+//! `TraitId`/`ImplId`s in declaration order, trait defs declared through the
+//! `DefTable`'s trait namespace at the crate root, and a `Builtins` handle
+//! struct whose snake-cased fields the checker references by name.
+
+use heck::ToSnakeCase;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use std::collections::HashMap;
+
+use crate::ast::{Input, Item};
+
+/// The closed scalar vocabulary an impl clause may name, with the type
+/// constructor each expands to.
+fn scalar_ctor(ident: &syn::Ident) -> Option<TokenStream> {
+    let ts = match ident.to_string().as_str() {
+        "i8" => quote!(tcx.mk_int(crate::semi::ty::IntTy::Signed(8))),
+        "i16" => quote!(tcx.mk_int(crate::semi::ty::IntTy::Signed(16))),
+        "i32" => quote!(tcx.mk_int(crate::semi::ty::IntTy::Signed(32))),
+        "i64" => quote!(tcx.mk_int(crate::semi::ty::IntTy::Signed(64))),
+        "u8" => quote!(tcx.mk_int(crate::semi::ty::IntTy::Unsigned(8))),
+        "u16" => quote!(tcx.mk_int(crate::semi::ty::IntTy::Unsigned(16))),
+        "u32" => quote!(tcx.mk_int(crate::semi::ty::IntTy::Unsigned(32))),
+        "u64" => quote!(tcx.mk_int(crate::semi::ty::IntTy::Unsigned(64))),
+        "f16" => quote!(tcx.mk_fp(crate::semi::ty::FpTy::Ieee(16))),
+        "f32" => quote!(tcx.mk_fp(crate::semi::ty::FpTy::Ieee(32))),
+        "f64" => quote!(tcx.mk_fp(crate::semi::ty::FpTy::Ieee(64))),
+        "bf16" => quote!(tcx.mk_fp(crate::semi::ty::FpTy::BFloat16)),
+        "f8" => quote!(tcx.mk_fp(crate::semi::ty::FpTy::Float8)),
+        _ => return None,
+    };
+    Some(ts)
+}
+
+const KNOWN_SCALARS: &str = "i8, i16, i32, i64, u8, u16, u32, u64, f16, f32, f64, bf16, f8";
+
+pub(crate) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
+    let input: Input = syn::parse2(input)?;
+
+    // Validation pass: names resolve backwards within the invocation, ids
+    // are declaration-ordered, structural traits stay impl-less.
+    let mut traits: Vec<&crate::ast::TraitDecl> = Vec::new();
+    let mut index: HashMap<String, usize> = HashMap::new();
+    let mut impl_clauses: Vec<(&crate::ast::ImplDecl, usize)> = Vec::new();
+    let mut seen_impl: HashMap<(String, String), ()> = HashMap::new();
+    for item in &input.items {
+        match item {
+            Item::Trait(decl) => {
+                let name = decl.name.to_string();
+                if index.contains_key(&name) {
+                    return Err(syn::Error::new_spanned(
+                        &decl.name,
+                        format!("trait `{name}` is declared more than once"),
+                    ));
+                }
+                for sup in &decl.supertraits {
+                    if !index.contains_key(&sup.to_string()) {
+                        return Err(syn::Error::new_spanned(
+                            sup,
+                            format!(
+                                "supertrait `{sup}` must be declared before `{name}` \
+                                 (declaration order is the id assignment)"
+                            ),
+                        ));
+                    }
+                }
+                if let Some(m) = decl.methods.first() {
+                    return Err(syn::Error::new_spanned(
+                        &m.name,
+                        "trait method signatures are not yet supported by `builtin_traits!`",
+                    ));
+                }
+                index.insert(name, traits.len());
+                traits.push(decl);
+            }
+            Item::Impl(decl) => {
+                let tname = decl.trait_name.to_string();
+                let Some(&t) = index.get(&tname) else {
+                    return Err(syn::Error::new_spanned(
+                        &decl.trait_name,
+                        format!("`impl` names undeclared trait `{tname}`"),
+                    ));
+                };
+                if traits[t].structural {
+                    return Err(syn::Error::new_spanned(
+                        &decl.trait_name,
+                        format!(
+                            "structural trait `{tname}` is answered by the checker \
+                             and cannot have impls"
+                        ),
+                    ));
+                }
+                for ty in &decl.self_tys {
+                    if scalar_ctor(ty).is_none() {
+                        return Err(syn::Error::new_spanned(
+                            ty,
+                            format!(
+                                "unknown scalar `{ty}`; the builtin impl vocabulary is \
+                                 {KNOWN_SCALARS}"
+                            ),
+                        ));
+                    }
+                    if seen_impl
+                        .insert((tname.clone(), ty.to_string()), ())
+                        .is_some()
+                    {
+                        return Err(syn::Error::new_spanned(
+                            ty,
+                            format!("duplicate impl of `{tname}` for `{ty}`"),
+                        ));
+                    }
+                }
+                impl_clauses.push((decl, t));
+            }
+        }
+    }
+
+    // Generation. Field order and id order are both declaration order.
+    let field_idents: Vec<syn::Ident> = traits
+        .iter()
+        .map(|t| format_ident!("{}", t.name.to_string().to_snake_case()))
+        .collect();
+    let fields = traits.iter().zip(&field_idents).map(|(t, field)| {
+        let docs = &t.docs;
+        quote! {
+            #(#docs)*
+            pub #field: crate::semi::traits::TraitId,
+        }
+    });
+
+    let trait_regs = traits
+        .iter()
+        .zip(&field_idents)
+        .enumerate()
+        .map(|(i, (t, field))| {
+            let i = proc_macro2::Literal::u32_unsuffixed(i as u32);
+            let name = t.name.to_string();
+            let sealed = t.sealed;
+            let supers = t.supertraits.iter().map(|sup| {
+                let s = &field_idents[index[&sup.to_string()]];
+                quote!(self_ref(#s))
+            });
+            quote! {
+                let #field = crate::semi::traits::TraitId(#i);
+                {
+                    let key = interner.get_or_intern(#name);
+                    let def = defs.declare_trait(key).expect("builtins precede user defs");
+                    db.add_trait(crate::semi::traits::def::TraitDef {
+                        id: #field,
+                        def,
+                        visibility: crate::surface::Visibility::Public,
+                        sealed: #sealed,
+                        params: vec![self_g],
+                        supertraits: vec![#(#supers),*],
+                        methods: vec![],
+                        assoc_tys: vec![],
+                    });
+                }
+            }
+        });
+
+    let mut next_impl = 0u32;
+    let impl_regs = impl_clauses.iter().flat_map(|(decl, t)| {
+        let field = &field_idents[*t];
+        decl.self_tys
+            .iter()
+            .map(|ty| {
+                let ctor = scalar_ctor(ty).expect("validated above");
+                let id = proc_macro2::Literal::u32_unsuffixed(next_impl);
+                next_impl += 1;
+                quote! {
+                    {
+                        let self_ty = #ctor;
+                        db.add_impl(crate::semi::traits::def::ImplDef {
+                            id: crate::semi::traits::ImplId(#id),
+                            generics: vec![],
+                            trait_ref: crate::semi::traits::TraitRef {
+                                trait_id: #field,
+                                args: vec![self_ty],
+                            },
+                            self_ty,
+                            where_clauses: vec![],
+                        });
+                    }
+                }
+            })
+            .collect::<Vec<_>>()
+    });
+
+    Ok(quote! {
+        /// Handles to the built-in traits, for the type checker to refer to
+        /// by name. Generated by `builtin_traits!`; declaration order is the
+        /// dense id order.
+        pub struct Builtins {
+            #(#fields)*
+        }
+
+        impl Builtins {
+            /// Register the built-in traits and their primitive impls into
+            /// `db`, declaring each trait in `defs`' trait namespace at the
+            /// crate root — prelude visibility for bare references,
+            /// shadowable by a same-named module-local trait.
+            pub fn register<'tcx>(
+                db: &mut crate::semi::traits::TraitDb<'tcx>,
+                defs: &mut crate::semi::resolve::DefTable,
+                interner: &mut impl reussir_syntax::Interner<reussir_syntax::kind::TokenKey>,
+                tcx: &crate::semi::ty::TyCtxt<'tcx>,
+            ) -> Builtins {
+                // Every built-in trait has a single `Self` parameter, generic
+                // #0 — deliberately UNALLOCATED in the elaborator's generics
+                // table (the builtin defs predate it, and allocating would
+                // shift every dump's `$n` numbering).
+                let self_g = crate::semi::ty::GenericId(0);
+                let self_ref = |trait_id| crate::semi::traits::TraitRef {
+                    trait_id,
+                    args: vec![tcx.mk_generic(self_g)],
+                };
+                let _ = &self_ref;
+                #(#trait_regs)*
+                #(#impl_regs)*
+                Builtins { #(#field_idents),* }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    fn full_table() -> TokenStream {
+        quote! {
+            #[sealed] trait Num;
+            #[sealed] trait Integral: Num;
+            #[sealed] trait FloatingPoint: Num;
+            #[sealed] trait PtrLike;
+            /// Marker (auto) trait.
+            #[sealed] #[structural] trait Sync;
+            impl Integral for i8 | u8 | i16 | u16 | i32 | u32 | i64 | u64;
+            impl FloatingPoint for f16 | f32 | f64 | bf16 | f8;
+        }
+    }
+
+    fn expand_ok(ts: TokenStream) -> String {
+        let out = expand(ts).expect("expansion");
+        // The output must be a valid Rust item sequence.
+        syn::parse2::<syn::File>(out.clone()).expect("parses as items");
+        out.to_string()
+    }
+
+    fn expand_err(ts: TokenStream) -> String {
+        expand(ts).expect_err("must fail").to_string()
+    }
+
+    #[test]
+    fn expand_full_builtin_table() {
+        let out = expand_ok(full_table());
+        // Field order = declaration order, snake-cased.
+        let num = out.find("pub num :").expect("num field");
+        let integral = out.find("pub integral :").expect("integral field");
+        let fp = out.find("pub floating_point :").expect("fp field");
+        let ptr = out.find("pub ptr_like :").expect("ptr field");
+        let sync = out.find("pub sync :").expect("sync field");
+        assert!(num < integral && integral < fp && fp < ptr && ptr < sync);
+        // Dense declaration-ordered ids: 5 traits, 13 impls (8 + 5).
+        for i in 0..5u32 {
+            assert!(out.contains(&format!("TraitId ({i})")), "TraitId({i})");
+        }
+        for i in 0..13u32 {
+            assert!(out.contains(&format!("ImplId ({i})")), "ImplId({i})");
+        }
+        assert_eq!(out.matches("add_trait").count(), 5);
+        assert_eq!(out.matches("add_impl").count(), 13);
+        // Every builtin is sealed.
+        assert_eq!(out.matches("sealed : true").count(), 5);
+        // The impl order preserves the listed scalar order.
+        let first = out.find("Signed (8)").expect("i8 impl");
+        let last = out.find("Float8").expect("f8 impl");
+        assert!(first < last);
+    }
+
+    #[test]
+    fn supertrait_reference_resolves_in_order() {
+        let out = expand_ok(quote! {
+            trait A;
+            trait B;
+            trait C: A + B;
+        });
+        let c = out.find("TraitId (2)").expect("C");
+        let refs = &out[c..];
+        let a = refs.find("self_ref (a)").expect("A ref");
+        let b = refs.find("self_ref (b)").expect("B ref");
+        assert!(a < b, "supertrait order preserved");
+    }
+
+    #[test]
+    fn doc_comments_forward_to_fields() {
+        let out = expand_ok(quote! {
+            /// The marker.
+            trait Sync;
+        });
+        assert!(out.contains("The marker."));
+    }
+
+    #[test]
+    fn forward_supertrait_is_an_error() {
+        let msg = expand_err(quote! { trait A: B; trait B; });
+        assert!(
+            msg.contains("supertrait `B` must be declared before `A`"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn impl_for_undeclared_trait_is_an_error() {
+        let msg = expand_err(quote! { impl Show for i8; });
+        assert!(msg.contains("undeclared trait `Show`"), "{msg}");
+    }
+
+    #[test]
+    fn structural_trait_with_impls_is_an_error() {
+        let msg = expand_err(quote! { #[structural] trait S; impl S for i8; });
+        assert!(msg.contains("structural trait `S`"), "{msg}");
+    }
+
+    #[test]
+    fn unknown_scalar_is_an_error() {
+        let msg = expand_err(quote! { trait Num; impl Num for i7; });
+        assert!(msg.contains("unknown scalar `i7`"), "{msg}");
+        assert!(msg.contains("i64"), "{msg}");
+    }
+
+    #[test]
+    fn duplicates_are_errors() {
+        let msg = expand_err(quote! { trait A; trait A; });
+        assert!(msg.contains("declared more than once"), "{msg}");
+        let msg = expand_err(quote! { trait A; impl A for i8 | i8; });
+        assert!(msg.contains("duplicate impl of `A` for `i8`"), "{msg}");
+    }
+
+    #[test]
+    fn method_sigs_parse_but_are_rejected() {
+        let msg = expand_err(quote! {
+            trait Num { fn add(self: Self, other: Self) -> Self; }
+        });
+        assert!(msg.contains("not yet supported"), "{msg}");
+    }
+
+    #[test]
+    fn unknown_attribute_is_an_error() {
+        let msg = expand_err(quote! { #[frobnicate] trait A; });
+        assert!(msg.contains("unknown attribute"), "{msg}");
+    }
+}

--- a/crates/reussir-trait-dsl/src/lib.rs
+++ b/crates/reussir-trait-dsl/src/lib.rs
@@ -1,0 +1,47 @@
+//! `builtin_traits!` — the declarative registration DSL for Reussir's
+//! built-in ("lang item") traits and their primitive impls.
+//!
+//! The macro replaces the hand-written registration table in
+//! `reussir-core::semi::traits::builtins` with a declaration that reads like
+//! the surface language:
+//!
+//! ```ignore
+//! builtin_traits! {
+//!     #[sealed] trait Num;
+//!     #[sealed] trait Integral: Num;
+//!     #[sealed] trait FloatingPoint: Num;
+//!     #[sealed] trait PtrLike;
+//!     /// Marker (auto) trait: reachable from any thread, concurrently.
+//!     #[sealed] #[structural] trait Sync;
+//!     impl Integral for i8 | u8 | i16 | u16 | i32 | u32 | i64 | u64;
+//!     impl FloatingPoint for f16 | f32 | f64 | bf16 | f8;
+//! }
+//! ```
+//!
+//! Expansion produces, at the invocation site (inside `reussir-core`, whose
+//! `crate::semi::…` paths the generated code references):
+//!
+//! * `pub struct Builtins` with one snake-cased `TraitId` field per declared
+//!   trait, in declaration order (doc comments forwarded);
+//! * `impl Builtins { pub fn register(db, defs, interner, tcx) -> Builtins }`
+//!   declaring each trait in the `DefTable`'s trait namespace at the crate
+//!   root and registering `TraitDef`s/`ImplDef`s with dense, declaration-
+//!   ordered ids — the exact contract of the hand-written table it replaces.
+//!
+//! Declaration order **is** the id assignment: reordering the invocation
+//! renumbers `TraitId`/`ImplId`. `#[sealed]` marks a trait unimplementable
+//! by user code; `#[structural]` additionally forbids impls *in this table*
+//! (the checker answers such traits structurally — `Sync`). Method
+//! signatures inside a `trait { … }` body parse (the grammar is reserved for
+//! the method-carrying future) but are rejected in expansion for now.
+
+mod ast;
+mod expand;
+
+/// See the crate docs.
+#[proc_macro]
+pub fn builtin_traits(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    expand::expand(input.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}


### PR DESCRIPTION
Stacked on #509 (T-DSL-1 of the trait stack — the macro DSL, leaf-only).

```rust
builtin_traits! {
    #[sealed] trait Num;
    #[sealed] trait Integral: Num;
    #[sealed] trait FloatingPoint: Num;
    #[sealed] trait PtrLike;
    /// Marker (auto) trait.
    #[sealed] #[structural] trait Sync;
    impl Integral for i8 | u8 | i16 | u16 | i32 | u32 | i64 | u64;
    impl FloatingPoint for f16 | f32 | f64 | bf16 | f8;
}
```

- **Grammar**: every DSL token is a real Rust keyword (`Token![trait]`/`Token![impl]`/`Token![for]`/`|`); `#[sealed]`, `#[structural]`, and doc comments are the only attributes. **Method signatures parse** (`fn add(self: Self, other: Self) -> Self;` — keyword-tolerant param names) but are **rejected in expansion** — the grammar is reserved for the method-carrying future, pinned by test.
- **Expansion** targets the exact #509 contract: `Builtins` handle (snake-cased `TraitId` fields, declaration order, docs forwarded) + `register(db, defs, interner, tcx)` declaring through the DefTable at the crate root and constructing `TraitDef { id, def, visibility, sealed, … }` / `ImplDef` with **dense declaration-ordered ids** — order IS the id assignment (unsuffixed literals, byte-compatible with the hand-written table). **No string tables generated** (no `lookup`/`NAMES`) — resolution stays with the DefTable, per review's no-stringly rule.
- **Validation** (spanned): duplicate traits/impl clauses, forward/unknown supertraits, impls on undeclared or `#[structural]` traits (Sync invariant guard), unknown scalars listing the closed vocabulary, unknown attributes.
- Workspace: crate joins members + default-members (host-only compile; `cargo test` covers it without the MLIR env); `proc-macro2`/`quote`/`syn 2`/`heck` join workspace deps. `trybuild` deliberately rejected (dev-dep cycle onto reussir-core); the migration PR (`builtin_traits!` invocation in `builtins.rs`) is the real type-check of the templates and lands after the trait-scan stack.

Gate: `cargo test` 546 green (10 DSL tests), `ninja -C build check` 462/465 (baseline), `rrc-test` green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788325816&installation_model_id=426051&pr_number=510&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F510&signature=4ef4b3c9c33ea7cd21e7e3e152972f1e97c10acc6143b4e978cf32e4fc7ae788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->