### PR TITLE
[frontend][std] char casts to integers; native write_char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
   Enum-variant payloads are unaffected — variants stay
   exactly as visible as their enum.
 
+- `char` casts to any integer type: `as` on a `char` source reads the
+  code point as an unsigned 32-bit value, truncating to narrower targets
+  (`'\u{1F600}' as u8` is `0`) and zero-extending to wider ones. Nothing
+  casts *to* `char` — an arbitrary integer is not necessarily a scalar
+  value, and the FFI boundary relies on every `char` being one. This
+  retires `std::hash`'s `char_code` FFI shim: `write_char` now casts
+  natively.
 - `str` is now usable, not just constructible (see `docs/design/str.md`:
   `str` is exactly the immutable static literal; growable strings stay
   outside the language behind the FFI). String literals gain the read

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -682,6 +682,9 @@ pub(super) fn num_class(ty: Ty<'_>) -> Result<NumClass> {
         TyKind::Int(IntTy::Signed(w)) => (w, true, false),
         TyKind::Int(IntTy::Unsigned(w)) => (w, false, false),
         TyKind::Bool => (1, false, false),
+        // A code point is an unsigned 32-bit scalar; only reachable as a
+        // cast *source* (the checker rejects casts to `char`).
+        TyKind::Char => (32, false, false),
         TyKind::Fp(FpTy::Ieee(w)) => (w, true, true),
         TyKind::Fp(FpTy::BFloat16) => (16, true, true),
         _ => return err("cast operand is not a numeric scalar"),

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -4322,6 +4322,36 @@ pub struct Rect { pub w: i64 }",
         );
     }
 
+    #[test]
+    fn char_casts_to_any_integer() {
+        // A code point casts to integers without a `Num` bound on `char`:
+        // truncating to a narrow width and zero-extending to a wide one.
+        let src = "fn f(c: char) -> u64 { (c as u8) as u64 + c as u64 + (c as i64) as u64 }";
+        assert!(reports_of(src).is_empty(), "{:#?}", reports_of(src));
+    }
+
+    #[test]
+    fn rejects_cast_to_char() {
+        // Nothing casts to `char`: an arbitrary integer is not necessarily a
+        // scalar value.
+        let src = "fn f(x: u32) -> char { x as char }";
+        assert!(
+            has_error(src, "cannot cast to `char`"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
+    #[test]
+    fn rejects_char_to_float_cast() {
+        let src = "fn f(c: char) -> f64 { c as f64 }";
+        assert!(
+            has_error(src, "casts only to an integer type"),
+            "{:#?}",
+            reports_of(src)
+        );
+    }
+
     // ----- closure-arity-and-convention -----
 
     #[test]

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -732,7 +732,34 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         // must satisfy `Num`. Registering a `Num` obligation on each means a
         // concrete non-numeric operand fails in the fulfillment loop with a
         // clear diagnostic, instead of surviving to a lowering-time crash.
+        //
+        // `char` is its own rule outside `Num`: the value is a code point, so
+        // a cast to any integer type is allowed (`as u8` truncates to the low
+        // byte, wider targets zero-extend), but nothing casts *to* `char` —
+        // an arbitrary integer is not necessarily a scalar value, and the FFI
+        // boundary relies on every `char` being one.
         let src_ty = self.infer.shallow_resolve(e.ty);
+        let target_head = self.infer.shallow_resolve(target);
+        if matches!(target_head.kind(), TyKind::Char) {
+            self.error(
+                span,
+                "cannot cast to `char`: not every integer is a valid code point",
+            );
+            return self.poison(span);
+        }
+        if matches!(src_ty.kind(), TyKind::Char) {
+            if !matches!(target_head.kind(), TyKind::Int(_)) {
+                self.error(
+                    span,
+                    format!(
+                        "`char` casts only to an integer type, not `{}`",
+                        self.ty_display(target_head)
+                    ),
+                );
+                return self.poison(span);
+            }
+            return self.mk_expr(ExprKind::Cast(Box::new(e), target), target, span);
+        }
         self.register_bound(self.lang.num, target, span);
         self.register_bound(self.lang.num, src_ty, span);
 

--- a/library/std/src/hash.rr
+++ b/library/std/src/hash.rr
@@ -49,12 +49,6 @@
 //! A hasher is a plain value: creating one is free, writes are a few
 //! arithmetic instructions, and the whole chain inlines.
 
-// `char` carries no `Num` bound, so the language's `as` casts do not
-// apply to it; the code point is obtained across the FFI instead, where
-// a Reussir `char` is rendered as a Rust `char`.
-#[ffi(import)]
-fn char_code(value: char) -> u32 [{ value as u32 }];
-
 /// A hash state that absorbs values and produces a digest.
 ///
 /// Every method consumes `self` and returns the advanced state, so
@@ -212,7 +206,7 @@ impl Hasher for FastHasher {
         self.write_u64(if value { 1 } else { 0 })
     }
     fn write_char(self: Self, value: char) -> Self {
-        self.write_u64(char_code(value) as u64)
+        self.write_u64(value as u64)
     }
     fn write_str(self: Self, value: str) -> Self {
         FastHasher { state: fx_write_str(self.state, value) }
@@ -359,7 +353,7 @@ impl Hasher for StrongHasher {
         self.write_u64(if value { 1 } else { 0 })
     }
     fn write_char(self: Self, value: char) -> Self {
-        self.write_u64(char_code(value) as u64)
+        self.write_u64(value as u64)
     }
     fn write_str(self: Self, value: str) -> Self {
         StrongHasher {

--- a/tests/integration/frontend/char_basics.c
+++ b/tests/integration/frontend/char_basics.c
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+// Driver for char_basics.rr: eight independent properties, one decimal
+// digit each.
+
+extern long long reussir_main(void);
+
+int main(void) { return reussir_main() == 11111111 ? 0 : 1; }

--- a/tests/integration/frontend/char_basics.rr
+++ b/tests/integration/frontend/char_basics.rr
@@ -1,0 +1,47 @@
+// `char` end to end: literals (including escapes and multi-byte scalars),
+// `match`, the comparison tower, casts to integers, and a record field,
+// verified through the emitted ops and an end-to-end run.
+
+// RUN: %rrc --package-root %S/../../../library/core/src --package-name core --core --emit rri -o %t.core.rri
+// RUN: %rrc %s --package-name charbasics --extern core=%t.core.rri --emit mlir -o - | %FileCheck %s
+// RUN: %rrc %s --package-name charbasics --extern core=%t.core.rri -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/char_basics.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+pub struct Keyed { key : char, id : i64 }
+
+fn classify(c : char) -> i64 {
+    match c {
+        'x' => 1,
+        '\n' => 2,
+        '\u{1F980}' => 3,
+        _ => 0
+    }
+}
+
+pub fn main() -> i64 {
+    let eq_ok = if 'a' == 'a' && 'a' != 'b' { 1 } else { 0 };
+    // Code points order as unsigned values: 'é' (U+00E9) sits above ASCII.
+    let ord_ok = if 'a' < 'b' && 'é' > 'z' && 'a' <= 'a' { 1 } else { 0 };
+    let match_ok = if classify('x') == 1 && classify('\n') == 2
+        && classify('🦀') == 3 && classify('q') == 0 { 1 } else { 0 };
+    let cmp_ok = match 'm'.cmp('m') { Ordering::Equal => 1, _ => 0 };
+    let widen_ok = if 'a' as u32 == 97 && 'é' as u32 == 233
+        && '🦀' as u64 == 129408 { 1 } else { 0 };
+    // 'a' widens signed too; U+1F600's low byte is 0, so `as u8` truncates.
+    let signed_ok = if 'a' as i64 == 97 { 1 } else { 0 };
+    let trunc_ok = if '\u{1F600}' as u8 == 0 && 'é' as u8 == 233 { 1 } else { 0 };
+    let keyed = Keyed { key: '@', id: 7 };
+    let field_ok = if keyed.key == '@' && keyed.key as u32 == 64 { 1 } else { 0 };
+    eq_ok + ord_ok * 10 + match_ok * 100 + cmp_ok * 1000 + widen_ok * 10000
+        + signed_ok * 100000 + trunc_ok * 1000000 + field_ok * 10000000
+}
+
+extern "C" trampoline "reussir_main" = main;
+
+// The match dispatches through the shared index switch, and the casts
+// stay unsigned: zero-extension outward, truncation down to `u8`.
+// CHECK-DAG: scf.index_switch
+// CHECK-DAG: arith.extui
+// CHECK-DAG: arith.trunci
+// CHECK-NOT: arith.extsi


### PR DESCRIPTION
## Summary

The task-list item "char literal syntax and parsing" turned out to be already complete end-to-end (lexing, patterns, decision trees, codegen, cmp tower, Hash, FFI, .rri round-trip). What was actually missing:

- **`char` → integer casts.** `char` carries no `Num` bound, so `c as u32` was a hard error; `std::hash` worked around it with a `char_code` FFI shim. `infer_cast` now gives `char` its own rule outside `Num`: a `char` source casts to any integer type with unsigned 32-bit semantics (truncate to narrower targets — `'\u{1F600}' as u8` is `0` — zero-extend to wider ones, via a `Char` arm in `num_class`).
- **Nothing casts *to* `char`** (`x as char` and `c as f64` are clean diagnostics): an arbitrary integer is not necessarily a scalar value, and the FFI boundary renders every `char` as a Rust `char`, so admitting unchecked construction would be unsound. Checked construction can come later as an intrinsic returning an option.
- **`write_char` goes native**: the `char_code` shim is deleted from `hash.rr`; both hashers cast directly.
- **Test backfill**: `char_basics.rr` + C driver (8 properties: literals, `match` incl. escape and multi-byte scalars, comparison tower, `cmp`, widening/signed/truncating casts, record field; pins `scf.index_switch`/`arith.extui`/`arith.trunci`, no `extsi`), plus three `semi.rs` unit tests for the cast legality rules.

## Tests

Full lit 491/491 (525 discovered, 34 unsupported), cargo workspace exit 0, ctest 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGAPjZfBhq5GN4PJQNBkHH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790099782&installation_model_id=426051&pr_number=582&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F582&signature=c1111950d38b1b702f6aa1833ce365c05b1c21f300b07a43d377e4655bb22328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->