### PR TITLE
[core] ship trait items in the export closure; thread MonoTraits

### DIFF
--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -183,7 +183,9 @@ pub(crate) fn frontend_package<'c, 'tcx>(
             records: &closure.records,
             file_root: file_root.as_deref(),
         });
-        let (traits, impls) = hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+        let (mut traits, mut impls) = hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+        traits.retain(|t| closure.traits.contains(&t.def));
+        impls.retain(|i| closure.traits.contains(&i.trait_def));
         let text = printer.with_traits(&traits, &impls).program(
             &elab.elaborated,
             &strings,
@@ -327,8 +329,11 @@ pub(crate) fn frontend<'c, 'tcx>(
                 ffi_preludes: &parsed.ffi_preludes,
                 strings: parsed.strings.clone(),
                 // A plain `.hir` re-entry is a closed world; interfaces load
-                // via `--extern` (package mode) only.
+                // via `--extern` (package mode) only. Its trait tables are
+                // rebuilt by the extern-reload pass; until a dump ships
+                // TraitCalls it monomorphizes identically without them.
                 externs: Default::default(),
+                traits: Default::default(),
             };
             let (full, reports) = monomorphize(&input);
             match &dump_sources {

--- a/crates/reussir-core/src/full/interface.rs
+++ b/crates/reussir-core/src/full/interface.rs
@@ -54,6 +54,12 @@ pub struct ExportClosure {
     pub records: FxHashSet<DefId>,
     /// String literals referenced by shipped bodies.
     pub strings: FxHashSet<StringToken>,
+    /// Trait items shipped, by the trait's def: `pub` traits, every trait a
+    /// shipped body's `TraitCall` or a shipped binder's bound names, and
+    /// their super-traits. An impl ships iff its trait does (coherence wants
+    /// consumers to see every impl of a trait they can name), so no separate
+    /// impl set exists.
+    pub traits: FxHashSet<DefId>,
 }
 
 /// Compute the export closure of an elaborated program.
@@ -73,7 +79,9 @@ pub fn export_closure(input: &MonoInput<'_, '_>) -> ExportClosure {
     let mut closure = ExportClosure::default();
     let mut tys: FxHashSet<Ty<'_>> = FxHashSet::default();
 
+    let db = input.traits.db;
     let mut queue: VecDeque<DefId> = VecDeque::new();
+    let mut trait_queue: VecDeque<crate::semi::traits::TraitId> = VecDeque::new();
     for f in input.elaborated {
         if f.visibility != Visibility::Public {
             continue;
@@ -84,42 +92,109 @@ pub fn export_closure(input: &MonoInput<'_, '_>) -> ExportClosure {
             queue.push_back(f.def);
         }
     }
-    while let Some(def) = queue.pop_front() {
-        let Some(func) = by_def.get(&def) else {
-            continue;
-        };
-        for (_, _, t) in &func.params {
-            tys.insert(*t);
+    // `pub` traits seed the trait closure (sealed builtins never ship; a
+    // consumer session re-registers them from the compiler).
+    if let Some(db) = db {
+        for id in (0..db.traits_len() as u32).map(crate::semi::traits::TraitId) {
+            let t = db.trait_def(id);
+            if !t.sealed && t.visibility == Visibility::Public && closure.traits.insert(t.def) {
+                trait_queue.push_back(id);
+            }
         }
-        tys.insert(func.return_ty);
-        let Some(body) = func.body.as_ref() else {
-            // A generic `#[ffi(import)]`: its texture is the body; nothing to
-            // walk, the signature types above are its whole reach.
-            continue;
-        };
-        for_each_expr(body, &mut |e| {
-            tys.insert(e.ty);
-            match &e.kind {
-                ExprKind::GlobalStr(s) => {
-                    closure.strings.insert(*s);
-                }
-                ExprKind::FuncCall { target, .. } => {
-                    let Some(callee) = by_def.get(target) else {
-                        return;
-                    };
-                    if callee.generics.is_empty() {
-                        closure.protos.insert(*target);
-                    } else if closure.bodies.insert(*target) {
-                        queue.push_back(*target);
+    }
+    // The fn queue and the trait queue feed each other: a shipped body's
+    // `TraitCall` (or a shipped binder's bound) ships a trait; a shipped
+    // trait ships its impls, whose generic methods are walked bodies.
+    loop {
+        while let Some(def) = queue.pop_front() {
+            let Some(func) = by_def.get(&def) else {
+                continue;
+            };
+            for (_, _, t) in &func.params {
+                tys.insert(*t);
+            }
+            tys.insert(func.return_ty);
+            if let (Some(db), Some(env)) = (db, input.traits.env) {
+                for (_, g) in &func.generics {
+                    for &bound in env
+                        .get(g.0 as usize)
+                        .map(|i| i.bounds.as_slice())
+                        .unwrap_or(&[])
+                    {
+                        let t = db.trait_def(bound);
+                        if !t.sealed && closure.traits.insert(t.def) {
+                            trait_queue.push_back(bound);
+                        }
                     }
                 }
-                // A TraitCall's reach — the trait item and the impls that can
-                // discharge it — joins the closure when the interface grows
-                // trait/impl sets alongside their serialization.
-                ExprKind::TraitCall { .. } => {}
-                _ => {}
             }
-        });
+            let Some(body) = func.body.as_ref() else {
+                // A generic `#[ffi(import)]`: its texture is the body; nothing
+                // to walk, the signature types above are its whole reach.
+                continue;
+            };
+            for_each_expr(body, &mut |e| {
+                tys.insert(e.ty);
+                match &e.kind {
+                    ExprKind::GlobalStr(s) => {
+                        closure.strings.insert(*s);
+                    }
+                    ExprKind::FuncCall { target, .. } => {
+                        let Some(callee) = by_def.get(target) else {
+                            return;
+                        };
+                        if callee.generics.is_empty() {
+                            closure.protos.insert(*target);
+                        } else if closure.bodies.insert(*target) {
+                            queue.push_back(*target);
+                        }
+                    }
+                    ExprKind::TraitCall { trait_def, .. } => {
+                        if closure.traits.insert(*trait_def)
+                            && let Some(db) = db
+                            && let Some(id) = db.trait_by_def(*trait_def)
+                        {
+                            trait_queue.push_back(id);
+                        }
+                    }
+                    _ => {}
+                }
+            });
+        }
+        let (Some(db), Some(id)) = (db, trait_queue.pop_front()) else {
+            break;
+        };
+        // Expand one shipped trait, then drain the fn queue it may refill.
+        let t = db.trait_def(id);
+        for sup in &t.supertraits {
+            let s = db.trait_def(sup.trait_id);
+            if !s.sealed && closure.traits.insert(s.def) {
+                trait_queue.push_back(sup.trait_id);
+            }
+        }
+        for m in &t.methods {
+            tys.extend(m.params.iter().copied());
+            tys.insert(m.ret);
+        }
+        for imp in db.impls() {
+            if imp.trait_ref.trait_id != id {
+                continue;
+            }
+            tys.extend(imp.trait_ref.args.iter().copied());
+            for &m in &imp.methods {
+                let Some(func) = by_def.get(&m) else {
+                    continue;
+                };
+                // A consumer instantiates generic impl methods itself (the
+                // `_RI` symbols dedup `weak_odr`); ground ones compile here
+                // and only the symbol crosses.
+                if func.generics.is_empty() {
+                    closure.protos.insert(m);
+                } else if closure.bodies.insert(m) {
+                    queue.push_back(m);
+                }
+            }
+        }
     }
     // Prototype signatures are surface too: a consumer type-checks calls
     // against them, and lowering a call inside an instantiated body needs
@@ -199,6 +274,77 @@ mod tests {
     use super::*;
     use crate::semi::elaborate;
     use crate::{surface, with_tcx};
+
+    /// The trait side of the closure, all rules at once: a `pub` trait
+    /// ships; a private trait ships when a shipped body's `TraitCall` or a
+    /// shipped binder's bound names it; an unreferenced private trait stays
+    /// home; shipped traits pull their impls' methods (generic ones as
+    /// walked bodies, ground ones as prototypes) and their impl heads into
+    /// the record closure; sealed builtins never ship.
+    #[test]
+    fn export_closure_ships_traits_with_their_impls() {
+        let source = "
+            pub trait Show { fn show(self: Self) -> i64; }
+            trait Hidden { fn h(self: Self) -> i64; }
+            trait Used { fn u(self: Self) -> i64; }
+            trait BoundOnly { fn b(self: Self) -> i64; }
+            pub struct P { pub x: i64 }
+            pub struct Box<T> { pub v: T }
+            impl Show for P { fn show(self: Self) -> i64 { self.x } }
+            impl<T : Num> Show for Box<T> { fn show(self: Self) -> i64 { 1 } }
+            impl Used for P { fn u(self: Self) -> i64 { 2 } }
+            impl Hidden for P { fn h(self: Self) -> i64 { 3 } }
+            pub fn go<T : Used>(x: T) -> i64 { x.u() }
+            pub fn constrained<T : BoundOnly>(x: T) -> i64 { 7 }
+        ";
+        with_tcx(|tcx| {
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
+            assert!(parse.ok(), "parse errors: {:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, &interner);
+            assert!(
+                !elab.has_errors(),
+                "elaboration errors: {:#?}",
+                elab.reports
+            );
+            let closure = export_closure(&elab.mono_input());
+            let names = |set: &FxHashSet<DefId>| -> Vec<String> {
+                let mut v: Vec<String> = set
+                    .iter()
+                    .map(|d| elab.defs.path(*d).display(elab.resolver))
+                    .collect();
+                v.sort();
+                v
+            };
+            // `Show` is pub; `Used` rides the TraitCall in `go`; `BoundOnly`
+            // rides `constrained`'s binder bound. `Hidden` stays home and no
+            // sealed builtin (`Num` bounds the generic impl) ever ships.
+            assert_eq!(names(&closure.traits), ["BoundOnly", "Show", "Used"]);
+            let bodies = names(&closure.bodies);
+            assert!(
+                bodies.contains(&"Show::Box::show".to_string()),
+                "generic impl methods ship as bodies: {bodies:?}"
+            );
+            let protos = names(&closure.protos);
+            for ground in ["Show::P::show", "Used::P::u"] {
+                assert!(
+                    protos.contains(&ground.to_string()),
+                    "ground impl methods ship as prototypes: {protos:?}"
+                );
+            }
+            assert!(
+                !protos.contains(&"Hidden::P::h".to_string())
+                    && !bodies.contains(&"Hidden::P::h".to_string()),
+                "an unshipped trait keeps its impls home: {protos:?} {bodies:?}"
+            );
+            let records = names(&closure.records);
+            assert!(
+                records.contains(&"P".to_string()) && records.contains(&"Box".to_string()),
+                "impl heads join the record closure: {records:?}"
+            );
+        });
+    }
 
     /// The closure over one mixed program, all four facts at once: `pub`
     /// generics and the generics they call ship bodies; grounds the shipped

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -97,6 +97,22 @@ pub struct MonoInput<'a, 'tcx> {
     /// The dependency-interface tables (`--extern`); empty defaults for a
     /// single-package compilation.
     pub externs: MonoExterns<'a, 'tcx>,
+    /// The trait tables `TraitCall` resolution and the export closure read;
+    /// default-empty inputs monomorphize exactly as before trait items
+    /// existed (dumps predating trait serialization keep their output).
+    pub traits: MonoTraits<'a, 'tcx>,
+}
+
+/// The trait side of a [`MonoInput`]: the session registry (for resolving
+/// `TraitCall`s and shipping impls) and the per-generic bound environment
+/// (for shipping bound-referenced traits).
+#[derive(Default, Clone, Copy)]
+pub struct MonoTraits<'a, 'tcx> {
+    /// `None` for inputs with no trait tables — a parsed dump until the
+    /// extern-reload pass rebuilds a registry from its trait items.
+    pub db: Option<&'a crate::semi::traits::TraitDb<'tcx>>,
+    /// Declared bounds per generic, dense by `GenericId`.
+    pub env: Option<&'a [crate::semi::ctxt::GenericInfo]>,
 }
 
 /// What loaded dependency interfaces contribute to monomorphization: the
@@ -146,6 +162,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 strings: &self.extern_strings,
                 ffi_imports: Some(&self.extern_ffi_imports),
                 ffi_preludes: &self.extern_ffi_preludes,
+            },
+            traits: MonoTraits {
+                db: Some(&self.traits),
+                env: Some(&self.generics),
             },
         }
     }
@@ -1895,6 +1915,7 @@ mod tests {
                 ffi_preludes: &parsed.ffi_preludes,
                 strings: parsed.strings.clone(),
                 externs: MonoExterns::default(),
+                traits: MonoTraits::default(),
             };
             let (mir1, r1) = monomorphize(&input);
             assert!(r1.is_empty(), "{r1:#?}");
@@ -2004,6 +2025,7 @@ mod tests {
                 ffi_preludes: &hir.ffi_preludes,
                 strings: hir.strings.clone(),
                 externs: MonoExterns::default(),
+                traits: MonoTraits::default(),
             };
             let (mir_resumed, r_resumed) = monomorphize(&resumed_input);
             assert!(r_resumed.is_empty(), "resumed mono reports: {r_resumed:#?}");

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -295,6 +295,9 @@ pub enum SwitchCases<'tcx> {
 /// [`trait_texts`]: crate::semi::hir::trait_texts
 #[derive(Clone, Debug)]
 pub struct TraitText<'tcx> {
+    /// The trait's def — identity for interface filtering and reload; not
+    /// itself printed (the path is).
+    pub def: DefId,
     pub is_pub: bool,
     pub path: String,
     /// Binders; `[0]` is the implicit `Self`. Names are display-only.
@@ -322,6 +325,8 @@ pub struct TraitMethodText<'tcx> {
 /// (`args[0]` = the self type) and method paths in trait-method order.
 #[derive(Clone, Debug)]
 pub struct ImplText<'tcx> {
+    /// The implemented trait's def (identity only, like [`TraitText::def`]).
+    pub trait_def: DefId,
     pub generics: Vec<(GenericId, Option<String>)>,
     pub trait_path: String,
     pub args: Vec<Ty<'tcx>>,
@@ -359,6 +364,7 @@ pub fn trait_texts<'tcx>(
                 .map(|&(name, g)| (g, Some(resolver.resolve(name).to_string()))),
         );
         traits.push(TraitText {
+            def: t.def,
             is_pub: t.visibility == crate::surface::Visibility::Public,
             path: path_of(t.def),
             generics,
@@ -394,6 +400,7 @@ pub fn trait_texts<'tcx>(
             continue;
         }
         impls.push(ImplText {
+            trait_def: db.trait_def(imp.trait_ref.trait_id).def,
             generics: imp.generics.iter().map(|&g| (g, None)).collect(),
             trait_path: path_of(db.trait_def(imp.trait_ref.trait_id).def),
             args: imp.trait_ref.args.clone(),

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -415,8 +415,9 @@ impl<'tcx> Builder<'_, 'tcx> {
         use crate::semi::traits::def::ReceiverForm;
         // Declare the def so `#path` references (and the round-trip print)
         // resolve to the same id the call form uses.
-        self.trait_item_def(&t.path);
+        let def = self.trait_item_def(&t.path);
         TraitText {
+            def,
             is_pub: t.is_pub,
             path: t.path.clone(),
             generics: self.text_generics(&t.generics),
@@ -449,6 +450,7 @@ impl<'tcx> Builder<'_, 'tcx> {
 
     fn impl_text(&mut self, i: &raw::ImplItem) -> ImplText<'tcx> {
         ImplText {
+            trait_def: self.trait_item_def(&i.trait_path),
             generics: self.text_generics(&i.generics),
             trait_path: i.trait_path.clone(),
             args: self.tys(&i.args),


### PR DESCRIPTION
Part 10 of the trait-system stack (base: #516). The interface learns which trait items to ship, and monomorphization learns where its trait tables come from.

- **`MonoTraits`** (new on `MonoInput`, default-empty): the session `TraitDb` plus the per-generic bound environment. `Elaborator::mono_input()` fills both; parsed-dump inputs stay `default()` until the extern-reload PR rebuilds a registry from their trait items — which keeps the resumability canary (`parsed_hir_monomorphizes_to_the_same_mir`) byte-identical.
- **`ExportClosure.traits`** (by trait def): seeded by `pub` traits; grown by every trait a shipped body's `TraitCall` names and every trait a shipped binder's *bound* names (a consumer must be able to resolve `$0 (T): Hidden` at reload); closed over super-traits. An impl ships iff its trait does — coherence wants consumers to see every impl of a trait they can name — so there is no separate impl set. Shipping a trait pulls its impls' methods into the function closure with the standard classification: generic impl methods ship as walked **bodies** (consumers instantiate them; `_RI` symbols dedup `weak_odr`), ground ones as **prototypes**; impl heads and method signature types join the record closure. The fn-queue and trait-queue feed each other to a fixed point.
- **Driver `--emit rri`** filters the printed trait/impl items by `closure.traits` (replacing #516's ship-everything superset). `TraitText`/`ImplText` gained a non-printed `def`/`trait_def` identity field to make that filter (and the coming reload) direct.
- Sealed builtins never enter the closure from any edge (`pub` seed, bound, `TraitCall`).

Test: one program exercising every rule at once — pub trait ships; private trait ships via `TraitCall`; private trait ships via a binder bound; unreferenced private trait stays home with its impls; generic impl method in `bodies`, ground impl methods in `protos`; impl heads in the record closure; `Num` (sealed) absent.

Gates: `cargo test` workspace-green, `cargo fmt`, `ninja -C build check`, `ninja -C build rrc-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788330738&installation_model_id=426051&pr_number=517&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F517&signature=78b91a28276bf463c356c25a1396b43a00fbf2caee734942112e343a85bd04c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->