### PR TITLE
[core] resolve TraitCall at monomorphization; trait resumability twin

### DIFF
--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -12,7 +12,7 @@ use reussir_codegen::lower::{
 use reussir_codegen::source::{FileId, SourceCache};
 use reussir_core::full::interface;
 use reussir_core::full::mir;
-use reussir_core::full::mono::{MonoInput, monomorphize};
+use reussir_core::full::mono::{MonoInput, MonoTraits, monomorphize};
 use reussir_core::semi::hir;
 use reussir_core::semi::resolve::DefTable;
 use reussir_core::semi::ty::TyCtxt;
@@ -280,7 +280,7 @@ pub(crate) fn frontend<'c, 'tcx>(
             )
         }
         Stage::Hir => {
-            let parsed =
+            let mut parsed =
                 hir::build::parse_program(tcx, source).map_err(|e| format!("{name}: {e}"))?;
             // An interface is not a resumable program: its prototypes have no
             // bodies to compile and its mono roots stayed home. Loading one
@@ -316,6 +316,7 @@ pub(crate) fn frontend<'c, 'tcx>(
                 );
                 return Ok(Produced::Text(text));
             }
+            let trait_db = parsed.rebuild_traits(tcx);
             let input = MonoInput {
                 tcx,
                 defs: &parsed.defs,
@@ -329,11 +330,12 @@ pub(crate) fn frontend<'c, 'tcx>(
                 ffi_preludes: &parsed.ffi_preludes,
                 strings: parsed.strings.clone(),
                 // A plain `.hir` re-entry is a closed world; interfaces load
-                // via `--extern` (package mode) only. Its trait tables are
-                // rebuilt by the extern-reload pass; until a dump ships
-                // TraitCalls it monomorphizes identically without them.
+                // via `--extern` (package mode) only.
                 externs: Default::default(),
-                traits: Default::default(),
+                traits: MonoTraits {
+                    db: Some(&trait_db),
+                    env: None,
+                },
             };
             let (full, reports) = monomorphize(&input);
             match &dump_sources {

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -321,6 +321,8 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
     let mut driver = Driver {
         tcx,
         resolver: input.resolver,
+        defs: input.defs,
+        traits: input.traits,
         mangler: Mangler::new(input.defs, input.resolver),
         symbols: Rodeo::default(),
         queue: VecDeque::new(),
@@ -928,6 +930,10 @@ struct Driver<'a, 'tcx> {
     tcx: &'a TyCtxt<'tcx>,
     /// Symbol resolution for diagnostics (member labels in `Sync` witnesses).
     resolver: &'a dyn Resolver<TokenKey>,
+    /// Path display for diagnostics (instance names, trait-call reports).
+    defs: &'a DefTable,
+    /// The trait tables `TraitCall` resolution selects against.
+    traits: MonoTraits<'a, 'tcx>,
     mangler: Mangler<'a>,
     /// Interner for every mangled symbol; moved into the final `mir::Program`.
     symbols: Rodeo,
@@ -983,6 +989,97 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         });
     }
 
+    /// Resolve a `TraitCall` at instance time: the substitution grounded
+    /// `Self`, so coherence names the unique impl. Returns the impl method
+    /// and its full instantiation — the impl's own generics (derived by the
+    /// one-way matcher inside selection) followed by the method's own
+    /// arguments (the grounded tail of the `TraitCall`'s `ty_args`).
+    fn resolve_trait_call(
+        &mut self,
+        trait_def: DefId,
+        method: u32,
+        ty_args: &'tcx [Ty<'tcx>],
+        span: Option<Span>,
+    ) -> Option<(DefId, &'tcx [Ty<'tcx>], bool)> {
+        use crate::semi::traits::{Evidence, Obligation, SelectCtxt, SelectError, TraitRef};
+        let path = |defs: &DefTable, def: DefId| defs.path(def).display(self.resolver);
+        let Some(db) = self.traits.db else {
+            let shown = path(self.defs, trait_def);
+            self.error(
+                span,
+                format!(
+                    "cannot resolve a call through trait `{shown}`: this input \
+                     carries no trait tables"
+                ),
+            );
+            return None;
+        };
+        let Some(tid) = db.trait_by_def(trait_def) else {
+            let shown = path(self.defs, trait_def);
+            self.error(span, format!("unknown trait `{shown}` in a trait call"));
+            return None;
+        };
+        let goal = Obligation::Trait(TraitRef {
+            trait_id: tid,
+            args: vec![ty_args[0]],
+        });
+        // Every type is ground here, so the assumption environment is empty.
+        let outcome = SelectCtxt::new(db, self.tcx, &[]).select(&goal);
+        let tdef = db.trait_def(tid);
+        let shown = path(self.defs, tdef.def);
+        let mname = self
+            .resolver
+            .try_resolve(tdef.methods[method as usize].name)
+            .unwrap_or("?")
+            .to_string();
+        let regional = tdef.methods[method as usize].is_regional;
+        match outcome {
+            Ok(Evidence::Impl { impl_id, args, .. }) => {
+                let imp = db.impl_def(impl_id);
+                let Some(&target) = imp.methods.get(method as usize) else {
+                    self.error(
+                        span,
+                        format!("the selected `impl {shown}` does not define method `{mname}`"),
+                    );
+                    return None;
+                };
+                let callee: Vec<Ty<'tcx>> = args
+                    .into_iter()
+                    .chain(ty_args[1..].iter().copied())
+                    .collect();
+                Some((target, self.tcx.alloc_slice(&callee), regional))
+            }
+            Ok(_) => {
+                self.error(
+                    span,
+                    format!(
+                        "no direct `impl {shown}` provides method `{mname}` for this \
+                         instantiation (the bound holds only through a sub-trait)"
+                    ),
+                );
+                None
+            }
+            Err(SelectError::NoImpl(inner)) => {
+                let inner_trait = path(self.defs, db.trait_def(inner.trait_id).def);
+                self.error(
+                    span,
+                    format!(
+                        "no implementation of `{shown}` applies in this instantiation: \
+                         `{inner_trait}` is not implemented for the required type",
+                    ),
+                );
+                None
+            }
+            Err(SelectError::DepthLimit(_)) => {
+                self.error(
+                    span,
+                    format!("overflow selecting an `impl {shown}` for this instantiation"),
+                );
+                None
+            }
+        }
+    }
+
     /// Enqueue a function instance if it has not been seen, recording the
     /// demanding site (`span` in [`cur_file`](Self::cur_file)) for the
     /// missing-definition diagnostic.
@@ -996,12 +1093,18 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             // looping forever. Ground types of depth <= the limit over a finite
             // set of `DefId`s are a finite set, so this guarantees termination.
             let depth = ty_args.iter().map(|&t| ty_depth(t)).max().unwrap_or(0);
-            assert!(
-                depth <= RECURSION_LIMIT,
-                "monomorphize: type-argument nesting depth {depth} exceeds the \
-                 recursion limit ({RECURSION_LIMIT}); this is almost certainly \
-                 unbounded instantiation from polymorphic recursion"
-            );
+            if depth > RECURSION_LIMIT {
+                let shown = self.defs.path(def).display(self.resolver);
+                self.error(
+                    span,
+                    format!(
+                        "type-argument nesting depth {depth} exceeds the recursion \
+                         limit ({RECURSION_LIMIT}) while instantiating `{shown}`; this \
+                         is almost certainly polymorphic recursion"
+                    ),
+                );
+                return;
+            }
             self.queue.push_back(inst);
         }
     }
@@ -1428,10 +1531,28 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         use mir::ExprKind as M;
         match kind {
             ExprKind::GlobalStr(s) => M::GlobalStr(*s),
-            ExprKind::TraitCall { .. } => todo!(
-                "TraitCall resolves at instance time; the rewrite lands with \
-                 the trait-mono stack"
-            ),
+            ExprKind::TraitCall {
+                trait_def,
+                method,
+                ty_args,
+                args,
+            } => {
+                let ty_args = self.ground_args(ty_args, subst);
+                match self.resolve_trait_call(*trait_def, *method, ty_args, span) {
+                    Some((target, callee_args, regional)) => {
+                        self.enqueue(target, callee_args, span);
+                        let callee = self.symbol_of(target, callee_args);
+                        M::Call {
+                            callee,
+                            args: self.lower_slice(args, subst),
+                            regional,
+                        }
+                    }
+                    // The failure is already reported; poison keeps the
+                    // instance lowering so one bad call yields one report.
+                    None => M::Poison,
+                }
+            }
             ExprKind::ConstChar(c) => M::ConstChar(*c),
             ExprKind::ConstInt(n) => M::ConstInt(n),
             ExprKind::ConstFloat(f) => M::ConstFloat(f),
@@ -1924,6 +2045,163 @@ mod tests {
             assert_eq!(
                 text0, text1,
                 "resumed MIR differs from the original:\n=== original ===\n{text0}\n=== resumed ===\n{text1}"
+            );
+        });
+    }
+
+    /// `TraitCall` resolution at instance time, through a chain: the root
+    /// instantiation grounds `Self = Box<P>`, selection commits to the
+    /// generic impl, whose method body holds another `TraitCall` that
+    /// grounds to `Self = P` — two hops of coherent static dispatch, no
+    /// dictionaries anywhere in the MIR.
+    #[test]
+    fn trait_calls_resolve_at_instance_time() {
+        use crate::full::mir::print::Printer as MirPrinter;
+        let source = "pub trait Show { fn show(self: Self) -> i64; }\n\
+                      pub struct P { pub x: i64 }\n\
+                      pub struct Box<T> { pub v: T }\n\
+                      impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+                      impl<T: Show> Show for Box<T> { fn show(self: Self) -> i64 { self.v.show() } }\n\
+                      fn describe<T: Show>(x: T) -> i64 { x.show() }\n\
+                      pub fn run(p: P) -> i64 { describe(p) + describe(Box { v: p }) }";
+        with_tcx(|tcx| {
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
+            assert!(parse.ok(), "{:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, &interner);
+            assert!(!elab.has_errors(), "{:#?}", elab.reports);
+            let (mir, reports) = monomorphize(&elab.mono_input());
+            assert!(reports.is_empty(), "{reports:#?}");
+            let text = MirPrinter::new(&elab.defs, elab.resolver).program(&mir);
+            assert!(!text.contains("poison"), "unresolved trait call:\n{text}");
+            // Both impl-method instances were emitted (the mangled names
+            // carry the `Show` path segment).
+            assert!(text.contains("4Show"), "impl methods missing:\n{text}");
+        });
+    }
+
+    /// **Resumability, trait edition**: the twin of
+    /// [`parsed_hir_monomorphizes_to_the_same_mir`] over a trait-using
+    /// program. The parsed dump rebuilds its trait tables via
+    /// [`Parsed::rebuild_traits`] and must reach byte-identical MIR.
+    ///
+    /// [`Parsed::rebuild_traits`]: crate::semi::hir::build::Parsed::rebuild_traits
+    #[test]
+    fn trait_calls_resume_from_parsed_hir() {
+        use crate::full::mir::print::Printer as MirPrinter;
+        use crate::semi::hir::build::parse_program;
+        use crate::semi::hir::print::Printer as HirPrinter;
+
+        let source = "pub trait Show { fn show(self: Self) -> i64; }\n\
+                      pub struct P { pub x: i64 }\n\
+                      pub struct Box<T> { pub v: T }\n\
+                      impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+                      impl<T: Show> Show for Box<T> { fn show(self: Self) -> i64 { self.v.show() } }\n\
+                      fn describe<T: Show>(x: T) -> i64 { x.show() }\n\
+                      pub fn run(p: P) -> i64 { describe(p) + describe(Box { v: p }) }";
+        with_tcx(|tcx| {
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
+            assert!(parse.ok(), "{:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, &interner);
+            assert!(!elab.has_errors(), "{:#?}", elab.reports);
+
+            let (mir0, r0) = monomorphize(&elab.mono_input());
+            assert!(r0.is_empty(), "{r0:#?}");
+            let text0 = MirPrinter::new(&elab.defs, elab.resolver).program(&mir0);
+
+            let strings = elab.strings.entries();
+            let bounds = elab.bound_names();
+            let (traits, impls) =
+                crate::semi::hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+            let hir_text = HirPrinter::new(&elab.defs, elab.resolver)
+                .with_bounds(&bounds)
+                .with_traits(&traits, &impls)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
+            let mut parsed = parse_program(tcx, &hir_text).expect("re-parse HIR");
+            let trait_db = parsed.rebuild_traits(tcx);
+            let input = MonoInput {
+                tcx,
+                defs: &parsed.defs,
+                resolver: &parsed.names,
+                elaborated: &parsed.funcs,
+                records: &parsed.records,
+                trampolines: &parsed.trampolines,
+                transform_anchors: &parsed.transform_anchors,
+                transform_scripts: &parsed.transform_scripts,
+                ffi_imports: &parsed.ffi_imports,
+                ffi_preludes: &parsed.ffi_preludes,
+                strings: parsed.strings.clone(),
+                externs: MonoExterns::default(),
+                traits: MonoTraits {
+                    db: Some(&trait_db),
+                    env: None,
+                },
+            };
+            let (mir1, r1) = monomorphize(&input);
+            assert!(r1.is_empty(), "{r1:#?}");
+            let text1 = MirPrinter::new(&parsed.defs, &parsed.names).program(&mir1);
+
+            assert_eq!(
+                text0, text1,
+                "resumed MIR differs from the original:\n=== original ===\n{text0}\n=== resumed ===\n{text1}"
+            );
+        });
+    }
+
+    /// A trait-using dump monomorphized *without* rebuilt trait tables is a
+    /// spanned diagnostic (and poison), never a panic.
+    #[test]
+    fn trait_calls_without_tables_report() {
+        use crate::semi::hir::build::parse_program;
+        use crate::semi::hir::print::Printer as HirPrinter;
+
+        let source = "pub trait Show { fn show(self: Self) -> i64; }\n\
+                      pub struct P { pub x: i64 }\n\
+                      pub struct Box<T> { pub v: T }\n\
+                      impl Show for P { fn show(self: Self) -> i64 { self.x } }\n\
+                      impl<T: Show> Show for Box<T> { fn show(self: Self) -> i64 { self.v.show() } }\n\
+                      fn describe<T: Show>(x: T) -> i64 { x.show() }\n\
+                      pub fn run(p: P) -> i64 { describe(p) + describe(Box { v: p }) }";
+        with_tcx(|tcx| {
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(source, interner.clone());
+            assert!(parse.ok(), "{:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, &interner);
+            assert!(!elab.has_errors(), "{:#?}", elab.reports);
+            let strings = elab.strings.entries();
+            let bounds = elab.bound_names();
+            let (traits, impls) =
+                crate::semi::hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+            let hir_text = HirPrinter::new(&elab.defs, elab.resolver)
+                .with_bounds(&bounds)
+                .with_traits(&traits, &impls)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
+            let parsed = parse_program(tcx, &hir_text).expect("re-parse HIR");
+            let input = MonoInput {
+                tcx,
+                defs: &parsed.defs,
+                resolver: &parsed.names,
+                elaborated: &parsed.funcs,
+                records: &parsed.records,
+                trampolines: &parsed.trampolines,
+                transform_anchors: &parsed.transform_anchors,
+                transform_scripts: &parsed.transform_scripts,
+                ffi_imports: &parsed.ffi_imports,
+                ffi_preludes: &parsed.ffi_preludes,
+                strings: parsed.strings.clone(),
+                externs: MonoExterns::default(),
+                traits: MonoTraits::default(),
+            };
+            let (_, reports) = monomorphize(&input);
+            assert!(
+                reports
+                    .iter()
+                    .any(|r| r.message.contains("carries no trait tables")),
+                "{reports:#?}"
             );
         });
     }

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -95,11 +95,165 @@ impl Names {
     }
 }
 
+impl reussir_syntax::Interner<TokenKey> for Names {
+    type Error = std::convert::Infallible;
+
+    fn try_get_or_intern(&mut self, text: &str) -> Result<TokenKey, Self::Error> {
+        Ok(self.intern(text))
+    }
+
+    fn get_or_intern(&mut self, text: &str) -> TokenKey {
+        self.intern(text)
+    }
+}
+
 impl Resolver<TokenKey> for Names {
     fn try_resolve(&self, key: TokenKey) -> Option<&str> {
         self.strings
             .get(key.into_u32() as usize)
             .map(String::as_str)
+    }
+}
+
+impl<'tcx> Parsed<'tcx> {
+    /// Rebuild a session [`TraitDb`] from this dump's trait items, for
+    /// pipeline re-entry: register the builtins (their names intern into
+    /// this dump's own key space), then the dump's traits (two passes, so a
+    /// forward super-reference resolves) and impls. Dump-global generic ids
+    /// carry over unchanged, exactly like everywhere else in a re-entry.
+    ///
+    /// [`TraitDb`]: crate::semi::traits::TraitDb
+    pub fn rebuild_traits(&mut self, tcx: &TyCtxt<'tcx>) -> crate::semi::traits::TraitDb<'tcx> {
+        use crate::semi::traits::builtins::Builtins;
+        use crate::semi::traits::def::MethodSig;
+        use crate::semi::traits::{ImplDef, ImplId, Obligation, TraitDef, TraitId, TraitRef};
+
+        let mut db = crate::semi::traits::TraitDb::new();
+        let _ = Builtins::register(&mut db, &mut self.defs, &mut self.names, tcx);
+        let lookup_trait = |names: &mut Names, defs: &DefTable, path: &str| {
+            let segs: Vec<TokenKey> = path.split("::").map(|s| names.intern(s)).collect();
+            defs.lookup_trait(&segs)
+        };
+        for t in &self.traits {
+            if db.trait_by_def(t.def).is_some() {
+                continue;
+            }
+            let id = TraitId(db.traits_len() as u32);
+            let (&(self_param, _), params) = t
+                .generics
+                .split_first()
+                .expect("trait binders carry `Self` first");
+            let params: Vec<(TokenKey, GenericId)> = params
+                .iter()
+                .map(|(g, name)| (self.names.intern(name.as_deref().unwrap_or("_")), *g))
+                .collect();
+            db.add_trait(TraitDef {
+                id,
+                def: t.def,
+                visibility: if t.is_pub {
+                    surface::Visibility::Public
+                } else {
+                    surface::Visibility::Private
+                },
+                sealed: false,
+                self_param,
+                params,
+                supertraits: Vec::new(),
+                methods: Vec::new(),
+                assoc_tys: Vec::new(),
+                span: t.span,
+                file: t.file,
+            });
+        }
+        for t in &self.traits {
+            let Some(id) = db.trait_by_def(t.def) else {
+                continue;
+            };
+            let supertraits: Vec<TraitRef<'tcx>> = t
+                .supers
+                .iter()
+                .filter_map(|(path, args)| {
+                    let def = lookup_trait(&mut self.names, &self.defs, path)?;
+                    Some(TraitRef {
+                        trait_id: db.trait_by_def(def)?,
+                        args: args.clone(),
+                    })
+                })
+                .collect();
+            let methods: Vec<MethodSig<'tcx>> = t
+                .methods
+                .iter()
+                .map(|m| MethodSig {
+                    name: self.names.intern(&m.name),
+                    generics: m
+                        .generics
+                        .iter()
+                        .map(|(g, name)| (self.names.intern(name.as_deref().unwrap_or("_")), *g))
+                        .collect(),
+                    receiver: m.receiver,
+                    params: m.params.clone(),
+                    ret: m.ret,
+                    is_regional: m.regional,
+                    span: m.span,
+                })
+                .collect();
+            let def = db.trait_def_mut(id);
+            def.supertraits = supertraits;
+            def.methods = methods;
+        }
+        for i in &self.impls {
+            let Some(tid) = db.trait_by_def(i.trait_def) else {
+                continue;
+            };
+            let self_ty = i.args[0];
+            let methods: Vec<DefId> = i
+                .methods
+                .iter()
+                .filter_map(|p| {
+                    let segs: Vec<TokenKey> = p.split("::").map(|s| self.names.intern(s)).collect();
+                    self.defs.lookup_function(&segs)
+                })
+                .collect();
+            let where_clauses: Vec<Obligation<'tcx>> = i
+                .generics
+                .iter()
+                .flat_map(|&(g, _)| {
+                    self.generic_bounds
+                        .get(&g)
+                        .map(|bs| {
+                            bs.iter()
+                                .filter_map(|b| {
+                                    let def = lookup_trait(
+                                        &mut self.names,
+                                        &self.defs,
+                                        &b.trait_path().to_string(),
+                                    )?;
+                                    Some(Obligation::Trait(TraitRef {
+                                        trait_id: db.trait_by_def(def)?,
+                                        args: vec![tcx.mk_generic(g)],
+                                    }))
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default()
+                })
+                .collect();
+            let id = ImplId(db.impls_len() as u32);
+            db.add_impl(ImplDef {
+                id,
+                generics: i.generics.iter().map(|&(g, _)| g).collect(),
+                trait_ref: TraitRef {
+                    trait_id: tid,
+                    args: i.args.clone(),
+                },
+                self_ty,
+                where_clauses,
+                methods,
+                span: i.span,
+                file: i.file,
+            });
+        }
+        db
     }
 }
 


### PR DESCRIPTION
Part 12 of the trait-system stack (base: #518). Monomorphization resolves `TraitCall`s — the last hole between a generic trait-method call and machine code — completing static dispatch: no dictionaries exist anywhere in the MIR.

- **`resolve_trait_call`** (replacing #515's `todo!` stub): the instance substitution grounded `Self`, so selection (empty assumption environment — everything is ground) commits to the unique impl; the call lowers to an ordinary `M::Call` on `impl.methods[index]` instantiated at the impl's derived generics followed by the grounded tail of the `TraitCall`'s own `ty_args`, and the instance enqueues like any other. Chains work: instantiating at `Box<P>` selects the generic impl, whose method body holds another `TraitCall` that grounds to `P`. Failures are spanned reports + poison, never panics: no trait tables in the input, unknown trait, sub-trait-only bound (no direct impl carries the body), no applicable impl, selection overflow.
- **`RECURSION_LIMIT` is now a diagnostic**: the type-argument-depth assert in `enqueue` becomes a spanned report at the demanding call site — "…exceeds the recursion limit (128) while instantiating `f`; this is almost certainly polymorphic recursion" — so runaway instantiation is a compile error, not an ICE. (The record-field twin keeps its assert: it guards arena growth with no source position to blame; converting it is follow-up material.)
- **`Parsed::rebuild_traits`**: pipeline re-entry rebuilds a session `TraitDb` from a dump's trait items — builtins registered first (their names intern into the dump's own key space via a new `Interner` impl for `Names`), then the dump's traits in two passes and its impls, with where-clauses re-derived from binder bounds. The driver's `.hir` re-entry threads it through `MonoTraits`, and `Driver` gains `defs`/`traits` fields for resolution and diagnostics.

Tests: two-hop chained resolution to clean MIR (no poison, both impl-method instances mangled in); **the trait resumability twin** — print → parse → `rebuild_traits` → monomorphize reaches byte-identical MIR to the original elaboration, extending the design's canary to trait programs; and a trait dump monomorphized without tables reports ("carries no trait tables") instead of panicking.

Gates: `cargo test` workspace-green, `cargo fmt`, `ninja -C build check`, `ninja -C build rrc-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331484&installation_model_id=426051&pr_number=519&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F519&signature=b9a4e9472035b4139f81c4936d2e240703c302b0468e3b88161d3ac4c73727e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->