### PR TITLE
[core] the lang-item mechanism: #[lang] declarations, registry, locations

### DIFF
--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -110,7 +110,8 @@ pub(crate) fn frontend_package<'c, 'tcx>(
         .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
         .with_bounds(&bounds);
         let (traits, impls) = hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
-        let printer = printer.with_traits(&traits, &impls);
+        let lang = elab.lang.declared_by_def();
+        let printer = printer.with_traits(&traits, &impls).with_lang(&lang);
         let strings = elab.strings.entries();
         // The dump describes the consumer package: extern-imported records
         // are filtered out (extern bodies never joined `elaborated`).
@@ -186,12 +187,11 @@ pub(crate) fn frontend_package<'c, 'tcx>(
         let (mut traits, mut impls) = hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
         traits.retain(|t| closure.traits.contains(&t.def));
         impls.retain(|i| closure.traits.contains(&i.trait_def));
-        let text = printer.with_traits(&traits, &impls).program(
-            &elab.elaborated,
-            &strings,
-            &elab.records,
-            &[],
-        );
+        let lang = elab.lang.declared_by_def();
+        let text = printer
+            .with_traits(&traits, &impls)
+            .with_lang(&lang)
+            .program(&elab.elaborated, &strings, &elab.records, &[]);
         return Ok(Produced::Text(text));
     }
     let (full, reports) = monomorphize(&elab.mono_input());
@@ -257,7 +257,8 @@ pub(crate) fn frontend<'c, 'tcx>(
                 .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
                 .with_bounds(&bounds);
                 let (traits, impls) = hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
-                let printer = printer.with_traits(&traits, &impls);
+                let lang = elab.lang.declared_by_def();
+                let printer = printer.with_traits(&traits, &impls).with_lang(&lang);
                 let strings = elab.strings.entries();
                 let text =
                     printer.program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
@@ -307,7 +308,8 @@ pub(crate) fn frontend<'c, 'tcx>(
                 .with_transform_metadata(&parsed.transform_anchors, &parsed.transform_scripts)
                 .with_ffi_metadata(&parsed.ffi_preludes, &parsed.ffi_imports)
                 .with_bounds(&parsed.generic_bounds)
-                .with_traits(&parsed.traits, &parsed.impls);
+                .with_traits(&parsed.traits, &parsed.impls)
+                .with_lang(&parsed.lang);
                 let text = printer.program(
                     &parsed.funcs,
                     &parsed.strings,

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -52,6 +52,8 @@ pub enum Token<'a> {
     Transform,
     #[token("trait")]
     Trait,
+    #[token("lang")]
+    Lang,
     #[token("impl")]
     Impl,
     #[token("transform_anchor")]

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -17,6 +17,7 @@
 
 // The Semi-phase type machinery.
 pub mod infer;
+pub mod lang;
 pub mod traits;
 pub mod ty;
 
@@ -1725,6 +1726,87 @@ mod tests {
                 assert_eq!(calls[0].1, "Shared::P::get");
             },
         );
+    }
+
+    #[test]
+    fn lang_items_declare_resolve_and_locate() {
+        use crate::semi::lang::LangItem;
+        check(
+            "#[lang(\"partial_eq\")]\n\
+             pub trait PartialEq { fn eq(self: Self, other: Self) -> bool; }\n\
+             #[lang(\"ordering\")]\n\
+             pub enum Ordering { Less(), Equal(), Greater() }",
+            |elab, _| {
+                let pe = elab.lang.get(LangItem::PartialEq).expect("declared");
+                assert_eq!(elab.sym(elab.defs.path(pe).name()), "PartialEq");
+                let (_, span) = elab.lang_item_site(LangItem::PartialEq).expect("site");
+                assert!(span.is_some(), "source declarations carry locations");
+                assert!(elab.lang.get(LangItem::Ordering).is_some());
+                // The fallback tower is compiler-provided: no declared site.
+                assert!(elab.lang_item_site(LangItem::Num).is_none());
+            },
+        );
+    }
+
+    #[test]
+    fn lang_item_diagnostics() {
+        elaborate_source(
+            "#[lang(\"nope\")] pub trait A { fn a(self: Self) -> i64; }\n\
+             #[lang(\"eq\")] pub struct B { pub x: i64 }\n\
+             #[lang(\"ordering\")] pub trait C { fn c(self: Self) -> i64; }\n\
+             #[lang(\"partial_eq\")] pub trait D { fn d(self: Self) -> i64; }\n\
+             #[lang(\"partial_eq\")] pub trait E { fn e(self: Self) -> i64; }\n\
+             #[lang(\"ord\")] pub fn f() -> i64 { 1 }",
+            |elab| {
+                let has = |m: &str| elab.reports.iter().any(|r| r.message.contains(m));
+                assert!(has("unknown lang item `nope`"), "{:#?}", elab.reports);
+                assert!(has("lang item `eq` must be a trait"), "{:#?}", elab.reports);
+                assert!(
+                    has("lang item `ordering` must be a struct or enum"),
+                    "{:#?}",
+                    elab.reports
+                );
+                assert!(
+                    has("lang item `partial_eq` is already declared by `D`"),
+                    "{:#?}",
+                    elab.reports
+                );
+                assert!(
+                    has("lang item `ord` must be a trait"),
+                    "{:#?}",
+                    elab.reports
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn rejected_batch_retracts_lang_items() {
+        use std::sync::Arc;
+
+        use crate::semi::lang::LangItem;
+        with_tcx(|tcx| {
+            let interner = Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = |src: &str| {
+                let p = reussir_syntax::parse_with_interner(src, interner.clone());
+                assert!(p.ok(), "parse errors for {src:?}: {:#?}", p.errors);
+                p
+            };
+            let mut elab = Elaborator::new(tcx, &interner);
+            // A batch that declares a lang item but fails elsewhere retracts
+            // the declaration with everything else…
+            let p1 = parse(
+                "#[lang(\"partial_eq\")]\npub trait P { fn e(self: Self) -> bool; }\n\
+                 fn bad() -> i64 { nonexistent() }",
+            );
+            elab.try_extend(&surface::program(&p1.root))
+                .expect_err("batch fails");
+            assert!(elab.lang.get(LangItem::PartialEq).is_none(), "retracted");
+            // …so the clean re-declaration is fresh, not a duplicate.
+            let p2 = parse("#[lang(\"partial_eq\")]\npub trait P { fn e(self: Self) -> bool; }");
+            elab.try_extend(&surface::program(&p2.root)).expect("clean");
+            assert!(elab.lang.get(LangItem::PartialEq).is_some());
+        });
     }
 
     #[test]

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -1732,10 +1732,12 @@ mod tests {
     fn lang_items_declare_resolve_and_locate() {
         use crate::semi::lang::LangItem;
         check(
-            "#[lang(\"partial_eq\")]\n\
-             pub trait PartialEq { fn eq(self: Self, other: Self) -> bool; }\n\
-             #[lang(\"ordering\")]\n\
-             pub enum Ordering { Less(), Equal(), Greater() }",
+            r#"
+            #[lang("partial_eq")]
+            pub trait PartialEq { fn eq(self: Self, other: Self) -> bool; }
+            #[lang("ordering")]
+            pub enum Ordering { Less(), Equal(), Greater() }
+            "#,
             |elab, _| {
                 let pe = elab.lang.get(LangItem::PartialEq).expect("declared");
                 assert_eq!(elab.sym(elab.defs.path(pe).name()), "PartialEq");
@@ -1751,12 +1753,14 @@ mod tests {
     #[test]
     fn lang_item_diagnostics() {
         elaborate_source(
-            "#[lang(\"nope\")] pub trait A { fn a(self: Self) -> i64; }\n\
-             #[lang(\"eq\")] pub struct B { pub x: i64 }\n\
-             #[lang(\"ordering\")] pub trait C { fn c(self: Self) -> i64; }\n\
-             #[lang(\"partial_eq\")] pub trait D { fn d(self: Self) -> i64; }\n\
-             #[lang(\"partial_eq\")] pub trait E { fn e(self: Self) -> i64; }\n\
-             #[lang(\"ord\")] pub fn f() -> i64 { 1 }",
+            r#"
+            #[lang("nope")] pub trait A { fn a(self: Self) -> i64; }
+            #[lang("eq")] pub struct B { pub x: i64 }
+            #[lang("ordering")] pub trait C { fn c(self: Self) -> i64; }
+            #[lang("partial_eq")] pub trait D { fn d(self: Self) -> i64; }
+            #[lang("partial_eq")] pub trait E { fn e(self: Self) -> i64; }
+            #[lang("ord")] pub fn f() -> i64 { 1 }
+            "#,
             |elab| {
                 let has = |m: &str| elab.reports.iter().any(|r| r.message.contains(m));
                 assert!(has("unknown lang item `nope`"), "{:#?}", elab.reports);
@@ -1796,14 +1800,17 @@ mod tests {
             // A batch that declares a lang item but fails elsewhere retracts
             // the declaration with everything else…
             let p1 = parse(
-                "#[lang(\"partial_eq\")]\npub trait P { fn e(self: Self) -> bool; }\n\
-                 fn bad() -> i64 { nonexistent() }",
+                r#"
+                #[lang("partial_eq")]
+                pub trait P { fn e(self: Self) -> bool; }
+                fn bad() -> i64 { nonexistent() }
+                "#,
             );
             elab.try_extend(&surface::program(&p1.root))
                 .expect_err("batch fails");
             assert!(elab.lang.get(LangItem::PartialEq).is_none(), "retracted");
             // …so the clean re-declaration is fresh, not a duplicate.
-            let p2 = parse("#[lang(\"partial_eq\")]\npub trait P { fn e(self: Self) -> bool; }");
+            let p2 = parse(r#"#[lang("partial_eq")] pub trait P { fn e(self: Self) -> bool; }"#);
             elab.try_extend(&surface::program(&p2.root)).expect("clean");
             assert!(elab.lang.get(LangItem::PartialEq).is_some());
         });

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -332,12 +332,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         match c {
             Const::ConstInt(i) => {
                 let hole = self.infer.new_hole_ty();
-                self.register_bound(self.builtins.integral, hole, span);
+                self.register_bound(self.lang.integral, hole, span);
                 self.mk_expr(ExprKind::ConstInt(self.tcx.alloc(i.clone())), hole, span)
             }
             Const::ConstFloat(f) => {
                 let hole = self.infer.new_hole_ty();
-                self.register_bound(self.builtins.floating_point, hole, span);
+                self.register_bound(self.lang.floating_point, hole, span);
                 self.mk_expr(ExprKind::ConstFloat(self.tcx.alloc(f.clone())), hole, span)
             }
             Const::ConstString(s) => {
@@ -516,7 +516,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod => {
                 let l = self.infer_expr(l);
                 let ty = l.ty;
-                self.register_bound(self.builtins.num, ty, span);
+                self.register_bound(self.lang.num, ty, span);
                 let r = self.check_expr(r, ty);
                 let aop = arith_op(op);
                 self.mk_expr(ExprKind::Arith(Box::new(l), aop, Box::new(r)), ty, span)
@@ -536,7 +536,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 let l = self.infer_expr(l);
                 let r = self.check_expr(r, l.ty);
                 if matches!(op, BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte) {
-                    self.register_bound(self.builtins.num, l.ty, span);
+                    self.register_bound(self.lang.num, l.ty, span);
                 }
                 let bool_ty = self.tcx.mk_bool();
                 let cop = cmp_op(op);
@@ -552,7 +552,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             UnaryOp::Negate => {
                 let e = self.infer_expr(e);
                 let ty = e.ty;
-                self.register_bound(self.builtins.num, ty, span);
+                self.register_bound(self.lang.num, ty, span);
                 self.mk_expr(ExprKind::Negate(Box::new(e)), ty, span)
             }
             UnaryOp::Not => {
@@ -580,8 +580,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // concrete non-numeric operand fails in the fulfillment loop with a
         // clear diagnostic, instead of surviving to a lowering-time crash.
         let src_ty = self.infer.shallow_resolve(e.ty);
-        self.register_bound(self.builtins.num, target, span);
-        self.register_bound(self.builtins.num, src_ty, span);
+        self.register_bound(self.lang.num, target, span);
+        self.register_bound(self.lang.num, src_ty, span);
 
         // When the source is still an unconstrained hole and the target is a
         // concrete numeric type, treat the cast as a type annotation and pin the
@@ -1863,7 +1863,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 return self.poison(span);
             }
         };
-        self.register_bound(self.builtins.floating_point, elem, span);
+        self.register_bound(self.lang.floating_point, elem, span);
 
         let kind = func.kind();
         let want = kind.value_args() + 1;

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -395,7 +395,7 @@ pub struct Elaborator<'a, 'tcx> {
     /// Resolves the surface AST's interned token keys back into source text.
     pub resolver: &'a dyn Resolver<TokenKey>,
     pub traits: TraitDb<'tcx>,
-    pub builtins: Builtins,
+    pub lang: crate::semi::lang::LangItems,
     /// Resolution registry: item `DefId`s and their fully-qualified paths.
     pub defs: DefTable,
     /// Frequency-and-recency weight per name, accumulated as names resolve
@@ -502,6 +502,7 @@ pub struct Checkpoint {
     pub(super) imports: usize,
     pub(super) elaborated: usize,
     pub(super) reports: usize,
+    pub(super) lang: usize,
 }
 
 impl<'a, 'tcx> Elaborator<'a, 'tcx> {
@@ -515,7 +516,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let mut defs = DefTable::new();
         let mut traits = TraitDb::new();
         let mut handle = interner.clone();
-        let builtins = Builtins::register(&mut traits, &mut defs, &mut handle, tcx);
+        let fallback = Builtins::register(&mut traits, &mut defs, &mut handle, tcx);
+        let lang = crate::semi::lang::LangItems::new(fallback);
         let self_name = interner.intern("Self");
         Elaborator {
             tcx,
@@ -523,7 +525,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             defs,
             frecency: Frecency::new(),
             traits,
-            builtins,
+            lang,
             trampolines: Vec::new(),
             transform_anchors: Vec::new(),
             transform_scripts: Vec::new(),
@@ -1282,6 +1284,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             ffi_preludes: self.ffi_preludes.len(),
             imports: self.imports.len(),
             elaborated: self.elaborated.len(),
+            lang: self.lang.len(),
             reports: self.reports.len(),
         }
     }
@@ -1305,6 +1308,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.ffi_preludes.truncate(cp.ffi_preludes);
         self.imports.truncate(cp.imports);
         self.elaborated.truncate(cp.elaborated);
+        self.lang.truncate(cp.lang);
         self.reports.truncate(cp.reports);
     }
 
@@ -1357,6 +1361,77 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// then populate record fields, check function bodies (each pass restores
     /// the owning item's file/module scope), and collect trampoline roots per
     /// file.
+    /// The `#[lang("…")]` marker on an item, validated: one string
+    /// argument naming a compiler-known lang item.
+    fn lang_attr(
+        &mut self,
+        attrs: &[surface::Attribute],
+        span: Option<Span>,
+    ) -> Option<crate::semi::lang::LangItem> {
+        let attr = attrs.iter().find(|a| self.sym(a.name) == "lang")?;
+        let [name] = attr.literals.as_slice() else {
+            self.error(
+                span,
+                "`#[lang]` takes exactly one string argument, e.g. `#[lang(\"partial_eq\")]`",
+            );
+            return None;
+        };
+        let Some(item) = crate::semi::lang::LangItem::from_name(name) else {
+            self.error(span, format!("unknown lang item `{name}`"));
+            return None;
+        };
+        Some(item)
+    }
+
+    /// Bind a scanned declaration to its lang item: kind check, then a
+    /// duplicate check against the registry (first declaration wins).
+    pub(super) fn declare_lang(
+        &mut self,
+        item: crate::semi::lang::LangItem,
+        def: DefId,
+        actual: crate::semi::lang::LangItemKind,
+        span: Option<Span>,
+    ) {
+        use crate::semi::lang::LangItemKind;
+        if item.kind() != actual {
+            let want = match item.kind() {
+                LangItemKind::Trait => "a trait",
+                LangItemKind::Record => "a struct or enum",
+            };
+            self.error(span, format!("lang item `{}` must be {want}", item.name()));
+            return;
+        }
+        if let Err(prior) = self.lang.declare(item, def) {
+            let shown = self.defs.path(prior).display(self.resolver);
+            self.error(
+                span,
+                format!(
+                    "lang item `{}` is already declared by `{shown}`",
+                    item.name()
+                ),
+            );
+        }
+    }
+
+    /// The declaration site of a lang item, for diagnostics, debug info,
+    /// and the LSP: the file and span of whichever declaration the
+    /// registry holds. `None` for fallback-registered items — they have no
+    /// source until their declarations live in `core`.
+    pub fn lang_item_site(
+        &self,
+        item: crate::semi::lang::LangItem,
+    ) -> Option<(FileId, Option<Span>)> {
+        let def = self.lang.get(item)?;
+        if let Some(tid) = self.traits.trait_by_def(def) {
+            let t = self.traits.trait_def(tid);
+            return Some((t.file, t.span));
+        }
+        if let Some(rec) = self.records.get(&def) {
+            return Some((rec.file, rec.span));
+        }
+        self.functions.get(&def).map(|f| (f.file, f.span))
+    }
+
     fn run_files(&mut self, files: &[(FileId, Vec<TokenKey>, &surface::Program)]) {
         // This batch's record fields are not populated yet, so `Arc` wf
         // checks (which need member types for the structural `Sync` half)
@@ -1390,13 +1465,23 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     surface::StmtKind::Record(rec) => {
                         self.validate_transform_anchor(&attrs, None);
                         let ffi = self.validate_ffi_record(&rec, ffi, span);
-                        records.push((rec, span, scope, ffi));
+                        let lang = self.lang_attr(&attrs, span);
+                        records.push((rec, span, scope, ffi, lang));
                     }
                     surface::StmtKind::Function(func) => {
                         let anchor =
                             self.validate_transform_anchor(&attrs, Some(func.body.is_some()));
                         let is_import = self.validate_ffi_function(&func, ffi, span);
                         let is_main = self.validate_main_attr(&attrs, &func, span);
+                        // No function-kinded lang item exists yet (intrinsic
+                        // prototypes arrive with the `core` scaffolding).
+                        if let Some(item) = self.lang_attr(&attrs, span) {
+                            let want = match item.kind() {
+                                crate::semi::lang::LangItemKind::Trait => "a trait",
+                                crate::semi::lang::LangItemKind::Record => "a struct or enum",
+                            };
+                            self.error(span, format!("lang item `{}` must be {want}", item.name()));
+                        }
                         functions.push((func, span, scope, anchor, is_import, is_main));
                     }
                     surface::StmtKind::ExternTrampoline(t) => {
@@ -1443,7 +1528,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     surface::StmtKind::Trait(td) => {
                         self.validate_transform_anchor(&attrs, None);
                         self.reject_ffi_attr(ffi, span);
-                        trait_decls.push((td, span, scope));
+                        let lang = self.lang_attr(&attrs, span);
+                        trait_decls.push((td, span, scope, lang));
                     }
                     // Foreign preludes register during this scan (like
                     // bindings) so they apply file-wide regardless of order.
@@ -1477,32 +1563,41 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // have a def and a TraitDb entry.
         let trait_ids: Vec<Option<TraitId>> = trait_decls
             .iter()
-            .map(|(td, span, scope)| {
+            .map(|(td, span, scope, lang)| {
                 self.set_current_file(scope.file);
                 self.defs.set_module(scope.module.to_vec());
-                self.scan_trait_stub(td, *span)
+                let id = self.scan_trait_stub(td, *span);
+                if let (Some(item), Some(id)) = (lang, id) {
+                    let def = self.traits.trait_def(id).def;
+                    self.declare_lang(*item, def, crate::semi::lang::LangItemKind::Trait, *span);
+                }
+                id
             })
             .collect();
         let record_defs: Vec<Option<DefId>> = records
             .iter()
-            .map(|(rec, span, scope, ffi)| {
+            .map(|(rec, span, scope, ffi, lang)| {
                 self.set_current_file(scope.file);
                 self.defs.set_module(scope.module.to_vec());
-                self.scan_record(rec, ffi.clone(), *span)
+                let def = self.scan_record(rec, ffi.clone(), *span);
+                if let (Some(item), Some(def)) = (lang, def) {
+                    self.declare_lang(*item, def, crate::semi::lang::LangItemKind::Record, *span);
+                }
+                def
             })
             .collect();
         // Phase C, split: every trait's own binder first (a supertrait's
         // arity gate reads the super's params, which a same-batch
         // later-declared super would otherwise still be missing), then
         // supertraits and member signatures (which need the record stubs).
-        for ((td, span, scope), id) in trait_decls.iter().zip(&trait_ids) {
+        for ((td, span, scope, _), id) in trait_decls.iter().zip(&trait_ids) {
             if let Some(id) = id {
                 self.set_current_file(scope.file);
                 self.defs.set_module(scope.module.to_vec());
                 self.populate_trait_params(td, *id, *span);
             }
         }
-        for ((td, span, scope), id) in trait_decls.iter().zip(&trait_ids) {
+        for ((td, span, scope, _), id) in trait_decls.iter().zip(&trait_ids) {
             if let Some(id) = id {
                 self.set_current_file(scope.file);
                 self.defs.set_module(scope.module.to_vec());
@@ -1601,7 +1696,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let record_defs: Vec<DefId> = records
             .iter()
             .zip(record_defs)
-            .filter_map(|((rec, _, _, _), def)| Some((rec, def?)))
+            .filter_map(|((rec, _, _, _, _), def)| Some((rec, def?)))
             .map(|(rec, def)| {
                 self.populate_record(rec, def);
                 def

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -351,6 +351,18 @@ impl<'tcx> Elaborator<'_, 'tcx> {
             });
         }
 
+        // Lang markers: bind the loaded declarations into the session
+        // registry (kind re-derived from what the def actually is here).
+        for (&pdef, &item) in &parsed.lang {
+            let def = defs[pdef.0 as usize];
+            let actual = if self.traits.trait_by_def(def).is_some() {
+                crate::semi::lang::LangItemKind::Trait
+            } else {
+                crate::semi::lang::LangItemKind::Record
+            };
+            self.declare_lang(item, def, actual, None);
+        }
+
         for func in &parsed.funcs {
             let def = defs[func.def.0 as usize];
             let generics =
@@ -813,9 +825,11 @@ mod tests {
         let bounds = elab.bound_names();
         let (traits, impls) =
             crate::semi::hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+        let lang = elab.lang.declared_by_def();
         let text = Printer::new(&elab.defs, elab.resolver)
             .with_bounds(&bounds)
             .with_traits(&traits, &impls)
+            .with_lang(&lang)
             .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
         crate::semi::hir::build::parse_program(tcx, &text).expect("re-parse")
     }
@@ -868,6 +882,23 @@ mod tests {
             elab.run_package(&files);
             f(&elab);
         });
+    }
+
+    /// `#[lang]` markers travel through the interface: the consumer's
+    /// registry binds the dependency's declaration, locations included.
+    #[test]
+    fn lang_items_reload_from_interfaces() {
+        use crate::semi::lang::LangItem;
+        check_with_dep(
+            "#[lang(\"partial_eq\")]\npub trait PartialEq { fn eq(self: Self, other: Self) -> bool; }",
+            &[(&[], "pub fn nop() -> i64 { 0 }")],
+            |elab| {
+                assert!(!elab.has_errors(), "{:#?}", elab.reports);
+                let def = elab.lang.get(LangItem::PartialEq).expect("reloaded");
+                assert_eq!(elab.sym(elab.defs.path(def).name()), "PartialEq");
+                assert!(elab.lang_item_site(LangItem::PartialEq).is_some());
+            },
+        );
     }
 
     const TRAIT_DEP: &str = "pub trait Show { fn show(self: Self) -> i64; }\n\
@@ -1072,7 +1103,7 @@ mod tests {
                 let (_, g) = api.generics[0];
                 assert_eq!(
                     elab.generic_bounds(g),
-                    [elab.builtins.num],
+                    [elab.lang.num],
                     "reloaded binder carries the serialized bound"
                 );
             },
@@ -1118,7 +1149,7 @@ mod tests {
                 let (_, g) = both.generics[0];
                 assert_eq!(
                     elab.generic_bounds(g),
-                    [elab.builtins.num, elab.builtins.sync],
+                    [elab.lang.num, elab.lang.sync],
                     "both bounds reload, in declaration order"
                 );
             },

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -890,7 +890,7 @@ mod tests {
     fn lang_items_reload_from_interfaces() {
         use crate::semi::lang::LangItem;
         check_with_dep(
-            "#[lang(\"partial_eq\")]\npub trait PartialEq { fn eq(self: Self, other: Self) -> bool; }",
+            r#"#[lang("partial_eq")] pub trait PartialEq { fn eq(self: Self, other: Self) -> bool; }"#,
             &[(&[], "pub fn nop() -> i64 { 0 }")],
             |elab| {
                 assert!(!elab.has_errors(), "{:#?}", elab.reports);

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -139,9 +139,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let f64_ty = self.tcx.mk_fp(FpTy::Ieee(64));
         let i64_ty = self.tcx.mk_int(IntTy::Signed(64));
         let passes = [
-            (self.builtins.floating_point, f64_ty),
-            (self.builtins.integral, i64_ty),
-            (self.builtins.num, i64_ty),
+            (self.lang.floating_point, f64_ty),
+            (self.lang.integral, i64_ty),
+            (self.lang.num, i64_ty),
         ];
         for (want, default) in passes {
             self.fulfill
@@ -249,7 +249,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 // `Sync` is the structural thread-safety auto trait: answered
                 // by the checker over the type's shape, never by impl search
                 // (docs/design/thread-safety.md §2.2).
-                if tref.trait_id == self.builtins.sync {
+                if tref.trait_id == self.lang.sync {
                     use crate::semi::traits::sync::{SyncVerdict, sync_verdict};
                     use crate::semi::ty_eval::ElabSyncEnv;
                     return match sync_verdict(&ElabSyncEnv { el: self }, self_ty) {

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -47,6 +47,8 @@ pub struct Parsed<'tcx> {
     pub traits: Vec<TraitText<'tcx>>,
     /// Impl items, print-ready (method paths unresolved strings).
     pub impls: Vec<ImplText<'tcx>>,
+    /// `#[lang("…")]` markers by (this dump's) def — records and traits.
+    pub lang: FxHashMap<DefId, crate::semi::lang::LangItem>,
     pub transform_anchors: Vec<DefId>,
     pub transform_scripts: Vec<TransformScript>,
     pub strings: Vec<(StringToken, String)>,
@@ -299,6 +301,28 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
     // Records first so their `DefId`s exist before function bodies reference them.
     let records: FxHashMap<DefId, Record<'tcx>> = raw.records.iter().map(|r| b.record(r)).collect();
     let traits: Vec<TraitText<'tcx>> = raw.traits.iter().map(|t| b.trait_text(t)).collect();
+    // Lang markers: resolve names against this compiler's item set — an
+    // unknown name means the dump came from a newer compiler.
+    let mut lang: FxHashMap<DefId, crate::semi::lang::LangItem> = FxHashMap::default();
+    let mut mark = |def: DefId, marker: &str| {
+        crate::semi::lang::LangItem::from_name(marker)
+            .map(|item| {
+                lang.insert(def, item);
+            })
+            .ok_or_else(|| {
+                format!("unknown lang item `{marker}`; this interface needs a newer compiler")
+            })
+    };
+    for r in &raw.records {
+        if let Some(marker) = r.lang.as_deref() {
+            mark(b.record_def(&r.path), marker)?;
+        }
+    }
+    for t in &raw.traits {
+        if let Some(marker) = t.lang.as_deref() {
+            mark(b.trait_item_def(&t.path), marker)?;
+        }
+    }
     let impls: Vec<ImplText<'tcx>> = raw.impls.iter().map(|i| b.impl_text(i)).collect();
     let funcs: Vec<Function<'tcx>> = raw.funcs.iter().map(|f| b.func(f)).collect();
     let transform_anchors = raw
@@ -347,6 +371,7 @@ pub fn parse_program<'tcx>(tcx: &TyCtxt<'tcx>, text: &str) -> Result<Parsed<'tcx
         funcs,
         traits,
         impls,
+        lang,
         transform_anchors,
         transform_scripts,
         strings,
@@ -984,11 +1009,13 @@ mod tests {
             let bounds = elab.bound_names();
             let (traits, impls) =
                 crate::semi::hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+            let lang = elab.lang.declared_by_def();
             let text = Printer::new(&elab.defs, elab.resolver)
                 .with_transform_metadata(&elab.transform_anchors, &elab.transform_scripts)
                 .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
                 .with_bounds(&bounds)
                 .with_traits(&traits, &impls)
+                .with_lang(&lang)
                 .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             let parsed = parse_program(tcx, &text).expect("re-parse");
             assert_eq!(parsed.transform_anchors.len(), elab.transform_anchors.len());
@@ -1008,6 +1035,7 @@ mod tests {
                 .with_ffi_metadata(&parsed.ffi_preludes, &parsed.ffi_imports)
                 .with_bounds(&parsed.generic_bounds)
                 .with_traits(&parsed.traits, &parsed.impls)
+                .with_lang(&parsed.lang)
                 .program(
                     &parsed.funcs,
                     &parsed.strings,
@@ -1426,6 +1454,16 @@ mod tests {
             "pub struct [regional] TestCell<T> { v: T, next: [field] TestCell<T> } \
              regional fn foo<T>(bar: [flex] T) -> i32 { 0 } \
              regional fn use_ok(c: [flex] TestCell<i32>) -> i32 { foo(c) }",
+        );
+    }
+
+    #[test]
+    fn lang_markers_roundtrip() {
+        roundtrip(
+            "#[lang(\"partial_eq\")]\n\
+                 pub trait PartialEq { fn eq(self: Self, other: Self) -> bool; }\n\
+                 #[lang(\"ordering\")]\n\
+                 pub enum Ordering { Less(), Equal(), Greater() }",
         );
     }
 

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -1460,10 +1460,12 @@ mod tests {
     #[test]
     fn lang_markers_roundtrip() {
         roundtrip(
-            "#[lang(\"partial_eq\")]\n\
-                 pub trait PartialEq { fn eq(self: Self, other: Self) -> bool; }\n\
-                 #[lang(\"ordering\")]\n\
-                 pub enum Ordering { Less(), Equal(), Greater() }",
+            r#"
+            #[lang("partial_eq")]
+            pub trait PartialEq { fn eq(self: Self, other: Self) -> bool; }
+            #[lang("ordering")]
+            pub enum Ordering { Less(), Equal(), Greater() }
+            "#,
         );
     }
 

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -60,9 +60,10 @@ Span: raw::Span = "[" <s:"int"> ".." <e:"int"> "]" => (raw::small_u32(&s), raw::
 ItemLoc: (u32, Option<raw::Span>) = "in" <f:"int"> <sp:Span?> => (raw::small_u32(&f), sp);
 
 RecordDecl: raw::Record = {
-    <p:"pub"?> <default_cap:DefaultCap> "struct" "#" <path:QPath> <generics:Generics?> <loc:ItemLoc?>
+    <lang:LangAttr?> <p:"pub"?> <default_cap:DefaultCap> "struct" "#" <path:QPath> <generics:Generics?> <loc:ItemLoc?>
     "{" <ms:Comma<Member>> "}" ";"
     => raw::Record {
+        lang,
         is_pub: p.is_some(),
         default_cap,
         repr_fixed: false,
@@ -74,9 +75,10 @@ RecordDecl: raw::Record = {
         body: raw::RecordBody::Compound(ms),
     },
     // An opaque `#[ffi]` record: `[shared] struct #Vec<$0> { ffi "path" };`.
-    <p:"pub"?> <default_cap:DefaultCap> "struct" "#" <path:QPath> <generics:Generics?> <loc:ItemLoc?>
+    <lang:LangAttr?> <p:"pub"?> <default_cap:DefaultCap> "struct" "#" <path:QPath> <generics:Generics?> <loc:ItemLoc?>
     "{" "ffi" <rust:"quoted"> "}" ";"
     => raw::Record {
+        lang,
         is_pub: p.is_some(),
         default_cap,
         repr_fixed: false,
@@ -88,9 +90,10 @@ RecordDecl: raw::Record = {
         body: raw::RecordBody::Opaque(unescape_debug_str(rust).into_owned()),
     },
     // Only an enum may carry the `fixed` marker (`#[repr(fixed)]`).
-    <p:"pub"?> <default_cap:DefaultCap> "enum" <fixed:"fixed"?> "#" <path:QPath> <generics:Generics?> <loc:ItemLoc?>
+    <lang:LangAttr?> <p:"pub"?> <default_cap:DefaultCap> "enum" <fixed:"fixed"?> "#" <path:QPath> <generics:Generics?> <loc:ItemLoc?>
     "{" <vs:Comma<Variant>> "}" ";"
     => raw::Record {
+        lang,
         is_pub: p.is_some(),
         default_cap,
         repr_fixed: fixed.is_some(),
@@ -163,13 +166,19 @@ Func: raw::Func =
         body,
     };
 
+/// The `#[lang("…")]` marker: the item is a language item the loading
+/// compiler wires into checking.
+LangAttr: String = "#" "[" "lang" "(" <s:"quoted"> ")" "]" => s.into();
+
 /// A trait item. The binder's first generic is the implicit `Self`; the
 /// super-references carry their full argument lists (args[0] = `Self`), so
 /// rebuilding involves no convention.
 TraitDecl: raw::TraitItem =
-    <p:"pub"?> "trait" "#" <path:QPath> <generics:Generics> <supers:(":" <CommaPlus<SuperRef>>)?>
+    <lang:LangAttr?> <p:"pub"?> "trait" "#" <path:QPath> <generics:Generics>
+    <supers:(":" <CommaPlus<SuperRef>>)?>
     <loc:ItemLoc?> "{" <methods:TraitMethodSig*> "}"
     => raw::TraitItem {
+        lang,
         is_pub: p.is_some(),
         path,
         generics,
@@ -279,6 +288,7 @@ BoundItem: Bound = <first:Name> <rest:("::" <Name>)*> => {
 /// Source identifiers remain legal when they spell a transform directive.
 Name: &'input str = {
     <name:"ident"> => name,
+    "lang" => "lang",
     "trait" => "trait",
     "impl" => "impl",
     "transform" => "transform",
@@ -529,6 +539,7 @@ extern {
         "glue" => Token::Glue,
         "transform" => Token::Transform,
         "trait" => Token::Trait,
+        "lang" => Token::Lang,
         "impl" => Token::Impl,
         "transform_anchor" => Token::TransformAnchor,
         "interface" => Token::Interface,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -56,6 +56,9 @@ pub struct Printer<'a> {
     /// program's views); empty for dumps that carry none.
     trait_items: &'a [super::TraitText<'a>],
     impl_items: &'a [super::ImplText<'a>],
+    /// `#[lang("…")]` markers by def (source- or interface-declared items
+    /// only; the compiler's fallback tower never serializes).
+    lang: Option<&'a rustc_hash::FxHashMap<DefId, crate::semi::lang::LangItem>>,
     interface: Option<InterfaceEmit<'a>>,
 }
 
@@ -96,6 +99,7 @@ impl<'a> Printer<'a> {
             bounds: None,
             trait_items: &[],
             impl_items: &[],
+            lang: None,
             interface: None,
         }
     }
@@ -117,6 +121,7 @@ impl<'a> Printer<'a> {
             bounds: None,
             trait_items: &[],
             impl_items: &[],
+            lang: None,
             interface: None,
         }
     }
@@ -153,6 +158,15 @@ impl<'a> Printer<'a> {
     ) -> Self {
         self.trait_items = traits;
         self.impl_items = impls;
+        self
+    }
+
+    /// Attach the `#[lang]` marker map.
+    pub fn with_lang(
+        mut self,
+        lang: &'a rustc_hash::FxHashMap<DefId, crate::semi::lang::LangItem>,
+    ) -> Self {
+        self.lang = Some(lang);
         self
     }
 
@@ -330,9 +344,19 @@ impl<'a> Printer<'a> {
         text("<") + comma_sep(parts) + text(">")
     }
 
+    /// The `#[lang("…")] ` prefix of a marked def, or nothing.
+    fn lang_prefix(&self, def: DefId) -> Doc<'static> {
+        match self.lang.and_then(|m| m.get(&def)) {
+            Some(item) => text(format!("#[lang({:?})] ", item.name())),
+            None => Doc::Null,
+        }
+    }
+
     fn trait_item(&self, t: &super::TraitText<'_>) -> Doc<'static> {
         let vis = if t.is_pub { "pub " } else { "" };
-        let mut head = text(format!("{vis}trait #{}", t.path)) + self.text_binder(&t.generics);
+        let mut head = self.lang_prefix(t.def)
+            + text(format!("{vis}trait #{}", t.path))
+            + self.text_binder(&t.generics);
         if !t.supers.is_empty() {
             let supers: Vec<Doc<'static>> = t
                 .supers
@@ -399,7 +423,8 @@ impl<'a> Printer<'a> {
             RecordKind::EnumKind if r.repr_fixed => "enum fixed #",
             RecordKind::EnumKind => "enum #",
         };
-        let head = text(format!("{vis}{cap}{kind}{}", self.path(r.def)))
+        let head = self.lang_prefix(r.def)
+            + text(format!("{vis}{cap}{kind}{}", self.path(r.def)))
             + self.generics_binder(&r.ty_params, &r.regional_generics)
             + self.item_loc(r.file, r.span);
         head + text(" { ") + self.record_body(r) + text(" };")

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -33,6 +33,8 @@ pub struct Program {
 /// A trait declaration item. `generics[0]` is the implicit `Self` binder.
 #[derive(Clone, Debug)]
 pub struct TraitItem {
+    /// A `#[lang("…")]` marker naming the language item this declares.
+    pub lang: Option<String>,
     pub is_pub: bool,
     pub path: String,
     pub generics: Vec<Generic>,
@@ -148,6 +150,8 @@ pub struct FfiPrelude {
 /// packages see the same field-access rights through a `.rri`.
 #[derive(Clone, Debug)]
 pub struct Record {
+    /// A `#[lang("…")]` marker naming the language item this declares.
+    pub lang: Option<String>,
     pub is_pub: bool,
     pub default_cap: DefaultCap,
     /// `#[repr(fixed)]`: uniform max-arm box sizing for an enum. Only ever set

--- a/crates/reussir-core/src/semi/lang.rs
+++ b/crates/reussir-core/src/semi/lang.rs
@@ -1,0 +1,167 @@
+//! Language items: the declarations the compiler itself must know.
+//!
+//! A lang item ties a name the compiler wires into checking (a numeric
+//! tower trait, an operator trait, the `Ordering` enum) to an actual
+//! declaration. The declaration comes from one of two places, in
+//! precedence order:
+//!
+//! 1. **Source or a loaded interface** carrying `#[lang("…")]` — how the
+//!    `core` package hands the compiler its declarations, complete with
+//!    real source locations for diagnostics, debug info, and the LSP.
+//! 2. **The compiler's fallback table** (`builtin_traits!`) — what a
+//!    session gets when no `core` is compiled against: unit tests, bare
+//!    `rrc file.rr`, the REPL today. Fallback items carry no source
+//!    location until their declarations migrate into `core`.
+//!
+//! The wired numeric/marker tower is fallback-registered in every session
+//! for now; migrated items will suppress their fallback entry instead
+//! (a later PR in this series).
+
+use rustc_hash::FxHashMap;
+
+use crate::semi::traits::TraitId;
+use crate::semi::traits::builtins::Builtins;
+use crate::semi::ty::DefId;
+
+/// Every language item the compiler recognizes. Closed: an unknown
+/// `#[lang("…")]` name is a diagnostic, so the set is versioned with the
+/// compiler.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum LangItem {
+    /// The numeric/marker tower — wired, fallback-registered today.
+    Num,
+    Integral,
+    FloatingPoint,
+    PtrLike,
+    Sync,
+    /// The comparison tower — declared by `core` (a later PR in this
+    /// series); the slots exist so its source can land without a compiler
+    /// release in between.
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    /// `core::cmp::Ordering`, the result of `Ord::cmp`.
+    Ordering,
+}
+
+/// What kind of declaration a lang item must be.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LangItemKind {
+    Trait,
+    Record,
+}
+
+impl LangItem {
+    pub const ALL: [LangItem; 10] = [
+        LangItem::Num,
+        LangItem::Integral,
+        LangItem::FloatingPoint,
+        LangItem::PtrLike,
+        LangItem::Sync,
+        LangItem::PartialEq,
+        LangItem::Eq,
+        LangItem::PartialOrd,
+        LangItem::Ord,
+        LangItem::Ordering,
+    ];
+
+    /// The attribute spelling: `#[lang("partial_eq")]`.
+    pub fn name(self) -> &'static str {
+        match self {
+            LangItem::Num => "num",
+            LangItem::Integral => "integral",
+            LangItem::FloatingPoint => "floating_point",
+            LangItem::PtrLike => "ptr_like",
+            LangItem::Sync => "sync",
+            LangItem::PartialEq => "partial_eq",
+            LangItem::Eq => "eq",
+            LangItem::PartialOrd => "partial_ord",
+            LangItem::Ord => "ord",
+            LangItem::Ordering => "ordering",
+        }
+    }
+
+    pub fn from_name(name: &str) -> Option<LangItem> {
+        Self::ALL.into_iter().find(|item| item.name() == name)
+    }
+
+    pub fn kind(self) -> LangItemKind {
+        match self {
+            LangItem::Ordering => LangItemKind::Record,
+            _ => LangItemKind::Trait,
+        }
+    }
+}
+
+/// The session's lang-item registry: the wired tower ids plus every
+/// `#[lang]`-declared item. Lives on the elaborator; declarations are
+/// insertion-ordered so the REPL checkpoint is a plain length and a
+/// rejected batch retracts exactly its own (the same truncate-and-retain
+/// scheme every other elaborator table uses).
+pub struct LangItems {
+    pub num: TraitId,
+    pub integral: TraitId,
+    pub floating_point: TraitId,
+    pub ptr_like: TraitId,
+    /// Marker (auto) trait: a value may be reached from any thread,
+    /// concurrently; answered structurally, never by impl search.
+    pub sync: TraitId,
+    declared: Vec<(LangItem, DefId)>,
+}
+
+impl LangItems {
+    /// A registry over the fallback-registered tower.
+    pub fn new(fallback: Builtins) -> Self {
+        LangItems {
+            num: fallback.num,
+            integral: fallback.integral,
+            floating_point: fallback.floating_point,
+            ptr_like: fallback.ptr_like,
+            sync: fallback.sync,
+            declared: Vec::new(),
+        }
+    }
+
+    /// Bind `item` to `def`. `Err` returns the prior declaration for the
+    /// duplicate diagnostic (re-declaring the *same* def is idempotent —
+    /// the same interface loaded twice).
+    pub fn declare(&mut self, item: LangItem, def: DefId) -> Result<(), DefId> {
+        match self.get(item) {
+            None => {
+                self.declared.push((item, def));
+                Ok(())
+            }
+            Some(prior) if prior == def => Ok(()),
+            Some(prior) => Err(prior),
+        }
+    }
+
+    /// The declared def of `item`, if any source/interface declared it.
+    pub fn get(&self, item: LangItem) -> Option<DefId> {
+        self.declared
+            .iter()
+            .find(|&&(i, _)| i == item)
+            .map(|&(_, def)| def)
+    }
+
+    /// Every `#[lang]`-declared binding, def-keyed — the serialization
+    /// view (`.rri` emission re-prints the markers; the wired fallback
+    /// tower is compiler-provided and never serializes).
+    pub fn declared_by_def(&self) -> FxHashMap<DefId, LangItem> {
+        self.declared
+            .iter()
+            .map(|&(item, def)| (def, item))
+            .collect()
+    }
+
+    /// The checkpoint counter, in the elaborator's truncate-and-retain
+    /// scheme.
+    pub(crate) fn len(&self) -> usize {
+        self.declared.len()
+    }
+
+    pub(crate) fn truncate(&mut self, len: usize) {
+        self.declared.truncate(len);
+    }
+}

--- a/crates/reussir-core/src/semi/pattern.rs
+++ b/crates/reussir-core/src/semi/pattern.rs
@@ -280,7 +280,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 // the `Integral` bound on the column type, exactly as an integer
                 // literal *expression* does; the eventual int-switch lowering
                 // reads the column's real type to pick the signed/unsigned cast.
-                self.register_bound(self.builtins.integral, ty, span);
+                self.register_bound(self.lang.integral, ty, span);
                 Ctor::Int(self.tcx.alloc(i.clone()))
             }
             Const::ConstBool(b) => {

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -871,12 +871,14 @@ fn let_name(node: &ResolvedNode) -> Option<&ResolvedToken> {
 
 /// An outer item attribute such as `#[transform_anchor]` or
 /// `#[ffi(import)]`. Bare arguments land in `args`; `key = "value"` pairs
-/// land in `values` (strings decoded).
+/// land in `values`; bare string arguments (`#[lang("partial_eq")]`) land
+/// in `literals` (all strings decoded).
 #[derive(Clone, Debug)]
 pub struct Attribute {
     pub name: TokenKey,
     pub args: Vec<TokenKey>,
     pub values: Vec<(TokenKey, String)>,
+    pub literals: Vec<String>,
     pub span: Span,
 }
 
@@ -1073,6 +1075,7 @@ fn attribute_of(node: &ResolvedNode) -> Attribute {
         .collect();
     let mut args = Vec::new();
     let mut values = Vec::new();
+    let mut literals = Vec::new();
     let mut idx = 1;
     while idx < toks.len() {
         let tok = toks[idx];
@@ -1089,6 +1092,8 @@ fn attribute_of(node: &ResolvedNode) -> Attribute {
         } else {
             if tok.kind().is_ident_like() {
                 args.push(key(tok));
+            } else if tok.kind() == StringLit {
+                literals.push(unescape_string(tok.text()));
             }
             idx += 1;
         }
@@ -1097,6 +1102,7 @@ fn attribute_of(node: &ResolvedNode) -> Attribute {
         name: key(toks.first().expect("attribute name")),
         args,
         values,
+        literals,
         span: node_span(node),
     }
 }

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -565,6 +565,9 @@ impl Parser<'_> {
                             self.bump();
                             self.expect(StringLit);
                         }
+                    } else if self.at(StringLit) {
+                        // A bare string argument (`#[lang("partial_eq")]`).
+                        self.bump();
                     } else {
                         self.error("expected an attribute argument");
                         break;


### PR DESCRIPTION
Part 1 of the std/core series: the **lang-item mechanism** — how `core` (written in Reussir) will hand the compiler its declarations, with real source locations for diagnostics, debug info, and the LSP.

- **`#[lang("…")]`**: the attribute grammar accepts bare string arguments (`Attribute.literals`), and the scan validates the marker — exactly one string, a compiler-known name — then binds the declared def into the session registry with kind checking (`lang item `eq` must be a trait`), duplicate detection (first declaration wins, the second reports `already declared by …`), and a clean rejection on function items until intrinsic prototypes land (PR 2 of the series).
- **`semi::lang`** (new): the closed `LangItem` enum (the wired tower `num`/`integral`/`floating_point`/`ptr_like`/`sync`, plus the comparison-tower slots `partial_eq`/`eq`/`partial_ord`/`ord`/`ordering` for the `core` source that lands later in the series) and the `LangItems` registry. `Builtins` becomes the **fallback provider**: sessions without `core` — unit tests, bare `rrc file.rr`, the REPL today — get identical behavior from the DSL table; declared items layer on top. Declarations are insertion-ordered, so the REPL checkpoint is a plain length and **a rejected batch retracts its lang items** (the same truncate-and-retain scheme as every other elaborator table). The `Elaborator.builtins` field becomes `lang`.
- **Locations**: `lang_item_site(item) -> Option<(FileId, Option<Span>)>` resolves the registry's declaration to its file/span through the def tables — the hook debug info and the LSP will use. Fallback items answer `None` until their declarations migrate into `core` source.
- **Serialization** (`RRI_FORMAT` stays 1, additive): trait and record items accept a `#[lang("…")]` prefix in the textual HIR — printed from a def-keyed view (`Printer::with_lang`), parsed into `Parsed.lang`, and **re-declared into the consumer's registry by the extern reload**, so `core.rri` binds the compiler the moment it loads. An unknown marker name is a load error naming the newer-compiler cause. The round-trip harness carries the map on both sides.

Tests: declaration + site resolution (source spans present; fallback tower site-less), the full diagnostic matrix (unknown name, kind mismatch both ways, duplicate, function-attached), REPL retraction and clean re-declaration, byte-exact round-trip, and cross-interface reload with the site preserved.

Gates: `cargo test` workspace-green, `cargo fmt`, `ninja -C build check`, `ninja -C build rrc-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cc4AzF8vyiAXfEKj5mZSu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788410628&installation_model_id=426051&pr_number=522&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F522&signature=c144ef326d63775f2b66ae24c59d940b2bb92b53718873a10fc6334b5a4726ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->