### PR TITLE
[core] elaborate `impl Trait for Type`: conformance, sealed builtins, impl-method identity

### DIFF
--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -321,6 +321,17 @@ mod tests {
         );
     }
 
+    /// A trait-impl method's path — `[impl-module.., trait-path.., head,
+    /// method]` — mangles through the same machinery: every segment is an
+    /// ordinary nested-path component.
+    #[test]
+    fn trait_impl_method_symbol_mangles_through_segments() {
+        assert_eq!(
+            mangle_segments(&["demo", "Show", "Vec", "norm"]),
+            "_RNvNvNvC4demo4Show3Vec4norm"
+        );
+    }
+
     /// A method's path carries its type as an ordinary segment; a generic
     /// instance flattens the impl+method arguments at the path tail.
     #[test]

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1090,38 +1090,199 @@ mod tests {
         );
     }
 
-    /// Until the impl-for stack lands, trait implementations are rejected
-    /// cleanly — and their members are never misattached as inherent
-    /// methods. (Trait declarations themselves now elaborate.)
     #[test]
-    fn trait_items_are_rejected_for_now() {
-        elaborate_source(
-            "pub struct P { pub x: i64 }
-             impl Show for P { fn show(self: Self) -> i64 { 1 } }
-             impl P { pub fn ok(self: Self) -> i64 { self.x } }",
-            |elab| {
+    fn trait_impl_conformance_accepted_and_bodies_check() {
+        check(
+            "pub trait Show { fn show(self: Self, k: i64) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl Show for P { fn show(self: Self, k: i64) -> i64 { self.x * k } }",
+            |elab, _| {
+                // The member declared under the trait-impl path and its body
+                // checked through the common flow.
+                let show = elab
+                    .functions
+                    .values()
+                    .find(|f| elab.sym(f.name) == "show")
+                    .expect("declared");
                 assert_eq!(
-                    elab.reports.len(),
-                    1,
-                    "exactly the placeholder, no cascades: {:#?}",
+                    elab.defs.path(show.def).display(elab.resolver),
+                    "Show::P::show"
+                );
+                assert!(elab.elaborated.iter().any(|f| f.def == show.def));
+            },
+        );
+    }
+
+    #[test]
+    fn trait_impl_conformance_matrix() {
+        let hdr = "pub trait Show { fn show(self: Self, k: i64) -> i64; }\n\
+                   pub struct P { pub x: i64 }\n";
+        for (src, needle) in [
+            ("impl Show for P { }", "is missing method(s) `show`"),
+            (
+                "impl Show for P { fn show(self: Self, k: i64) -> i64 { k } \
+                 fn extra(self: Self) -> i64 { 0 } }",
+                "`extra` is not a member of trait `Show`",
+            ),
+            (
+                "impl Show for P { fn show(self: Self, k: bool) -> i64 { 1 } }",
+                "parameter 1 of method `show` has type `bool` but trait `Show` requires `i64`",
+            ),
+            (
+                "impl Show for P { fn show(self: Self, k: i64) -> bool { true } }",
+                "returns `bool` but trait `Show` requires `i64`",
+            ),
+            (
+                "impl Show for P { fn show(self: Arc<Self>, k: i64) -> i64 { k } }",
+                "the receiver of `show` must be `self: Self` to match trait `Show`",
+            ),
+            (
+                "impl Show for P { regional fn show(self: Self, k: i64) -> i64 { k } }",
+                "is not `regional` in trait `Show` but is in this impl",
+            ),
+            (
+                "impl Show for P { fn show<U: Num>(self: Self, k: i64) -> i64 { k } }",
+                "declares 1 generic parameter(s); trait `Show` declares 0",
+            ),
+            (
+                "impl Show for P { pub fn show(self: Self, k: i64) -> i64 { k } }",
+                "visibility is not allowed on a trait impl method",
+            ),
+        ] {
+            let source = format!("{hdr}{src}");
+            elaborate_source(&source, |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r.message.contains(needle)),
+                    "wanted {needle:?} in {:#?}",
                     elab.reports
                 );
+            });
+        }
+    }
+
+    #[test]
+    fn sealed_builtins_cannot_be_implemented() {
+        for tr in ["Num", "Integral", "FloatingPoint", "PtrLike", "Sync"] {
+            let source = format!("pub struct P {{ pub x: i64 }}\nimpl {tr} for P {{ }}");
+            elaborate_source(&source, |elab| {
                 assert!(
-                    elab.reports[0].message.contains(
-                        "trait implementations (`impl Trait for Type`) are not supported yet"
-                    ),
+                    elab.reports.iter().any(|r| r
+                        .message
+                        .contains("is a built-in trait and cannot be implemented")),
+                    "{tr}: {:#?}",
+                    elab.reports
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn trait_and_inherent_methods_coexist() {
+        check(
+            "pub trait Show { fn norm(self: Self) -> i64; }\n\
+             pub struct V { pub x: i64 }\n\
+             impl V { pub fn norm(self: Self) -> i64 { self.x } }\n\
+             impl Show for V { fn norm(self: Self) -> i64 { 0 - self.x } }",
+            |elab, _| {
+                // Distinct paths: [V, norm] inherent, [Show, V, norm] trait.
+                let paths: Vec<String> = elab
+                    .functions
+                    .values()
+                    .filter(|f| elab.sym(f.name) == "norm")
+                    .map(|f| elab.defs.path(f.def).display(elab.resolver))
+                    .collect();
+                assert_eq!(paths.len(), 2, "{paths:?}");
+                assert!(paths.contains(&"V::norm".to_string()));
+                assert!(paths.contains(&"Show::V::norm".to_string()));
+            },
+        );
+    }
+
+    #[test]
+    fn duplicate_ground_trait_impls_hit_the_guided_clash() {
+        elaborate_source(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl Show for P { fn show(self: Self) -> i64 { 1 } }\n\
+             impl Show for P { fn show(self: Self) -> i64 { 2 } }",
+            |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r
+                        .message
+                        .contains("already declared by another impl; merge the impls")),
                     "{:#?}",
                     elab.reports
                 );
-                // The trait impl's member was not declared as an inherent
-                // method, while the inherent block's member was.
-                assert!(
-                    !elab.functions.values().any(|f| elab.sym(f.name) == "show"),
-                    "misattached trait-impl member"
-                );
-                assert!(elab.functions.values().any(|f| elab.sym(f.name) == "ok"));
             },
         );
+    }
+
+    #[test]
+    fn impl_where_clauses_from_inline_bounds() {
+        check(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct Box<T> { pub v: T }\n\
+             impl<T: Num> Show for Box<T> { fn show(self: Self) -> i64 { 1 } }",
+            |elab, _| {
+                let imp = (0..elab.traits.impls_len() as u32)
+                    .map(crate::semi::traits::ImplId)
+                    .map(|i| elab.traits.impl_def(i))
+                    .find(|i| !i.generics.is_empty())
+                    .expect("generic impl registered");
+                assert_eq!(imp.where_clauses.len(), 1, "T: Num recorded");
+                assert_eq!(imp.methods.len(), 1);
+            },
+        );
+    }
+
+    #[test]
+    fn impl_generic_must_be_constrained() {
+        elaborate_source(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl<T: Num> Show for P { fn show(self: Self) -> i64 { 1 } }",
+            |elab| {
+                assert!(
+                    elab.reports
+                        .iter()
+                        .any(|r| r.message.contains("impl generic `T` is not constrained")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn rejected_batch_retracts_trait_impls() {
+        use std::sync::Arc;
+        with_tcx(|tcx| {
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = |src: &str| {
+                let p = reussir_syntax::parse_with_interner(src, interner.clone());
+                assert!(p.ok(), "parse errors for {src:?}: {:#?}", p.errors);
+                p
+            };
+            let mut elab = Elaborator::new(tcx, &interner);
+            let p1 = parse(
+                "pub trait Show { fn show(self: Self) -> i64; }\n\
+                 pub struct P { pub x: i64 }",
+            );
+            elab.try_extend(&surface::program(&p1.root)).expect("decl");
+            let impls_before = elab.traits.impls_len();
+
+            // A batch whose impl member body fails is rejected wholesale …
+            let p2 = parse("impl Show for P { fn show(self: Self) -> i64 { true } }");
+            elab.try_extend(&surface::program(&p2.root))
+                .expect_err("bad body");
+            assert_eq!(elab.traits.impls_len(), impls_before, "impl retracted");
+
+            // … and the corrected impl registers cleanly (no phantom impl,
+            // no phantom method defs).
+            let p3 = parse("impl Show for P { fn show(self: Self) -> i64 { self.x } }");
+            elab.try_extend(&surface::program(&p3.root)).expect("fixed");
+            assert_eq!(elab.traits.impls_len(), impls_before + 1);
+        });
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -295,6 +295,10 @@ pub(super) struct ImplCtx<'x, 'tcx> {
     /// The applied target type — what `Self` (and a receiver annotation)
     /// means inside the block, in the record's unrefined coloring.
     pub self_ty: Ty<'tcx>,
+    /// For a *trait* impl member: the implemented trait (declaration goes
+    /// under `[impl-module.., trait-path.., head-name, method]`, visibility
+    /// is the trait's, and the clash diagnostic names the trait).
+    pub trait_of: Option<TraitId>,
 }
 
 fn collect_regional_generic(t: Ty<'_>, out: &mut Vec<GenericId>) {
@@ -1426,17 +1430,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                                  mark individual members `pub` instead",
                             );
                         }
-                        if ib.trait_ref.is_some() {
-                            // Not collected: members must not be declared as
-                            // inherent methods of the target.
-                            self.error(
-                                span,
-                                "trait implementations (`impl Trait for Type`) \
-                                 are not supported yet",
-                            );
-                        } else {
-                            impls.push((ib, span, scope));
-                        }
+                        impls.push((ib, span, scope));
                     }
                     surface::StmtKind::Trait(td) => {
                         self.validate_transform_anchor(&attrs, None);
@@ -1528,6 +1522,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         for (ib, span, scope) in &impls {
             self.set_current_file(scope.file);
             self.defs.set_module(scope.module.to_vec());
+            if ib.trait_ref.is_some() {
+                let declared = self.scan_trait_impl(ib, *span);
+                for (m, def) in ib.members.iter().zip(declared) {
+                    let mspan = Some(surface::Span {
+                        start: m.start,
+                        end: m.end,
+                    });
+                    methods.push((&m.value, mspan, def));
+                }
+                continue;
+            }
             let target = self.scan_impl_target(ib, *span);
             let impl_generics = target.map(|_| self.collect_generics(&ib.generics, *span));
             // The applied target type: `Self` inside the block. Evaluated
@@ -1558,6 +1563,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                             target,
                             generics,
                             self_ty,
+                            trait_of: None,
                         };
                         self.scan_method(&m.value, false, Some(&ctx), mspan)
                     }
@@ -1982,6 +1988,351 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.scan_method(func, is_ffi_import, None, span)
     }
 
+    /// Scan a trait implementation `impl<G..> Trait<args> for Type<..>`:
+    /// resolve and gate the trait (sealed builtins rejected), validate the
+    /// target and trait-argument arity, enforce E0207 constrainedness,
+    /// declare every member under the trait-impl path, check conformance
+    /// against the trait's method signatures (exact set, positional, Self
+    /// substituted), and register the `ImplDef`. Returns each member's
+    /// declared def in member order so bodies join the common check flow.
+    fn scan_trait_impl(
+        &mut self,
+        ib: &surface::ImplBlock,
+        span: Option<Span>,
+    ) -> Vec<Option<DefId>> {
+        let nones = vec![None; ib.members.len()];
+        let tref = ib.trait_ref.as_ref().expect("trait impl");
+        let (tpath, targs_surface) = (&tref.path, &tref.args);
+
+        // Resolve the trait through the trait namespace.
+        let expanded = self.expand_path(tpath);
+        let rpath = expanded.as_ref().unwrap_or(tpath);
+        let tdef = if self.extern_head(rpath).is_some() {
+            self.resolve_extern(rpath, DefKind::Trait)
+        } else if rpath.segments.is_empty() {
+            self.defs.resolve_trait(rpath.basename)
+        } else {
+            self.defs
+                .resolve_trait_path(&self.classify_segs(rpath), rpath.basename)
+        };
+        let Some(tid) = tdef.and_then(|d| self.traits.trait_by_def(d)) else {
+            if let Some(msg) = self.extern_private_msg(rpath, DefKind::Trait) {
+                self.error(span, msg);
+                return nones;
+            }
+            let hint = if rpath.segments.is_empty() {
+                self.trait_suggestion(self.sym(rpath.basename))
+            } else {
+                String::new()
+            };
+            let shown = self.path_display(rpath);
+            self.error(
+                span,
+                format!("cannot implement unknown trait `{shown}`{hint}"),
+            );
+            return nones;
+        };
+        if self.traits.trait_def(tid).sealed {
+            self.error(
+                span,
+                format!(
+                    "`{}` is a built-in trait and cannot be implemented; its \
+                     impls are provided by the language",
+                    self.trait_display(tid)
+                ),
+            );
+            return nones;
+        }
+
+        let Some(target) = self.scan_impl_target(ib, span) else {
+            return nones;
+        };
+        let generics = self.collect_generics(&ib.generics, span);
+
+        // Trait arguments and the self type evaluate under the block
+        // generics.
+        self.generic_names = generics.iter().map(|(n, id)| (*n, *id)).collect();
+        let trait_args: Vec<Ty<'tcx>> = targs_surface.iter().map(|a| self.eval_type(a)).collect();
+        let self_args: Vec<Ty<'tcx>> = ib.target_args.iter().map(|a| self.eval_type(a)).collect();
+        self.generic_names.clear();
+        let flex = match self.records[&target].default_cap {
+            DefaultCap::Value | DefaultCap::Shared => Flexivity::Irrelevant,
+            DefaultCap::Regional => Flexivity::Regional,
+        };
+        let self_ty = self.tcx.mk_record(target, &self_args, flex);
+
+        let expected = self.traits.trait_def(tid).params.len();
+        if trait_args.len() != expected {
+            self.error(
+                span,
+                format!(
+                    "trait `{}` expects {expected} type argument(s), got {}",
+                    self.trait_display(tid),
+                    trait_args.len()
+                ),
+            );
+            return nones;
+        }
+
+        // E0207: every block generic must be constrained by the trait
+        // reference or the self type, or monomorphization could never derive
+        // its instantiation.
+        let mut constrained = rustc_hash::FxHashSet::default();
+        std::iter::once(self_ty)
+            .chain(trait_args.iter().copied())
+            .for_each(|t| crate::semi::traits::subst::collect_generics_of(t, &mut constrained));
+        generics
+            .iter()
+            .filter(|(_, g)| !constrained.contains(g))
+            .map(|&(name, _)| {
+                format!(
+                    "impl generic `{}` is not constrained by the trait \
+                     reference or the self type",
+                    self.sym(name)
+                )
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .for_each(|msg| self.error(span, msg));
+
+        // Members: declare + conformance, in member order; track coverage in
+        // trait-method order for the missing-set diagnostic and the
+        // ImplDef's method table.
+        let sigs = self.traits.trait_def(tid).methods.clone();
+        let mut by_sig: Vec<Option<DefId>> = vec![None; sigs.len()];
+        let declared: Vec<Option<DefId>> = ib
+            .members
+            .iter()
+            .map(|m| {
+                let func = &m.value;
+                let mspan = Some(Span {
+                    start: m.start,
+                    end: m.end,
+                });
+                let Some(sig_idx) = sigs.iter().position(|sig| sig.name == func.name) else {
+                    self.error(
+                        mspan,
+                        format!(
+                            "`{}` is not a member of trait `{}`",
+                            self.sym(func.name),
+                            self.trait_display(tid)
+                        ),
+                    );
+                    return None;
+                };
+                if func.visibility == surface::Visibility::Public {
+                    self.error(
+                        mspan,
+                        "visibility is not allowed on a trait impl method; the \
+                         trait's visibility applies",
+                    );
+                }
+                self.defs.set_module(self.defs.module().to_vec());
+                let ctx = ImplCtx {
+                    target,
+                    generics: &generics,
+                    self_ty,
+                    trait_of: Some(tid),
+                };
+                let def = self.scan_method(func, false, Some(&ctx), mspan)?;
+                if by_sig[sig_idx].replace(def).is_some() {
+                    // Duplicate member: the declare clash already reported.
+                    return Some(def);
+                }
+                self.check_conformance(
+                    tid,
+                    &sigs[sig_idx],
+                    def,
+                    self_ty,
+                    &trait_args,
+                    generics.len(),
+                    mspan,
+                );
+                Some(def)
+            })
+            .collect();
+
+        let missing: Vec<String> = sigs
+            .iter()
+            .zip(&by_sig)
+            .filter(|(_, d)| d.is_none())
+            .map(|(sig, _)| format!("`{}`", self.sym(sig.name)))
+            .collect();
+        if !missing.is_empty() {
+            self.error(
+                span,
+                format!(
+                    "impl of trait `{}` for `{}` is missing method(s) {}",
+                    self.trait_display(tid),
+                    self.ty_display(self_ty),
+                    missing.join(", ")
+                ),
+            );
+            return declared;
+        }
+
+        let id = crate::semi::traits::ImplId(self.traits.impls_len() as u32);
+        let mut args = Vec::with_capacity(1 + trait_args.len());
+        args.push(self_ty);
+        args.extend(trait_args.iter().copied());
+        let where_clauses = generics
+            .iter()
+            .flat_map(|(_, g)| {
+                let gt = self.tcx.mk_generic(*g);
+                self.generic_bounds(*g)
+                    .iter()
+                    .map(move |&b| {
+                        crate::semi::traits::Obligation::Trait(crate::semi::traits::TraitRef {
+                            trait_id: b,
+                            args: vec![gt],
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        self.traits.add_impl(crate::semi::traits::def::ImplDef {
+            id,
+            generics: generics.iter().map(|(_, g)| *g).collect(),
+            trait_ref: crate::semi::traits::TraitRef {
+                trait_id: tid,
+                args,
+            },
+            self_ty,
+            where_clauses,
+            methods: by_sig
+                .into_iter()
+                .map(|d| d.expect("missing checked"))
+                .collect(),
+            span,
+            file: self.current_file,
+        });
+        declared
+    }
+
+    /// Conformance of one declared member against its trait signature: the
+    /// trait's binder substituted (`Self` -> the impl self type, trait
+    /// params -> the impl's trait arguments, the signature's own generics ->
+    /// the member's own), then positional pointer-equality over the
+    /// non-receiver parameters and the return type, plus receiver-form,
+    /// regional, and generic-count parity.
+    #[allow(clippy::too_many_arguments)]
+    fn check_conformance(
+        &mut self,
+        tid: TraitId,
+        sig: &crate::semi::traits::def::MethodSig<'tcx>,
+        def: DefId,
+        self_ty: Ty<'tcx>,
+        trait_args: &[Ty<'tcx>],
+        block_generics: usize,
+        span: Option<Span>,
+    ) {
+        use crate::semi::traits::def::ReceiverForm;
+        let proto = self.functions[&def].clone();
+        let tdef = self.traits.trait_def(tid);
+        let name = self.sym(proto.name).to_owned();
+        let tr = self.trait_display(tid);
+
+        // The member's own generics follow the block's in its binder.
+        let own = &proto.generics[block_generics..];
+        if own.len() != sig.generics.len() {
+            self.error(
+                span,
+                format!(
+                    "method `{name}` declares {} generic parameter(s); trait \
+                     `{tr}` declares {}",
+                    own.len(),
+                    sig.generics.len()
+                ),
+            );
+            return;
+        }
+
+        let map: FxHashMap<GenericId, Ty<'tcx>> = std::iter::once((tdef.self_param, self_ty))
+            .chain(
+                tdef.params
+                    .iter()
+                    .zip(trait_args)
+                    .map(|(&(_, p), &a)| (p, a)),
+            )
+            .chain(
+                sig.generics
+                    .iter()
+                    .zip(own)
+                    .map(|(&(_, sg), &(_, ig))| (sg, self.tcx.mk_generic(ig))),
+            )
+            .collect();
+
+        if sig.params.len() != proto.params.len() {
+            self.error(
+                span,
+                format!(
+                    "method `{name}` takes {} parameter(s); trait `{tr}` \
+                     requires {}",
+                    proto.params.len(),
+                    sig.params.len()
+                ),
+            );
+            return;
+        }
+        // Receiver: form parity, not type equality (flexivity refinement and
+        // the arc peel make the spellings differ structurally).
+        let impl_form = {
+            let (_, pty) = &proto.params[0];
+            match pty.kind() {
+                TyKind::Arc(_) => ReceiverForm::Arc,
+                _ if self.is_flex(*pty) => ReceiverForm::Flex,
+                _ => ReceiverForm::Value,
+            }
+        };
+        if impl_form != sig.receiver {
+            let want = match sig.receiver {
+                ReceiverForm::Value => "self: Self",
+                ReceiverForm::Arc => "self: Arc<Self>",
+                ReceiverForm::Flex => "self: [flex] Self",
+            };
+            self.error(
+                span,
+                format!("the receiver of `{name}` must be `{want}` to match trait `{tr}`"),
+            );
+        }
+        for (i, ((_, ity), &sty)) in proto.params.iter().zip(&sig.params).enumerate().skip(1) {
+            let want = crate::semi::traits::subst::replace_generics(self.tcx, sty, &map);
+            if *ity != want {
+                self.error(
+                    span,
+                    format!(
+                        "parameter {i} of method `{name}` has type `{}` but trait \
+                         `{tr}` requires `{}`",
+                        self.ty_display(*ity),
+                        self.ty_display(want)
+                    ),
+                );
+            }
+        }
+        let want_ret = crate::semi::traits::subst::replace_generics(self.tcx, sig.ret, &map);
+        if proto.return_ty != want_ret {
+            self.error(
+                span,
+                format!(
+                    "method `{name}` returns `{}` but trait `{tr}` requires `{}`",
+                    self.ty_display(proto.return_ty),
+                    self.ty_display(want_ret)
+                ),
+            );
+        }
+        if sig.is_regional != proto.is_regional {
+            let (a, b) = if sig.is_regional {
+                ("is", "but not in this impl")
+            } else {
+                ("is not", "but is in this impl")
+            };
+            self.error(
+                span,
+                format!("method `{name}` {a} `regional` in trait `{tr}` {b}"),
+            );
+        }
+    }
+
     /// Validate an `impl` block's target: it must resolve to a record this
     /// package defines, in the module the block appears in, with a fully
     /// applied generic head.
@@ -2130,8 +2481,23 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
         let name = func.name;
         let declared = match impl_ctx {
-            // A member declares under the type's own qualified path, so
-            // `Type::method` resolves like any path and mangles unchanged.
+            // A trait-impl member declares under
+            // `[impl-module.., trait-path.., head-name, method]` — unique by
+            // coherence, never spelled at call sites (dispatch goes through
+            // the trait), mangled by the ordinary path machinery.
+            Some(ctx) if ctx.trait_of.is_some() => {
+                let tid = ctx.trait_of.expect("checked");
+                let module = self.defs.module().to_vec();
+                let mut decl = module.clone();
+                decl.extend(self.defs.path(self.traits.trait_def(tid).def).0.iter());
+                decl.push(self.defs.path(ctx.target).name());
+                self.defs.set_module(decl);
+                let def = self.defs.declare_function(name);
+                self.defs.set_module(module);
+                def
+            }
+            // An inherent member declares under the type's own qualified
+            // path, so `Type::method` resolves like any path.
             Some(ctx) => {
                 let module = self.defs.module().to_vec();
                 let type_path = self.defs.path(ctx.target).0.clone();
@@ -2144,6 +2510,20 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
         let Some(def) = declared else {
             match impl_ctx {
+                Some(ctx) if ctx.trait_of.is_some() => {
+                    let tid = ctx.trait_of.expect("checked");
+                    let ty = self.sym(self.defs.path(ctx.target).name()).to_owned();
+                    let tr = self.trait_display(tid);
+                    self.error(
+                        span,
+                        format!(
+                            "a method `{0}` for `{ty}` under trait `{tr}` is already \
+                             declared by another impl; merge the impls of `{tr}` for \
+                             `{ty}` into one parameterized impl",
+                            self.sym(name)
+                        ),
+                    );
+                }
                 Some(ctx) => {
                     let ty = self.sym(self.defs.path(ctx.target).name());
                     self.error(
@@ -2162,10 +2542,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             }
             return None;
         };
+        let visibility = match impl_ctx {
+            // Trait members take the trait's visibility.
+            Some(ctx) if ctx.trait_of.is_some() => {
+                self.traits
+                    .trait_def(ctx.trait_of.expect("checked"))
+                    .visibility
+            }
+            _ => func.visibility,
+        };
         let proto = FuncProto {
             def,
             name,
-            visibility: func.visibility,
+            visibility,
             generics,
             regional_generics,
             params,

--- a/crates/reussir-core/src/semi/traits.rs
+++ b/crates/reussir-core/src/semi/traits.rs
@@ -13,6 +13,7 @@
 pub mod builtins;
 pub mod db;
 pub mod def;
+pub mod subst;
 pub mod sync;
 
 pub use db::{SelectError, TraitDb};

--- a/crates/reussir-core/src/semi/traits/builtins.rs
+++ b/crates/reussir-core/src/semi/traits/builtins.rs
@@ -117,6 +117,9 @@ impl Builtins {
                 },
                 self_ty,
                 where_clauses: vec![],
+                methods: vec![],
+                span: None,
+                file: reussir_syntax::source::FileId::ROOT,
             });
         };
 

--- a/crates/reussir-core/src/semi/traits/db.rs
+++ b/crates/reussir-core/src/semi/traits/db.rs
@@ -99,6 +99,10 @@ impl<'tcx> TraitDb<'tcx> {
         &self.traits[id.0 as usize]
     }
 
+    pub fn impl_def(&self, id: ImplId) -> &ImplDef<'tcx> {
+        &self.impls[id.0 as usize]
+    }
+
     /// Mutable access for the elaborator's two-phase populate: trait stubs
     /// register first (so bounds resolve during the record/function scans),
     /// then supertraits and members fill in.
@@ -241,6 +245,9 @@ mod tests {
                 },
                 self_ty: unit,
                 where_clauses: vec![],
+                methods: vec![],
+                span: None,
+                file: reussir_syntax::source::FileId::ROOT,
             });
             assert_eq!(db.trait_by_def(def), Some(id));
 
@@ -349,6 +356,9 @@ mod tests {
                 },
                 self_ty: unit,
                 where_clauses: vec![],
+                methods: vec![],
+                span: None,
+                file: reussir_syntax::source::FileId::ROOT,
             });
 
             // `unit: Top` is two hops away (Sub -> Mid -> Top): the evidence must

--- a/crates/reussir-core/src/semi/traits/def.rs
+++ b/crates/reussir-core/src/semi/traits/def.rs
@@ -84,6 +84,13 @@ pub struct ImplDef<'tcx> {
     /// The trait being implemented; `trait_ref.args[0]` is `self_ty`.
     pub trait_ref: TraitRef<'tcx>,
     pub self_ty: Ty<'tcx>,
-    /// Obligations the impl assumes (`where …`).
+    /// Obligations the impl assumes (`where …`; populated from the block
+    /// generics' inline bounds this cut).
     pub where_clauses: Vec<Obligation<'tcx>>,
+    /// The declared method bodies, as function defs in *trait-method order*
+    /// — the future `TraitCall { method index }` targets. Empty for the
+    /// builtin (method-less) impls.
+    pub methods: Vec<DefId>,
+    pub span: Option<Span>,
+    pub file: FileId,
 }

--- a/crates/reussir-core/src/semi/traits/subst.rs
+++ b/crates/reussir-core/src/semi/traits/subst.rs
@@ -1,0 +1,82 @@
+//! A total structural substituter over `Ty` for trait machinery.
+//!
+//! Unlike `full::subst::subst_ty` — which panics on an unmapped generic
+//! (monomorphization must ground everything) — this walker lets unmapped
+//! generics pass through: conformance checking substitutes only the trait's
+//! binder while the member's own generics stay rigid.
+
+use rustc_hash::FxHashMap;
+
+use crate::semi::ty::{GenericId, Ty, TyCtxt, TyKind};
+
+pub fn replace_generics<'tcx>(
+    tcx: &TyCtxt<'tcx>,
+    ty: Ty<'tcx>,
+    map: &FxHashMap<GenericId, Ty<'tcx>>,
+) -> Ty<'tcx> {
+    match *ty.kind() {
+        TyKind::Generic(g) => map.get(&g).copied().unwrap_or(ty),
+        TyKind::Nullable(inner) => {
+            let n = replace_generics(tcx, inner, map);
+            if n == inner { ty } else { tcx.mk_nullable(n) }
+        }
+        TyKind::Arc(inner) => {
+            let n = replace_generics(tcx, inner, map);
+            if n == inner { ty } else { tcx.mk_arc(n) }
+        }
+        TyKind::Cell { elem, kind } => {
+            let n = replace_generics(tcx, elem, map);
+            if n == elem { ty } else { tcx.mk_cell(n, kind) }
+        }
+        TyKind::Record {
+            def,
+            ref args,
+            flex,
+        } => {
+            let new: Vec<Ty> = args
+                .iter()
+                .map(|&a| replace_generics(tcx, a, map))
+                .collect();
+            if new.iter().zip(args.iter()).all(|(a, b)| a == b) {
+                ty
+            } else {
+                tcx.mk_record(def, &new, flex)
+            }
+        }
+        TyKind::Closure { ref params, ret } => {
+            let new: Vec<Ty> = params
+                .iter()
+                .map(|&p| replace_generics(tcx, p, map))
+                .collect();
+            let r = replace_generics(tcx, ret, map);
+            if r == ret && new.iter().zip(params.iter()).all(|(a, b)| a == b) {
+                ty
+            } else {
+                tcx.mk_closure(&new, r)
+            }
+        }
+        TyKind::Array { elem, ref dims } => {
+            let n = replace_generics(tcx, elem, map);
+            if n == elem { ty } else { tcx.mk_array(n, dims) }
+        }
+        _ => ty,
+    }
+}
+
+/// Collect every generic occurring in `ty` — the E0207 constrainedness walk.
+pub fn collect_generics_of(ty: Ty<'_>, out: &mut rustc_hash::FxHashSet<GenericId>) {
+    match *ty.kind() {
+        TyKind::Generic(g) => {
+            out.insert(g);
+        }
+        TyKind::Nullable(inner) | TyKind::Arc(inner) => collect_generics_of(inner, out),
+        TyKind::Cell { elem, .. } => collect_generics_of(elem, out),
+        TyKind::Record { ref args, .. } => args.iter().for_each(|&a| collect_generics_of(a, out)),
+        TyKind::Closure { ref params, ret } => {
+            params.iter().for_each(|&p| collect_generics_of(p, out));
+            collect_generics_of(ret, out);
+        }
+        TyKind::Array { elem, .. } => collect_generics_of(elem, out),
+        _ => {}
+    }
+}

--- a/crates/reussir-trait-dsl/src/expand.rs
+++ b/crates/reussir-trait-dsl/src/expand.rs
@@ -187,6 +187,9 @@ pub(crate) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                             },
                             self_ty,
                             where_clauses: vec![],
+                            methods: vec![],
+                            span: None,
+                            file: reussir_syntax::source::FileId::ROOT,
                         });
                     }
                 }


### PR DESCRIPTION
Stacked on #511 (T-SEM-3 of the trait stack — trait impls elaborate).

```rust
pub trait Show { fn show(self: Self, k: i64) -> i64; }
pub struct Box<T> { pub v: T }
impl<T: Num> Show for Box<T> { fn show(self: Self, k: i64) -> i64 { k } }
```

- **Gates in order**: unknown-trait (is-private split preserved) → **sealed builtins** (`impl Num/Sync for T` rejected with the provided-by-the-language wording; Sync's structural discharge untouched) → target validation (existing machinery) → trait-arg arity → **E0207** (every impl generic must occur in the trait ref or self type — without it mono could never derive the instantiation; review amendment).
- **Conformance = exact set, positional** (per review A4/A6): membership, generic count, receiver *form* parity (Value/Arc/Flex, derived symmetrically with the trait side), param/return pointer-equality under {`Self`→self ty, trait params→trait args, sig generics→member's own} via the new total substituter `traits/subst.rs`, regional parity, no member `pub`; missing methods aggregate. Full matrix pinned (8 diagnostics).
- **Impl-method identity (D-D)**: ordinary functions at `[impl-module.., trait-path.., head, method]` — `Show::V::norm` coexists with inherent `V::norm` (pinned), duplicate ground impls hit the guided *merge-your-impls* clash, symbols mangle through the existing segment machinery (`_RNvNvNvC4demo4Show3Vec4norm` pinned).
- **`ImplDef` registration**: generics, full `trait_ref` (`args = [self] ++ trait_args`), where-clauses from inline bounds (D-H), and `methods: Vec<DefId>` in *trait-method order* — the future `TraitCall{method index}` targets. Bodies check through the common flow; **rejected batches retract the ImplDef + method defs atomically** (pinned: no phantom impls, corrected impl re-registers).
- Interim state (per the review's A1 plan, stated openly): generic trait impls register but are **unselectable until the select rewrite PR** — obligations on them fail closed ("does not implement"), never silently mis-resolve.

Gate: `cargo test` 560 green, `ninja -C build check` 462/465 (baseline), `rrc-test` green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788326729&installation_model_id=426051&pr_number=512&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F512&signature=653417e956e613698686bda2fdce8be56cb36684262d4c1fe3d8febd1fbcb0f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->