### PR TITLE
[partial-move] schedule owned constructions before inlining

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -139,6 +139,7 @@ unsafe extern "C" {
     pub fn reussirCreateSpecialPointerTagPass(arch_independent: bool) -> MlirPass;
     pub fn reussirCreateClosureBetaReductionPass() -> MlirPass;
     pub fn reussirCreateRcDispatchFusionPass() -> MlirPass;
+    pub fn reussirCreateEarlyPartialMovePass() -> MlirPass;
     pub fn reussirCreatePartialMovePass() -> MlirPass;
     pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -347,9 +347,9 @@ pub fn run_lowering_pipeline(
             if options.opt == OptLevel::Aggressive => {
                 module: sys::reussirCreateUniqueCarryingRecursionAnalysisPass();
             }
-            // Schedule complete carrier moves and fresh owned constructions
-            // while source-level call structure is still present. The late
-            // phase remains responsible for post-dispatch fusion.
+            // Schedule fresh owned constructions while source-level call
+            // structure is still present. Complete-owner scheduling and
+            // fusion remain in the late post-dispatch phase.
             func:   sys::reussirCreateEarlyPartialMovePass();
             module: sys::reussirCreateDefaultInlinerPass();
             // Beta-reduce the closure chains the inliner just made visible:

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -347,6 +347,10 @@ pub fn run_lowering_pipeline(
             if options.opt == OptLevel::Aggressive => {
                 module: sys::reussirCreateUniqueCarryingRecursionAnalysisPass();
             }
+            // Schedule complete carrier moves and fresh owned constructions
+            // while source-level call structure is still present. The late
+            // phase remains responsible for post-dispatch fusion.
+            func:   sys::reussirCreateEarlyPartialMovePass();
             module: sys::reussirCreateDefaultInlinerPass();
             // Beta-reduce the closure chains the inliner just made visible:
             // create→apply→eval collapses to the spliced body, and chained
@@ -367,9 +371,9 @@ pub fn run_lowering_pipeline(
         // Fuse pattern-match consumption into destructuring decrements before
         // the cancellation pass (which cancels `inc; destructuring dec` into
         // borrow semantics) and the decrement expansion (which expands the
-        // tagged decs shallowly). PartialMove must follow dispatch fusion:
-        // variant fusion exposes adjacent compound-consumption sites that the
-        // old combined pass handled in that order.
+        // tagged decs shallowly). The late PartialMove phase must follow
+        // dispatch fusion: variant fusion exposes adjacent
+        // compound-consumption sites that do not exist in the early IR.
         func:   sys::reussirCreateRcDispatchFusionPass();
         func:   sys::reussirCreatePartialMovePass();
         func:   sys::reussirCreateIncDecCancellationPass();

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -61,6 +61,7 @@ MlirPass reussirCreateSpecialPointerTagPass(bool archIndependent);
 /// `begin` without an `end` names it). Intended for verbose/diagnostic runs.
 void reussirPassManagerAttachPhaseLogger(MlirPassManager pm);
 MlirPass reussirCreateRcDispatchFusionPass(void);
+MlirPass reussirCreateEarlyPartialMovePass(void);
 MlirPass reussirCreatePartialMovePass(void);
 MlirPass reussirCreateRcCreateFusionPass(void);
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void);

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -100,6 +100,29 @@ def ReussirRcCreateFusionPass
 //===----------------------------------------------------------------------===//
 // PartialMove
 //===----------------------------------------------------------------------===//
+def ReussirEarlyPartialMovePass
+    : Pass<"reussir-early-partial-move", "::mlir::func::FuncOp"> {
+  let summary = "schedule complete partial moves before inlining";
+  let description = [{
+    `reussir-early-partial-move` runs the scheduling half of PartialMove while
+    source-level call structure is still present. It gathers every projection
+    of a compound owner at the first consuming use, transfers all nontrivial
+    top-level members, and ends the owner before a crossed call.
+
+    The early phase also recognizes a closed fresh-owned construction placed
+    immediately after a call despite all inputs being available before it. If
+    the chain consumes a retained projected owner, it moves the compound,
+    variant, and allocation before the call. This changes placement rather
+    than RC volume and recovers the ordering available to hand-scheduled
+    source.
+
+    This pass deliberately omits adjacent retain/decrement fusion. That
+    canonical late rewrite remains in `reussir-partial-move`, after dispatch
+    fusion has exposed additional sites.
+  }];
+  let dependentDialects = ["::reussir::ReussirDialect"];
+}
+
 def ReussirPartialMovePass
     : Pass<"reussir-partial-move", "::mlir::func::FuncOp"> {
   let summary = "recognize and materialize partial moves";
@@ -112,10 +135,10 @@ def ReussirPartialMovePass
     count observation that may alias the root. Complete transfer is required
     because an unbound member's early drop may invoke observable cleanup glue.
 
-    The already-adjacent retain/decrement pattern is the degenerate case. Both
-    forms materialize as a tagless destructuring decrement whose
-    `boundMembers` transfer on the unique path and rematerialize their retains
-    on the shared path.
+    For shared boxed owners, the already-adjacent retain/decrement pattern is
+    the degenerate case. Both forms materialize as a tagless destructuring
+    decrement whose `boundMembers` transfer on the unique path and
+    rematerialize their retains on the shared path.
   }];
   let dependentDialects = ["::reussir::ReussirDialect"];
 }

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -102,23 +102,19 @@ def ReussirRcCreateFusionPass
 //===----------------------------------------------------------------------===//
 def ReussirEarlyPartialMovePass
     : Pass<"reussir-early-partial-move", "::mlir::func::FuncOp"> {
-  let summary = "schedule complete partial moves before inlining";
+  let summary = "schedule fresh owned constructions before inlining";
   let description = [{
-    `reussir-early-partial-move` runs the scheduling half of PartialMove while
-    source-level call structure is still present. It gathers every projection
-    of a compound owner at the first consuming use, transfers all nontrivial
-    top-level members, and ends the owner before a crossed call.
+    `reussir-early-partial-move` recognizes a closed fresh-owned construction
+    placed immediately after a call despite all inputs being available before
+    it. If the chain consumes a retained projected owner, it moves the
+    compound, variant, and allocation before the call. This changes placement
+    rather than RC volume and recovers the ordering available to
+    hand-scheduled source.
 
-    The early phase also recognizes a closed fresh-owned construction placed
-    immediately after a call despite all inputs being available before it. If
-    the chain consumes a retained projected owner, it moves the compound,
-    variant, and allocation before the call. This changes placement rather
-    than RC volume and recovers the ordering available to hand-scheduled
-    source.
-
-    This pass deliberately omits adjacent retain/decrement fusion. That
-    canonical late rewrite remains in `reussir-partial-move`, after dispatch
-    fusion has exposed additional sites.
+    This pass deliberately omits complete-owner scheduling and adjacent
+    retain/decrement fusion. Those rewrites remain in
+    `reussir-partial-move`, after dispatch fusion has exposed their canonical
+    late forms.
   }];
   let dependentDialects = ["::reussir::ReussirDialect"];
 }

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -112,6 +112,9 @@ MlirPass reussirCreateRcCreateSinkPass(void) {
 MlirPass reussirCreateRcDispatchFusionPass(void) {
   return wrapOwned(reussir::createReussirRcDispatchFusionPass());
 }
+MlirPass reussirCreateEarlyPartialMovePass(void) {
+  return wrapOwned(reussir::createReussirEarlyPartialMovePass());
+}
 MlirPass reussirCreatePartialMovePass(void) {
   return wrapOwned(reussir::createReussirPartialMovePass());
 }

--- a/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
+++ b/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
@@ -72,6 +72,7 @@
 #include <mlir/Analysis/AliasAnalysis.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Builders.h>
+#include <mlir/IR/Dominance.h>
 #include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Interfaces/ControlFlowInterfaces.h>
 #include <mlir/Pass/Pass.h>
@@ -720,10 +721,7 @@ struct EarlyPartialMovePass
     : public impl::ReussirEarlyPartialMovePassBase<EarlyPartialMovePass> {
   using Base::Base;
 
-  void runOnOperation() override {
-    scheduleOwnedConstructions(getOperation());
-    scheduleCompleteMoves(getOperation());
-  }
+  void runOnOperation() override { scheduleOwnedConstructions(getOperation()); }
 };
 
 struct PartialMovePass

--- a/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
+++ b/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
@@ -65,8 +65,8 @@
 #include "Reussir/IR/ReussirTypes.h"
 #include "Reussir/Transformation/Passes.h"
 
-#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Analysis/AliasAnalysis.h>
@@ -79,6 +79,7 @@
 namespace reussir {
 
 #define GEN_PASS_DEF_REUSSIRRCDISPATCHFUSIONPASS
+#define GEN_PASS_DEF_REUSSIREARLYPARTIALMOVEPASS
 #define GEN_PASS_DEF_REUSSIRPARTIALMOVEPASS
 #include "Reussir/Transformation/Passes.h.inc"
 
@@ -435,7 +436,7 @@ bool scheduleCompleteCompoundMove(ReussirRcDecOp dec,
 
   llvm::SmallVector<llvm::SmallVector<mlir::Operation *>> retainsByMember(
       record.getMembers().size());
-  for (const CompoundExtraction &extraction : extractions) {
+  for (CompoundExtraction &extraction : extractions) {
     if (extraction.index < 0 ||
         static_cast<size_t>(extraction.index) >= retainsByMember.size())
       return false;
@@ -513,6 +514,107 @@ bool scheduleCompleteCompoundMove(ReussirRcDecOp dec,
     }
   }
   return true;
+}
+
+bool isOwnedConstruction(mlir::Operation *op) {
+  return op && llvm::isa<ReussirRecordCompoundOp, ReussirRecordVariantOp,
+                         ReussirRcCreateOp>(op);
+}
+
+// Match the source-level scheduling lever available in a pattern arm:
+// materialize a fresh owned value immediately after a call even though every
+// input was already available before it. Moving that closed construction
+// chain before the call consumes projected owners eagerly and exactly matches
+// the hand-scheduled spelling, without advancing any release or changing RC
+// volume. Keep this deliberately narrow: fresh nonregional allocation, a
+// contiguous compound/variant/create chain, and at least one retained value
+// loaded from a projected reference.
+bool scheduleOwnedConstructionBeforeCall(ReussirRcCreateOp create,
+                                         mlir::DominanceInfo &dominance) {
+  if (create.getToken() || create.getRegion() || create.getSkipRc())
+    return false;
+
+  llvm::SmallPtrSet<mlir::Operation *, 4> chainSet;
+  llvm::SmallVector<mlir::Operation *> worklist{create};
+  while (!worklist.empty()) {
+    mlir::Operation *op = worklist.pop_back_val();
+    if (!chainSet.insert(op).second)
+      continue;
+    if (!isOwnedConstruction(op))
+      return false;
+    for (mlir::Value operand : op->getOperands()) {
+      mlir::Operation *def = operand.getDefiningOp();
+      if (def && def->getBlock() == create->getBlock() &&
+          isOwnedConstruction(def))
+        worklist.push_back(def);
+    }
+  }
+
+  llvm::SmallVector<mlir::Operation *> chain;
+  for (mlir::Operation &op : *create->getBlock())
+    if (chainSet.contains(&op))
+      chain.push_back(&op);
+  if (chain.empty() || chain.back() != create)
+    return false;
+
+  mlir::Operation *call = chain.front()->getPrevNode();
+  if (!llvm::isa_and_present<mlir::CallOpInterface>(call))
+    return false;
+  for (auto [left, right] : llvm::zip(chain, llvm::drop_begin(chain)))
+    if (left->getNextNode() != right)
+      return false;
+
+  mlir::Operation *insertionPoint = call;
+  while (isOwnedConstruction(insertionPoint->getPrevNode()))
+    insertionPoint = insertionPoint->getPrevNode();
+
+  bool consumesProjectedOwner = false;
+  for (mlir::Operation *op : chain) {
+    for (mlir::Value operand : op->getOperands()) {
+      mlir::Operation *def = operand.getDefiningOp();
+      if (def && chainSet.contains(def))
+        continue;
+      if (!dominance.properlyDominates(operand, insertionPoint))
+        return false;
+      if (!llvm::isa<RcType>(operand.getType()))
+        continue;
+      auto load = llvm::dyn_cast_if_present<ReussirRefLoadOp>(def);
+      if (!load || !llvm::isa_and_present<ReussirRefProjectOp>(
+                       load.getRef().getDefiningOp()))
+        continue;
+      for (mlir::Operation *user : operand.getUsers()) {
+        auto retain = llvm::dyn_cast<ReussirRcIncOp>(user);
+        if (retain && retain->getBlock() == call->getBlock() &&
+            retain->isBeforeInBlock(insertionPoint)) {
+          consumesProjectedOwner = true;
+          break;
+        }
+      }
+    }
+  }
+  if (!consumesProjectedOwner)
+    return false;
+
+  for (mlir::Operation *op : chain)
+    op->moveBefore(insertionPoint);
+  return true;
+}
+
+void scheduleOwnedConstructions(mlir::func::FuncOp function) {
+  mlir::DominanceInfo dominance(function);
+  llvm::SmallVector<ReussirRcCreateOp> creates;
+  function.walk([&](ReussirRcCreateOp create) { creates.push_back(create); });
+  for (ReussirRcCreateOp create : creates)
+    scheduleOwnedConstructionBeforeCall(create, dominance);
+}
+
+void scheduleCompleteMoves(mlir::func::FuncOp function) {
+  mlir::AliasAnalysis aliasAnalysis(function);
+  registerAliasAnalysisImplementations(aliasAnalysis);
+  llvm::SmallVector<ReussirRcDecOp> decrements;
+  function.walk([&](ReussirRcDecOp dec) { decrements.push_back(dec); });
+  for (ReussirRcDecOp dec : decrements)
+    scheduleCompleteCompoundMove(dec, aliasAnalysis);
 }
 
 // Fuse a rebuild-style consumption of a compound box: scan backward from a
@@ -614,20 +716,27 @@ struct RcDispatchFusionPass
   }
 };
 
+struct EarlyPartialMovePass
+    : public impl::ReussirEarlyPartialMovePassBase<EarlyPartialMovePass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    scheduleOwnedConstructions(getOperation());
+    scheduleCompleteMoves(getOperation());
+  }
+};
+
 struct PartialMovePass
     : public impl::ReussirPartialMovePassBase<PartialMovePass> {
   using Base::Base;
 
   void runOnOperation() override {
-    mlir::AliasAnalysis aliasAnalysis(getOperation());
-    registerAliasAnalysisImplementations(aliasAnalysis);
+    scheduleCompleteMoves(getOperation());
     llvm::SmallVector<ReussirRcDecOp> decrements;
     getOperation()->walk(
         [&](ReussirRcDecOp dec) { decrements.push_back(dec); });
-    for (ReussirRcDecOp dec : decrements) {
-      scheduleCompleteCompoundMove(dec, aliasAnalysis);
+    for (ReussirRcDecOp dec : decrements)
       fuseCompoundConsumption(dec);
-    }
   }
 };
 

--- a/tests/integration/conversion/early_partial_move_pipeline.mlir
+++ b/tests/integration/conversion/early_partial_move_pipeline.mlir
@@ -1,0 +1,76 @@
+// RUN: %reussir-opt %s --reussir-default-inliner --reussir-partial-move \
+// RUN:   | %FileCheck %s --check-prefix=LATE-ONLY
+// RUN: %reussir-opt %s --reussir-early-partial-move \
+// RUN:   --reussir-default-inliner --reussir-partial-move \
+// RUN:   | %FileCheck %s --check-prefix=SPLIT
+
+// A natural match-arm spelling constructs a fresh owned tail after a recursive
+// call even though every input is already available. The early phase moves the
+// closed compound/variant/create chain before the call, matching the source
+// ordering that measured faster without changing RC operation counts. The late
+// phase keeps its existing release/rebuild responsibilities.
+
+!leaf = !reussir.record<compound "Leaf" [value] {i64}>
+!elem = !reussir.record<variant "Elem" {!leaf}>
+!rc_elem = !reussir.rc<!elem>
+!pair = !reussir.record<compound "Pair" [value] {!elem, !elem}>
+!digit = !reussir.record<variant "Digit" {!pair}>
+!rc_digit = !reussir.rc<!digit>
+!holder = !reussir.record<compound "Holder" {!elem}>
+!rc_holder = !reussir.rc<!holder>
+!dependent_pair = !reussir.record<compound "DependentPair" [value] {!elem, !digit}>
+!dependent = !reussir.record<variant "Dependent" {!dependent_pair}>
+!rc_dependent = !reussir.rc<!dependent>
+
+func.func private @recurse(!rc_digit, !rc_elem) -> !rc_digit
+
+// LATE-ONLY-LABEL: func.func @natural(
+// LATE-ONLY: %[[CALL:.+]] = call @recurse
+// LATE-ONLY-NEXT: %[[PAIR:.+]] = reussir.record.compound
+// LATE-ONLY-NEXT: %[[VARIANT:.+]] = reussir.record.variant
+// LATE-ONLY-NEXT: %[[TAIL:.+]] = reussir.rc.create
+// LATE-ONLY: return %[[TAIL]]
+
+// SPLIT-LABEL: func.func @natural(
+// SPLIT: %[[PAIR:.+]] = reussir.record.compound
+// SPLIT-NEXT: %[[VARIANT:.+]] = reussir.record.variant
+// SPLIT-NEXT: %[[TAIL:.+]] = reussir.rc.create
+// SPLIT-NEXT: %[[CALL:.+]] = call @recurse
+// SPLIT: return %[[TAIL]]
+func.func @natural(%holder: !rc_holder, %other: !rc_elem,
+                   %middle: !rc_digit, %node: !rc_elem) -> !rc_digit {
+  %ref = reussir.rc.borrow (%holder : !rc_holder) : !reussir.ref<!holder>
+  %slot = reussir.ref.project (%ref : !reussir.ref<!holder>) [0] : !reussir.ref<!rc_elem>
+  %member = reussir.ref.load (%slot : !reussir.ref<!rc_elem>) : !rc_elem
+  reussir.rc.inc (%member : !rc_elem)
+  reussir.rc.dec (%holder : !rc_holder)
+  %updated = func.call @recurse(%middle, %node) : (!rc_digit, !rc_elem) -> !rc_digit
+  %pair = reussir.record.compound(%member, %other : !rc_elem, !rc_elem) : !pair
+  %variant = reussir.record.variant[0] (%pair : !pair) : !digit
+  %tail = reussir.rc.create value(%variant : !digit) : !rc_digit
+  reussir.rc.dec (%updated : !rc_digit)
+  return %tail : !rc_digit
+}
+
+// A construction that consumes the call result cannot move before that call.
+// This is the dominance guard exercised by the natural fingertree corpus when
+// a broader first implementation tried to schedule unrelated result carriers.
+// SPLIT-LABEL: func.func @depends_on_call(
+// SPLIT: %[[CALL:.+]] = call @recurse
+// SPLIT-NEXT: %[[PAIR:.+]] = reussir.record.compound
+// SPLIT-NEXT: %[[VARIANT:.+]] = reussir.record.variant
+// SPLIT-NEXT: %[[RESULT:.+]] = reussir.rc.create
+// SPLIT: return %[[RESULT]]
+func.func @depends_on_call(%holder: !rc_holder, %middle: !rc_digit,
+                           %node: !rc_elem) -> !rc_dependent {
+  %ref = reussir.rc.borrow (%holder : !rc_holder) : !reussir.ref<!holder>
+  %slot = reussir.ref.project (%ref : !reussir.ref<!holder>) [0] : !reussir.ref<!rc_elem>
+  %member = reussir.ref.load (%slot : !reussir.ref<!rc_elem>) : !rc_elem
+  reussir.rc.inc (%member : !rc_elem)
+  reussir.rc.dec (%holder : !rc_holder)
+  %updated = func.call @recurse(%middle, %node) : (!rc_digit, !rc_elem) -> !rc_digit
+  %pair = reussir.record.compound(%member, %updated : !rc_elem, !rc_digit) : !dependent_pair
+  %variant = reussir.record.variant[0] (%pair : !dependent_pair) : !dependent
+  %result = reussir.rc.create value(%variant : !dependent) : !rc_dependent
+  return %result : !rc_dependent
+}

--- a/tests/integration/conversion/partial_move_fusion.mlir
+++ b/tests/integration/conversion/partial_move_fusion.mlir
@@ -1,4 +1,5 @@
 // RUN: %reussir-opt %s --reussir-rc-dispatch-fusion --reussir-partial-move | %FileCheck %s
+// RUN: %reussir-opt %s --reussir-early-partial-move | %FileCheck %s --check-prefix=EARLY
 
 // Projection-only compound owners can move at their first consuming use even
 // when a late scalar projection originally kept the carrier alive across a
@@ -27,6 +28,18 @@ func.func private @consume_one(!rc_tree)
 // CHECK-SAME: boundMembers = array<i64: 0>
 // CHECK-NEXT: %{{.+}} = call @consume_tree(%[[TREE]],
 // CHECK: return %[[LATE]]
+// Complete-owner scheduling is late-only. Running it before the inliner made
+// this decrement destructuring before the call; wavl_fold_traverse exposed the
+// resulting transfer as a use-after-free in the full pipeline.
+// EARLY-LABEL: func.func @lazy_projection(
+// EARLY-NOT: boundMembers
+// EARLY: reussir.rc.inc
+// EARLY-NOT: boundMembers
+// EARLY: call @consume_tree
+// EARLY-NOT: boundMembers
+// EARLY: reussir.rc.dec
+// EARLY-NOT: boundMembers
+// EARLY: return
 func.func @lazy_projection(%carrier: !rc_carrier) -> i1 {
   %ref = reussir.rc.borrow (%carrier : !rc_carrier) : !reussir.ref<!carrier>
   %tree_slot = reussir.ref.project (%ref : !reussir.ref<!carrier>) [0] : !reussir.ref<!rc_tree>

--- a/tests/integration/conversion/partial_move_fusion.mlir
+++ b/tests/integration/conversion/partial_move_fusion.mlir
@@ -1,4 +1,5 @@
 // RUN: %reussir-opt %s --reussir-rc-dispatch-fusion --reussir-partial-move | %FileCheck %s
+// RUN: %reussir-opt %s --reussir-early-partial-move | %FileCheck %s
 
 // Projection-only compound owners can move at their first consuming use even
 // when a late scalar projection originally kept the carrier alive across a

--- a/tests/integration/conversion/partial_move_fusion.mlir
+++ b/tests/integration/conversion/partial_move_fusion.mlir
@@ -1,5 +1,4 @@
 // RUN: %reussir-opt %s --reussir-rc-dispatch-fusion --reussir-partial-move | %FileCheck %s
-// RUN: %reussir-opt %s --reussir-early-partial-move | %FileCheck %s
 
 // Projection-only compound owners can move at their first consuming use even
 // when a late scalar projection originally kept the carrier alive across a

--- a/tool/reussir-opt/main.cpp
+++ b/tool/reussir-opt/main.cpp
@@ -59,6 +59,9 @@ int main(int argc, char **argv) {
     return reussir::createReussirClosureBetaReductionPass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return reussir::createReussirDefaultInlinerPass();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return reussir::createReussirRcCreateSinkPass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
@@ -66,6 +69,9 @@ int main(int argc, char **argv) {
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return reussir::createReussirRcDispatchFusionPass();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return reussir::createReussirEarlyPartialMovePass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return reussir::createReussirPartialMovePass();


### PR DESCRIPTION
## Summary

- add an early owned-construction scheduling phase before `reussir-default-inliner`, while keeping complete-owner scheduling and fusion in the existing late post-dispatch phase
- schedule a narrowly matched fresh `record.compound -> record.variant -> rc.create` chain before a call when all inputs already dominate it and it consumes a retained projected owner
- expose/register the early pass through C++, C API, Rust, and `reussir-opt`
- add positive pipeline coverage and a dominance-negative regression

## Measured recovery

Against baseline `eb4cfcc0`, task #8's exact natural fingertree `snoc` Deep/Four source plus this phase is byte-identical to the hand-scheduled source at:

- end-of-MLIR pipeline
- translated LLVM IR
- `llc -O3` object

Natural source without this phase differs at all three boundaries. This is the site previously measured at about 11% for hand scheduling; the current std fingertree already uses the natural spelling, so this improves shipped source without a source rewrite.

Historical runtime provenance: `promaxgb10-edf0`, native Linux aarch64, shared/unpinned; base `484048bf`, #538 `e1e1a2d`, `-Oaggressive --reuse-across-call`, one 40-run hyperfine invocation. The robust estimate is 10.7-10.9% by median and 11.6-11.7% by minimum. Means are intentionally excluded: the byte-identical natural null pair differs 0.2% by median but 8.5% by mean, exposing uncontrolled contention.

The claim is intentionally site-scoped. Broader `[value]` carrier work did not recover the hand-project-first downstream result and was removed. Existing WAVL/map/binomial hand scheduling remains untouched and #550 should remain open for that strand.

## Verification

- rebuilt `reussir-opt` and `rrc`
- 4 focused FileCheck pipelines passed, including the call-result dominance rejection and a regression proving complete-owner scheduling stays late
- `reussir-ut`: 30/30 passed
- the corrected phase is inert (apart from printer newline) on raw IR for all three non-rene programs that failed hosted CI in the initial revision
- exact fingertree end-of-MLIR identity remains `C666C517...` after the correction
- `git diff --check`: clean

The initial revision reused complete boxed-owner scheduling in the pre-inliner phase. Hosted arm64/macOS runs correctly exposed invalid early destructuring transfers and UAF/correctness failures; commit `6419902` removes that unsafe reuse and leaves it late-only.

Partial implementation of #550.

