### PR TITLE
[std] make the single-constructor carriers value structs

### DIFF
--- a/.github/workflows/rene-test.yml
+++ b/.github/workflows/rene-test.yml
@@ -54,6 +54,35 @@ jobs:
           toolchain: nightly-2026-02-15
           components: clippy
 
+      # sailfish's derive serializes template compilation on a lock file under
+      # `target/`, and a process that loses the race gives up after only
+      # 100 * 10ms = 1s, panicking with "Lock file ... is stuck" — which then
+      # cascades into a bogus unsatisfied-trait-bound error for the template
+      # struct. Two things conspire to blow that budget here:
+      #
+      #   * `--all-targets` builds rene's lib and its test harness as two
+      #     concurrent rustc processes, and both expand the same derive.
+      #   * The templates are recompiled on *every* run even with `target/`
+      #     restored from cache: sailfish stamps each output back to its
+      #     input's mtime, and a fresh checkout stamps the sources newer than
+      #     any cached output, so `input_filetime > output_filetime` always
+      #     holds.
+      #
+      # So the winner does the full compile while the loser waits on a
+      # one-second fuse. Compiling the templates once, on their own, leaves
+      # the parallel pass with nothing to do but a timestamp check.
+      #
+      # Separately, a build killed while the lock is held leaks the file, and
+      # the cache restores it on the next run — at which point nobody is ever
+      # going to remove it. Clearing it is safe (pure build state), and has to
+      # come first, or the warm-up is what trips over it.
+      - name: Clear stale sailfish template locks
+        shell: bash
+        run: find target -path '*sailfish-compiler*/out/templates/*.lock' -delete 2>/dev/null || true
+
+      - name: Warm the sailfish template cache
+        run: cargo clippy -p rene --lib
+
       - name: Clippy
         run: cargo clippy -p rene --all-targets -- -D warnings
 

--- a/crates/reussir-rt/src/hash.rs
+++ b/crates/reussir-rt/src/hash.rs
@@ -18,6 +18,15 @@
 //!
 //! One-shot entry points sit alongside for hashing a single value, where
 //! building a hasher would be pure overhead.
+//!
+//! Everything reachable from a PolyFFI texture is `#[inline]`. A texture
+//! is compiled as its own crate, and these wrappers are the first
+//! non-generic runtime functions a texture calls — generic APIs
+//! monomorphize into the texture and inline for free, while a bare
+//! non-generic call would survive as a real cross-crate call on the
+//! hashing hot path. The attribute exports their MIR so they inline the
+//! same way, leaving one-shot digests and per-write marshalling with no
+//! call overhead over upstream rapidhash.
 
 use std::hash::Hasher as _;
 
@@ -35,40 +44,48 @@ pub const DEFAULT_SEED: u64 = fast::RapidHasher::DEFAULT_SEED;
 pub struct FastHasher(Rc<fast::RapidHasher<'static>>);
 
 impl Default for FastHasher {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl FastHasher {
+    #[inline]
     pub fn new() -> Self {
         Self(Rc::new(fast::RapidHasher::default_const()))
     }
 
+    #[inline]
     pub fn with_seed(seed: u64) -> Self {
         Self(Rc::new(fast::RapidHasher::new(seed)))
     }
 
+    #[inline]
     pub fn write_u64(mut self, value: u64) -> Self {
         self.0.make_mut().write_u64(value);
         self
     }
 
+    #[inline]
     pub fn write_u32(mut self, value: u32) -> Self {
         self.0.make_mut().write_u32(value);
         self
     }
 
+    #[inline]
     pub fn write_u16(mut self, value: u16) -> Self {
         self.0.make_mut().write_u16(value);
         self
     }
 
+    #[inline]
     pub fn write_u8(mut self, value: u8) -> Self {
         self.0.make_mut().write_u8(value);
         self
     }
 
+    #[inline]
     pub fn finish(&self) -> u64 {
         self.0.data_ref().finish()
     }
@@ -81,40 +98,48 @@ impl FastHasher {
 pub struct StrongHasher(Rc<quality::RapidHasher<'static>>);
 
 impl Default for StrongHasher {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl StrongHasher {
+    #[inline]
     pub fn new() -> Self {
         Self(Rc::new(quality::RapidHasher::default_const()))
     }
 
+    #[inline]
     pub fn with_seed(seed: u64) -> Self {
         Self(Rc::new(quality::RapidHasher::new(seed)))
     }
 
+    #[inline]
     pub fn write_u64(mut self, value: u64) -> Self {
         self.0.make_mut().write_u64(value);
         self
     }
 
+    #[inline]
     pub fn write_u32(mut self, value: u32) -> Self {
         self.0.make_mut().write_u32(value);
         self
     }
 
+    #[inline]
     pub fn write_u16(mut self, value: u16) -> Self {
         self.0.make_mut().write_u16(value);
         self
     }
 
+    #[inline]
     pub fn write_u8(mut self, value: u8) -> Self {
         self.0.make_mut().write_u8(value);
         self
     }
 
+    #[inline]
     pub fn finish(&self) -> u64 {
         self.0.data_ref().finish()
     }
@@ -123,6 +148,7 @@ impl StrongHasher {
 /// One-shot: the `fast` digest of a single 64-bit value under the default
 /// seed. Equivalent to creating a hasher, writing, and finishing, without
 /// the allocation.
+#[inline]
 pub fn fast_hash_u64(value: u64) -> u64 {
     let mut h = fast::RapidHasher::default_const();
     h.write_u64(value);
@@ -130,6 +156,7 @@ pub fn fast_hash_u64(value: u64) -> u64 {
 }
 
 /// One-shot `fast` digest under an explicit seed.
+#[inline]
 pub fn fast_hash_u64_seeded(value: u64, seed: u64) -> u64 {
     let mut h = fast::RapidHasher::new(seed);
     h.write_u64(value);
@@ -138,6 +165,7 @@ pub fn fast_hash_u64_seeded(value: u64, seed: u64) -> u64 {
 
 /// One-shot: the `quality` digest of a single 64-bit value under the
 /// default seed.
+#[inline]
 pub fn strong_hash_u64(value: u64) -> u64 {
     let mut h = quality::RapidHasher::default_const();
     h.write_u64(value);
@@ -145,6 +173,7 @@ pub fn strong_hash_u64(value: u64) -> u64 {
 }
 
 /// One-shot `quality` digest under an explicit seed.
+#[inline]
 pub fn strong_hash_u64_seeded(value: u64, seed: u64) -> u64 {
     let mut h = quality::RapidHasher::new(seed);
     h.write_u64(value);

--- a/library/std/src/collections/pure/binomial_heap.rr
+++ b/library/std/src/collections/pure/binomial_heap.rr
@@ -165,19 +165,18 @@ fn min_root<T : Ord>(ts : List<Tree<T>>) -> Option<T> {
 }
 
 // The minimum-rooted tree pulled out of the forest, and the rest.
-enum [value] Split<T> { S(Tree<T>, List<Tree<T>>) }
+struct [value] Split<T> { tree : Tree<T>, rest : List<Tree<T>> }
 
 fn remove_min_tree<T : Ord>(ts : List<Tree<T>>) -> Split<T> {
     match ts {
         List::Nil => core::intrinsic::panic::panic(),
-        List::Cons(t, List::Nil) => Split::S { t, List::Nil },
-        List::Cons(t, rest) => match remove_min_tree(rest) {
-            Split::S(t2, rest2) => {
-                if root(t) <= root(t2) {
-                    Split::S { t, rest }
-                } else {
-                    Split::S { t2, List::Cons { t, rest2 } }
-                }
+        List::Cons(t, List::Nil) => Split { tree: t, rest: List::Nil },
+        List::Cons(t, rest) => {
+            let below = remove_min_tree(rest);
+            if root(t) <= root(below.tree) {
+                Split { tree: t, rest }
+            } else {
+                Split { tree: below.tree, rest: List::Cons { t, below.rest } }
             }
         }
     }
@@ -197,11 +196,10 @@ fn reverse_trees<T>(
 // children run high-to-low rank, so they are reversed before merging back
 // into the increasing-rank forest.
 fn without_min<T : Ord>(ts : List<Tree<T>>) -> List<Tree<T>> {
-    match remove_min_tree(ts) {
-        Split::S(t, rest) => match t {
-            Tree::Node(_, _, cs) =>
-                merge_trees(reverse_trees(cs, List::Nil), rest)
-        }
+    let split = remove_min_tree(ts);
+    match split.tree {
+        Tree::Node(_, _, cs) =>
+            merge_trees(reverse_trees(cs, List::Nil), split.rest)
     }
 }
 

--- a/library/std/src/collections/pure/binomial_heap.rr
+++ b/library/std/src/collections/pure/binomial_heap.rr
@@ -173,10 +173,12 @@ fn remove_min_tree<T : Ord>(ts : List<Tree<T>>) -> Split<T> {
         List::Cons(t, List::Nil) => Split { tree: t, rest: List::Nil },
         List::Cons(t, rest) => {
             let below = remove_min_tree(rest);
-            if root(t) <= root(below.tree) {
+            let best = below.tree;
+            let others = below.rest;
+            if root(t) <= root(best) {
                 Split { tree: t, rest }
             } else {
-                Split { tree: below.tree, rest: List::Cons { t, below.rest } }
+                Split { tree: best, rest: List::Cons { t, others } }
             }
         }
     }
@@ -197,9 +199,11 @@ fn reverse_trees<T>(
 // into the increasing-rank forest.
 fn without_min<T : Ord>(ts : List<Tree<T>>) -> List<Tree<T>> {
     let split = remove_min_tree(ts);
-    match split.tree {
+    let best = split.tree;
+    let others = split.rest;
+    match best {
         Tree::Node(_, _, cs) =>
-            merge_trees(reverse_trees(cs, List::Nil), split.rest)
+            merge_trees(reverse_trees(cs, List::Nil), others)
     }
 }
 

--- a/library/std/src/collections/pure/wavlmap.rr
+++ b/library/std/src/collections/pure/wavlmap.rr
@@ -144,38 +144,40 @@ fn bal_right_ins<K, V>(
     }
 }
 
-enum [value] Changed<K, V> { C(Tree<K, V>, bool) }
+struct [value] Changed<K, V> { tree : Tree<K, V>, changed : bool }
 
 fn ins<K : Ord, V>(t : Tree<K, V>, x : K, xv : V) -> Changed<K, V> {
     match t {
-        Tree::Leaf => Changed::C {
-            Tree::Node { 0, Tree::Leaf, x, xv, Tree::Leaf },
-            true
+        Tree::Leaf => Changed {
+            tree: Tree::Node { 0, Tree::Leaf, x, xv, Tree::Leaf },
+            changed: true
         },
         Tree::Node(r, l, k, v, rt) => match x.cmp(k) {
-            Ordering::Less => match ins(l, x, xv) {
-                Changed::C(l2, added) => Changed::C {
-                    if added {
-                        bal_left_ins(r, l2, k, v, rt)
+            Ordering::Less => {
+                let below = ins(l, x, xv);
+                Changed {
+                    tree: if below.changed {
+                        bal_left_ins(r, below.tree, k, v, rt)
                     } else {
-                        Tree::Node { r, l2, k, v, rt }
+                        Tree::Node { r, below.tree, k, v, rt }
                     },
-                    added
+                    changed: below.changed
                 }
             },
-            Ordering::Greater => match ins(rt, x, xv) {
-                Changed::C(rt2, added) => Changed::C {
-                    if added {
-                        bal_right_ins(r, l, k, v, rt2)
+            Ordering::Greater => {
+                let below = ins(rt, x, xv);
+                Changed {
+                    tree: if below.changed {
+                        bal_right_ins(r, l, k, v, below.tree)
                     } else {
-                        Tree::Node { r, l, k, v, rt2 }
+                        Tree::Node { r, l, k, v, below.tree }
                     },
-                    added
+                    changed: below.changed
                 }
             },
-            Ordering::Equal => Changed::C {
-                Tree::Node { r, l, k, xv, rt },
-                false
+            Ordering::Equal => Changed {
+                tree: Tree::Node { r, l, k, xv, rt },
+                changed: false
             }
         }
     }
@@ -321,14 +323,19 @@ fn bal_right_del<K, V>(
     }
 }
 
-enum [value] DelMin<K, V> { D(K, V, Tree<K, V>) }
+struct [value] DelMin<K, V> { key : K, value : V, tree : Tree<K, V> }
 
 fn del_min<K, V>(t : Tree<K, V>) -> DelMin<K, V> {
     match t {
-        Tree::Node(_, Tree::Leaf, k, v, rt) => DelMin::D { k, v, rt },
-        Tree::Node(r, l, k, v, rt) => match del_min(l) {
-            DelMin::D(m, mv, l2) =>
-                DelMin::D { m, mv, bal_left_del(r, l2, k, v, rt) }
+        Tree::Node(_, Tree::Leaf, k, v, rt) =>
+            DelMin { key: k, value: v, tree: rt },
+        Tree::Node(r, l, k, v, rt) => {
+            let least = del_min(l);
+            DelMin {
+                key: least.key,
+                value: least.value,
+                tree: bal_left_del(r, least.tree, k, v, rt)
+            }
         },
         Tree::Leaf => core::intrinsic::panic::panic()
     }
@@ -339,45 +346,48 @@ fn remove_root<K, V>(r : i64, l : Tree<K, V>, rt : Tree<K, V>) -> Tree<K, V> {
         Tree::Leaf => rt,
         Tree::Node(lrank, ll, lk, lv, lr) => match rt {
             Tree::Leaf => Tree::Node { lrank, ll, lk, lv, lr },
-            Tree::Node(rrank, rl, rk, rv, rr) =>
-                match del_min(Tree::Node { rrank, rl, rk, rv, rr }) {
-                    DelMin::D(m, mv, rt2) => bal_right_del(
-                        r,
-                        Tree::Node { lrank, ll, lk, lv, lr },
-                        m,
-                        mv,
-                        rt2
-                    )
-                }
+            Tree::Node(rrank, rl, rk, rv, rr) => {
+                let least = del_min(Tree::Node { rrank, rl, rk, rv, rr });
+                bal_right_del(
+                    r,
+                    Tree::Node { lrank, ll, lk, lv, lr },
+                    least.key,
+                    least.value,
+                    least.tree
+                )
+            }
         }
     }
 }
 
 fn del<K : Ord, V>(t : Tree<K, V>, x : K) -> Changed<K, V> {
     match t {
-        Tree::Leaf => Changed::C { Tree::Leaf, false },
+        Tree::Leaf => Changed { tree: Tree::Leaf, changed: false },
         Tree::Node(r, l, k, v, rt) => match x.cmp(k) {
-            Ordering::Less => match del(l, x) {
-                Changed::C(l2, found) => Changed::C {
-                    if found {
-                        bal_left_del(r, l2, k, v, rt)
+            Ordering::Less => {
+                let below = del(l, x);
+                Changed {
+                    tree: if below.changed {
+                        bal_left_del(r, below.tree, k, v, rt)
                     } else {
-                        Tree::Node { r, l2, k, v, rt }
+                        Tree::Node { r, below.tree, k, v, rt }
                     },
-                    found
+                    changed: below.changed
                 }
             },
-            Ordering::Greater => match del(rt, x) {
-                Changed::C(rt2, found) => Changed::C {
-                    if found {
-                        bal_right_del(r, l, k, v, rt2)
+            Ordering::Greater => {
+                let below = del(rt, x);
+                Changed {
+                    tree: if below.changed {
+                        bal_right_del(r, l, k, v, below.tree)
                     } else {
-                        Tree::Node { r, l, k, v, rt2 }
+                        Tree::Node { r, l, k, v, below.tree }
                     },
-                    found
+                    changed: below.changed
                 }
             },
-            Ordering::Equal => Changed::C { remove_root(r, l, rt), true }
+            Ordering::Equal =>
+                Changed { tree: remove_root(r, l, rt), changed: true }
         }
     }
 }
@@ -465,21 +475,19 @@ impl<K : Ord, V> WavlMap<K, V> {
 
     /// Adds or replaces the entry for `key`. O(log n).
     pub fn insert(self : Self, key : K, value : V) -> Self {
-        match ins(self.root, key, value) {
-            Changed::C(root, added) => WavlMap {
-                size: if added { self.size + 1 } else { self.size },
-                root
-            }
+        let r = ins(self.root, key, value);
+        WavlMap {
+            size: if r.changed { self.size + 1 } else { self.size },
+            root: r.tree
         }
     }
 
     /// Removes the entry for `key` when present. O(log n).
     pub fn remove(self : Self, key : K) -> Self {
-        match del(self.root, key) {
-            Changed::C(root, found) => WavlMap {
-                size: if found { self.size - 1 } else { self.size },
-                root
-            }
+        let r = del(self.root, key);
+        WavlMap {
+            size: if r.changed { self.size - 1 } else { self.size },
+            root: r.tree
         }
     }
 

--- a/library/std/src/collections/pure/wavlmap.rr
+++ b/library/std/src/collections/pure/wavlmap.rr
@@ -155,24 +155,28 @@ fn ins<K : Ord, V>(t : Tree<K, V>, x : K, xv : V) -> Changed<K, V> {
         Tree::Node(r, l, k, v, rt) => match x.cmp(k) {
             Ordering::Less => {
                 let below = ins(l, x, xv);
+                let sub = below.tree;
+                let changed = below.changed;
                 Changed {
-                    tree: if below.changed {
-                        bal_left_ins(r, below.tree, k, v, rt)
+                    tree: if changed {
+                        bal_left_ins(r, sub, k, v, rt)
                     } else {
-                        Tree::Node { r, below.tree, k, v, rt }
+                        Tree::Node { r, sub, k, v, rt }
                     },
-                    changed: below.changed
+                    changed
                 }
             },
             Ordering::Greater => {
                 let below = ins(rt, x, xv);
+                let sub = below.tree;
+                let changed = below.changed;
                 Changed {
-                    tree: if below.changed {
-                        bal_right_ins(r, l, k, v, below.tree)
+                    tree: if changed {
+                        bal_right_ins(r, l, k, v, sub)
                     } else {
-                        Tree::Node { r, l, k, v, below.tree }
+                        Tree::Node { r, l, k, v, sub }
                     },
-                    changed: below.changed
+                    changed
                 }
             },
             Ordering::Equal => Changed {
@@ -331,11 +335,10 @@ fn del_min<K, V>(t : Tree<K, V>) -> DelMin<K, V> {
             DelMin { key: k, value: v, tree: rt },
         Tree::Node(r, l, k, v, rt) => {
             let least = del_min(l);
-            DelMin {
-                key: least.key,
-                value: least.value,
-                tree: bal_left_del(r, least.tree, k, v, rt)
-            }
+            let m = least.key;
+            let mv = least.value;
+            let sub = least.tree;
+            DelMin { key: m, value: mv, tree: bal_left_del(r, sub, k, v, rt) }
         },
         Tree::Leaf => core::intrinsic::panic::panic()
     }
@@ -348,12 +351,15 @@ fn remove_root<K, V>(r : i64, l : Tree<K, V>, rt : Tree<K, V>) -> Tree<K, V> {
             Tree::Leaf => Tree::Node { lrank, ll, lk, lv, lr },
             Tree::Node(rrank, rl, rk, rv, rr) => {
                 let least = del_min(Tree::Node { rrank, rl, rk, rv, rr });
+                let m = least.key;
+                let mv = least.value;
+                let sub = least.tree;
                 bal_right_del(
                     r,
                     Tree::Node { lrank, ll, lk, lv, lr },
-                    least.key,
-                    least.value,
-                    least.tree
+                    m,
+                    mv,
+                    sub
                 )
             }
         }
@@ -366,24 +372,28 @@ fn del<K : Ord, V>(t : Tree<K, V>, x : K) -> Changed<K, V> {
         Tree::Node(r, l, k, v, rt) => match x.cmp(k) {
             Ordering::Less => {
                 let below = del(l, x);
+                let sub = below.tree;
+                let changed = below.changed;
                 Changed {
-                    tree: if below.changed {
-                        bal_left_del(r, below.tree, k, v, rt)
+                    tree: if changed {
+                        bal_left_del(r, sub, k, v, rt)
                     } else {
-                        Tree::Node { r, below.tree, k, v, rt }
+                        Tree::Node { r, sub, k, v, rt }
                     },
-                    changed: below.changed
+                    changed
                 }
             },
             Ordering::Greater => {
                 let below = del(rt, x);
+                let sub = below.tree;
+                let changed = below.changed;
                 Changed {
-                    tree: if below.changed {
-                        bal_right_del(r, l, k, v, below.tree)
+                    tree: if changed {
+                        bal_right_del(r, l, k, v, sub)
                     } else {
-                        Tree::Node { r, l, k, v, below.tree }
+                        Tree::Node { r, l, k, v, sub }
                     },
-                    changed: below.changed
+                    changed
                 }
             },
             Ordering::Equal =>

--- a/library/std/src/collections/pure/wavlset.rr
+++ b/library/std/src/collections/pure/wavlset.rr
@@ -211,14 +211,23 @@ fn ins<T : Ord>(t : Tree<T>, x : T) -> Ins<T> {
             },
         View::Node(p, l, k, rt) => match x.cmp(k) {
             Ordering::Less => {
+                // Project the whole carrier before the call: leaving a
+                // field unread across it would keep the carrier alive and
+                // make the subtree a second reference, costing a retain.
                 let below = ins(l, x);
-                let reb = bal_left_ins(p, below.tree, k, rt, below.raised);
-                Ins { tree: reb.tree, added: below.added, raised: reb.moved }
+                let sub = below.tree;
+                let added = below.added;
+                let raised = below.raised;
+                let reb = bal_left_ins(p, sub, k, rt, raised);
+                Ins { tree: reb.tree, added, raised: reb.moved }
             },
             Ordering::Greater => {
                 let below = ins(rt, x);
-                let reb = bal_right_ins(p, l, k, below.tree, below.raised);
-                Ins { tree: reb.tree, added: below.added, raised: reb.moved }
+                let sub = below.tree;
+                let added = below.added;
+                let raised = below.raised;
+                let reb = bal_right_ins(p, l, k, sub, raised);
+                Ins { tree: reb.tree, added, raised: reb.moved }
             },
             Ordering::Equal =>
                 Ins { tree: mk(p, l, k, rt), added: false, raised: false }
@@ -377,8 +386,11 @@ fn del_min<T>(t : Tree<T>) -> Min<T> {
                 Min { key: k, tree: rt, dropped: true }
             } else {
                 let least = del_min(l);
-                let reb = bal_left_del(p, least.tree, k, rt, least.dropped);
-                Min { key: least.key, tree: reb.tree, dropped: reb.moved }
+                let m = least.key;
+                let sub = least.tree;
+                let dropped = least.dropped;
+                let reb = bal_left_del(p, sub, k, rt, dropped);
+                Min { key: m, tree: reb.tree, dropped: reb.moved }
             }
         },
         View::Leaf => core::intrinsic::panic::panic()
@@ -393,7 +405,10 @@ fn remove_root<T>(p : bool, l : Tree<T>, rt : Tree<T>) -> Reb<T> {
             Reb { tree: l, moved: true }
         } else {
             let least = del_min(rt);
-            bal_right_del(p, l, least.key, least.tree, least.dropped)
+            let m = least.key;
+            let sub = least.tree;
+            let dropped = least.dropped;
+            bal_right_del(p, l, m, sub, dropped)
         }
     }
 }
@@ -404,13 +419,19 @@ fn del<T : Ord>(t : Tree<T>, x : T) -> Del<T> {
         View::Node(p, l, k, rt) => match x.cmp(k) {
             Ordering::Less => {
                 let below = del(l, x);
-                let reb = bal_left_del(p, below.tree, k, rt, below.dropped);
-                Del { tree: reb.tree, found: below.found, dropped: reb.moved }
+                let sub = below.tree;
+                let found = below.found;
+                let dropped = below.dropped;
+                let reb = bal_left_del(p, sub, k, rt, dropped);
+                Del { tree: reb.tree, found, dropped: reb.moved }
             },
             Ordering::Greater => {
                 let below = del(rt, x);
-                let reb = bal_right_del(p, l, k, below.tree, below.dropped);
-                Del { tree: reb.tree, found: below.found, dropped: reb.moved }
+                let sub = below.tree;
+                let found = below.found;
+                let dropped = below.dropped;
+                let reb = bal_right_del(p, l, k, sub, dropped);
+                Del { tree: reb.tree, found, dropped: reb.moved }
             },
             Ordering::Equal => {
                 let reb = remove_root(p, l, rt);

--- a/library/std/src/collections/pure/wavlset.rr
+++ b/library/std/src/collections/pure/wavlset.rr
@@ -95,12 +95,12 @@ fn view<T>(t : Tree<T>) -> View<T> {
 
 // A rebalanced subtree plus whether its own rank moved (raised on the
 // insertion path, dropped on the deletion path).
-enum [value] Reb<T> { R(Tree<T>, bool) }
+struct [value] Reb<T> { tree : Tree<T>, moved : bool }
 
 // The subtree, whether the set changed, and whether the rank moved.
-enum [value] Ins<T> { I(Tree<T>, bool, bool) }
-enum [value] Del<T> { D(Tree<T>, bool, bool) }
-enum [value] Min<T> { M(T, Tree<T>, bool) }
+struct [value] Ins<T> { tree : Tree<T>, added : bool, raised : bool }
+struct [value] Del<T> { tree : Tree<T>, found : bool, dropped : bool }
+struct [value] Min<T> { key : T, tree : Tree<T>, dropped : bool }
 
 // Rebalance after an insertion into the left child raised its rank:
 // promote while the sibling difference is 1, otherwise rotate once or
@@ -113,33 +113,36 @@ fn bal_left_ins<T>(
     raised : bool
 ) -> Reb<T> {
     if !raised {
-        Reb::R { mk(p, l, k, rt), false }
+        Reb { tree: mk(p, l, k, rt), moved: false }
     } else {
         if p != parity(l) {
             // The difference was 2 and is now 1: still legal, stop here.
-            Reb::R { mk(p, l, k, rt), false }
+            Reb { tree: mk(p, l, k, rt), moved: false }
         } else {
             if p != parity(rt) {
                 // Left difference hit 0 with a 1-difference sibling: promote.
-                Reb::R { mk(!p, l, k, rt), true }
+                Reb { tree: mk(!p, l, k, rt), moved: true }
             } else {
                 match view(l) {
                     View::Node(_, ll, lk, lr) => {
                         if parity(lr) == p {
                             // The left child is (1,2): one right rotation.
-                            Reb::R { mk(p, ll, lk, mk(!p, lr, k, rt)), false }
+                            Reb {
+                                tree: mk(p, ll, lk, mk(!p, lr, k, rt)),
+                                moved: false
+                            }
                         } else {
                             // The left child is (2,1): rotate through its
                             // inner grandchild.
                             match view(lr) {
-                                View::Node(_, zl, zk, zr) => Reb::R {
-                                    mk(
+                                View::Node(_, zl, zk, zr) => Reb {
+                                    tree: mk(
                                         p,
                                         mk(!p, ll, lk, zl),
                                         zk,
                                         mk(!p, zr, k, rt)
                                     ),
-                                    false
+                                    moved: false
                                 },
                                 View::Leaf => core::intrinsic::panic::panic()
                             }
@@ -160,28 +163,31 @@ fn bal_right_ins<T>(
     raised : bool
 ) -> Reb<T> {
     if !raised {
-        Reb::R { mk(p, l, k, rt), false }
+        Reb { tree: mk(p, l, k, rt), moved: false }
     } else {
         if p != parity(rt) {
-            Reb::R { mk(p, l, k, rt), false }
+            Reb { tree: mk(p, l, k, rt), moved: false }
         } else {
             if p != parity(l) {
-                Reb::R { mk(!p, l, k, rt), true }
+                Reb { tree: mk(!p, l, k, rt), moved: true }
             } else {
                 match view(rt) {
                     View::Node(_, rl, rk, rr) => {
                         if parity(rl) == p {
-                            Reb::R { mk(p, mk(!p, l, k, rl), rk, rr), false }
+                            Reb {
+                                tree: mk(p, mk(!p, l, k, rl), rk, rr),
+                                moved: false
+                            }
                         } else {
                             match view(rl) {
-                                View::Node(_, zl, zk, zr) => Reb::R {
-                                    mk(
+                                View::Node(_, zl, zk, zr) => Reb {
+                                    tree: mk(
                                         p,
                                         mk(!p, l, k, zl),
                                         zk,
                                         mk(!p, zr, rk, rr)
                                     ),
-                                    false
+                                    moved: false
                                 },
                                 View::Leaf => core::intrinsic::panic::panic()
                             }
@@ -198,21 +204,24 @@ fn ins<T : Ord>(t : Tree<T>, x : T) -> Ins<T> {
     match view(t) {
         View::Leaf =>
             // A fresh leaf has rank 0: even, and it raises its parent.
-            Ins::I { mk(false, Tree::Leaf, x, Tree::Leaf), true, true },
+            Ins {
+                tree: mk(false, Tree::Leaf, x, Tree::Leaf),
+                added: true,
+                raised: true
+            },
         View::Node(p, l, k, rt) => match x.cmp(k) {
-            Ordering::Less => match ins(l, x) {
-                Ins::I(l2, added, raised) =>
-                    match bal_left_ins(p, l2, k, rt, raised) {
-                        Reb::R(t2, raised2) => Ins::I { t2, added, raised2 }
-                    }
+            Ordering::Less => {
+                let below = ins(l, x);
+                let reb = bal_left_ins(p, below.tree, k, rt, below.raised);
+                Ins { tree: reb.tree, added: below.added, raised: reb.moved }
             },
-            Ordering::Greater => match ins(rt, x) {
-                Ins::I(rt2, added, raised) =>
-                    match bal_right_ins(p, l, k, rt2, raised) {
-                        Reb::R(t2, raised2) => Ins::I { t2, added, raised2 }
-                    }
+            Ordering::Greater => {
+                let below = ins(rt, x);
+                let reb = bal_right_ins(p, l, k, below.tree, below.raised);
+                Ins { tree: reb.tree, added: below.added, raised: reb.moved }
             },
-            Ordering::Equal => Ins::I { mk(p, l, k, rt), false, false }
+            Ordering::Equal =>
+                Ins { tree: mk(p, l, k, rt), added: false, raised: false }
         }
     }
 }
@@ -228,28 +237,34 @@ fn bal_left_del<T>(
     dropped : bool
 ) -> Reb<T> {
     if !dropped {
-        Reb::R { mk(p, l, k, rt), false }
+        Reb { tree: mk(p, l, k, rt), moved: false }
     } else {
         if p == parity(l) {
             // The difference was 1 and is now 2, which is legal unless a
             // (2,2) leaf formed — that must demote to rank 0.
             if is_leaf(l) && is_leaf(rt) {
-                Reb::R { mk(false, l, k, rt), true }
+                Reb { tree: mk(false, l, k, rt), moved: true }
             } else {
-                Reb::R { mk(p, l, k, rt), false }
+                Reb { tree: mk(p, l, k, rt), moved: false }
             }
         } else {
             match view(rt) {
                 View::Node(py, yl, yk, yr) => {
                     if py == p {
                         // The sibling is a 2-child: demote and keep climbing.
-                        Reb::R { mk(!p, l, k, mk(py, yl, yk, yr)), true }
+                        Reb {
+                            tree: mk(!p, l, k, mk(py, yl, yk, yr)),
+                            moved: true
+                        }
                     } else {
                         let same_yl = parity(yl) == py;
                         let same_yr = parity(yr) == py;
                         if same_yl && same_yr {
                             // The sibling is (2,2): demote both, keep climbing.
-                            Reb::R { mk(!p, l, k, mk(p, yl, yk, yr)), true }
+                            Reb {
+                                tree: mk(!p, l, k, mk(p, yl, yk, yr)),
+                                moved: true
+                            }
                         } else {
                             if !same_yr {
                                 // One left rotation. The demoted pivot may
@@ -259,20 +274,20 @@ fn bal_left_del<T>(
                                 } else {
                                     !p
                                 };
-                                Reb::R {
-                                    mk(p, mk(xp, l, k, yl), yk, yr),
-                                    false
+                                Reb {
+                                    tree: mk(p, mk(xp, l, k, yl), yk, yr),
+                                    moved: false
                                 }
                             } else {
                                 match view(yl) {
-                                    View::Node(_, zl, zk, zr) => Reb::R {
-                                        mk(
+                                    View::Node(_, zl, zk, zr) => Reb {
+                                        tree: mk(
                                             p,
                                             mk(p, l, k, zl),
                                             zk,
                                             mk(p, zr, yk, yr)
                                         ),
-                                        false
+                                        moved: false
                                     },
                                     View::Leaf =>
                                         core::intrinsic::panic::panic()
@@ -295,24 +310,30 @@ fn bal_right_del<T>(
     dropped : bool
 ) -> Reb<T> {
     if !dropped {
-        Reb::R { mk(p, l, k, rt), false }
+        Reb { tree: mk(p, l, k, rt), moved: false }
     } else {
         if p == parity(rt) {
             if is_leaf(l) && is_leaf(rt) {
-                Reb::R { mk(false, l, k, rt), true }
+                Reb { tree: mk(false, l, k, rt), moved: true }
             } else {
-                Reb::R { mk(p, l, k, rt), false }
+                Reb { tree: mk(p, l, k, rt), moved: false }
             }
         } else {
             match view(l) {
                 View::Node(py, yl, yk, yr) => {
                     if py == p {
-                        Reb::R { mk(!p, mk(py, yl, yk, yr), k, rt), true }
+                        Reb {
+                            tree: mk(!p, mk(py, yl, yk, yr), k, rt),
+                            moved: true
+                        }
                     } else {
                         let same_yl = parity(yl) == py;
                         let same_yr = parity(yr) == py;
                         if same_yl && same_yr {
-                            Reb::R { mk(!p, mk(p, yl, yk, yr), k, rt), true }
+                            Reb {
+                                tree: mk(!p, mk(p, yl, yk, yr), k, rt),
+                                moved: true
+                            }
                         } else {
                             if !same_yl {
                                 let xp = if is_leaf(yr) && is_leaf(rt) {
@@ -320,20 +341,20 @@ fn bal_right_del<T>(
                                 } else {
                                     !p
                                 };
-                                Reb::R {
-                                    mk(p, yl, yk, mk(xp, yr, k, rt)),
-                                    false
+                                Reb {
+                                    tree: mk(p, yl, yk, mk(xp, yr, k, rt)),
+                                    moved: false
                                 }
                             } else {
                                 match view(yr) {
-                                    View::Node(_, zl, zk, zr) => Reb::R {
-                                        mk(
+                                    View::Node(_, zl, zk, zr) => Reb {
+                                        tree: mk(
                                             p,
                                             mk(p, yl, yk, zl),
                                             zk,
                                             mk(p, zr, k, rt)
                                         ),
-                                        false
+                                        moved: false
                                     },
                                     View::Leaf =>
                                         core::intrinsic::panic::panic()
@@ -353,13 +374,11 @@ fn del_min<T>(t : Tree<T>) -> Min<T> {
         View::Node(p, l, k, rt) => {
             if is_leaf(l) {
                 // A leaf or right-unary node: removing it drops the rank.
-                Min::M { k, rt, true }
+                Min { key: k, tree: rt, dropped: true }
             } else {
-                match del_min(l) {
-                    Min::M(m, l2, d) => match bal_left_del(p, l2, k, rt, d) {
-                        Reb::R(t2, d2) => Min::M { m, t2, d2 }
-                    }
-                }
+                let least = del_min(l);
+                let reb = bal_left_del(p, least.tree, k, rt, least.dropped);
+                Min { key: least.key, tree: reb.tree, dropped: reb.moved }
             }
         },
         View::Leaf => core::intrinsic::panic::panic()
@@ -368,36 +387,34 @@ fn del_min<T>(t : Tree<T>) -> Min<T> {
 
 fn remove_root<T>(p : bool, l : Tree<T>, rt : Tree<T>) -> Reb<T> {
     if is_leaf(l) {
-        Reb::R { rt, true }
+        Reb { tree: rt, moved: true }
     } else {
         if is_leaf(rt) {
-            Reb::R { l, true }
+            Reb { tree: l, moved: true }
         } else {
-            match del_min(rt) {
-                Min::M(m, rt2, d) => bal_right_del(p, l, m, rt2, d)
-            }
+            let least = del_min(rt);
+            bal_right_del(p, l, least.key, least.tree, least.dropped)
         }
     }
 }
 
 fn del<T : Ord>(t : Tree<T>, x : T) -> Del<T> {
     match view(t) {
-        View::Leaf => Del::D { Tree::Leaf, false, false },
+        View::Leaf => Del { tree: Tree::Leaf, found: false, dropped: false },
         View::Node(p, l, k, rt) => match x.cmp(k) {
-            Ordering::Less => match del(l, x) {
-                Del::D(l2, found, dropped) =>
-                    match bal_left_del(p, l2, k, rt, dropped) {
-                        Reb::R(t2, d2) => Del::D { t2, found, d2 }
-                    }
+            Ordering::Less => {
+                let below = del(l, x);
+                let reb = bal_left_del(p, below.tree, k, rt, below.dropped);
+                Del { tree: reb.tree, found: below.found, dropped: reb.moved }
             },
-            Ordering::Greater => match del(rt, x) {
-                Del::D(rt2, found, dropped) =>
-                    match bal_right_del(p, l, k, rt2, dropped) {
-                        Reb::R(t2, d2) => Del::D { t2, found, d2 }
-                    }
+            Ordering::Greater => {
+                let below = del(rt, x);
+                let reb = bal_right_del(p, l, k, below.tree, below.dropped);
+                Del { tree: reb.tree, found: below.found, dropped: reb.moved }
             },
-            Ordering::Equal => match remove_root(p, l, rt) {
-                Reb::R(t2, d2) => Del::D { t2, true, d2 }
+            Ordering::Equal => {
+                let reb = remove_root(p, l, rt);
+                Del { tree: reb.tree, found: true, dropped: reb.moved }
             }
         }
     }
@@ -471,21 +488,19 @@ impl<T : Ord> WavlSet<T> {
 
     /// Adds `value`, keeping the existing element on equality. O(log n).
     pub fn insert(self : Self, value : T) -> Self {
-        match ins(self.root, value) {
-            Ins::I(root, added, _) => WavlSet {
-                size: if added { self.size + 1 } else { self.size },
-                root
-            }
+        let r = ins(self.root, value);
+        WavlSet {
+            size: if r.added { self.size + 1 } else { self.size },
+            root: r.tree
         }
     }
 
     /// Removes `value` when present. O(log n).
     pub fn remove(self : Self, value : T) -> Self {
-        match del(self.root, value) {
-            Del::D(root, found, _) => WavlSet {
-                size: if found { self.size - 1 } else { self.size },
-                root
-            }
+        let r = del(self.root, value);
+        WavlSet {
+            size: if r.found { self.size - 1 } else { self.size },
+            root: r.tree
         }
     }
 


### PR DESCRIPTION
The WAVL and binomial-heap helpers returned single-constructor enums that every caller immediately destructured. That is a product type spelled as a sum: each use paid a `match` that could only go one way, and the payloads were positional — `Ins::I(t, b1, b2)` carried two `bool`s whose meaning lived only in the declaration.

Seven of them are now `struct [value]` with named fields:

| was | now |
|---|---|
| `enum [value] Reb { R(Tree, bool) }` | `struct [value] Reb { tree, moved }` |
| `enum [value] Ins { I(Tree, bool, bool) }` | `struct [value] Ins { tree, added, raised }` |
| `enum [value] Del { D(Tree, bool, bool) }` | `struct [value] Del { tree, found, dropped }` |
| `enum [value] Min { M(T, Tree, bool) }` | `struct [value] Min { key, tree, dropped }` |
| `enum [value] Changed { C(Tree, bool) }` | `struct [value] Changed { tree, changed }` |
| `enum [value] DelMin { D(K, V, Tree) }` | `struct [value] DelMin { key, value, tree }` |
| `enum [value] Split { S(Tree, List&gt;) }` | `struct [value] Split { tree, rest }` |

**`View` in `wavlset` stays an enum.** It genuinely has two constructors (`Leaf`/`Node`) and exists to drive a match, the same role `list.rr`&#39;s `Helper` plays. That is the distinction: a single-constructor enum earns its keep when the point is simultaneous pattern matching, and is noise when the point is returning several values.

## Ownership: bind every field before the call

The conversion is not free by default. Destructuring an enum consumes the carrier and moves all fields out at once. Reading a field *after* a call keeps the carrier alive across it, so the subtree becomes a second reference rather than a move — a retain in, a release when the carrier dies:

```rust
// costs a retain: below.added is read after the call, so below outlives it
let below = ins(l, x);
let reb = bal_left_ins(p, below.tree, k, rt, below.raised);
Ins { tree: reb.tree, added: below.added, raised: reb.moved }

// carrier is dead at the call, so the subtree moves
let below = ins(l, x);
let sub = below.tree;
let added = below.added;
let raised = below.raised;
let reb = bal_left_ins(p, sub, k, rt, raised);
Ins { tree: reb.tree, added, raised: reb.moved }
```

Project-first is applied at every site where a field is read across a call: `ins`, `del` and `del_min` in both wavl containers, `remove_root`, and the binomial heap&#39;s two `Split` consumers.

&gt; Follow-up, not in this PR: the compiler could recognise this shape directly — a projection whose carrier is dead afterwards is a move, not a retain — and then the natural spelling would be optimal without the manual binding. Prototyped in #538.

## No performance degradation

Instruction counts under callgrind, which is deterministic (wall clock at this scale is noisier than the effect; the heap figures below differ by 56 instructions out of 7.1M and read as ±5% in wall time):

| workload | main | this PR | delta |
|---|---|---|---|
| set insert | 61,810,099 | 59,670,738 | −3.46% |
| set build+drain | 116,999,644 | 113,205,770 | −3.24% |
| set lookup | 82,260,969 | 80,121,606 | −2.60% |
| set iterate | 74,487,672 | 72,348,268 | −2.87% |
| map insert | 56,722,985 | 54,234,075 | −4.38% |
| map build+remove | 109,717,553 | 104,814,966 | −4.46% |
| map get | 71,662,860 | 69,174,028 | −3.47% |
| map iterate | 68,530,914 | 66,005,340 | −3.68% |
| heap insert | 7,149,145 | 7,149,201 | 0% |
| heap build+drain | 87,614,765 | 87,388,447 | −0.25% |
| heap merge | 19,824,271 | 19,824,371 | 0% |

Every workload is neutral or faster; nothing regresses. The heap is flat because `Split` sits off its hot path. Allocation counts are unchanged (1,815,932 over 100k set inserts, identical to main), so uniqueness and in-place reuse behave exactly as before — the gain is reference-count traffic removed, not a change in what gets allocated.

For contrast, the intermediate version of this PR that read a field across the call measured **+3.9%** on set insert, which is what motivated the project-first rule above.

## Also in this PR

- `[rt]` The `std::hash` FFI wrappers are `#[inline]`: they are the first non-generic runtime functions a PolyFFI texture calls, and the attribute exports their MIR so they inline into the texture like the monomorphized generic APIs, keeping per-write marshalling at zero call overhead.
- `[ci]` The recurring ubuntu-arm rene clippy failure ("Lock file ... is stuck", cascading into a bogus `TemplateSimple` trait-bound error) was a race, not a stale file: sailfish&#39;s derive gives the lock loser only 100 × 10 ms, `--all-targets` expands the derive in two concurrent rustc processes, and the templates recompile on every CI run because a fresh checkout stamps the sources newer than any cached output. A solo `--lib` warm-up pass compiles the templates once before the parallel pass; genuinely leaked locks are cleared first.

Earlier revisions of this branch carried an `XFAIL: windows` quarantine and diagnostic rework for the WAVL test; both were dropped in the rebase — #539 root-caused that failure to a stale sccache&#39;d `rrc` and rewrote the test&#39;s observations properly, so the quarantine would only have turned into an XPASS failure.

## Testing

Behavior is unchanged. All eleven benchmark workloads produce byte-identical output between the two builds. The `std_collections_pure_wavl_test` package (public API, ascending iteration, persistence, model-checked churn), the heap tests including cross-implementation agreement, the full lit suite, and the C++ unit tests all pass, as does a scratch driver churning 20k randomized set and map operations against a sorted-list model. After the rebase onto #543 + #539, the wavl (including the new fold-traverse regressions), heap, fingertree, and hash lit tests were re-verified locally against the merged main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS