### PR TITLE
[core] elaborate trait declarations: three-phase scan, receiver forms, cycle severing

### DIFF
--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1090,19 +1090,11 @@ mod tests {
         );
     }
 
-    /// Until the trait stacks land, trait items are rejected cleanly — and
-    /// a trait impl's members are never misattached as inherent methods.
+    /// Until the impl-for stack lands, trait implementations are rejected
+    /// cleanly — and their members are never misattached as inherent
+    /// methods. (Trait declarations themselves now elaborate.)
     #[test]
     fn trait_items_are_rejected_for_now() {
-        elaborate_source("trait X { fn m(self: Self); }", |elab| {
-            assert!(
-                elab.reports.iter().any(|r| r
-                    .message
-                    .contains("`trait` declarations are not supported yet")),
-                "{:#?}",
-                elab.reports
-            );
-        });
         elaborate_source(
             "pub struct P { pub x: i64 }
              impl Show for P { fn show(self: Self) -> i64 { 1 } }
@@ -1130,6 +1122,220 @@ mod tests {
                 assert!(elab.functions.values().any(|f| elab.sym(f.name) == "ok"));
             },
         );
+    }
+
+    #[test]
+    fn user_trait_bounds_resolve_and_imply_through_supertraits() {
+        // A user trait resolves as a bound; a user supertrait chain onto a
+        // builtin discharges the builtin obligation on the generic.
+        check(
+            "trait Show { fn norm(self: Self) -> f64; }
+             fn f<T: Show>(x: T) -> T { x }",
+            |elab, _| {
+                let f = elab
+                    .functions
+                    .values()
+                    .find(|p| elab.sym(p.name) == "f")
+                    .expect("f");
+                let (_, g) = f.generics[0];
+                assert_eq!(elab.generic_bounds(g).len(), 1);
+            },
+        );
+        check(
+            "trait Croppable: Num { fn crop(self: Self) -> Self; }
+             fn double<T: Croppable>(x: T) -> T { x + x }",
+            |elab, _| {
+                let _ = elab;
+            },
+        );
+    }
+
+    #[test]
+    fn parameterized_supertrait_references_are_rejected() {
+        // The surface shape carries the arguments; admitting them is the
+        // deferred half, so the reference is refused, not silently bared.
+        elaborate_source(
+            "pub trait A { fn a(self: Self) -> i64; }\n\
+             pub trait B : A<i64> { fn b(self: Self) -> i64; }",
+            |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r
+                        .message
+                        .contains("parameterized supertrait references are not supported yet")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn supertrait_cycle_is_reported_and_severed() {
+        elaborate_source(
+            "trait A: B { fn a(self: Self); }
+             trait B: A { fn b(self: Self); }
+             fn f<T: A>(x: T) -> T { x }",
+            |elab| {
+                assert!(
+                    elab.reports
+                        .iter()
+                        .any(|r| r.message.contains("super-trait cycle")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn trait_redeclaration_diagnostics() {
+        elaborate_source(
+            "trait A { fn m(self: Self); }
+trait A { fn n(self: Self); }",
+            |elab| {
+                assert!(
+                    elab.reports
+                        .iter()
+                        .any(|r| r.message.contains("trait `A` is defined more than once")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+        elaborate_source("trait Num { fn m(self: Self); }", |elab| {
+            assert!(
+                elab.reports.iter().any(|r| r
+                    .message
+                    .contains("`Num` is a built-in trait and cannot be redeclared")),
+                "{:#?}",
+                elab.reports
+            );
+        });
+    }
+
+    #[test]
+    fn trait_member_rejections() {
+        elaborate_source("trait T { fn m(x: i64) -> i64; }", |elab| {
+            assert!(
+                elab.reports.iter().any(|r| r
+                    .message
+                    .contains("a trait method must take `self` as its first parameter")),
+                "{:#?}",
+                elab.reports
+            );
+        });
+        elaborate_source(
+            "trait T { fn m(self: Self); fn m(self: Self) -> i64; }",
+            |elab| {
+                assert!(
+                    elab.reports
+                        .iter()
+                        .any(|r| r.message.contains("declares method `m` more than once")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+        elaborate_source("trait T<Self> { fn m(self: Self); }", |elab| {
+            assert!(
+                elab.reports
+                    .iter()
+                    .any(|r| r.message.contains("`Self` is implicit in a trait")),
+                "{:#?}",
+                elab.reports
+            );
+        });
+        elaborate_source(
+            "trait Convert<T> { fn conv(self: Self) -> T; }
+             trait Bad: Convert { fn b(self: Self); }",
+            |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r
+                        .message
+                        .contains("parameterized bounds are not supported here")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+        elaborate_source("trait T<A> { fn m<A: Num>(self: Self, a: A); }", |elab| {
+            assert!(
+                elab.reports
+                    .iter()
+                    .any(|r| r.message.contains("shadows the trait's generic")),
+                "{:#?}",
+                elab.reports
+            );
+        });
+        elaborate_source("trait T { fn m(self: [flex] Self); }", |elab| {
+            assert!(
+                elab.reports
+                    .iter()
+                    .any(|r| r.message.contains("requires a `regional fn`")),
+                "{:#?}",
+                elab.reports
+            );
+        });
+    }
+
+    #[test]
+    fn trait_method_receiver_forms_recorded() {
+        use crate::semi::traits::def::ReceiverForm;
+        check(
+            "trait Multi {
+                 fn v(self: Self) -> i64;
+                 fn a(self: Arc<Self>) -> i64;
+                 regional fn f(self: [flex] Self);
+             }",
+            |elab, _| {
+                let id = elab
+                    .traits
+                    .trait_by_def(
+                        (0..elab.defs.len() as u32)
+                            .map(crate::semi::ty::DefId)
+                            .find(|d| {
+                                elab.defs.info(*d).kind == crate::semi::resolve::DefKind::Trait
+                                    && elab.sym(elab.defs.path(*d).name()) == "Multi"
+                            })
+                            .expect("Multi def"),
+                    )
+                    .expect("registered");
+                let def = elab.traits.trait_def(id);
+                let forms: Vec<ReceiverForm> = def.methods.iter().map(|m| m.receiver).collect();
+                assert_eq!(
+                    forms,
+                    [ReceiverForm::Value, ReceiverForm::Arc, ReceiverForm::Flex]
+                );
+                assert!(def.methods[2].is_regional);
+            },
+        );
+    }
+
+    #[test]
+    fn rejected_batch_retracts_trait_decls() {
+        use std::sync::Arc;
+        with_tcx(|tcx| {
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = |src: &str| {
+                let p = reussir_syntax::parse_with_interner(src, interner.clone());
+                assert!(p.ok(), "parse errors for {src:?}: {:#?}", p.errors);
+                p
+            };
+            let mut elab = Elaborator::new(tcx, &interner);
+
+            // A batch with an unknown supertrait is rejected wholesale …
+            let p1 = parse("trait Broken: Nope { fn m(self: Self); }");
+            elab.try_extend(&surface::program(&p1.root))
+                .expect_err("unknown supertrait");
+            assert!(!elab.has_errors());
+
+            // … and the same trait name declares cleanly next batch: the
+            // DefTable entry, the TraitDb stub, and its generics all rolled
+            // back.
+            let p2 = parse("trait Broken { fn m(self: Self); }");
+            elab.try_extend(&surface::program(&p2.root))
+                .expect("retracted name is reusable");
+        });
     }
 
     #[test]
@@ -2481,8 +2687,6 @@ pub struct Rect { pub w: i64 }",
         // batch's own sweep, or the error doubles.
         with_tcx(|tcx| {
             let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
-            let resolver: &dyn reussir_syntax::kind::Resolver<reussir_syntax::kind::TokenKey> =
-                &interner;
             let mut elab = Elaborator::new(tcx, &interner);
             for src in [
                 "struct Q { x: i64 }\nstruct S { p: Q }",

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1,6 +1,7 @@
 //! The elaboration context: collected items, global + per-function state, and
 //! the scan/collect driver.
 
+use reussir_syntax::SharedInterner;
 use reussir_syntax::kind::{Resolver, TokenKey};
 use reussir_syntax::source::{FileId, SourceCache};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -464,6 +465,10 @@ pub struct Elaborator<'a, 'tcx> {
     /// accumulated — reset by `enter_function` and after signature eval, so
     /// no Checkpoint entry.
     pub(super) self_alias: Option<Ty<'tcx>>,
+    /// The interned spelling of `Self` — the display name given to each user
+    /// trait's implicit `Self` generic (interned once at construction; the
+    /// scan passes have no interner).
+    pub(super) self_name: TokenKey,
     pub inside_region: bool,
     /// Generics required to be regional, accumulated while checking the current
     /// function body (e.g. a generic assigned into a flex link). Seeded from the
@@ -507,6 +512,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let mut traits = TraitDb::new();
         let mut handle = interner.clone();
         let builtins = Builtins::register(&mut traits, &mut defs, &mut handle, tcx);
+        let self_name = interner.intern("Self");
         Elaborator {
             tcx,
             resolver: &**interner,
@@ -538,6 +544,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             vars: VarEnv::default(),
             generic_names: FxHashMap::default(),
             self_alias: None,
+            self_name,
             inside_region: false,
             regional_generics: Vec::new(),
             fulfill: FulfillCtxt::default(),
@@ -1356,6 +1363,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let mut functions = Vec::new();
         let mut trampolines = Vec::new();
         let mut impls = Vec::new();
+        let mut trait_decls = Vec::new();
         for (file, module, program) in files {
             for stmt in *program {
                 let scope = Scope {
@@ -1430,10 +1438,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                             impls.push((ib, span, scope));
                         }
                     }
-                    surface::StmtKind::Trait(_) => {
+                    surface::StmtKind::Trait(td) => {
                         self.validate_transform_anchor(&attrs, None);
                         self.reject_ffi_attr(ffi, span);
-                        self.error(span, "`trait` declarations are not supported yet");
+                        trait_decls.push((td, span, scope));
                     }
                     // Foreign preludes register during this scan (like
                     // bindings) so they apply file-wide regardless of order.
@@ -1462,6 +1470,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // re-resolving the name — so an item whose declaration failed (e.g. a
         // duplicate) is skipped instead of clobbering the previously declared
         // item's fields or checking a body against the wrong prototype.
+        // Phase A: trait stubs first — the record/function stub scans
+        // resolve generic bounds immediately, so every trait must already
+        // have a def and a TraitDb entry.
+        let trait_ids: Vec<Option<TraitId>> = trait_decls
+            .iter()
+            .map(|(td, span, scope)| {
+                self.set_current_file(scope.file);
+                self.defs.set_module(scope.module.to_vec());
+                self.scan_trait_stub(td, *span)
+            })
+            .collect();
         let record_defs: Vec<Option<DefId>> = records
             .iter()
             .map(|(rec, span, scope, ffi)| {
@@ -1470,6 +1489,27 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.scan_record(rec, ffi.clone(), *span)
             })
             .collect();
+        // Phase C, split: every trait's own binder first (a supertrait's
+        // arity gate reads the super's params, which a same-batch
+        // later-declared super would otherwise still be missing), then
+        // supertraits and member signatures (which need the record stubs).
+        for ((td, span, scope), id) in trait_decls.iter().zip(&trait_ids) {
+            if let Some(id) = id {
+                self.set_current_file(scope.file);
+                self.defs.set_module(scope.module.to_vec());
+                self.populate_trait_params(td, *id, *span);
+            }
+        }
+        for ((td, span, scope), id) in trait_decls.iter().zip(&trait_ids) {
+            if let Some(id) = id {
+                self.set_current_file(scope.file);
+                self.defs.set_module(scope.module.to_vec());
+                self.populate_trait_members(td, *id, *span);
+            }
+        }
+        // Phase D: reject (and sever) super-trait cycles — `reaches`
+        // recurses unguarded, so a surviving cycle would overflow.
+        self.reject_supertrait_cycles(trait_ids.iter().flatten().copied());
         let function_defs: Vec<Option<DefId>> = functions
             .iter()
             .map(|(func, span, scope, _, is_import, _)| {
@@ -2149,6 +2189,293 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
         }
         Some(def)
+    }
+
+    /// Phase A of the trait scan: declare the trait's def and register a
+    /// stub `TraitDef` so bounds resolve against it from the very first
+    /// record/function stub scan. Params, supertraits, and members fill in
+    /// during the populate phases.
+    fn scan_trait_stub(&mut self, td: &surface::TraitDecl, span: Option<Span>) -> Option<TraitId> {
+        let Some(def) = self.defs.declare_trait(td.name) else {
+            // The name is taken in this module's trait namespace: a sealed
+            // builtin (only reachable at the crate root) gets its own
+            // wording, everything else is an ordinary redeclaration.
+            let mut path = self.defs.module().to_vec();
+            path.push(td.name);
+            let existing = self
+                .defs
+                .lookup_trait(&path)
+                .and_then(|d| self.traits.trait_by_def(d));
+            let msg = match existing {
+                Some(id) if self.traits.trait_def(id).sealed => format!(
+                    "`{}` is a built-in trait and cannot be redeclared",
+                    self.sym(td.name)
+                ),
+                _ => format!("trait `{}` is defined more than once", self.sym(td.name)),
+            };
+            self.error(span, msg);
+            return None;
+        };
+        let id = TraitId(self.traits.traits_len() as u32);
+        self.traits.add_trait(crate::semi::traits::def::TraitDef {
+            id,
+            def,
+            visibility: td.visibility,
+            sealed: false,
+            // Placeholder until `populate_trait_params`; nothing reads a
+            // stub's binder before that phase runs.
+            self_param: GenericId(0),
+            params: Vec::new(),
+            supertraits: Vec::new(),
+            methods: Vec::new(),
+            assoc_tys: Vec::new(),
+            span,
+            file: self.current_file,
+        });
+        Some(id)
+    }
+
+    /// Phase C1: allocate the trait's own binder — the implicit `Self` and
+    /// the declared parameters — for every stub before any supertrait or
+    /// member resolves against it.
+    fn populate_trait_params(&mut self, td: &surface::TraitDecl, id: TraitId, span: Option<Span>) {
+        let self_param = self.fresh_generic(self.self_name, Vec::new());
+        if td.generics.iter().any(|&(name, _)| name == self.self_name) {
+            self.error(span, "`Self` is implicit in a trait; do not declare it");
+        }
+        let self_name = self.self_name;
+        let params: Vec<(TokenKey, GenericId)> = td
+            .generics
+            .iter()
+            .filter(|(name, _)| *name != self_name)
+            .map(|(name, bounds)| {
+                let bounds = self.resolve_bounds(bounds, span);
+                (*name, self.fresh_generic(*name, bounds))
+            })
+            .collect();
+        let def = self.traits.trait_def_mut(id);
+        def.self_param = self_param;
+        def.params = params;
+    }
+
+    /// Phase C2: resolve supertraits and member signatures (record stubs
+    /// exist by now, so signature types evaluate).
+    fn populate_trait_members(&mut self, td: &surface::TraitDecl, id: TraitId, span: Option<Span>) {
+        let self_param = self.traits.trait_def(id).self_param;
+        let trait_params = self.traits.trait_def(id).params.clone();
+        let self_ty = self.tcx.mk_generic(self_param);
+
+        let supertraits: Vec<crate::semi::traits::TraitRef<'tcx>> = td
+            .supertraits
+            .iter()
+            .filter_map(|sup_ref| {
+                // Trait references are not parameterized yet: the surface
+                // shape carries arguments (and the core `TraitRef`,
+                // serialization, and reload all plumb them), but admitting
+                // them here needs their evaluation under the trait's binder
+                // — deferred, so a spelled argument list is a clean
+                // rejection rather than a silent drop.
+                if !sup_ref.args.is_empty() {
+                    self.error(
+                        span,
+                        "parameterized supertrait references are not supported yet",
+                    );
+                    return None;
+                }
+                let sup = self.resolve_bound(&sup_ref.path, span)?;
+                let arity = self.traits.trait_def(sup).params.len();
+                if arity != 0 {
+                    self.error(
+                        span,
+                        format!(
+                            "trait `{}` takes {arity} type argument(s); parameterized \
+                             bounds are not supported here",
+                            self.trait_display(sup),
+                        ),
+                    );
+                    return None;
+                }
+                Some(crate::semi::traits::TraitRef {
+                    trait_id: sup,
+                    args: vec![self_ty],
+                })
+            })
+            .collect();
+
+        let mut methods: Vec<crate::semi::traits::def::MethodSig<'tcx>> = Vec::new();
+        for member in &td.members {
+            let mspan = Some(Span {
+                start: member.start,
+                end: member.end,
+            });
+            if methods.iter().any(|m| m.name == member.value.name) {
+                self.error(
+                    mspan,
+                    format!(
+                        "trait `{}` declares method `{}` more than once",
+                        self.sym(td.name),
+                        self.sym(member.value.name)
+                    ),
+                );
+                continue;
+            }
+            methods.extend(self.trait_method_sig(&member.value, mspan, &trait_params, self_ty));
+        }
+        let def = self.traits.trait_def_mut(id);
+        def.supertraits = supertraits;
+        def.methods = methods;
+    }
+
+    /// One member of a `trait` body as a [`MethodSig`]: allocate its own
+    /// binder after the trait's, evaluate the positional parameter types,
+    /// and derive the receiver form from the first parameter. `None` (with
+    /// a report) if no `self` receiver leads.
+    ///
+    /// [`MethodSig`]: crate::semi::traits::def::MethodSig
+    fn trait_method_sig(
+        &mut self,
+        func: &surface::Function,
+        mspan: Option<Span>,
+        trait_params: &[(TokenKey, GenericId)],
+        self_ty: Ty<'tcx>,
+    ) -> Option<crate::semi::traits::def::MethodSig<'tcx>> {
+        use crate::semi::traits::def::ReceiverForm;
+
+        // The member's binder: the trait's params, then its own.
+        self.generic_names = trait_params.iter().copied().collect();
+        let own: Vec<(TokenKey, GenericId)> = func
+            .generics
+            .iter()
+            .map(|(name, bounds)| {
+                if trait_params.iter().any(|(n, _)| n == name) {
+                    self.error(
+                        mspan,
+                        format!(
+                            "generic `{0}` on the method shadows the trait's generic `{0}`",
+                            self.sym(*name)
+                        ),
+                    );
+                }
+                let bounds = self.resolve_bounds(bounds, mspan);
+                let g = self.fresh_generic(*name, bounds);
+                self.generic_names.insert(*name, g);
+                (*name, g)
+            })
+            .collect();
+        self.self_alias = Some(self_ty);
+
+        let params: Vec<Ty<'tcx>> = func
+            .params
+            .iter()
+            .map(|(_, ty, flex)| self.eval_type_flex(ty, *flex))
+            .collect();
+        // The receiver is the leading parameter named `self`; its evaluated
+        // type (or the `[flex]` marker) picks the form.
+        let receiver = func
+            .params
+            .first()
+            .filter(|(pname, _, _)| self.sym(*pname) == "self")
+            .map(|&(_, _, flex)| {
+                if flex {
+                    ReceiverForm::Flex
+                } else {
+                    match params[0].kind() {
+                        TyKind::Arc(inner) if *inner == self_ty => ReceiverForm::Arc,
+                        _ if params[0] == self_ty => ReceiverForm::Value,
+                        _ => {
+                            self.error(
+                                mspan,
+                                "the receiver of a trait method must be `Self`, \
+                                 `Arc<Self>`, or `[flex] Self`",
+                            );
+                            ReceiverForm::Value
+                        }
+                    }
+                }
+            });
+        let ret = match &func.return_type {
+            Some((ty, flex)) => self.eval_type_flex(ty, *flex),
+            None => self.tcx.mk_unit(),
+        };
+        self.generic_names.clear();
+        self.self_alias = None;
+
+        let Some(receiver) = receiver else {
+            self.error(
+                mspan,
+                "a trait method must take `self` as its first parameter",
+            );
+            return None;
+        };
+        if receiver == ReceiverForm::Flex && !func.is_regional {
+            self.error(
+                mspan,
+                "a `[flex] Self` receiver requires a `regional fn`: a flex \
+                 value cannot escape its region",
+            );
+        }
+        Some(crate::semi::traits::def::MethodSig {
+            name: func.name,
+            generics: own,
+            receiver,
+            params,
+            ret,
+            is_regional: func.is_regional,
+            span: mspan,
+        })
+    }
+
+    /// Phase D: a tricolor DFS over the batch's supertrait edges. A back
+    /// edge is reported and SEVERED — `TraitDb::reaches` recurses without a
+    /// guard, so a surviving cycle would overflow the checker later.
+    fn reject_supertrait_cycles(&mut self, batch: impl Iterator<Item = TraitId>) {
+        #[derive(Clone, Copy, PartialEq)]
+        enum Color {
+            White,
+            Gray,
+            Black,
+        }
+        let n = self.traits.traits_len();
+        let mut color = vec![Color::White; n];
+        for root in batch {
+            // Iterative DFS with an explicit stack of (node, next-edge).
+            let mut stack: Vec<(TraitId, usize)> = vec![(root, 0)];
+            if color[root.0 as usize] != Color::White {
+                continue;
+            }
+            color[root.0 as usize] = Color::Gray;
+            while let Some(&mut (node, ref mut edge)) = stack.last_mut() {
+                let supers = &self.traits.trait_def(node).supertraits;
+                if *edge >= supers.len() {
+                    color[node.0 as usize] = Color::Black;
+                    stack.pop();
+                    continue;
+                }
+                let next = supers[*edge].trait_id;
+                *edge += 1;
+                match color[next.0 as usize] {
+                    Color::White => {
+                        color[next.0 as usize] = Color::Gray;
+                        stack.push((next, 0));
+                    }
+                    Color::Gray => {
+                        // Back edge: node -> next closes a cycle.
+                        let span = self.traits.trait_def(node).span;
+                        let chain = format!(
+                            "trait `{0}` participates in a super-trait cycle: \
+                             `{0}`: `{1}`",
+                            self.trait_display(node),
+                            self.trait_display(next),
+                        );
+                        self.error(span, chain);
+                        let idx = *edge - 1;
+                        self.traits.trait_def_mut(node).supertraits.remove(idx);
+                        *stack.last_mut().map(|(_, e)| e).unwrap_or(&mut 0) -= 1;
+                    }
+                    Color::Black => {}
+                }
+            }
+        }
     }
 
     /// Allocate generics for a list of `(name, bounds)` declarations.

--- a/crates/reussir-core/src/semi/traits/builtins.rs
+++ b/crates/reussir-core/src/semi/traits/builtins.rs
@@ -83,10 +83,13 @@ impl Builtins {
                     def,
                     visibility: surface::Visibility::Public,
                     sealed: true,
-                    params: vec![self_g],
+                    self_param: self_g,
+                    params: vec![],
                     supertraits,
                     methods: vec![],
                     assoc_tys: vec![],
+                    span: None,
+                    file: reussir_syntax::source::FileId::ROOT,
                 });
             };
         declare(num, "Num", vec![], db, defs);

--- a/crates/reussir-core/src/semi/traits/db.rs
+++ b/crates/reussir-core/src/semi/traits/db.rs
@@ -99,6 +99,13 @@ impl<'tcx> TraitDb<'tcx> {
         &self.traits[id.0 as usize]
     }
 
+    /// Mutable access for the elaborator's two-phase populate: trait stubs
+    /// register first (so bounds resolve during the record/function scans),
+    /// then supertraits and members fill in.
+    pub(crate) fn trait_def_mut(&mut self, id: TraitId) -> &mut TraitDef<'tcx> {
+        &mut self.traits[id.0 as usize]
+    }
+
     /// Does holding `have` imply holding `want`? True when they are equal or
     /// `want` is in `have`'s super-trait closure.
     pub fn implies(&self, have: TraitId, want: TraitId) -> bool {
@@ -216,10 +223,13 @@ mod tests {
                 def,
                 visibility: crate::surface::Visibility::Public,
                 sealed: false,
-                params: vec![crate::semi::ty::GenericId(0)],
+                self_param: crate::semi::ty::GenericId(0),
+                params: vec![],
                 supertraits: vec![],
                 methods: vec![],
                 assoc_tys: vec![],
+                span: None,
+                file: reussir_syntax::source::FileId::ROOT,
             });
             let unit = tcx.mk_unit();
             db.add_impl(ImplDef {
@@ -245,10 +255,13 @@ mod tests {
                 def,
                 visibility: crate::surface::Visibility::Public,
                 sealed: false,
-                params: vec![crate::semi::ty::GenericId(0)],
+                self_param: crate::semi::ty::GenericId(0),
+                params: vec![],
                 supertraits: vec![],
                 methods: vec![],
                 assoc_tys: vec![],
+                span: None,
+                file: reussir_syntax::source::FileId::ROOT,
             });
             assert_eq!(db.trait_by_def(def), Some(id));
         });
@@ -314,10 +327,13 @@ mod tests {
                 def: crate::semi::ty::DefId(def),
                 visibility: crate::surface::Visibility::Public,
                 sealed: false,
-                params: vec![self_g],
+                self_param: self_g,
+                params: vec![],
                 supertraits: supers,
                 methods: vec![],
                 assoc_tys: vec![],
+                span: None,
+                file: reussir_syntax::source::FileId::ROOT,
             };
             db.add_trait(def(top, 0, vec![]));
             db.add_trait(def(mid, 1, vec![self_ref(top)]));

--- a/crates/reussir-core/src/semi/traits/def.rs
+++ b/crates/reussir-core/src/semi/traits/def.rs
@@ -3,17 +3,39 @@
 //! These are the program's trait items after name resolution. Method bodies are
 //! deliberately absent in Phase 0 — only the shapes the resolver needs.
 
+use reussir_syntax::kind::TokenKey;
+use reussir_syntax::source::FileId;
+
 use crate::semi::ty::{DefId, GenericId, Ty};
-use crate::surface;
+use crate::surface::{self, Span};
 
 use super::{ImplId, Obligation, TraitId, TraitRef};
 
+/// How a trait method takes its receiver. Tracked out of band because the
+/// flex coloring is dropped on the generic `Self`, and `Arc<Self>` peels.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReceiverForm {
+    /// `self: Self`.
+    Value,
+    /// `self: Arc<Self>`.
+    Arc,
+    /// `self: [flex] Self` (implies `regional fn`).
+    Flex,
+}
+
 /// A method declared by a trait. Bodies live on the impl side (Phase 1+).
+/// Parameters are positional (`params[0]` is the receiver): conformance is
+/// positional and no bodies exist, so names would serialize dead weight.
 #[derive(Clone, Debug)]
 pub struct MethodSig<'tcx> {
-    pub name: String,
+    pub name: TokenKey,
+    /// The method's own generics, following the trait's in the binder.
+    pub generics: Vec<(TokenKey, GenericId)>,
+    pub receiver: ReceiverForm,
     pub params: Vec<Ty<'tcx>>,
     pub ret: Ty<'tcx>,
+    pub is_regional: bool,
+    pub span: Option<Span>,
 }
 
 /// An associated type declaration. Reserved so the IR can grow into projections
@@ -38,13 +60,19 @@ pub struct TraitDef<'tcx> {
     /// value-class traits (whose operations lower by ground type) and the
     /// structural `Sync`.
     pub sealed: bool,
-    /// Type parameters; `params[0]` is the implicit `Self`.
-    pub params: Vec<GenericId>,
+    /// The implicit `Self` parameter. `GenericId(0)`-unallocated for the
+    /// builtins (their defs predate the elaborator's generics table);
+    /// `fresh_generic`-allocated for user traits.
+    pub self_param: GenericId,
+    /// The trait's declared (non-`Self`) type parameters.
+    pub params: Vec<(TokenKey, GenericId)>,
     /// Super-traits (`trait Sub: Super`). These subsume the old hard-coded class
     /// DAG: `Integral: Num` is just a super-trait edge.
     pub supertraits: Vec<TraitRef<'tcx>>,
     pub methods: Vec<MethodSig<'tcx>>,
     pub assoc_tys: Vec<AssocTyDef>,
+    pub span: Option<Span>,
+    pub file: FileId,
 }
 
 /// An impl declaration.

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -268,9 +268,8 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
                     _ => (expr, None),
                 };
                 let export = format!("__repl_expr_{}", self.counter);
-                let name = Interner::get_or_intern(&mut self.interner.clone(), &export);
-                let dec_name =
-                    Interner::get_or_intern(&mut self.interner.clone(), &format!("{export}_dec"));
+                let name = self.interner.intern(&export);
+                let dec_name = self.interner.intern(&format!("{export}_dec"));
                 let in_scope: Vec<_> = self.bindings.iter().map(|b| (b.name, b.ty)).collect();
                 match self.elab.try_repl_expr(
                     &reussir_core::semi::repl::ReplExprRequest {
@@ -458,8 +457,8 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         }
         let expr = surface::repl_expr(&parsed.parse.root);
         let cp = self.elab.checkpoint();
-        let name = Interner::get_or_intern(&mut self.interner.clone(), "__repl_type_probe");
-        let dec_name = Interner::get_or_intern(&mut self.interner.clone(), "__repl_type_probe_dec");
+        let name = self.interner.intern("__repl_type_probe");
+        let dec_name = self.interner.intern("__repl_type_probe_dec");
         let in_scope: Vec<_> = self.bindings.iter().map(|b| (b.name, b.ty)).collect();
         let result = self.elab.try_repl_expr(
             &reussir_core::semi::repl::ReplExprRequest {

--- a/crates/reussir-trait-dsl/src/expand.rs
+++ b/crates/reussir-trait-dsl/src/expand.rs
@@ -154,10 +154,13 @@ pub(crate) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                         def,
                         visibility: crate::surface::Visibility::Public,
                         sealed: #sealed,
-                        params: vec![self_g],
+                        self_param: self_g,
+                        params: vec![],
                         supertraits: vec![#(#supers),*],
                         methods: vec![],
                         assoc_tys: vec![],
+                        span: None,
+                        file: reussir_syntax::source::FileId::ROOT,
                     });
                 }
             }


### PR DESCRIPTION
Stacked on #510 (T-SEM-2 of the trait stack — trait declarations elaborate).

- **Three-phase scan**, ordered around the batch's other items: **A** stubs before record/function scans (their `collect_generics` resolves bounds immediately); **C1** every trait's own binder before any supertrait resolves (closes the review-flagged same-batch arity hazard: `trait A: Convert` before `trait Convert<T>` must still reject); **C2** supertraits + member signatures (record stubs available); **D** tricolor DFS that reports **and severs** super-trait cycles (`reaches` recurses unguarded — severing is load-bearing, pinned by a does-not-overflow test).
- **`MethodSig` reshaped** per the review amendments: positional `params: Vec<Ty>` (receiver at `[0]`), own `generics`, out-of-band `ReceiverForm { Value, Arc, Flex }`, `is_regional`, span. `TraitDef` splits `self_param` (fresh per user trait, named by the once-interned `Self` key) from declared `params`, and carries span/file. Builtins + DSL templates updated to the new shape.
- **Diagnostics** (all pinned): builtin-redeclaration wording vs ordinary duplicate; `Self` declared as generic; parameterized supertrait ("parameterized bounds are not supported here"); method-shadows-trait-generic; missing receiver; malformed receiver ("must be `Self`, `Arc<Self>`, or `[flex] Self`"); duplicate method; `[flex] Self` without `regional fn`. Parser-owned rejections (bodies/`pub` members/foreign bodies) deliberately not duplicated here, per review A3.
- **Working end to end**: `fn f<T: Show>` resolves a user trait bound; `T: Croppable` with `Croppable: Num` discharges `x + x` through the existing supertrait closure; REPL batches with a bad trait retract atomically and the name redeclares (`rejected_batch_retracts_trait_decls`).
- Trait *implementations* remain cleanly rejected until the next PR (impl-for + conformance).

Gate: `cargo test` 552 green, `ninja -C build check` 462/465 (baseline), `rrc-test` green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788326254&installation_model_id=426051&pr_number=511&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F511&signature=b4d422bd69ccc50a9b60b808c94e3f59c68e7514d32ee50f499e4cf12597ed9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->