### PR TITLE
[syntax] Bind suffix chains before prefix operators

### DIFF
--- a/crates/reussir-syntax/src/lib.rs
+++ b/crates/reussir-syntax/src/lib.rs
@@ -681,7 +681,7 @@ mod tests {
 
     #[test]
     fn casts_and_prefix() {
-        // The postfix cast applies on top of the prefixed atom:
+        // A cast remains outside the prefix:
         // `-x as f64` is `Cast f64 (Negate x)`.
         let v = json_of("fn f(x: i32) -> f64 { -x as f64 }");
         let body = &unwrap_span(&v[0])["contents"]["funcBody"];
@@ -693,6 +693,21 @@ mod tests {
             "UnaryOpExpr",
             "{v}"
         );
+    }
+
+    #[test]
+    fn suffix_chain_binds_tighter_than_prefix() {
+        let v = json_of("fn f(x: Option<i32>) -> bool { !x.is_some() }");
+        let body = &unwrap_span(&v[0])["contents"]["funcBody"];
+        let seq = &unwrap_span(body)["contents"][0];
+        let not = unwrap_span(seq);
+        assert_eq!(not["tag"], "UnaryOpExpr", "{v}");
+        assert_eq!(not["contents"][0], "Not", "{v}");
+
+        let call = unwrap_span(&not["contents"][1]);
+        assert_eq!(call["tag"], "CallExpr", "{v}");
+        let access = unwrap_span(&call["contents"][0]);
+        assert_eq!(access["tag"], "AccessChain", "{v}");
     }
 
     /// Strip a `SpannedExpr` / `SpannedStmt` / `TypeSpanned` wrapper.

--- a/crates/reussir-syntax/src/parser/expr.rs
+++ b/crates/reussir-syntax/src/parser/expr.rs
@@ -2,15 +2,16 @@
 //!
 //! Operator table (tightest to loosest):
 //!
-//! | level | operators                                      | associativity |
-//! |-------|------------------------------------------------|---------------|
-//! | 6     | prefix `-` `!`; postfix `as T` or suffix chain | one prefix and one postfix application per term |
-//! | 5     | `*` `/` `%`                                    | left          |
-//! | 4     | `+` `-`                                        | left          |
-//! | 3     | `==` `!=` `<` `>` `<=` `>=`                    | none          |
-//! | 2     | `&&`                                           | left          |
-//! | 1     | `\|\|`                                         | left          |
-//! | 0     | `lhs -> field := rhs`                          | none          |
+//! | level | operators                     | associativity |
+//! |-------|-------------------------------|---------------|
+//! | 7     | call / access suffix chain    | left          |
+//! | 6     | prefix `-` `!`; postfix `as T` | one each      |
+//! | 5     | `*` `/` `%`                   | left          |
+//! | 4     | `+` `-`                       | left          |
+//! | 3     | `==` `!=` `<` `>` `<=` `>=`   | none          |
+//! | 2     | `&&`                          | left          |
+//! | 1     | `\|\|`                        | left          |
+//! | 0     | `lhs -> field := rhs`         | none          |
 //!
 //! ## The algorithm: precedence climbing
 //!
@@ -61,10 +62,9 @@
 //!
 //! * a lambda is only recognized at full-expression entry points, never as
 //!   an operand of a binary operator — `1 + |x| x` is not an expression;
-//! * each term takes at most one prefix and one postfix application, and
-//!   the postfix applies on top of the prefix: `- x as i32` is
-//!   `Cast(i32, Negate x)`, while `x.f as i32` needs parentheses because a
-//!   suffix chain and a cast are alternative postfixes;
+//! * a call / access suffix chain binds inside a prefix operator, while a
+//!   cast binds outside it: `!x.f()` is `Not(Call(Access(x, f)))`, and
+//!   `-x.f as i32` is `Cast(i32, Negate(Access(x, f)))`;
 //! * consecutive `.a.b` accesses group into a single access-chain node,
 //!   while every call suffix creates its own node;
 //! * struct-literal constructors are suppressed in scrutinee/condition
@@ -210,36 +210,46 @@ impl Parser<'_> {
         Some(lhs)
     }
 
-    /// One term: at most one prefix and one postfix application; the
-    /// postfix applies to the prefixed atom.
+    /// One term: a call / access suffix chain binds more tightly than an
+    /// optional prefix, while an optional cast binds more loosely.
     fn unary_term(&mut self, allow_struct: bool) -> Option<CompletedMarker> {
         stacker::maybe_grow(STACK_RED_ZONE, STACK_GROW, || {
             let base = if self.at(Minus) || self.at(Bang) {
                 let m = self.start();
                 self.bump();
-                if self.atom(allow_struct).is_none() {
-                    self.error(format!(
-                        "expected an expression after the unary operator, found {}",
-                        self.current().describe()
-                    ));
+                match self.atom(allow_struct) {
+                    Some(operand) => {
+                        self.suffix_chain(operand);
+                    }
+                    None => {
+                        self.error(format!(
+                            "expected an expression after the unary operator, found {}",
+                            self.current().describe()
+                        ));
+                    }
                 }
                 m.complete(self, PrefixExpr)
             } else {
-                self.atom(allow_struct)?
+                let atom = self.atom(allow_struct)?;
+                self.suffix_chain(atom)
             };
-            Some(self.postfix_opt(base))
+            Some(self.cast_opt(base))
         })
     }
 
-    /// One postfix application: either a cast (`as T`) or a chain of call /
-    /// access suffixes.
-    fn postfix_opt(&mut self, mut e: CompletedMarker) -> CompletedMarker {
+    /// An optional cast, which applies outside a prefix expression.
+    fn cast_opt(&mut self, e: CompletedMarker) -> CompletedMarker {
         if self.at(AsKw) {
             let m = e.precede(self);
             self.bump();
             self.type_();
             return m.complete(self, CastExpr);
         }
+        e
+    }
+
+    /// A left-to-right chain of call / access suffixes.
+    fn suffix_chain(&mut self, mut e: CompletedMarker) -> CompletedMarker {
         loop {
             if self.at(LParen) {
                 let m = e.precede(self);

--- a/tests/integration/frontend/prefix_postfix_precedence.rr
+++ b/tests/integration/frontend/prefix_postfix_precedence.rr
@@ -1,0 +1,25 @@
+// A call / access suffix chain binds more tightly than unary `!`: the method
+// returns `bool`, and that result is the operand of `!`.
+// RUN: %rrc %s --package-name precedence --emit hir --no-source-locations -o - | %FileCheck %s
+
+pub enum Option<T> {
+    Some(T),
+    None
+}
+
+impl<T> Option<T> {
+    pub fn is_some(self: Self) -> bool {
+        match self {
+            Option::Some(_) => true,
+            None => false
+        }
+    }
+
+    pub fn is_none(self: Self) -> bool {
+        !self.is_some()
+    }
+}
+
+// CHECK: pub fn #precedence::Option::is_none<$1 (T)>(v0 (self): #precedence::Option::<$1>) -> bool {
+// CHECK-NEXT:     !(#precedence::Option::is_some::<$1>(v0 : #precedence::Option::<$1>) : bool) : bool
+// CHECK-NEXT: }


### PR DESCRIPTION
## Summary

- make call and access suffix chains bind more tightly than unary prefix operators
- preserve cast ordering so negated or negative values are cast after the prefix operation
- add parser AST and frontend elaboration regressions for !self.is_some()

## Validation

- cmake --build build --target reussir-syntax-test -j 2
- cmake --build build --target rrc-test -j 2
- cmake --build build --target reussir-ut -j 2; build/bin/reussir-ut
- cmake --build build --target check -j 2 (474 passed, 6 unsupported)
- rene scan-deps/color compatibility smoke test against library/std

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788584552&installation_model_id=426051&pr_number=530&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F530&signature=b79ee3908f08f90772c31f8f6bb5f810a27ae4ca07b7236f8f941ac1dfc265a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->