### PR TITLE
[syntax][core][codegen] integer bitwise operators and bit-counting intrinsics

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -2795,6 +2795,16 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             (ArithOp::Mod, false, false) => arith::remui(lv, rv, loc),
             (ArithOp::And, ..) => arith::andi(lv, rv, loc),
             (ArithOp::Or, ..) => arith::ori(lv, rv, loc),
+            // Bitwise: the checker admits only `Integral` operands, so the
+            // float flag is always false here. The shift amount shares the
+            // operand type; a right shift follows the operand's signedness
+            // (arithmetic for signed, logical for unsigned).
+            (ArithOp::BitAnd, ..) => arith::andi(lv, rv, loc),
+            (ArithOp::BitOr, ..) => arith::ori(lv, rv, loc),
+            (ArithOp::BitXor, ..) => arith::xori(lv, rv, loc),
+            (ArithOp::Shl, ..) => arith::shli(lv, rv, loc),
+            (ArithOp::Shr, _, true) => arith::shrsi(lv, rv, loc),
+            (ArithOp::Shr, _, false) => arith::shrui(lv, rv, loc),
         };
         Ok(self.append(block, op))
     }

--- a/crates/reussir-codegen/src/lower/math.rs
+++ b/crates/reussir-codegen/src/lower/math.rs
@@ -115,5 +115,19 @@ pub(super) fn math_operation<'c>(
                 None => b.build().into(),
             }
         }
+        // The integer ops carry no fastmath attribute (the checker never
+        // passes one), and their result type is inferable.
+        MathFn::Ctpop => math::CtPopOperationBuilder::new(context, location)
+            .operand(operands[0])
+            .build()
+            .into(),
+        MathFn::Ctlz => math::CountLeadingZerosOperationBuilder::new(context, location)
+            .operand(operands[0])
+            .build()
+            .into(),
+        MathFn::Cttz => math::CountTrailingZerosOperationBuilder::new(context, location)
+            .operand(operands[0])
+            .build()
+            .into(),
     }
 }

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -611,6 +611,11 @@ fn arith(op: raw::ArithOp) -> ArithOp {
         raw::ArithOp::Mod => ArithOp::Mod,
         raw::ArithOp::And => ArithOp::And,
         raw::ArithOp::Or => ArithOp::Or,
+        raw::ArithOp::BitAnd => ArithOp::BitAnd,
+        raw::ArithOp::BitOr => ArithOp::BitOr,
+        raw::ArithOp::BitXor => ArithOp::BitXor,
+        raw::ArithOp::Shl => ArithOp::Shl,
+        raw::ArithOp::Shr => ArithOp::Shr,
     }
 }
 

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -328,6 +328,13 @@ ArithOp: raw::ArithOp = {
     "%" => raw::ArithOp::Mod,
     "&&" => raw::ArithOp::And,
     "||" => raw::ArithOp::Or,
+    "&" => raw::ArithOp::BitAnd,
+    "|" => raw::ArithOp::BitOr,
+    "^" => raw::ArithOp::BitXor,
+    // Shifts are two adjacent angle tokens: a `<<`/`>>` token would make
+    // the lexer eat nested generic closers (`List<List<i64>>`) whole.
+    "<" "<" => raw::ArithOp::Shl,
+    ">" ">" => raw::ArithOp::Shr,
 };
 
 CmpOp: raw::CmpOp = {
@@ -453,6 +460,9 @@ extern {
         "%" => Token::Percent,
         "&&" => Token::AndAnd,
         "||" => Token::OrOr,
+        "&" => Token::Amp,
+        "|" => Token::Pipe,
+        "^" => Token::Caret,
         "<=" => Token::Le,
         ">=" => Token::Ge,
         "==" => Token::EqEq,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -707,6 +707,11 @@ fn arith_sym(op: ArithOp) -> &'static str {
         ArithOp::Mod => "%",
         ArithOp::And => "&&",
         ArithOp::Or => "||",
+        ArithOp::BitAnd => "&",
+        ArithOp::BitOr => "|",
+        ArithOp::BitXor => "^",
+        ArithOp::Shl => "<<",
+        ArithOp::Shr => ">>",
     }
 }
 

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -439,6 +439,11 @@ pub enum ArithOp {
     Mod,
     And,
     Or,
+    BitAnd,
+    BitOr,
+    BitXor,
+    Shl,
+    Shr,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -20,6 +20,10 @@ pub enum MathKind {
     Fma,
     /// Float base and `i32` exponent in, float out.
     Fpowi,
+    /// One integer in, same integer out (`ctpop`, `ctlz`, `cttz`). Bounded
+    /// by `Integral` rather than `FloatingPoint`, and takes no fast-math
+    /// flag — the MLIR integer math ops have no such attribute.
+    IntUnary,
 }
 
 macro_rules! math_fns {
@@ -98,6 +102,9 @@ math_fns! {
     Powf => "powf": Binary,
     Fma => "fma": Fma,
     Fpowi => "fpowi": Fpowi,
+    Ctpop => "ctpop": IntUnary,
+    Ctlz => "ctlz": IntUnary,
+    Cttz => "cttz": IntUnary,
 }
 
 impl MathKind {
@@ -105,7 +112,7 @@ impl MathKind {
     /// flag is one more).
     pub fn value_args(self) -> usize {
         match self {
-            MathKind::Unary | MathKind::Check => 1,
+            MathKind::Unary | MathKind::Check | MathKind::IntUnary => 1,
             MathKind::Binary | MathKind::Fpowi => 2,
             MathKind::Fma => 3,
         }

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -224,6 +224,12 @@ pub enum Token<'a> {
     Ne,
     #[token("!")]
     Bang,
+    #[token("&")]
+    Amp,
+    #[token("|")]
+    Pipe,
+    #[token("^")]
+    Caret,
 
     // ----- literals & identifiers -----
     /// `v<id>` — a local variable.

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -505,6 +505,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     /// Binary operators synthesize:
     /// (ARITH) `op∈{+,-,*,/,%}`: `l ⇒ T`, `Num ⊳ T`, `r ⇐ T`, result `T`.
+    /// (BIT) `op∈{&,|,^,<<,>>}`: `l ⇒ T`, `Integral ⊳ T`, `r ⇐ T`, result `T`.
     /// (LOGIC) `op∈{&&,||}`: `l ⇐ Bool`, `r ⇐ Bool`, result `Bool`.
     /// (CMP-SCALAR) comparisons with `l ⇒ T` for scalar-or-hole `T`: `r ⇐ T`, result
     /// `Bool`, lowered intrinsically; equality registers `PartialEq ⊳ T`, orderings
@@ -525,6 +526,17 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 let l = self.infer_expr(l);
                 let ty = l.ty;
                 self.register_bound(self.lang.num, ty, span);
+                let r = self.check_expr(r, ty);
+                let aop = arith_op(op);
+                self.mk_expr(ExprKind::Arith(Box::new(l), aop, Box::new(r)), ty, span)
+            }
+            BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor | BinOp::Shl | BinOp::Shr => {
+                // (BIT) like (ARITH) but integers only, `Integral ⊳ T`.
+                // Both operands share `T` — a shift amount is the operand
+                // type, not a separate width.
+                let l = self.infer_expr(l);
+                let ty = l.ty;
+                self.register_bound(self.lang.integral, ty, span);
                 let r = self.check_expr(r, ty);
                 let aop = arith_op(op);
                 self.mk_expr(ExprKind::Arith(Box::new(l), aop, Box::new(r)), ty, span)
@@ -2253,7 +2265,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         };
 
         // The shared element type: an optional single explicit type argument,
-        // else inferred — either way bounded by `FloatingPoint`.
+        // else inferred — either way bounded by `FloatingPoint` (`Integral`
+        // for the integer ops).
         let elem = match fc.ty_args.as_slice() {
             [] | [None] => self.infer.new_hole_ty(),
             [Some(t)] => self.eval_type(t),
@@ -2265,9 +2278,36 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 return self.poison(span);
             }
         };
-        self.register_bound(self.lang.floating_point, elem, span);
-
         let kind = func.kind();
+        let bound = if kind == MathKind::IntUnary {
+            self.lang.integral
+        } else {
+            self.lang.floating_point
+        };
+        self.register_bound(bound, elem, span);
+
+        // The integer ops (`ctpop`, `ctlz`, `cttz`) take no fast-math flag:
+        // their MLIR forms have no such attribute.
+        if kind == MathKind::IntUnary {
+            if fc.args.len() != 1 {
+                self.error(
+                    span,
+                    format!("`{name}` expects exactly 1 argument, got {}", fc.args.len()),
+                );
+                return self.poison(span);
+            }
+            let arg = self.check_expr(&fc.args[0], elem);
+            let op = IntrinsicOp::Math { func, flag: 0 };
+            return self.mk_expr(
+                ExprKind::Intrinsic {
+                    op,
+                    args: vec![arg],
+                },
+                elem,
+                span,
+            );
+        }
+
         let want = kind.value_args() + 1;
         if fc.args.len() != want {
             self.error(
@@ -3517,7 +3557,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     }
 }
 
-/// Map a surface arithmetic/boolean operator to the HIR form.
+/// Map a surface arithmetic/boolean/bitwise operator to the HIR form.
 fn arith_op(op: BinOp) -> ArithOp {
     match op {
         BinOp::Add => ArithOp::Add,
@@ -3527,6 +3567,11 @@ fn arith_op(op: BinOp) -> ArithOp {
         BinOp::Mod => ArithOp::Mod,
         BinOp::And => ArithOp::And,
         BinOp::Or => ArithOp::Or,
+        BinOp::BitAnd => ArithOp::BitAnd,
+        BinOp::BitOr => ArithOp::BitOr,
+        BinOp::BitXor => ArithOp::BitXor,
+        BinOp::Shl => ArithOp::Shl,
+        BinOp::Shr => ArithOp::Shr,
         _ => unreachable!("not an arithmetic operator"),
     }
 }

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -81,7 +81,7 @@ pub struct VarId(pub u32);
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct ExprId(pub u32);
 
-/// Arithmetic / boolean binary operators.
+/// Arithmetic / boolean / bitwise binary operators.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ArithOp {
     Add,
@@ -91,6 +91,11 @@ pub enum ArithOp {
     Mod,
     And,
     Or,
+    BitAnd,
+    BitOr,
+    BitXor,
+    Shl,
+    Shr,
 }
 
 /// Comparison operators (all produce `bool`).

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -1023,6 +1023,11 @@ fn arith(op: raw::ArithOp) -> ArithOp {
         raw::ArithOp::Mod => ArithOp::Mod,
         raw::ArithOp::And => ArithOp::And,
         raw::ArithOp::Or => ArithOp::Or,
+        raw::ArithOp::BitAnd => ArithOp::BitAnd,
+        raw::ArithOp::BitOr => ArithOp::BitOr,
+        raw::ArithOp::BitXor => ArithOp::BitXor,
+        raw::ArithOp::Shl => ArithOp::Shl,
+        raw::ArithOp::Shr => ArithOp::Shr,
     }
 }
 

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -503,6 +503,13 @@ ArithOp: raw::ArithOp = {
     "%" => raw::ArithOp::Mod,
     "&&" => raw::ArithOp::And,
     "||" => raw::ArithOp::Or,
+    "&" => raw::ArithOp::BitAnd,
+    "|" => raw::ArithOp::BitOr,
+    "^" => raw::ArithOp::BitXor,
+    // Shifts are two adjacent angle tokens: a `<<`/`>>` token would make
+    // the lexer eat nested generic closers (`List<List<i64>>`) whole.
+    "<" "<" => raw::ArithOp::Shl,
+    ">" ">" => raw::ArithOp::Shr,
 };
 
 CmpOp: raw::CmpOp = {
@@ -626,6 +633,9 @@ extern {
         "%" => Token::Percent,
         "&&" => Token::AndAnd,
         "||" => Token::OrOr,
+        "&" => Token::Amp,
+        "|" => Token::Pipe,
+        "^" => Token::Caret,
         "<=" => Token::Le,
         ">=" => Token::Ge,
         "==" => Token::EqEq,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -1022,6 +1022,11 @@ fn arith_sym(op: ArithOp) -> &'static str {
         ArithOp::Mod => "%",
         ArithOp::And => "&&",
         ArithOp::Or => "||",
+        ArithOp::BitAnd => "&",
+        ArithOp::BitOr => "|",
+        ArithOp::BitXor => "^",
+        ArithOp::Shl => "<<",
+        ArithOp::Shr => ">>",
     }
 }
 

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -105,6 +105,11 @@ pub enum BinOp {
     Neq,
     And,
     Or,
+    BitAnd,
+    BitOr,
+    BitXor,
+    Shl,
+    Shr,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -353,8 +358,24 @@ fn binary_op(kind: SyntaxKind) -> Option<BinOp> {
         BangEq => BinOp::Neq,
         AmpAmp => BinOp::And,
         PipePipe => BinOp::Or,
+        Amp => BinOp::BitAnd,
+        Pipe => BinOp::BitOr,
+        Caret => BinOp::BitXor,
         _ => return None,
     })
+}
+
+/// The operator of a `BinExpr` node. Shifts have no token of their own —
+/// the parser glues two adjacent angle tokens — so a pair of operator
+/// tokens reads as the shift, and a single token maps directly.
+fn bin_expr_op(node: &ResolvedNode) -> Option<BinOp> {
+    let mut ops = tokens(node).filter_map(|t| Some((t.kind(), binary_op(t.kind())?)));
+    let (first_kind, first) = ops.next()?;
+    match (first_kind, ops.next()) {
+        (LAngle, Some((LAngle, _))) => Some(BinOp::Shl),
+        (RAngle, Some((RAngle, _))) => Some(BinOp::Shr),
+        _ => Some(first),
+    }
 }
 
 fn prim_type(text: &str) -> TypeKind {
@@ -764,9 +785,7 @@ impl Expr {
                 ExprKind::Lambda(Box::new(Lambda { args, body, ret_ty }))
             }
             BinExpr => {
-                let op = tokens(node)
-                    .find_map(|t| binary_op(t.kind()))
-                    .expect("binary operator");
+                let op = bin_expr_op(node).expect("binary operator");
                 let mut operands = expr_children(node);
                 let lhs = Expr::new(operands.next().expect("lhs"));
                 let rhs = Expr::new(operands.next().expect("rhs"));

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -663,9 +663,7 @@ impl Emitter<'_> {
                 )
             }
             BinExpr => {
-                let op = tokens(node)
-                    .find_map(|t| binary_op_name(t.kind()))
-                    .expect("binary operator");
+                let op = bin_expr_op_name(node).expect("binary operator");
                 let mut operands = expr_children(node).map(|e| self.expr(e));
                 let lhs = operands.next().expect("lhs");
                 let rhs = operands.next().expect("rhs");
@@ -867,8 +865,24 @@ fn binary_op_name(kind: SyntaxKind) -> Option<&'static str> {
         BangEq => "Neq",
         AmpAmp => "And",
         PipePipe => "Or",
+        Amp => "BitAnd",
+        Pipe => "BitOr",
+        Caret => "BitXor",
         _ => return None,
     })
+}
+
+/// The operator name of a `BinExpr` node. Shifts have no token of their
+/// own — the parser glues two adjacent angle tokens — so a pair of
+/// operator tokens reads as the shift, and a single token maps directly.
+fn bin_expr_op_name(node: &ResolvedNode) -> Option<&'static str> {
+    let mut ops = tokens(node).filter_map(|t| Some((t.kind(), binary_op_name(t.kind())?)));
+    let (first_kind, first) = ops.next()?;
+    match (first_kind, ops.next()) {
+        (LAngle, Some((LAngle, _))) => Some("Shl"),
+        (RAngle, Some((RAngle, _))) => Some("Shr"),
+        _ => Some(first),
+    }
 }
 
 fn prim_type(text: &str) -> Value {

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -104,6 +104,10 @@ pub enum SyntaxKind {
     Bang,
     /// `|`
     Pipe,
+    /// `&`
+    Amp,
+    /// `^`
+    Caret,
     /// `#`
     Pound,
     /// `_`
@@ -315,6 +319,8 @@ impl SyntaxKind {
             Percent => "`%`",
             Bang => "`!`",
             Pipe => "`|`",
+            Amp => "`&`",
+            Caret => "`^`",
             Pound => "`#`",
             Underscore => "`_`",
             Eof => "the end of the input",

--- a/crates/reussir-syntax/src/lexer.rs
+++ b/crates/reussir-syntax/src/lexer.rs
@@ -144,6 +144,10 @@ pub enum RawToken {
     Bang,
     #[token("|")]
     Pipe,
+    #[token("&")]
+    Amp,
+    #[token("^")]
+    Caret,
     #[token("#")]
     Pound,
     #[token("_")]
@@ -385,6 +389,8 @@ impl RawToken {
             RawToken::Percent => SyntaxKind::Percent,
             RawToken::Bang => SyntaxKind::Bang,
             RawToken::Pipe => SyntaxKind::Pipe,
+            RawToken::Amp => SyntaxKind::Amp,
+            RawToken::Caret => SyntaxKind::Caret,
             RawToken::Pound => SyntaxKind::Pound,
             RawToken::Underscore => SyntaxKind::Underscore,
         }

--- a/crates/reussir-syntax/src/parser/expr.rs
+++ b/crates/reussir-syntax/src/parser/expr.rs
@@ -124,11 +124,21 @@ fn binary_bp(kind: SyntaxKind) -> Option<BindingPower> {
         PipePipe => BindingPower::left_assoc(2),
         AmpAmp => BindingPower::left_assoc(4),
         EqEq | BangEq | LAngle | RAngle | LtEq | GtEq => BindingPower::non_assoc(6),
-        Plus | Minus => BindingPower::left_assoc(8),
-        Star | Slash | Percent => BindingPower::left_assoc(10),
+        // The bitwise ladder sits between comparisons and arithmetic —
+        // Rust's order, so `a & b == c` is `(a & b) == c` (not C's trap)
+        // and `a | b + c` is `a | (b + c)`.
+        Pipe => BindingPower::left_assoc(8),
+        Caret => BindingPower::left_assoc(10),
+        Amp => BindingPower::left_assoc(12),
+        Plus | Minus => BindingPower::left_assoc(16),
+        Star | Slash | Percent => BindingPower::left_assoc(18),
         _ => return None,
     })
 }
+
+/// Shifts sit between `&` and `+`/`-` on the ladder. They have no token of
+/// their own — see [`Parser::glued_shift`].
+const SHIFT_BP: BindingPower = BindingPower::left_assoc(14);
 
 const ASSIGN_BP: u8 = 1;
 
@@ -186,8 +196,17 @@ impl Parser<'_> {
                 continue;
             }
 
-            let Some(bp) = binary_bp(self.current()) else {
-                break;
+            // `<<`/`>>` are two glued angle tokens, not a lexer token of
+            // their own: the lexer keeps angles single so the type grammar
+            // can close nested generics (`List<List<T>>`) one level at a
+            // time. Gluing happens only here, in infix-operator position.
+            let shift = self.glued_shift();
+            let bp = match shift {
+                Some(_) => SHIFT_BP,
+                None => match binary_bp(self.current()) {
+                    Some(bp) => bp,
+                    None => break,
+                },
             };
             if bp.left < min_bp {
                 break;
@@ -198,6 +217,9 @@ impl Parser<'_> {
             }
             let m = lhs.precede(self);
             self.bump(); // the operator
+            if shift.is_some() {
+                self.bump(); // the glued second half of `<<` / `>>`
+            }
             if self.expr_bp(bp.right, allow_struct).is_none() {
                 self.error(format!(
                     "expected an expression after the operator, found {}",

--- a/crates/reussir-syntax/src/parser/mod.rs
+++ b/crates/reussir-syntax/src/parser/mod.rs
@@ -103,6 +103,21 @@ impl<'s> Parser<'s> {
         self.current() == kind
     }
 
+    /// An adjacent `<<`/`>>` pair glued into a shift operator, or `None`.
+    /// The lexer keeps angle tokens single so the type grammar can close
+    /// nested generics one level at a time; a shift operator therefore
+    /// exists only as two angle tokens with nothing between them, detected
+    /// where an infix operator is expected. Returns the angle kind.
+    pub(crate) fn glued_shift(&self) -> Option<SyntaxKind> {
+        let kind = self.current();
+        if !matches!(kind, SyntaxKind::LAngle | SyntaxKind::RAngle) || self.nth(1) != kind {
+            return None;
+        }
+        let a = self.tokens.get(self.pos)?;
+        let b = self.tokens.get(self.pos + 1)?;
+        (a.range.1 == b.range.0).then_some(kind)
+    }
+
     pub(crate) fn at_eof(&self) -> bool {
         self.at(SyntaxKind::Eof)
     }

--- a/library/core/src/intrinsic/math.rr
+++ b/library/core/src/intrinsic/math.rr
@@ -121,3 +121,20 @@ pub fn fma<F: FloatingPoint>(x: F, y: F, z: F, fastmath: i64) -> F;
 
 #[lang("core::intrinsic::math::fpowi")]
 pub fn fpowi<F: FloatingPoint>(x: F, e: i32, fastmath: i64) -> F;
+
+// The integer bit-counting operations. Unlike the floating-point family
+// they take no fast-math flag: their MLIR forms carry no such attribute.
+
+/// Population count: the number of set bits in `x`.
+#[lang("core::intrinsic::math::ctpop")]
+pub fn ctpop<I: Integral>(x: I) -> I;
+
+/// Count of leading zero bits, from the most significant end. `ctlz(0)`
+/// is the operand's bit width.
+#[lang("core::intrinsic::math::ctlz")]
+pub fn ctlz<I: Integral>(x: I) -> I;
+
+/// Count of trailing zero bits, from the least significant end. `cttz(0)`
+/// is the operand's bit width.
+#[lang("core::intrinsic::math::cttz")]
+pub fn cttz<I: Integral>(x: I) -> I;

--- a/tests/integration/frontend/bitwise.rr
+++ b/tests/integration/frontend/bitwise.rr
@@ -14,11 +14,10 @@
 import core::intrinsic::math;
 
 // HIR: fn #combine
-// HIR-DAG: {{.*}} & {{.*}}
-// HIR-DAG: {{.*}} | {{.*}}
-// HIR-DAG: {{.*}} ^ {{.*}}
+// HIR-DAG: & v1
+// HIR-DAG: | v1
+// HIR-DAG: ^ v1
 // MIR: fn @{{.*}}combine
-// LLVM-LABEL: combine
 // LLVM-DAG: and i64
 // LLVM-DAG: or i64
 // LLVM-DAG: xor i64
@@ -29,22 +28,19 @@ pub fn combine(a : i64, b : i64) -> i64 {
 // The MIR text spells a shift as two adjacent angle tokens (`<<`), and the
 // re-entry RUN lines above prove the printed form parses back.
 // HIR: fn #shifts
-// HIR-DAG: {{.*}} << {{.*}}
-// HIR-DAG: {{.*}} >> {{.*}}
-// LLVM-LABEL: shifts
+// HIR-DAG: << v1
+// HIR-DAG: >> v1
 // LLVM-DAG: shl i64
 // LLVM-DAG: ashr i64
 pub fn shifts(x : i64, n : i64) -> i64 {
     (x << n) + (x >> n)
 }
 
-// LLVM-LABEL: shifts_unsigned
-// LLVM: lshr i64
+// LLVM-DAG: lshr i64
 pub fn shifts_unsigned(x : u64, n : u64) -> u64 {
     x >> n
 }
 
-// LLVM-LABEL: counts
 // LLVM-DAG: llvm.ctpop.i32
 // LLVM-DAG: llvm.ctlz.i32
 // LLVM-DAG: llvm.cttz.i32
@@ -67,8 +63,6 @@ pub fn mixed(x : u32) -> u32 {
 }
 
 // The hash-trie rank idiom the intrinsics exist for.
-// LLVM-LABEL: rank
-// LLVM: llvm.ctpop.i32
 pub fn rank(bitmap : u32, bit : u32) -> u32 {
     math::ctpop(bitmap & (bit - 1))
 }

--- a/tests/integration/frontend/bitwise.rr
+++ b/tests/integration/frontend/bitwise.rr
@@ -1,0 +1,74 @@
+// Integer bitwise operators and the bit-counting intrinsics, through every
+// textual stage: the HIR and MIR forms round-trip (shifts print as adjacent
+// angle tokens and re-parse), and the LLVM lowering picks the shift by the
+// operand's signedness — `ashr` for signed, `lshr` for unsigned.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o %t.hir
+// RUN: %FileCheck %s --check-prefix=HIR < %t.hir
+// RUN: %rrc %s --emit mir --no-source-locations -o %t.mir
+// RUN: %FileCheck %s --check-prefix=MIR < %t.mir
+// RUN: %rrc %t.hir --emit mir --no-source-locations -o -
+// RUN: %rrc %t.mir --emit llvm-ir -Onone -o %t.ll
+// RUN: %FileCheck %s --check-prefix=LLVM < %t.ll
+
+import core::intrinsic::math;
+
+// HIR: fn #combine
+// HIR-DAG: {{.*}} & {{.*}}
+// HIR-DAG: {{.*}} | {{.*}}
+// HIR-DAG: {{.*}} ^ {{.*}}
+// MIR: fn @{{.*}}combine
+// LLVM-LABEL: combine
+// LLVM-DAG: and i64
+// LLVM-DAG: or i64
+// LLVM-DAG: xor i64
+pub fn combine(a : i64, b : i64) -> i64 {
+    (a & b) + (a | b) + (a ^ b)
+}
+
+// The MIR text spells a shift as two adjacent angle tokens (`<<`), and the
+// re-entry RUN lines above prove the printed form parses back.
+// HIR: fn #shifts
+// HIR-DAG: {{.*}} << {{.*}}
+// HIR-DAG: {{.*}} >> {{.*}}
+// LLVM-LABEL: shifts
+// LLVM-DAG: shl i64
+// LLVM-DAG: ashr i64
+pub fn shifts(x : i64, n : i64) -> i64 {
+    (x << n) + (x >> n)
+}
+
+// LLVM-LABEL: shifts_unsigned
+// LLVM: lshr i64
+pub fn shifts_unsigned(x : u64, n : u64) -> u64 {
+    x >> n
+}
+
+// LLVM-LABEL: counts
+// LLVM-DAG: llvm.ctpop.i32
+// LLVM-DAG: llvm.ctlz.i32
+// LLVM-DAG: llvm.cttz.i32
+pub fn counts(x : u32) -> u32 {
+    math::ctpop(x) + math::ctlz(x) + math::cttz(x)
+}
+
+// The operators still coexist with the syntax they share tokens with:
+// lambdas after `|`, generic closers alongside the shift gluing.
+enum Pair<T> { P(T, T) }
+
+pub fn mixed(x : u32) -> u32 {
+    let p = Pair::P { x | 1, x & 7 };
+    match p {
+        Pair::P(a, b) => {
+            let dbl = |v : u32| v << 1;
+            dbl(a) + b
+        }
+    }
+}
+
+// The hash-trie rank idiom the intrinsics exist for.
+// LLVM-LABEL: rank
+// LLVM: llvm.ctpop.i32
+pub fn rank(bitmap : u32, bit : u32) -> u32 {
+    math::ctpop(bitmap & (bit - 1))
+}

--- a/tests/integration/frontend/bitwise_errors.rr
+++ b/tests/integration/frontend/bitwise_errors.rr
@@ -1,0 +1,17 @@
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+// The bitwise operators are integer-only: `Integral ⊳ T`, which excludes
+// floats and — unlike Rust — `bool`, whose connectives are `&&`/`||`.
+
+// CHECK-DAG: `f64` does not implement `Integral`
+pub fn on_float(x : f64, y : f64) -> f64 { x & y }
+
+// CHECK-DAG: `bool` does not implement `Integral`
+pub fn on_bool(x : bool, y : bool) -> bool { x | y }
+
+// CHECK-DAG: `f32` does not implement `Integral`
+pub fn shift_float(x : f32) -> f32 { x << 2 }
+
+// The bit-counting intrinsics carry the same bound.
+// CHECK-DAG: `f64` does not implement `Integral`
+pub fn count_float(x : f64) -> f64 { core::intrinsic::math::ctpop(x) }

--- a/tests/integration/repl-rs/bitwise.repl
+++ b/tests/integration/repl-rs/bitwise.repl
@@ -1,0 +1,79 @@
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror -Onone | %FileCheck %s
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
+
+// The bitwise ladder sits between comparisons and arithmetic, Rust's
+// order: `&` binds tighter than `==`, `+` binds tighter than the shifts.
+
+12 & 10
+// CHECK: 8 : i64
+
+12 | 3
+// CHECK: 15 : i64
+
+12 ^ 10
+// CHECK: 6 : i64
+
+1 << 10
+// CHECK: 1024 : i64
+
+// A right shift follows the operand's signedness: arithmetic on signed …
+-16 >> 2
+// CHECK: -4 : i64
+
+// … logical on unsigned (the sign bit shifts in as zero; an arithmetic
+// shift here would smear it into 18446744073709551608).
+1 as u64 << 63 >> 60
+// CHECK: 8 : u64
+
+// `&` over `==`: `(6 & 2) == 2`, not C's `6 & (2 == 2)`.
+6 & 2 == 2
+// CHECK: true : bool
+
+// Arithmetic over shifts: `1 << (1 + 2)`.
+1 << 1 + 2
+// CHECK: 8 : i64
+
+// Shifts over `&`: `(32 >> 2) & 12`.
+32 >> 2 & 12
+// CHECK: 8 : i64
+
+// `&` over `^` over `|`: `(1 | (2 ^ (2 & 3)))`.
+1 | 2 ^ 2 & 3
+// CHECK: 1 : i64
+
+// Left association: `(256 >> 4) >> 2`.
+256 >> 4 >> 2
+// CHECK: 16 : i64
+
+// Shifts glue two adjacent angle tokens, so generic calls and
+// comparisons keep working around them.
+fn same<T>(x: T) -> T { x }
+// CHECK: Definition added.
+
+same(3) << same(2)
+// CHECK: 24 : i64
+
+1 << 3 > 7
+// CHECK: true : bool
+
+// The bit-counting intrinsics.
+core::intrinsic::math::ctpop(255 as u8)
+// CHECK: 8 : u8
+
+core::intrinsic::math::ctpop(2863311530 as u32)
+// CHECK: 16 : u32
+
+core::intrinsic::math::ctlz(1 as u32)
+// CHECK: 31 : u32
+
+core::intrinsic::math::cttz(64 as u32)
+// CHECK: 6 : u32
+
+core::intrinsic::math::cttz(0 as u16)
+// CHECK: 16 : u16
+
+// The hash-trie rank idiom: how many occupied slots sit below slot 6 of
+// an occupancy bitmap — `ctpop(bitmap & (bit - 1))`.
+core::intrinsic::math::ctpop((1 as u32 << 1 | 1 << 4 | 1 << 6) & ((1 << 6) - 1))
+// CHECK: 2 : u32

--- a/tests/integration/repl-rs/bitwise.repl
+++ b/tests/integration/repl-rs/bitwise.repl
@@ -44,7 +44,7 @@
 
 // Left association: `(256 >> 4) >> 2`.
 256 >> 4 >> 2
-// CHECK: 16 : i64
+// CHECK: 4 : i64
 
 // Shifts glue two adjacent angle tokens, so generic calls and
 // comparisons keep working around them.
@@ -52,7 +52,7 @@ fn same<T>(x: T) -> T { x }
 // CHECK: Definition added.
 
 same(3) << same(2)
-// CHECK: 24 : i64
+// CHECK: 12 : i64
 
 1 << 3 > 7
 // CHECK: true : bool


### PR DESCRIPTION
First of the three PRs toward the hash map: `&`, `|`, `^`, `<<`, `>>` on `Integral` operands, and `ctpop`/`ctlz`/`cttz` in `core::intrinsic::math`.

## Semantics

- Precedence is Rust&#39;s, not C&#39;s: the bitwise ladder sits between comparisons and arithmetic (`||` &lt; `&&` &lt; comparisons &lt; `|` &lt; `^` &lt; `&` &lt; shifts &lt; `+ -` &lt; `* / %`), so `a & b == c` is `(a & b) == c` and `a | b + c` is `a | (b + c)`. All left-associative.
- Both operands share one type, `Integral ⊳ T` — the shift amount is the operand type, not a separate width. A right shift follows the operand&#39;s signedness: `arith.shrsi` (→ `ashr`) on signed, `arith.shrui` (→ `lshr`) on unsigned.
- `bool` is **not** admitted (stricter than Rust): its connectives are `&&`/`||`, and `Integral` excludes it. `f64 & f64` and `bool | bool` both report ``does not implement `Integral` ``.

## Shifts have no token

A greedy `<<`/`>>` lexer token would eat nested generic closers (`List<List<T>>`) whole. Angle tokens stay single everywhere; the Pratt loop glues two adjacent angles — byte-range adjacency, checked only where an infix operator is expected — so generic-argument parsing, comparisons, and the instantiation trial parse are untouched. The textual HIR/MIR grammars spell the same form as a two-token rule (`"<" "<"`), so printed IR re-parses; both textual re-entries (`.hir` → mir, `.mir` → llvm-ir) are exercised in the new frontend test.

## Bit intrinsics

`ctpop`, `ctlz`, `cttz` join the math family as a new `IntUnary` kind: `Integral`-bounded and flagless (the MLIR integer math ops carry no `fastmath`), built through the same ODS path and lowered by the registered MathToLLVM interface to `llvm.ctpop/ctlz/cttz`. The core coverage test that asserts every `MathFn` has a prototype in `core` pins the new declarations.

The operation these exist for — the hash-trie rank `ctpop(bitmap & (bit - 1))` — compiles to exactly `and` + `ctpop`.

## Tests

- `frontend/bitwise.rr`: HIR/MIR/LLVM FileCheck, both textual re-entries, `ashr`-vs-`lshr` selection, operators alongside lambdas and generic instantiation.
- `frontend/bitwise_errors.rr`: the `Integral` rejections, including `bool`.
- `repl-rs/bitwise.repl`: evaluated precedence table (each rung against its neighbors), left-associativity, signedness of `>>`, glued shifts coexisting with generic calls and comparisons, intrinsic values including `cttz(0) = width`.

Full lit suite locally: 485/494, with the 7 usual unsupported and 2 failures unrelated to this branch — `sanitizer/e2e/cells_sync_parallel.rr` fails identically under the pre-branch compiler binary (a 112-byte `___kmp_allocate_align` leak entirely inside libomp&#39;s startup, no Reussir frames — local toolchain drift), and the repl suite needed the conda `libstdc++` on the loader path after a local rebuild, an environment quirk CI doesn&#39;t share. 462 `reussir-core` unit tests, clippy, and fmt are clean.

Follow-ups in this series: trait associated functions (`Trait::`/`Impl::` call forms) for `Hasher::default`/`from_entropy`, then rc-element array plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788731171&installation_model_id=426051&pr_number=545&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F545&signature=de622830eb29c84ac643764bcfafa405b520df026e3fbc7ea2699aab6840bc7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->