### PR TITLE
[core] enforce trait coherence: orphan rule and two-sided overlap checking

### DIFF
--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -98,6 +98,8 @@ pub fn elaborate_package_with_externs<'a, 'tcx>(
 
 #[cfg(test)]
 mod tests {
+    use reussir_syntax::SharedInterner;
+
     use super::*;
     use crate::semi::ty::{Flexivity, IntTy, TyKind};
     use crate::with_tcx;
@@ -1200,11 +1202,29 @@ mod tests {
 
     #[test]
     fn duplicate_ground_trait_impls_hit_the_guided_clash() {
+        // Identical impls are an overlap conflict (coherence speaks first)…
         elaborate_source(
             "pub trait Show { fn show(self: Self) -> i64; }\n\
              pub struct P { pub x: i64 }\n\
              impl Show for P { fn show(self: Self) -> i64 { 1 } }\n\
              impl Show for P { fn show(self: Self) -> i64 { 2 } }",
+            |elab| {
+                assert!(
+                    elab.reports
+                        .iter()
+                        .any(|r| r.message.contains("conflicting implementations of trait")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+        // …while DISJOINT impls in one module collide only on the method
+        // path, and get steered toward a single parameterized impl.
+        elaborate_source(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct Box<T> { pub v: T }\n\
+             impl Show for Box<i32> { fn show(self: Self) -> i64 { 1 } }\n\
+             impl Show for Box<bool> { fn show(self: Self) -> i64 { 2 } }",
             |elab| {
                 assert!(
                     elab.reports.iter().any(|r| r
@@ -1246,6 +1266,201 @@ mod tests {
                     elab.reports
                         .iter()
                         .any(|r| r.message.contains("impl generic `T` is not constrained")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn cross_module_duplicate_impls_hit_overlap() {
+        // Different modules dodge the method-path clash; the (trait, head)
+        // bucket catches the conflict.
+        check_package(
+            "p",
+            &[
+                (
+                    &[],
+                    "mod a; mod b;\n\
+                     pub trait Show { fn show(self: Self) -> i64; }\n\
+                     pub struct P { pub x: i64 }",
+                ),
+                (
+                    &["a"],
+                    "impl super::Show for super::P { fn show(self: Self) -> i64 { 1 } }",
+                ),
+                (
+                    &["b"],
+                    "impl super::Show for super::P { fn show(self: Self) -> i64 { 2 } }",
+                ),
+            ],
+            |elab, _| {
+                assert!(
+                    elab.reports
+                        .iter()
+                        .any(|r| r.message.contains("conflicting implementations of trait")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn crossing_generic_impls_overlap() {
+        check_package(
+            "p",
+            &[
+                (
+                    &[],
+                    "mod a; mod b;\n\
+                     pub trait Show { fn show(self: Self) -> i64; }\n\
+                     pub struct Pair<A, B> { pub a: A, pub b: B }",
+                ),
+                (
+                    &["a"],
+                    "impl<T: Num> super::Show for super::Pair<T, i32> {\n\
+                         fn show(self: Self) -> i64 { 1 }\n\
+                     }",
+                ),
+                (
+                    &["b"],
+                    "impl<U: Num> super::Show for super::Pair<u8, U> {\n\
+                         fn show(self: Self) -> i64 { 2 }\n\
+                     }",
+                ),
+            ],
+            |elab, _| {
+                assert!(
+                    elab.reports
+                        .iter()
+                        .any(|r| r.message.contains("conflicting implementations of trait")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn disjoint_ground_impls_coexist_across_modules() {
+        check_package(
+            "p",
+            &[
+                (
+                    &[],
+                    "mod a; mod b;\n\
+                     pub trait Show { fn show(self: Self) -> i64; }\n\
+                     pub struct Box<T> { pub v: T }",
+                ),
+                (
+                    &["a"],
+                    "impl super::Show for super::Box<i32> { fn show(self: Self) -> i64 { 1 } }",
+                ),
+                (
+                    &["b"],
+                    "impl super::Show for super::Box<bool> { fn show(self: Self) -> i64 { 2 } }",
+                ),
+            ],
+            |elab, _| assert!(!elab.has_errors(), "{:#?}", elab.reports),
+        );
+    }
+
+    #[test]
+    fn orphan_rule_package_granularity() {
+        use std::sync::Arc;
+        with_tcx(|tcx| {
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = |src: &str| {
+                let p = reussir_syntax::parse_with_interner(src, interner.clone());
+                assert!(p.ok(), "parse errors for {src:?}: {:#?}", p.errors);
+                p
+            };
+            let mut elab = Elaborator::new(tcx, &interner);
+            let p1 = parse(
+                "pub trait Ext { fn e(self: Self) -> i64; }\n\
+                 pub struct Far { pub x: i64 }",
+            );
+            elab.try_extend(&surface::program(&p1.root)).expect("decls");
+            // Mark both as extern-owned, simulating .rri provenance (trait
+            // serialization lands in a later stack; the gate reads only the
+            // provenance map).
+            let head = interner.intern("dep");
+            let trait_def = (0..elab.defs.len() as u32)
+                .map(crate::semi::ty::DefId)
+                .find(|d| {
+                    elab.defs.info(*d).kind == crate::semi::resolve::DefKind::Trait
+                        && elab.sym(elab.defs.path(*d).name()) == "Ext"
+                })
+                .expect("trait def");
+            let far_def = (0..elab.defs.len() as u32)
+                .map(crate::semi::ty::DefId)
+                .find(|d| {
+                    elab.defs.info(*d).kind == crate::semi::resolve::DefKind::Record
+                        && elab.sym(elab.defs.path(*d).name()) == "Far"
+                })
+                .expect("record def");
+            elab.extern_defs.insert(trait_def, head);
+            elab.extern_defs.insert(far_def, head);
+
+            // Both extern: rejected by the orphan rule.
+            let p2 = parse("impl Ext for Far { fn e(self: Self) -> i64 { 1 } }");
+            let errs = elab
+                .try_extend(&surface::program(&p2.root))
+                .expect_err("orphan");
+            assert!(
+                errs.iter().any(|r| r
+                    .message
+                    .contains("the trait or the self type's head must be local")),
+                "{errs:#?}"
+            );
+
+            // A local trait for the extern type is admissible.
+            let p3 = parse(
+                "pub trait Local { fn l(self: Self) -> i64; }\n\
+                 impl Local for Far { fn l(self: Self) -> i64 { self.x } }",
+            );
+            elab.try_extend(&surface::program(&p3.root))
+                .expect("local trait, extern head");
+
+            // The extern trait for a local type is admissible too.
+            let p4 = parse(
+                "pub struct Near { pub y: i64 }\n\
+                 impl Ext for Near { fn e(self: Self) -> i64 { self.y } }",
+            );
+            elab.try_extend(&surface::program(&p4.root))
+                .expect("extern trait, local head");
+        });
+    }
+
+    #[test]
+    fn generic_impl_overlaps_its_ground_instance() {
+        check_package(
+            "p",
+            &[
+                (
+                    &[],
+                    "mod a; mod b;\n\
+                     pub trait Show { fn show(self: Self) -> i64; }\n\
+                     pub struct Box<T> { pub v: T }",
+                ),
+                (
+                    &["a"],
+                    "impl<T: Num> super::Show for super::Box<T> {\n\
+                         fn show(self: Self) -> i64 { 1 }\n\
+                     }",
+                ),
+                (
+                    &["b"],
+                    "impl super::Show for super::Box<i32> { fn show(self: Self) -> i64 { 2 } }",
+                ),
+            ],
+            |elab, _| {
+                assert!(
+                    elab.reports
+                        .iter()
+                        .any(|r| r.message.contains("conflicting implementations of trait")),
                     "{:#?}",
                     elab.reports
                 );

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1533,7 +1533,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 }
                 continue;
             }
-            let target = self.scan_impl_target(ib, *span);
+            let target = self.scan_impl_target(ib, false, *span);
             let impl_generics = target.map(|_| self.collect_generics(&ib.generics, *span));
             // The applied target type: `Self` inside the block. Evaluated
             // once, under the block-level generics.
@@ -2044,7 +2044,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return nones;
         }
 
-        let Some(target) = self.scan_impl_target(ib, span) else {
+        let Some(target) = self.scan_impl_target(ib, true, span) else {
             return nones;
         };
         let generics = self.collect_generics(&ib.generics, span);
@@ -2094,6 +2094,70 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             .collect::<Vec<_>>()
             .into_iter()
             .for_each(|msg| self.error(span, msg));
+
+        // ORPHAN (package granularity): the trait or the self type's head
+        // must be local — extern provenance is exactly the extern_defs map.
+        let trait_local = !self
+            .extern_defs
+            .contains_key(&self.traits.trait_def(tid).def);
+        let head_local = !self.extern_defs.contains_key(&target);
+        if !trait_local && !head_local {
+            self.error(
+                span,
+                format!(
+                    "cannot implement extern trait `{}` for extern type `{}`: \
+                     the trait or the self type's head must be local to this \
+                     package",
+                    self.trait_display(tid),
+                    self.defs.path(target).display(self.resolver)
+                ),
+            );
+            return nones;
+        }
+
+        // OVERLAP: within the (trait, head) bucket, two-sided unification —
+        // both impls' generics unifiable — so crossing generic heads
+        // (`Pair<T, i32>` vs `Pair<u8, U>`) conflict. Coherence is what
+        // makes selection's committed choice unique.
+        let head = crate::semi::traits::coherence::head_key(self_ty)
+            .expect("impl targets resolve to record heads");
+        let new_args: Vec<Ty<'tcx>> = std::iter::once(self_ty)
+            .chain(trait_args.iter().copied())
+            .collect();
+        let conflict = self
+            .traits
+            .impls_for(tid, head)
+            .iter()
+            .find_map(|&existing| {
+                let other = self.traits.impl_def(existing);
+                let vars: rustc_hash::FxHashSet<GenericId> = other
+                    .generics
+                    .iter()
+                    .chain(generics.iter().map(|(_, g)| g))
+                    .copied()
+                    .collect();
+                let mut subst = FxHashMap::default();
+                crate::semi::traits::coherence::unify_args(
+                    &other.trait_ref.args,
+                    &new_args,
+                    &vars,
+                    &mut subst,
+                )
+                .then_some(other.self_ty)
+            });
+        if let Some(other_self) = conflict {
+            self.error(
+                span,
+                format!(
+                    "conflicting implementations of trait `{}` for `{}`: \
+                     `{0}` is already implemented for `{}`",
+                    self.trait_display(tid),
+                    self.ty_display(self_ty),
+                    self.ty_display(other_self)
+                ),
+            );
+            return nones;
+        }
 
         // Members: declare + conformance, in member order; track coverage in
         // trait-method order for the missing-set diagnostic and the
@@ -2336,7 +2400,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Validate an `impl` block's target: it must resolve to a record this
     /// package defines, in the module the block appears in, with a fully
     /// applied generic head.
-    fn scan_impl_target(&mut self, ib: &surface::ImplBlock, span: Option<Span>) -> Option<DefId> {
+    fn scan_impl_target(
+        &mut self,
+        ib: &surface::ImplBlock,
+        extern_target_ok: bool,
+        span: Option<Span>,
+    ) -> Option<DefId> {
         let Some(def) = self.resolve_record_ref(&ib.target) else {
             // A private record of a loaded extern package reports access,
             // not absence — though methods for it are rejected either way.
@@ -2356,7 +2425,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             }
             return None;
         };
-        if let Some(&head) = self.extern_defs.get(&def) {
+        if !extern_target_ok && let Some(&head) = self.extern_defs.get(&def) {
             self.error(
                 span,
                 format!(

--- a/crates/reussir-core/src/semi/traits.rs
+++ b/crates/reussir-core/src/semi/traits.rs
@@ -11,6 +11,7 @@
 //! [`TraitDb::select`] entry point.
 
 pub mod builtins;
+pub mod coherence;
 pub mod db;
 pub mod def;
 pub mod subst;

--- a/crates/reussir-core/src/semi/traits/coherence.rs
+++ b/crates/reussir-core/src/semi/traits/coherence.rs
@@ -1,0 +1,212 @@
+//! Coherence: the head keying and the unification engine behind the overlap
+//! and orphan gates (RFC §5.2).
+//!
+//! One matching engine serves two callers with different variable sets:
+//! coherence's overlap check passes BOTH impls' generics as unifiable —
+//! `Pair<T, i32>` vs `Pair<u8, U>` overlap exactly because a two-sided
+//! unifier maps `T ↦ u8, U ↦ i32`, which one-way matching in either
+//! direction misses — while selection (a later stack) passes only the
+//! candidate's generics, making the same routine a one-way matcher.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::semi::ty::{CellKind, DefId, FpTy, GenericId, IntTy, Ty, TyKind};
+
+/// The head constructor an impl's self type is keyed under —
+/// `(TraitId, HeadKey)` buckets make candidate lookup and overlap checking
+/// per-head instead of per-program. `None` (no key) means the self type has
+/// no ground head: a bare generic (a blanket impl, rejected) or an
+/// error-poisoned `Bottom`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum HeadKey {
+    Record(DefId),
+    Int(IntTy),
+    Fp(FpTy),
+    Bool,
+    Str,
+    Char,
+    Unit,
+    Closure,
+    Array,
+    Cell(CellKind),
+    Nullable,
+    Arc,
+}
+
+/// The head key of a self type, `None` for headless types
+/// (`Generic`/`Hole`/`Bottom`).
+pub fn head_key(ty: Ty<'_>) -> Option<HeadKey> {
+    Some(match *ty.kind() {
+        TyKind::Record { def, .. } => HeadKey::Record(def),
+        TyKind::Int(i) => HeadKey::Int(i),
+        TyKind::Fp(f) => HeadKey::Fp(f),
+        TyKind::Bool => HeadKey::Bool,
+        TyKind::Str => HeadKey::Str,
+        TyKind::Char => HeadKey::Char,
+        TyKind::Unit => HeadKey::Unit,
+        TyKind::Closure { .. } => HeadKey::Closure,
+        TyKind::Array { .. } => HeadKey::Array,
+        TyKind::Cell { kind, .. } => HeadKey::Cell(kind),
+        TyKind::Nullable(_) => HeadKey::Nullable,
+        TyKind::Arc(_) => HeadKey::Arc,
+        TyKind::Generic(_) | TyKind::Hole(_) | TyKind::Bottom => return None,
+    })
+}
+
+/// First-order syntactic unification of two argument lists, assigning only
+/// the generics in `vars`. `subst` accumulates the assignment
+/// (resolve-through on both sides, occurs check on binding). Returns whether
+/// the lists unify — for overlap, a `true` is a conflict.
+pub fn unify_args<'tcx>(
+    a: &[Ty<'tcx>],
+    b: &[Ty<'tcx>],
+    vars: &FxHashSet<GenericId>,
+    subst: &mut FxHashMap<GenericId, Ty<'tcx>>,
+) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(&x, &y)| unify_ty(x, y, vars, subst))
+}
+
+fn resolve<'tcx>(mut ty: Ty<'tcx>, subst: &FxHashMap<GenericId, Ty<'tcx>>) -> Ty<'tcx> {
+    while let TyKind::Generic(g) = *ty.kind() {
+        match subst.get(&g) {
+            Some(&next) => ty = next,
+            None => break,
+        }
+    }
+    ty
+}
+
+fn occurs(g: GenericId, ty: Ty<'_>, subst: &FxHashMap<GenericId, Ty<'_>>) -> bool {
+    let ty = resolve(ty, subst);
+    match *ty.kind() {
+        TyKind::Generic(h) => g == h,
+        TyKind::Nullable(inner) | TyKind::Arc(inner) => occurs(g, inner, subst),
+        TyKind::Cell { elem, .. } | TyKind::Array { elem, .. } => occurs(g, elem, subst),
+        TyKind::Record { ref args, .. } => args.iter().any(|&a| occurs(g, a, subst)),
+        TyKind::Closure { ref params, ret } => {
+            params.iter().any(|&p| occurs(g, p, subst)) || occurs(g, ret, subst)
+        }
+        _ => false,
+    }
+}
+
+fn unify_ty<'tcx>(
+    a: Ty<'tcx>,
+    b: Ty<'tcx>,
+    vars: &FxHashSet<GenericId>,
+    subst: &mut FxHashMap<GenericId, Ty<'tcx>>,
+) -> bool {
+    let a = resolve(a, subst);
+    let b = resolve(b, subst);
+    if a == b {
+        return true;
+    }
+    match (a.kind(), b.kind()) {
+        (&TyKind::Generic(g), _) if vars.contains(&g) => {
+            if occurs(g, b, subst) {
+                return false;
+            }
+            subst.insert(g, b);
+            true
+        }
+        (_, &TyKind::Generic(g)) if vars.contains(&g) => {
+            if occurs(g, a, subst) {
+                return false;
+            }
+            subst.insert(g, a);
+            true
+        }
+        (TyKind::Nullable(x), TyKind::Nullable(y)) | (TyKind::Arc(x), TyKind::Arc(y)) => {
+            unify_ty(*x, *y, vars, subst)
+        }
+        (TyKind::Cell { elem: x, kind: kx }, TyKind::Cell { elem: y, kind: ky }) => {
+            kx == ky && unify_ty(*x, *y, vars, subst)
+        }
+        (
+            TyKind::Record {
+                def: dx, args: xs, ..
+            },
+            TyKind::Record {
+                def: dy, args: ys, ..
+            },
+        ) => dx == dy && unify_args(xs, ys, vars, subst),
+        (
+            TyKind::Closure {
+                params: xs,
+                ret: rx,
+            },
+            TyKind::Closure {
+                params: ys,
+                ret: ry,
+            },
+        ) => unify_args(xs, ys, vars, subst) && unify_ty(*rx, *ry, vars, subst),
+        (TyKind::Array { elem: x, dims: dx }, TyKind::Array { elem: y, dims: dy }) => {
+            dx == dy && unify_ty(*x, *y, vars, subst)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::semi::ty::TyCtxt;
+    use crate::with_tcx;
+
+    #[test]
+    fn head_keys_are_total_over_ground_heads_and_none_for_headless() {
+        with_tcx(|tcx: &TyCtxt| {
+            assert_eq!(
+                head_key(tcx.mk_int(IntTy::Signed(32))),
+                Some(HeadKey::Int(IntTy::Signed(32)))
+            );
+            assert_eq!(head_key(tcx.mk_bool()), Some(HeadKey::Bool));
+            assert_eq!(head_key(tcx.mk_generic(GenericId(7))), None);
+            assert_eq!(head_key(tcx.mk(TyKind::Bottom)), None);
+        });
+    }
+
+    #[test]
+    fn crossing_generic_heads_overlap_two_sided() {
+        // Pair<T, i32> vs Pair<u8, U>: one-way matching fails in both
+        // directions; the two-sided unifier finds T ↦ u8, U ↦ i32.
+        with_tcx(|tcx: &TyCtxt| {
+            let t = GenericId(1);
+            let u = GenericId(2);
+            let pair = DefId(0);
+            let i32t = tcx.mk_int(IntTy::Signed(32));
+            let u8t = tcx.mk_int(IntTy::Unsigned(8));
+            let a = tcx.mk_record(
+                pair,
+                &[tcx.mk_generic(t), i32t],
+                crate::semi::ty::Flexivity::Irrelevant,
+            );
+            let b = tcx.mk_record(
+                pair,
+                &[u8t, tcx.mk_generic(u)],
+                crate::semi::ty::Flexivity::Irrelevant,
+            );
+            let vars: FxHashSet<GenericId> = [t, u].into_iter().collect();
+            let mut subst = FxHashMap::default();
+            assert!(unify_args(&[a], &[b], &vars, &mut subst));
+            // Disjoint instantiations stay disjoint.
+            let c = tcx.mk_record(pair, &[i32t, i32t], crate::semi::ty::Flexivity::Irrelevant);
+            let d = tcx.mk_record(pair, &[u8t, u8t], crate::semi::ty::Flexivity::Irrelevant);
+            let mut subst = FxHashMap::default();
+            assert!(!unify_args(&[c], &[d], &vars, &mut subst));
+        });
+    }
+
+    #[test]
+    fn occurs_check_rejects_infinite_solutions() {
+        with_tcx(|tcx: &TyCtxt| {
+            let t = GenericId(1);
+            let list = DefId(0);
+            let g = tcx.mk_generic(t);
+            let wrapped = tcx.mk_record(list, &[g], crate::semi::ty::Flexivity::Irrelevant);
+            let vars: FxHashSet<GenericId> = [t].into_iter().collect();
+            let mut subst = FxHashMap::default();
+            assert!(!unify_args(&[g], &[wrapped], &vars, &mut subst));
+        });
+    }
+}

--- a/crates/reussir-core/src/semi/traits/db.rs
+++ b/crates/reussir-core/src/semi/traits/db.rs
@@ -9,9 +9,11 @@
 //! [`TraitDb::select`] entry point.
 
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 
 use crate::semi::ty::DefId;
 
+use super::coherence::{HeadKey, head_key};
 use super::def::{ImplDef, TraitDef};
 use super::{Evidence, ImplId, Obligation, TraitId, TraitRef};
 
@@ -22,6 +24,9 @@ pub struct TraitDb<'tcx> {
     impls: Vec<ImplDef<'tcx>>,
     /// The dense [`TraitId`] of each path-keyed trait def.
     by_def: FxHashMap<DefId, TraitId>,
+    /// Impls bucketed by `(trait, self-head)` — the candidate index for
+    /// overlap checking (and, in the selection stack, for `select`).
+    by_head: FxHashMap<(TraitId, HeadKey), SmallVec<[ImplId; 2]>>,
 }
 
 /// Why an obligation could not be discharged.
@@ -80,7 +85,19 @@ impl<'tcx> TraitDb<'tcx> {
                 "by_def must point at the popped trait"
             );
         }
-        self.impls.truncate(impls);
+        while self.impls.len() > impls {
+            let def = self.impls.pop().expect("len checked above");
+            let head = head_key(def.self_ty).expect("registered with a head");
+            let bucket = self
+                .by_head
+                .get_mut(&(def.trait_ref.trait_id, head))
+                .expect("registered impls have a bucket");
+            let popped = bucket.pop();
+            debug_assert_eq!(popped, Some(def.id), "buckets append in id order");
+            if bucket.is_empty() {
+                self.by_head.remove(&(def.trait_ref.trait_id, head));
+            }
+        }
     }
 
     pub fn add_impl(&mut self, def: ImplDef<'tcx>) -> ImplId {
@@ -91,8 +108,21 @@ impl<'tcx> TraitDb<'tcx> {
             "impl ids must be dense"
         );
         let id = def.id;
+        let head = head_key(def.self_ty).expect("blanket impls are rejected before registration");
+        self.by_head
+            .entry((def.trait_ref.trait_id, head))
+            .or_default()
+            .push(id);
         self.impls.push(def);
         id
+    }
+
+    /// The impls of `trait_id` whose self head is `head`.
+    pub fn impls_for(&self, trait_id: TraitId, head: HeadKey) -> &[ImplId] {
+        self.by_head
+            .get(&(trait_id, head))
+            .map(SmallVec::as_slice)
+            .unwrap_or(&[])
     }
 
     pub fn trait_def(&self, id: TraitId) -> &TraitDef<'tcx> {


### PR DESCRIPTION
Part 6 of the trait-system stack (base: #512). Coherence: every `(trait, self-head)` pair has at most one applicable impl, package-wide.

- **`semi/traits/coherence.rs`** (new): `HeadKey` — the ground head constructor an impl is keyed under (`Record(DefId)`, ints/fps, `Arc`, cells, …; `None` for headless `Generic`/`Hole`/`Bottom`) — plus a first-order unification engine (`unify_args`/`unify_ty`, occurs check, resolve-through substitution). The variable set is caller-supplied: coherence passes **both** impls' generics (two-sided), which is exactly what catches crossing heads like `Pair<T, i32>` vs `Pair<u8, U>` that one-way matching misses in either direction. The selection stack will pass only the candidate's generics, turning the same routine into a one-way matcher.
- **`TraitDb::by_head`**: impls bucketed by `(TraitId, HeadKey)` — the candidate index for overlap now and `select` later. `add_impl` inserts; `truncate` pops bucket tails (REPL rollback keeps buckets exact).
- **Orphan rule** (package granularity): in `scan_trait_impl`, the trait or the self type's head must be local — provenance is the `extern_defs` map. `impl LocalTrait for extern::Type` and `impl extern::Trait for LocalType` are both admissible; both-extern is rejected. `scan_impl_target` gains `extern_target_ok` so trait impls (unlike inherent impls) may name an extern head.
- **Overlap rule**: before members are declared, the new impl's `[self, trait_args…]` is unified against every impl in its bucket; success is a conflict (`conflicting implementations of trait …`). Identical impls in one module now get the coherence error (previously the method-path clash spoke first); *disjoint* ground impls in one module still hit the guided "merge the impls into one parameterized impl" clash, which stays pinned by test.

Tests: crossing-generic overlap through surface syntax, cross-module duplicate ground impls (method paths differ, bucket catches them), generic-vs-ground overlap (`Box<T>` vs `Box<i32>`), disjoint ground impls coexisting across modules, orphan admissibility matrix (extern provenance simulated via `extern_defs` until trait serialization lands later in the stack), head-key totality and occurs-check pins.

Gates: `cargo test` workspace-green, `cargo fmt`, `ninja -C build check`, `ninja -C build rrc-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788327463&installation_model_id=426051&pr_number=513&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F513&signature=51158ba1a7556f916554861a5f14e9a99b114111432744d73bdd51e604e6b16a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->