### PR TITLE
[core] dispatch trait methods: dot form, Trait::method paths, TraitCall

### DIFF
--- a/crates/reussir-core/src/full/interface.rs
+++ b/crates/reussir-core/src/full/interface.rs
@@ -113,6 +113,10 @@ pub fn export_closure(input: &MonoInput<'_, '_>) -> ExportClosure {
                         queue.push_back(*target);
                     }
                 }
+                // A TraitCall's reach — the trait item and the impls that can
+                // discharge it — joins the closure when the interface grows
+                // trait/impl sets alongside their serialization.
+                ExprKind::TraitCall { .. } => {}
                 _ => {}
             }
         });

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -219,7 +219,7 @@ pub(crate) fn for_each_expr<'e, 'tcx>(expr: &'e Expr<'tcx>, f: &mut impl FnMut(&
         }
         Let { value, .. } => for_each_expr(value, f),
         Seq(es) => es.iter().for_each(|e| for_each_expr(e, f)),
-        FuncCall { args, .. } => {
+        FuncCall { args, .. } | TraitCall { args, .. } => {
             args.iter().for_each(|e| for_each_expr(e, f));
         }
         // Compound/variant targets name records, not functions; only their
@@ -1408,6 +1408,10 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         use mir::ExprKind as M;
         match kind {
             ExprKind::GlobalStr(s) => M::GlobalStr(*s),
+            ExprKind::TraitCall { .. } => todo!(
+                "TraitCall resolves at instance time; the rewrite lands with \
+                 the trait-mono stack"
+            ),
             ExprKind::ConstChar(c) => M::ConstChar(*c),
             ExprKind::ConstInt(n) => M::ConstInt(n),
             ExprKind::ConstFloat(f) => M::ConstFloat(f),

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1507,6 +1507,226 @@ mod tests {
         );
     }
 
+    /// The function named `name` in the elaborated set, with its body.
+    #[cfg(test)]
+    fn body_of<'a, 'tcx>(
+        elab: &'a Elaborator<'_, 'tcx>,
+        name: &str,
+    ) -> &'a crate::semi::hir::Expr<'tcx> {
+        elab.elaborated
+            .iter()
+            .find(|f| elab.sym(f.name) == name)
+            .and_then(|f| f.body.as_ref())
+            .expect("function with a body")
+    }
+
+    /// Collect `(is_trait_call, target_path)` for every call in `body` —
+    /// `target_path` rendered as `::`-joined segments for `FuncCall`s.
+    #[cfg(test)]
+    fn call_targets(elab: &Elaborator<'_, '_>, name: &str) -> Vec<(bool, String)> {
+        let mut out = Vec::new();
+        crate::full::mono::for_each_expr(body_of(elab, name), &mut |e| match &e.kind {
+            crate::semi::hir::ExprKind::FuncCall { target, .. } => {
+                let path = elab
+                    .defs
+                    .path(*target)
+                    .0
+                    .iter()
+                    .map(|k| elab.sym(*k).to_string())
+                    .collect::<Vec<_>>()
+                    .join("::");
+                out.push((false, path));
+            }
+            crate::semi::hir::ExprKind::TraitCall { trait_def, .. } => {
+                let path = elab
+                    .defs
+                    .path(*trait_def)
+                    .0
+                    .iter()
+                    .map(|k| elab.sym(*k).to_string())
+                    .collect::<Vec<_>>()
+                    .join("::");
+                out.push((true, path));
+            }
+            _ => {}
+        });
+        out
+    }
+
+    #[test]
+    fn trait_methods_dispatch_on_dot_for_ground_receivers() {
+        check(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+             pub fn go(p: P) -> i64 { p.show() }",
+            |elab, _| {
+                let calls = call_targets(elab, "go");
+                // Ground receiver: committed to the impl method at check
+                // time — an ordinary FuncCall through the impl's path.
+                assert_eq!(calls.len(), 1, "{calls:?}");
+                assert!(!calls[0].0, "no TraitCall for a ground receiver");
+                assert_eq!(calls[0].1, "Show::P::show");
+            },
+        );
+    }
+
+    #[test]
+    fn trait_methods_dispatch_on_dot_for_generic_receivers() {
+        check(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+             pub fn go<T: Show>(x: T) -> i64 { x.show() }",
+            |elab, _| {
+                let calls = call_targets(elab, "go");
+                assert_eq!(calls.len(), 1, "{calls:?}");
+                assert!(calls[0].0, "generic receiver defers to a TraitCall");
+                assert_eq!(calls[0].1, "Show");
+            },
+        );
+    }
+
+    #[test]
+    fn inherent_methods_win_over_trait_methods() {
+        check(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl P { pub fn show(self: P) -> i64 { 1 } }\n\
+             impl Show for P { fn show(self: Self) -> i64 { 2 } }\n\
+             pub fn go(p: P) -> i64 { p.show() }",
+            |elab, _| {
+                let calls = call_targets(elab, "go");
+                assert_eq!(calls.len(), 1, "{calls:?}");
+                // The inherent path is `P::show`; the trait impl's method
+                // lives under `Show::P::show`.
+                assert_eq!(calls[0], (false, "P::show".to_string()), "{calls:?}");
+            },
+        );
+    }
+
+    #[test]
+    fn trait_method_wins_over_field_and_parens_force_the_field() {
+        check(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct P { pub show: (i64) -> i64, pub x: i64 }\n\
+             impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+             pub fn method(p: P) -> i64 { p.show() }\n\
+             pub fn field(p: P) -> i64 { (p.show)(3) }",
+            |elab, _| {
+                let m = call_targets(elab, "method");
+                assert_eq!(m.len(), 1, "{m:?}");
+                assert_eq!(m[0].1, "Show::P::show", "method-first, ahead of the field");
+                assert!(
+                    call_targets(elab, "field").is_empty(),
+                    "paren form is a closure call"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn ambiguous_trait_methods_are_reported() {
+        elaborate_source(
+            "pub trait A { fn m(self: Self) -> i64; }\n\
+             pub trait B { fn m(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl A for P { fn m(self: Self) -> i64 { 1 } }\n\
+             impl B for P { fn m(self: Self) -> i64 { 2 } }\n\
+             pub fn go(p: P) -> i64 { p.m() }",
+            |elab| {
+                assert!(
+                    elab.reports
+                        .iter()
+                        .any(|r| r.message.contains("multiple traits provide method `m`")
+                            && r.message.contains("`A` and `B`")),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn trait_path_calls_dispatch_both_ways() {
+        check(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+             pub fn ground(p: P) -> i64 { Show::show(p) }\n\
+             pub fn generic<T: Show>(x: T) -> i64 { Show::show(x) }",
+            |elab, _| {
+                let g = call_targets(elab, "ground");
+                assert_eq!(g, vec![(false, "Show::P::show".to_string())], "{g:?}");
+                let t = call_targets(elab, "generic");
+                assert_eq!(t, vec![(true, "Show".to_string())], "{t:?}");
+            },
+        );
+    }
+
+    #[test]
+    fn trait_dispatch_failure_diagnostics() {
+        elaborate_source(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             pub struct Q { pub y: i64 }\n\
+             impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+             pub fn miss(q: Q) -> i64 { q.show() }\n\
+             pub fn unbounded<T>(x: T) -> i64 { x.show() }\n\
+             pub fn wrong(p: P) -> i64 { Show::nope(p) }",
+            |elab| {
+                let has = |m: &str| elab.reports.iter().any(|r| r.message.contains(m));
+                assert!(
+                    has("no field or method `show` on `Q`; trait `Show` declares it"),
+                    "{:#?}",
+                    elab.reports
+                );
+                assert!(
+                    has("no method `show` on `T`; its bounds do not declare one"),
+                    "{:#?}",
+                    elab.reports
+                );
+                assert!(
+                    has("trait `Show` has no method `nope`"),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn supertrait_methods_reach_through_bounds() {
+        check(
+            "pub trait A { fn m(self: Self) -> i64; }\n\
+             pub trait B : A { fn extra(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl A for P { fn m(self: Self) -> i64 { self.x } }\n\
+             pub fn go<T: B>(x: T) -> i64 { x.m() }",
+            |elab, _| {
+                let calls = call_targets(elab, "go");
+                // The `B` bound reaches `A::m` through the super edge; the
+                // TraitCall names the declaring trait.
+                assert_eq!(calls, vec![(true, "A".to_string())], "{calls:?}");
+            },
+        );
+    }
+
+    #[test]
+    fn arc_receiver_trait_methods_dispatch() {
+        check(
+            "pub trait Shared { fn get(self: Arc<Self>) -> i64; }\n\
+             pub struct [shared] P { pub x: i64 }\n\
+             impl Shared for P { fn get(self: Arc<Self>) -> i64 { self.x } }\n\
+             pub fn go(a: Arc<P>) -> i64 { a.get() }",
+            |elab, _| {
+                let calls = call_targets(elab, "go");
+                assert_eq!(calls.len(), 1, "{calls:?}");
+                assert_eq!(calls[0].1, "Shared::P::get");
+            },
+        );
+    }
+
     #[test]
     fn rejected_batch_retracts_trait_impls() {
         use std::sync::Arc;

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -4,7 +4,7 @@ use reussir_syntax::kind::TokenKey;
 
 use crate::semi::infer::Instantiation;
 use crate::semi::resolve::DefKind;
-use crate::semi::traits::{Obligation, TraitId, TraitRef};
+use crate::semi::traits::{Evidence, Obligation, SelectCtxt, SelectError, TraitId, TraitRef};
 use crate::semi::ty::CellKind;
 use crate::semi::ty::{DefId, Flexivity, GenericId, Ty, TyKind};
 use crate::surface::{self, BinOp, Const, Span, UnaryOp};
@@ -650,6 +650,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.error(span, msg);
                 return self.poison(span);
             }
+            // `Trait::method(recv, …)` — the path prefix names a trait.
+            if !fc.name.segments.is_empty()
+                && let Some(done) = self.try_trait_path_call(fc, span)
+            {
+                return done;
+            }
             let hint = if fc.name.segments.is_empty() {
                 self.function_suggestion(fc.name.basename)
             } else {
@@ -733,6 +739,18 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
         let arced = matches!(raw.kind(), TyKind::Arc(_));
         let cur = self.peel_arc(raw);
+        // A bare-generic receiver has no fields; its dot calls dispatch
+        // through the traits its bounds provide.
+        if let TyKind::Generic(g) = *cur.kind()
+            && let surface::Access::Named(name) = last
+        {
+            let receiver = if indices.is_empty() {
+                base
+            } else {
+                self.mk_expr(ExprKind::Proj(Box::new(base), indices), raw, span)
+            };
+            return self.dispatch_generic_dot(g, cur, receiver, *name, args, span);
+        }
         let TyKind::Record {
             def,
             args: rargs,
@@ -747,15 +765,49 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return self.poison(span);
         };
         let (def, flex) = (*def, *flex);
-        if let surface::Access::Named(name) = last
-            && let Some(method) = self.dot_method_candidate(def, *name)
-        {
-            let receiver = if indices.is_empty() {
-                base
+        if let surface::Access::Named(name) = last {
+            if let Some(method) = self.dot_method_candidate(def, *name) {
+                let receiver = if indices.is_empty() {
+                    base
+                } else {
+                    self.mk_expr(ExprKind::Proj(Box::new(base), indices), raw, span)
+                };
+                return self.infer_method_call(receiver, def, method, *name, args, span);
+            }
+            // No inherent method: trait methods are next in line, still
+            // ahead of fields. An unresolved receiver cannot probe impls —
+            // ask for annotations when a matching trait method could exist.
+            let rcur = self.infer.resolve(cur);
+            if ty_has_hole(rcur) {
+                if !self.traits_declaring(*name).is_empty() {
+                    self.error(
+                        span,
+                        format!(
+                            "type annotations needed: cannot resolve `{}` on `{}`",
+                            self.sym(*name),
+                            self.ty_display(rcur)
+                        ),
+                    );
+                    return self.poison(span);
+                }
             } else {
-                self.mk_expr(ExprKind::Proj(Box::new(base), indices), raw, span)
-            };
-            return self.infer_method_call(receiver, def, method, *name, args, span);
+                let cands = self.ground_trait_candidates(rcur, *name);
+                match cands[..] {
+                    [] => {}
+                    [(tid, midx)] => {
+                        let receiver = if indices.is_empty() {
+                            base
+                        } else {
+                            self.mk_expr(ExprKind::Proj(Box::new(base), indices), raw, span)
+                        };
+                        return self.dispatch_trait_method(tid, midx, receiver, args, span);
+                    }
+                    [(a, _), (b, _), ..] => {
+                        self.ambiguous_method_error(*name, rcur, a, b, span);
+                        return self.poison(span);
+                    }
+                }
+            }
         }
         match self.resolve_field(def, rargs, flex, last) {
             Ok((idx, field_ty, _)) => {
@@ -800,10 +852,23 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         ),
                     );
                 } else {
+                    // A trait declares it but the receiver holds no impl:
+                    // steer toward the missing impl instead of a bare miss.
+                    let hint = self
+                        .traits_declaring(*name)
+                        .first()
+                        .map(|&(tid, _)| {
+                            format!(
+                                "; trait `{}` declares it, but `{type_display}` does not \
+                                 implement `{0}`",
+                                self.trait_display(tid)
+                            )
+                        })
+                        .unwrap_or_default();
                     self.error(
                         span,
                         format!(
-                            "no field or method `{}` on `{type_display}`",
+                            "no field or method `{}` on `{type_display}`{hint}",
                             self.sym(*name)
                         ),
                     );
@@ -910,6 +975,335 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             result,
             span,
         )
+    }
+
+    // ----- trait-method dispatch -----
+
+    /// Every trait whose method table declares `name`, with the method's
+    /// index. Deterministic: ascending trait id. Multi-parameter traits
+    /// never qualify — a dot call (or `Trait::m` path call) supplies only
+    /// `Self`, so their non-`Self` arguments have no instantiation source
+    /// until turbofish lands on trait-method calls.
+    fn traits_declaring(&self, name: TokenKey) -> Vec<(TraitId, usize)> {
+        (0..self.traits.traits_len() as u32)
+            .map(TraitId)
+            .filter_map(|tid| {
+                let def = self.traits.trait_def(tid);
+                if !def.params.is_empty() {
+                    return None;
+                }
+                def.methods
+                    .iter()
+                    .position(|m| m.name == name)
+                    .map(|idx| (tid, idx))
+            })
+            .collect()
+    }
+
+    /// Dot candidates for a *ground-headed* receiver: the declaring traits
+    /// whose goal `recv : Trait` the solver proves. Probing runs real
+    /// selection, so a candidate impl's where-clauses count — `Box<bool>`
+    /// is not a `Show` candidate under `impl<T: Num> Show for Box<T>`.
+    fn ground_trait_candidates(&self, recv: Ty<'tcx>, name: TokenKey) -> Vec<(TraitId, usize)> {
+        self.traits_declaring(name)
+            .into_iter()
+            .filter(|&(tid, _)| {
+                let goal = Obligation::Trait(TraitRef {
+                    trait_id: tid,
+                    args: vec![recv],
+                });
+                SelectCtxt::new(&self.traits, self.tcx, &self.generics)
+                    .select(&goal)
+                    .is_ok()
+            })
+            .collect()
+    }
+
+    /// Dot candidates for a bare-generic receiver: declaring traits
+    /// reachable from the generic's bounds — a bound's super-traits
+    /// dispatch too (`T: Integral` reaches a method `Num` declares).
+    fn generic_trait_candidates(&self, g: GenericId, name: TokenKey) -> Vec<(TraitId, usize)> {
+        let mut reach: Vec<TraitId> = Vec::new();
+        let mut work: Vec<TraitId> = self.generic_bounds(g).to_vec();
+        while let Some(t) = work.pop() {
+            if reach.contains(&t) {
+                continue;
+            }
+            reach.push(t);
+            work.extend(
+                self.traits
+                    .trait_def(t)
+                    .supertraits
+                    .iter()
+                    .map(|s| s.trait_id),
+            );
+        }
+        reach.sort_by_key(|t| t.0);
+        reach
+            .into_iter()
+            .filter_map(|tid| {
+                let def = self.traits.trait_def(tid);
+                if !def.params.is_empty() {
+                    return None;
+                }
+                def.methods
+                    .iter()
+                    .position(|m| m.name == name)
+                    .map(|idx| (tid, idx))
+            })
+            .collect()
+    }
+
+    /// (T-METHOD) Dispatch a resolved trait method — `recv.m(args)` or the
+    /// `Trait::m(recv, args…)` spelling — per the receiver's shape:
+    ///
+    /// * a **ground-headed** receiver commits at check time: coherence makes
+    ///   the selected impl unique, and the call becomes an ordinary
+    ///   [`ExprKind::FuncCall`] to that impl's method;
+    /// * a **bare-generic** receiver has no impl until monomorphization
+    ///   grounds `Self`, so the call is a serializable
+    ///   [`ExprKind::TraitCall`] resolved per instance.
+    fn dispatch_trait_method(
+        &mut self,
+        tid: TraitId,
+        midx: usize,
+        receiver: Expr<'tcx>,
+        args: &[surface::Expr],
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
+        let raw = self.infer.resolve(receiver.ty);
+        let peeled = self.peel_arc(raw);
+        if let TyKind::Generic(_) = peeled.kind() {
+            return self.trait_call_generic(tid, midx, receiver, peeled, args, span);
+        }
+        let mname = self.traits.trait_def(tid).methods[midx].name;
+        if ty_has_hole(peeled) {
+            self.error(
+                span,
+                format!(
+                    "type annotations needed: cannot resolve `{}` on `{}`",
+                    self.sym(mname),
+                    self.ty_display(peeled)
+                ),
+            );
+            return self.poison(span);
+        }
+        let goal = Obligation::Trait(TraitRef {
+            trait_id: tid,
+            args: vec![peeled],
+        });
+        let outcome = SelectCtxt::new(&self.traits, self.tcx, &self.generics).select(&goal);
+        match outcome {
+            Ok(Evidence::Impl { impl_id, .. }) => {
+                let Some(&def) = self.traits.impl_def(impl_id).methods.get(midx) else {
+                    // The impl elaborated with errors, reported at its site.
+                    return self.poison(span);
+                };
+                let TyKind::Record { def: head, .. } = *peeled.kind() else {
+                    unreachable!("user impls target records, so a selected method has one");
+                };
+                self.infer_method_call(receiver, head, def, mname, args, span)
+            }
+            Ok(_) => {
+                // Super-projected evidence proves the bound, but only a
+                // direct impl carries the method body.
+                let shown = self.trait_display(tid);
+                self.error(
+                    span,
+                    format!(
+                        "`{ty}` reaches `{shown}` only through a sub-trait; calling `{m}` \
+                         needs a direct `impl {shown} for {ty}`",
+                        ty = self.ty_display(peeled),
+                        m = self.sym(mname),
+                    ),
+                );
+                self.poison(span)
+            }
+            Err(SelectError::NoImpl(inner)) => {
+                let msg = self.no_impl_message(peeled, tid, &inner);
+                self.error(span, msg);
+                self.poison(span)
+            }
+            Err(SelectError::DepthLimit(g)) => {
+                let msg = self.depth_limit_message(&g);
+                self.error(span, msg);
+                self.poison(span)
+            }
+        }
+    }
+
+    /// The generic-receiver half of (T-METHOD): type the call against the
+    /// trait's [`MethodSig`] with `Self ↦` the receiver and the method's own
+    /// generics fresh, and emit the [`ExprKind::TraitCall`].
+    ///
+    /// [`MethodSig`]: crate::semi::traits::MethodSig
+    fn trait_call_generic(
+        &mut self,
+        tid: TraitId,
+        midx: usize,
+        receiver: Expr<'tcx>,
+        self_ty: Ty<'tcx>,
+        args: &[surface::Expr],
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
+        let tdef = self.traits.trait_def(tid);
+        if !tdef.params.is_empty() {
+            let shown = self.trait_display(tid);
+            self.error(
+                span,
+                format!(
+                    "cannot dispatch a method of multi-parameter trait `{shown}` \
+                     on a generic receiver"
+                ),
+            );
+            return self.poison(span);
+        }
+        let trait_def_id = tdef.def;
+        let self_param = tdef.self_param;
+        let sig = tdef.methods[midx].clone();
+        self.record_use(sig.name);
+        if sig.is_regional && !self.inside_region {
+            self.error(span, "cannot call a regional function outside of a region");
+        }
+        let mut inst = self.instantiate(&sig.generics, &[], span);
+        inst.insert(self_param, self_ty);
+        let expected_recv = self.infer.instantiate_ty(sig.params[0], &inst);
+        self.expect(receiver.ty, expected_recv, span);
+        let rest = &sig.params[1..];
+        if args.len() != rest.len() {
+            self.error(
+                span,
+                format!(
+                    "method `{}` expects {} argument(s) besides the receiver, got {}",
+                    self.sym(sig.name),
+                    rest.len(),
+                    args.len()
+                ),
+            );
+        }
+        let out: Vec<Expr<'tcx>> = std::iter::once(receiver)
+            .chain(args.iter().zip(rest).map(|(arg, &pty)| {
+                let expected = self.infer.instantiate_ty(pty, &inst);
+                self.check_expr(arg, expected)
+            }))
+            .collect();
+        let ty_args: Vec<Ty<'tcx>> = std::iter::once(self_ty)
+            .chain(self.inst_args(&sig.generics, &inst))
+            .collect();
+        let result = self.infer.instantiate_ty(sig.ret, &inst);
+        self.mk_expr(
+            ExprKind::TraitCall {
+                trait_def: trait_def_id,
+                method: midx as u32,
+                ty_args,
+                args: out,
+            },
+            result,
+            span,
+        )
+    }
+
+    /// The dot form on a bare-generic receiver: search the generic's bounds
+    /// for the (unique) declaring trait.
+    fn dispatch_generic_dot(
+        &mut self,
+        g: GenericId,
+        recv_ty: Ty<'tcx>,
+        receiver: Expr<'tcx>,
+        name: TokenKey,
+        args: &[surface::Expr],
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
+        let cands = self.generic_trait_candidates(g, name);
+        match cands[..] {
+            [] => {
+                self.error(
+                    span,
+                    format!(
+                        "no method `{}` on `{}`; its bounds do not declare one",
+                        self.sym(name),
+                        self.ty_display(recv_ty)
+                    ),
+                );
+                self.poison(span)
+            }
+            [(tid, midx)] => self.dispatch_trait_method(tid, midx, receiver, args, span),
+            [(a, _), (b, _), ..] => {
+                self.ambiguous_method_error(name, recv_ty, a, b, span);
+                self.poison(span)
+            }
+        }
+    }
+
+    fn ambiguous_method_error(
+        &mut self,
+        name: TokenKey,
+        recv_ty: Ty<'tcx>,
+        a: TraitId,
+        b: TraitId,
+        span: Option<Span>,
+    ) {
+        let (da, db) = (self.trait_display(a), self.trait_display(b));
+        self.error(
+            span,
+            format!(
+                "multiple traits provide method `{m}` for `{ty}`: `{da}` and `{db}`; \
+                 disambiguate with a trait path call like `{da}::{m}(…)`",
+                m = self.sym(name),
+                ty = self.ty_display(recv_ty),
+            ),
+        );
+    }
+
+    /// The `Trait::method(recv, args…)` path spelling: the path prefix names
+    /// the trait, the basename its method, and the first argument is the
+    /// receiver. `None` when the prefix is not a trait — the caller falls
+    /// back to its unknown-function diagnostic.
+    fn try_trait_path_call(
+        &mut self,
+        fc: &surface::FuncCall,
+        span: Option<Span>,
+    ) -> Option<Expr<'tcx>> {
+        let (tname, prefix) = fc.name.segments.split_last()?;
+        let tpath = surface::Path {
+            basename: *tname,
+            segments: prefix.iter().copied().collect(),
+        };
+        let def = self.resolve_trait_ref_quiet(&tpath)?;
+        let tid = self
+            .traits
+            .trait_by_def(def)
+            .expect("every trait-namespace def has a TraitDb entry");
+        let mname = self.sym(fc.name.basename).to_string();
+        let Some(midx) = self
+            .traits
+            .trait_def(tid)
+            .methods
+            .iter()
+            .position(|m| m.name == fc.name.basename)
+        else {
+            let shown = self.trait_display(tid);
+            self.error(span, format!("trait `{shown}` has no method `{mname}`"));
+            return Some(self.poison(span));
+        };
+        if !fc.ty_args.is_empty() {
+            self.error(
+                span,
+                "type arguments on a trait-method call are not supported yet",
+            );
+            return Some(self.poison(span));
+        }
+        let Some(recv_src) = fc.args.first() else {
+            let shown = self.trait_display(tid);
+            self.error(
+                span,
+                format!("`{shown}::{mname}` takes its receiver as the first argument"),
+            );
+            return Some(self.poison(span));
+        };
+        self.record_use(fc.name.basename);
+        let receiver = self.infer_expr(recv_src);
+        Some(self.dispatch_trait_method(tid, midx, receiver, &fc.args[1..], span))
     }
 
     /// (APP) `Γ ⊢ callee(args) ⇒ (ClosureCall{hc,[hᵢ]} : R)`: synthesize the callee to
@@ -2691,6 +3085,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 op,
                 args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
             },
+            TraitCall {
+                trait_def,
+                method,
+                ty_args,
+                args,
+            } => TraitCall {
+                trait_def,
+                method,
+                ty_args: ty_args.into_iter().map(|t| self.zonk_ty(t, span)).collect(),
+                args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
+            },
             other => other,
         }
     }
@@ -2763,9 +3168,10 @@ fn var_occurrences<'tcx>(e: &Expr<'tcx>, used: &mut Vec<VarId>, bound: &mut Vec<
             bound.push(*var);
         }
         Seq(es) => es.iter().for_each(|e| var_occurrences(e, used, bound)),
-        FuncCall { args, .. } | CompoundCall { args, .. } | VariantCall { args, .. } => {
-            args.iter().for_each(|e| var_occurrences(e, used, bound))
-        }
+        FuncCall { args, .. }
+        | TraitCall { args, .. }
+        | CompoundCall { args, .. }
+        | VariantCall { args, .. } => args.iter().for_each(|e| var_occurrences(e, used, bound)),
         NullableCall(e) => {
             if let Some(e) = e {
                 var_occurrences(e, used, bound)

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -1165,17 +1165,25 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// heads gate on `pub`, bare names see the current module then the crate
     /// root (where the builtins live), qualified paths resolve like any
     /// other reference.
-    pub fn resolve_bound(&mut self, path: &surface::Path, span: Option<Span>) -> Option<TraitId> {
-        let expanded = self.expand_path(path);
-        let path = expanded.as_ref().unwrap_or(path);
-        let def = if self.extern_head(path).is_some() {
+    /// Resolve a (possibly qualified) trait reference without reporting —
+    /// shared by [`Self::resolve_bound`] (which diagnoses on `None`) and
+    /// trait-path method calls (which fall back to other interpretations).
+    /// The path must already be import-expanded.
+    pub(super) fn resolve_trait_ref_quiet(&mut self, path: &surface::Path) -> Option<DefId> {
+        if self.extern_head(path).is_some() {
             self.resolve_extern(path, DefKind::Trait)
         } else if path.segments.is_empty() {
             self.defs.resolve_trait(path.basename)
         } else {
             self.defs
                 .resolve_trait_path(&self.classify_segs(path), path.basename)
-        };
+        }
+    }
+
+    pub fn resolve_bound(&mut self, path: &surface::Path, span: Option<Span>) -> Option<TraitId> {
+        let expanded = self.expand_path(path);
+        let path = expanded.as_ref().unwrap_or(path);
+        let def = self.resolve_trait_ref_quiet(path);
         let Some(def) = def else {
             if let Some(msg) = self.extern_private_msg(path, DefKind::Trait) {
                 self.error(span, msg);

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -403,6 +403,17 @@ impl<'tcx> Remapper<'_, '_, 'tcx> {
                 args: self.exprs(args),
                 regional: *regional,
             },
+            ExprKind::TraitCall {
+                trait_def,
+                method,
+                ty_args,
+                args,
+            } => ExprKind::TraitCall {
+                trait_def: self.def(*trait_def),
+                method: *method,
+                ty_args: self.tys(ty_args),
+                args: self.exprs(args),
+            },
             ExprKind::CompoundCall {
                 target,
                 ty_args,

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -274,19 +274,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 match select.select(&goal) {
                     Ok(_) => Discharge::Solved,
                     Err(SelectError::NoImpl(inner)) => {
-                        let name = self.trait_display(tref.trait_id);
-                        let mut msg =
-                            format!("`{}` does not implement `{name}`", self.ty_display(self_ty));
-                        // A where-clause failure on the chosen impl bubbles
-                        // the inner goal; name the root cause.
-                        if inner.trait_id != tref.trait_id || inner.self_ty() != self_ty {
-                            msg.push_str(&format!(
-                                ": `{}` does not implement `{}`",
-                                self.ty_display(inner.self_ty()),
-                                self.trait_display(inner.trait_id)
-                            ));
-                        }
-                        Discharge::Failed(msg)
+                        Discharge::Failed(self.no_impl_message(self_ty, tref.trait_id, &inner))
                     }
                     Err(SelectError::DepthLimit(g)) => {
                         Discharge::Failed(self.depth_limit_message(&g))
@@ -296,7 +284,30 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
     }
 
-    fn depth_limit_message(&self, goal: &TraitRef<'tcx>) -> String {
+    /// "`τ` does not implement `Trait`", with the bubbled inner goal named
+    /// as the root cause when a where-clause on the chosen impl failed.
+    /// Shared by obligation discharge and trait-method dispatch.
+    pub(super) fn no_impl_message(
+        &self,
+        self_ty: crate::semi::ty::Ty<'tcx>,
+        trait_id: crate::semi::traits::TraitId,
+        inner: &TraitRef<'tcx>,
+    ) -> String {
+        let name = self.trait_display(trait_id);
+        let mut msg = format!("`{}` does not implement `{name}`", self.ty_display(self_ty));
+        // A where-clause failure on the chosen impl bubbles the inner goal;
+        // name the root cause.
+        if inner.trait_id != trait_id || inner.self_ty() != self_ty {
+            msg.push_str(&format!(
+                ": `{}` does not implement `{}`",
+                self.ty_display(inner.self_ty()),
+                self.trait_display(inner.trait_id)
+            ));
+        }
+        msg
+    }
+
+    pub(super) fn depth_limit_message(&self, goal: &TraitRef<'tcx>) -> String {
         use crate::semi::traits::select::SELECT_DEPTH_LIMIT;
         format!(
             "overflow evaluating the bound `{}: {}` (depth limit {SELECT_DEPTH_LIMIT})",

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -172,6 +172,23 @@ pub enum ExprKind<'tcx> {
         args: Vec<Expr<'tcx>>,
         regional: bool,
     },
+    /// A trait-method call whose receiver is a bare in-scope generic, so the
+    /// impl is unknowable until monomorphization grounds `Self` and selects
+    /// it. A call with any *ground-headed* receiver is resolved at check
+    /// time to the unique impl's method as an ordinary [`FuncCall`] —
+    /// coherence guarantees the choice — so this variant never reaches
+    /// codegen; monomorphization rewrites it.
+    TraitCall {
+        /// The trait's path-keyed identity (stable across serialization,
+        /// unlike the session-dense `TraitId`).
+        trait_def: DefId,
+        /// Index into the trait's method table (= the impl's method order).
+        method: u32,
+        /// `[Self] ++ trait args ++ the method's own generics`.
+        ty_args: Vec<Ty<'tcx>>,
+        /// The receiver first, then the remaining arguments.
+        args: Vec<Expr<'tcx>>,
+    },
     /// A struct (compound) constructor call.
     CompoundCall {
         target: DefId,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -599,6 +599,10 @@ impl<'a> Printer<'a> {
     /// The bare form of a value node, without its `: ty` suffix.
     fn atom(&self, e: &Expr<'_>) -> Doc<'static> {
         match &e.kind {
+            ExprKind::TraitCall { .. } => unimplemented!(
+                "trait-method calls have no HIR text form yet; it lands with \
+                 trait serialization"
+            ),
             ExprKind::GlobalStr(s) => text(str_lit(s.words())),
             ExprKind::ConstInt(n) => text(format!("{n}")),
             ExprKind::ConstFloat(f) => text(f.to_string()),

--- a/crates/reussir-core/src/semi/infer.rs
+++ b/crates/reussir-core/src/semi/infer.rs
@@ -108,6 +108,12 @@ impl<'tcx> Instantiation<'tcx> {
     pub fn get(&self, generic: GenericId) -> Option<Ty<'tcx>> {
         self.map.get(&generic).copied()
     }
+
+    /// Extend with an explicit pair. Trait-method dispatch adds the trait's
+    /// `Self` (the receiver type) alongside the method's own fresh generics.
+    pub fn insert(&mut self, generic: GenericId, ty: Ty<'tcx>) {
+        self.map.insert(generic, ty);
+    }
 }
 
 /// The inference context: the hole table, the current level, and the interner.


### PR DESCRIPTION
Part 8 of the trait-system stack (base: #514). Trait methods become callable — dot form and `Trait::method` path form — with the receiver's shape deciding *when* the impl is chosen.

- **`ExprKind::TraitCall`** (new): `{ trait_def: DefId, method: u32, ty_args: [Self, method generics…], args }`. Emitted **only** for a bare-generic receiver, where no impl is knowable until monomorphization grounds `Self`; a ground-headed receiver commits at check time — coherence makes the selected impl unique — and becomes an ordinary `FuncCall` to the impl's method, so `TraitCall` never reaches codegen. All walkers gained arms in lockstep (`for_each_expr`, zonk, `var_occurrences`, the externs `Remapper`, the interface walk); the HIR-text form and the mono rewrite are explicit `unimplemented!`/`todo!` stubs replaced by the next PRs in the stack.
- **Dot dispatch order** (per the settled method-first design): inherent method → trait method → field, with `(e.f)(x)` still forcing the field. Ground receivers probe candidacy with the *real* solver, so where-clauses count (`Box<bool>` is not a `Show` candidate under `impl<T: Num> Show for Box<T>`); two applicable traits is an ambiguity error steering to the path spelling. Bare-generic receivers search the bounds' super-closure (`T: Integral` reaches a method `Num` declares) and emit `TraitCall` against the *declaring* trait.
- **`Trait::method(recv, args…)` path calls** resolve through the trait namespace (quiet — a non-trait prefix falls back to the unknown-function diagnostic) and reuse the same dispatch, so both spellings agree.
- **Diagnostics**: missing impl reuses the root-cause `no_impl_message` from #514; a receiver that reaches the trait only through a sub-trait (bound projection) is told a direct impl is required; unresolved receivers ask for annotations; `no field or method` now hints at a declaring trait when one exists.
- Support: `Instantiation::insert` (dispatch adds `Self ↦ receiver` beside the method's fresh generics), `resolve_trait_ref_quiet` factored out of `resolve_bound` (no wording changes), `no_impl_message`/`depth_limit_message` shared `pub(super)`.

Scope cuts (explicit in code/messages): multi-parameter traits never dot-dispatch (no instantiation source for their non-`Self` args until turbofish), and turbofish on trait-method calls is rejected with "not supported yet".

Tests: ground→`FuncCall{Show::P::show}` and generic→`TraitCall{Show}` pins, inherent-beats-trait, trait-beats-field + paren escape, ambiguity wording, both path-call forms, the three failure diagnostics, supertrait reach through bounds, and `Arc<Self>` receivers.

Gates: `cargo test` workspace-green, `cargo fmt`, `ninja -C build check`, `ninja -C build rrc-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788329329&installation_model_id=426051&pr_number=515&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F515&signature=94a1bca9fc43ea882acd7bf4074044801af6715b97e4b94abc2ec45743982449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->