### PR TITLE
[build][tests] don't declare absent archive candidates; gate the repl test

### DIFF
--- a/crates/reussir-backend-sys/native_archive.rs
+++ b/crates/reussir-backend-sys/native_archive.rs
@@ -58,8 +58,24 @@ pub fn track(lib_dir: &Path, archives: &[&str]) -> io::Result<()> {
     // whenever any linked native archive does.
     println!("cargo:rustc-cfg=reussir_native_archive_fingerprint_{fingerprint}");
 
+    // Only the candidates that exist, mirroring `fingerprint()`. Cargo cannot
+    // stat a path that is not there and treats it as changed, so declaring all
+    // three re-runs this script on *every* build — and at least two of the
+    // three are always absent, on every platform (`lib<x>.a` off Windows,
+    // `<x>.lib`/`lib<x>.lib` off Unix). Measured on Windows before this guard:
+    // a second build with no source changes re-ran the script and relinked
+    // rrc, 56s of work for nothing.
+    //
+    // The trade: an archive appearing where none existed at this script's last
+    // run is not noticed by itself. That is fine here because CMake builds the
+    // native archives before it invokes cargo, so an archive that is going to
+    // exist already does — and if one is later added to `archives`, the
+    // fingerprint in the emitted cfg changes and re-runs the link anyway.
     for archive in archives {
         for path in archive_candidates(lib_dir, archive) {
+            if !path.is_file() {
+                continue;
+            }
             println!("cargo:rerun-if-changed={}", path.display());
         }
     }

--- a/tests/integration/repl-rs/polymorphic_math.repl
+++ b/tests/integration/repl-rs/polymorphic_math.repl
@@ -1,3 +1,4 @@
+// REQUIRES: rrepl
 // RUN: %rrepl -i %s -lerror -Onone | %FileCheck %s
 
 fn cos_squared(x: f64) -> f64 { let y = core::intrinsic::math::cos(x, 0); y * y }


### PR DESCRIPTION
Two independent one-liners, both found while validating #543 on Windows. @Kylin asked me to take them together.

## `track()` re-ran the build script on every build

The Copilot reviewer flagged this on #539 and it is correct. `native_archive.rs::track()` emitted `cargo:rerun-if-changed` for all three archive spellings without checking existence:

```rust
lib{archive}.a   {archive}.lib   lib{archive}.lib
```

Cargo cannot stat a path that is not there and treats it as changed, so the script re-ran every build. At least two of the three are **always** absent, on every platform — `lib<x>.a` off Windows, `<x>.lib`/`lib<x>.lib` off Unix. `fingerprint()` right above it already skipped missing candidates; `track()` now mirrors it, as requested.

**Measured on Windows x64** (conda LLVM 22.1.8, VS 18, `nightly-2026-02-15-x86_64-pc-windows-msvc`), second build with no source changes:

| | build script | cargo | no-op build |
|---|---|---|---|
| before | **re-ran** | relinked `rrc` | **56.2s** |
| after | unchanged | does nothing | **6.2s** |

The `build/bin/rrc.exe` timestamp still moves after the fix — that is CMake's install step copying, not a relink. Checked separately: the cargo-produced `build/target/release/rrc.exe` is untouched.

**The trade, stated so it's chosen rather than discovered:** an archive appearing where none existed at the script's last run is no longer noticed on its own. That is safe here because CMake builds the native archives before invoking cargo, so an archive that will exist already does; and if one is added to `archives`, the fingerprint in the emitted cfg changes and re-runs the link anyway. The comment in the source says this.

Worth noting the symmetry with #542, which this does **not** address: that is a build script skipping when its inputs did change; this is one running when nothing had. Both come of deciding freshness from filesystem metadata rather than content.

## One lit test was missing its feature gate

`repl-rs/polymorphic_math.repl` was the only one of 23 repl cases without `REQUIRES: rrepl`. On a tree where `rrepl` isn't built it FAILS where its 22 siblings are correctly UNSUPPORTED — it was the single failure in my full Windows suite run for #543, and had nothing to do with what that run was checking. Now `UNSUPPORTED`, verified.

## Verification

- The no-op rebuild measurement above, before and after, on the same tree.
- `lit --filter polymorphic_math` → `UNSUPPORTED` instead of `FAIL`.
- No codegen source changed, so no performance benchmark applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788749412&installation_model_id=426051&pr_number=548&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F548&signature=78ba0d3bfa749dc392108611fb3c94b81aeba6bfaa63991edaafaf26ee4be209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->