### PR TITLE
[core] declare the builtin traits through the builtin_traits! DSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,6 +3194,7 @@ dependencies = [
  "pprint",
  "rapidhash",
  "reussir-syntax",
+ "reussir-trait-dsl",
  "roaring",
  "rustc-hash",
  "smallvec",

--- a/crates/reussir-core/Cargo.toml
+++ b/crates/reussir-core/Cargo.toml
@@ -38,6 +38,9 @@ malachite-base.workspace = true
 malachite-nz.workspace = true
 # The surface AST is a set of typed views over the parser's lossless CST.
 reussir-syntax = { path = "../reussir-syntax" }
+# The builtin_traits! registration DSL: the trait/impl table in
+# semi::traits::builtins is a declaration, not hand-written registration.
+reussir-trait-dsl = { path = "../reussir-trait-dsl" }
 # Backends for utils::bitset's small-set-optimized VarId live-sets: a dense
 # fixedbitset that promotes to a compressed roaring bitmap past 512 bits.
 roaring.workspace = true

--- a/crates/reussir-core/src/semi/traits/builtins.rs
+++ b/crates/reussir-core/src/semi/traits/builtins.rs
@@ -2,7 +2,10 @@
 //!
 //! These replace the formerly hard-coded primitive class hierarchy. Membership
 //! now lives in ordinary [`TraitDef`]/[`ImplDef`] data resolved by the same
-//! engine as any user trait — there is no special-cased DAG. The hierarchy is:
+//! engine as any user trait — there is no special-cased DAG, and the table
+//! below is a *declaration*: [`reussir_trait_dsl::builtin_traits!`] expands it
+//! into the `Builtins` struct and its `register` function, assigning dense
+//! `TraitId`/`ImplId`s in declaration order. The hierarchy is:
 //!
 //! ```text
 //! Num            PtrLike      Sync
@@ -10,147 +13,78 @@
 //! └── FloatingPoint (impl: f16..f8)
 //! ```
 //!
-//! `Sync` is the single thread-safety marker (auto) trait: a value may be
-//! reached from any thread, concurrently. It subsumes both of Rust's `Send`
-//! and `Sync` — duplicable rc handles make transfer-without-sharing
-//! unprovable, so the two predicates collapse (see
-//! `docs/design/thread-safety.md`). It is declared here for name resolution
-//! and bound syntax only: ground `Sync` goals are answered *structurally* by
-//! [`crate::semi::traits::sync`], never by impl search, so it has no impls.
+//! [`TraitDef`]: super::TraitDef
+//! [`ImplDef`]: super::ImplDef
 
-use reussir_syntax::Interner;
-use reussir_syntax::kind::TokenKey;
+use reussir_trait_dsl::builtin_traits;
 
-use crate::semi::resolve::DefTable;
-use crate::semi::ty::{FpTy, GenericId, IntTy, Ty, TyCtxt};
-use crate::surface;
-
-use super::def::{ImplDef, TraitDef};
-use super::{ImplId, TraitDb, TraitId, TraitRef};
-
-/// Handles to the built-in traits, for the type checker to refer to by name.
-pub struct Builtins {
-    pub num: TraitId,
-    pub integral: TraitId,
-    pub floating_point: TraitId,
-    pub ptr_like: TraitId,
+builtin_traits! {
+    /// The root numeric class: arithmetic and numeric literals.
+    #[sealed]
+    trait Num;
+    /// Whole-number types; `Num` through the super-trait edge.
+    #[sealed]
+    trait Integral: Num;
+    /// Floating-point types; `Num` through the super-trait edge.
+    #[sealed]
+    trait FloatingPoint: Num;
+    /// Pointer-shaped values (nullable-niche eligible).
+    #[sealed]
+    trait PtrLike;
     /// Marker (auto) trait: a value may be reached from any thread,
-    /// concurrently. Subsumes both of Rust's `Send` and `Sync`
-    /// (`docs/design/thread-safety.md`).
-    pub sync: TraitId,
+    /// concurrently. It subsumes both of Rust's `Send` and `Sync` —
+    /// duplicable rc handles make transfer-without-sharing unprovable, so
+    /// the two predicates collapse (see `docs/design/thread-safety.md`).
+    /// Declared for name resolution and bound syntax only: ground `Sync`
+    /// goals are answered *structurally* by [`crate::semi::traits::sync`],
+    /// never by impl search, so it has (and can have) no impls.
+    #[sealed]
+    #[structural]
+    trait Sync;
+
+    impl Integral for i8 | u8 | i16 | u16 | i32 | u32 | i64 | u64;
+    impl FloatingPoint for f16 | f32 | f64 | bf16 | f8;
 }
 
-impl Builtins {
-    /// Register the built-in traits and their primitive impls into `db`,
-    /// declaring each trait in `defs`' trait namespace at the crate root —
-    /// so a bare `Num` resolves from any module through the root fallback
-    /// (prelude visibility), while a same-named user trait in a module
-    /// shadows it for bare references.
-    pub fn register<'tcx>(
-        db: &mut TraitDb<'tcx>,
-        defs: &mut DefTable,
-        interner: &mut impl Interner<TokenKey>,
-        tcx: &TyCtxt<'tcx>,
-    ) -> Builtins {
-        // Every built-in trait has a single `Self` parameter, generic #0 —
-        // deliberately UNALLOCATED in the elaborator's generics table (the
-        // builtin defs predate it, and allocating would shift every dump's
-        // `$n` numbering).
-        let self_g = GenericId(0);
-        let self_ref = |trait_id: TraitId| TraitRef {
-            trait_id,
-            args: vec![tcx.mk_generic(self_g)],
-        };
+#[cfg(test)]
+mod tests {
+    use super::Builtins;
+    use crate::semi::traits::{TraitDb, TraitId};
+    use crate::with_tcx;
 
-        let mut next = 0u32;
-        let mut fresh_trait = || {
-            let id = TraitId(next);
-            next += 1;
-            id
-        };
-        let num = fresh_trait();
-        let integral = fresh_trait();
-        let floating_point = fresh_trait();
-        let ptr_like = fresh_trait();
-        let sync = fresh_trait();
-
-        let mut declare =
-            |id, name: &str, supertraits, db: &mut TraitDb<'tcx>, defs: &mut DefTable| {
-                let key = interner.get_or_intern(name);
-                let def = defs.declare_trait(key).expect("builtins precede user defs");
-                db.add_trait(TraitDef {
-                    id,
-                    def,
-                    visibility: surface::Visibility::Public,
-                    sealed: true,
-                    self_param: self_g,
-                    params: vec![],
-                    supertraits,
-                    methods: vec![],
-                    assoc_tys: vec![],
-                    span: None,
-                    file: reussir_syntax::source::FileId::ROOT,
-                });
+    /// The generated table is the old hand-written one, exactly: dense
+    /// declaration-ordered trait ids, 8 integral + 5 floating impls, all
+    /// sealed, `Sync` impl-less.
+    #[test]
+    fn generated_table_matches_the_handwritten_contract() {
+        with_tcx(|tcx| {
+            let mut db = TraitDb::new();
+            let mut defs = crate::semi::resolve::DefTable::new();
+            let mut interner = lasso::Rodeo::<reussir_syntax::kind::TokenKey>::new();
+            let b = Builtins::register(&mut db, &mut defs, &mut interner, tcx);
+            assert_eq!(
+                [b.num, b.integral, b.floating_point, b.ptr_like, b.sync],
+                [TraitId(0), TraitId(1), TraitId(2), TraitId(3), TraitId(4)]
+            );
+            assert_eq!(db.traits_len(), 5);
+            assert_eq!(db.impls_len(), 13, "8 integral + 5 floating impls");
+            for i in 0..5u32 {
+                assert!(db.trait_def(TraitId(i)).sealed);
+            }
+            assert!(
+                db.impls().all(|imp| imp.trait_ref.trait_id != b.sync),
+                "Sync is structural; it must have no impls"
+            );
+            let supers = |t: TraitId| -> Vec<TraitId> {
+                db.trait_def(t)
+                    .supertraits
+                    .iter()
+                    .map(|s| s.trait_id)
+                    .collect()
             };
-        declare(num, "Num", vec![], db, defs);
-        declare(integral, "Integral", vec![self_ref(num)], db, defs);
-        declare(
-            floating_point,
-            "FloatingPoint",
-            vec![self_ref(num)],
-            db,
-            defs,
-        );
-        declare(ptr_like, "PtrLike", vec![], db, defs);
-        declare(sync, "Sync", vec![], db, defs);
-
-        let mut next_impl = 0u32;
-        let mut implement = |trait_id: TraitId, self_ty: Ty<'tcx>, db: &mut TraitDb<'tcx>| {
-            let id = ImplId(next_impl);
-            next_impl += 1;
-            db.add_impl(ImplDef {
-                id,
-                generics: vec![],
-                trait_ref: TraitRef {
-                    trait_id,
-                    args: vec![self_ty],
-                },
-                self_ty,
-                where_clauses: vec![],
-                methods: vec![],
-                span: None,
-                file: reussir_syntax::source::FileId::ROOT,
-            });
-        };
-
-        let mut ints = Vec::new();
-        for width in [8u16, 16, 32, 64] {
-            ints.push(tcx.mk_int(IntTy::Signed(width)));
-            ints.push(tcx.mk_int(IntTy::Unsigned(width)));
-        }
-        let mut fps = Vec::new();
-        for fp in [
-            FpTy::Ieee(16),
-            FpTy::Ieee(32),
-            FpTy::Ieee(64),
-            FpTy::BFloat16,
-            FpTy::Float8,
-        ] {
-            fps.push(tcx.mk_fp(fp));
-        }
-
-        for &ty in &ints {
-            implement(integral, ty, db);
-        }
-        for &ty in &fps {
-            implement(floating_point, ty, db);
-        }
-        Builtins {
-            num,
-            integral,
-            floating_point,
-            ptr_like,
-            sync,
-        }
+            assert_eq!(supers(b.integral), [b.num]);
+            assert_eq!(supers(b.floating_point), [b.num]);
+            assert!(supers(b.num).is_empty() && supers(b.sync).is_empty());
+        });
     }
 }


### PR DESCRIPTION
Part 13 of the trait-system stack (base: #519). The hand-written builtin registration table becomes a declaration: `semi/traits/builtins.rs` is now a `builtin_traits!` invocation (the proc-macro DSL landed in #510), reading like the surface language it bootstraps:

```rust
builtin_traits! {
    #[sealed] trait Num;
    #[sealed] trait Integral: Num;
    #[sealed] trait FloatingPoint: Num;
    #[sealed] trait PtrLike;
    #[sealed] #[structural] trait Sync;

    impl Integral for i8 | u8 | i16 | u16 | i32 | u32 | i64 | u64;
    impl FloatingPoint for f16 | f32 | f64 | bf16 | f8;
}
```

The expansion is contract-identical to the code it replaces — same `Builtins` struct (doc comments forwarded), same `register` signature, dense declaration-ordered `TraitId`/`ImplId`s, `Self` as the unallocated `GenericId(0)`, crate-root prelude declaration — which is why every existing selection/builtin/dispatch test passes unchanged. `Num` still carries no impls of its own (reached from `Integral`/`FloatingPoint` via super-projection), and `#[structural]` `Sync` is rejected by the macro if given any impl.

A pin test freezes the contract explicitly: trait ids 0–4 in declaration order, 13 impls (8 integral + 5 floating), everything sealed, `Sync` impl-less, and the two super-edges.

`reussir-core` gains the (workspace-internal, proc-macro) `reussir-trait-dsl` dependency.

Gates: `cargo test` workspace-green, `cargo fmt`, `ninja -C build check`, `ninja -C build rrc-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331712&installation_model_id=426051&pr_number=520&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F520&signature=472aa2a6105772e43c632720bb93572ec7d2f871b49b983f395e50a32f4708d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->