### PR TITLE
[core] serialize trait items and TraitCall in the textual HIR

### DIFF
--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -109,6 +109,8 @@ pub(crate) fn frontend_package<'c, 'tcx>(
         .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
         .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
         .with_bounds(&bounds);
+        let (traits, impls) = hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+        let printer = printer.with_traits(&traits, &impls);
         let strings = elab.strings.entries();
         // The dump describes the consumer package: extern-imported records
         // are filtered out (extern bodies never joined `elaborated`).
@@ -181,7 +183,13 @@ pub(crate) fn frontend_package<'c, 'tcx>(
             records: &closure.records,
             file_root: file_root.as_deref(),
         });
-        let text = printer.program(&elab.elaborated, &strings, &elab.records, &[]);
+        let (traits, impls) = hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+        let text = printer.with_traits(&traits, &impls).program(
+            &elab.elaborated,
+            &strings,
+            &elab.records,
+            &[],
+        );
         return Ok(Produced::Text(text));
     }
     let (full, reports) = monomorphize(&elab.mono_input());
@@ -246,6 +254,8 @@ pub(crate) fn frontend<'c, 'tcx>(
                 .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
                 .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
                 .with_bounds(&bounds);
+                let (traits, impls) = hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+                let printer = printer.with_traits(&traits, &impls);
                 let strings = elab.strings.entries();
                 let text =
                     printer.program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
@@ -294,7 +304,8 @@ pub(crate) fn frontend<'c, 'tcx>(
                 }
                 .with_transform_metadata(&parsed.transform_anchors, &parsed.transform_scripts)
                 .with_ffi_metadata(&parsed.ffi_preludes, &parsed.ffi_imports)
-                .with_bounds(&parsed.generic_bounds);
+                .with_bounds(&parsed.generic_bounds)
+                .with_traits(&parsed.traits, &parsed.impls);
                 let text = printer.program(
                     &parsed.funcs,
                     &parsed.strings,

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -50,6 +50,10 @@ pub enum Token<'a> {
     Glue,
     #[token("transform")]
     Transform,
+    #[token("trait")]
+    Trait,
+    #[token("impl")]
+    Impl,
     #[token("transform_anchor")]
     TransformAnchor,
     #[token("interface")]

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -558,8 +558,11 @@ mod tests {
         assert!(!elab.has_errors(), "dep elab errors: {:#?}", elab.reports);
         let strings = elab.strings.entries();
         let bounds = elab.bound_names();
+        let (traits, impls) =
+            crate::semi::hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
         let text = Printer::new(&elab.defs, elab.resolver)
             .with_bounds(&bounds)
+            .with_traits(&traits, &impls)
             .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
         crate::semi::hir::build::parse_program(tcx, &text).expect("re-parse")
     }
@@ -1045,8 +1048,11 @@ mod tests {
             assert!(!elab.has_errors(), "dep elab errors: {:#?}", elab.reports);
             let cache = SourceCache::single("lib.rr", dep_src);
             let strings = elab.strings.entries();
+            let (traits, impls) =
+                crate::semi::hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
             let text = Printer::with_sources(&elab.defs, elab.resolver, &cache)
                 .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
+                .with_traits(&traits, &impls)
                 .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             let parsed = crate::semi::hir::build::parse_program(tcx, &text).expect("re-parse");
             assert_eq!(parsed.files, ["lib.rr"], "table travels");

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -286,6 +286,125 @@ pub enum SwitchCases<'tcx> {
     },
 }
 
+/// A trait item in print-ready form: paths and names pre-rendered. Both the
+/// elaborator (from its `TraitDb`, via [`trait_texts`]) and the HIR-text
+/// parser produce this shape, so one printer serves emission and the
+/// parse-side round trip; the extern reload resolves it back into a session
+/// `TraitDb`.
+///
+/// [`trait_texts`]: crate::semi::hir::trait_texts
+#[derive(Clone, Debug)]
+pub struct TraitText<'tcx> {
+    pub is_pub: bool,
+    pub path: String,
+    /// Binders; `[0]` is the implicit `Self`. Names are display-only.
+    pub generics: Vec<(GenericId, Option<String>)>,
+    /// Super-references: rendered path + full args (`args[0]` = `Self`).
+    pub supers: Vec<(String, Vec<Ty<'tcx>>)>,
+    pub methods: Vec<TraitMethodText<'tcx>>,
+    pub file: FileId,
+    pub span: Option<Span>,
+}
+
+/// A trait method signature in print-ready form (receiver at `params[0]`).
+#[derive(Clone, Debug)]
+pub struct TraitMethodText<'tcx> {
+    pub regional: bool,
+    pub name: String,
+    pub generics: Vec<(GenericId, Option<String>)>,
+    pub receiver: crate::semi::traits::def::ReceiverForm,
+    pub params: Vec<Ty<'tcx>>,
+    pub ret: Ty<'tcx>,
+    pub span: Option<Span>,
+}
+
+/// An impl item in print-ready form: trait path + full args
+/// (`args[0]` = the self type) and method paths in trait-method order.
+#[derive(Clone, Debug)]
+pub struct ImplText<'tcx> {
+    pub generics: Vec<(GenericId, Option<String>)>,
+    pub trait_path: String,
+    pub args: Vec<Ty<'tcx>>,
+    pub methods: Vec<String>,
+    pub file: FileId,
+    pub span: Option<Span>,
+}
+
+/// Render the user-declared traits and impls of `db` print-ready. Sealed
+/// traits (the builtins) and their impls are skipped: they are re-registered
+/// from the compiler itself in every session, never shipped.
+pub fn trait_texts<'tcx>(
+    db: &crate::semi::traits::TraitDb<'tcx>,
+    defs: &crate::semi::resolve::DefTable,
+    resolver: &dyn reussir_syntax::kind::Resolver<TokenKey>,
+) -> (Vec<TraitText<'tcx>>, Vec<ImplText<'tcx>>) {
+    let path_of = |def: DefId| {
+        defs.path(def)
+            .0
+            .iter()
+            .map(|k| resolver.resolve(*k))
+            .collect::<Vec<_>>()
+            .join("::")
+    };
+    let mut traits = Vec::new();
+    for id in (0..db.traits_len() as u32).map(crate::semi::traits::TraitId) {
+        let t = db.trait_def(id);
+        if t.sealed {
+            continue;
+        }
+        let mut generics = vec![(t.self_param, Some("Self".to_string()))];
+        generics.extend(
+            t.params
+                .iter()
+                .map(|&(name, g)| (g, Some(resolver.resolve(name).to_string()))),
+        );
+        traits.push(TraitText {
+            is_pub: t.visibility == crate::surface::Visibility::Public,
+            path: path_of(t.def),
+            generics,
+            supers: t
+                .supertraits
+                .iter()
+                .map(|s| (path_of(db.trait_def(s.trait_id).def), s.args.clone()))
+                .collect(),
+            methods: t
+                .methods
+                .iter()
+                .map(|m| TraitMethodText {
+                    regional: m.is_regional,
+                    name: resolver.resolve(m.name).to_string(),
+                    generics: m
+                        .generics
+                        .iter()
+                        .map(|&(name, g)| (g, Some(resolver.resolve(name).to_string())))
+                        .collect(),
+                    receiver: m.receiver,
+                    params: m.params.clone(),
+                    ret: m.ret,
+                    span: m.span,
+                })
+                .collect(),
+            file: t.file,
+            span: t.span,
+        });
+    }
+    let mut impls = Vec::new();
+    for imp in db.impls() {
+        if db.trait_def(imp.trait_ref.trait_id).sealed {
+            continue;
+        }
+        impls.push(ImplText {
+            generics: imp.generics.iter().map(|&g| (g, None)).collect(),
+            trait_path: path_of(db.trait_def(imp.trait_ref.trait_id).def),
+            args: imp.trait_ref.args.clone(),
+            methods: imp.methods.iter().map(|&d| path_of(d)).collect(),
+            file: imp.file,
+            span: imp.span,
+        });
+    }
+    (traits, impls)
+}
+
 /// A type-checked function, the unit of Semi output.
 #[derive(Clone, Debug)]
 pub struct Function<'tcx> {

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -23,8 +23,8 @@ use crate::semi::ctxt::{
 use crate::semi::hir::grammar as hir_ir;
 use crate::semi::hir::raw;
 use crate::semi::hir::{
-    ArithOp, Bound, ClosureExpr, CmpOp, DecisionTree, Expr, ExprId, ExprKind, Function, PatVarRef,
-    SwitchCases, VarId,
+    ArithOp, Bound, ClosureExpr, CmpOp, DecisionTree, Expr, ExprId, ExprKind, Function, ImplText,
+    PatVarRef, SwitchCases, TraitMethodText, TraitText, VarId,
 };
 use crate::semi::resolve::DefTable;
 use crate::semi::ty::{DefId, Flexivity, FpTy, GenericId, IntTy, Ty, TyCtxt, TyKind};
@@ -42,6 +42,11 @@ pub struct Parsed<'tcx> {
     /// caller's job.
     pub header: Option<raw::InterfaceHeader>,
     pub funcs: Vec<Function<'tcx>>,
+    /// Trait items, print-ready; the extern reload resolves them into the
+    /// session `TraitDb`.
+    pub traits: Vec<TraitText<'tcx>>,
+    /// Impl items, print-ready (method paths unresolved strings).
+    pub impls: Vec<ImplText<'tcx>>,
     pub transform_anchors: Vec<DefId>,
     pub transform_scripts: Vec<TransformScript>,
     pub strings: Vec<(StringToken, String)>,
@@ -139,6 +144,8 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
     };
     // Records first so their `DefId`s exist before function bodies reference them.
     let records: FxHashMap<DefId, Record<'tcx>> = raw.records.iter().map(|r| b.record(r)).collect();
+    let traits: Vec<TraitText<'tcx>> = raw.traits.iter().map(|t| b.trait_text(t)).collect();
+    let impls: Vec<ImplText<'tcx>> = raw.impls.iter().map(|i| b.impl_text(i)).collect();
     let funcs: Vec<Function<'tcx>> = raw.funcs.iter().map(|f| b.func(f)).collect();
     let transform_anchors = raw
         .funcs
@@ -184,6 +191,8 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
     Ok(Parsed {
         header: raw.header.clone(),
         funcs,
+        traits,
+        impls,
         transform_anchors,
         transform_scripts,
         strings,
@@ -227,6 +236,18 @@ impl<'tcx> Builder<'_, 'tcx> {
         let (name, module) = segs.split_last().expect("paths are never empty");
         self.defs.set_module(module.to_vec());
         self.defs.declare_function(*name).expect("fresh fn decl")
+    }
+
+    /// Resolve-or-declare a trait path (the `trait#path#idx(…)` call form
+    /// and trait items share the id, in any order).
+    fn trait_item_def(&mut self, path: &str) -> DefId {
+        let segs: Vec<_> = path.split("::").map(|s| self.names.intern(s)).collect();
+        if let Some(id) = self.defs.lookup_trait(&segs) {
+            return id;
+        }
+        let (name, module) = segs.split_last().expect("paths are never empty");
+        self.defs.set_module(module.to_vec());
+        self.defs.declare_trait(*name).expect("fresh trait decl")
     }
 
     fn record_def(&mut self, path: &str) -> DefId {
@@ -377,6 +398,66 @@ impl<'tcx> Builder<'_, 'tcx> {
         }
     }
 
+    /// Rebuild a text-view binder list, banking bounds like [`Self::generics`].
+    fn text_generics(&mut self, gs: &[raw::Generic]) -> Vec<(GenericId, Option<String>)> {
+        gs.iter()
+            .map(|g| {
+                if !g.bounds.is_empty() {
+                    self.generic_bounds
+                        .insert(GenericId(g.id), g.bounds.clone());
+                }
+                (GenericId(g.id), g.name.clone())
+            })
+            .collect()
+    }
+
+    fn trait_text(&mut self, t: &raw::TraitItem) -> TraitText<'tcx> {
+        use crate::semi::traits::def::ReceiverForm;
+        // Declare the def so `#path` references (and the round-trip print)
+        // resolve to the same id the call form uses.
+        self.trait_item_def(&t.path);
+        TraitText {
+            is_pub: t.is_pub,
+            path: t.path.clone(),
+            generics: self.text_generics(&t.generics),
+            supers: t
+                .supers
+                .iter()
+                .map(|(p, args)| (p.clone(), self.tys(args)))
+                .collect(),
+            methods: t
+                .methods
+                .iter()
+                .map(|m| TraitMethodText {
+                    regional: m.regional,
+                    name: m.name.clone(),
+                    generics: self.text_generics(&m.generics),
+                    receiver: match m.receiver {
+                        raw::RecvForm::Value => ReceiverForm::Value,
+                        raw::RecvForm::Arc => ReceiverForm::Arc,
+                        raw::RecvForm::Flex => ReceiverForm::Flex,
+                    },
+                    params: self.tys(&m.params),
+                    ret: self.ty(&m.ret),
+                    span: span_of(m.span),
+                })
+                .collect(),
+            file: file_of(t.file),
+            span: span_of(t.span),
+        }
+    }
+
+    fn impl_text(&mut self, i: &raw::ImplItem) -> ImplText<'tcx> {
+        ImplText {
+            generics: self.text_generics(&i.generics),
+            trait_path: i.trait_path.clone(),
+            args: self.tys(&i.args),
+            methods: i.methods.clone(),
+            file: file_of(i.file),
+            span: span_of(i.span),
+        }
+    }
+
     fn ty(&mut self, t: &raw::Ty) -> Ty<'tcx> {
         match t {
             raw::Ty::Signed(w) => self.tcx.mk_int(IntTy::Signed(*w)),
@@ -484,6 +565,20 @@ impl<'tcx> Builder<'_, 'tcx> {
                     ty_args: self.tys(ty_args),
                     args: self.exprs(args),
                     regional: *regional,
+                }
+            }
+            raw::Kind::TraitCall {
+                path,
+                method,
+                ty_args,
+                args,
+            } => {
+                let trait_def = self.trait_item_def(path);
+                ExprKind::TraitCall {
+                    trait_def,
+                    method: *method,
+                    ty_args: self.tys(ty_args),
+                    args: self.exprs(args),
                 }
             }
             raw::Kind::CompoundCall {
@@ -731,10 +826,13 @@ mod tests {
 
             let strings = elab.strings.entries();
             let bounds = elab.bound_names();
+            let (traits, impls) =
+                crate::semi::hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
             let text = Printer::new(&elab.defs, elab.resolver)
                 .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
                 .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
                 .with_bounds(&bounds)
+                .with_traits(&traits, &impls)
                 .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             let parsed = parse_program(tcx, &text).expect("re-parse");
             assert_eq!(parsed.transform_anchors.len(), elab.transform_anchors.len());
@@ -753,6 +851,7 @@ mod tests {
                 .with_transform_metadata(&parsed.transform_anchors, &parsed.transform_scripts)
                 .with_ffi_metadata(&parsed.ffi_preludes, &parsed.ffi_imports)
                 .with_bounds(&parsed.generic_bounds)
+                .with_traits(&parsed.traits, &parsed.impls)
                 .program(
                     &parsed.funcs,
                     &parsed.strings,
@@ -1172,6 +1271,66 @@ mod tests {
              regional fn foo<T>(bar: [flex] T) -> i32 { 0 } \
              regional fn use_ok(c: [flex] TestCell<i32>) -> i32 { foo(c) }",
         );
+    }
+
+    #[test]
+    fn trait_items_roundtrip() {
+        // Declarations exercise every serialized facet: supertraits, method
+        // generics with bounds, all three receiver forms (value / Arc /
+        // [flex]), regional methods, bounded impl generics, and both ground
+        // and generic impls.
+        roundtrip(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub trait Fancy : Show {\n\
+                 fn fancy<U: Num>(self: Self, u: U) -> i64;\n\
+             }\n\
+             pub trait Shared { fn get(self: Arc<Self>) -> i64; }\n\
+             pub trait Ticker { regional fn tick(self: [flex] Self) -> unit; }\n\
+             pub struct P { pub x: i64 }\n\
+             pub struct Box<T> { pub v: T }\n\
+             impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+             impl<T: Num> Show for Box<T> { fn show(self: Self) -> i64 { 1 } }",
+        );
+    }
+
+    #[test]
+    fn trait_calls_roundtrip() {
+        // Both TraitCall spellings survive: the dot form and the trait path
+        // form, in a generic body (ground receivers resolve to plain calls).
+        roundtrip(
+            "pub trait Show { fn show(self: Self) -> i64; }\n\
+             pub struct P { pub x: i64 }\n\
+             impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+             pub fn dot<T: Show>(x: T) -> i64 { x.show() }\n\
+             pub fn path<T: Show>(x: T) -> i64 { Show::show(x) }\n\
+             pub fn ground(p: P) -> i64 { p.show() }",
+        );
+    }
+
+    #[test]
+    fn sealed_builtins_never_serialize() {
+        with_tcx(|tcx| {
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let source = "pub trait Show { fn show(self: Self) -> i64; }";
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
+            assert!(parse.ok());
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, &interner);
+            assert!(!elab.has_errors(), "{:#?}", elab.reports);
+            let (traits, impls) =
+                crate::semi::hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+            let strings = elab.strings.entries();
+            let text = Printer::new(&elab.defs, elab.resolver)
+                .with_traits(&traits, &impls)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
+            assert!(text.contains("trait #Show"), "{text}");
+            for builtin in ["Num", "Integral", "FloatingPoint", "PtrLike", "Sync"] {
+                assert!(
+                    !text.contains(&format!("trait #{builtin}")),
+                    "sealed `{builtin}` must not serialize:\n{text}"
+                );
+            }
+        });
     }
 
     #[test]

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -39,6 +39,8 @@ Item: raw::Item = {
     <t:TrampDecl> => raw::Item::Tramp(t),
     <t:TransformDecl> => raw::Item::Transform(t),
     <p:FfiPreludeDecl> => raw::Item::FfiPrelude(p),
+    <t:TraitDecl> => raw::Item::Trait(t),
+    <i:ImplDecl> => raw::Item::Impl(i),
     <f:Func> => raw::Item::Func(f),
 };
 
@@ -161,6 +163,62 @@ Func: raw::Func =
         body,
     };
 
+/// A trait item. The binder's first generic is the implicit `Self`; the
+/// super-references carry their full argument lists (args[0] = `Self`), so
+/// rebuilding involves no convention.
+TraitDecl: raw::TraitItem =
+    <p:"pub"?> "trait" "#" <path:QPath> <generics:Generics> <supers:(":" <CommaPlus<SuperRef>>)?>
+    <loc:ItemLoc?> "{" <methods:TraitMethodSig*> "}"
+    => raw::TraitItem {
+        is_pub: p.is_some(),
+        path,
+        generics,
+        supers: supers.unwrap_or_default(),
+        methods,
+        file: loc.map(|l| l.0),
+        span: loc.and_then(|l| l.1),
+    };
+
+SuperRef: (String, Vec<raw::Ty>) = "#" <p:PathArgs> => p;
+
+/// A trait method signature: positional parameter types (params[0] is the
+/// receiver), with an `Arc`/`flex` tag disambiguating the receiver form
+/// (absent = by-value `Self`).
+TraitMethodSig: raw::TraitMethodItem =
+    <r:"regional"?> "fn" <name:Name> <generics:Generics?> <recv:RecvForm?>
+    "(" <params:Comma<Ty>> ")" "->" <ret:Ty> <sp:Span?> ";"
+    => raw::TraitMethodItem {
+        regional: r.is_some(),
+        name: name.to_string(),
+        generics: generics.unwrap_or_default(),
+        receiver: recv.unwrap_or(raw::RecvForm::Value),
+        params,
+        ret,
+        span: sp,
+    };
+
+RecvForm: raw::RecvForm = {
+    "Arc" => raw::RecvForm::Arc,
+    "flex" => raw::RecvForm::Flex,
+};
+
+/// An impl item: the trait reference carries its full argument list
+/// (args[0] is the self type), and the body lists the impl's method
+/// definitions by qualified path in trait-method order — the functions
+/// themselves serialize as ordinary items.
+ImplDecl: raw::ImplItem =
+    "impl" <generics:Generics?> "#" <tr:PathArgs> <loc:ItemLoc?> "{" <methods:Comma<MethodRef>> "}"
+    => raw::ImplItem {
+        generics: generics.unwrap_or_default(),
+        trait_path: tr.0,
+        args: tr.1,
+        methods,
+        file: loc.map(|l| l.0),
+        span: loc.and_then(|l| l.1),
+    };
+
+MethodRef: String = "#" <p:QPath> => p;
+
 Generics: Vec<raw::Generic> = "<" <CommaPlus<Generic>> ">";
 
 /// A fully-qualified item path: `a::b::Name`. Serialized with its segments
@@ -221,6 +279,8 @@ BoundItem: Bound = <first:Name> <rest:("::" <Name>)*> => {
 /// Source identifiers remain legal when they spell a transform directive.
 Name: &'input str = {
     <name:"ident"> => name,
+    "trait" => "trait",
+    "impl" => "impl",
     "transform" => "transform",
     "transform_anchor" => "transform_anchor",
     "import" => "import",
@@ -345,6 +405,8 @@ Atom: raw::Kind = {
         => raw::Kind::Assign(dst, raw::small_u32(&field), src),
     <r:"regional"?> "#" <path:PathArgs> "(" <args:Comma<Expr>> ")"
         => raw::Kind::FuncCall { regional: r.is_some(), path: path.0, ty_args: path.1, args },
+    "trait" "#" <path:PathArgs> "#" <m:"int"> "(" <args:Comma<Expr>> ")"
+        => raw::Kind::TraitCall { path: path.0, ty_args: path.1, method: raw::small_u32(&m), args },
     "#" <path:PathArgs> "{" <args:Comma<Expr>> "}"
         => raw::Kind::CompoundCall { path: path.0, ty_args: path.1, args },
     "#" <path:PathArgs> "#" <v:"int"> "(" <args:Comma<Expr>> ")"
@@ -466,6 +528,8 @@ extern {
         "texture" => Token::Texture,
         "glue" => Token::Glue,
         "transform" => Token::Transform,
+        "trait" => Token::Trait,
+        "impl" => Token::Impl,
         "transform_anchor" => Token::TransformAnchor,
         "interface" => Token::Interface,
         "package" => Token::Package,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -52,6 +52,10 @@ pub struct Printer<'a> {
     /// for display-only dumps that predate the caller wiring; the
     /// round-trip helpers and the driver always attach it.
     bounds: Option<&'a rustc_hash::FxHashMap<GenericId, Vec<Bound>>>,
+    /// Trait/impl items to emit (see [`super::trait_texts`] and the parsed
+    /// program's views); empty for dumps that carry none.
+    trait_items: &'a [super::TraitText<'a>],
+    impl_items: &'a [super::ImplText<'a>],
     interface: Option<InterfaceEmit<'a>>,
 }
 
@@ -90,6 +94,8 @@ impl<'a> Printer<'a> {
             ffi_preludes: &[],
             ffi_imports: None,
             bounds: None,
+            trait_items: &[],
+            impl_items: &[],
             interface: None,
         }
     }
@@ -109,6 +115,8 @@ impl<'a> Printer<'a> {
             ffi_preludes: &[],
             ffi_imports: None,
             bounds: None,
+            trait_items: &[],
+            impl_items: &[],
             interface: None,
         }
     }
@@ -137,6 +145,17 @@ impl<'a> Printer<'a> {
     }
 
     /// Attach per-generic bounds to serialize in binders.
+    /// Attach trait/impl items to emit.
+    pub fn with_traits(
+        mut self,
+        traits: &'a [super::TraitText<'a>],
+        impls: &'a [super::ImplText<'a>],
+    ) -> Self {
+        self.trait_items = traits;
+        self.impl_items = impls;
+        self
+    }
+
     pub fn with_bounds(mut self, bounds: &'a rustc_hash::FxHashMap<GenericId, Vec<Bound>>) -> Self {
         self.bounds = Some(bounds);
         self
@@ -187,6 +206,8 @@ impl<'a> Printer<'a> {
         // elaboration and a reparse, unlike the session-local `DefId`).
         recs.sort_by_key(|r| self.path(r.def));
         items.extend(recs.into_iter().map(|record| self.record(record)));
+        items.extend(self.trait_items.iter().map(|t| self.trait_item(t)));
+        items.extend(self.impl_items.iter().map(|i| self.impl_item(i)));
         items.extend(
             trampolines
                 .iter()
@@ -281,6 +302,84 @@ impl<'a> Printer<'a> {
             })
             .collect();
         text("<") + comma_sep(parts) + text(">")
+    }
+
+    /// A binder list over pre-rendered names (`$5 (Self), $6: Num`); a
+    /// nameless binder prints bare. Bounds come from the shared map.
+    fn text_binder(&self, generics: &[(GenericId, Option<String>)]) -> Doc<'static> {
+        if generics.is_empty() {
+            return Doc::Null;
+        }
+        let parts: Vec<Doc<'static>> = generics
+            .iter()
+            .map(|(g, name)| {
+                let named = match name {
+                    Some(n) => format!(" ({})", spell_name(n)),
+                    None => String::new(),
+                };
+                let bounds = match self.bounds.and_then(|m| m.get(g)) {
+                    Some(bs) if !bs.is_empty() => {
+                        let spelled: Vec<String> = bs.iter().map(Bound::to_string).collect();
+                        format!(": {}", spelled.join(" + "))
+                    }
+                    _ => String::new(),
+                };
+                text(format!("${}{named}{bounds}", g.0))
+            })
+            .collect();
+        text("<") + comma_sep(parts) + text(">")
+    }
+
+    fn trait_item(&self, t: &super::TraitText<'_>) -> Doc<'static> {
+        let vis = if t.is_pub { "pub " } else { "" };
+        let mut head = text(format!("{vis}trait #{}", t.path)) + self.text_binder(&t.generics);
+        if !t.supers.is_empty() {
+            let supers: Vec<Doc<'static>> = t
+                .supers
+                .iter()
+                .map(|(path, args)| text(format!("#{path}")) + self.ty_args(args))
+                .collect();
+            head = head + text(" : ") + comma_sep(supers);
+        }
+        head = head + self.item_loc(t.file, t.span);
+        let methods: Vec<Doc<'static>> = t
+            .methods
+            .iter()
+            .map(|m| {
+                let regional = if m.regional { "regional " } else { "" };
+                let recv = match m.receiver {
+                    crate::semi::traits::def::ReceiverForm::Value => "",
+                    crate::semi::traits::def::ReceiverForm::Arc => " Arc",
+                    crate::semi::traits::def::ReceiverForm::Flex => " flex",
+                };
+                let params: Vec<Doc<'static>> = m.params.iter().map(|p| self.ty(*p)).collect();
+                text(format!("{regional}fn {}", m.name))
+                    + self.text_binder(&m.generics)
+                    + text(recv)
+                    + text(" (")
+                    + comma_sep(params)
+                    + text(") -> ")
+                    + self.ty(m.ret)
+                    + self.span_doc(m.span)
+                    + text(";")
+            })
+            .collect();
+        let body = methods
+            .into_iter()
+            .fold(Doc::Null, |body, m| body + hardline() + m);
+        head + text(" {") + indent(body) + hardline() + text("}")
+    }
+
+    fn impl_item(&self, i: &super::ImplText<'_>) -> Doc<'static> {
+        let methods: Vec<Doc<'static>> = i.methods.iter().map(|m| text(format!("#{m}"))).collect();
+        text("impl")
+            + self.text_binder(&i.generics)
+            + text(format!(" #{}", i.trait_path))
+            + self.ty_args(&i.args)
+            + self.item_loc(i.file, i.span)
+            + text(" { ")
+            + comma_sep(methods)
+            + text(" }")
     }
 
     fn record(&self, r: &Record<'_>) -> Doc<'static> {
@@ -599,10 +698,18 @@ impl<'a> Printer<'a> {
     /// The bare form of a value node, without its `: ty` suffix.
     fn atom(&self, e: &Expr<'_>) -> Doc<'static> {
         match &e.kind {
-            ExprKind::TraitCall { .. } => unimplemented!(
-                "trait-method calls have no HIR text form yet; it lands with \
-                 trait serialization"
-            ),
+            ExprKind::TraitCall {
+                trait_def,
+                method,
+                ty_args,
+                args,
+            } => {
+                text(format!("trait#{}", self.path(*trait_def)))
+                    + self.ty_args(ty_args)
+                    + text(format!("#{method}("))
+                    + self.arg_list(args)
+                    + text(")")
+            }
             ExprKind::GlobalStr(s) => text(str_lit(s.words())),
             ExprKind::ConstInt(n) => text(format!("{n}")),
             ExprKind::ConstFloat(f) => text(f.to_string()),

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -26,6 +26,55 @@ pub struct Program {
     pub transforms: Vec<Transform>,
     pub ffi_preludes: Vec<FfiPrelude>,
     pub funcs: Vec<Func>,
+    pub traits: Vec<TraitItem>,
+    pub impls: Vec<ImplItem>,
+}
+
+/// A trait declaration item. `generics[0]` is the implicit `Self` binder.
+#[derive(Clone, Debug)]
+pub struct TraitItem {
+    pub is_pub: bool,
+    pub path: String,
+    pub generics: Vec<Generic>,
+    /// Super-trait references: qualified path + full argument list
+    /// (`args[0]` = `Self`).
+    pub supers: Vec<(String, Vec<Ty>)>,
+    pub methods: Vec<TraitMethodItem>,
+    pub file: Option<u32>,
+    pub span: Option<Span>,
+}
+
+/// A trait method signature; parameters are positional types with the
+/// receiver at `params[0]`.
+#[derive(Clone, Debug)]
+pub struct TraitMethodItem {
+    pub regional: bool,
+    pub name: String,
+    pub generics: Vec<Generic>,
+    pub receiver: RecvForm,
+    pub params: Vec<Ty>,
+    pub ret: Ty,
+    pub span: Option<Span>,
+}
+
+/// The serialized receiver form tag; `Value` is the unmarked default.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecvForm {
+    Value,
+    Arc,
+    Flex,
+}
+
+/// An impl item: trait path + full argument list (`args[0]` = self type)
+/// and the method definitions by qualified path in trait-method order.
+#[derive(Clone, Debug)]
+pub struct ImplItem {
+    pub generics: Vec<Generic>,
+    pub trait_path: String,
+    pub args: Vec<Ty>,
+    pub methods: Vec<String>,
+    pub file: Option<u32>,
+    pub span: Option<Span>,
 }
 
 /// The `.rri` header: format integer, the package the interface describes,
@@ -48,6 +97,8 @@ pub enum Item {
     Transform(Transform),
     FfiPrelude(FfiPrelude),
     Func(Func),
+    Trait(TraitItem),
+    Impl(ImplItem),
 }
 
 impl Program {
@@ -61,6 +112,8 @@ impl Program {
             transforms: Vec::new(),
             ffi_preludes: Vec::new(),
             funcs: Vec::new(),
+            traits: Vec::new(),
+            impls: Vec::new(),
         };
         for item in items {
             match item {
@@ -71,6 +124,8 @@ impl Program {
                 Item::Transform(t) => p.transforms.push(t),
                 Item::FfiPrelude(f) => p.ffi_preludes.push(f),
                 Item::Func(f) => p.funcs.push(f),
+                Item::Trait(t) => p.traits.push(t),
+                Item::Impl(i) => p.impls.push(i),
             }
         }
         p
@@ -309,6 +364,12 @@ pub enum Kind {
     FuncCall {
         regional: bool,
         path: String,
+        ty_args: Vec<Ty>,
+        args: Vec<Expr>,
+    },
+    TraitCall {
+        path: String,
+        method: u32,
         ty_args: Vec<Ty>,
         args: Vec<Expr>,
     },

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -3,6 +3,8 @@
 
 use std::sync::Arc;
 
+use reussir_syntax::SharedInterner;
+
 use melior::Context;
 // Brings `verify` into scope for the pre-JIT module check.
 use melior::ir::operation::OperationLike as _;


### PR DESCRIPTION
Part 9 of the trait-system stack (base: #515). Trait declarations, impls, and `TraitCall` gain a textual HIR form, in the usual four-file lockstep (`print.rs` / `grammar.lalrpop` / `raw.rs` / `build.rs`) plus the shared `ir_lex` lexer. **`RRI_FORMAT` stays 1** — every form is an additive grammar production; old dumps parse unchanged.

- **Grammar** (all under the existing conventions — `$n` global generic numbering, `in <file> [span]` locations, bounds on binders):
  - `pub trait #path <$5 (Self), …> : #Super<$5>, … in f [s] { regional? fn name <…> Arc|flex? (tys…) -> ty [s]; … }` — binder `[0]` is `Self`; method params are positional with the receiver at `[0]`; an `Arc`/`flex` tag disambiguates the receiver form (absent = by-value).
  - `impl <$8: Num> #Show<#Box<$8>> in f [s] { #Show::Box::show, … }` — the trait reference carries its **full** argument list (`args[0]` = the self type, no convention to rebuild), and the body lists method definitions by qualified path in trait-method order; the functions themselves serialize as ordinary items. Impl where-clauses are not printed — they are derivable from the binder bounds, exactly how the scan built them.
  - `trait#Show<$5>#0(x)` — the `TraitCall` expression, replacing the `unimplemented!` stub from #515.
  - `trait`/`impl` join the lexer and the `Name` whitelist, so items named with those (contextual) words keep parsing as path segments.
- **`TraitText` / `ImplText`** (new, in `hir.rs`): print-ready views with pre-rendered paths. Both producers emit them — the elaborator via `trait_texts(&TraitDb, …)` (sealed builtins and their impls are skipped: they are re-registered from the compiler every session, never shipped) and the parser (`Parsed.traits`/`Parsed.impls`) — so one printer serves emission and the parse-side round trip, and the extern-reload PR consumes the parsed views directly.
- **Printer** stays 4-ary: trait/impl items attach builder-style (`.with_traits(…)`), so only the sites that ship traits changed — the driver's `--emit hir`/`--emit rri` paths, the externs test rig, and the round-trip harness (which now covers traits in every existing round-trip test).
- Fixed in passing: 18 test-only `elaborate` call sites in `reussir-codegen` had been broken since the interner threading landed (#509) — never noticed because that crate is not a default workspace member and no gate compiles its test targets. They now use the `parse_with_interner` pattern.

Tests: full-facet trait round-trip (supertraits, method generics with bounds, all three receiver forms, regional methods, ground + generic impls), both `TraitCall` spellings round-tripping inside generic bodies, and a pin that sealed builtins never serialize.

Note for the stack: interface-mode filtering of trait items to the export closure lands with the ExportClosure/MonoTraits PR (T-DIS-3b); until then `--emit rri` ships all user traits, a safe superset.

Gates: `cargo test` workspace-green, `cargo fmt`, `ninja -C build check`, `ninja -C build rrc-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788330296&installation_model_id=426051&pr_number=516&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F516&signature=c32dcef32d5ced41cb7bf29248305a2c767eb9eea8db123387e2f1e04079be61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->