### PR TITLE
[core] rewrite impl selection: one-way matching, assumptions, depth limit

### DIFF
--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1469,6 +1469,45 @@ mod tests {
     }
 
     #[test]
+    fn generic_impls_are_selected_through_bounds() {
+        // The one-way matcher at work: `use_show` needs `U: Show`, the call
+        // instantiates `U = Box<T>`, and the generic impl applies with its
+        // `T: Num` clause discharged by `go`'s own assumption.
+        check(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct Box<T> { pub v: T }\n\
+             impl<T: Num> Show for Box<T> { fn show(self: Self) -> i64 { 1 } }\n\
+             pub fn use_show<U: Show>(u: U) -> i64 { 2 }\n\
+             pub fn go<T: Num>(b: Box<T>) -> i64 { use_show(b) }",
+            |elab, _| assert!(!elab.has_errors(), "{:#?}", elab.reports),
+        );
+    }
+
+    #[test]
+    fn where_clause_failure_names_the_root_cause() {
+        // `Box<bool>` matches the impl head, but its `T: Num` clause has no
+        // proof — the diagnostic must surface the inner goal, not just the
+        // outer one.
+        elaborate_source(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct Box<T> { pub v: T }\n\
+             impl<T: Num> Show for Box<T> { fn show(self: Self) -> i64 { 1 } }\n\
+             pub fn use_show<U: Show>(u: U) -> i64 { 2 }\n\
+             pub fn go(b: Box<bool>) -> i64 { use_show(b) }",
+            |elab| {
+                assert!(
+                    elab.reports.iter().any(|r| r.message.contains(
+                        "`Box<bool>` does not implement `Show`: \
+                         `bool` does not implement `Num`"
+                    )),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
     fn rejected_batch_retracts_trait_impls() {
         use std::sync::Arc;
         with_tcx(|tcx| {

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -16,7 +16,7 @@
 //! each obligation against the (now solved) self type — via impl search for
 //! concrete types and super-trait subsumption for in-scope generics.
 
-use crate::semi::traits::{Obligation, TraitRef};
+use crate::semi::traits::{Obligation, SelectCtxt, SelectError, TraitRef};
 use crate::semi::ty::{FpTy, HoleId, IntTy, TyKind};
 use crate::surface::Span;
 
@@ -198,48 +198,53 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     ///                  o ⇝ ✗
     /// ```
     ///
-    /// Caveat: (defer) fires only on a *head* hole. A self type with holes nested
-    /// under a constructor (`List<?h>`) is read as concrete, so (no-impl) can
-    /// fire spuriously instead of deferring — latent until parameterized impls
-    /// exist; the fix is to defer when the *deeply* resolved self type still
-    /// holds any hole.
-    ///
-    /// The (impl) rule rebuilds the goal with only the resolved `self` argument;
-    /// a trait's other arguments — a multi-parameter `Rhs`, an associated-type
-    /// output — are dropped here. Supporting them means matching *all* arguments
-    /// in `select` and unifying the chosen impl's against the obligation's, which
-    /// is where discharge starts solving holes (see `resolve_obligations`).
+    /// The (impl) and (param) rules are realized by [`SelectCtxt`]: the goal
+    /// carries *all* of the obligation's arguments (deeply resolved), impl
+    /// search one-way-matches generic impls, residual where-clauses recurse,
+    /// and a bare-generic self is proved from the enclosing definition's
+    /// declared bounds — so `Box<G> : Show` holds under `impl<T: Num> Show
+    /// for Box<T>` when `G : Num` is assumed. A goal whose arguments still
+    /// hold holes (head or nested, `List<?h>`) defers instead of failing
+    /// spuriously.
     fn discharge_trait(&mut self, tref: &TraitRef<'tcx>) -> Discharge {
         let self_ty = self.infer.shallow_resolve(tref.self_ty());
         match self_ty.kind() {
             TyKind::Hole(_) => Discharge::Defer,
-            // In-scope generic: satisfied iff one of its declared bounds implies
-            // the required trait (super-trait subsumption).
-            TyKind::Generic(g) => {
-                let want = tref.trait_id;
-                if self
-                    .generic_bounds(*g)
-                    .iter()
-                    .any(|&have| self.traits.implies(have, want))
-                {
-                    Discharge::Solved
-                } else {
-                    let name = self.trait_display(want);
-                    Discharge::Failed(format!(
-                        "the bound `{name}` is not satisfied by this generic"
-                    ))
+            // In-scope generic: satisfied iff a declared bound proves the
+            // goal (directly, or through the super-trait closure).
+            TyKind::Generic(_) => {
+                let args: Vec<_> = tref.args.iter().map(|&a| self.infer.resolve(a)).collect();
+                if args.iter().any(|&a| ty_has_hole(a)) {
+                    return Discharge::Defer;
+                }
+                let goal = Obligation::Trait(TraitRef {
+                    trait_id: tref.trait_id,
+                    args,
+                });
+                let mut select = SelectCtxt::new(&self.traits, self.tcx, &self.generics);
+                match select.select(&goal) {
+                    Ok(_) => Discharge::Solved,
+                    Err(err) => {
+                        let name = self.trait_display(tref.trait_id);
+                        Discharge::Failed(match err {
+                            SelectError::NoImpl(_) => {
+                                format!("the bound `{name}` is not satisfied by this generic")
+                            }
+                            SelectError::DepthLimit(g) => self.depth_limit_message(&g),
+                        })
+                    }
                 }
             }
             _ => {
-                // Deeply resolve before deciding: a self type whose *head* is a
-                // constructor may still hold holes under it (`List<?h>`). Reading
-                // such a type as ground would let (no-impl) fire spuriously
-                // instead of deferring. Defer while any hole remains so the
-                // obligation is retried once more of the substitution is known.
-                let self_ty = self.infer.resolve(self_ty);
-                if ty_has_hole(self_ty) {
+                // Deeply resolve before deciding: a type whose *head* is a
+                // constructor may still hold holes under it (`List<?h>`).
+                // Defer while any hole remains so the obligation is retried
+                // once more of the substitution is known.
+                let args: Vec<_> = tref.args.iter().map(|&a| self.infer.resolve(a)).collect();
+                if args.iter().any(|&a| ty_has_hole(a)) {
                     return Discharge::Defer;
                 }
+                let self_ty = args[0];
                 // `Sync` is the structural thread-safety auto trait: answered
                 // by the checker over the type's shape, never by impl search
                 // (docs/design/thread-safety.md §2.2).
@@ -263,20 +268,41 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 }
                 let goal = Obligation::Trait(TraitRef {
                     trait_id: tref.trait_id,
-                    args: vec![self_ty],
+                    args,
                 });
-                match self.traits.select(&goal) {
+                let mut select = SelectCtxt::new(&self.traits, self.tcx, &self.generics);
+                match select.select(&goal) {
                     Ok(_) => Discharge::Solved,
-                    Err(_) => {
+                    Err(SelectError::NoImpl(inner)) => {
                         let name = self.trait_display(tref.trait_id);
-                        Discharge::Failed(format!(
-                            "`{}` does not implement `{name}`",
-                            self.ty_display(self_ty)
-                        ))
+                        let mut msg =
+                            format!("`{}` does not implement `{name}`", self.ty_display(self_ty));
+                        // A where-clause failure on the chosen impl bubbles
+                        // the inner goal; name the root cause.
+                        if inner.trait_id != tref.trait_id || inner.self_ty() != self_ty {
+                            msg.push_str(&format!(
+                                ": `{}` does not implement `{}`",
+                                self.ty_display(inner.self_ty()),
+                                self.trait_display(inner.trait_id)
+                            ));
+                        }
+                        Discharge::Failed(msg)
+                    }
+                    Err(SelectError::DepthLimit(g)) => {
+                        Discharge::Failed(self.depth_limit_message(&g))
                     }
                 }
             }
         }
+    }
+
+    fn depth_limit_message(&self, goal: &TraitRef<'tcx>) -> String {
+        use crate::semi::traits::select::SELECT_DEPTH_LIMIT;
+        format!(
+            "overflow evaluating the bound `{}: {}` (depth limit {SELECT_DEPTH_LIMIT})",
+            self.ty_display(goal.self_ty()),
+            self.trait_display(goal.trait_id)
+        )
     }
 }
 

--- a/crates/reussir-core/src/semi/traits.rs
+++ b/crates/reussir-core/src/semi/traits.rs
@@ -8,19 +8,21 @@
 //!
 //! Flexivity-as-a-bound is deferred (see [`crate::semi::ty::Flexivity`]); if it
 //! lands it becomes a second [`Obligation`] variant discharged through the same
-//! [`TraitDb::select`] entry point.
+//! [`SelectCtxt::select`] entry point.
 
 pub mod builtins;
 pub mod coherence;
 pub mod db;
 pub mod def;
+pub mod select;
 pub mod subst;
 pub mod sync;
 
 pub use db::{SelectError, TraitDb};
 pub use def::{AssocTyDef, ImplDef, MethodSig, TraitDef};
+pub use select::{ParamEnv, SELECT_DEPTH_LIMIT, SelectCtxt};
 
-use crate::semi::ty::Ty;
+use crate::semi::ty::{GenericId, Ty};
 
 /// Identifies a trait declaration.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -66,9 +68,11 @@ pub enum Evidence<'tcx> {
         args: Vec<Ty<'tcx>>,
         sub: Vec<Evidence<'tcx>>,
     },
-    /// Discharged by an in-scope assumption (a `T: Trait` bound on the enclosing
-    /// definition). Phase 1.
-    Param(usize),
+    /// Discharged by an in-scope assumption: the `index`-th declared bound of
+    /// `generic` on the enclosing definition. At monomorphization the
+    /// instantiating context re-selects with the generic grounded, so this
+    /// never survives to codegen.
+    Param { generic: GenericId, index: usize },
     /// Projected from a super-trait of other evidence; `index` is the position
     /// in the sub-trait's super-trait list.
     Super {

--- a/crates/reussir-core/src/semi/traits/coherence.rs
+++ b/crates/reussir-core/src/semi/traits/coherence.rs
@@ -66,7 +66,13 @@ pub fn unify_args<'tcx>(
     a.len() == b.len() && a.iter().zip(b).all(|(&x, &y)| unify_ty(x, y, vars, subst))
 }
 
-fn resolve<'tcx>(mut ty: Ty<'tcx>, subst: &FxHashMap<GenericId, Ty<'tcx>>) -> Ty<'tcx> {
+/// Chase a binding chain to its representative. Shallow: only a `Generic`
+/// *head* is followed; selection grounds whole types by feeding the resolved
+/// bindings through `replace_generics`.
+pub(crate) fn resolve_binding<'tcx>(
+    mut ty: Ty<'tcx>,
+    subst: &FxHashMap<GenericId, Ty<'tcx>>,
+) -> Ty<'tcx> {
     while let TyKind::Generic(g) = *ty.kind() {
         match subst.get(&g) {
             Some(&next) => ty = next,
@@ -77,7 +83,7 @@ fn resolve<'tcx>(mut ty: Ty<'tcx>, subst: &FxHashMap<GenericId, Ty<'tcx>>) -> Ty
 }
 
 fn occurs(g: GenericId, ty: Ty<'_>, subst: &FxHashMap<GenericId, Ty<'_>>) -> bool {
-    let ty = resolve(ty, subst);
+    let ty = resolve_binding(ty, subst);
     match *ty.kind() {
         TyKind::Generic(h) => g == h,
         TyKind::Nullable(inner) | TyKind::Arc(inner) => occurs(g, inner, subst),
@@ -96,8 +102,8 @@ fn unify_ty<'tcx>(
     vars: &FxHashSet<GenericId>,
     subst: &mut FxHashMap<GenericId, Ty<'tcx>>,
 ) -> bool {
-    let a = resolve(a, subst);
-    let b = resolve(b, subst);
+    let a = resolve_binding(a, subst);
+    let b = resolve_binding(b, subst);
     if a == b {
         return true;
     }

--- a/crates/reussir-core/src/semi/traits/db.rs
+++ b/crates/reussir-core/src/semi/traits/db.rs
@@ -1,12 +1,9 @@
-//! The trait/impl registry and a trivial resolver.
+//! The trait/impl registry: dense-id storage, the `(trait, head)` candidate
+//! index, super-trait reachability, and REPL-checkpoint truncation.
 //!
-//! Phase 0 resolves only *ground* obligations: a concrete self type is matched
-//! exactly against impls (a pointer comparison, thanks to interning), with
-//! super-trait projection, plus the capability lattice. Candidate gathering from
-//! in-scope assumptions, one-way matching of generic impls, where-clause
-//! discharge against an environment, and suspension of obligations whose self
-//! type is still a hole all arrive in Phase 1 — slotting into this same
-//! [`TraitDb::select`] entry point.
+//! Resolution lives in [`super::select::SelectCtxt`], which reads this
+//! registry; coherence (the overlap and orphan gates in the elaborator)
+//! is what entitles selection to commit to the first matching candidate.
 
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
@@ -15,7 +12,7 @@ use crate::semi::ty::DefId;
 
 use super::coherence::{HeadKey, head_key};
 use super::def::{ImplDef, TraitDef};
-use super::{Evidence, ImplId, Obligation, TraitId, TraitRef};
+use super::{ImplId, TraitId, TraitRef};
 
 /// The collected trait program plus resolution.
 #[derive(Default)]
@@ -32,8 +29,12 @@ pub struct TraitDb<'tcx> {
 /// Why an obligation could not be discharged.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SelectError<'tcx> {
-    /// No impl makes `τ : Trait` hold.
+    /// No impl makes `τ : Trait` hold. Carries the *deepest* failing goal:
+    /// a where-clause failure on the unique applicable impl surfaces the
+    /// inner obligation, which is the root cause.
     NoImpl(TraitRef<'tcx>),
+    /// Proof search exceeded [`super::select::SELECT_DEPTH_LIMIT`].
+    DepthLimit(TraitRef<'tcx>),
 }
 
 impl<'tcx> TraitDb<'tcx> {
@@ -153,75 +154,10 @@ impl<'tcx> TraitDb<'tcx> {
             .any(|s| s.trait_id == target || self.reaches(self.trait_def(s.trait_id), target))
     }
 
-    /// Discharge an obligation, producing evidence.
-    pub fn select(
-        &self,
-        obligation: &Obligation<'tcx>,
-    ) -> Result<Evidence<'tcx>, SelectError<'tcx>> {
-        let Obligation::Trait(goal) = obligation;
-        self.select_trait(goal)
-    }
-
-    fn select_trait(&self, goal: &TraitRef<'tcx>) -> Result<Evidence<'tcx>, SelectError<'tcx>> {
-        // A direct impl of the goal trait for this exact self type. With
-        // interned types this self-type check is a pointer comparison.
-        for imp in &self.impls {
-            if imp.trait_ref.trait_id == goal.trait_id && imp.self_ty == goal.self_ty() {
-                let mut sub = Vec::with_capacity(imp.where_clauses.len());
-                for clause in &imp.where_clauses {
-                    sub.push(self.select(clause)?);
-                }
-                return Ok(Evidence::Impl {
-                    impl_id: imp.id,
-                    args: imp.trait_ref.args.clone(),
-                    sub,
-                });
-            }
-        }
-
-        // Otherwise, reach the goal through one or more super-trait hops: some
-        // impl for this self type implements a sub-trait whose super-trait
-        // closure contains the goal. (This is what the old class DAG did by
-        // hand.) The evidence projects the impl up the full hop chain.
-        for imp in &self.impls {
-            if imp.self_ty != goal.self_ty() || imp.trait_ref.trait_id == goal.trait_id {
-                continue;
-            }
-            let Ok(base) = self.select_trait(&imp.trait_ref) else {
-                continue;
-            };
-            let sub_def = self.trait_def(imp.trait_ref.trait_id);
-            if let Some(ev) = self.project_super(sub_def, base, goal.trait_id) {
-                return Ok(ev);
-            }
-        }
-
-        Err(SelectError::NoImpl(goal.clone()))
-    }
-
-    /// Project `of` — evidence that the self type implements `def` — up to
-    /// `target` through super-traits, building one [`Evidence::Super`] hop per
-    /// edge on the path. `None` if `target` is not in `def`'s super-trait
-    /// closure.
-    fn project_super(
-        &self,
-        def: &TraitDef<'tcx>,
-        of: Evidence<'tcx>,
-        target: TraitId,
-    ) -> Option<Evidence<'tcx>> {
-        for (i, sup) in def.supertraits.iter().enumerate() {
-            let step = Evidence::Super {
-                of: Box::new(of.clone()),
-                index: i,
-            };
-            if sup.trait_id == target {
-                return Some(step);
-            }
-            if let Some(ev) = self.project_super(self.trait_def(sup.trait_id), step, target) {
-                return Some(ev);
-            }
-        }
-        None
+    /// All impls in registration (dense-id) order — the deterministic scan
+    /// order for super-trait projection in selection.
+    pub fn impls(&self) -> impl Iterator<Item = &ImplDef<'tcx>> {
+        self.impls.iter()
     }
 }
 
@@ -231,13 +167,6 @@ mod tests {
     use crate::semi::traits::builtins::Builtins;
     use crate::semi::ty::{FpTy, IntTy, Ty, TyCtxt};
     use crate::with_tcx;
-
-    fn needs(trait_id: TraitId, self_ty: Ty<'_>) -> Obligation<'_> {
-        Obligation::Trait(TraitRef {
-            trait_id,
-            args: vec![self_ty],
-        })
-    }
 
     #[test]
     fn truncate_retracts_traits_and_impls() {
@@ -313,99 +242,6 @@ mod tests {
             let b = Builtins::register(&mut db, &mut defs, &mut interner, tcx);
             for id in [b.num, b.integral, b.floating_point, b.ptr_like, b.sync] {
                 assert_eq!(db.trait_by_def(db.trait_def(id).def), Some(id));
-            }
-        });
-    }
-
-    #[test]
-    fn primitive_membership_is_data_not_hardcoded() {
-        with_tcx(|tcx: &TyCtxt| {
-            let mut db = TraitDb::new();
-            let mut defs = crate::semi::resolve::DefTable::new();
-            let mut interner = lasso::Rodeo::<reussir_syntax::kind::TokenKey>::new();
-            let b = Builtins::register(&mut db, &mut defs, &mut interner, tcx);
-
-            let i32 = tcx.mk_int(IntTy::Signed(32));
-            let f32 = tcx.mk_fp(FpTy::Ieee(32));
-
-            // i32 is Integral directly, and Num through the super-trait edge.
-            assert!(db.select(&needs(b.integral, i32)).is_ok());
-            assert!(db.select(&needs(b.num, i32)).is_ok());
-
-            // f32 is FloatingPoint and (super) Num, but not Integral.
-            assert!(db.select(&needs(b.floating_point, f32)).is_ok());
-            assert!(db.select(&needs(b.num, f32)).is_ok());
-            assert!(db.select(&needs(b.integral, f32)).is_err());
-
-            // bool belongs to no numeric trait.
-            assert!(db.select(&needs(b.num, tcx.mk_bool())).is_err());
-        });
-    }
-
-    // `Sync` has no impls: ground goals are answered structurally by
-    // `traits::sync` (see its tests), so nothing here selects it.
-
-    #[test]
-    fn transitive_super_traits_build_a_full_evidence_chain() {
-        use crate::semi::traits::def::{ImplDef, TraitDef};
-        use crate::semi::traits::{Evidence, ImplId, TraitRef};
-
-        with_tcx(|tcx: &TyCtxt| {
-            // A 3-level chain: Sub : Mid : Top.
-            let mut db = TraitDb::new();
-            let self_g = crate::semi::ty::GenericId(0);
-            let self_ref = |t: TraitId| TraitRef {
-                trait_id: t,
-                args: vec![tcx.mk_generic(self_g)],
-            };
-            let (top, mid, sub) = (TraitId(0), TraitId(1), TraitId(2));
-            let def = |id: TraitId, def: u32, supers| TraitDef {
-                id,
-                def: crate::semi::ty::DefId(def),
-                visibility: crate::surface::Visibility::Public,
-                sealed: false,
-                self_param: self_g,
-                params: vec![],
-                supertraits: supers,
-                methods: vec![],
-                assoc_tys: vec![],
-                span: None,
-                file: reussir_syntax::source::FileId::ROOT,
-            };
-            db.add_trait(def(top, 0, vec![]));
-            db.add_trait(def(mid, 1, vec![self_ref(top)]));
-            db.add_trait(def(sub, 2, vec![self_ref(mid)]));
-
-            let unit = tcx.mk_unit();
-            db.add_impl(ImplDef {
-                id: ImplId(0),
-                generics: vec![],
-                trait_ref: TraitRef {
-                    trait_id: sub,
-                    args: vec![unit],
-                },
-                self_ty: unit,
-                where_clauses: vec![],
-                methods: vec![],
-                span: None,
-                file: reussir_syntax::source::FileId::ROOT,
-            });
-
-            // `unit: Top` is two hops away (Sub -> Mid -> Top): the evidence must
-            // nest two `Super` projections over the `Sub` impl.
-            let ev = db.select(&needs(top, unit)).expect("unit: Top should hold");
-            match ev {
-                Evidence::Super {
-                    of: outer,
-                    index: 0,
-                } => match *outer {
-                    Evidence::Super {
-                        of: inner,
-                        index: 0,
-                    } => assert!(matches!(*inner, Evidence::Impl { .. })),
-                    other => panic!("expected a nested Super, got {other:?}"),
-                },
-                other => panic!("expected a two-hop Super chain, got {other:?}"),
             }
         });
     }

--- a/crates/reussir-core/src/semi/traits/select.rs
+++ b/crates/reussir-core/src/semi/traits/select.rs
@@ -1,0 +1,542 @@
+//! Impl selection: discharging a trait obligation into [`Evidence`].
+//!
+//! Selection is the run-time face of coherence: because the overlap gate
+//! guarantees at most one impl per `(trait, self-head)` pair can apply, the
+//! first candidate that matches *is* the unique one, and a failing
+//! where-clause on it is a hard error rather than a backtrack point.
+//!
+//! The matcher is [`unify_args`] with only the *candidate impl's* generics
+//! as variables — the goal's own generics (an enclosing function's `T`)
+//! stay rigid, so `impl<T: Num> Show for Box<T>` matches the goal
+//! `Box<G> : Show` by binding the impl's `T ↦ G`, and the residual clause
+//! `G : Num` is discharged against the [`ParamEnv`] assumptions.
+//!
+//! Known cut: a *ground* `Sync` goal is answered structurally by the
+//! fulfillment pass before selection runs, but a `Sync` clause reached
+//! *through* where-clause recursion has no structural hook here and reports
+//! no-impl; wiring the verdict into selection lands with dispatch.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::semi::ctxt::GenericInfo;
+use crate::semi::traits::coherence::{head_key, resolve_binding, unify_args};
+use crate::semi::traits::def::ImplDef;
+use crate::semi::traits::subst::replace_generics;
+use crate::semi::traits::{Evidence, Obligation, SelectError, TraitDb, TraitId, TraitRef};
+use crate::semi::ty::{GenericId, Ty, TyCtxt, TyKind};
+
+/// The proof-search depth bound. Where-clause instantiation descends
+/// structurally into the self type, so honest programs terminate; the limit
+/// converts a pathological or accidental cycle into a diagnostic. Distinct
+/// from monomorphization's `RECURSION_LIMIT`, which bounds *instance*
+/// expansion — this bounds *proof* depth at check time.
+pub const SELECT_DEPTH_LIMIT: usize = 64;
+
+/// The in-scope assumptions selection may discharge a goal against: the
+/// enclosing definition's generics with their declared bounds, dense by
+/// [`GenericId`]. Empty at monomorphization time, where every self type is
+/// ground.
+pub type ParamEnv<'a> = &'a [GenericInfo];
+
+/// One selection session: a database view, an assumption environment, and a
+/// memo table keyed by goal. Construct per obligation sweep (or per mono
+/// instance); the memo pays for repeated sub-goals within one proof.
+pub struct SelectCtxt<'a, 'tcx> {
+    db: &'a TraitDb<'tcx>,
+    tcx: &'a TyCtxt<'tcx>,
+    env: ParamEnv<'a>,
+    memo: FxHashMap<(TraitId, Vec<Ty<'tcx>>), Result<Evidence<'tcx>, SelectError<'tcx>>>,
+}
+
+impl<'a, 'tcx> SelectCtxt<'a, 'tcx> {
+    pub fn new(db: &'a TraitDb<'tcx>, tcx: &'a TyCtxt<'tcx>, env: ParamEnv<'a>) -> Self {
+        Self {
+            db,
+            tcx,
+            env,
+            memo: FxHashMap::default(),
+        }
+    }
+
+    /// Discharge an obligation, producing evidence.
+    pub fn select(
+        &mut self,
+        obligation: &Obligation<'tcx>,
+    ) -> Result<Evidence<'tcx>, SelectError<'tcx>> {
+        let Obligation::Trait(goal) = obligation;
+        self.select_trait(goal, 0)
+    }
+
+    fn select_trait(
+        &mut self,
+        goal: &TraitRef<'tcx>,
+        depth: usize,
+    ) -> Result<Evidence<'tcx>, SelectError<'tcx>> {
+        if depth > SELECT_DEPTH_LIMIT {
+            return Err(SelectError::DepthLimit(goal.clone()));
+        }
+        let key = (goal.trait_id, goal.args.clone());
+        if let Some(hit) = self.memo.get(&key) {
+            return hit.clone();
+        }
+        let result = self.select_uncached(goal, depth);
+        // An overflow is relative to the depth it was probed at, so caching
+        // it would poison shallower queries of the same goal.
+        if !matches!(result, Err(SelectError::DepthLimit(_))) {
+            self.memo.insert(key, result.clone());
+        }
+        result
+    }
+
+    fn select_uncached(
+        &mut self,
+        goal: &TraitRef<'tcx>,
+        depth: usize,
+    ) -> Result<Evidence<'tcx>, SelectError<'tcx>> {
+        let db = self.db;
+        let self_ty = goal.self_ty();
+
+        // A bare in-scope generic has no head, so no impl can apply (blanket
+        // impls are rejected); only the environment's assumptions prove it.
+        if let TyKind::Generic(g) = *self_ty.kind() {
+            return self
+                .prove_by_assumption(g, self_ty, goal)
+                .ok_or_else(|| SelectError::NoImpl(goal.clone()));
+        }
+
+        let Some(head) = head_key(self_ty) else {
+            // `Hole` is deferred by the caller; `Bottom` is already reported.
+            return Err(SelectError::NoImpl(goal.clone()));
+        };
+
+        // The direct candidates: impls of the goal trait bucketed under this
+        // head. Coherence makes at most one match; commit to it.
+        for &id in db.impls_for(goal.trait_id, head) {
+            let imp = db.impl_def(id);
+            let Some(subst) = match_impl(&imp.trait_ref.args, goal.args.as_slice(), imp) else {
+                continue;
+            };
+            let args: Vec<Ty<'tcx>> = imp
+                .generics
+                .iter()
+                .map(|&g| resolve_binding(self.tcx.mk_generic(g), &subst))
+                .collect();
+            let subst: FxHashMap<GenericId, Ty<'tcx>> = imp
+                .generics
+                .iter()
+                .copied()
+                .zip(args.iter().copied())
+                .collect();
+            // A failing clause on the unique applicable impl is the root
+            // cause; bubble the *inner* goal for the diagnostic.
+            let sub = imp
+                .where_clauses
+                .iter()
+                .map(|clause| {
+                    let Obligation::Trait(c) = clause;
+                    let inst = TraitRef {
+                        trait_id: c.trait_id,
+                        args: c
+                            .args
+                            .iter()
+                            .map(|&t| replace_generics(self.tcx, t, &subst))
+                            .collect(),
+                    };
+                    self.select_trait(&inst, depth + 1)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            return Ok(Evidence::Impl {
+                impl_id: id,
+                args,
+                sub,
+            });
+        }
+
+        // Otherwise reach the goal through super-trait hops: an impl of a
+        // sub-trait for this head whose super-closure contains the goal.
+        // (This subsumes the old hard-coded class DAG: `i32 : Num` holds via
+        // `impl Integral for i32` and the `Integral: Num` edge.) Impls are
+        // scanned in registration order, so a (legal) diamond resolves
+        // deterministically to the earliest sub-impl.
+        for imp in db.impls() {
+            if imp.trait_ref.trait_id == goal.trait_id
+                || head_key(imp.self_ty) != Some(head)
+                || !db.implies(imp.trait_ref.trait_id, goal.trait_id)
+            {
+                continue;
+            }
+            let Some(binding) = match_impl(&imp.trait_ref.args[..1], &goal.args[..1], imp) else {
+                continue;
+            };
+            let subst: FxHashMap<GenericId, Ty<'tcx>> = imp
+                .generics
+                .iter()
+                .map(|&g| (g, resolve_binding(self.tcx.mk_generic(g), &binding)))
+                .collect();
+            let inst_ref = TraitRef {
+                trait_id: imp.trait_ref.trait_id,
+                args: imp
+                    .trait_ref
+                    .args
+                    .iter()
+                    .map(|&t| replace_generics(self.tcx, t, &subst))
+                    .collect(),
+            };
+            let base = match self.select_trait(&inst_ref, depth + 1) {
+                Ok(base) => base,
+                // Overflow is a hard stop, not a candidate that failed to
+                // apply — swallowing it would mislabel the result NoImpl
+                // (and poison the memo with a depth-relative failure).
+                Err(err @ SelectError::DepthLimit(_)) => return Err(err),
+                Err(SelectError::NoImpl(_)) => continue,
+            };
+            if let Some(ev) = self.project_super(&inst_ref, base, goal) {
+                return Ok(ev);
+            }
+        }
+
+        Err(SelectError::NoImpl(goal.clone()))
+    }
+
+    /// Prove a bare-generic goal from the environment: a declared bound that
+    /// *is* the goal yields [`Evidence::Param`]; a bound whose super-closure
+    /// contains the goal projects up from it.
+    fn prove_by_assumption(
+        &mut self,
+        g: GenericId,
+        self_ty: Ty<'tcx>,
+        goal: &TraitRef<'tcx>,
+    ) -> Option<Evidence<'tcx>> {
+        let env = self.env;
+        env.get(g.0 as usize)?
+            .bounds
+            .iter()
+            .enumerate()
+            .find_map(|(index, &have)| {
+                let base = Evidence::Param { generic: g, index };
+                let base_ref = TraitRef {
+                    trait_id: have,
+                    args: vec![self_ty],
+                };
+                if have == goal.trait_id && base_ref.args == goal.args {
+                    return Some(base);
+                }
+                self.project_super(&base_ref, base, goal)
+            })
+    }
+
+    /// Project `base` — evidence that the fully-instantiated `base_ref`
+    /// holds — up the super-trait closure to `goal`, one [`Evidence::Super`]
+    /// hop per edge. Args are carried through each hop by instantiating the
+    /// declaring trait's binder, so a multi-parameter super-reference stays
+    /// faithful.
+    fn project_super(
+        &self,
+        base_ref: &TraitRef<'tcx>,
+        base: Evidence<'tcx>,
+        goal: &TraitRef<'tcx>,
+    ) -> Option<Evidence<'tcx>> {
+        let def = self.db.trait_def(base_ref.trait_id);
+        let mut map = FxHashMap::default();
+        map.insert(def.self_param, base_ref.args[0]);
+        for (&(_, p), &a) in def.params.iter().zip(base_ref.args.iter().skip(1)) {
+            map.insert(p, a);
+        }
+        def.supertraits.iter().enumerate().find_map(|(index, sup)| {
+            let sup_ref = TraitRef {
+                trait_id: sup.trait_id,
+                args: sup
+                    .args
+                    .iter()
+                    .map(|&t| replace_generics(self.tcx, t, &map))
+                    .collect(),
+            };
+            let step = Evidence::Super {
+                of: Box::new(base.clone()),
+                index,
+            };
+            if sup.trait_id == goal.trait_id && sup_ref.args == goal.args {
+                return Some(step);
+            }
+            self.project_super(&sup_ref, step, goal)
+        })
+    }
+}
+
+/// One-way match of an impl's argument list against a goal's: only the
+/// impl's own generics bind. `None` if the shapes disagree.
+fn match_impl<'tcx>(
+    imp_args: &[Ty<'tcx>],
+    goal_args: &[Ty<'tcx>],
+    imp: &ImplDef<'tcx>,
+) -> Option<FxHashMap<GenericId, Ty<'tcx>>> {
+    let vars: FxHashSet<GenericId> = imp.generics.iter().copied().collect();
+    let mut binding = FxHashMap::default();
+    unify_args(imp_args, goal_args, &vars, &mut binding).then_some(binding)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::semi::traits::ImplId;
+    use crate::semi::traits::builtins::Builtins;
+    use crate::semi::traits::def::{ImplDef, TraitDef};
+    use crate::semi::ty::{DefId, Flexivity, FpTy, IntTy, TyCtxt};
+    use crate::with_tcx;
+
+    fn needs(trait_id: TraitId, self_ty: Ty<'_>) -> Obligation<'_> {
+        Obligation::Trait(TraitRef {
+            trait_id,
+            args: vec![self_ty],
+        })
+    }
+
+    fn trait_def<'tcx>(id: TraitId, def: u32, supers: Vec<TraitRef<'tcx>>) -> TraitDef<'tcx> {
+        TraitDef {
+            id,
+            def: DefId(def),
+            visibility: crate::surface::Visibility::Public,
+            sealed: false,
+            self_param: GenericId(0),
+            params: vec![],
+            supertraits: supers,
+            methods: vec![],
+            assoc_tys: vec![],
+            span: None,
+            file: reussir_syntax::source::FileId::ROOT,
+        }
+    }
+
+    fn impl_def<'tcx>(
+        id: u32,
+        generics: Vec<GenericId>,
+        trait_id: TraitId,
+        self_ty: Ty<'tcx>,
+        where_clauses: Vec<Obligation<'tcx>>,
+    ) -> ImplDef<'tcx> {
+        ImplDef {
+            id: ImplId(id),
+            generics,
+            trait_ref: TraitRef {
+                trait_id,
+                args: vec![self_ty],
+            },
+            self_ty,
+            where_clauses,
+            methods: vec![],
+            span: None,
+            file: reussir_syntax::source::FileId::ROOT,
+        }
+    }
+
+    #[test]
+    fn primitive_membership_is_data_not_hardcoded() {
+        with_tcx(|tcx: &TyCtxt| {
+            let mut db = TraitDb::new();
+            let mut defs = crate::semi::resolve::DefTable::new();
+            let mut interner = lasso::Rodeo::<reussir_syntax::kind::TokenKey>::new();
+            let b = Builtins::register(&mut db, &mut defs, &mut interner, tcx);
+            let mut sel = SelectCtxt::new(&db, tcx, &[]);
+
+            let i32 = tcx.mk_int(IntTy::Signed(32));
+            let f32 = tcx.mk_fp(FpTy::Ieee(32));
+
+            // i32 is Integral directly, and Num through the super-trait edge.
+            assert!(sel.select(&needs(b.integral, i32)).is_ok());
+            assert!(sel.select(&needs(b.num, i32)).is_ok());
+
+            // f32 is FloatingPoint and (super) Num, but not Integral.
+            assert!(sel.select(&needs(b.floating_point, f32)).is_ok());
+            assert!(sel.select(&needs(b.num, f32)).is_ok());
+            assert!(sel.select(&needs(b.integral, f32)).is_err());
+
+            // bool belongs to no numeric trait.
+            assert!(sel.select(&needs(b.num, tcx.mk_bool())).is_err());
+        });
+    }
+
+    #[test]
+    fn transitive_super_traits_build_a_full_evidence_chain() {
+        with_tcx(|tcx: &TyCtxt| {
+            // A 3-level chain: Sub : Mid : Top.
+            let mut db = TraitDb::new();
+            let self_ref = |t: TraitId| TraitRef {
+                trait_id: t,
+                args: vec![tcx.mk_generic(GenericId(0))],
+            };
+            let (top, mid, sub) = (TraitId(0), TraitId(1), TraitId(2));
+            db.add_trait(trait_def(top, 0, vec![]));
+            db.add_trait(trait_def(mid, 1, vec![self_ref(top)]));
+            db.add_trait(trait_def(sub, 2, vec![self_ref(mid)]));
+
+            let unit = tcx.mk_unit();
+            db.add_impl(impl_def(0, vec![], sub, unit, vec![]));
+
+            // `unit: Top` is two hops away (Sub -> Mid -> Top): the evidence must
+            // nest two `Super` projections over the `Sub` impl.
+            let mut sel = SelectCtxt::new(&db, tcx, &[]);
+            let ev = sel
+                .select(&needs(top, unit))
+                .expect("unit: Top should hold");
+            match ev {
+                Evidence::Super {
+                    of: outer,
+                    index: 0,
+                } => match *outer {
+                    Evidence::Super {
+                        of: inner,
+                        index: 0,
+                    } => {
+                        assert!(matches!(*inner, Evidence::Impl { .. }))
+                    }
+                    other => panic!("expected a nested Super, got {other:?}"),
+                },
+                other => panic!("expected a two-hop Super chain, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn generic_impl_matches_and_discharges_clauses() {
+        with_tcx(|tcx: &TyCtxt| {
+            // trait Num; trait Show; struct Box<T>;
+            // impl Num for i32; impl<T: Num> Show for Box<T>;
+            let mut db = TraitDb::new();
+            let (num, show) = (TraitId(0), TraitId(1));
+            db.add_trait(trait_def(num, 0, vec![]));
+            db.add_trait(trait_def(show, 1, vec![]));
+            let bx = DefId(10);
+            let i32t = tcx.mk_int(IntTy::Signed(32));
+            let t = GenericId(3);
+            let box_t = tcx.mk_record(bx, &[tcx.mk_generic(t)], Flexivity::Irrelevant);
+            db.add_impl(impl_def(0, vec![], num, i32t, vec![]));
+            db.add_impl(impl_def(
+                1,
+                vec![t],
+                show,
+                box_t,
+                vec![needs(num, tcx.mk_generic(t))],
+            ));
+
+            // Ground: Box<i32> : Show — the impl's T grounds to i32 and the
+            // clause i32 : Num holds by the direct impl.
+            let box_i32 = tcx.mk_record(bx, &[i32t], Flexivity::Irrelevant);
+            let mut sel = SelectCtxt::new(&db, tcx, &[]);
+            match sel.select(&needs(show, box_i32)).expect("Box<i32>: Show") {
+                Evidence::Impl { impl_id, args, sub } => {
+                    assert_eq!(impl_id, ImplId(1));
+                    assert_eq!(args, vec![i32t], "T instantiated to i32");
+                    assert!(matches!(
+                        sub[0],
+                        Evidence::Impl {
+                            impl_id: ImplId(0),
+                            ..
+                        }
+                    ));
+                }
+                other => panic!("expected the generic impl, got {other:?}"),
+            }
+
+            // The failing clause is the root cause: Box<bool> matches the
+            // impl but bool : Num has no proof, and THAT goal bubbles.
+            let box_bool = tcx.mk_record(bx, &[tcx.mk_bool()], Flexivity::Irrelevant);
+            match sel.select(&needs(show, box_bool)) {
+                Err(SelectError::NoImpl(inner)) => {
+                    assert_eq!(inner.trait_id, num);
+                    assert_eq!(inner.self_ty(), tcx.mk_bool());
+                }
+                other => panic!("expected the inner Num goal to fail, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn assumptions_prove_generic_goals_with_projection() {
+        with_tcx(|tcx: &TyCtxt| {
+            // trait Num; trait Integral: Num; fn f<G: Integral> — inside f,
+            // G : Integral holds by assumption and G : Num by projection.
+            let mut db = TraitDb::new();
+            let (num, integral) = (TraitId(0), TraitId(1));
+            db.add_trait(trait_def(num, 0, vec![]));
+            db.add_trait(trait_def(
+                integral,
+                1,
+                vec![TraitRef {
+                    trait_id: num,
+                    args: vec![tcx.mk_generic(GenericId(0))],
+                }],
+            ));
+
+            let g = GenericId(0);
+            let key =
+                lasso::Rodeo::<reussir_syntax::kind::TokenKey>::new().get_or_intern_static("G");
+            let env = vec![crate::semi::ctxt::GenericInfo {
+                name: key,
+                bounds: vec![integral],
+            }];
+            let g_ty = tcx.mk_generic(g);
+            let mut sel = SelectCtxt::new(&db, tcx, &env);
+            match sel.select(&needs(integral, g_ty)).expect("G: Integral") {
+                Evidence::Param { generic, index } => {
+                    assert_eq!(generic, g);
+                    assert_eq!(index, 0);
+                }
+                other => panic!("expected the assumption itself, got {other:?}"),
+            }
+            match sel.select(&needs(num, g_ty)).expect("G: Num via super") {
+                Evidence::Super { of, index: 0 } => {
+                    assert!(matches!(*of, Evidence::Param { .. }))
+                }
+                other => panic!("expected projection over the assumption, got {other:?}"),
+            }
+            // An unrelated goal is not assumed.
+            let other_trait = TraitId(0);
+            let unbound = tcx.mk_generic(GenericId(7));
+            assert!(sel.select(&needs(other_trait, unbound)).is_err());
+        });
+    }
+
+    #[test]
+    fn deep_recursion_hits_the_depth_limit() {
+        with_tcx(|tcx: &TyCtxt| {
+            // impl<T: Show> Show for Box<T> — proving Box^n<i32> : Show
+            // descends n clause levels. Shallow nesting fails with the root
+            // NoImpl (i32 : Show missing); past the limit it overflows.
+            let mut db = TraitDb::new();
+            let show = TraitId(0);
+            db.add_trait(trait_def(show, 0, vec![]));
+            let bx = DefId(10);
+            let t = GenericId(0);
+            let box_t = tcx.mk_record(bx, &[tcx.mk_generic(t)], Flexivity::Irrelevant);
+            db.add_impl(impl_def(
+                0,
+                vec![t],
+                show,
+                box_t,
+                vec![needs(show, tcx.mk_generic(t))],
+            ));
+
+            let nest = |depth: usize| {
+                let mut ty = tcx.mk_int(IntTy::Signed(32));
+                for _ in 0..depth {
+                    ty = tcx.mk_record(bx, &[ty], Flexivity::Irrelevant);
+                }
+                ty
+            };
+            let mut sel = SelectCtxt::new(&db, tcx, &[]);
+            match sel.select(&needs(show, nest(10))) {
+                Err(SelectError::NoImpl(inner)) => {
+                    assert_eq!(inner.self_ty(), tcx.mk_int(IntTy::Signed(32)));
+                }
+                other => panic!("expected the i32 root cause, got {other:?}"),
+            }
+            // A fresh session: the shallow probe above memoized its NoImpl
+            // prefixes, which would truncate this descent below the limit.
+            let mut sel = SelectCtxt::new(&db, tcx, &[]);
+            assert!(matches!(
+                sel.select(&needs(show, nest(SELECT_DEPTH_LIMIT + 6))),
+                Err(SelectError::DepthLimit(_))
+            ));
+        });
+    }
+}


### PR DESCRIPTION
Part 7 of the trait-system stack (base: #513). Rewrites impl selection from ground-pointer-equality-first-match into a real solver, in the new `semi/traits/select.rs`.

- **`SelectCtxt`**: one selection session over the `TraitDb`, a `ParamEnv` (the enclosing definition's generics with their declared bounds; empty at mono time), and a per-session memo. Coherence (#513) is what entitles it to *commit* to the first matching candidate: at most one impl per `(trait, self-head)` can apply, so a failing where-clause on it is a hard error, not a backtrack point.
- **One-way matching**: candidates come from the `(trait, head)` buckets and are matched by the coherence unifier with only the *impl's* generics as variables — the goal's generics stay rigid. `impl<T: Num> Show for Box<T>` now applies to `Box<G>` by binding `T ↦ G`; the instantiated clause `G: Num` is discharged against the assumptions, producing `Evidence::Param { generic, index }` (payload upgraded from the never-constructed `Param(usize)`).
- **Super-projection, args-faithful**: `i32: Num` still holds via `impl Integral for i32` + the `Integral: Num` edge, but hops now instantiate each declaring trait's binder so multi-parameter super-references carry their arguments correctly. Assumption bounds project the same way (`G: Integral` proves `G: Num` as `Super(Param)`).
- **`SELECT_DEPTH_LIMIT` = 64**: proof depth is bounded; overflow is `SelectError::DepthLimit`, rendered as "overflow evaluating the bound `…: …`" — distinct from mono's instance `RECURSION_LIMIT`. Overflow results are deliberately not memoized (they are depth-relative), and a candidate probe that overflows aborts the search rather than being mislabeled `NoImpl`.
- **Fulfillment stops dropping non-`Self` args**: `discharge_trait` deeply resolves *all* goal arguments (deferring while any holds a hole) and passes them through; the structural `Sync` fast-path and the existing diagnostic wordings are preserved. `NoImpl` now carries the *deepest* failing goal, so a where-clause failure names its root cause: ``` `Box<bool>` does not implement `Show`: `bool` does not implement `Num` ```.
- `TraitDb` sheds the resolver (kept: storage, buckets, `implies`); old select tests migrate to `select.rs` alongside new coverage: generic-impl match + clause discharge, assumption projection, root-cause bubbling, depth-limit overflow vs shallow `NoImpl`, and the end-to-end bound test `generic_impls_are_selected_through_bounds` — the exact case pointer-equality select could never solve.

Gates: `cargo test` workspace-green, `cargo fmt`, `ninja -C build check`, `ninja -C build rrc-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788328412&installation_model_id=426051&pr_number=514&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F514&signature=9a180ceb8620c53fbc15613711b9f4b17928552f3655e1eaa0656318563ecbda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->