### PR TITLE
[rt][frontend] bridge comparisons into PolyFFI containers

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -512,6 +512,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
     ) -> Result<[Operation<'c>; 2]> {
         let loc = Location::unknown(self.context);
         let ty = self.tys.mlir_ty(glue.ty)?;
+        let attributes = self.ffi_glue_attributes();
         let build = |symbol: &str, inc: bool| -> Result<Operation<'c>> {
             let block = Block::new(&[(ty, loc)]);
             let arg = block
@@ -532,7 +533,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 StringAttribute::new(self.context, symbol),
                 TypeAttribute::new(FunctionType::new(self.context, &[ty], &[]).into()),
                 region,
-                &[],
+                &attributes,
                 loc,
             ))
         };
@@ -540,6 +541,67 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             build(self.program.symbol(glue.acquire), true)?,
             build(self.program.symbol(glue.release), false)?,
         ])
+    }
+
+    /// Build one borrowed comparison entry. The foreign caller retains both
+    /// operands; two increments turn them into the owned arguments consumed by
+    /// the ordinary semantic adapter. No decrement belongs here: ownership in
+    /// the target settles those acquired values.
+    pub(super) fn ffi_trait_glue(&self, glue: &mir::FfiTraitGlue<'tcx>) -> Result<Operation<'c>> {
+        let loc = Location::unknown(self.context);
+        let ty = self.tys.mlir_ty(glue.ty)?;
+        let ret = self.tys.mlir_ty(glue.ret)?;
+        let block = Block::new(&[(ty, loc), (ty, loc)]);
+        let lhs: Value<'c, '_> = block
+            .argument(0)
+            .map_err(|e| LoweringError(format!("missing trait-glue argument: {e}").into()))?
+            .into();
+        let rhs: Value<'c, '_> = block
+            .argument(1)
+            .map_err(|e| LoweringError(format!("missing trait-glue argument: {e}").into()))?
+            .into();
+        block.append_operation(dialect::rc_inc(self.context, lhs, loc).into());
+        block.append_operation(dialect::rc_inc(self.context, rhs, loc).into());
+        let target = FlatSymbolRefAttribute::new(self.context, self.program.symbol(glue.target));
+        let call =
+            block.append_operation(func::call(self.context, target, &[lhs, rhs], &[ret], loc));
+        let result = call
+            .result(0)
+            .map_err(|e| LoweringError(format!("missing trait-glue result: {e}").into()))?
+            .into();
+        block.append_operation(func::r#return(&[result], loc));
+        let region = Region::new();
+        region.append_block(block);
+
+        let attributes = self.ffi_glue_attributes();
+        Ok(func::func(
+            self.context,
+            StringAttribute::new(self.context, self.program.symbol(glue.entry)),
+            TypeAttribute::new(FunctionType::new(self.context, &[ty, ty], &[ret]).into()),
+            region,
+            &attributes,
+            loc,
+        ))
+    }
+
+    /// Ground FFI glue can be emitted independently by multiple downstream
+    /// packages. AOT links coalesce identical definitions; JIT keeps ordinary
+    /// external linkage, matching the generic-instance policy.
+    fn ffi_glue_attributes(&self) -> SmallVec<[(Identifier<'c>, Attribute<'c>); 1]> {
+        if matches!(
+            self.linkage,
+            LinkagePolicy::Aot {
+                dedup_instances: true
+            }
+        ) {
+            SmallVec::from_buf([(
+                Identifier::new(self.context, "llvm.linkage"),
+                Attribute::parse(self.context, "#llvm.linkage<weak_odr>")
+                    .expect("valid weak_odr linkage attribute"),
+            )])
+        } else {
+            SmallVec::new()
+        }
     }
 
     /// Declare an opaque instance's drop hook: `func.func private
@@ -583,7 +645,14 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         match self.linkage {
             LinkagePolicy::Jit => None,
             LinkagePolicy::Aot { dedup_instances } => {
-                if symbol.starts_with("_RI") {
+                if self
+                    .program
+                    .ffi_trait_glue
+                    .iter()
+                    .any(|glue| glue.target == func.symbol)
+                {
+                    dedup_instances.then_some("weak_odr")
+                } else if symbol.starts_with("_RI") {
                     // Another compilation unit may instantiate the same
                     // generic — emit the definition as mergeable. This holds
                     // for private generics too: a pub generic caller can force

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -438,6 +438,14 @@ pub fn lower_unit<'c, 'tcx>(
             body.append_operation(op);
         }
     }
+    // Borrowed comparison entries are mergeable by their ground record symbol;
+    // each is defined in exactly one home unit and calls a normal MIR adapter.
+    for glue in &program.ffi_trait_glue {
+        if !unit.is_home(program.symbol(glue.entry)) {
+            continue;
+        }
+        body.append_operation(lowerer.ffi_trait_glue(glue)?);
+    }
     // Every opaque instance's drop hook is declared in every unit: the
     // `rc.dec` lowering calls it, and its verifier requires the symbol. The
     // definition arrives with the linked foreign bitcode.

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -686,6 +686,7 @@ fn byte_offset_at(text: &str, line: usize, column: usize) -> Option<usize> {
 mod tests {
     use super::*;
     use reussir_backend::melior::ir::operation::OperationLike;
+    use reussir_core::full::mir::build::parse_program;
     use reussir_core::full::mono::monomorphize;
     use reussir_core::{in_arena, semi::elaborate, surface};
 
@@ -941,6 +942,129 @@ transform [{
         // The assignment is a pure function of the symbol (deterministic).
         let unit = CodegenUnit { index: 1, count: 3 };
         assert_eq!(unit.is_home("_RNvC1p1a"), unit.is_home("_RNvC1p1a"));
+    }
+
+    #[test]
+    fn lowers_borrowed_ffi_trait_glue_once_with_dedup_linkage() {
+        const CASES: [(&str, &str, &str); 2] = [
+            // MLIR integers are signless, so Reussir u8 and i8 both lower to i8.
+            ("_RC3Key_ffi_eq", "_RC11semantic_eq", "i8"),
+            ("_RC3Key_ffi_cmp", "_RC12semantic_cmp", "i8"),
+        ];
+        let text = concat!(
+            "record @_RC3Key : shared struct Key { \"value\": i64 };\n\n",
+            "fn @_RC11semantic_eq(v0 (lhs): Key, v1 (rhs): Key) -> u8 {\n",
+            "    1 : u8\n",
+            "}\n\n",
+            "fn @_RC12semantic_cmp(v0 (lhs): Key, v1 (rhs): Key) -> i8 {\n",
+            "    0 : i8\n",
+            "}\n\n",
+            "ffi trait glue @_RC3Key_ffi_eq = @_RC11semantic_eq : Key => u8;\n\n",
+            "ffi trait glue @_RC3Key_ffi_cmp = @_RC12semantic_cmp : Key => i8;\n",
+        );
+        let context = crate::testing::context();
+
+        in_arena(|tcx| {
+            let parsed = parse_program(tcx, text).expect("parse trait-glue MIR");
+            let defined_function = |mlir: &str, symbol: &str| {
+                let marker = format!("@{symbol}(");
+                let symbol_start = mlir
+                    .find(&marker)
+                    .unwrap_or_else(|| panic!("missing {symbol}:\n{mlir}"));
+                let start = mlir[..symbol_start].rfind('\n').map_or(0, |line| line + 1);
+                let rest = &mlir[start..];
+                let end = rest
+                    .find("\n  }")
+                    .unwrap_or_else(|| panic!("missing body end for {symbol}:\n{rest}"))
+                    + 4;
+                rest[..end].to_owned()
+            };
+            let lower = |policy| {
+                let module = lower_program(&context, tcx, &parsed.program, None, None, policy, &[])
+                    .expect("lower trait glue");
+                assert!(
+                    module.as_operation().verify(),
+                    "trait-glue module verifies:\n{}",
+                    module.as_operation()
+                );
+                module.as_operation().to_string()
+            };
+
+            let deduplicated = lower(LinkagePolicy::Aot {
+                dedup_instances: true,
+            });
+            for (entry, target, ret) in CASES {
+                let borrowed_entry = defined_function(&deduplicated, entry);
+                assert_eq!(borrowed_entry.matches("reussir.rc.inc").count(), 2);
+                assert_eq!(
+                    borrowed_entry.matches(&format!("call @{target}")).count(),
+                    1
+                );
+                assert!(
+                    !borrowed_entry.contains("reussir.rc.dec"),
+                    "{borrowed_entry}"
+                );
+                let return_line = borrowed_entry
+                    .lines()
+                    .find(|line| line.trim_start().starts_with("return "))
+                    .expect("scalar glue return");
+                assert!(return_line.contains(&format!(": {ret}")), "{return_line}");
+                assert!(
+                    borrowed_entry
+                        .lines()
+                        .next()
+                        .is_some_and(|head| head.contains("#llvm.linkage<weak_odr>")),
+                    "{borrowed_entry}"
+                );
+
+                let adapter = defined_function(&deduplicated, target);
+                assert!(adapter.contains("reussir.rc.dec"), "{adapter}");
+                assert!(
+                    adapter
+                        .lines()
+                        .next()
+                        .is_some_and(|head| head.contains("#llvm.linkage<weak_odr>")),
+                    "{adapter}"
+                );
+            }
+
+            let non_deduplicated = lower(LinkagePolicy::Aot {
+                dedup_instances: false,
+            });
+            for (entry, target, _) in CASES {
+                for symbol in [entry, target] {
+                    let function = defined_function(&non_deduplicated, symbol);
+                    let head = function.lines().next().expect("function head");
+                    assert!(!head.contains("llvm.linkage"), "{head}");
+                }
+            }
+
+            for (entry, _, _) in CASES {
+                let definitions = (0..3)
+                    .map(|index| {
+                        let module = lower_unit(
+                            &context,
+                            tcx,
+                            &parsed.program,
+                            None,
+                            None,
+                            CodegenUnit { index, count: 3 },
+                            LinkagePolicy::Aot {
+                                dedup_instances: true,
+                            },
+                            &[],
+                        )
+                        .expect("lower partitioned trait glue");
+                        module
+                            .as_operation()
+                            .to_string()
+                            .matches(&format!("func.func @{entry}"))
+                            .count()
+                    })
+                    .sum::<usize>();
+                assert_eq!(definitions, 1, "trait glue has exactly one home unit");
+            }
+        });
     }
 
     #[test]

--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -319,6 +319,11 @@ pub(crate) fn frontend<'c, 'tcx>(
                 return Ok(Produced::Text(text));
             }
             let trait_db = parsed.rebuild_traits(tcx);
+            // The dump's own bound table, resolved against those rebuilt
+            // trait identities: bounds steer PolyFFI bridge rendering and the
+            // export closure, so dropping them would resume a different
+            // program rather than the serialized one.
+            let generic_env = parsed.rebuild_generic_env(&trait_db);
             let input = MonoInput {
                 tcx,
                 defs: &parsed.defs,
@@ -336,7 +341,7 @@ pub(crate) fn frontend<'c, 'tcx>(
                 externs: Default::default(),
                 traits: MonoTraits {
                     db: Some(&trait_db),
-                    env: None,
+                    env: Some(&generic_env),
                 },
                 // The dump's `#[lang]` markers, so re-entered comparison
                 // dispatch keeps its intrinsic lowering.

--- a/crates/reussir-core/src/full/ffi.rs
+++ b/crates/reussir-core/src/full/ffi.rs
@@ -170,7 +170,7 @@ impl WrapperDecl<'_> {
             let _ = write!(
                 d,
                 "impl ::reussir_rt::bridge::PartialOrdBridge for {sym} {{\n\
-                 \x20   fn partial_cmp_bridge(&self, other: &Self) -> Option<::core::cmp::Ordering> {{\n"
+                 \x20   fn partial_cmp_bridge(&self, other: &Self) -> Option<::std::cmp::Ordering> {{\n"
             );
             if self.needs.ord() {
                 let _ = write!(
@@ -181,9 +181,9 @@ impl WrapperDecl<'_> {
                 let _ = write!(
                     d,
                     "        match unsafe {{ {sym}_ffi_partial_cmp(self.0, other.0) }} {{\n\
-                     \x20           n if n < 0 => Some(::core::cmp::Ordering::Less),\n\
-                     \x20           0 => Some(::core::cmp::Ordering::Equal),\n\
-                     \x20           1 => Some(::core::cmp::Ordering::Greater),\n\
+                     \x20           n if n < 0 => Some(::std::cmp::Ordering::Less),\n\
+                     \x20           0 => Some(::std::cmp::Ordering::Equal),\n\
+                     \x20           1 => Some(::std::cmp::Ordering::Greater),\n\
                      \x20           _ => None,\n\
                      \x20       }}\n"
                 );
@@ -194,11 +194,11 @@ impl WrapperDecl<'_> {
             let _ = write!(
                 d,
                 "impl ::reussir_rt::bridge::OrdBridge for {sym} {{\n\
-                 \x20   fn cmp_bridge(&self, other: &Self) -> ::core::cmp::Ordering {{\n\
+                 \x20   fn cmp_bridge(&self, other: &Self) -> ::std::cmp::Ordering {{\n\
                  \x20       match unsafe {{ {sym}_ffi_cmp(self.0, other.0) }} {{\n\
-                 \x20           n if n < 0 => ::core::cmp::Ordering::Less,\n\
-                 \x20           0 => ::core::cmp::Ordering::Equal,\n\
-                 \x20           _ => ::core::cmp::Ordering::Greater,\n\
+                 \x20           n if n < 0 => ::std::cmp::Ordering::Less,\n\
+                 \x20           0 => ::std::cmp::Ordering::Equal,\n\
+                 \x20           _ => ::std::cmp::Ordering::Greater,\n\
                  \x20       }}\n\
                  \x20   }}\n\
                  }}\n"

--- a/crates/reussir-core/src/full/ffi.rs
+++ b/crates/reussir-core/src/full/ffi.rs
@@ -231,6 +231,24 @@ impl<'a, 'tcx> FfiCtx<'a, 'tcx> {
         self.rust_name_with_needs(ty, ComparisonBridgeNeeds::default(), decls)
     }
 
+    /// The Rust spelling of the ground argument one *binder* was instantiated
+    /// at, carrying that binder's own declared comparison bounds.
+    ///
+    /// A bounded container is not the only source of a comparison
+    /// requirement: an `#[ffi(import)]` signature may bound its own generic
+    /// (`fn same<T: PartialEq>(lhs: T, rhs: T) -> bool`), and its Rust body
+    /// then compares the rendered values directly. Without the bridge those
+    /// bodies fail inside `rustc` on a `Bridge<_>: PartialEq` bound instead of
+    /// using the implementation the signature already promised.
+    pub fn rust_name_for_generic(
+        &self,
+        ty: Ty<'tcx>,
+        generic: crate::semi::ty::GenericId,
+        decls: &mut BTreeMap<String, WrapperDecl<'tcx>>,
+    ) -> Result<String, String> {
+        self.rust_name_with_needs(ty, self.generic_bridge_needs(generic), decls)
+    }
+
     fn rust_name_with_needs(
         &self,
         ty: Ty<'tcx>,

--- a/crates/reussir-core/src/full/ffi.rs
+++ b/crates/reussir-core/src/full/ffi.rs
@@ -46,21 +46,175 @@ use std::fmt::Write as _;
 
 use rustc_hash::FxHashMap;
 
-use crate::semi::ctxt::{DefaultCap, Record};
+use crate::semi::ctxt::{DefaultCap, GenericInfo, Record};
+use crate::semi::lang::LangItem;
+use crate::semi::traits::TraitDb;
 use crate::semi::ty::{DefId, FpTy, IntTy, Ty, TyKind};
 
-/// A shared-record boundary wrapper collected while rendering: its Rust
-/// declaration text and the instance type its rc glue operates on. Keyed by
-/// the instance's v0 symbol in a `BTreeMap` for deterministic emission.
+/// Which Rust comparison capabilities a foreign container requires from a
+/// shared Reussir type. The bits are normalized over the comparison
+/// super-trait tower, so `Ord` includes all four capabilities.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ComparisonBridgeNeeds(u8);
+
+impl ComparisonBridgeNeeds {
+    const PARTIAL_EQ: u8 = 1 << 0;
+    const EQ: u8 = 1 << 1;
+    const PARTIAL_ORD: u8 = 1 << 2;
+    const ORD: u8 = 1 << 3;
+
+    fn insert_lang(&mut self, item: LangItem) {
+        self.0 |= match item {
+            LangItem::PartialEq => Self::PARTIAL_EQ,
+            LangItem::Eq => Self::PARTIAL_EQ | Self::EQ,
+            LangItem::PartialOrd => Self::PARTIAL_EQ | Self::PARTIAL_ORD,
+            LangItem::Ord => Self::PARTIAL_EQ | Self::EQ | Self::PARTIAL_ORD | Self::ORD,
+            _ => 0,
+        };
+    }
+
+    pub fn union(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+
+    pub fn partial_eq(self) -> bool {
+        self.0 & Self::PARTIAL_EQ != 0
+    }
+
+    pub fn eq(self) -> bool {
+        self.0 & Self::EQ != 0
+    }
+
+    pub fn partial_ord(self) -> bool {
+        self.0 & Self::PARTIAL_ORD != 0
+    }
+
+    pub fn ord(self) -> bool {
+        self.0 & Self::ORD != 0
+    }
+}
+
+/// A shared-record boundary wrapper collected while rendering. Its declaration
+/// is rendered only after all mentions have unioned their comparison needs.
+/// Keyed by the instance's v0 symbol in a `BTreeMap` for deterministic output.
+#[derive(Clone)]
 pub struct WrapperDecl<'tcx> {
-    pub decl: String,
+    pub symbol: String,
     pub ty: Ty<'tcx>,
+    pub needs: ComparisonBridgeNeeds,
+}
+
+impl WrapperDecl<'_> {
+    /// Render the existing one-pointer owner plus the comparison behavior its
+    /// enclosing foreign types require. Standard Rust comparison traits live
+    /// on `reussir_rt::bridge::Bridge<T>`; this inner type implements only the
+    /// local bridge traits, preserving the orphan-rule boundary.
+    pub fn render(&self) -> String {
+        let sym = &self.symbol;
+        let mut d = String::new();
+        let _ = write!(
+            d,
+            "#[repr(transparent)]\n\
+             pub struct {sym}(*mut ::std::ffi::c_void);\n\
+             unsafe extern \"C\" {{\n\
+             \x20   unsafe fn {sym}_ffi_acquire(this: *mut ::std::ffi::c_void);\n\
+             \x20   unsafe fn {sym}_ffi_release(this: *mut ::std::ffi::c_void);\n"
+        );
+        if self.needs.partial_eq() {
+            let _ = writeln!(
+                d,
+                "    unsafe fn {sym}_ffi_eq(lhs: *mut ::std::ffi::c_void, rhs: *mut ::std::ffi::c_void) -> u8;"
+            );
+        }
+        if self.needs.partial_ord() && !self.needs.ord() {
+            let _ = writeln!(
+                d,
+                "    unsafe fn {sym}_ffi_partial_cmp(lhs: *mut ::std::ffi::c_void, rhs: *mut ::std::ffi::c_void) -> i8;"
+            );
+        }
+        if self.needs.ord() {
+            let _ = writeln!(
+                d,
+                "    unsafe fn {sym}_ffi_cmp(lhs: *mut ::std::ffi::c_void, rhs: *mut ::std::ffi::c_void) -> i8;"
+            );
+        }
+        let _ = write!(
+            d,
+            "}}\n\
+             impl Clone for {sym} {{\n\
+             \x20   fn clone(&self) -> Self {{\n\
+             \x20       unsafe {{ {sym}_ffi_acquire(self.0) }};\n\
+             \x20       Self(self.0)\n\
+             \x20   }}\n\
+             }}\n\
+             impl Drop for {sym} {{\n\
+             \x20   fn drop(&mut self) {{\n\
+             \x20       unsafe {{ {sym}_ffi_release(self.0) }};\n\
+             \x20   }}\n\
+             }}\n"
+        );
+        if self.needs.partial_eq() {
+            let _ = write!(
+                d,
+                "impl ::reussir_rt::bridge::PartialEqBridge for {sym} {{\n\
+                 \x20   fn eq_bridge(&self, other: &Self) -> bool {{\n\
+                 \x20       unsafe {{ {sym}_ffi_eq(self.0, other.0) != 0 }}\n\
+                 \x20   }}\n\
+                 }}\n"
+            );
+        }
+        if self.needs.eq() {
+            let _ = writeln!(d, "impl ::reussir_rt::bridge::EqBridge for {sym} {{}}");
+        }
+        if self.needs.partial_ord() {
+            let _ = write!(
+                d,
+                "impl ::reussir_rt::bridge::PartialOrdBridge for {sym} {{\n\
+                 \x20   fn partial_cmp_bridge(&self, other: &Self) -> Option<::core::cmp::Ordering> {{\n"
+            );
+            if self.needs.ord() {
+                let _ = write!(
+                    d,
+                    "        Some(<Self as ::reussir_rt::bridge::OrdBridge>::cmp_bridge(self, other))\n"
+                );
+            } else {
+                let _ = write!(
+                    d,
+                    "        match unsafe {{ {sym}_ffi_partial_cmp(self.0, other.0) }} {{\n\
+                     \x20           n if n < 0 => Some(::core::cmp::Ordering::Less),\n\
+                     \x20           0 => Some(::core::cmp::Ordering::Equal),\n\
+                     \x20           1 => Some(::core::cmp::Ordering::Greater),\n\
+                     \x20           _ => None,\n\
+                     \x20       }}\n"
+                );
+            }
+            let _ = write!(d, "    }}\n}}\n");
+        }
+        if self.needs.ord() {
+            let _ = write!(
+                d,
+                "impl ::reussir_rt::bridge::OrdBridge for {sym} {{\n\
+                 \x20   fn cmp_bridge(&self, other: &Self) -> ::core::cmp::Ordering {{\n\
+                 \x20       match unsafe {{ {sym}_ffi_cmp(self.0, other.0) }} {{\n\
+                 \x20           n if n < 0 => ::core::cmp::Ordering::Less,\n\
+                 \x20           0 => ::core::cmp::Ordering::Equal,\n\
+                 \x20           _ => ::core::cmp::Ordering::Greater,\n\
+                 \x20       }}\n\
+                 \x20   }}\n\
+                 }}\n"
+            );
+        }
+        d
+    }
 }
 
 /// Rendering context: the elaborated record table (capabilities, `#[ffi]`
 /// templates, generic parameter names) and a symbol source for instances.
 pub struct FfiCtx<'a, 'tcx> {
     pub records: &'a FxHashMap<DefId, Record<'tcx>>,
+    pub traits: Option<&'a TraitDb<'tcx>>,
+    pub generic_env: Option<&'a [GenericInfo]>,
+    pub lang: &'a FxHashMap<DefId, LangItem>,
     /// Mangle a ground record instance to its v0 symbol.
     pub instance_symbol: &'a dyn Fn(DefId, &'tcx [Ty<'tcx>]) -> String,
 }
@@ -72,6 +226,15 @@ impl<'a, 'tcx> FfiCtx<'a, 'tcx> {
     pub fn rust_name(
         &self,
         ty: Ty<'tcx>,
+        decls: &mut BTreeMap<String, WrapperDecl<'tcx>>,
+    ) -> Result<String, String> {
+        self.rust_name_with_needs(ty, ComparisonBridgeNeeds::default(), decls)
+    }
+
+    fn rust_name_with_needs(
+        &self,
+        ty: Ty<'tcx>,
+        needs: ComparisonBridgeNeeds,
         decls: &mut BTreeMap<String, WrapperDecl<'tcx>>,
     ) -> Result<String, String> {
         match *ty.kind() {
@@ -93,14 +256,20 @@ impl<'a, 'tcx> FfiCtx<'a, 'tcx> {
                             if i > 0 {
                                 name.push_str(", ");
                             }
-                            name.push_str(&self.rust_name(arg, decls)?);
+                            let arg_needs = record
+                                .ty_params
+                                .get(i)
+                                .map_or_else(ComparisonBridgeNeeds::default, |(_, gid)| {
+                                    self.generic_bridge_needs(*gid)
+                                });
+                            name.push_str(&self.rust_name_with_needs(arg, arg_needs, decls)?);
                         }
                         name.push('>');
                     }
                     return Ok(name);
                 }
                 match record.default_cap {
-                    DefaultCap::Shared => Ok(self.shared_wrapper(def, args, ty, decls)),
+                    DefaultCap::Shared => Ok(self.shared_wrapper(def, args, ty, needs, decls)),
                     DefaultCap::Value => {
                         Err("a `[value]` record cannot cross the FFI boundary yet".into())
                     }
@@ -122,6 +291,31 @@ impl<'a, 'tcx> FfiCtx<'a, 'tcx> {
         }
     }
 
+    /// Comparison lang items implied by the declared bounds on one generic.
+    /// A custom bound such as `T: Sorted` is recognized when `Sorted: Ord`.
+    fn generic_bridge_needs(&self, generic: crate::semi::ty::GenericId) -> ComparisonBridgeNeeds {
+        let (Some(db), Some(info)) = (
+            self.traits,
+            self.generic_env.and_then(|env| env.get(generic.0 as usize)),
+        ) else {
+            return ComparisonBridgeNeeds::default();
+        };
+        let mut needs = ComparisonBridgeNeeds::default();
+        for item in LangItem::CMP_TRAITS {
+            let Some(target) = self
+                .lang
+                .iter()
+                .find_map(|(&def, &bound)| (bound == item).then(|| db.trait_by_def(def)).flatten())
+            else {
+                continue;
+            };
+            if info.bounds.iter().any(|&have| db.implies(have, target)) {
+                needs.insert_lang(item);
+            }
+        }
+        needs
+    }
+
     /// The `#[repr(transparent)]` pointer wrapper for a shared Reussir
     /// record instance, registering its declaration (and thereby its rc-glue
     /// requirement) under the instance symbol.
@@ -130,34 +324,19 @@ impl<'a, 'tcx> FfiCtx<'a, 'tcx> {
         def: DefId,
         args: &'tcx [Ty<'tcx>],
         ty: Ty<'tcx>,
+        needs: ComparisonBridgeNeeds,
         decls: &mut BTreeMap<String, WrapperDecl<'tcx>>,
     ) -> String {
         let sym = (self.instance_symbol)(def, args);
-        if !decls.contains_key(&sym) {
-            let mut d = String::new();
-            let _ = write!(
-                d,
-                "#[repr(transparent)]\n\
-                 pub struct {sym}(*mut ::std::ffi::c_void);\n\
-                 unsafe extern \"C\" {{\n\
-                 \x20   unsafe fn {sym}_ffi_acquire(this: *mut ::std::ffi::c_void);\n\
-                 \x20   unsafe fn {sym}_ffi_release(this: *mut ::std::ffi::c_void);\n\
-                 }}\n\
-                 impl Clone for {sym} {{\n\
-                 \x20   fn clone(&self) -> Self {{\n\
-                 \x20       unsafe {{ {sym}_ffi_acquire(self.0) }};\n\
-                 \x20       Self(self.0)\n\
-                 \x20   }}\n\
-                 }}\n\
-                 impl Drop for {sym} {{\n\
-                 \x20   fn drop(&mut self) {{\n\
-                 \x20       unsafe {{ {sym}_ffi_release(self.0) }};\n\
-                 \x20   }}\n\
-                 }}\n"
-            );
-            decls.insert(sym.clone(), WrapperDecl { decl: d, ty });
-        }
-        sym
+        decls
+            .entry(sym.clone())
+            .and_modify(|decl| decl.needs.union(needs))
+            .or_insert_with(|| WrapperDecl {
+                symbol: sym.clone(),
+                ty,
+                needs,
+            });
+        format!("::reussir_rt::bridge::Bridge<{sym}>")
     }
 
     /// Whether the type lowers to an LLVM integer or pointer at the
@@ -245,7 +424,7 @@ pub fn import_texture(
 ) -> String {
     let mut out = texture_head(preludes);
     for decl in decls.values() {
-        out.push_str(&decl.decl);
+        out.push_str(&decl.render());
     }
     let attrs = "#[linkage = \"weak_odr\"]\n#[unsafe(no_mangle)]\n";
     if trivial {
@@ -323,7 +502,7 @@ pub fn drop_texture(
 ) -> String {
     let mut out = texture_head(&[]);
     for decl in decls.values() {
-        out.push_str(&decl.decl);
+        out.push_str(&decl.render());
     }
     let _ = write!(
         out,

--- a/crates/reussir-core/src/full/ffi.rs
+++ b/crates/reussir-core/src/full/ffi.rs
@@ -173,9 +173,9 @@ impl WrapperDecl<'_> {
                  \x20   fn partial_cmp_bridge(&self, other: &Self) -> Option<::std::cmp::Ordering> {{\n"
             );
             if self.needs.ord() {
-                let _ = write!(
+                let _ = writeln!(
                     d,
-                    "        Some(<Self as ::reussir_rt::bridge::OrdBridge>::cmp_bridge(self, other))\n"
+                    "        Some(<Self as ::reussir_rt::bridge::OrdBridge>::cmp_bridge(self, other))"
                 );
             } else {
                 let _ = write!(

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -68,6 +68,9 @@ pub struct Program<'tcx> {
     /// Reussir-side rc glue exposed to foreign wrappers: per shared-record
     /// instance crossing the boundary, tiny acquire/release functions.
     pub ffi_rc_glue: Vec<FfiRcGlue<'tcx>>,
+    /// Borrowed comparison entries exposed to foreign `Bridge<T>` wrappers.
+    /// Each acquires both operands, then calls its ground semantic target.
+    pub ffi_trait_glue: Vec<FfiTraitGlue<'tcx>>,
     /// Interner backing every [`Symbol`] in this program.
     pub symbols: Rodeo,
 }
@@ -214,6 +217,18 @@ pub struct FfiRcGlue<'tcx> {
     pub ty: Ty<'tcx>,
     pub acquire: Symbol,
     pub release: Symbol,
+}
+
+/// Reussir-side comparison glue for one shared record instance. Rust lends two
+/// pointers, so lowering increments each exactly once before calling `target`,
+/// whose ordinary Reussir signature consumes the resulting owned values and
+/// returns the scalar `ret` ABI type.
+#[derive(Clone, Copy, Debug)]
+pub struct FfiTraitGlue<'tcx> {
+    pub ty: Ty<'tcx>,
+    pub ret: Ty<'tcx>,
+    pub entry: Symbol,
+    pub target: Symbol,
 }
 
 /// A monomorphized expression: a ground type, the structure, and a source span.

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -223,6 +223,16 @@ impl<'tcx> Builder<'_, 'tcx> {
                 release: self.sym(&g.release),
             })
             .collect();
+        let ffi_trait_glue: Vec<mir::FfiTraitGlue<'tcx>> = raw
+            .ffi_trait_glue
+            .iter()
+            .map(|g| mir::FfiTraitGlue {
+                ty: self.ty(&g.ty),
+                ret: self.ty(&g.ret),
+                entry: self.sym(&g.entry),
+                target: self.sym(&g.target),
+            })
+            .collect();
         let functions: Vec<mir::Function<'tcx>> = raw.funcs.iter().map(|f| self.func(f)).collect();
         let transform_scripts = raw
             .transforms
@@ -251,6 +261,7 @@ impl<'tcx> Builder<'_, 'tcx> {
             ffi_imports,
             ffi_textures,
             ffi_rc_glue,
+            ffi_trait_glue,
             symbols,
         }
     }

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -831,6 +831,43 @@ mod tests {
     }
 
     #[test]
+    fn roundtrips_ffi_trait_glue() {
+        let text = concat!(
+            "record @_RC3Key : shared struct Key { \"value\": i64 };\n\n",
+            "ffi trait glue @_RC3Key_ffi_eq = @_RC11semantic_eq : Key => u8;\n\n",
+            "ffi trait glue @_RC3Key_ffi_cmp = @_RC12semantic_cmp : Key => i8;\n",
+        );
+
+        with_tcx(|tcx| {
+            let parsed = parse_program(tcx, text).expect("parse trait glue");
+            assert_eq!(parsed.program.ffi_trait_glue.len(), 2);
+            let [eq, cmp] = parsed.program.ffi_trait_glue.as_slice() else {
+                unreachable!()
+            };
+            assert_eq!(parsed.program.symbol(eq.entry), "_RC3Key_ffi_eq");
+            assert_eq!(parsed.program.symbol(eq.target), "_RC11semantic_eq");
+            assert_eq!(parsed.program.symbol(cmp.entry), "_RC3Key_ffi_cmp");
+            assert_eq!(parsed.program.symbol(cmp.target), "_RC12semantic_cmp");
+            assert_eq!(eq.ty, cmp.ty);
+            assert!(matches!(
+                *eq.ret.kind(),
+                crate::semi::ty::TyKind::Int(crate::semi::ty::IntTy::Unsigned(8))
+            ));
+            assert!(matches!(
+                *cmp.ret.kind(),
+                crate::semi::ty::TyKind::Int(crate::semi::ty::IntTy::Signed(8))
+            ));
+
+            let printed = Printer::new(&parsed.defs, &parsed.names).program(&parsed.program);
+            assert_eq!(printed, text);
+            let reparsed = parse_program(tcx, &printed).expect("re-parse trait glue");
+            let printed_again =
+                Printer::new(&reparsed.defs, &reparsed.names).program(&reparsed.program);
+            assert_eq!(printed_again, printed);
+        });
+    }
+
+    #[test]
     fn roundtrips_cells() {
         roundtrip(
             r#"

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -37,6 +37,8 @@ Item: raw::Item = {
         }),
     "ffi" "glue" "@" <acquire:Sym> "@" <release:Sym> ":" <t:Ty> ";"
         => raw::Item::FfiRcGlue(raw::FfiRcGlue { acquire, release, ty: t }),
+    "ffi" "trait" "glue" "@" <entry:Sym> "=" "@" <target:Sym> ":" <t:Ty> "=>" <ret:Ty> ";"
+        => raw::Item::FfiTraitGlue(raw::FfiTraitGlue { entry, target, ty: t, ret }),
 };
 
 /// One source-file table entry: `0 = "src/lib.rr";`. Spans are byte offsets
@@ -107,6 +109,7 @@ Name: &'input str = {
     "ffi" => "ffi",
     "texture" => "texture",
     "glue" => "glue",
+    "trait" => "trait",
 };
 
 /// A user debug name (parameter and let names, variant names). A name that
@@ -379,6 +382,7 @@ extern {
         "ffi" => Token::Ffi,
         "texture" => Token::Texture,
         "glue" => Token::Glue,
+        "trait" => Token::Trait,
         "transform" => Token::Transform,
         "transform_anchor" => Token::TransformAnchor,
         "interface" => Token::Interface,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -135,6 +135,16 @@ impl<'a> Printer<'a> {
             )) + r.ty(glue.ty)
                 + text(";")
         }));
+        items.extend(program.ffi_trait_glue.iter().map(|glue| {
+            text(format!(
+                "ffi trait glue @{} = @{} : ",
+                r.sym(glue.entry),
+                r.sym(glue.target),
+            )) + r.ty(glue.ty)
+                + text(" => ")
+                + r.ty(glue.ret)
+                + text(";")
+        }));
 
         // One blank line between top-level items.
         let mut doc = Doc::Null;

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -72,6 +72,7 @@ pub struct Program {
     pub ffi_imports: Vec<FfiImport>,
     pub ffi_textures: Vec<FfiTexture>,
     pub ffi_rc_glue: Vec<FfiRcGlue>,
+    pub ffi_trait_glue: Vec<FfiTraitGlue>,
 }
 
 /// One top-level item, as the grammar yields them before partitioning.
@@ -86,6 +87,7 @@ pub enum Item {
     FfiImport(FfiImport),
     FfiTexture(FfiTexture),
     FfiRcGlue(FfiRcGlue),
+    FfiTraitGlue(FfiTraitGlue),
 }
 
 /// A ground record declaration: its v0 symbol, the capability it declares by
@@ -158,6 +160,7 @@ impl Program {
             ffi_imports: Vec::new(),
             ffi_textures: Vec::new(),
             ffi_rc_glue: Vec::new(),
+            ffi_trait_glue: Vec::new(),
         };
         for item in items {
             match item {
@@ -170,6 +173,7 @@ impl Program {
                 Item::FfiImport(f) => p.ffi_imports.push(f),
                 Item::FfiTexture(t) => p.ffi_textures.push(t),
                 Item::FfiRcGlue(g) => p.ffi_rc_glue.push(g),
+                Item::FfiTraitGlue(g) => p.ffi_trait_glue.push(g),
             }
         }
         p
@@ -226,6 +230,16 @@ pub struct FfiRcGlue {
     pub acquire: String,
     pub release: String,
     pub ty: Ty,
+}
+
+/// Borrowed comparison glue:
+/// `ffi trait glue @entry = @target : ty => ret;`.
+#[derive(Clone, Debug)]
+pub struct FfiTraitGlue {
+    pub entry: String,
+    pub target: String,
+    pub ty: Ty,
+    pub ret: Ty,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -342,6 +342,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         ids: mir::ExprIdGen::default(),
         lang: &input.lang,
         synthetic_cmps: FxHashMap::default(),
+        bridge_attempts: FxHashSet::default(),
         synthetic_fns: Vec::new(),
     };
 
@@ -535,10 +536,13 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
                 let ret_direct =
                     matches!(*return_ty.kind(), TyKind::Unit) || fctx.integer_like(return_ty);
                 // `[:T:]` placeholders in the body substitute to the
-                // instance's Rust spellings.
+                // instance's Rust spellings. Each argument is rendered under
+                // its own binder's bounds: a signature that promises
+                // `T: PartialEq` must bridge that capability even when no
+                // bounded container in the signature mentions it.
                 let mut placeholders: FxHashMap<&str, String> = FxHashMap::default();
-                for ((gname, _), &ty) in func.generics.iter().zip(inst.ty_args.iter()) {
-                    if let Ok(rendered) = fctx.rust_name(ty, &mut decls) {
+                for ((gname, gid), &ty) in func.generics.iter().zip(inst.ty_args.iter()) {
+                    if let Ok(rendered) = fctx.rust_name_for_generic(ty, *gid, &mut decls) {
                         placeholders.insert(input.resolver.resolve(*gname), rendered);
                     }
                 }
@@ -575,6 +579,11 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
                     target: symbol,
                     import: true,
                 });
+                // A capability introduced by the signature's own binders has
+                // no bounded container instance behind it, so the record scan
+                // never sees it: this texture is the only site that can
+                // demand its entries, and therefore must define them.
+                driver.register_ffi_bridges(&decls, fimport.span, &mut ffi_trait_glue);
                 for (sym, decl) in decls {
                     glue.entry(sym)
                         .and_modify(|old| old.needs.union(decl.needs))
@@ -1032,6 +1041,11 @@ struct Driver<'a, 'tcx> {
     /// Synthesized three-way comparisons (`Ord::cmp` over a scalar), one
     /// per scalar type; see [`Driver::three_way_call`].
     synthetic_cmps: FxHashMap<Ty<'tcx>, mir::Symbol>,
+    /// Comparison-bridge entries already attempted, by entry name. An import
+    /// texture and the ground record scan can demand the same entry, so the
+    /// set records *attempts*, not successes: a rejected bridge is diagnosed
+    /// once rather than once per site that wanted it.
+    bridge_attempts: FxHashSet<String>,
     synthetic_fns: Vec<mir::Function<'tcx>>,
 }
 
@@ -1273,7 +1287,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         out: &mut std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>>,
     ) {
         let entry_name = format!("{base}_ffi_eq");
-        if out.contains_key(&entry_name) {
+        if !self.bridge_attempts.insert(entry_name.clone()) {
             return;
         }
         let Some((callee, method_ret, name)) =
@@ -1321,7 +1335,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         out: &mut std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>>,
     ) {
         let entry_name = format!("{base}_ffi_cmp");
-        if out.contains_key(&entry_name) {
+        if !self.bridge_attempts.insert(entry_name.clone()) {
             return;
         }
         let Some((callee, ordering, name)) =
@@ -1401,7 +1415,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         out: &mut std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>>,
     ) {
         let entry_name = format!("{base}_ffi_partial_cmp");
-        if out.contains_key(&entry_name) {
+        if !self.bridge_attempts.insert(entry_name.clone()) {
             return;
         }
         let Some((eq, eq_ret, name)) =
@@ -1482,7 +1496,9 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         out: &mut std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>>,
     ) {
         for (base, decl) in decls {
-            if decl.needs.eq() {
+            // `Eq` carries no method to synthesize, so it has no entry of its
+            // own to dedup on; give it a marker key in the same set.
+            if decl.needs.eq() && self.bridge_attempts.insert(format!("{base}_ffi_eq_marker")) {
                 self.require_comparison_trait(crate::semi::lang::LangItem::Eq, decl.ty, span);
             }
             if decl.needs.partial_eq() {
@@ -2631,6 +2647,205 @@ mod tests {
         })
     }
 
+    /// A shared record implementing the whole comparison tower — so what a
+    /// texture renders is decided by the *bound* it is reached through, never
+    /// by what the type happens to implement.
+    const ORD_KEY: &str = r#"
+        pub struct Key { value: i64 }
+        impl PartialEq for Key {
+            fn eq(self: Self, other: Self) -> bool { self.value == other.value }
+        }
+        impl Eq for Key {}
+        impl PartialOrd for Key {
+            fn lt(self: Self, other: Self) -> bool { self.value < other.value }
+            fn le(self: Self, other: Self) -> bool { self.value <= other.value }
+            fn gt(self: Self, other: Self) -> bool { self.value > other.value }
+            fn ge(self: Self, other: Self) -> bool { self.value >= other.value }
+        }
+        impl Ord for Key {
+            fn cmp(self: Self, other: Self) -> Ordering {
+                if self.value < other.value { Ordering::Less } else {
+                    if self.value == other.value { Ordering::Equal }
+                    else { Ordering::Greater }
+                }
+            }
+        }
+    "#;
+
+    /// A bounded container is not the only source of a comparison
+    /// requirement: an `#[ffi(import)]` signature may bound its own generic,
+    /// and its Rust body then compares the rendered values directly. The
+    /// texture must carry that bridge — and exactly that one, even though
+    /// `Key` implements the whole tower.
+    #[test]
+    fn an_import_binder_bound_renders_its_own_bridge() {
+        let source = format!(
+            r#"{CMP_TOWER}{ORD_KEY}
+            #[ffi(import)]
+            pub fn same<T: PartialEq>(lhs: T, rhs: T) -> bool [{{ lhs == rhs }}];
+
+            pub fn run(a: Key, b: Key) -> bool {{ same(a, b) }}"#
+        );
+        with_full(&source, |full| {
+            let entries: Vec<_> = full
+                .ffi_trait_glue
+                .iter()
+                .map(|glue| full.symbol(glue.entry))
+                .collect();
+            assert!(
+                entries.iter().any(|entry| entry.ends_with("_ffi_eq")),
+                "the binder's `PartialEq` bound defines no equality entry: {entries:?}"
+            );
+            assert_eq!(entries.len(), 1, "extra comparison entries: {entries:?}");
+
+            let [texture] = full.ffi_imports.as_slice() else {
+                panic!("expected exactly one import texture");
+            };
+            let texture = &texture.texture;
+            assert!(
+                texture.contains("impl ::reussir_rt::bridge::PartialEqBridge for"),
+                "{texture}"
+            );
+            // Qualified: `EqBridge` is a suffix of `PartialEqBridge`, and
+            // `OrdBridge` of `PartialOrdBridge`.
+            for stronger in [
+                "bridge::EqBridge for",
+                "bridge::PartialOrdBridge for",
+                "bridge::OrdBridge for",
+            ] {
+                assert!(
+                    !texture.contains(stronger),
+                    "the bound is `PartialEq`, yet the texture grants {stronger}:\n{texture}"
+                );
+            }
+        });
+    }
+
+    /// An import texture and the ground record scan can demand the same
+    /// entry. A bridge the evidence rejects is then wanted twice, and the
+    /// programmer must still be told once.
+    #[test]
+    fn a_rejected_bridge_is_diagnosed_once() {
+        let source = format!(
+            r#"{CMP_TOWER}
+            #[ffi(rust = "::std::collections::BTreeSet")]
+            pub struct BTreeSet<T: Ord>;
+
+            pub struct Key {{ value: i64 }}
+
+            #[ffi(import)]
+            pub fn empty<T>() -> BTreeSet<T> [{{ Default::default() }}];
+
+            pub fn run() -> BTreeSet<Key> {{ empty<Key>() }}"#
+        );
+        let rejected: Vec<_> = mono_reports(&source)
+            .into_iter()
+            .filter(|report| report.starts_with("cannot synthesize a Rust FFI comparison bridge"))
+            .collect();
+        assert_eq!(rejected.len(), 1, "{rejected:#?}");
+    }
+
+    /// **Resumability, PolyFFI edition**: bridge rendering reads the binder
+    /// bounds a dump serializes, so a program resumed from its HIR must reach
+    /// the same MIR — the same textures and the same comparison entries — as
+    /// the one built from source. Losing the bound table does not degrade
+    /// gracefully: it silently resumes a *different* program whose textures
+    /// no longer compile.
+    #[test]
+    fn comparison_bridges_resume_from_parsed_hir() {
+        use crate::full::mir::print::Printer as MirPrinter;
+        use crate::semi::hir::build::parse_program;
+        use crate::semi::hir::print::Printer as HirPrinter;
+
+        // Both discovery routes at once: the container's declared `T: Ord`
+        // and the import binder's own `T: PartialEq`.
+        let source = format!(
+            r#"{CMP_TOWER}{ORD_KEY}
+            #[ffi(rust = "::std::collections::BTreeSet")]
+            pub struct BTreeSet<T: Ord>;
+
+            #[ffi(import)]
+            pub fn insert<T: Ord>(set: BTreeSet<T>, value: T) -> BTreeSet<T> [{{
+                set.insert(value)
+            }}];
+
+            #[ffi(import)]
+            pub fn same<T: PartialEq>(lhs: T, rhs: T) -> bool [{{ lhs == rhs }}];
+
+            pub fn run(set: BTreeSet<Key>, a: Key, b: Key) -> bool {{
+                let grown = insert(set, a);
+                same(a, b)
+            }}"#
+        );
+        with_tcx(|tcx| {
+            let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
+            let parse = reussir_syntax::parse_with_interner(&source, interner.clone());
+            assert!(parse.ok(), "{:#?}", parse.errors);
+            let prog = surface::program(&parse.root);
+            let elab = elaborate(tcx, &prog, &interner);
+            assert!(!elab.has_errors(), "{:#?}", elab.reports);
+
+            let (mir0, r0) = monomorphize(&elab.mono_input());
+            assert!(r0.is_empty(), "{r0:#?}");
+            let text0 = MirPrinter::new(&elab.defs, elab.resolver).program(&mir0);
+
+            let strings = elab.strings.entries();
+            let bounds = elab.bound_names();
+            let lang = elab.lang.declared_by_def();
+            let (traits, impls) =
+                crate::semi::hir::trait_texts(&elab.traits, &elab.defs, elab.resolver);
+            let hir_text = HirPrinter::new(&elab.defs, elab.resolver)
+                .with_bounds(&bounds)
+                .with_traits(&traits, &impls)
+                .with_lang(&lang)
+                .with_ffi_metadata(&elab.ffi_preludes, &elab.ffi_imports)
+                .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
+            let mut parsed = parse_program(tcx, &hir_text).expect("re-parse HIR");
+            let trait_db = parsed.rebuild_traits(tcx);
+            let generic_env = parsed.rebuild_generic_env(&trait_db);
+            let input = MonoInput {
+                tcx,
+                defs: &parsed.defs,
+                resolver: &parsed.names,
+                elaborated: &parsed.funcs,
+                records: &parsed.records,
+                trampolines: &parsed.trampolines,
+                transform_anchors: &parsed.transform_anchors,
+                transform_scripts: &parsed.transform_scripts,
+                ffi_imports: &parsed.ffi_imports,
+                ffi_preludes: &parsed.ffi_preludes,
+                strings: parsed.strings.clone(),
+                externs: MonoExterns::default(),
+                traits: MonoTraits {
+                    db: Some(&trait_db),
+                    env: Some(&generic_env),
+                },
+                lang: parsed.lang.clone(),
+            };
+            let (mir1, r1) = monomorphize(&input);
+            assert!(r1.is_empty(), "{r1:#?}");
+            let text1 = MirPrinter::new(&parsed.defs, &parsed.names).program(&mir1);
+
+            // Non-vacuity: two empty programs would compare equal too.
+            for expected in [
+                "ffi trait glue",
+                "_ffi_cmp",
+                "_ffi_eq",
+                "bridge::OrdBridge for",
+                "bridge::PartialEqBridge for",
+            ] {
+                assert!(
+                    text1.contains(expected),
+                    "resumed MIR lost `{expected}`:\n{text1}"
+                );
+            }
+            assert_eq!(
+                text0, text1,
+                "resumed MIR differs from the original:\n=== original ===\n{text0}\n=== resumed ===\n{text1}"
+            );
+        });
+    }
+
     /// An opaque container reachable only through another record's field has
     /// no import texture to trigger bridge discovery. Record closure at the
     /// queue fixed point must still synthesize its comparison glue before
@@ -3009,6 +3224,7 @@ mod tests {
                 .program(&elab.elaborated, &strings, &elab.records, &elab.trampolines);
             let mut parsed = parse_program(tcx, &hir_text).expect("re-parse HIR");
             let trait_db = parsed.rebuild_traits(tcx);
+            let generic_env = parsed.rebuild_generic_env(&trait_db);
             let input = MonoInput {
                 tcx,
                 defs: &parsed.defs,
@@ -3024,7 +3240,7 @@ mod tests {
                 externs: MonoExterns::default(),
                 traits: MonoTraits {
                     db: Some(&trait_db),
-                    env: None,
+                    env: Some(&generic_env),
                 },
                 lang: Default::default(),
             };

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -367,7 +367,8 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
     let mut import_trampolines: Vec<mir::Trampoline> = Vec::new();
     // Shared-record wrappers referenced by any texture, keyed by instance
     // symbol (deterministic order) — each becomes one acquire/release pair.
-    let mut glue: std::collections::BTreeMap<String, Ty<'tcx>> = std::collections::BTreeMap::new();
+    let mut glue: std::collections::BTreeMap<String, WrapperDecl<'tcx>> =
+        std::collections::BTreeMap::new();
 
     let mut functions = Vec::new();
     while let Some(inst) = driver.queue.pop_front() {
@@ -450,6 +451,9 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         if let Some(fimport) = ffi_import {
             let fctx = FfiCtx {
                 records: input.records,
+                traits: input.traits.db,
+                generic_env: input.traits.env,
+                lang: &input.lang,
                 instance_symbol: &instance_symbol,
             };
             let mut decls: std::collections::BTreeMap<String, WrapperDecl<'tcx>> =
@@ -533,7 +537,9 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
                     import: true,
                 });
                 for (sym, decl) in decls {
-                    glue.entry(sym).or_insert(decl.ty);
+                    glue.entry(sym)
+                        .and_modify(|old| old.needs.union(decl.needs))
+                        .or_insert(decl);
                 }
             }
         }
@@ -600,6 +606,9 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         if let Some(record) = input.records.get(&def).filter(|r| r.ffi.is_some()) {
             let fctx = FfiCtx {
                 records: input.records,
+                traits: input.traits.db,
+                generic_env: input.traits.env,
+                lang: &input.lang,
                 instance_symbol: &instance_symbol,
             };
             let mut decls: std::collections::BTreeMap<String, WrapperDecl<'tcx>> =
@@ -617,7 +626,9 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
                         texture,
                     });
                     for (sym, decl) in decls {
-                        glue.entry(sym).or_insert(decl.ty);
+                        glue.entry(sym)
+                            .and_modify(|old| old.needs.union(decl.needs))
+                            .or_insert(decl);
                     }
                     layout
                 }
@@ -686,9 +697,9 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
     // referenced. The wrapped instances were noted during rendering, so
     // their layouts are resolved above.
     let ffi_rc_glue: Vec<mir::FfiRcGlue<'tcx>> = glue
-        .into_iter()
-        .map(|(sym, ty)| mir::FfiRcGlue {
-            ty,
+        .iter()
+        .map(|(sym, decl)| mir::FfiRcGlue {
+            ty: decl.ty,
             acquire: mir::Symbol(driver.symbols.get_or_intern(format!("{sym}_ffi_acquire"))),
             release: mir::Symbol(driver.symbols.get_or_intern(format!("{sym}_ffi_release"))),
         })

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -1331,6 +1331,91 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         );
     }
 
+    /// Reussir exposes partial-order predicates rather than `partial_cmp`.
+    /// Classify them inside one semantic adapter so Rust crosses the boundary
+    /// once; `2` is the stable ABI code for incomparable values (`None`).
+    fn synthesize_partial_cmp_bridge(
+        &mut self,
+        base: &str,
+        ty: Ty<'tcx>,
+        span: Option<Span>,
+        out: &mut std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>>,
+    ) {
+        let entry_name = format!("{base}_ffi_partial_cmp");
+        if out.contains_key(&entry_name) {
+            return;
+        }
+        let Some((eq, eq_ret, name)) =
+            self.comparison_callee(crate::semi::lang::LangItem::PartialEq, "eq", ty, span)
+        else {
+            return;
+        };
+        let Some((lt, lt_ret, _)) =
+            self.comparison_callee(crate::semi::lang::LangItem::PartialOrd, "lt", ty, span)
+        else {
+            return;
+        };
+        let Some((gt, gt_ret, _)) =
+            self.comparison_callee(crate::semi::lang::LangItem::PartialOrd, "gt", ty, span)
+        else {
+            return;
+        };
+        if [eq_ret, lt_ret, gt_ret]
+            .into_iter()
+            .any(|ret| !matches!(*ret.kind(), TyKind::Bool))
+        {
+            self.error(span, "comparison predicate methods must return `bool`");
+            return;
+        }
+        let ret = self.tcx.mk_int(IntTy::Signed(8));
+        let gt_call = self.bridge_call(gt, ty, gt_ret);
+        let greater = self.bridge_const(1, ret);
+        let unordered = self.bridge_const(2, ret);
+        let gt_body = self.synth_node(
+            mir::ExprKind::If(
+                self.tcx.alloc(gt_call),
+                self.tcx.alloc(greater),
+                self.tcx.alloc(unordered),
+            ),
+            ret,
+        );
+        let lt_call = self.bridge_call(lt, ty, lt_ret);
+        let less = self.bridge_const(-1, ret);
+        let lt_body = self.synth_node(
+            mir::ExprKind::If(
+                self.tcx.alloc(lt_call),
+                self.tcx.alloc(less),
+                self.tcx.alloc(gt_body),
+            ),
+            ret,
+        );
+        let eq_call = self.bridge_call(eq, ty, eq_ret);
+        let equal = self.bridge_const(0, ret);
+        let body = self.synth_node(
+            mir::ExprKind::If(
+                self.tcx.alloc(eq_call),
+                self.tcx.alloc(equal),
+                self.tcx.alloc(lt_body),
+            ),
+            ret,
+        );
+        let adapter = mir::Symbol(
+            self.symbols
+                .get_or_intern(format!("{base}_ffi_partial_cmp_adapter")),
+        );
+        self.push_bridge_adapter(adapter, name, ty, ret, body);
+        let entry = mir::Symbol(self.symbols.get_or_intern(&entry_name));
+        out.insert(
+            entry_name,
+            mir::FfiTraitGlue {
+                ty,
+                ret,
+                entry,
+                target: adapter,
+            },
+        );
+    }
+
     fn register_ffi_bridges(
         &mut self,
         decls: &std::collections::BTreeMap<String, WrapperDecl<'tcx>>,
@@ -1343,6 +1428,9 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             }
             if decl.needs.partial_eq() {
                 self.synthesize_eq_bridge(base, decl.ty, span, out);
+            }
+            if decl.needs.partial_ord() && !decl.needs.ord() {
+                self.synthesize_partial_cmp_bridge(base, decl.ty, span, out);
             }
             if decl.needs.ord() {
                 self.synthesize_cmp_bridge(base, decl.ty, span, out);

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -737,6 +737,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             ffi_imports: ffi_imports_out,
             ffi_textures,
             ffi_rc_glue,
+            ffi_trait_glue: Vec::new(),
             symbols,
         },
         reports,

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -369,6 +369,8 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
     // symbol (deterministic order) — each becomes one acquire/release pair.
     let mut glue: std::collections::BTreeMap<String, WrapperDecl<'tcx>> =
         std::collections::BTreeMap::new();
+    let mut ffi_trait_glue: std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>> =
+        std::collections::BTreeMap::new();
 
     let mut functions = Vec::new();
     while let Some(inst) = driver.queue.pop_front() {
@@ -503,6 +505,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
                         placeholders.insert(input.resolver.resolve(*gname), rendered);
                     }
                 }
+                driver.register_ffi_bridges(&decls, fimport.span, &mut ffi_trait_glue);
                 let body_text = ffi_render::substitute_placeholders(&fimport.body, &placeholders);
                 // File ids are one space (externs remap at declaration), so
                 // the per-file prelude pairing holds across both tables.
@@ -737,7 +740,7 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             ffi_imports: ffi_imports_out,
             ffi_textures,
             ffi_rc_glue,
-            ffi_trait_glue: Vec::new(),
+            ffi_trait_glue: ffi_trait_glue.into_values().collect(),
             symbols,
         },
         reports,
@@ -1041,6 +1044,227 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             kind,
             ty,
             span: None,
+        }
+    }
+
+    /// Select one ground comparison method and enqueue its concrete body or
+    /// prototype. Bridge synthesis uses the same judgment as an ordinary
+    /// `TraitCall`, so implementations loaded from dependency interfaces work
+    /// without a second instance mechanism.
+    fn comparison_callee(
+        &mut self,
+        item: crate::semi::lang::LangItem,
+        method_name: &str,
+        ty: Ty<'tcx>,
+        span: Option<Span>,
+    ) -> Option<(mir::Symbol, Ty<'tcx>, TokenKey)> {
+        let (trait_def, method, ret, name) = {
+            let db = self.traits.db?;
+            let (&trait_def, _) = self.lang.iter().find(|(_, found)| **found == item)?;
+            let tid = db.trait_by_def(trait_def)?;
+            let tdef = db.trait_def(tid);
+            let (method, sig) = tdef
+                .methods
+                .iter()
+                .enumerate()
+                .find(|(_, sig)| self.resolver.try_resolve(sig.name) == Some(method_name))?;
+            let mut subst = Subst::default();
+            subst.insert(tdef.self_param, ty);
+            (
+                trait_def,
+                method as u32,
+                subst_ty(self.tcx, sig.ret, &subst),
+                sig.name,
+            )
+        };
+        match self.resolve_trait_call(trait_def, method, self.tcx.intern_tys(&[ty]), span)? {
+            TraitCallTarget::Call {
+                target,
+                ty_args,
+                regional: false,
+            } => {
+                self.enqueue(target, ty_args, span);
+                Some((self.symbol_of(target, ty_args), ret, name))
+            }
+            _ => {
+                self.error(
+                    span,
+                    format!(
+                        "a PolyFFI comparison bridge for a shared record requires a \
+                         non-regional implementation of `{method_name}`"
+                    ),
+                );
+                None
+            }
+        }
+    }
+
+    /// Validate a marker-only ground bound (currently `Eq`) before Rust source
+    /// is emitted, producing a Reussir diagnostic instead of deferring failure
+    /// to an `OrdBridge is not implemented` rustc message.
+    fn require_comparison_trait(
+        &mut self,
+        item: crate::semi::lang::LangItem,
+        ty: Ty<'tcx>,
+        span: Option<Span>,
+    ) -> bool {
+        use crate::semi::traits::{Obligation, SelectCtxt, SelectError, TraitRef};
+        let Some(db) = self.traits.db else {
+            self.error(span, "comparison-bound PolyFFI requires trait metadata");
+            return false;
+        };
+        let Some((&trait_def, _)) = self.lang.iter().find(|(_, found)| **found == item) else {
+            self.error(
+                span,
+                format!(
+                    "comparison-bound PolyFFI requires the `#[lang(\"{}\")]` trait",
+                    item.name()
+                ),
+            );
+            return false;
+        };
+        let Some(tid) = db.trait_by_def(trait_def) else {
+            self.error(
+                span,
+                "comparison lang item is absent from the trait database",
+            );
+            return false;
+        };
+        let goal = Obligation::Trait(TraitRef {
+            trait_id: tid,
+            args: vec![ty],
+        });
+        match SelectCtxt::new(db, self.tcx, &[]).select(&goal) {
+            Ok(_) => true,
+            Err(error) => {
+                let record = match *ty.kind() {
+                    TyKind::Record { def, .. } => {
+                        self.defs.path(def).display(self.resolver).to_string()
+                    }
+                    _ => format!("{ty:?}"),
+                };
+                let required = self.defs.path(trait_def).display(self.resolver);
+                let reason = match error {
+                    SelectError::NoImpl(_) => "has no applicable implementation",
+                    SelectError::DepthLimit(_) => "overflowed trait selection",
+                };
+                self.error(
+                    span,
+                    format!(
+                        "cannot synthesize a Rust FFI comparison bridge for `{record}`: \
+                         required Reussir trait `{required}` {reason}"
+                    ),
+                );
+                false
+            }
+        }
+    }
+
+    fn bridge_call(
+        &mut self,
+        callee: mir::Symbol,
+        arg_ty: Ty<'tcx>,
+        ret: Ty<'tcx>,
+    ) -> mir::Expr<'tcx> {
+        let lhs = self.synth_node(mir::ExprKind::Var(hir::VarId(0)), arg_ty);
+        let rhs = self.synth_node(mir::ExprKind::Var(hir::VarId(1)), arg_ty);
+        let args = self.tcx.alloc_slice(&[lhs, rhs]);
+        self.synth_node(
+            mir::ExprKind::Call {
+                callee,
+                args,
+                regional: false,
+            },
+            ret,
+        )
+    }
+
+    fn bridge_const(&mut self, value: i8, ty: Ty<'tcx>) -> mir::Expr<'tcx> {
+        let value = self.tcx.alloc(literal::Integer::from(value));
+        self.synth_node(mir::ExprKind::ConstInt(value), ty)
+    }
+
+    fn push_bridge_adapter(
+        &mut self,
+        symbol: mir::Symbol,
+        name: TokenKey,
+        ty: Ty<'tcx>,
+        ret: Ty<'tcx>,
+        body: mir::Expr<'tcx>,
+    ) {
+        let param = |var| mir::Param { name, var, ty };
+        self.synthetic_fns.push(mir::Function {
+            symbol,
+            transform_anchor: false,
+            visibility: crate::surface::Visibility::Private,
+            mono_exported: false,
+            is_regional: false,
+            params: vec![param(hir::VarId(0)), param(hir::VarId(1))],
+            return_ty: ret,
+            body: Some(self.tcx.alloc(body)),
+            file: self.cur_file,
+        });
+    }
+
+    fn synthesize_eq_bridge(
+        &mut self,
+        base: &str,
+        ty: Ty<'tcx>,
+        span: Option<Span>,
+        out: &mut std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>>,
+    ) {
+        let entry_name = format!("{base}_ffi_eq");
+        if out.contains_key(&entry_name) {
+            return;
+        }
+        let Some((callee, method_ret, name)) =
+            self.comparison_callee(crate::semi::lang::LangItem::PartialEq, "eq", ty, span)
+        else {
+            return;
+        };
+        if !matches!(*method_ret.kind(), TyKind::Bool) {
+            self.error(span, "`PartialEq::eq` must return `bool`");
+            return;
+        }
+        let ret = self.tcx.mk_int(IntTy::Unsigned(8));
+        let call = self.bridge_call(callee, ty, method_ret);
+        let one = self.bridge_const(1, ret);
+        let zero = self.bridge_const(0, ret);
+        let body = self.synth_node(
+            mir::ExprKind::If(
+                self.tcx.alloc(call),
+                self.tcx.alloc(one),
+                self.tcx.alloc(zero),
+            ),
+            ret,
+        );
+        let adapter = mir::Symbol(self.symbols.get_or_intern(format!("{base}_ffi_eq_adapter")));
+        self.push_bridge_adapter(adapter, name, ty, ret, body);
+        let entry = mir::Symbol(self.symbols.get_or_intern(&entry_name));
+        out.insert(
+            entry_name,
+            mir::FfiTraitGlue {
+                ty,
+                ret,
+                entry,
+                target: adapter,
+            },
+        );
+    }
+
+    fn register_ffi_bridges(
+        &mut self,
+        decls: &std::collections::BTreeMap<String, WrapperDecl<'tcx>>,
+        span: Option<Span>,
+        out: &mut std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>>,
+    ) {
+        for (base, decl) in decls {
+            if decl.needs.eq() {
+                self.require_comparison_trait(crate::semi::lang::LangItem::Eq, decl.ty, span);
+            }
+            if decl.needs.partial_eq() {
+                self.synthesize_eq_bridge(base, decl.ty, span, out);
+            }
         }
     }
 

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -1252,6 +1252,85 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         );
     }
 
+    /// Convert `core::cmp::Ordering` to the stable Rust-facing `i8` ABI code.
+    /// Variant names, not source tag order, define the mapping.
+    fn synthesize_cmp_bridge(
+        &mut self,
+        base: &str,
+        ty: Ty<'tcx>,
+        span: Option<Span>,
+        out: &mut std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>>,
+    ) {
+        let entry_name = format!("{base}_ffi_cmp");
+        if out.contains_key(&entry_name) {
+            return;
+        }
+        let Some((callee, ordering, name)) =
+            self.comparison_callee(crate::semi::lang::LangItem::Ord, "cmp", ty, span)
+        else {
+            return;
+        };
+        let TyKind::Record { def, args, .. } = *ordering.kind() else {
+            self.error(span, "`Ord::cmp` must return `core`'s `Ordering`");
+            return;
+        };
+        let Some(RecordFields::Variants(variants)) =
+            self.record_defs.get(&def).and_then(|r| r.fields.as_ref())
+        else {
+            self.error(span, "`Ord::cmp` must return `core`'s `Ordering`");
+            return;
+        };
+        let codes: Option<Vec<i8>> = variants
+            .iter()
+            .map(|variant| match self.resolver.try_resolve(variant.name) {
+                Some("Less") => Some(-1),
+                Some("Equal") => Some(0),
+                Some("Greater") => Some(1),
+                _ => None,
+            })
+            .collect();
+        let Some(codes) = codes.filter(|codes| codes.len() == 3) else {
+            self.error(
+                span,
+                "`Ordering` must have exactly `Less`, `Equal`, and `Greater` variants",
+            );
+            return;
+        };
+        self.record_symbol(def, args);
+        let ret = self.tcx.mk_int(IntTy::Signed(8));
+        let call = self.bridge_call(callee, ty, ordering);
+        let arms: Vec<mir::DecisionTree<'tcx>> = codes
+            .into_iter()
+            .map(|code| {
+                let body = self.bridge_const(code, ret);
+                mir::DecisionTree::Leaf {
+                    body: self.tcx.alloc(body),
+                    bindings: &[],
+                }
+            })
+            .collect();
+        let tree = mir::DecisionTree::Switch {
+            scrutinee: &[],
+            cases: mir::SwitchCases::Ctor(self.tcx.alloc_slice(&arms)),
+        };
+        let body = self.synth_node(mir::ExprKind::Match(self.tcx.alloc(call), tree), ret);
+        let adapter = mir::Symbol(
+            self.symbols
+                .get_or_intern(format!("{base}_ffi_cmp_adapter")),
+        );
+        self.push_bridge_adapter(adapter, name, ty, ret, body);
+        let entry = mir::Symbol(self.symbols.get_or_intern(&entry_name));
+        out.insert(
+            entry_name,
+            mir::FfiTraitGlue {
+                ty,
+                ret,
+                entry,
+                target: adapter,
+            },
+        );
+    }
+
     fn register_ffi_bridges(
         &mut self,
         decls: &std::collections::BTreeMap<String, WrapperDecl<'tcx>>,
@@ -1264,6 +1343,9 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             }
             if decl.needs.partial_eq() {
                 self.synthesize_eq_bridge(base, decl.ty, span, out);
+            }
+            if decl.needs.ord() {
+                self.synthesize_cmp_bridge(base, decl.ty, span, out);
             }
         }
     }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -371,9 +371,46 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
         std::collections::BTreeMap::new();
     let mut ffi_trait_glue: std::collections::BTreeMap<String, mir::FfiTraitGlue<'tcx>> =
         std::collections::BTreeMap::new();
+    let mut bridge_scanned_records: FxHashSet<(DefId, &'tcx [Ty<'tcx>])> = FxHashSet::default();
+    let mut closed_record_count = 0;
 
     let mut functions = Vec::new();
-    while let Some(inst) = driver.queue.pop_front() {
+    while let Some(inst) = {
+        // Reaching an empty queue is a fixed-point opportunity: close ground
+        // layouts over fields, then discover bridge needs in every newly seen
+        // opaque instance. Selection may enqueue comparison methods, in which
+        // case this same loop resumes and drains them normally.
+        if driver.queue.is_empty() && driver.records.len() != closed_record_count {
+            driver.close_records_over_fields(input.records, tcx);
+            closed_record_count = driver.records.len();
+        }
+        if driver.queue.is_empty() {
+            let mut candidates: Vec<_> = driver.records.iter().copied().collect();
+            candidates.sort_by_cached_key(|(def, args)| instance_symbol(*def, args));
+            for (def, args) in candidates {
+                if !bridge_scanned_records.insert((def, args)) {
+                    continue;
+                }
+                let Some(record) = input.records.get(&def).filter(|r| r.ffi.is_some()) else {
+                    continue;
+                };
+                let fctx = FfiCtx {
+                    records: input.records,
+                    traits: input.traits.db,
+                    generic_env: input.traits.env,
+                    lang: &input.lang,
+                    instance_symbol: &instance_symbol,
+                };
+                let ty = tcx.mk_record(def, args, Flexivity::Irrelevant);
+                let mut decls = std::collections::BTreeMap::new();
+                if fctx.rust_name(ty, &mut decls).is_ok() {
+                    driver.cur_file = record.file;
+                    driver.register_ffi_bridges(&decls, record.span, &mut ffi_trait_glue);
+                }
+            }
+        }
+        driver.queue.pop_front()
+    } {
         let Some(func) = by_def.get(&inst.def) else {
             // Neither a local definition nor an imported body/prototype: with
             // externs in play a silent skip would manufacture an undefined
@@ -505,7 +542,6 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
                         placeholders.insert(input.resolver.resolve(*gname), rendered);
                     }
                 }
-                driver.register_ffi_bridges(&decls, fimport.span, &mut ffi_trait_glue);
                 let body_text = ffi_render::substitute_placeholders(&fimport.body, &placeholders);
                 // File ids are one space (externs remap at declaration), so
                 // the per-file prelude pairing holds across both tables.
@@ -559,11 +595,6 @@ pub fn monomorphize<'a, 'tcx>(input: &MonoInput<'a, 'tcx>) -> (mir::Program<'tcx
             file: func.file,
         });
     }
-
-    // Close the record set over fields before resolving layouts: a record used
-    // only as another record's field is otherwise never collected, leaving its
-    // layout unresolved.
-    driver.close_records_over_fields(input.records, tcx);
 
     // Reject inline-recursive record *instances* before resolving layouts: a
     // `[value]` record stored inside itself through a chain of inline members
@@ -1059,15 +1090,43 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
         span: Option<Span>,
     ) -> Option<(mir::Symbol, Ty<'tcx>, TokenKey)> {
         let (trait_def, method, ret, name) = {
-            let db = self.traits.db?;
-            let (&trait_def, _) = self.lang.iter().find(|(_, found)| **found == item)?;
-            let tid = db.trait_by_def(trait_def)?;
+            let Some(db) = self.traits.db else {
+                self.error(span, "comparison-bound PolyFFI requires trait metadata");
+                return None;
+            };
+            let Some((&trait_def, _)) = self.lang.iter().find(|(_, found)| **found == item) else {
+                self.error(
+                    span,
+                    format!(
+                        "comparison-bound PolyFFI requires the `#[lang(\"{}\")]` trait",
+                        item.name()
+                    ),
+                );
+                return None;
+            };
+            let Some(tid) = db.trait_by_def(trait_def) else {
+                self.error(
+                    span,
+                    "comparison lang item is absent from the trait database",
+                );
+                return None;
+            };
             let tdef = db.trait_def(tid);
-            let (method, sig) = tdef
+            let Some((method, sig)) = tdef
                 .methods
                 .iter()
                 .enumerate()
-                .find(|(_, sig)| self.resolver.try_resolve(sig.name) == Some(method_name))?;
+                .find(|(_, sig)| self.resolver.try_resolve(sig.name) == Some(method_name))
+            else {
+                self.error(
+                    span,
+                    format!(
+                        "comparison lang trait `#[lang(\"{}\")]` does not define `{method_name}`",
+                        item.name()
+                    ),
+                );
+                return None;
+            };
             let mut subst = Subst::default();
             subst.insert(tdef.self_param, ty);
             (
@@ -2570,6 +2629,58 @@ mod tests {
             assert!(reports.is_empty(), "mono diagnostics: {reports:#?}");
             MirPrinter::new(&elab.defs, elab.resolver).program(&full)
         })
+    }
+
+    /// An opaque container reachable only through another record's field has
+    /// no import texture to trigger bridge discovery. Record closure at the
+    /// queue fixed point must still synthesize its comparison glue before
+    /// layouts and drop textures are emitted.
+    #[test]
+    fn opaque_drop_texture_discovers_nested_comparison_bridges() {
+        let source = format!(
+            r#"{CMP_TOWER}
+            #[ffi(rust = "::std::collections::BTreeSet")]
+            pub struct BTreeSet<T: Ord>;
+
+            pub struct Key {{ value: i64 }}
+            impl PartialEq for Key {{
+                fn eq(self: Self, other: Self) -> bool {{ self.value == other.value }}
+            }}
+            impl Eq for Key {{}}
+            impl PartialOrd for Key {{
+                fn lt(self: Self, other: Self) -> bool {{ self.value < other.value }}
+                fn le(self: Self, other: Self) -> bool {{ self.value <= other.value }}
+                fn gt(self: Self, other: Self) -> bool {{ self.value > other.value }}
+                fn ge(self: Self, other: Self) -> bool {{ self.value >= other.value }}
+            }}
+            impl Ord for Key {{
+                fn cmp(self: Self, other: Self) -> Ordering {{
+                    if self.value < other.value {{ Ordering::Less }} else {{
+                        if self.value == other.value {{ Ordering::Equal }}
+                        else {{ Ordering::Greater }}
+                    }}
+                }}
+            }}
+
+            pub struct Holder {{ set: BTreeSet<Key> }}
+            pub fn keep(value: Holder) -> Holder {{ value }}"#
+        );
+        with_full(&source, |full| {
+            assert!(
+                full.ffi_imports.is_empty(),
+                "the fixture has no import texture"
+            );
+            let entries: Vec<_> = full
+                .ffi_trait_glue
+                .iter()
+                .map(|glue| full.symbol(glue.entry))
+                .collect();
+            assert!(entries.iter().any(|entry| entry.ends_with("_ffi_eq")));
+            assert!(entries.iter().any(|entry| entry.ends_with("_ffi_cmp")));
+            assert!(full.ffi_textures.iter().any(|texture| {
+                texture.texture.contains("BTreeSet<") && texture.texture.contains("bridge::Bridge<")
+            }));
+        });
     }
 
     /// A `TraitCall` that selects a method-less compiler impl of an

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -257,6 +257,81 @@ impl<'tcx> Parsed<'tcx> {
         }
         db
     }
+
+    /// Rebuild the per-generic bound environment this dump serialized, dense
+    /// by [`GenericId`] — the same table an elaborated session hands
+    /// monomorphization ([`crate::semi::ctxt::Ctxt::generics`]).
+    ///
+    /// A binder's declared bounds are not just checking material: they decide
+    /// which comparison bridges a PolyFFI texture renders and which traits the
+    /// interface export closure ships. Resuming without them is not a
+    /// conservative choice — it silently produces a *different* program. Pass
+    /// the [`TraitDb`] this dump's [`rebuild_traits`] returned, so bound paths
+    /// resolve against the same trait identities.
+    ///
+    /// Bounds naming a trait this dump does not carry are dropped: the
+    /// serialized program never mentioned it, so nothing downstream can select
+    /// through it either.
+    ///
+    /// [`TraitDb`]: crate::semi::traits::TraitDb
+    /// [`rebuild_traits`]: Self::rebuild_traits
+    pub fn rebuild_generic_env(
+        &mut self,
+        db: &crate::semi::traits::TraitDb<'tcx>,
+    ) -> Vec<crate::semi::ctxt::GenericInfo> {
+        use crate::semi::ctxt::GenericInfo;
+
+        // Binder names live on the items, the bounds in their own table; a
+        // generic that appears in neither still needs a dense slot.
+        let mut names: FxHashMap<GenericId, TokenKey> = FxHashMap::default();
+        let item_binders = self
+            .funcs
+            .iter()
+            .map(|f| f.generics.as_slice())
+            .chain(self.records.values().map(|r| r.ty_params.as_slice()));
+        for &(name, g) in item_binders.flatten() {
+            names.insert(g, name);
+        }
+        for t in &self.traits {
+            for (g, name) in &t.generics {
+                names.insert(*g, self.names.intern(name.as_deref().unwrap_or("_")));
+            }
+        }
+        let len = names
+            .keys()
+            .chain(self.generic_bounds.keys())
+            .map(|g| g.0 as usize + 1)
+            .max()
+            .unwrap_or(0);
+        let anonymous = self.names.intern("_");
+        let mut env: Vec<GenericInfo> = (0..len)
+            .map(|i| GenericInfo {
+                name: names
+                    .get(&GenericId(i as u32))
+                    .copied()
+                    .unwrap_or(anonymous),
+                bounds: Vec::new(),
+            })
+            .collect();
+        for (&g, bounds) in &self.generic_bounds {
+            let Some(slot) = env.get_mut(g.0 as usize) else {
+                continue;
+            };
+            slot.bounds = bounds
+                .iter()
+                .filter_map(|b| {
+                    let segs: Vec<TokenKey> = b
+                        .trait_path()
+                        .to_string()
+                        .split("::")
+                        .map(|s| self.names.intern(s))
+                        .collect();
+                    db.trait_by_def(self.defs.lookup_trait(&segs)?)
+                })
+                .collect();
+        }
+        env
+    }
 }
 
 /// Parse `text` into a fresh HIR program (interning types into `tcx`).

--- a/crates/reussir-core/src/semi/traits/coherence.rs
+++ b/crates/reussir-core/src/semi/traits/coherence.rs
@@ -100,8 +100,8 @@ fn occurs(g: GenericId, ty: Ty<'_>, subst: &FxHashMap<GenericId, Ty<'_>>) -> boo
         TyKind::Generic(h) => g == h,
         TyKind::Nullable(inner) | TyKind::Arc(inner) => occurs(g, inner, subst),
         TyKind::Cell { elem, .. } | TyKind::Array { elem, .. } => occurs(g, elem, subst),
-        TyKind::Record { ref args, .. } => args.iter().any(|&a| occurs(g, a, subst)),
-        TyKind::Closure { ref params, ret } => {
+        TyKind::Record { args, .. } => args.iter().any(|&a| occurs(g, a, subst)),
+        TyKind::Closure { params, ret } => {
             params.iter().any(|&p| occurs(g, p, subst)) || occurs(g, ret, subst)
         }
         _ => false,

--- a/crates/reussir-core/src/semi/traits/db.rs
+++ b/crates/reussir-core/src/semi/traits/db.rs
@@ -165,7 +165,7 @@ impl<'tcx> TraitDb<'tcx> {
 mod tests {
     use super::*;
     use crate::semi::traits::builtins::Builtins;
-    use crate::semi::ty::{FpTy, IntTy, Ty, TyCtxt};
+    use crate::semi::ty::TyCtxt;
     use crate::with_tcx;
 
     #[test]

--- a/crates/reussir-core/src/semi/traits/subst.rs
+++ b/crates/reussir-core/src/semi/traits/subst.rs
@@ -28,11 +28,7 @@ pub fn replace_generics<'tcx>(
             let n = replace_generics(tcx, elem, map);
             if n == elem { ty } else { tcx.mk_cell(n, kind) }
         }
-        TyKind::Record {
-            def,
-            ref args,
-            flex,
-        } => {
+        TyKind::Record { def, args, flex } => {
             let new: Vec<Ty> = args
                 .iter()
                 .map(|&a| replace_generics(tcx, a, map))
@@ -43,7 +39,7 @@ pub fn replace_generics<'tcx>(
                 tcx.mk_record(def, &new, flex)
             }
         }
-        TyKind::Closure { ref params, ret } => {
+        TyKind::Closure { params, ret } => {
             let new: Vec<Ty> = params
                 .iter()
                 .map(|&p| replace_generics(tcx, p, map))
@@ -55,7 +51,7 @@ pub fn replace_generics<'tcx>(
                 tcx.mk_closure(&new, r)
             }
         }
-        TyKind::Array { elem, ref dims } => {
+        TyKind::Array { elem, dims } => {
             let n = replace_generics(tcx, elem, map);
             if n == elem { ty } else { tcx.mk_array(n, dims) }
         }
@@ -71,8 +67,8 @@ pub fn collect_generics_of(ty: Ty<'_>, out: &mut rustc_hash::FxHashSet<GenericId
         }
         TyKind::Nullable(inner) | TyKind::Arc(inner) => collect_generics_of(inner, out),
         TyKind::Cell { elem, .. } => collect_generics_of(elem, out),
-        TyKind::Record { ref args, .. } => args.iter().for_each(|&a| collect_generics_of(a, out)),
-        TyKind::Closure { ref params, ret } => {
+        TyKind::Record { args, .. } => args.iter().for_each(|&a| collect_generics_of(a, out)),
+        TyKind::Closure { params, ret } => {
             params.iter().for_each(|&p| collect_generics_of(p, out));
             collect_generics_of(ret, out);
         }

--- a/crates/reussir-rt/src/bridge.rs
+++ b/crates/reussir-rt/src/bridge.rs
@@ -1,0 +1,191 @@
+use std::cmp::Ordering;
+
+/// Supplies equality for a compiler-emitted PolyFFI wrapper.
+pub trait PartialEqBridge {
+    fn eq_bridge(&self, other: &Self) -> bool;
+}
+
+/// Marks a bridged equality implementation as reflexive.
+pub trait EqBridge: PartialEqBridge {}
+
+/// Supplies partial ordering for a compiler-emitted PolyFFI wrapper.
+pub trait PartialOrdBridge: PartialEqBridge {
+    fn partial_cmp_bridge(&self, other: &Self) -> Option<Ordering>;
+}
+
+/// Supplies total ordering for a compiler-emitted PolyFFI wrapper.
+pub trait OrdBridge: EqBridge + PartialOrdBridge {
+    fn cmp_bridge(&self, other: &Self) -> Ordering;
+}
+
+/// Adds Rust comparison traits to a compiler-emitted PolyFFI wrapper.
+///
+/// The inner type owns the Reussir-specific behavior. This transparent newtype
+/// only adapts that behavior to Rust's standard traits and does not add runtime
+/// state to values crossing the FFI boundary.
+#[repr(transparent)]
+pub struct Bridge<T>(T);
+
+impl<T> Bridge<T> {
+    pub const fn new(inner: T) -> Self {
+        Self(inner)
+    }
+
+    pub const fn as_inner(&self) -> &T {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T: Clone> Clone for Bridge<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: PartialEqBridge> PartialEq for Bridge<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq_bridge(&other.0)
+    }
+}
+
+impl<T: EqBridge> Eq for Bridge<T> {}
+
+impl<T: PartialOrdBridge> PartialOrd for Bridge<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp_bridge(&other.0)
+    }
+}
+
+impl<T: OrdBridge> Ord for Bridge<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp_bridge(&other.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::Cell, mem};
+
+    use super::*;
+
+    struct CountingValue<'a> {
+        value: i32,
+        calls: &'a Cell<usize>,
+    }
+
+    impl PartialEqBridge for CountingValue<'_> {
+        fn eq_bridge(&self, other: &Self) -> bool {
+            self.calls.set(self.calls.get() + 1);
+            self.value == other.value
+        }
+    }
+
+    impl EqBridge for CountingValue<'_> {}
+
+    impl PartialOrdBridge for CountingValue<'_> {
+        fn partial_cmp_bridge(&self, other: &Self) -> Option<Ordering> {
+            self.calls.set(self.calls.get() + 1);
+            Some(self.value.cmp(&other.value))
+        }
+    }
+
+    impl OrdBridge for CountingValue<'_> {
+        fn cmp_bridge(&self, other: &Self) -> Ordering {
+            self.calls.set(self.calls.get() + 1);
+            self.value.cmp(&other.value)
+        }
+    }
+
+    struct PartialValue(f32);
+
+    impl PartialEqBridge for PartialValue {
+        fn eq_bridge(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    impl PartialOrdBridge for PartialValue {
+        fn partial_cmp_bridge(&self, other: &Self) -> Option<Ordering> {
+            self.0.partial_cmp(&other.0)
+        }
+    }
+
+    #[test]
+    fn bridge_is_transparent_and_dispatches_once() {
+        assert_eq!(mem::size_of::<Bridge<usize>>(), mem::size_of::<usize>());
+        assert_eq!(mem::align_of::<Bridge<usize>>(), mem::align_of::<usize>());
+
+        let calls = Cell::new(0);
+        let lhs = Bridge::new(CountingValue {
+            value: 4,
+            calls: &calls,
+        });
+        let rhs = Bridge::new(CountingValue {
+            value: 7,
+            calls: &calls,
+        });
+
+        assert!(lhs != rhs);
+        assert_eq!(calls.get(), 1);
+        calls.set(0);
+        assert_eq!(lhs.cmp(&rhs), Ordering::Less);
+        assert_eq!(calls.get(), 1);
+
+        fn requires_eq<T: Eq>(_: &T) {}
+        requires_eq(&lhs);
+    }
+
+    #[test]
+    fn partial_order_preserves_all_results() {
+        let one = Bridge::new(PartialValue(1.0));
+        let two = Bridge::new(PartialValue(2.0));
+        let nan = Bridge::new(PartialValue(f32::NAN));
+
+        assert_eq!(one.partial_cmp(&two), Some(Ordering::Less));
+        assert_eq!(two.partial_cmp(&two), Some(Ordering::Equal));
+        assert_eq!(two.partial_cmp(&one), Some(Ordering::Greater));
+        assert_eq!(one.partial_cmp(&nan), None);
+    }
+
+    struct Tracked<'a> {
+        clones: &'a Cell<usize>,
+        drops: &'a Cell<usize>,
+    }
+
+    impl Clone for Tracked<'_> {
+        fn clone(&self) -> Self {
+            self.clones.set(self.clones.get() + 1);
+            Self {
+                clones: self.clones,
+                drops: self.drops,
+            }
+        }
+    }
+
+    impl Drop for Tracked<'_> {
+        fn drop(&mut self) {
+            self.drops.set(self.drops.get() + 1);
+        }
+    }
+
+    #[test]
+    fn clone_and_drop_delegate_to_the_inner_value() {
+        let clones = Cell::new(0);
+        let drops = Cell::new(0);
+        let original = Bridge::new(Tracked {
+            clones: &clones,
+            drops: &drops,
+        });
+
+        let cloned = original.clone();
+        assert_eq!(clones.get(), 1);
+        drop(cloned);
+        assert_eq!(drops.get(), 1);
+        drop(original);
+        assert_eq!(drops.get(), 2);
+    }
+}

--- a/crates/reussir-rt/src/collections/btree_set.rs
+++ b/crates/reussir-rt/src/collections/btree_set.rs
@@ -1,0 +1,89 @@
+use std::collections::BTreeSet as StdBTreeSet;
+
+use crate::rc::Rc;
+
+/// A functional, copy-on-write ordered set for Reussir's polymorphic FFI.
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct BTreeSet<T: Ord + Clone>(Rc<StdBTreeSet<T>>);
+
+impl<T: Ord + Clone> Default for BTreeSet<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Ord + Clone> BTreeSet<T> {
+    pub fn new() -> Self {
+        Self(Rc::new(StdBTreeSet::new()))
+    }
+
+    pub fn insert(mut self, value: T) -> Self {
+        self.0.make_mut().insert(value);
+        self
+    }
+
+    pub fn remove(mut self, value: T) -> Self {
+        self.0.make_mut().remove(&value);
+        self
+    }
+
+    pub fn clear(mut self) -> Self {
+        self.0.make_mut().clear();
+        self
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn contains(&self, value: &T) -> bool {
+        self.0.contains(value)
+    }
+
+    pub fn first(&self) -> Option<T> {
+        self.0.first().cloned()
+    }
+
+    pub fn last(&self) -> Option<T> {
+        self.0.last().cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordered_set_operations() {
+        let set = BTreeSet::new().insert(2).insert(1).insert(3).insert(2);
+
+        assert_eq!(set.len(), 3);
+        assert!(!set.is_empty());
+        assert!(set.contains(&2));
+        assert_eq!(set.first(), Some(1));
+        assert_eq!(set.last(), Some(3));
+
+        let set = set.remove(2);
+        assert_eq!(set.len(), 2);
+        assert!(!set.contains(&2));
+        assert!(set.clear().is_empty());
+    }
+
+    #[test]
+    fn mutation_is_copy_on_write() {
+        let original = BTreeSet::new().insert(1).insert(2);
+        let changed = original.clone().insert(3).remove(1);
+
+        assert_eq!(original.len(), 2);
+        assert!(original.contains(&1));
+        assert!(!original.contains(&3));
+        assert_eq!(changed.len(), 2);
+        assert!(!changed.contains(&1));
+        assert!(changed.contains(&3));
+    }
+}

--- a/crates/reussir-rt/src/collections/mod.rs
+++ b/crates/reussir-rt/src/collections/mod.rs
@@ -1,2 +1,3 @@
+pub mod btree_set;
 pub mod string;
 pub mod vec;

--- a/crates/reussir-rt/src/lib.rs
+++ b/crates/reussir-rt/src/lib.rs
@@ -12,6 +12,7 @@
 static GLOBAL: alloc::ReussirGlobalAlloc = alloc::ReussirGlobalAlloc;
 
 pub mod alloc;
+pub mod bridge;
 pub mod collections;
 pub mod nullable;
 pub mod option;

--- a/docs/design/polymorphic-ffi.md
+++ b/docs/design/polymorphic-ffi.md
@@ -139,13 +139,23 @@ fn insert(
 ) -> RuntimeBTreeSet<Bridge<KeyInner>>
 ```
 
-When rendering an opaque FFI record, the compiler matches its formal generic
-parameters to the ground arguments and examines their declared bounds.
+A binder's declared bounds are what a rendered argument must satisfy, and
+both kinds of binder count. When rendering an opaque FFI record, the compiler
+matches its formal generic parameters to the ground arguments and examines
+their declared bounds. An `#[ffi(import)]` signature's own generics are the
+other source: `fn same<T: PartialEq>(lhs: T, rhs: T) -> bool` promises
+equality that its Rust body then uses directly, with no container in sight.
 Comparison lang items are found through trait identity and supertrait
 implication, not by spelling. Requirements from repeated appearances of the
 same shared-record instance are unioned before its inner declaration is
 rendered. Primitive arguments keep their native Rust spelling and use Rust's
 built-in comparison implementations; they are never wrapped in `Bridge`.
+
+Discovery is therefore a property of the *serialized* program, not of one
+compilation: HIR dumps carry their binder bounds, and a resumed build rebuilds
+that table alongside the trait database before monomorphizing. A resume that
+dropped it would not render a weaker program — it would render Rust that no
+longer compiles.
 
 The comparison tower is normalized and only the necessary foreign entries are
 emitted:
@@ -161,7 +171,8 @@ For `Ord`, `PartialOrdBridge::partial_cmp_bridge` returns `Some(cmp_bridge(...))
 so there is no separate partial-order entry. `EqBridge` is marker-only, matching
 Reussir's `Eq`; equality is supplied by `PartialEq`. A missing ground Reussir
 implementation is diagnosed during monomorphization, before the generated Rust
-is handed to `rustc`.
+is handed to `rustc` — once per rejected entry, however many textures and
+container instances wanted it.
 
 ### Borrowed comparison entries
 

--- a/docs/design/polymorphic-ffi.md
+++ b/docs/design/polymorphic-ffi.md
@@ -69,13 +69,145 @@ Both directions reduce to reference counts:
   mirroring the compiler's box header. `rc.dec` lowers to a call of the
   per-instance drop hook `<inst>_ffi_drop`, a generated Rust function that
   takes the value and drops it.
-* **Rust holding a Reussir value** (`Vec<List>`): the element is a generated
-  `#[repr(transparent)]` pointer wrapper named by the instance's v0 symbol,
-  whose `Clone`/`Drop` call compiler-emitted glue functions —
-  `<inst>_ffi_acquire` / `<inst>_ffi_release`, tiny Reussir functions
-  containing a single `rc.inc` / `rc.dec` (so fused headers, atomicity, and
-  drop dispatch are handled by the compiler's own lowering, uniformly for
-  structs and enums).
+* **Rust holding a Reussir value** (`Vec<List>`): the element is rendered as
+  `reussir_rt::bridge::Bridge<Inner>`. `Inner` is the generated
+  `#[repr(transparent)]` one-pointer wrapper named by the instance's v0
+  symbol. It remains the pointer's owner: its `Clone`/`Drop` call
+  compiler-emitted `<inst>_ffi_acquire` / `<inst>_ffi_release` functions,
+  tiny Reussir functions containing a single `rc.inc` / `rc.dec` (so fused
+  headers, atomicity, and drop dispatch are handled by the compiler's own
+  lowering, uniformly for structs and enums). `Bridge` is another transparent
+  layer; its `Clone` delegates to `Inner` and ordinary field destruction drops
+  `Inner`. It stores no descriptor, callback, or additional pointer.
+
+## Comparison bridges for foreign containers
+
+Rust containers place standard-trait bounds on their elements. For example,
+`std::collections::BTreeSet<T>` requires Rust's `Ord`, while a shared Reussir
+record implements Reussir's `core::cmp::Ord`. The two traits are distinct
+across the language boundary. Emitting every standard-trait adapter directly
+on every generated pointer wrapper would duplicate the generic Rust-facing
+part of the bridge in each PolyFFI texture.
+
+The runtime therefore owns a transparent adapter and four local behavior
+traits:
+
+```rust
+pub trait PartialEqBridge {
+    fn eq_bridge(&self, other: &Self) -> bool;
+}
+pub trait EqBridge: PartialEqBridge {}
+pub trait PartialOrdBridge: PartialEqBridge {
+    fn partial_cmp_bridge(&self, other: &Self) -> Option<std::cmp::Ordering>;
+}
+pub trait OrdBridge: EqBridge + PartialOrdBridge {
+    fn cmp_bridge(&self, other: &Self) -> std::cmp::Ordering;
+}
+
+#[repr(transparent)]
+pub struct Bridge<T>(T);
+
+impl<T: PartialEqBridge> PartialEq for Bridge<T> { /* delegate to T */ }
+impl<T: EqBridge> Eq for Bridge<T> {}
+impl<T: PartialOrdBridge> PartialOrd for Bridge<T> { /* delegate to T */ }
+impl<T: OrdBridge> Ord for Bridge<T> { /* delegate to T */ }
+```
+
+PolyFFI emits the Reussir-specific bridge-trait implementations on `Inner`,
+which is local to the generated texture; `reussir-rt` owns `Bridge` and the
+standard Rust implementations. This division satisfies Rust's coherence rules
+without a runtime trait object. `Bridge<Inner>` is still exactly one pointer.
+It does not use `reussir_rt::rc::Rc<Marker>`: that type owns a Rust `RcBox` and
+would run the wrong payload destruction for a compiler-owned Reussir record.
+
+### Uniform rendering and bound discovery
+
+A shared Reussir ground type is rendered uniformly as `Bridge<Inner>` at every
+position in a texture, whether or not a particular position supplied the
+comparison requirement. Thus an import such as
+
+```rust
+fn insert<T: Ord>(set: BTreeSet<T>, value: T) -> BTreeSet<T>
+```
+
+has one consistent Rust shape:
+
+```rust
+fn insert(
+    set: RuntimeBTreeSet<Bridge<KeyInner>>,
+    value: Bridge<KeyInner>,
+) -> RuntimeBTreeSet<Bridge<KeyInner>>
+```
+
+When rendering an opaque FFI record, the compiler matches its formal generic
+parameters to the ground arguments and examines their declared bounds.
+Comparison lang items are found through trait identity and supertrait
+implication, not by spelling. Requirements from repeated appearances of the
+same shared-record instance are unioned before its inner declaration is
+rendered. Primitive arguments keep their native Rust spelling and use Rust's
+built-in comparison implementations; they are never wrapped in `Bridge`.
+
+The comparison tower is normalized and only the necessary foreign entries are
+emitted:
+
+| Reussir requirement | generated behavior on `Inner` | foreign entries |
+|---------------------|--------------------------------|-----------------|
+| `PartialEq` | `PartialEqBridge` | `_ffi_eq` |
+| `Eq` | `PartialEqBridge`, `EqBridge` | `_ffi_eq` |
+| `PartialOrd` | `PartialEqBridge`, `PartialOrdBridge` | `_ffi_eq`, `_ffi_partial_cmp` |
+| `Ord` | all four bridge traits | `_ffi_eq`, `_ffi_cmp` |
+
+For `Ord`, `PartialOrdBridge::partial_cmp_bridge` returns `Some(cmp_bridge(...))`,
+so there is no separate partial-order entry. `EqBridge` is marker-only, matching
+Reussir's `Eq`; equality is supplied by `PartialEq`. A missing ground Reussir
+implementation is diagnosed during monomorphization, before the generated Rust
+is handed to `rustc`.
+
+### Borrowed comparison entries
+
+Rust's comparison methods borrow both operands, whereas Reussir's comparison
+methods consume shared values. Each generated entry therefore accepts two raw
+RC handles borrowed from `Inner`, performs exactly two compiler-side acquires
+(`rc.inc`, one per operand), and directly calls a synthesized semantic adapter.
+The adapter consumes those acquired values under the ordinary Reussir ownership
+rules and returns a scalar ABI code. The entry performs no matching release:
+the selected method and ownership lowering settle the two acquired references.
+There are no Rust-side clones, acquire callbacks, dictionaries, or allocations
+on this path, and optimized builds can inline through the linked texture.
+
+The scalar contracts are stable and independent of enum layout:
+
+* `_ffi_eq` returns `u8` zero or one after calling the selected
+  `PartialEq::eq` implementation;
+* `_ffi_cmp` calls `Ord::cmp` and classifies `Ordering` by variant name as
+  `Less = -1`, `Equal = 0`, `Greater = 1` in an `i8`;
+* `_ffi_partial_cmp` makes one foreign entry call and classifies through
+  `PartialEq::eq`, then `PartialOrd::lt`, then `PartialOrd::gt` as needed. Its
+  `i8` codes are `Less = -1`, `Equal = 0`, `Greater = 1`, and
+  `Incomparable = 2`; Rust maps the final code to `Option<Ordering>`.
+
+The semantic adapter is an ordinary monomorphic MIR function. Consequently its
+trait calls use the same selection, ownership, optimization, and diagnostics as
+source-level Reussir calls. The borrowed entry itself is small and direct: two
+increments, one adapter call, and one scalar return.
+
+### Comparison implementations from another package
+
+No comparison dictionary or global instance registry is added for PolyFFI.
+Suppose package A defines a public shared `A::Key` and implements the core
+comparison traits, while only package B instantiates
+`BTreeSet<A::Key>`. A's RRI already exports the relevant impl metadata and
+method prototypes or generic bodies. When B loads that interface, its ordinary
+trait database reconstructs those impls. Bridge synthesis in B performs normal
+ground trait selection, selects A's implementation, and enqueues the same
+method symbol an ordinary trait call would use.
+
+A ground implementation method resolves from A's linked archive; an exported
+generic body can be instantiated in B. `rene` supplies the transitive RRI and
+archive dependency cone, while a direct `rrc` invocation must pass the
+corresponding `--extern` interface and `--link-lib` archive. Bridge entry names
+derive from the ground record symbol and use coalescible linkage, so identical
+downstream bridge generation does not create a second instance mechanism.
 
 ## The boundary convention
 
@@ -112,6 +244,9 @@ valid v0 mangling is a prefix of another:
 | `<fn instance>_ffi`         | the Rust-side boundary wrapper          |
 | `<record instance>_ffi_drop`| an opaque instance's drop hook          |
 | `<record instance>_ffi_acquire` / `_ffi_release` | Reussir rc glue    |
+| `<record instance>_ffi_eq`  | borrowed equality entry (`u8`)          |
+| `<record instance>_ffi_partial_cmp` | borrowed partial classifier (`i8`) |
+| `<record instance>_ffi_cmp` | borrowed total-order entry (`i8`)       |
 
 ## Boundary types (v1)
 
@@ -161,11 +296,15 @@ gather polyffi modules yet and rejects programs containing them.
   (`ffi_attr`, `validate_ffi_record`, `validate_ffi_function`,
   `FfiPrelude`/`FfiImport` tables, `RecordFields::Opaque`);
 * rendering: `crates/reussir-core/src/full/ffi.rs` (Rust spellings,
-  classification, wrapper/drop textures), driven per instance from
-  `full/mono.rs`; MIR carries `ffi_imports`/`ffi_textures`/`ffi_rc_glue`
-  and `RecordLayout::Opaque`, round-tripping through both textual IRs;
+  comparison-bound discovery, `Bridge<Inner>` declarations,
+  wrapper/drop textures), driven per instance from `full/mono.rs` (ground
+  comparison selection and semantic adapters); MIR carries
+  `ffi_imports`/`ffi_textures`/`ffi_rc_glue`/`ffi_trait_glue` and
+  `RecordLayout::Opaque`, round-tripping through both textual IRs;
+* runtime adapters: `crates/reussir-rt/src/bridge.rs` (the four behavior
+  traits and transparent `Bridge<T>` standard-trait implementations);
 * codegen: `crates/reussir-codegen/src/lower/{mod,ty,expr}.rs` (rc'd
-  `ffi_object` types, polyffi/trampoline emission, glue and hook
-  functions);
+  `ffi_object` types, polyffi/trampoline emission, lifecycle glue, borrowed
+  comparison entries, and hook functions);
 * MLIR: `reussir.trampoline` import direction materializes the native
   marshaling body (`lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp`).

--- a/tests/integration/frontend/ffi_btree_set_record_e2e.c
+++ b/tests/integration/frontend/ffi_btree_set_record_e2e.c
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+// Driver for ffi_btree_set_record_e2e.rr. The result encodes the old set's
+// first key and length followed by the new set's length and first key:
+// old={2,4}, new={1,2,3,4} => 2 2 4 1.
+
+#include <stdint.h>
+
+extern int64_t reussir_main(void);
+
+int main(void) { return reussir_main() == 2241 ? 0 : 1; }

--- a/tests/integration/frontend/ffi_btree_set_record_e2e.rr
+++ b/tests/integration/frontend/ffi_btree_set_record_e2e.rr
@@ -1,0 +1,113 @@
+// UNSUPPORTED: darwin
+// A Rust BTreeSet orders compiler-owned Reussir records through the Ord
+// bridge. Keeping `old` live while deriving `new` shares the runtime set;
+// the first insertion into `new` therefore takes the copy-on-write path and
+// clones every element through its compiler-emitted acquire glue. The
+// duplicate insertion also exercises equality without changing the length.
+
+// RUN: %rrc --package-root %S/../../../library/core/src --package-name core --core --emit rri -o %t.core.rri
+// RUN: %rrc %s --package-name btreeset --extern core=%t.core.rri --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=TEXTURE \
+// RUN:   --implicit-check-not="::reussir_rt::bridge::Bridge<i64>" \
+// RUN:   --implicit-check-not="_RNvC8btreeset3Key_ffi_partial_cmp" \
+// RUN:   --implicit-check-not="impl ::std::cmp::PartialEq for _RNvC8btreeset3Key" \
+// RUN:   --implicit-check-not="impl ::std::cmp::Eq for _RNvC8btreeset3Key" \
+// RUN:   --implicit-check-not="impl ::std::cmp::PartialOrd for _RNvC8btreeset3Key" \
+// RUN:   --implicit-check-not="impl ::std::cmp::Ord for _RNvC8btreeset3Key"
+// RUN: %rrc %s --package-name btreeset --extern core=%t.core.rri -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/ffi_btree_set_record_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s --package-name btreeset --extern core=%t.core.rri -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/ffi_btree_set_record_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+extern "rust" [{
+    use reussir_rt::collections::btree_set::BTreeSet as RBTreeSet;
+}];
+
+#[ffi(rust = "::reussir_rt::collections::btree_set::BTreeSet")]
+pub struct BTreeSet<T: Ord>;
+
+pub struct Key { value: i64 }
+
+impl PartialEq for Key {
+    fn eq(self: Self, other: Self) -> bool { self.value == other.value }
+}
+
+impl Eq for Key {}
+
+impl PartialOrd for Key {
+    fn lt(self: Self, other: Self) -> bool { self.value < other.value }
+    fn le(self: Self, other: Self) -> bool { self.value <= other.value }
+    fn gt(self: Self, other: Self) -> bool { self.value > other.value }
+    fn ge(self: Self, other: Self) -> bool { self.value >= other.value }
+}
+
+impl Ord for Key {
+    fn cmp(self: Self, other: Self) -> Ordering {
+        if self.value < other.value {
+            Ordering::Less
+        } else {
+            if self.value == other.value {
+                Ordering::Equal
+            } else {
+                Ordering::Greater
+            }
+        }
+    }
+}
+
+// Repeat the bound on every operation: opaque record application alone does
+// not establish the ground evidence needed by a generated bridge.
+#[ffi(import)]
+pub fn new<T: Ord>() -> BTreeSet<T> [{ RBTreeSet::new() }];
+
+#[ffi(import)]
+pub fn insert<T: Ord>(set: BTreeSet<T>, value: T) -> BTreeSet<T> [{
+    set.insert(value)
+}];
+
+#[ffi(import)]
+pub fn len<T: Ord>(set: BTreeSet<T>) -> i64 [{ set.len() as i64 }];
+
+#[ffi(import)]
+pub fn first<T: Ord>(set: BTreeSet<T>) -> T [{ set.first().unwrap() }];
+
+pub fn main() -> i64 {
+    let old = insert(insert(new<Key>(), Key{2}), Key{4});
+
+    // `old` remains live below, so deriving `new` first shares the outer
+    // Rust Rc. Inserting 1 clones the old tree and its bridged Key elements.
+    let changed = insert(old, Key{1});
+    let changed = insert(changed, Key{3});
+    let changed = insert(changed, Key{2});
+
+    let old_first = first(old).value;
+    let old_len = len(old);
+    let new_len = len(changed);
+    let new_first = first(changed).value;
+
+    // Also instantiate the same opaque container with a primitive key. It
+    // must use Rust's native Ord implementation and emit no Bridge<i64>.
+    let primitive_len = len(insert(new<i64>(), 9));
+    if primitive_len == 1 {
+        old_first * 1000 + old_len * 100 + new_len * 10 + new_first
+    } else {
+        0
+    }
+}
+
+extern "C" trampoline "reussir_main" = main;
+
+// Shared Key is rendered uniformly through Bridge<Inner>, including as the
+// BTreeSet element. PolyFFI emits only local bridge behavior on the inner
+// wrapper; the Rust standard comparison implementations remain in Bridge.
+// TEXTURE-DAG: ::reussir_rt::collections::btree_set::BTreeSet<::reussir_rt::bridge::Bridge<_RNvC8btreeset3Key>>
+// TEXTURE-DAG: unsafe fn _RNvC8btreeset3Key_ffi_eq(
+// TEXTURE-DAG: unsafe fn _RNvC8btreeset3Key_ffi_cmp(
+// TEXTURE-DAG: impl ::reussir_rt::bridge::PartialEqBridge for _RNvC8btreeset3Key
+// TEXTURE-DAG: impl ::reussir_rt::bridge::EqBridge for _RNvC8btreeset3Key
+// TEXTURE-DAG: impl ::reussir_rt::bridge::PartialOrdBridge for _RNvC8btreeset3Key
+// TEXTURE-DAG: impl ::reussir_rt::bridge::OrdBridge for _RNvC8btreeset3Key
+
+// Primitive keys remain unwrapped.
+// TEXTURE-DAG: ::reussir_rt::collections::btree_set::BTreeSet<i64>

--- a/tests/integration/frontend/ffi_btree_set_record_e2e.rr
+++ b/tests/integration/frontend/ffi_btree_set_record_e2e.rr
@@ -5,14 +5,13 @@
 // clones every element through its compiler-emitted acquire glue. The
 // duplicate insertion also exercises equality without changing the length.
 
+// The absent patterns run as their own prefix over the same texture rather
+// than through `--implicit-check-not`: the Python `filecheck` replacement used
+// on Windows rejects that flag.
 // RUN: %rrc --package-root %S/../../../library/core/src --package-name core --core --emit rri -o %t.core.rri
-// RUN: %rrc %s --package-name btreeset --extern core=%t.core.rri --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=TEXTURE \
-// RUN:   --implicit-check-not="::reussir_rt::bridge::Bridge<i64>" \
-// RUN:   --implicit-check-not="_RNvC8btreeset3Key_ffi_partial_cmp" \
-// RUN:   --implicit-check-not="impl ::std::cmp::PartialEq for _RNvC8btreeset3Key" \
-// RUN:   --implicit-check-not="impl ::std::cmp::Eq for _RNvC8btreeset3Key" \
-// RUN:   --implicit-check-not="impl ::std::cmp::PartialOrd for _RNvC8btreeset3Key" \
-// RUN:   --implicit-check-not="impl ::std::cmp::Ord for _RNvC8btreeset3Key"
+// RUN: %rrc %s --package-name btreeset --extern core=%t.core.rri --emit mlir --no-source-locations -o %t.texture.mlir
+// RUN: %FileCheck %s --check-prefix=TEXTURE --input-file=%t.texture.mlir
+// RUN: %FileCheck %s --check-prefix=ABSENT --input-file=%t.texture.mlir
 // RUN: %rrc %s --package-name btreeset --extern core=%t.core.rri -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/ffi_btree_set_record_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
@@ -111,3 +110,13 @@ extern "C" trampoline "reussir_main" = main;
 
 // Primitive keys remain unwrapped.
 // TEXTURE-DAG: ::reussir_rt::collections::btree_set::BTreeSet<i64>
+
+// A primitive element never grows bridge glue, a total order never falls back
+// to the four-state partial comparison, and the standard comparison traits are
+// implemented for `Bridge` in the runtime — never for the inner wrapper.
+// ABSENT-NOT: ::reussir_rt::bridge::Bridge<i64>
+// ABSENT-NOT: _RNvC8btreeset3Key_ffi_partial_cmp
+// ABSENT-NOT: impl ::std::cmp::PartialEq for _RNvC8btreeset3Key
+// ABSENT-NOT: impl ::std::cmp::Eq for _RNvC8btreeset3Key
+// ABSENT-NOT: impl ::std::cmp::PartialOrd for _RNvC8btreeset3Key
+// ABSENT-NOT: impl ::std::cmp::Ord for _RNvC8btreeset3Key

--- a/tests/integration/frontend/ffi_cmp_bridge_capabilities_e2e.c
+++ b/tests/integration/frontend/ffi_cmp_bridge_capabilities_e2e.c
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+// Driver for ffi_cmp_bridge_capabilities_e2e.rr. The Reussir entry point
+// returns 42 only after all exact-capability and four-state partial-order
+// checks have passed through Rust.
+
+#include <stdint.h>
+
+extern int64_t reussir_main(void);
+
+int main(void) { return reussir_main() == 42 ? 0 : 1; }

--- a/tests/integration/frontend/ffi_cmp_bridge_capabilities_e2e.rr
+++ b/tests/integration/frontend/ffi_cmp_bridge_capabilities_e2e.rr
@@ -1,0 +1,170 @@
+// UNSUPPORTED: darwin
+// Exact comparison capabilities on compiler-owned shared values crossing
+// PolyFFI. Each probe takes the element before its bounded Vec: rendering the
+// element first creates an unqualified wrapper request, then rendering the
+// container must union the stronger request before the texture is emitted.
+// The three distinct element types ensure the bridge does not accidentally
+// grant a stronger Rust comparison trait than the Reussir implementation.
+
+// RUN: %rrc --package-root %S/../../../library/core/src --package-name core --core --emit rri -o %t.core.rri
+// RUN: %rrc %s --package-name cmpcaps --extern core=%t.core.rri --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=TEXTURE \
+// RUN:   --implicit-check-not="bridge::EqBridge for _RNvC7cmpcaps6PeqKey" \
+// RUN:   --implicit-check-not="bridge::PartialOrdBridge for _RNvC7cmpcaps6PeqKey" \
+// RUN:   --implicit-check-not="bridge::OrdBridge for _RNvC7cmpcaps6PeqKey" \
+// RUN:   --implicit-check-not="bridge::PartialOrdBridge for _RNvC7cmpcaps5EqKey" \
+// RUN:   --implicit-check-not="bridge::OrdBridge for _RNvC7cmpcaps5EqKey" \
+// RUN:   --implicit-check-not="bridge::EqBridge for _RNvC7cmpcaps7PordKey" \
+// RUN:   --implicit-check-not="bridge::OrdBridge for _RNvC7cmpcaps7PordKey" \
+// RUN:   --implicit-check-not="_RNvC7cmpcaps6PeqKey_ffi_partial_cmp" \
+// RUN:   --implicit-check-not="_RNvC7cmpcaps6PeqKey_ffi_cmp" \
+// RUN:   --implicit-check-not="_RNvC7cmpcaps5EqKey_ffi_partial_cmp" \
+// RUN:   --implicit-check-not="_RNvC7cmpcaps5EqKey_ffi_cmp" \
+// RUN:   --implicit-check-not="_RNvC7cmpcaps7PordKey_ffi_cmp"
+// RUN: %rrc %s --package-name cmpcaps --extern core=%t.core.rri -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/ffi_cmp_bridge_capabilities_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s --package-name cmpcaps --extern core=%t.core.rri -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/ffi_cmp_bridge_capabilities_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+extern "rust" [{
+    use reussir_rt::collections::vec::Vec as RVec;
+}];
+
+#[ffi(rust = "::reussir_rt::collections::vec::Vec")]
+pub struct PartialEqVec<T: PartialEq>;
+
+#[ffi(rust = "::reussir_rt::collections::vec::Vec")]
+pub struct EqVec<T: Eq>;
+
+#[ffi(rust = "::reussir_rt::collections::vec::Vec")]
+pub struct PartialOrdVec<T: PartialOrd>;
+
+pub struct PeqKey { value: i64 }
+
+impl PartialEq for PeqKey {
+    fn eq(self: Self, other: Self) -> bool { self.value == other.value }
+}
+
+pub struct EqKey { value: i64 }
+
+impl PartialEq for EqKey {
+    fn eq(self: Self, other: Self) -> bool { self.value == other.value }
+}
+
+impl Eq for EqKey {}
+
+pub struct PordKey { group: i64, value: i64 }
+
+impl PartialEq for PordKey {
+    fn eq(self: Self, other: Self) -> bool {
+        self.group == other.group && self.value == other.value
+    }
+}
+
+impl PartialOrd for PordKey {
+    fn lt(self: Self, other: Self) -> bool {
+        self.group == other.group && self.value < other.value
+    }
+
+    fn le(self: Self, other: Self) -> bool {
+        self.group == other.group && self.value <= other.value
+    }
+
+    fn gt(self: Self, other: Self) -> bool {
+        self.group == other.group && self.value > other.value
+    }
+
+    fn ge(self: Self, other: Self) -> bool {
+        self.group == other.group && self.value >= other.value
+    }
+}
+
+#[ffi(import)]
+pub fn peq_new<T: PartialEq>() -> PartialEqVec<T> [{ RVec::new() }];
+
+#[ffi(import)]
+pub fn peq_push<T: PartialEq>(
+    values: PartialEqVec<T>,
+    value: T,
+) -> PartialEqVec<T> [{ values.push(value) }];
+
+#[ffi(import)]
+pub fn peq_same<T: PartialEq>(value: T, values: PartialEqVec<T>) -> bool [{
+    value == values.get(0).unwrap()
+}];
+
+#[ffi(import)]
+pub fn eq_new<T: Eq>() -> EqVec<T> [{ RVec::new() }];
+
+#[ffi(import)]
+pub fn eq_push<T: Eq>(values: EqVec<T>, value: T) -> EqVec<T> [{
+    values.push(value)
+}];
+
+#[ffi(import)]
+pub fn eq_same<T: Eq>(value: T, values: EqVec<T>) -> bool [{
+    fn requires_eq<T: Eq>(lhs: &T, rhs: &T) -> bool { lhs == rhs }
+    let first = values.get(0).unwrap();
+    requires_eq(&value, &first)
+}];
+
+#[ffi(import)]
+pub fn pord_new<T: PartialOrd>() -> PartialOrdVec<T> [{ RVec::new() }];
+
+#[ffi(import)]
+pub fn pord_push<T: PartialOrd>(
+    values: PartialOrdVec<T>,
+    value: T,
+) -> PartialOrdVec<T> [{ values.push(value) }];
+
+#[ffi(import)]
+pub fn pord_cmp<T: PartialOrd>(value: T, values: PartialOrdVec<T>) -> i64 [{
+    let first = values.get(0).unwrap();
+    match value.partial_cmp(&first) {
+        Some(::std::cmp::Ordering::Less) => -1,
+        Some(::std::cmp::Ordering::Equal) => 0,
+        Some(::std::cmp::Ordering::Greater) => 1,
+        None => 2,
+    }
+}];
+
+pub fn main() -> i64 {
+    let peq_values = peq_push(peq_new<PeqKey>(), PeqKey{7});
+    let peq_equal = peq_same(PeqKey{7}, peq_values);
+    let peq_different = peq_same(PeqKey{8}, peq_values);
+
+    let eq_values = eq_push(eq_new<EqKey>(), EqKey{11});
+    let eq_equal = eq_same(EqKey{11}, eq_values);
+    let eq_different = eq_same(EqKey{12}, eq_values);
+
+    let pord_values = pord_push(
+        pord_new<PordKey>(),
+        PordKey{group: 0, value: 20},
+    );
+    let less = pord_cmp(PordKey{group: 0, value: 10}, pord_values);
+    let equal = pord_cmp(PordKey{group: 0, value: 20}, pord_values);
+    let greater = pord_cmp(PordKey{group: 0, value: 30}, pord_values);
+    let incomparable = pord_cmp(PordKey{group: 1, value: 20}, pord_values);
+
+    if peq_equal && !peq_different
+        && eq_equal && !eq_different
+        && less == -1 && equal == 0 && greater == 1 && incomparable == 2 {
+        42
+    } else {
+        0
+    }
+}
+
+extern "C" trampoline "reussir_main" = main;
+
+// The element is rendered before the container in each probe texture, yet the
+// final declaration has the exact capability requested by the later container.
+// TEXTURE-DAG: reussir.polyffi texture("{{.*}}unsafe fn _RNvC7cmpcaps6PeqKey_ffi_eq({{.*}}impl ::reussir_rt::bridge::PartialEqBridge for _RNvC7cmpcaps6PeqKey{{.*}}fn _RINvC7cmpcaps8peq_sameNvC7cmpcaps6PeqKeyE_ffi(r#value: ::reussir_rt::bridge::Bridge<_RNvC7cmpcaps6PeqKey>, r#values: ::reussir_rt::collections::vec::Vec<::reussir_rt::bridge::Bridge<_RNvC7cmpcaps6PeqKey>>)
+
+// Eq adds only its marker to PartialEq; it must not synthesize ordering glue.
+// TEXTURE-DAG: reussir.polyffi texture("{{.*}}unsafe fn _RNvC7cmpcaps5EqKey_ffi_eq({{.*}}impl ::reussir_rt::bridge::PartialEqBridge for _RNvC7cmpcaps5EqKey{{.*}}impl ::reussir_rt::bridge::EqBridge for _RNvC7cmpcaps5EqKey{{.*}}fn _RINvC7cmpcaps7eq_sameNvC7cmpcaps5EqKeyE_ffi(r#value: ::reussir_rt::bridge::Bridge<_RNvC7cmpcaps5EqKey>, r#values: ::reussir_rt::collections::vec::Vec<::reussir_rt::bridge::Bridge<_RNvC7cmpcaps5EqKey>>)
+
+// A partial order has equality plus the four-state partial comparison bridge,
+// but neither the Eq marker nor the total-order bridge.
+// TEXTURE-DAG: reussir.polyffi texture("{{.*}}unsafe fn _RNvC7cmpcaps7PordKey_ffi_eq({{.*}}unsafe fn _RNvC7cmpcaps7PordKey_ffi_partial_cmp({{.*}}impl ::reussir_rt::bridge::PartialEqBridge for _RNvC7cmpcaps7PordKey{{.*}}impl ::reussir_rt::bridge::PartialOrdBridge for _RNvC7cmpcaps7PordKey{{.*}}fn _RINvC7cmpcaps8pord_cmpNvC7cmpcaps7PordKeyE_ffi(r#value: ::reussir_rt::bridge::Bridge<_RNvC7cmpcaps7PordKey>, r#values: ::reussir_rt::collections::vec::Vec<::reussir_rt::bridge::Bridge<_RNvC7cmpcaps7PordKey>>)

--- a/tests/integration/frontend/ffi_cmp_bridge_capabilities_e2e.rr
+++ b/tests/integration/frontend/ffi_cmp_bridge_capabilities_e2e.rr
@@ -6,20 +6,13 @@
 // The three distinct element types ensure the bridge does not accidentally
 // grant a stronger Rust comparison trait than the Reussir implementation.
 
+// The absent patterns run as their own prefix over the same texture rather
+// than through `--implicit-check-not`: the Python `filecheck` replacement used
+// on Windows rejects that flag.
 // RUN: %rrc --package-root %S/../../../library/core/src --package-name core --core --emit rri -o %t.core.rri
-// RUN: %rrc %s --package-name cmpcaps --extern core=%t.core.rri --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=TEXTURE \
-// RUN:   --implicit-check-not="bridge::EqBridge for _RNvC7cmpcaps6PeqKey" \
-// RUN:   --implicit-check-not="bridge::PartialOrdBridge for _RNvC7cmpcaps6PeqKey" \
-// RUN:   --implicit-check-not="bridge::OrdBridge for _RNvC7cmpcaps6PeqKey" \
-// RUN:   --implicit-check-not="bridge::PartialOrdBridge for _RNvC7cmpcaps5EqKey" \
-// RUN:   --implicit-check-not="bridge::OrdBridge for _RNvC7cmpcaps5EqKey" \
-// RUN:   --implicit-check-not="bridge::EqBridge for _RNvC7cmpcaps7PordKey" \
-// RUN:   --implicit-check-not="bridge::OrdBridge for _RNvC7cmpcaps7PordKey" \
-// RUN:   --implicit-check-not="_RNvC7cmpcaps6PeqKey_ffi_partial_cmp" \
-// RUN:   --implicit-check-not="_RNvC7cmpcaps6PeqKey_ffi_cmp" \
-// RUN:   --implicit-check-not="_RNvC7cmpcaps5EqKey_ffi_partial_cmp" \
-// RUN:   --implicit-check-not="_RNvC7cmpcaps5EqKey_ffi_cmp" \
-// RUN:   --implicit-check-not="_RNvC7cmpcaps7PordKey_ffi_cmp"
+// RUN: %rrc %s --package-name cmpcaps --extern core=%t.core.rri --emit mlir --no-source-locations -o %t.texture.mlir
+// RUN: %FileCheck %s --check-prefix=TEXTURE --input-file=%t.texture.mlir
+// RUN: %FileCheck %s --check-prefix=ABSENT --input-file=%t.texture.mlir
 // RUN: %rrc %s --package-name cmpcaps --extern core=%t.core.rri -o %t.o --relocation-mode pic
 // RUN: %cc %t.o %S/ffi_cmp_bridge_capabilities_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
 // RUN: %t.exe
@@ -168,3 +161,18 @@ extern "C" trampoline "reussir_main" = main;
 // A partial order has equality plus the four-state partial comparison bridge,
 // but neither the Eq marker nor the total-order bridge.
 // TEXTURE-DAG: reussir.polyffi texture("{{.*}}unsafe fn _RNvC7cmpcaps7PordKey_ffi_eq({{.*}}unsafe fn _RNvC7cmpcaps7PordKey_ffi_partial_cmp({{.*}}impl ::reussir_rt::bridge::PartialEqBridge for _RNvC7cmpcaps7PordKey{{.*}}impl ::reussir_rt::bridge::PartialOrdBridge for _RNvC7cmpcaps7PordKey{{.*}}fn _RINvC7cmpcaps8pord_cmpNvC7cmpcaps7PordKeyE_ffi(r#value: ::reussir_rt::bridge::Bridge<_RNvC7cmpcaps7PordKey>, r#values: ::reussir_rt::collections::vec::Vec<::reussir_rt::bridge::Bridge<_RNvC7cmpcaps7PordKey>>)
+
+// No probe may grant a Rust comparison trait, or synthesize the glue behind
+// one, that its element's Reussir implementations do not justify.
+// ABSENT-NOT: bridge::EqBridge for _RNvC7cmpcaps6PeqKey
+// ABSENT-NOT: bridge::PartialOrdBridge for _RNvC7cmpcaps6PeqKey
+// ABSENT-NOT: bridge::OrdBridge for _RNvC7cmpcaps6PeqKey
+// ABSENT-NOT: bridge::PartialOrdBridge for _RNvC7cmpcaps5EqKey
+// ABSENT-NOT: bridge::OrdBridge for _RNvC7cmpcaps5EqKey
+// ABSENT-NOT: bridge::EqBridge for _RNvC7cmpcaps7PordKey
+// ABSENT-NOT: bridge::OrdBridge for _RNvC7cmpcaps7PordKey
+// ABSENT-NOT: _RNvC7cmpcaps6PeqKey_ffi_partial_cmp
+// ABSENT-NOT: _RNvC7cmpcaps6PeqKey_ffi_cmp
+// ABSENT-NOT: _RNvC7cmpcaps5EqKey_ffi_partial_cmp
+// ABSENT-NOT: _RNvC7cmpcaps5EqKey_ffi_cmp
+// ABSENT-NOT: _RNvC7cmpcaps7PordKey_ffi_cmp

--- a/tests/integration/frontend/ffi_cmp_bridge_errors.rr
+++ b/tests/integration/frontend/ffi_cmp_bridge_errors.rr
@@ -1,0 +1,24 @@
+// Ground bridge validation must report a Reussir trait-selection error before
+// the generated Rust texture reaches rustc. This deliberately exploits the
+// current opaque-record application gap: `empty` omits `T: Ord`, so `Key`
+// reaches monomorphization without satisfying BTreeSet's declared bound.
+
+// RUN: %rrc --package-root %S/../../../library/core/src --package-name core --core --emit rri -o %t.core.rri
+// RUN: %not %rrc %s --package-name cmpbridge_error --extern core=%t.core.rri --emit mir -o - 2>&1 | %FileCheck %s
+
+#[ffi(rust = "::reussir_rt::collections::btree_set::BTreeSet")]
+pub struct BTreeSet<T: Ord>;
+
+pub struct Key { value: i64 }
+
+#[ffi(import)]
+pub fn empty<T>() -> BTreeSet<T> [{
+    ::reussir_rt::collections::btree_set::BTreeSet::new()
+}];
+
+pub fn main() -> BTreeSet<Key> { empty<Key>() }
+
+// CHECK-DAG: cannot synthesize a Rust FFI comparison bridge for `cmpbridge_error::Key`: required Reussir trait `core::cmp::Eq` has no applicable implementation
+// CHECK-DAG: no implementation of `core::cmp::PartialEq` applies in this instantiation
+// CHECK-DAG: no implementation of `core::cmp::Ord` applies in this instantiation
+// CHECK-NOT: OrdBridge is not implemented

--- a/tests/integration/frontend/ffi_cmp_bridge_fn_bound_e2e.c
+++ b/tests/integration/frontend/ffi_cmp_bridge_fn_bound_e2e.c
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+// Driver for ffi_cmp_bridge_fn_bound_e2e.rr. The Reussir entry point returns
+// 42 only after both binder-bound comparisons behaved as the Reussir
+// implementations define them.
+
+#include <stdint.h>
+
+extern int64_t reussir_main(void);
+
+int main(void) { return reussir_main() == 42 ? 0 : 1; }

--- a/tests/integration/frontend/ffi_cmp_bridge_fn_bound_e2e.rr
+++ b/tests/integration/frontend/ffi_cmp_bridge_fn_bound_e2e.rr
@@ -1,0 +1,71 @@
+// UNSUPPORTED: darwin
+// An `#[ffi(import)]` signature can be the only source of a comparison
+// requirement: no bounded container appears here, yet the Rust bodies compare
+// and order the rendered values directly. `Key` orders as the reverse of its
+// numeric payload, so `largest` answering with the numerically smaller value
+// proves Rust reached the Reussir implementation rather than any fallback.
+
+// RUN: %rrc --package-root %S/../../../library/core/src --package-name core --core --emit rri -o %t.core.rri
+// RUN: %rrc %s --package-name fnbound --extern core=%t.core.rri --emit mlir --no-source-locations -o %t.texture.mlir
+// RUN: %FileCheck %s --check-prefix=TEXTURE --input-file=%t.texture.mlir
+// RUN: %rrc %s --package-name fnbound --extern core=%t.core.rri -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/ffi_cmp_bridge_fn_bound_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s --package-name fnbound --extern core=%t.core.rri -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/ffi_cmp_bridge_fn_bound_e2e.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+pub struct Key { value: i64 }
+
+impl PartialEq for Key {
+    fn eq(self: Self, other: Self) -> bool { self.value == other.value }
+}
+
+impl Eq for Key {}
+
+// Deliberately the reverse of the numeric order.
+impl PartialOrd for Key {
+    fn lt(self: Self, other: Self) -> bool { self.value > other.value }
+    fn le(self: Self, other: Self) -> bool { self.value >= other.value }
+    fn gt(self: Self, other: Self) -> bool { self.value < other.value }
+    fn ge(self: Self, other: Self) -> bool { self.value <= other.value }
+}
+
+impl Ord for Key {
+    fn cmp(self: Self, other: Self) -> Ordering {
+        if self.value > other.value {
+            Ordering::Less
+        } else {
+            if self.value == other.value { Ordering::Equal }
+            else { Ordering::Greater }
+        }
+    }
+}
+
+#[ffi(import)]
+pub fn same<T: PartialEq>(lhs: T, rhs: T) -> bool [{ lhs == rhs }];
+
+#[ffi(import)]
+pub fn largest<T: Ord>(lhs: T, rhs: T) -> T [{ ::std::cmp::max(lhs, rhs) }];
+
+pub fn main() -> i64 {
+    let equal = same(Key{7}, Key{7});
+    let different = same(Key{7}, Key{8});
+
+    // Under the reversed order the greatest Key carries the smallest payload.
+    let top = largest(Key{2}, Key{5}).value;
+
+    if equal && !different && top == 2 { 42 } else { 0 }
+}
+
+extern "C" trampoline "reussir_main" = main;
+
+// The `PartialEq` binder asks for equality alone; the `Ord` binder normalizes
+// over the whole tower. Both entries are borrowed comparison glue on the one
+// shared record the program declares.
+// TEXTURE-DAG: unsafe fn {{[A-Za-z0-9_]+}}_ffi_eq(
+// TEXTURE-DAG: unsafe fn {{[A-Za-z0-9_]+}}_ffi_cmp(
+// TEXTURE-DAG: impl ::reussir_rt::bridge::PartialEqBridge for
+// TEXTURE-DAG: impl ::reussir_rt::bridge::EqBridge for
+// TEXTURE-DAG: impl ::reussir_rt::bridge::PartialOrdBridge for
+// TEXTURE-DAG: impl ::reussir_rt::bridge::OrdBridge for

--- a/tests/integration/rene/btree_set_rc.rr
+++ b/tests/integration/rene/btree_set_rc.rr
@@ -1,0 +1,29 @@
+// A comparison implementation can live in a dependency even when only its
+// consumer instantiates an FFI container requiring that comparison evidence.
+// `ordered` owns the shared Key record and all four comparison impls, while
+// this root package alone declares and uses the Rust-backed BTreeSet.
+//
+// The app retains the old set while deriving the changed set, forcing the
+// runtime BTreeSet's copy-on-write path to clone bridged Key values. Key's
+// reverse ordering makes first() observable as the greatest numeric value.
+
+// UNSUPPORTED: darwin
+
+// RUN: %rene build --manifest-path %S/btree_set_rc/rene.ncl --build-dir %t.bdir %rrc_linker | %FileCheck %s --check-prefix=DEV
+// DEV: {{[/\\]}}dev{{[/\\]}}btree_rc
+
+// The implementer's interface must carry every comparison capability even
+// though that package never mentions BTreeSet.
+// RUN: %FileCheck %s --check-prefix=RRI < %t.bdir/dev/deps/ordered.rri
+// RRI: interface 1 package "ordered"
+// RRI-DAG: impl #core::cmp::PartialEq::<#ordered::Key> in
+// RRI-DAG: impl #core::cmp::Eq::<#ordered::Key> in
+// RRI-DAG: impl #core::cmp::PartialOrd::<#ordered::Key> in
+// RRI-DAG: impl #core::cmp::Ord::<#ordered::Key> in
+
+// RUN: %t.bdir/dev/btree_rc%exe_ext | %FileCheck %s --check-prefix=OUT
+// OUT: 2445
+
+// RUN: %rene build --manifest-path %S/btree_set_rc/rene.ncl --build-dir %t.bdir --profile release %rrc_linker | %FileCheck %s --check-prefix=RELEASE
+// RELEASE: {{[/\\]}}release{{[/\\]}}btree_rc
+// RUN: %t.bdir/release/btree_rc%exe_ext | %FileCheck %s --check-prefix=OUT

--- a/tests/integration/rene/btree_set_rc/lit.local.cfg
+++ b/tests/integration/rene/btree_set_rc/lit.local.cfg
@@ -1,0 +1,2 @@
+# The package compiled by btree_set_rc.rr, not a test directory itself.
+config.suffixes = []

--- a/tests/integration/rene/btree_set_rc/rene.ncl
+++ b/tests/integration/rene/btree_set_rc/rene.ncl
@@ -1,0 +1,15 @@
+# The root is the only package that knows about the Rust-backed BTreeSet.
+# Its ordered dependency supplies a public shared type and comparison impls,
+# exercising bridge selection from an imported RRI.
+{
+  package = {
+    name | String = "btree_rc",
+    version = "1.0.0",
+  },
+  dependencies = {
+    ordered = { path = "vendor/ordered", version = "^0.1" },
+  },
+  targets = {
+    btree_rc = { kind = 'executable },
+  },
+}

--- a/tests/integration/rene/btree_set_rc/src/lib.rr
+++ b/tests/integration/rene/btree_set_rc/src/lib.rr
@@ -1,0 +1,48 @@
+// The pure container consumer: Key and its comparison implementations come
+// from `ordered`; this package alone declares the Rust-backed BTreeSet.
+
+extern "rust" [{
+    use reussir_rt::collections::btree_set::BTreeSet as RBTreeSet;
+}];
+
+#[ffi(rust = "::reussir_rt::collections::btree_set::BTreeSet")]
+pub struct BTreeSet<T: Ord>;
+
+// Repeat the bound at each operation so every ground FFI instantiation has
+// explicit trait evidence available when its comparison bridge is emitted.
+#[ffi(import)]
+pub fn new<T: Ord>() -> BTreeSet<T> [{ RBTreeSet::new() }];
+
+#[ffi(import)]
+pub fn insert<T: Ord>(set: BTreeSet<T>, value: T) -> BTreeSet<T> [{
+    set.insert(value)
+}];
+
+#[ffi(import)]
+pub fn len<T: Ord>(set: BTreeSet<T>) -> i64 [{ set.len() as i64 }];
+
+#[ffi(import)]
+pub fn first<T: Ord>(set: BTreeSet<T>) -> T [{ set.first().unwrap() }];
+
+#[ffi(import)]
+fn print_i64(value: i64) [{ println!("{value}") }];
+
+#[main]
+pub fn entry() {
+    let old = insert(insert(new<ordered::Key>(), ordered::Key { value: 1 }),
+                     ordered::Key { value: 4 });
+
+    // `old` remains live below, so the first insertion into `changed` clones
+    // the shared Rust tree and its compiler-owned Key elements.
+    let changed = insert(old, ordered::Key { value: 2 });
+    let changed = insert(changed, ordered::Key { value: 5 });
+    let changed = insert(changed, ordered::Key { value: 1 });
+
+    let old_len = len(old);
+    let new_len = len(changed);
+    let old_first = first(old).value;
+    let new_first = first(changed).value;
+
+    // old={4,1}, changed={5,4,2,1} in reverse comparison order.
+    print_i64(old_len * 1000 + new_len * 100 + old_first * 10 + new_first);
+}

--- a/tests/integration/rene/btree_set_rc/vendor/ordered/rene.ncl
+++ b/tests/integration/rene/btree_set_rc/vendor/ordered/rene.ncl
@@ -1,0 +1,5 @@
+# The implementer owns Key and its comparison impls but deliberately has no
+# foreign-container declaration, Rust texture, or PolyFFI dependency.
+{
+  package = { name = "ordered", version = "0.1.0" },
+}

--- a/tests/integration/rene/btree_set_rc/vendor/ordered/src/lib.rr
+++ b/tests/integration/rene/btree_set_rc/vendor/ordered/src/lib.rr
@@ -1,0 +1,34 @@
+// A public shared record whose ordering is intentionally the reverse of its
+// numeric payload. The consumer can therefore observe whether foreign code
+// reached these imported implementations rather than a local fallback.
+
+pub struct Key {
+    pub value: i64,
+}
+
+impl PartialEq for Key {
+    fn eq(self: Self, other: Self) -> bool { self.value == other.value }
+}
+
+impl Eq for Key {}
+
+impl PartialOrd for Key {
+    fn lt(self: Self, other: Self) -> bool { self.value > other.value }
+    fn le(self: Self, other: Self) -> bool { self.value >= other.value }
+    fn gt(self: Self, other: Self) -> bool { self.value < other.value }
+    fn ge(self: Self, other: Self) -> bool { self.value <= other.value }
+}
+
+impl Ord for Key {
+    fn cmp(self: Self, other: Self) -> Ordering {
+        if self.value > other.value {
+            Ordering::Less
+        } else {
+            if self.value == other.value {
+                Ordering::Equal
+            } else {
+                Ordering::Greater
+            }
+        }
+    }
+}

--- a/tests/integration/rene/core_math.rr
+++ b/tests/integration/rene/core_math.rr
@@ -14,7 +14,7 @@
 // RUN: %FileCheck %s --check-prefix=RRI < %t.bdir/dev/deps/core.rri
 
 // RRI: interface 1 package "core"
-// RRI-DAG: #[lang("core::intrinsic::math::sqrt")] pub fn #core::intrinsic::math::sqrt<{{.*}}: FloatingPoint>({{.*}}) -> {{.*}} in {{[0-9]+}} [{{[0-9]+}}..{{[0-9]+}}];
+// RRI-DAG: #[lang("core::intrinsic::math::sqrt")] pub fn #core::intrinsic::math::sqrt<{{.*}}: core::num::FloatingPoint>({{.*}}) -> {{.*}} in {{[0-9]+}} [{{[0-9]+}}..{{[0-9]+}}];
 // RRI-DAG: #[lang("core::intrinsic::math::powf")]
 
 // RUN: %t.bdir/dev/mathdemo%exe_ext | %FileCheck %s --check-prefix=OUT

--- a/tests/integration/sanitizer/e2e/ffi-btree-set-record.rr
+++ b/tests/integration/sanitizer/e2e/ffi-btree-set-record.rr
@@ -1,0 +1,13 @@
+// REQUIRES: asan
+// UNSUPPORTED: darwin
+// ASan+LSan gate over frontend/ffi_btree_set_record_e2e.rr. The old/new
+// BTreeSet versions force Rust-side COW, bridged comparisons temporarily
+// acquire their borrowed Reussir operands, and a duplicate key is rejected.
+// Instrumenting the linked Rust bitcode together with the Reussir IR catches
+// leaks, double releases, and use-after-free across all of those paths.
+
+// RUN: %rrc --package-root %S/../../../../library/core/src --package-name core --core --emit rri -o %t.core.rri
+// RUN: %rrc %S/../../frontend/ffi_btree_set_record_e2e.rr --package-name btreeset_asan --extern core=%t.core.rri -o %t.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.ll -o %t.o
+// RUN: %cc %asan_flags %t.o %S/../../frontend/ffi_btree_set_record_e2e.c %reussir_rt_asan -o %t.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.exe


### PR DESCRIPTION
## Summary

- add a transparent `Bridge<T>` adapter with `PartialEqBridge`, `EqBridge`, `PartialOrdBridge`, and `OrdBridge`
- extend PolyFFI to discover comparison bounds and emit monomorphic comparison behavior for compiler-owned shared values
- add an RC-backed, copy-on-write `BTreeSet` runtime container
- support downstream container instantiation when the element type and comparison implementations live in a dependency package

## Design

The existing compiler-emitted shared wrapper remains a transparent one-pointer owner whose `Clone` and `Drop` call Reussir acquire/release glue. PolyFFI now renders it uniformly as `Bridge<Inner>` and implements only the Reussir-specific bridge traits on `Inner`; `reussir-rt` owns the generic Rust standard-trait implementations.

Comparison entries are monomorphic direct calls. They contain no descriptors, dictionaries, vtables, extra value fields, or allocations. Borrowed Rust operands are acquired exactly once each before invoking an ordinary Reussir semantic adapter. Bridge symbols and adapters use deduplicatable linkage.

Ground bridge discovery reaches a fixed point across normal and drop-only textures, validates Reussir trait evidence before invoking rustc, and follows comparison bounds through supertraits. Primitive values continue to use their native Rust representations without bridge glue.

For the cross-package case, package A may define a public shared `Key` and its comparison implementations without mentioning `BTreeSet`. Package B selects A's exported implementation while synthesizing the concrete bridge where `BTreeSet<A::Key>` appears.

## Validation

- `cargo test -p reussir-rt` — 24 passed
- `cargo test -p reussir-core` — 457 passed
- `cargo test -p reussir-codegen` — unit and integration suites passed
- C++ unit suite — 30 passed
- local capability, diagnostic, and RC `BTreeSet` lit tests passed
- cross-package rene fixture passed in development and release profiles
- dedicated ASan/LSan RC `BTreeSet` end-to-end test passed
- `ninja -C build check` — 471 passed, 7 unsupported, 0 failed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788503555&installation_model_id=426051&pr_number=527&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F527&signature=90b9e3bcfcb18173419e5f62c9b9e73e9184cdbf45a4471866032dbf39664a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->